### PR TITLE
Refactor pooling operations on TTIR level

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3532,11 +3532,11 @@ def TTIR_PoolingOp : TTIR_NamedOp<"pooling", [AttrSizedOperandSegments]> {
 
     Attributes:
     - `pooling_method` (Enum): The pooling method to use (MAX, AVG, SUM).
-    - `window_dimensions` (Array of Integer): Dimensions of the pooling window.
-    - `window_strides` (Array of Integer): Stride of the pooling window.
-    - `base_dilations` (Array of Integer): Dilation factors for the input.
-    - `window_dilations` (Array of Integer): Dilation factors for the pooling window.
-    - `padding` (Array of Integer): Padding to apply to the input.
+    - `window_dimensions` (Array of Integer): Dimensions of the pooling window. The rank of this array is the same as the rank of the input tensors.
+    - `window_strides` (Array of Integer): Stride of the pooling window. The rank of this array is the same as the rank of the input tensors.
+    - `base_dilations` (Array of Integer): Dilation factors for the input. The rank of this array is the same as the rank of the input tensors.
+    - `window_dilations` (Array of Integer): Dilation factors for the pooling window. The rank of this array is the same as the rank of the input tensors.
+    - `padding` (Array of Integer): Padding to apply to the input. The rank of this array is twice the rank of the input tensors, representing padding for each dimension.
 
     Outputs:
     - `results` (Variadic Tensor): Output tensors after pooling.
@@ -3576,17 +3576,11 @@ def TTIR_AvgPool2dOp : TTIR_NamedOp<"avg_pool2d"> {
                                         //   [7, 8, 9]]]]
     %output = ttir.empty() : tensor<1x2x2x1xf32>
     %result = ttir.avg_pool2d(%input, %output) {
-        kernel_height = 2 : i32,
-        kernel_width = 2 : i32,
-        stride_height = 1 : i32,
-        stride_width = 1 : i32,
-        dilation_height = 1 : i32,
-        dilation_width = 1 : i32,
-        ceil_mode = false,
-        padding_left = 0 : i32,
-        padding_right = 0 : i32,
-        padding_top = 0 : i32,
-        padding_bottom = 0 : i32
+        kernel = [2, 2],
+        stride = [1, 1],
+        dilation = [1, 1],
+        padding = [0, 0, 0, 0],
+        ceil_mode = false
     } : tensor<1x3x3x1xf32>, tensor<1x2x2x1xf32> -> tensor<1x2x2x1xf32>
     // Result: [[[3, 4],
     //           [6, 7]]]]
@@ -3597,14 +3591,20 @@ def TTIR_AvgPool2dOp : TTIR_NamedOp<"avg_pool2d"> {
     - `input` (Tensor): Input tensor in NHWC format (batch, height, width, channels).
 
     Attributes:
-    - `kernel_height` (Integer): Height of the pooling kernel.
-    - `kernel_width` (Integer): Width of the pooling kernel.
-    - `stride_height` (Integer): Stride along the height dimension.
-    - `stride_width` (Integer): Stride along the width dimension.
-    - `dilation_height` (Integer): Dilation factor for height dimension.
-    - `dilation_width` (Integer): Dilation factor for width dimension.
+    - `kernel` (i32 | array<2xi32>):
+        - i32: Same kernel size for height and width dimensions (kH = kW = value).
+        - array<2xi32>: [kH, kW] where kH is kernel size for height and kW is kernel size for width.
+    - `stride` (i32 | array<2xi32>):
+        - i32: Same stride for height and width dimensions (sH = sW = value).
+        - array<2xi32>: [sH, sW] where sH is stride for height and sW is stride for width.
+    - `dilation` (i32 | array<2xi32>):
+        - i32: Same dilation for height and width dimensions (dH = dW = value).
+        - array<2xi32>: [dH, dW] where dH is dilation for height and dW is dilation for width.
+    - `padding` (i32 | array<2xi32> | array<4xi32>):
+        - i32: Same padding for all sides (pT = pL = pB = pR = value).
+        - array<2xi32>: [pH, pW] where pH is padding for height (top/bottom) and pW is padding for width (left/right).
+        - array<4xi32>: [pT, pL, pB, pR] for top, left, bottom, and right padding respectively.
     - `ceil_mode` (Boolean): When true, uses ceil instead of floor for output shape calculation.
-    - `padding_left`, `padding_right`, `padding_top`, `padding_bottom` (Integer): Padding on each side.
 
     Outputs:
     - `result` (Tensor): Output tensor after average pooling.
@@ -3612,17 +3612,11 @@ def TTIR_AvgPool2dOp : TTIR_NamedOp<"avg_pool2d"> {
 
   let arguments = (ins AnyRankedTensor:$input,
                        AnyRankedTensor:$output,
-                       SI32Attr:$kernel_height,
-                       SI32Attr:$kernel_width,
-                       SI32Attr:$stride_height,
-                       SI32Attr:$stride_width,
-                       SI32Attr:$dilation_height,
-                       SI32Attr:$dilation_width,
+                       AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$kernel,
+                       AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$stride,
+                       AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$dilation,
+                       AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$padding,
                        BoolAttr:$ceil_mode,
-                       SI32Attr:$padding_left,
-                       SI32Attr:$padding_right,
-                       SI32Attr:$padding_top,
-                       SI32Attr:$padding_bottom,
                        DefaultValuedAttr<TTIR_FlattenedCompatInfoAttr, "nullptr">:$flattened_compat_info);
 
   let results = (outs AnyRankedTensor:$result);
@@ -3649,17 +3643,11 @@ def TTIR_MaxPool2dOp : TTIR_NamedOp<"max_pool2d"> {
                                         //   [7, 8, 9]]]]
     %output = ttir.empty() : tensor<1x2x2x1xf32>
     %result = ttir.max_pool2d(%input, %output) {
-        kernel_height = 2 : i32,
-        kernel_width = 2 : i32,
-        stride_height = 1 : i32,
-        stride_width = 1 : i32,
-        dilation_height = 1 : i32,
-        dilation_width = 1 : i32,
-        ceil_mode = false,
-        padding_left = 0 : i32,
-        padding_right = 0 : i32,
-        padding_top = 0 : i32,
-        padding_bottom = 0 : i32
+        kernel = [2, 2],
+        stride = [1, 1],
+        dilation = [1, 1],
+        padding = [0, 0, 0, 0],
+        ceil_mode = false
     } : tensor<1x3x3x1xf32>, tensor<1x2x2x1xf32> -> tensor<1x2x2x1xf32>
     // Result: [[[5, 6],
     //           [8, 9]]]]
@@ -3670,14 +3658,20 @@ def TTIR_MaxPool2dOp : TTIR_NamedOp<"max_pool2d"> {
     - `input` (Tensor): Input tensor in NHWC format (batch, height, width, channels).
 
     Attributes:
-    - `kernel_height` (Integer): Height of the pooling kernel.
-    - `kernel_width` (Integer): Width of the pooling kernel.
-    - `stride_height` (Integer): Stride along the height dimension.
-    - `stride_width` (Integer): Stride along the width dimension.
-    - `dilation_height` (Integer): Dilation factor for height dimension.
-    - `dilation_width` (Integer): Dilation factor for width dimension.
+    - `kernel` (i32 | array<2xi32>):
+        - i32: Same kernel size for height and width dimensions (kH = kW = value).
+        - array<2xi32>: [kH, kW] where kH is kernel size for height and kW is kernel size for width.
+    - `stride` (i32 | array<2xi32>):
+        - i32: Same stride for height and width dimensions (sH = sW = value).
+        - array<2xi32>: [sH, sW] where sH is stride for height and sW is stride for width.
+    - `dilation` (i32 | array<2xi32>):
+        - i32: Same dilation for height and width dimensions (dH = dW = value).
+        - array<2xi32>: [dH, dW] where dH is dilation for height and dW is dilation for width.
+    - `padding` (i32 | array<2xi32> | array<4xi32>):
+        - i32: Same padding for all sides (pT = pL = pB = pR = value).
+        - array<2xi32>: [pH, pW] where pH is padding for height (top/bottom) and pW is padding for width (left/right).
+        - array<4xi32>: [pT, pL, pB, pR] for top, left, bottom, and right padding respectively.
     - `ceil_mode` (Boolean): When true, uses ceil instead of floor for output shape calculation.
-    - `padding_left`, `padding_right`, `padding_top`, `padding_bottom` (Integer): Padding on each side.
 
     Outputs:
     - `result` (Tensor): Output tensor after maximum pooling.
@@ -3685,17 +3679,11 @@ def TTIR_MaxPool2dOp : TTIR_NamedOp<"max_pool2d"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
-                         SI32Attr:$kernel_height,
-                         SI32Attr:$kernel_width,
-                         SI32Attr:$stride_height,
-                         SI32Attr:$stride_width,
-                         SI32Attr:$dilation_height,
-                         SI32Attr:$dilation_width,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$kernel,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$stride,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$dilation,
+                         AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$padding,
                          BoolAttr:$ceil_mode,
-                         SI32Attr:$padding_left,
-                         SI32Attr:$padding_right,
-                         SI32Attr:$padding_top,
-                         SI32Attr:$padding_bottom,
                          DefaultValuedAttr<TTIR_FlattenedCompatInfoAttr, "nullptr">:$flattened_compat_info);
 
     let results = (outs AnyRankedTensor:$result);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1192,40 +1192,67 @@ public:
   matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!adaptor.getFlattenedCompatInfo()) {
-      return rewriter.notifyMatchFailure(
-          op, "TTNN only supports flattened input tensors for " +
-                  op.getOperationName() +
-                  ". Please "
-                  "run the FlattenSlidingWindow pass before lowering to TTNN.");
+      return op.emitOpError()
+             << "only supports lowering to TTNN for flattened input tensors."
+             << " Please run the FlattenSlidingWindow pass before lowering to "
+                "TTNN";
     }
-    if (adaptor.getPaddingBottom() != adaptor.getPaddingTop()) {
-      return rewriter.notifyMatchFailure(
-          op, op.getOperationName() +
-                  "does not support asymmetric padding for top/bottom.");
+
+    // Extract kernel dimensions.
+    auto kernelPairOrError =
+        ttmlir::utils::getPairOfInteger<int32_t>(adaptor.getKernel());
+    assert(kernelPairOrError && "Expected valid kernel attribute");
+    DenseI32ArrayAttr kernelSizeAttr = rewriter.getDenseI32ArrayAttr(
+        {kernelPairOrError->first, kernelPairOrError->second});
+
+    // Extract stride dimensions.
+    auto stridePairOrError =
+        ttmlir::utils::getPairOfInteger<int32_t>(adaptor.getStride());
+    assert(stridePairOrError && "Expected valid stride attribute");
+    DenseI32ArrayAttr strideAttr = rewriter.getDenseI32ArrayAttr(
+        {stridePairOrError->first, stridePairOrError->second});
+
+    // Extract dilation dimensions.
+    auto dilationPairOrError =
+        ttmlir::utils::getPairOfInteger<int32_t>(adaptor.getDilation());
+    assert(dilationPairOrError && "Expected valid dilation attribute");
+    DenseI32ArrayAttr dilationAttr = rewriter.getDenseI32ArrayAttr(
+        {dilationPairOrError->first, dilationPairOrError->second});
+
+    // TTNN only supports lowering of AvgPool2dOp with dilation of (1, 1).
+    if constexpr (std::is_same_v<TTIROpTy, ttir::AvgPool2dOp>) {
+      if (dilationPairOrError->first != 1 || dilationPairOrError->second != 1) {
+        return op.emitOpError()
+               << "only supports lowering to TTNN for dilation of (1, 1)";
+      }
     }
-    if (adaptor.getPaddingLeft() != adaptor.getPaddingRight()) {
-      return rewriter.notifyMatchFailure(
-          op, op.getOperationName() +
-                  "does not support asymmetric padding for left/right.");
+
+    // Extract padding values.
+    auto paddingQuad =
+        ttmlir::utils::getQuadrupleOfInteger<int32_t>(adaptor.getPadding());
+    assert(paddingQuad && "Expected valid padding attribute");
+    int32_t paddingTop = std::get<0>(*paddingQuad);
+    int32_t paddingLeft = std::get<1>(*paddingQuad);
+    int32_t paddingBottom = std::get<2>(*paddingQuad);
+    int32_t paddingRight = std::get<3>(*paddingQuad);
+
+    // Check for asymmetric padding.
+    if (paddingBottom != paddingTop) {
+      return op.emitOpError() << "only supports lowering to TTNN for symmetric "
+                                 "padding for top/bottom";
     }
+
+    if (paddingLeft != paddingRight) {
+      return op.emitOpError() << "only supports lowering to TTNN for symmetric "
+                                 "padding for left/right";
+    }
+
+    DenseI32ArrayAttr paddingAttr =
+        rewriter.getDenseI32ArrayAttr({paddingTop, paddingLeft});
 
     auto batchSize = adaptor.getFlattenedCompatInfo().getBatchSize();
     constexpr unsigned int CHANNEL_DIM = 3;
     auto channels = op.getInput().getType().getDimSize(CHANNEL_DIM);
-
-    DenseI32ArrayAttr kernelSizeAttr = rewriter.getDenseI32ArrayAttr(
-        {adaptor.getKernelHeight(), adaptor.getKernelWidth()});
-
-    DenseI32ArrayAttr strideAttr = rewriter.getDenseI32ArrayAttr(
-        {adaptor.getStrideHeight(), adaptor.getStrideWidth()});
-
-    assert(adaptor.getPaddingTop() == adaptor.getPaddingBottom());
-    assert(adaptor.getPaddingLeft() == adaptor.getPaddingRight());
-    DenseI32ArrayAttr paddingAttr = rewriter.getDenseI32ArrayAttr(
-        {adaptor.getPaddingTop(), adaptor.getPaddingLeft()});
-
-    DenseI32ArrayAttr dilationAttr = rewriter.getDenseI32ArrayAttr(
-        {adaptor.getDilationHeight(), adaptor.getDilationWidth()});
 
     rewriter.replaceOpWithNewOp<TTNNOpTy>(
         op, this->getTypeConverter()->convertType(op.getResult().getType()),

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -66,7 +66,6 @@ MemRefType getBufferType(Type type, bool isView) {
       fullMemrefShape, tensorType.getElementType(), layoutAttr,
       ttcore::MemorySpaceAttr::get(ctx, layout.getMemorySpace()));
 }
-} // namespace mlir::tt::ttir
 
 //===----------------------------------------------------------------------===//
 // BitwiseXorOp
@@ -451,19 +450,20 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 
 // Conv2dOp verification
 ::mlir::LogicalResult mlir::tt::ttir::Conv2dOp::verify() {
-  using namespace mlir::tt::ttir::verification_utils::conv2d_verification;
-
-  if (verifyTensorRanks(this).failed()) {
+  // Verify tensor ranks.
+  if (verification_utils::verifyTensorRanks<Conv2dOp, true>(this).failed()) {
     return mlir::failure();
   }
 
   auto flatInfo = getFlattenedCompatInfoAttr();
-  if (flatInfo && flatInfo.getBatchSize() * flatInfo.getInputHeight() *
-                          flatInfo.getInputWidth() !=
-                      getInput().getType().getDimSize(FLATTENED_DIM)) {
+  if (flatInfo &&
+      flatInfo.getBatchSize() * flatInfo.getInputHeight() *
+              flatInfo.getInputWidth() !=
+          getInput().getType().getDimSize(verification_utils::FLATTENED_DIM)) {
     int64_t expectedSize = flatInfo.getBatchSize() * flatInfo.getInputHeight() *
                            flatInfo.getInputWidth();
-    int64_t actualSize = getInput().getType().getDimSize(FLATTENED_DIM);
+    int64_t actualSize =
+        getInput().getType().getDimSize(verification_utils::FLATTENED_DIM);
     return emitOpError()
            << "The input tensor's flattened dimension (" << actualSize
            << ") does not match the product of batch_size * input_height * "
@@ -473,13 +473,15 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
            << ").";
   }
 
-  auto [inputDims, weightDims, biasDims] = getConv2dInputDims(this);
-  OutputTensorDims outputDims = getConv2dOutputDims(this);
-  auto expectedParams = getConv2dParams(this);
+  auto [inputDims, weightDims, biasDims] =
+      verification_utils::getConv2dInputDims(this);
+  verification_utils::OutputTensorDims outputDims =
+      verification_utils::getConv2dOutputDims(this);
+  auto expectedParams = verification_utils::getConv2dParams(this);
   if (auto error = expectedParams.takeError()) {
     return emitOpError() << llvm::toString(std::move(error));
   }
-  Conv2dParams params = *expectedParams;
+  verification_utils::Conv2dParams params = *expectedParams;
 
   if (verifyConv2dParams(this, params).failed()) {
     return mlir::failure();
@@ -1007,92 +1009,48 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// Common verifier for pooling ops
+// Generic Pool2dOp verification
 //===----------------------------------------------------------------------===//
-static mlir::LogicalResult verifyPoolingOp(
-    llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
-    mlir::RankedTensorType inputType, mlir::RankedTensorType outputType,
-    mlir::tt::ttir::FlattenedCompatInfoAttr flattenInfo, int32_t kernelHeight,
-    int32_t kernelWidth, llvm::StringRef opName) {
-  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
-  llvm::ArrayRef<int64_t> outputShape = outputType.getShape();
 
-  if (inputType.getRank() != 4) {
-    return emitOpError()
-           << "Input tensor rank must be 4. Received input with rank "
-           << inputType.getRank() << ". Shape: (" << inputShape << ").";
+template <typename PoolingOp>
+static mlir::LogicalResult verifyPooling2dOp(PoolingOp *op) {
+
+  // Verify tensor ranks.
+  if (verification_utils::verifyTensorRanks(op).failed()) {
+    return mlir::failure();
   }
 
-  if (outputType.getRank() != 4) {
-    return emitOpError()
-           << "Output tensor rank must be 4. Received output with rank "
-           << outputType.getRank() << ". Shape: (" << outputShape << ").";
+  // Verify flattened compatibility info if present.
+  if (mlir::failed(verification_utils::verifyFlattenedCompatInfo(op))) {
+    return mlir::failure();
   }
 
-  // FLATTEN_DIM corresponds to the second last dimension as it is where N, H, W
-  // are flattened to by FlattenSlidingWindow.
-  constexpr unsigned int BATCH_DIM = 0, HEIGHT_DIM = 1, WIDTH_DIM = 2,
-                         CHANNEL_DIM = 3, FLATTEN_DIM = 2;
+  // Get input and output dimensions with flattened support.
+  verification_utils::InputTensorDims inputDims =
+      verification_utils::getPool2dInputDims(op);
+  verification_utils::OutputTensorDims outputDims =
+      verification_utils::getPool2dOutputDims(op);
+  auto expectedParams = verification_utils::getPool2dParams(op);
+  if (auto error = expectedParams.takeError()) {
+    return op->emitOpError() << llvm::toString(std::move(error));
+  }
+  verification_utils::Pool2dParams params = *expectedParams;
 
-  int64_t inputHeight = inputType.getDimSize(HEIGHT_DIM);
-  int64_t inputWidth = inputType.getDimSize(WIDTH_DIM);
-  int64_t inChannels = inputType.getDimSize(CHANNEL_DIM);
-  int64_t outChannels = outputType.getDimSize(CHANNEL_DIM);
-  if (flattenInfo) {
-    auto batchSize = flattenInfo.getBatchSize();
-    inputHeight = flattenInfo.getInputHeight();
-    inputWidth = flattenInfo.getInputWidth();
-
-    if (inputType.getDimSize(2) != batchSize * inputHeight * inputWidth) {
-      return emitOpError() << "Expected dim 2 of the input tensor to have size "
-                           << batchSize * inputHeight * inputWidth
-                           << " but got " << inputType.getDimSize(FLATTEN_DIM);
-    }
+  // Verify pooling parameters.
+  if (mlir::failed(verification_utils::verifyPool2dParams(op, params))) {
+    return mlir::failure();
   }
 
-  if (!flattenInfo &&
-      inputType.getDimSize(BATCH_DIM) != outputType.getDimSize(BATCH_DIM)) {
-    return emitOpError()
-           << "Batch size from the input tensor ("
-           << inputType.getDimSize(BATCH_DIM)
-           << ") must match the first dimension of the output tensor ("
-           << outputType.getDimSize(BATCH_DIM) << ")";
+  // Verify input dimensions constraints.
+  if (mlir::failed(
+          verification_utils::verifyPool2dInputDims(op, inputDims, params))) {
+    return mlir::failure();
   }
 
-  if (outChannels != outputType.getDimSize(CHANNEL_DIM)) {
-    return emitOpError() << "Expected dim 3 of the output tensor to have size "
-                         << outChannels << " but got "
-                         << outputType.getDimSize(CHANNEL_DIM);
-  }
-
-  if (inChannels != inputType.getDimSize(CHANNEL_DIM)) {
-    return emitOpError() << "Expected dim 3 of the input tensor to have size "
-                         << inChannels << " but got "
-                         << inputType.getDimSize(CHANNEL_DIM);
-  }
-
-  if (outChannels != inChannels) {
-    return emitOpError() << "Output tensor channels (" << outChannels
-                         << ") must match input tensor channels (" << inChannels
-                         << ").";
-  }
-
-  if (kernelHeight > inputHeight) {
-    return emitOpError() << "Kernel height " << kernelHeight
-                         << " is greater than input height " << inputHeight
-                         << (flattenInfo
-                                 ? " (as defined in flattened_compat_info)"
-                                 : "")
-                         << ". This " << opName << " configuration is invalid.";
-  }
-
-  if (kernelWidth > inputWidth) {
-    return emitOpError() << "Kernel width " << kernelWidth
-                         << " is greater than input width " << inputWidth
-                         << (flattenInfo
-                                 ? " (as defined in flattened_compat_info)"
-                                 : "")
-                         << ". This " << opName << " configuration is invalid.";
+  // Verify output dimensions match expected calculations.
+  if (mlir::failed(verification_utils::verifyPool2dOutputDims(
+          op, inputDims, outputDims, params))) {
+    return mlir::failure();
   }
 
   return mlir::success();
@@ -1104,10 +1062,7 @@ static mlir::LogicalResult verifyPoolingOp(
 
 // AvgPool2dOp verification
 ::mlir::LogicalResult mlir::tt::ttir::AvgPool2dOp::verify() {
-  return verifyPoolingOp([&]() { return emitOpError(); }, getInput().getType(),
-                         getOutput().getType(), getFlattenedCompatInfo(),
-                         getKernelHeight(), getKernelWidth(),
-                         getOperationName());
+  return verifyPooling2dOp(this);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1116,10 +1071,7 @@ static mlir::LogicalResult verifyPoolingOp(
 
 // MaxPool2dOp verification
 ::mlir::LogicalResult mlir::tt::ttir::MaxPool2dOp::verify() {
-  return verifyPoolingOp([&]() { return emitOpError(); }, getInput().getType(),
-                         getOutput().getType(), getFlattenedCompatInfo(),
-                         getKernelHeight(), getKernelWidth(),
-                         getOperationName());
+  return verifyPooling2dOp(this);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4566,3 +4518,4 @@ static mlir::Region *getParentRegionOfType(mlir::Operation *op) {
       ttmlir::utils::getRegionWithParentOfType<GenericOp, func::FuncOp>(
           getOperation()));
 }
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/FlattenSlidingWindow.cpp
+++ b/lib/Dialect/TTIR/Transforms/FlattenSlidingWindow.cpp
@@ -103,12 +103,8 @@ public:
 
     auto newPool = ttir::utils::createDPSOp<Pooling2dOp>(
         rewriter, op.getLoc(), getNHWFlattenedType(outputType), flattenedInput,
-        adaptor.getKernelHeight(), adaptor.getKernelWidth(),
-        adaptor.getStrideHeight(), adaptor.getStrideWidth(),
-        adaptor.getDilationHeight(), adaptor.getDilationWidth(),
-        adaptor.getCeilMode(), adaptor.getPaddingLeft(),
-        adaptor.getPaddingRight(), adaptor.getPaddingTop(),
-        adaptor.getPaddingBottom(), flattenedCompatInfoAttr);
+        adaptor.getKernel(), adaptor.getStride(), adaptor.getDilation(),
+        adaptor.getPadding(), adaptor.getCeilMode(), flattenedCompatInfoAttr);
 
     Value output = generateReshape(newPool, outputType, rewriter);
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1075,25 +1075,19 @@ def test_conv_transpose2d(
 
 
 @pytest.mark.parametrize(
-    "kernel_height,kernel_width,stride_height,stride_width,dilation_height,dilation_width,ceil_mode,padding_left,padding_right,padding_top, padding_bottom",
-    [(2, 2, 2, 2, 1, 1, False, 0, 0, 0, 0)],
+    "kernel,stride,dilation,padding,ceil_mode",
+    [([2, 2], [2, 2], [1, 1], [0, 0, 0, 0], False)],
 )
 @pytest.mark.parametrize("shapes", [[(1, 128, 128, 32), (1, 64, 64, 32)]])
 @pytest.mark.parametrize("dtypes", [[torch.float32] * 2])
 def test_max_pool2d(
     shapes: List[Shape],
     dtypes: List[torch.dtype],
-    kernel_height: int,
-    kernel_width: int,
-    stride_height: int,
-    stride_width: int,
-    dilation_height: int,
-    dilation_width: int,
+    kernel: List[int],
+    stride: List[int],
+    dilation: List[int],
+    padding: List[int],
     ceil_mode: bool,
-    padding_left: int,
-    padding_right: int,
-    padding_top: int,
-    padding_bottom: int,
     request,
 ):
     def max_pool2d(
@@ -1105,17 +1099,11 @@ def test_max_pool2d(
         return builder.max_pool2d(
             in0,
             in1,
-            kernel_height=kernel_height,
-            kernel_width=kernel_width,
-            stride_height=stride_height,
-            stride_width=stride_width,
-            dilation_height=dilation_height,
-            dilation_width=dilation_width,
+            kernel=kernel,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
             ceil_mode=ceil_mode,
-            padding_left=padding_left,
-            padding_right=padding_right,
-            padding_top=padding_top,
-            padding_bottom=padding_bottom,
             unit_attrs=unit_attrs,
         )
 

--- a/test/ttmlir/Conversion/TTIRToTTNN/pool/avg_pool2d_negative_tests.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/pool/avg_pool2d_negative_tests.mlir
@@ -1,0 +1,57 @@
+// RUN: not ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn %s 2>&1 | FileCheck %s
+
+// Test 1: Missing flattened compat info
+module {
+  func.func @avg_pool2d_no_flattened_compat(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
+    %0 = ttir.empty() : tensor<1x64x64x32xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op only supports lowering to TTNN for flattened input tensors. Please run the FlattenSlidingWindow pass before lowering to TTNN
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+        kernel = array<i32: 2, 2>,
+        stride = array<i32: 2, 2>,
+        dilation = array<i32: 1, 1>,
+        padding = array<i32: 0, 0, 0, 0>,
+        ceil_mode = false
+    }> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    return %1 : tensor<1x64x64x32xbf16>
+  }
+}
+
+// -----
+// Test 2: Test that for avg_pool2d, dilation is not supported
+module {
+  func.func @avg_pool2d_with_dilation(%arg0: tensor<1x1x16384x32xbf16>) -> tensor<1x1x3969x32xbf16> {
+    %0 = ttir.empty() : tensor<1x1x3969x32xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op only supports lowering to TTNN for dilation of (1, 1)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+        kernel = array<i32: 2, 2>,
+        stride = array<i32: 2, 2>,
+        dilation = array<i32: 3, 3>, // Dilation is not supported
+        padding = array<i32: 0, 0, 0, 0>,
+        ceil_mode = false,
+        flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 128, input_width = 128>
+    }> : (tensor<1x1x16384x32xbf16>, tensor<1x1x3969x32xbf16>) -> tensor<1x1x3969x32xbf16>
+    return %1 : tensor<1x1x3969x32xbf16>
+  }
+}
+
+// -----
+// Test 3: Asymmetric padding (top != bottom)
+module {
+  func.func @avg_pool2d_asymmetric_padding_top_bottom(%arg0: tensor<1x1x16384x32xbf16>) -> tensor<1x1x16510x32xbf16> {
+    %0 = ttir.empty() : tensor<1x1x16510x32xbf16>
+    // CHECK: 'ttir.avg_pool2d' op only supports lowering to TTNN for symmetric padding for top/bottom
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 1, 1>, dilation = array<i32: 1, 1>, padding = array<i32: 1, 0, 2, 0>, ceil_mode = false, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 128, input_width = 128>}> : (tensor<1x1x16384x32xbf16>, tensor<1x1x16510x32xbf16>) -> tensor<1x1x16510x32xbf16>
+    return %1 : tensor<1x1x16510x32xbf16>
+  }
+}
+
+// -----
+// Test 4: Asymmetric padding (left != right)
+module {
+  func.func @avg_pool2d_asymmetric_padding_left_right(%arg0: tensor<1x1x16384x32xbf16>) -> tensor<1x1x4160x32xbf16> {
+    %0 = ttir.empty() : tensor<1x1x4160x32xbf16>
+    // CHECK: 'ttir.avg_pool2d' op only supports lowering to TTNN for symmetric padding for left/right
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 1, 0, 2>, ceil_mode = false, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 128, input_width = 128>}> : (tensor<1x1x16384x32xbf16>, tensor<1x1x4160x32xbf16>) -> tensor<1x1x4160x32xbf16>
+    return %1 : tensor<1x1x4160x32xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTNN/pool/max_pool2d_negative_tests.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/pool/max_pool2d_negative_tests.mlir
@@ -1,0 +1,39 @@
+// RUN: not ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn %s 2>&1 | FileCheck %s
+
+// Test 1: Missing flattened compat info
+module {
+  func.func @max_pool2d_no_flattened_compat(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
+    %0 = ttir.empty() : tensor<1x64x64x32xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op only supports lowering to TTNN for flattened input tensors. Please run the FlattenSlidingWindow pass before lowering to TTNN
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+        kernel = array<i32: 2, 2>,
+        stride = array<i32: 2, 2>,
+        dilation = array<i32: 1, 1>,
+        padding = array<i32: 0, 0, 0, 0>,
+        ceil_mode = false
+    }> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    return %1 : tensor<1x64x64x32xbf16>
+  }
+}
+
+// -----
+// Test 2: Asymmetric padding (top != bottom)
+module {
+  func.func @max_pool2d_asymmetric_padding_top_bottom(%arg0: tensor<1x1x16384x32xbf16>) -> tensor<1x1x16510x32xbf16> {
+    %0 = ttir.empty() : tensor<1x1x16510x32xbf16>
+    // CHECK: 'ttir.max_pool2d' op only supports lowering to TTNN for symmetric padding for top/bottom
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 1, 1>, dilation = array<i32: 1, 1>, padding = array<i32: 1, 0, 2, 0>, ceil_mode = false, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 128, input_width = 128>}> : (tensor<1x1x16384x32xbf16>, tensor<1x1x16510x32xbf16>) -> tensor<1x1x16510x32xbf16>
+    return %1 : tensor<1x1x16510x32xbf16>
+  }
+}
+
+// -----
+// Test 3: Asymmetric padding (left != right)
+module {
+  func.func @max_pool2d_asymmetric_padding_left_right(%arg0: tensor<1x1x16384x32xbf16>) -> tensor<1x1x4160x32xbf16> {
+    %0 = ttir.empty() : tensor<1x1x4160x32xbf16>
+    // CHECK: 'ttir.max_pool2d' op only supports lowering to TTNN for symmetric padding for left/right
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 1, 0, 2>, ceil_mode = false, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 128, input_width = 128>}> : (tensor<1x1x16384x32xbf16>, tensor<1x1x4160x32xbf16>) -> tensor<1x1x4160x32xbf16>
+    return %1 : tensor<1x1x4160x32xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/TosaToTTIR/maxpool2d_op.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/maxpool2d_op.mlir
@@ -9,4 +9,15 @@ module attributes {} {
     // CHECK: return %[[VAL]] : [[OUT_SIZE]]
     return %1 : tensor<32x400x300x6xf32>
   }
+
+  func.func @test_maxpool_with_different_padding(%arg0: tensor<32x800x600x6xf32>) -> tensor<32x398x302x6xf32> {
+    // CHECK: func.func {{.+}} [[IN_SIZE:tensor<[0-9]+x[0-9]+x[0-9]+x[0-9]+xf32>]]{{.*}} ->
+    %1 = tosa.max_pool2d %arg0 {kernel = array<i64: 8, 8>, pad = array<i64: 0, 2, 4, 6>, stride = array<i64: 2, 2>} : (tensor<32x800x600x6xf32>) -> tensor<32x398x302x6xf32>
+    // CHECK: %[[OP_OUT:[0-9]+]] = ttir.empty() : [[OUT_SIZE:tensor<[0-9]+x[0-9]+x[0-9]+x[0-9]+xf32>]]
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.max_pool2d"(%arg{{[0-9]+}}, %[[OP_OUT]])
+    // CHECK-SAME: padding = array<i32: 0, 4, 2, 6>
+    // CHECK-SAME: ([[IN_SIZE]], [[OUT_SIZE]]) -> [[OUT_SIZE]]
+    // CHECK: return %[[VAL]] : [[OUT_SIZE]]
+    return %1 : tensor<32x398x302x6xf32>
+  }
 }

--- a/test/ttmlir/Dialect/TTIR/Decomposition/avg_pool2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/avg_pool2d.mlir
@@ -11,11 +11,11 @@ module attributes {} {
     // CHECK-SAME: (tensor<1x192x28x28xbf16>, tensor<1x28x28x192xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
-    // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 1 : si32, kernel_width = 1 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: ceil_mode = false
+    // CHECK-SAME: dilation = array<i32: 1, 1>
+    // CHECK-SAME: kernel = array<i32: 1, 1>
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x28x28x192xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Average>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 1>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x28x28xbf16>) -> tensor<1x192x28x28xbf16>
@@ -36,11 +36,11 @@ module attributes {} {
     // CHECK-SAME: (tensor<1x256x28x28xbf16>, tensor<1x28x28x256xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x256xbf16>
     // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
-    // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 3 : si32, kernel_width = 3 : si32,
-    // CHECK-SAME: padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: ceil_mode = false
+    // CHECK-SAME: dilation = array<i32: 1, 1>
+    // CHECK-SAME: kernel = array<i32: 3, 3>
+    // CHECK-SAME: padding = array<i32: 1, 1, 1, 1>
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x256xbf16>, tensor<1x28x28x256xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x256xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 1, 1, 1, 1>, pooling_method = #ttir<pooling_method Average>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x256x28x28xbf16>, tensor<1x256x28x28xbf16>) -> tensor<1x256x28x28xbf16>
@@ -62,10 +62,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 2 : si32, kernel_width = 1 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>
+    // CHECK-SAME: kernel = array<i32: 2, 1>
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x27x28x192xbf16>)
     // CHECK-SAME: -> tensor<1x27x28x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Average>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 2, 1>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x27x28xbf16>) -> tensor<1x192x27x28xbf16>
@@ -87,10 +87,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 1 : si32, kernel_width = 2 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 3 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>
+    // CHECK-SAME: kernel = array<i32: 1, 2>
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>
+    // CHECK-SAME: stride = array<i32: 3, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x10x27x192xbf16>)
     // CHECK-SAME: -> tensor<1x10x27x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Average>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 2>, window_strides = array<i64: 1, 1, 3, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x10x27xbf16>) -> tensor<1x192x10x27xbf16>

--- a/test/ttmlir/Dialect/TTIR/Decomposition/max_pool2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/max_pool2d.mlir
@@ -12,10 +12,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 1 : si32, kernel_width = 1 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: kernel = array<i32: 1, 1>,
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>,
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x28x28x192xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 1>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x28x28xbf16>) -> tensor<1x192x28x28xbf16>
@@ -37,10 +37,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x256xbf16>
     // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 3 : si32, kernel_width = 3 : si32,
-    // CHECK-SAME: padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: kernel = array<i32: 3, 3>,
+    // CHECK-SAME: padding = array<i32: 1, 1, 1, 1>,
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x256xbf16>, tensor<1x28x28x256xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x256xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 1, 1, 1, 1>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x256x28x28xbf16>, tensor<1x256x28x28xbf16>) -> tensor<1x256x28x28xbf16>
@@ -62,10 +62,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 2 : si32, kernel_width = 1 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: kernel = array<i32: 2, 1>,
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>,
+    // CHECK-SAME: stride = array<i32: 1, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x27x28x192xbf16>)
     // CHECK-SAME: -> tensor<1x27x28x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 2, 1>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x27x28xbf16>) -> tensor<1x192x27x28xbf16>
@@ -87,10 +87,10 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x28x28x192xbf16>
     // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]],
     // CHECK-SAME: ceil_mode = false,
-    // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-    // CHECK-SAME: kernel_height = 1 : si32, kernel_width = 2 : si32,
-    // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-    // CHECK-SAME: stride_height = 3 : si32, stride_width = 1 : si32
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: kernel = array<i32: 1, 2>,
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>,
+    // CHECK-SAME: stride = array<i32: 3, 1>
     // CHECK-SAME: (tensor<1x28x28x192xbf16>, tensor<1x10x27x192xbf16>)
     // CHECK-SAME: -> tensor<1x10x27x192xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 2>, window_strides = array<i64: 1, 1, 3, 1>}> : (tensor<1x192x28x28xbf16>, tensor<1x192x10x27xbf16>) -> tensor<1x192x10x27xbf16>

--- a/test/ttmlir/Dialect/TTIR/Decomposition/sum_pool2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/sum_pool2d.mlir
@@ -11,10 +11,10 @@ func.func public @test_avgpool2d_workaround(%arg0: tensor<8x256x6x6xf32>) -> ten
   // CHECK-SAME: -> tensor<8x6x6x256xf32>
   // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
   // CHECK-SAME: ceil_mode = false,
-  // CHECK-SAME: dilation_height = 1 : si32, dilation_width = 1 : si32,
-  // CHECK-SAME: kernel_height = 1 : si32, kernel_width = 1 : si32,
-  // CHECK-SAME: padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32,
-  // CHECK-SAME: stride_height = 1 : si32, stride_width = 1 : si32
+  // CHECK-SAME: dilation = array<i32: 1, 1>,
+  // CHECK-SAME: kernel = array<i32: 1, 1>,
+  // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>,
+  // CHECK-SAME: stride = array<i32: 1, 1>
   // CHECK-SAME: (tensor<8x6x6x256xf32>, tensor<8x6x6x256xf32>)
   // CHECK-SAME: -> tensor<8x6x6x256xf32>
   %3 = "ttir.pooling"(%arg0, %2) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Sum>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 1, 1>, window_strides = array<i64: 1, 1, 1, 1>}> : (tensor<8x256x6x6xf32>, tensor<8x256x6x6xf32>) -> tensor<8x256x6x6xf32>

--- a/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
@@ -5,7 +5,7 @@
 module {
   func.func @conv2d_invalid_input_shape(%arg0: tensor<32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Input must be a 4D tensor
+    // CHECK: error: 'ttir.conv2d' op input must be a 4D tensor
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -21,7 +21,7 @@ module {
 module {
   func.func @conv2d_invalid_weight_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Weight must be a 4D tensor
+    // CHECK: error: 'ttir.conv2d' op weight must be a 4D tensor
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -37,7 +37,7 @@ module {
 module {
   func.func @conv2d_invalid_bias_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Bias must be a 4D tensor
+    // CHECK: error: 'ttir.conv2d' op bias must be a 4D tensor
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -53,7 +53,7 @@ module {
 module {
   func.func @conv2d_invalid_output_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<30x30x64xbf16> {
     %0 = ttir.empty() : tensor<30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Output must be a 4D tensor
+    // CHECK: error: 'ttir.conv2d' op output must be a 4D tensor
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,

--- a/test/ttmlir/Dialect/TTIR/flatten_sliding_window.mlir
+++ b/test/ttmlir/Dialect/TTIR/flatten_sliding_window.mlir
@@ -26,20 +26,7 @@ module {
     // CHECK: %[[POOL:[0-9]+]] = "ttir.max_pool2d"(%[[RESHAPE1]]
     // CHECK: #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
     // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%[[POOL]]
-    %1 = "ttir.max_pool2d"(%arg0, %0)
-            <{
-              stride_height = 1: si32,
-              stride_width = 1: si32,
-              padding_top = 0: si32,
-              padding_bottom = 0: si32,
-              padding_left = 0: si32,
-              padding_right = 0: si32,
-              dilation_height = 1: si32,
-              dilation_width = 1: si32,
-              kernel_height = 3: si32,
-              kernel_width = 3: si32,
-              ceil_mode = false
-            }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 3, 3>, stride = array<i32: 1, 1>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %1 : tensor<1x30x30x64xbf16>
   }
 }
@@ -51,20 +38,7 @@ module {
     // CHECK: %[[POOL:[0-9]+]] = "ttir.avg_pool2d"(%[[RESHAPE1]]
     // CHECK: #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
     // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%[[POOL]]
-    %1 = "ttir.avg_pool2d"(%arg0, %0)
-            <{
-              stride_height = 1: si32,
-              stride_width = 1: si32,
-              padding_top = 0: si32,
-              padding_bottom = 0: si32,
-              padding_left = 0: si32,
-              padding_right = 0: si32,
-              dilation_height = 1: si32,
-              dilation_width = 1: si32,
-              kernel_height = 3: si32,
-              kernel_width = 3: si32,
-              ceil_mode = false
-            }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 3, 3>, stride = array<i32: 1, 1>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %1 : tensor<1x30x30x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/pool/avg_pool2d_negative_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/pool/avg_pool2d_negative_tests.mlir
@@ -1,0 +1,355 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for avg_pool2d operation
+
+// Test 1: AvgPool2dOp with invalid tensor rank (input)
+module {
+  func.func @avg_pool2d_invalid_input_rank(%arg0: tensor<1x1024xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op input must be a 4D tensor
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1024xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 2: AvgPool2dOp with invalid tensor rank (output)
+module {
+  func.func @avg_pool2d_invalid_output_rank(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x900xbf16> {
+    %0 = ttir.empty() : tensor<1x900xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op output must be a 4D tensor
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      ceil_mode = false,
+      padding = array<i32: 0, 0, 0, 0>,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x900xbf16>) -> tensor<1x900xbf16>
+    return %1 : tensor<1x900xbf16>
+  }
+}
+
+// -----
+// Test 3: AvgPool2dOp with invalid FlattenedCompatInfoAttr
+module {
+  func.func @avg_pool2d_invalid_flattened_compat_info(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op the input tensor's flattened dimension (1024) does not match the product of batch_size * input_height * input_width from FlattenedCompatInfo (1 * 32 * 64 = 2048)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 64>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 4: AvgPool2dOp with invalid kernel
+module {
+  func.func @avg_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op kernel size attribute values must be > 0
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: -1, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 5: AvgPool2dOp with invalid stride
+module {
+  func.func @avg_pool2d_invalid_stride(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op stride attribute values must be > 0
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: -1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 6: AvgPool2dOp with invalid dilation
+module {
+  func.func @avg_pool2d_invalid_dilation(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op dilation attribute values must be > 0
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: -1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 7: AvgPool2dOp with invalid padding
+module {
+  func.func @avg_pool2d_invalid_padding(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op padding attribute values must be >= 0
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: -1, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 8: AvgPool2dOp with effective kernel size larger than input size
+module {
+  func.func @avg_pool2d_effective_kernel_larger_than_input(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op effective kernel size (64, 64) cannot be greater than the padded input size per channel (32, 32)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 64, 64>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 9: AvgPool2dOp without flattened compat info and ceil mode set to true with uneven padding
+module {
+  func.func @avg_pool2d_no_flattened_compat_batch_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<2x31x31x64xbf16> {
+    %0 = ttir.empty() : tensor<2x30x30x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op padding must be symmetric for AvgPool2dOp with ceil_mode=true
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 1, 1, 0, 0>,
+      ceil_mode = true
+    }> : (tensor<1x32x32x64xbf16>, tensor<2x30x30x64xbf16>) -> tensor<2x30x30x64xbf16>
+    return %1 : tensor<2x30x30x64xbf16>
+  }
+}
+
+// -----
+// Test 10: AvgPool2dOp without flattened compat info and mismatch on batch size
+module {
+  func.func @avg_pool2d_no_flattened_compat_batch_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<2x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<2x30x30x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op batch size from the input tensor (1) must match the first dimension of the output tensor (2)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<2x30x30x64xbf16>) -> tensor<2x30x30x64xbf16>
+    return %1 : tensor<2x30x30x64xbf16>
+  }
+}
+
+// -----
+// Test 11: AvgPool2dOp without flattened compat info and mismatch on channel size
+module {
+  func.func @avg_pool2d_no_flattened_compat_channel_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x128xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x128xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op number of output channels from the output tensor (128) must match the number of input channels (64)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x128xbf16>) -> tensor<1x30x30x128xbf16>
+    return %1 : tensor<1x30x30x128xbf16>
+  }
+}
+
+// -----
+// Test 12: AvgPool2dOp without flattened compat info and mismatch on height dimension
+module {
+  func.func @avg_pool2d_no_flattened_compat_height_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x28x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x28x30x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op output tensor height and width dimension (28, 30) do not match the expected dimensions (30, 30)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x28x30x64xbf16>) -> tensor<1x28x30x64xbf16>
+    return %1 : tensor<1x28x30x64xbf16>
+  }
+}
+
+// -----
+// Test 13: AvgPool2dOp without flattened compat info and mismatch on width dimension
+module {
+  func.func @avg_pool2d_no_flattened_compat_width_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x28x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x28x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op output tensor height and width dimension (30, 28) do not match the expected dimensions (30, 30)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x28x64xbf16>) -> tensor<1x30x28x64xbf16>
+    return %1 : tensor<1x30x28x64xbf16>
+  }
+}
+
+// -----
+// Test 14: AvgPool2dOp without flattened compat info and mismatch on height and width dimensions
+module {
+  func.func @avg_pool2d_no_flattened_compat_height_width_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x28x28x64xbf16> {
+    %0 = ttir.empty() : tensor<1x28x28x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (30, 30)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x28x28x64xbf16>) -> tensor<1x28x28x64xbf16>
+    return %1 : tensor<1x28x28x64xbf16>
+  }
+}
+
+// -----
+// Test 15: AvgPool2dOp with flattened compat info and mismatch on channel size
+module {
+  func.func @avg_pool2d_flattened_channel_mismatch(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x128xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x128xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op number of output channels from the output tensor (128) must match the number of input channels (64)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x128xbf16>) -> tensor<1x1x900x128xbf16>
+    return %1 : tensor<1x1x900x128xbf16>
+  }
+}
+
+// -----
+// Test 16: AvgPool2dOp with flattened compat info and mismatch on flattened dimension
+module {
+  func.func @avg_pool2d_flattened_flatten_mismatch(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x1024x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op output tensor's flattened dimension (1024) does not match the product of batch_size * output_height * output_width (1 * 30 * 30 = 900)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    return %1 : tensor<1x1x1024x64xbf16>
+  }
+}
+
+// -----
+// Test 17: AvgPool2dOp with invalid kernel array size
+module {
+  func.func @avg_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op Expected integer or pair of integers, got tuple of size 3 for kernel attribute
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2, 1>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 18: AvgPool2dOp with invalid stride array size
+module {
+  func.func @avg_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op Expected integer or pair of integers, got tuple of size 3 for stride attribute
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 19: AvgPool2dOp with invalid dilation array size
+module {
+  func.func @avg_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op Expected integer or pair of integers, got tuple of size 3 for dilation attribute
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 20: AvgPool2dOp with invalid padding array size
+module {
+  func.func @avg_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.avg_pool2d' op Expected integer, pair, or tuple of size 4, but got tuple of size 5 for padding attribute
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0, 1>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/pool/avg_pool2d_positive_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/pool/avg_pool2d_positive_tests.mlir
@@ -1,0 +1,83 @@
+// RUN: ttmlir-opt --split-input-file -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// Positive tests for avg_pool2d operation
+
+// Test 1: AvgPool2dOp without flattened compat info and with kernel specified
+module {
+  func.func @avg_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: ttir.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}
+
+// Test 2: AvgPool2dOp without flattened compat info and with kernel and stride specified
+module {
+  func.func @avg_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x15x15x64xbf16> {
+    %0 = ttir.empty() : tensor<1x15x15x64xbf16>
+    // CHECK: ttir.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x15x15x64xbf16>) -> tensor<1x15x15x64xbf16>
+    return %1 : tensor<1x15x15x64xbf16>
+  }
+}
+
+// Test 3: AvgPool2dOp with flattened compat info and with kernel, stride and dilation specified
+module {
+  func.func @avg_pool2d_flattened_with_kernel_stride_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x10x10x64xbf16> {
+    %0 = ttir.empty() : tensor<1x10x10x64xbf16>
+    // CHECK: ttir.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x10x10x64xbf16>) -> tensor<1x10x10x64xbf16>
+    return %1 : tensor<1x10x10x64xbf16>
+  }
+}
+
+// Test 4: AvgPool2dOp with flattened compat info and with kernel, stride, dilation and padding specified
+module {
+  func.func @avg_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x11x11x64xbf16> {
+    %0 = ttir.empty() : tensor<1x11x11x64xbf16>
+    // CHECK: ttir.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 1, 1, 2, 2>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x11x11x64xbf16>) -> tensor<1x11x11x64xbf16>
+    return %1 : tensor<1x11x11x64xbf16>
+  }
+}
+
+// Test 5: AvgPool2dOp with flattened compat info and with kernel, stride, dilation, padding and ceil_mode specified
+module {
+  func.func @avg_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
+    %0 = ttir.empty() : tensor<1x17x17x64xbf16>
+    // CHECK: ttir.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = true
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x17x17x64xbf16>) -> tensor<1x17x17x64xbf16>
+    return %1 : tensor<1x17x17x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/pool/max_pool2d_negative_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/pool/max_pool2d_negative_tests.mlir
@@ -1,0 +1,338 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for max_pool2d operation
+
+// Test 1: MaxPool2dOp with invalid tensor rank (input)
+module {
+  func.func @max_pool2d_invalid_input_rank(%arg0: tensor<1x1024xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op input must be a 4D tensor
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1024xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 2: MaxPool2dOp with invalid tensor rank (output)
+module {
+  func.func @max_pool2d_invalid_output_rank(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x900xbf16> {
+    %0 = ttir.empty() : tensor<1x900xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op output must be a 4D tensor
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      ceil_mode = false,
+      padding = array<i32: 0, 0, 0, 0>,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x900xbf16>) -> tensor<1x900xbf16>
+    return %1 : tensor<1x900xbf16>
+  }
+}
+
+// -----
+// Test 3: MaxPool2dOp with invalid FlattenedCompatInfoAttr
+module {
+  func.func @max_pool2d_invalid_flattened_compat_info(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x1860x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x1860x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op the input tensor's flattened dimension (1024) does not match the product of batch_size * input_height * input_width from FlattenedCompatInfo (1 * 32 * 64 = 2048)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 64>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x1860x64xbf16>) -> tensor<1x1x1860x64xbf16>
+    return %1 : tensor<1x1x1860x64xbf16>
+  }
+}
+
+// -----
+// Test 4: MaxPool2dOp with invalid kernel size
+module {
+  func.func @max_pool2d_invalid_kernel_size(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op kernel size attribute values must be > 0
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: -1, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 5: MaxPool2dOp with invalid stride
+module {
+  func.func @max_pool2d_invalid_stride(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op stride attribute values must be > 0
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: -1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 6: MaxPool2dOp with invalid dilation
+module {
+  func.func @max_pool2d_invalid_dilation(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op dilation attribute values must be > 0
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: -1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 7: MaxPool2dOp with invalid padding
+module {
+  func.func @max_pool2d_invalid_padding(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op padding attribute values must be >= 0
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: -1, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 8: MaxPool2dOp with effective kernel size larger than input size
+module {
+  func.func @max_pool2d_effective_kernel_larger_than_input(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op effective kernel size (33, 33) cannot be greater than the padded input size per channel (32, 32)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 32, 32>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 9: MaxPool2dOp without flattened compat info and mismatch on batch size
+module {
+  func.func @max_pool2d_no_flattened_compat_batch_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<2x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<2x30x30x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op batch size from the input tensor (1) must match the first dimension of the output tensor (2)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<2x30x30x64xbf16>) -> tensor<2x30x30x64xbf16>
+    return %1 : tensor<2x30x30x64xbf16>
+  }
+}
+
+// -----
+// Test 10: MaxPool2dOp without flattened compat info and mismatch on channel size
+module {
+  func.func @max_pool2d_no_flattened_compat_channel_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x128xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x128xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op number of output channels from the output tensor (128) must match the number of input channels (64)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x128xbf16>) -> tensor<1x30x30x128xbf16>
+    return %1 : tensor<1x30x30x128xbf16>
+  }
+}
+
+// -----
+// Test 11: MaxPool2dOp without flattened compat info and mismatch on height dimension
+module {
+  func.func @max_pool2d_no_flattened_compat_height_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x28x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x28x30x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 30) do not match the expected dimensions (30, 30)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x28x30x64xbf16>) -> tensor<1x28x30x64xbf16>
+    return %1 : tensor<1x28x30x64xbf16>
+  }
+}
+
+// -----
+// Test 12: MaxPool2dOp without flattened compat info and mismatch on width dimension
+module {
+  func.func @max_pool2d_no_flattened_compat_width_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x28x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x28x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op output tensor height and width dimension (30, 28) do not match the expected dimensions (30, 30)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x28x64xbf16>) -> tensor<1x30x28x64xbf16>
+    return %1 : tensor<1x30x28x64xbf16>
+  }
+}
+
+// -----
+// Test 13: MaxPool2dOp without flattened compat info and mismatch on height and width dimensions
+module {
+  func.func @max_pool2d_no_flattened_compat_height_width_mismatch(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x28x28x64xbf16> {
+    %0 = ttir.empty() : tensor<1x28x28x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (30, 30)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x28x28x64xbf16>) -> tensor<1x28x28x64xbf16>
+    return %1 : tensor<1x28x28x64xbf16>
+  }
+}
+
+// -----
+// Test 14: MaxPool2dOp with flattened compat info and mismatch on channel size
+module {
+  func.func @max_pool2d_flattened_channel_mismatch(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x128xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x128xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op number of output channels from the output tensor (128) must match the number of input channels (64)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x128xbf16>) -> tensor<1x1x900x128xbf16>
+    return %1 : tensor<1x1x900x128xbf16>
+  }
+}
+
+// -----
+// Test 15: MaxPool2dOp with flattened compat info and mismatch on flattened dimension
+module {
+  func.func @max_pool2d_flattened_flatten_mismatch(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x1024x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op output tensor's flattened dimension (1024) does not match the product of batch_size * output_height * output_width (1 * 30 * 30 = 900)
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x1024x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    return %1 : tensor<1x1x1024x64xbf16>
+  }
+}
+
+// -----
+// Test 16: MaxPool2dOp with invalid kernel array size
+module {
+  func.func @max_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op Expected integer or pair of integers, got tuple of size 3 for kernel attribute
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2, 1>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 17: MaxPool2dOp with invalid stride array size
+module {
+  func.func @max_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op Expected integer or pair of integers, got tuple of size 3 for stride attribute
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 18: MaxPool2dOp with invalid dilation array size
+module {
+  func.func @max_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op Expected integer or pair of integers, got tuple of size 3 for dilation attribute
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+// Test 19: MaxPool2dOp with invalid padding array size
+module {
+  func.func @max_pool2d_invalid_kernel(%arg0: tensor<1x1x1024x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = ttir.empty() : tensor<1x1x900x64xbf16>
+    // CHECK:  error: 'ttir.max_pool2d' op Expected integer, pair, or tuple of size 4, but got tuple of size 5 for padding attribute
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 2, 2>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0, 1>,
+      ceil_mode = false,
+      flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    }> : (tensor<1x1x1024x64xbf16>, tensor<1x1x900x64xbf16>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/pool/max_pool2d_positive_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/pool/max_pool2d_positive_tests.mlir
@@ -1,0 +1,83 @@
+// RUN: ttmlir-opt --split-input-file -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// Positive tests for max_pool2d operation
+
+// Test 1: MaxPool2dOp without flattened compat info and with kernel specified
+module {
+  func.func @max_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: ttir.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}
+
+// Test 2: MaxPool2dOp without flattened compat info and with kernel and stride specified
+module {
+  func.func @max_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x15x15x64xbf16> {
+    %0 = ttir.empty() : tensor<1x15x15x64xbf16>
+    // CHECK: ttir.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x15x15x64xbf16>) -> tensor<1x15x15x64xbf16>
+    return %1 : tensor<1x15x15x64xbf16>
+  }
+}
+
+// Test 3: MaxPool2dOp with flattened compat info and with kernel, stride and dilation specified
+module {
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x10x10x64xbf16> {
+    %0 = ttir.empty() : tensor<1x10x10x64xbf16>
+    // CHECK: ttir.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x10x10x64xbf16>) -> tensor<1x10x10x64xbf16>
+    return %1 : tensor<1x10x10x64xbf16>
+  }
+}
+
+// Test 4: MaxPool2dOp with flattened compat info and with kernel, stride, dilation and padding specified
+module {
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x11x11x64xbf16> {
+    %0 = ttir.empty() : tensor<1x11x11x64xbf16>
+    // CHECK: ttir.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 1, 1, 2, 2>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x11x11x64xbf16>) -> tensor<1x11x11x64xbf16>
+    return %1 : tensor<1x11x11x64xbf16>
+  }
+}
+
+// Test 5: MaxPool2dOp with flattened compat info and with kernel, stride, dilation, padding and ceil_mode specified
+module {
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
+    %0 = ttir.empty() : tensor<1x17x17x64xbf16>
+    // CHECK: ttir.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = true
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x17x17x64xbf16>) -> tensor<1x17x17x64xbf16>
+    return %1 : tensor<1x17x17x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/pooling/avg_pool2d_negative_pipeline_tests.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/avg_pool2d_negative_pipeline_tests.mlir
@@ -1,0 +1,54 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline %s 2>&1 | FileCheck %s
+// Negative tests for avg_pool2d pipeline
+
+// Test 1: AvgPool2dOp with asymmetric padding top/bottom
+module {
+  func.func @avg_pool2d_invalid_padding_horizontal(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op only supports lowering to TTNN for symmetric padding for top/bottom
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 4, 4>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 1, 1, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}
+
+// -----
+
+// Test 2: AvgPool2dOp with asymmetric padding left/right
+module {
+  func.func @avg_pool2d_invalid_padding_vertical(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x29x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x29x30x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op only supports lowering to TTNN for symmetric padding for left/right
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 4, 4>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 1, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x29x30x64xbf16>) -> tensor<1x29x30x64xbf16>
+    return %1 : tensor<1x29x30x64xbf16>
+  }
+}
+
+// -----
+
+// Test 3: AvgPool2dOp with non-default dilation
+module {
+  func.func @avg_pool2d_invalid_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x28x28x64xbf16> {
+    %0 = ttir.empty() : tensor<1x28x28x64xbf16>
+    // CHECK: error: 'ttir.avg_pool2d' op only supports lowering to TTNN for dilation of (1, 1)
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x28x28x64xbf16>) -> tensor<1x28x28x64xbf16>
+    return %1 : tensor<1x28x28x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/pooling/max_pool2d_negative_pipeline_tests.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/max_pool2d_negative_pipeline_tests.mlir
@@ -1,0 +1,36 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline %s 2>&1 | FileCheck %s
+// Negative tests for max_pool2d pipeline
+
+// Test 1: MaxPool2dOp with asymmetric padding top/bottom
+module {
+  func.func @max_pool2d_invalid_padding_horizontal(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op only supports lowering to TTNN for symmetric padding for top/bottom
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 4, 4>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 1, 1, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}
+
+// -----
+
+// Test 2: MaxPool2dOp with asymmetric padding left/right
+module {
+  func.func @max_pool2d_invalid_padding_vertical(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x29x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x29x30x64xbf16>
+    // CHECK: error: 'ttir.max_pool2d' op only supports lowering to TTNN for symmetric padding for left/right
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 4, 4>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 1, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x29x30x64xbf16>) -> tensor<1x29x30x64xbf16>
+    return %1 : tensor<1x29x30x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/pooling/simple_avgpool2d.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/simple_avgpool2d.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xf32>) -> tensor<1x64x64x32xf32> {
     %0 = ttir.empty() : tensor<1x64x64x32xf32>
     // CHECK: = "ttnn.avg_pool2d"
-    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xf32>, tensor<1x64x64x32xf32>) -> tensor<1x64x64x32xf32>
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xf32>, tensor<1x64x64x32xf32>) -> tensor<1x64x64x32xf32>
     return %1 : tensor<1x64x64x32xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/pooling/simple_maxpool2d.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/simple_maxpool2d.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xf32>) -> tensor<1x64x64x32xf32> {
     %0 = ttir.empty() : tensor<1x64x64x32xf32>
     // CHECK: = "ttnn.max_pool2d"
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xf32>, tensor<1x64x64x32xf32>) -> tensor<1x64x64x32xf32>
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xf32>, tensor<1x64x64x32xf32>) -> tensor<1x64x64x32xf32>
     return %1 : tensor<1x64x64x32xf32>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/models/resnet.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/resnet.mlir
@@ -19,7 +19,7 @@ module @ResNetForImageClassification attributes {} {
     %10 = ttir.empty() : tensor<1x112x112x64xbf16>
     %11 = "ttir.relu"(%9, %10) : (tensor<1x112x112x64xbf16>, tensor<1x112x112x64xbf16>) -> tensor<1x112x112x64xbf16>
     %12 = ttir.empty() : tensor<1x56x56x64xbf16>
-    %13 = "ttir.max_pool2d"(%11, %12) <{ceil_mode = false, dilation_height = 1 : si32, dilation_width = 1 : si32, kernel_height = 3 : si32, kernel_width = 3 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = true} : (tensor<1x112x112x64xbf16>, tensor<1x56x56x64xbf16>) -> tensor<1x56x56x64xbf16>
+    %13 = "ttir.max_pool2d"(%11, %12) <{kernel = array<i32: 3, 3>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 1, 1, 1, 1>, ceil_mode = false}> {channel_last = true} : (tensor<1x112x112x64xbf16>, tensor<1x56x56x64xbf16>) -> tensor<1x56x56x64xbf16>
     %14 = ttir.empty() : tensor<1x56x56x64xbf16>
     %15 = "ttir.conv2d"(%13, %arg108, %14) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<1x56x56x64xbf16>, tensor<64x64x1x1xbf16>, tensor<1x56x56x64xbf16>) -> tensor<1x56x56x64xbf16>
     %16 = ttir.empty() : tensor<1x56x56x64xbf16>

--- a/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @avg_pool2d(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
-    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @max_pool2d(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/resnet50_first_module.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/resnet50_first_module.mlir
@@ -20,7 +20,7 @@ module @ResNetForImageClassification attributes {} {
     %10 = ttir.empty() : tensor<8x112x112x64xbf16> loc(#loc254)
     %11 = "ttir.relu"(%9, %10) : (tensor<8x112x112x64xbf16>, tensor<8x112x112x64xbf16>) -> tensor<8x112x112x64xbf16> loc(#loc254)
     %12 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc255)
-    %13 = "ttir.max_pool2d"(%11, %12) <{ceil_mode = false, dilation_height = 1 : si32, dilation_width = 1 : si32, kernel_height = 3 : si32, kernel_width = 3 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = true} : (tensor<8x112x112x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc255)
+    %13 = "ttir.max_pool2d"(%11, %12) <{ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 3>, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 2, 2>}> {channel_last = true} : (tensor<8x112x112x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc255)
     %14 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc256)
     %15 = "ttir.conv2d"(%13, %arg108, %14) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<8x56x56x64xbf16>, tensor<64x64x1x1xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc256)
     %16 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc257)

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/resnet_hf.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/resnet_hf.mlir
@@ -16,7 +16,7 @@ module @ResNetForImageClassification attributes {} {
     %10 = ttir.empty() : tensor<1x112x112x64xf32> loc(#loc254)
     %11 = "ttir.relu"(%9, %10) : (tensor<1x112x112x64xf32>, tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32> loc(#loc254)
     %12 = ttir.empty() : tensor<1x56x56x64xf32> loc(#loc255)
-    %13 = "ttir.max_pool2d"(%11, %12) <{ceil_mode = false, dilation_height = 1 : si32, dilation_width = 1 : si32, kernel_height = 3 : si32, kernel_width = 3 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = true} : (tensor<1x112x112x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> loc(#loc255)
+    %13 = "ttir.max_pool2d"(%11, %12) <{kernel = array<i32: 3, 3>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 1, 1, 1, 1>, ceil_mode = false}> {channel_last = true} : (tensor<1x112x112x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> loc(#loc255)
     %14 = ttir.empty() : tensor<1x56x56x64xf32> loc(#loc256)
     %15 = "ttir.conv2d"(%13, %arg108, %14) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x1x1xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> loc(#loc256)
     %16 = ttir.empty() : tensor<1x56x56x64xf32> loc(#loc257)

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_avgpool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_avgpool2d.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     // CHECK-LABEL: @test_avgpool2d
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
     // CHECK: = "ttnn.avg_pool2d"
-    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, ceil_mode=false, padding = array<i32: 0, 0, 0, 0>}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_maxpool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_maxpool2d.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
     // CHECK: = "ttnn.max_pool2d"
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/pooling/avg_pool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/pooling/avg_pool2d.mlir
@@ -1,0 +1,61 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+  // Test 1: AvgPool2dOp without flattened compat info and with kernel specified
+  func.func @avg_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: ttnn.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+
+  // Test 2: AvgPool2dOp without flattened compat info and with kernel and stride specified
+  func.func @avg_pool2d_non_flattened_with_kernel_stride(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x15x15x64xbf16> {
+    %0 = ttir.empty() : tensor<1x15x15x64xbf16>
+    // CHECK: ttnn.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x15x15x64xbf16>) -> tensor<1x15x15x64xbf16>
+    return %1 : tensor<1x15x15x64xbf16>
+  }
+
+  // Test 3: AvgPool2dOp with flattened compat info and with kernel, stride and padding specified
+  func.func @avg_pool2d_flattened_with_kernel_stride_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
+    %0 = ttir.empty() : tensor<1x17x17x64xbf16>
+    // CHECK: ttnn.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 4, 4>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x17x17x64xbf16>) -> tensor<1x17x17x64xbf16>
+    return %1 : tensor<1x17x17x64xbf16>
+  }
+
+  // Test 4: AvgPool2dOp with flattened compat info and with kernel, stride, padding and ceil_mode specified
+  func.func @avg_pool2d_flattened_with_kernel_stride_dilation_padding_ceil(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
+    %0 = ttir.empty() : tensor<1x17x17x64xbf16>
+    // CHECK: ttnn.avg_pool2d
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = true
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x17x17x64xbf16>) -> tensor<1x17x17x64xbf16>
+    return %1 : tensor<1x17x17x64xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d.mlir
@@ -1,0 +1,61 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+  // Test 1: MaxPool2dOp without flattened compat info and with kernel specified
+  func.func @max_pool2d_non_flattened_with_kernel(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 1, 1>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+
+  // Test 2: MaxPool2dOp without flattened compat info and with kernel and stride specified
+  func.func @max_pool2d_non_flattened_with_kernel_stride(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x15x15x64xbf16> {
+    %0 = ttir.empty() : tensor<1x15x15x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 1, 1>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x15x15x64xbf16>) -> tensor<1x15x15x64xbf16>
+    return %1 : tensor<1x15x15x64xbf16>
+  }
+
+  // Test 3: MaxPool2dOp with flattened compat info and with kernel, stride and dilation specified
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x10x10x64xbf16> {
+    %0 = ttir.empty() : tensor<1x10x10x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x10x10x64xbf16>) -> tensor<1x10x10x64xbf16>
+    return %1 : tensor<1x10x10x64xbf16>
+  }
+
+  // Test 4: MaxPool2dOp with flattened compat info and with kernel, stride, dilation and padding specified
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x11x11x64xbf16> {
+    %0 = ttir.empty() : tensor<1x11x11x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x11x11x64xbf16>) -> tensor<1x11x11x64xbf16>
+    return %1 : tensor<1x11x11x64xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d_unsupported.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d_unsupported.mlir
@@ -1,0 +1,21 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
+// Currently unsupported as test fails in runtime when ceil_mode is true and dilation is specified.
+// tt-Metal issue: https://github.com/tenstorrent/tt-metal/issues/25894
+module {
+  // Test 5: MaxPool2dOp with flattened compat info and with kernel, stride, dilation, padding and ceil_mode specified
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding_ceil(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
+    %0 = ttir.empty() : tensor<1x17x17x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 2, 2>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = true
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x17x17x64xbf16>) -> tensor<1x17x17x64xbf16>
+    return %1 : tensor<1x17x17x64xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/simple_avgpool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_avgpool2d.mlir
@@ -6,7 +6,7 @@ module attributes {} {
     // CHECK-LABEL: @test_avgpool2d
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
     // CHECK: = "ttnn.avg_pool2d"
-    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.avg_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_maxpool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_maxpool2d.mlir
@@ -5,7 +5,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
     %0 = ttir.empty() : tensor<1x64x64x32xbf16>
     // CHECK: = "ttnn.max_pool2d"
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0, 0, 0>, ceil_mode = false}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
     return %1 : tensor<1x64x64x32xbf16>
   }
 }

--- a/tools/ttir-builder/ops.py
+++ b/tools/ttir-builder/ops.py
@@ -2859,17 +2859,11 @@ class TTIRBuilderOps:
         self,
         in0: Operand,
         in1: Operand,
-        kernel_height: int,
-        kernel_width: int,
-        stride_height: int,
-        stride_width: int,
-        dilation_height: int,
-        dilation_width: int,
+        kernel: Union[int, List[int]],
+        stride: Union[int, List[int]],
+        dilation: Union[int, List[int]],
+        padding: Union[int, List[int]],
         ceil_mode: bool,
-        padding_left: int,
-        padding_right: int,
-        padding_top: int,
-        padding_bottom: int,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         """
@@ -2906,24 +2900,34 @@ class TTIRBuilderOps:
             ttir.MaxPool2dOp,
             [in0],
             golden_kwargs={
-                "kernel_size": (kernel_height, kernel_width),
-                "stride": (stride_height, stride_width),
-                "padding": (padding_top, padding_left),
-                "dilation": (dilation_height, dilation_width),
+                "kernel": kernel,
+                "stride": stride,
+                "dilation": dilation,
+                "padding": padding,
                 "ceil_mode": ceil_mode,
             },
             ttir_kwargs={
-                "kernel_height": kernel_height,
-                "kernel_width": kernel_width,
-                "stride_height": stride_height,
-                "stride_width": stride_width,
-                "dilation_height": dilation_height,
-                "dilation_width": dilation_width,
+                "kernel": (
+                    IntegerAttr.get(IntegerType.get_signed(32), kernel)
+                    if isinstance(kernel, int)
+                    else DenseI32ArrayAttr.get(kernel)
+                ),
+                "stride": (
+                    IntegerAttr.get(IntegerType.get_signed(32), stride)
+                    if isinstance(stride, int)
+                    else DenseI32ArrayAttr.get(stride)
+                ),
+                "dilation": (
+                    IntegerAttr.get(IntegerType.get_signed(32), dilation)
+                    if isinstance(dilation, int)
+                    else DenseI32ArrayAttr.get(dilation)
+                ),
+                "padding": (
+                    IntegerAttr.get(IntegerType.get_signed(32), padding)
+                    if isinstance(padding, int)
+                    else DenseI32ArrayAttr.get(padding)
+                ),
                 "ceil_mode": ceil_mode,
-                "padding_left": padding_left,
-                "padding_right": padding_right,
-                "padding_top": padding_top,
-                "padding_bottom": padding_bottom,
             },
             unit_attrs=unit_attrs,
         )
@@ -2992,20 +2996,28 @@ class TTIRBuilderOps:
     def max_pool2d_golden_function(
         self,
         input_tensor: Operand,
-        kernel_size: tuple[int],
-        stride: tuple[int],
-        padding: tuple[int],
-        dilation: tuple[int],
+        kernel: List[int],
+        stride: List[int],
+        dilation: List[int],
+        padding: List[int],
         ceil_mode: bool,
     ):
-        # TTIR  max_pool2d is channels last. PyTorch max_pool2d is channels first.
-        # We need to transpose the input tensor to channels first before applying max_pool2d,
-        # and transpose back to channels last afterward to properly calculate the golden tensor.
+        # We model TTIR padding with 4 values that can be different for each side:
+        # [top, left, bottom, right]
+        # PyTorch max_pool2d uses a single value or a tuple of two values for padding:
+        # - single value: pads all sides with the same amount
+        # - tuple of two values: pads top/bottom and left/right with the same amount
+        if len(padding) == 4:
+            assert (padding[0] == padding[2]) and (
+                padding[1] == padding[3]
+            ), "TTIR max_pool2d padding must be symmetric for top/bottom and left/right in order to match PyTorch's padding behavior."
+            padding = [padding[0], padding[1]]
+
         # TTIR  max_pool2d is channels last. PyTorch max_pool2d is channels first.
         # We need to transpose the input tensor to channels first before applying max_pool2d,
         # and transpose back to channels last afterward to properly calculate the golden tensor.
         maxpool_object = torch.nn.MaxPool2d(
-            kernel_size, stride, padding, dilation, ceil_mode
+            kernel, stride, padding, dilation, ceil_mode
         )
         input_tensor = input_tensor.transpose(-2, -1).transpose(-3, -2)
         result = maxpool_object(input_tensor)


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/4033
Closes https://github.com/tenstorrent/tt-mlir/issues/4099

### Problem description
This PR adds comprehensive verification and validation for TTIR pooling operations (AvgPool2d and
MaxPool2d) with flattened input tensors, improving error handling, and fixing the pooling dimension calculations to include ceil_mode and proper dilation support.

### What's changed
- Changed the op signatures to use array arguments:
  - for example, instead of `kernel_height` and `kernel_width`, we are now using `kernel[h, w]`
- New comprehensive verification utils in VerificationUtils.h for pooling operations
- Proper ceil_mode and dilation support in verifying pooling output
  - Previous incorrect formula: `calculatedHOut = (paddedHeight - kernel) / stride + 1;`
  - New correct formula: `calculatedHOut = (paddedHeight - effectiveKernel) / stride + 1; effectiveKernel = dilation * (kernel - 1) + 1` where ceiling parameter is also used into consideration
- In TTIR to TTNN conversion, added validation that AvgPool2d only supports dilation (1,1)
   for TTNN lowering (matching PyTorch behavior)
- Added a bunch of tests to validate the updated verification behaviour
- Added silicon tests to validate various pooling operation parameters
   
   
### Checklist
- [x] New/Existing tests provide coverage for changes
