### PR TITLE
Uplift third_party/tt-metal to d78b2f9ae3d33c468d71c99ee5e8ab7f3606c89d 2025-07-31

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1193,10 +1193,14 @@ llvm::Expected<OpConstraints> OpModel<SliceOp>::getOpConstraints(
   ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
+  ttsl::Span<const int> beginsSpan = ::ttsl::make_const_span(beginsVec);
+  ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
+  ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
+
   // Create query closure
   auto sliceOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
+        ::ttnn::slice, device, inputSpec, beginsSpan, endsSpan, stepSpan,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt,
         std::nullopt);
     // conversion::getShape(outputShape), std::nullopt);
@@ -1232,10 +1236,14 @@ llvm::Expected<size_t> OpModel<SliceOp>::getOpRuntime(
   ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
+  ttsl::Span<const int> beginsSpan = ::ttsl::make_const_span(beginsVec);
+  ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
+  ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
+
   // Create query closure
   auto sliceOpQuery = [=]() {
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
+        ::ttnn::slice, device, inputSpec, beginsSpan, endsSpan, stepSpan,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt,
         std::nullopt);
   };

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -31,7 +31,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/quantization/quantization.hpp"
-#include "ttnn/operations/eltwise/ternary/where.hpp"
+#include "ttnn/operations/eltwise/ternary/where/where.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/operations/kv_cache/kv_cache.hpp"

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -20,7 +20,11 @@ void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
   ::ttsl::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
   ::ttsl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
 
-  ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
+  ttsl::Span<const int32_t> beginsSpan(begins.data(), begins.size());
+  ttsl::Span<const int32_t> endsSpan(ends.data(), ends.size());
+  ttsl::Span<const int32_t> stepSpan(step.data(), step.size());
+
+  ::ttnn::Tensor out = ::ttnn::slice(in, beginsSpan, endsSpan, stepSpan);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2175,6 +2175,7 @@ def test_binary_eltwise_ops_implicit_broadcast(
     )
 
 
+@pytest.mark.fails_golden
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -2232,6 +2233,7 @@ def test_ternary_eltwise_ops_implicit_broadcast(
             where,
             [(64, 64)] * 3,
             [torch.float32, torch.float32, torch.float32],
+            marks=pytest.mark.fails_golden,
         ),
     ],
 )

--- a/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d.mlir
@@ -30,32 +30,4 @@ module {
     }> : (tensor<1x32x32x64xbf16>, tensor<1x15x15x64xbf16>) -> tensor<1x15x15x64xbf16>
     return %1 : tensor<1x15x15x64xbf16>
   }
-
-  // Test 3: MaxPool2dOp with flattened compat info and with kernel, stride and dilation specified
-  func.func @max_pool2d_flattened_with_kernel_stride_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x10x10x64xbf16> {
-    %0 = ttir.empty() : tensor<1x10x10x64xbf16>
-    // CHECK: ttnn.max_pool2d
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{
-      kernel = array<i32: 3, 3>,
-      stride = array<i32: 3, 3>,
-      dilation = array<i32: 2, 2>,
-      padding = array<i32: 0, 0, 0, 0>,
-      ceil_mode = false
-    }> : (tensor<1x32x32x64xbf16>, tensor<1x10x10x64xbf16>) -> tensor<1x10x10x64xbf16>
-    return %1 : tensor<1x10x10x64xbf16>
-  }
-
-  // Test 4: MaxPool2dOp with flattened compat info and with kernel, stride, dilation and padding specified
-  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x11x11x64xbf16> {
-    %0 = ttir.empty() : tensor<1x11x11x64xbf16>
-    // CHECK: ttnn.max_pool2d
-    %1 = "ttir.max_pool2d"(%arg0, %0) <{
-      kernel = array<i32: 3, 3>,
-      stride = array<i32: 3, 3>,
-      dilation = array<i32: 2, 2>,
-      padding = array<i32: 2, 2, 2, 2>,
-      ceil_mode = false
-    }> : (tensor<1x32x32x64xbf16>, tensor<1x11x11x64xbf16>) -> tensor<1x11x11x64xbf16>
-    return %1 : tensor<1x11x11x64xbf16>
-  }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d_unsupported.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/pooling/max_pool2d_unsupported.mlir
@@ -2,9 +2,41 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // UNSUPPORTED: true
-// Currently unsupported as test fails in runtime when ceil_mode is true and dilation is specified.
+// Test 5 is currently unsupported as test fails in runtime when ceil_mode is true and dilation is specified.
 // tt-Metal issue: https://github.com/tenstorrent/tt-metal/issues/25894
+// Tests 3 and 4 are currently unsupported as test fails in runtime when a non 1 dilation is specified
+// tt-Metal issue: https://github.com/tenstorrent/tt-metal/issues/25845
+
+
 module {
+  // Test 3: MaxPool2dOp with flattened compat info and with kernel, stride and dilation != 1 specified
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x10x10x64xbf16> {
+    %0 = ttir.empty() : tensor<1x10x10x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 0, 0, 0, 0>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x10x10x64xbf16>) -> tensor<1x10x10x64xbf16>
+    return %1 : tensor<1x10x10x64xbf16>
+  }
+
+  // Test 4: MaxPool2dOp with flattened compat info and with kernel, stride, dilation != 1 and padding specified
+  func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x11x11x64xbf16> {
+    %0 = ttir.empty() : tensor<1x11x11x64xbf16>
+    // CHECK: ttnn.max_pool2d
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{
+      kernel = array<i32: 3, 3>,
+      stride = array<i32: 3, 3>,
+      dilation = array<i32: 2, 2>,
+      padding = array<i32: 2, 2, 2, 2>,
+      ceil_mode = false
+    }> : (tensor<1x32x32x64xbf16>, tensor<1x11x11x64xbf16>) -> tensor<1x11x11x64xbf16>
+    return %1 : tensor<1x11x11x64xbf16>
+  }
+
   // Test 5: MaxPool2dOp with flattened compat info and with kernel, stride, dilation, padding and ceil_mode specified
   func.func @max_pool2d_flattened_with_kernel_stride_dilation_padding_ceil(%arg0: tensor<1x32x32x64xbf16>) -> tensor<1x17x17x64xbf16> {
     %0 = ttir.empty() : tensor<1x17x17x64xbf16>

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -229,6 +229,8 @@ protected:
     const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
+    // Need to reset device other wise hangs. See tt-metal issue #25772
+    SingletonDeviceContext::resetInstance();
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
         CreateWorkerGrid(), inputShape, inputLayout, dimArg, keepDim,
         outputLayout);
@@ -374,11 +376,15 @@ TEST_F(OpModelTest, Reshape) {
   EXPECT_EQ(opCstr.cbL1PeakSize, 5120);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  SingletonDeviceContext::resetInstance();
 
   auto runtimeExp = OpModel<ReshapeOp>::getOpRuntime(
       tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  SingletonDeviceContext::resetInstance();
 
   constraintsExp = OpModel<ReshapeOp>::getOpConstraints(
       CreateWorkerGrid(), tensorShape, layoutDRAM, {workerCoresN300 * 4, 256},
@@ -388,11 +394,15 @@ TEST_F(OpModelTest, Reshape) {
   EXPECT_EQ(opCstr.cbL1PeakSize, 5120);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 2048);
   EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  SingletonDeviceContext::resetInstance();
 
   runtimeExp = OpModel<ReshapeOp>::getOpRuntime(
       tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutL1);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  SingletonDeviceContext::resetInstance();
 }
 
 TEST_F(OpModelTest, Slice) {

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -915,7 +915,8 @@ INSTANTIATE_TEST_SUITE_P(LessThanTests, OpModelLessThanParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(LogicalAndTests, OpModelLogicalAndParam,
-                         generateBinaryEltwiseParams(binaryEltwiseParams));
+                         generateBinaryEltwiseParams(
+                             binaryEltwiseParams, /*extraCbRequirement=*/4096));
 
 INSTANTIATE_TEST_SUITE_P(LogicalOrTests, OpModelLogicalOrParam,
                          generateBinaryEltwiseParams(

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2050,8 +2050,8 @@ TEST_F(OpModelTest, Where) {
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
       constraintsExp.get();
-  EXPECT_EQ(cbSize, 12288);
-  EXPECT_EQ(peakSize, 10240);
+  EXPECT_EQ(cbSize, 16384);
+  EXPECT_EQ(peakSize, 2048);
   EXPECT_EQ(outputSize, 2048);
 
   auto runtimeExp = OpModel<WhereOp>::getOpRuntime(

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -386,7 +386,7 @@ const std::vector<BinaryOpTestParams> binaryOpTestParams = {
     {"GreaterThan", createGT, binaryExpected},
     {"LessEqual", createLE, binaryExpected},
     {"LessThan", createLT, binaryExpected},
-    {"LogicalAnd", createAnd, binaryExpected},
+    {"LogicalAnd", createAnd, binaryExpected_extraCb4096},
     {"LogicalOr", createOr, binaryExpected_extraCb4096},
     {"LogicalXor", createXor, binaryExpected_extraCb4096},
     {"Maximum", createMax, binaryExpected},

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1929,8 +1929,8 @@ TEST_F(OpModelBase, WhereOpInterface) {
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 10240);
+    EXPECT_EQ(cbSize, 16384);
+    EXPECT_EQ(peakSize, 2048);
     EXPECT_EQ(outputSize, 2048);
   } else {
     FAIL() << "Missing L1 constraints; Error="

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -762,6 +762,9 @@ TEST_F(OpModelBase, SumOpInterface) {
       this, builder, input, output.getType(), /*expectedCbSize=*/12288,
       /*expectedPeakSize=*/2048, /*expectedOutputSize=*/2048,
       &OpModelBase::getOpConstraints, &OpModelBase::getOpRuntime);
+
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
 }
 
 TEST_F(OpModelBase, ReshapeOpInterface) {
@@ -772,6 +775,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   auto input = createEmptyTensor(tensorShapeA);
   auto output = createEmptyTensor(tensorShapeO);
 
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
   auto reshape = builder.create<ReshapeOp>(
       builder.getUnknownLoc(), output.getType(), mlir::ValueRange{input});
   reshape.setShapeAttr(builder.getArrayAttr(llvm::SmallVector<mlir::Attribute>{
@@ -782,6 +787,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   opConstraintsCache().clear();
   opRuntimeCache().clear();
 
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
   // test reshape Op interface
   auto constraintsExp = getOpConstraints(reshape.getOperation());
   if (constraintsExp) {
@@ -801,6 +808,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   } else {
     FAIL() << llvm::toString(runtimeExp.takeError());
   }
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
 
   auto cachedConstraintsExp = getOpConstraints(reshape.getOperation());
   if (cachedConstraintsExp) {
@@ -813,6 +822,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
 
   auto cachedRuntimeExp = getOpRuntime(reshape.getOperation());
   if (cachedRuntimeExp) {
@@ -826,6 +837,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
 
   EXPECT_EQ(opRuntimeCache().getStats().hits, 1);
   EXPECT_EQ(opRuntimeCache().getStats().misses, 1);
+  // Need to reset device other wise hangs. See tt-metal issue #25772
+  op_model::SingletonDeviceContext::resetInstance();
 }
 
 TEST_F(OpModelBase, SliceOpInterface) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "f3d22baacac0fc96fc302d20ed68c00206c4e01d")
+set(TT_METAL_VERSION "d78b2f9ae3d33c468d71c99ee5e8ab7f3606c89d")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "94e5d6df95db69c08502c9079eb24ba790c05c85")
+set(TT_METAL_VERSION "f3d22baacac0fc96fc302d20ed68c00206c4e01d")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d78b2f9ae3d33c468d71c99ee5e8ab7f3606c89d

- Update implicit smallvec to span conversions after std span used in metal change 8549c9458a
  - Follow up in https://github.com/tenstorrent/tt-mlir/issues/4312 to clean up emitc implementation
- Move MaxPool2D ops with non 1 dilation dims to unsupported testlist due to tt-metal commit a79ebb8
  - Follow up in https://github.com/tenstorrent/tt-mlir/issues/4314 to shift left the dilation assertion to compile time
- Reset device in between tests for opmodel after metal commit 90cd6e4
- Update cbsize for logicalAnd op in opmodel tests after metal commit 662a1a3
- Update where op path after metal commit d7cba8cb92
  - Follow up to investigate failure in https://github.com/tenstorrent/tt-mlir/issues/4313

Bisect note:
- Metal commit `fcde4e5a98` introduces ND behavior for pow op, caught in emitc tests, resolved by metal commit `f3d22baaca`
- Metal commit `6b8640090d` introduces double definition of a kernel helper function in llk, caught in FFE llama_prefill crashing, resolved by metal commit `d78b2f9ae3`
