### PR TITLE
Remove some binary op workarounds

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -385,35 +385,6 @@ binaryOpDTypeWorkaround(mlir::Operation *op, mlir::Type elementType) {
     return mlir::tt::ttcore::DataType::Int32;
   }
 
-  if (isa<ttnn::RemainderOp>(op)) {
-    return {};
-  }
-
-  if (isa<ttnn::AddOp, ttnn::SubtractOp>(op)) {
-    if (dType == mlir::tt::ttcore::DataType::Float32 ||
-        dType == mlir::tt::ttcore::DataType::BFloat16 ||
-        dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||
-        dType == mlir::tt::ttcore::DataType::BFP_BFloat4) {
-      return {};
-    }
-    if (dType == mlir::tt::ttcore::DataType::Int32) {
-      // Although TTNN claims to support int32 for Add and Subtract ops,
-      // broadcasting with int32 inputs does not currently work as expected.
-      // As a temporary workaround, we fall back to BFloat16 when input shapes
-      // differ. This should be removed once int32 broadcasting is properly
-      // supported.
-      auto lhsType =
-          mlir::cast<mlir::RankedTensorType>(op->getOperand(0).getType());
-      auto rhsType =
-          mlir::cast<mlir::RankedTensorType>(op->getOperand(1).getType());
-
-      if (lhsType.getShape() != rhsType.getShape()) {
-        return mlir::tt::ttcore::DataType::BFloat16;
-      }
-      return {};
-    }
-    return mlir::tt::ttcore::DataType::BFloat16;
-  }
   // Left shift and right shift ops have same requirements but they are not
   // implemented for TTNN dialect currently.
   if (isa<ttnn::BitwiseAndOp, ttnn::BitwiseOrOp, ttnn::BitwiseXorOp>(op)) {
@@ -422,14 +393,21 @@ binaryOpDTypeWorkaround(mlir::Operation *op, mlir::Type elementType) {
     }
     return mlir::tt::ttcore::DataType::Int32;
   }
+
   // All remaining binary ops.
-  if (dType == mlir::tt::ttcore::DataType::Float32 ||
-      dType == mlir::tt::ttcore::DataType::BFloat16 ||
-      dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||
-      dType == mlir::tt::ttcore::DataType::BFP_BFloat4) {
-    return {};
+  // Tracked in :
+  // https://github.com/issues/created?issue=tenstorrent%7Ctt-metal%7C25112
+  if (isa<ttnn::DivideOp, ttnn::PowOp, ttnn::GreaterEqualOp, ttnn::GreaterThanOp, ttnn::LessEqualOp, ttnn::LessThanOp>(op)) {
+    if (dType == mlir::tt::ttcore::DataType::Float32 ||
+        dType == mlir::tt::ttcore::DataType::BFloat16 ||
+        dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||
+        dType == mlir::tt::ttcore::DataType::BFP_BFloat4) {
+      return {};
+    }
+    return mlir::tt::ttcore::DataType::Float32;
   }
-  return mlir::tt::ttcore::DataType::BFloat16;
+
+  return {};
 }
 
 // Factory method to create a set of workarounds for binary operation operands.

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -397,7 +397,8 @@ binaryOpDTypeWorkaround(mlir::Operation *op, mlir::Type elementType) {
   // All remaining binary ops.
   // Tracked in :
   // https://github.com/issues/created?issue=tenstorrent%7Ctt-metal%7C25112
-  if (isa<ttnn::DivideOp, ttnn::PowOp, ttnn::GreaterEqualOp, ttnn::GreaterThanOp, ttnn::LessEqualOp, ttnn::LessThanOp>(op)) {
+  if (isa<ttnn::DivideOp, ttnn::PowOp, ttnn::GreaterEqualOp,
+          ttnn::GreaterThanOp, ttnn::LessEqualOp, ttnn::LessThanOp>(op)) {
     if (dType == mlir::tt::ttcore::DataType::Float32 ||
         dType == mlir::tt::ttcore::DataType::BFloat16 ||
         dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2357,10 +2357,10 @@ def test_bitwise_binary_ops(test_fn: Callable, shape: Shape, request):
 @pytest.mark.parametrize(
     "test_fn",
     [
-        add | Marks(pytest.mark.run_error),
-        multiply | Marks(pytest.mark.run_error),
-        subtract | Marks(pytest.mark.run_error),
-        eq | Marks(pytest.mark.run_error),
+        add,
+        multiply,
+        subtract,
+        eq,
         ne,
         le,
         lt,


### PR DESCRIPTION
### Problem description
- Remove some binary op workarounds for Int32 after recent metal changes
- Operations that still do not support Int32 are tracked here: https://github.com/issues/created?issue=tenstorrent%7Ctt-metal%7C25112

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] tt-forge-fe CI: https://github.com/tenstorrent/tt-forge-fe/actions/runs/17074727196
- [x] tt-xla CI: https://github.com/tenstorrent/tt-xla/actions/runs/17074734696
- [x] tt-torch CI: https://github.com/tenstorrent/tt-torch/actions/runs/17074742289
