### PR TITLE
Return empty data vector

### DIFF
--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -196,8 +196,6 @@ Tensor createOwnedHostTensor(const void *data,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
   using RetType = Tensor;
-  LOG_ASSERT(!shape.empty());
-  LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -332,8 +332,15 @@ std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       utils::getTTNNTensorFromRuntimeTensor(tensor);
   void *dataPtr = nullptr;
-  std::vector<std::byte> dataVec(getTensorElementSize(tensor) *
-                                 getTensorVolume(tensor));
+  std::uint32_t tensorVolume = getTensorVolume(tensor);
+
+  if (tensorVolume == 0) {
+    LOG_WARNING("getTensorDataBuffer: Tensor has zero volume; returning an "
+                "empty data vector.");
+    return {};
+  }
+
+  std::vector<std::byte> dataVec(getTensorElementSize(tensor) * tensorVolume);
 
   // Need to `memcpy` in each case because the vector will go out of scope if we
   // wait until after the switch case


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/4242

### Problem description
Runtime provides 'getTensorDataBuffer' function to extract the data from ttnn::Tensor and return it as data vector. However, it assumes that the underlying tensor will always contain some data and assert otherwise. This assumption is not true in case of empty tensor.

### What's changed
Update the functionality to return empty data vector in case of empty 'ttnn::Tensor'

### Checklist
- [ ] New/Existing tests provide coverage for changes
