### PR TITLE
fix embeddingOp Constraint API to handle nullptr output layout

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2492,7 +2492,7 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::UpsampleOp>::getOpRuntime(
 struct EmbeddingOpArgs {
   ::ttnn::TensorSpec inputSpec;
   ::ttnn::TensorSpec weightSpec;
-  ::ttnn::TensorSpec outputSpec;
+  std::optional<::ttnn::TensorSpec> outputSpec;
 };
 
 llvm::Expected<EmbeddingOpArgs>
@@ -2516,12 +2516,15 @@ getEmbeddingOpArgs(::tt::tt_metal::distributed::MeshDevice *device,
   }
   ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
-  auto outputSpecExp =
-      detail::convertToTensorSpec(device, weightShape, outputLayout);
-  if (!outputSpecExp) {
-    return outputSpecExp.takeError();
+  std::optional<::ttnn::TensorSpec> outputSpec = std::nullopt;
+  if (outputLayout) {
+    auto outputSpecExp =
+        detail::convertToTensorSpec(device, weightShape, outputLayout);
+    if (!outputSpecExp) {
+      return outputSpecExp.takeError();
+    }
+    outputSpec = outputSpecExp.get();
   }
-  ::ttnn::TensorSpec outputSpec = outputSpecExp.get();
 
   return EmbeddingOpArgs{inputSpec, weightSpec, outputSpec};
 }
@@ -2549,16 +2552,15 @@ OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpConstraints(
   // as in the runtime/embedding.cpp. Subject to change in the future.
   std::optional<int> padToken = std::nullopt;
   ::ttnn::Layout layout =
-      outputLayout.isTiled() ? ::ttnn::TILE_LAYOUT : ::ttnn::ROW_MAJOR_LAYOUT;
+      inputLayout.isTiled() ? ::ttnn::TILE_LAYOUT : ::ttnn::ROW_MAJOR_LAYOUT;
   auto embeddingsType = ::ttnn::operations::embedding::EmbeddingsType::GENERIC;
-  ::ttnn::DataType outputDataType =
-      conversion::getDataType(outputLayout.getDataType());
+  ::ttnn::DataType dtype = conversion::getDataType(inputLayout.getDataType());
 
   auto embeddingOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::embedding, device, embeddingOpArgs.inputSpec,
-        embeddingOpArgs.weightSpec, padToken, layout, embeddingsType,
-        outputDataType, detail::getNullableMemoryConfig(outputLayout),
+        embeddingOpArgs.weightSpec, padToken, layout, embeddingsType, dtype,
+        detail::getNullableMemoryConfig(outputLayout),
         embeddingOpArgs.outputSpec);
   };
 
@@ -2590,16 +2592,15 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpRuntime(
   // as in the runtime/embedding.cpp. Subject to change in the future.
   std::optional<int> padToken = std::nullopt;
   ::ttnn::Layout layout =
-      outputLayout.isTiled() ? ::ttnn::TILE_LAYOUT : ::ttnn::ROW_MAJOR_LAYOUT;
+      inputLayout.isTiled() ? ::ttnn::TILE_LAYOUT : ::ttnn::ROW_MAJOR_LAYOUT;
   auto embeddingsType = ::ttnn::operations::embedding::EmbeddingsType::GENERIC;
-  ::ttnn::DataType outputDataType =
-      conversion::getDataType(outputLayout.getDataType());
+  ::ttnn::DataType dtype = conversion::getDataType(inputLayout.getDataType());
 
   auto embeddingOpQuery = [=]() {
     return ::ttnn::graph::query_op_runtime(
         ::ttnn::embedding, device, embeddingOpArgs.inputSpec,
-        embeddingOpArgs.weightSpec, padToken, layout, embeddingsType,
-        outputDataType, detail::getNullableMemoryConfig(outputLayout),
+        embeddingOpArgs.weightSpec, padToken, layout, embeddingsType, dtype,
+        detail::getNullableMemoryConfig(outputLayout),
         embeddingOpArgs.outputSpec);
   };
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1783,6 +1783,47 @@ TEST_F(OpModelBase, EmbeddingOpInterface) {
   }
 }
 
+TEST_F(OpModelBase, EmbeddingOpNullOutputLayout) {
+  // Create input tensors for embedding op
+  // [batch_size, seq_len]
+  llvm::SmallVector<int64_t> inputShape = {workerCoresN300, 1024};
+  // [vocab_size, hidden_size]
+  llvm::SmallVector<int64_t> weightShape = {256, 128};
+  // [batch_size, seq_len, hidden_size]
+  llvm::SmallVector<int64_t> outputShape = {workerCoresN300, 1024, 128};
+
+  auto input = createEmptyTensor(inputShape);
+  auto weight = createEmptyTensor(weightShape);
+  auto outputType = createRankedTensorType(outputShape);
+
+  // Create EmbeddingOp
+  auto embedding = builder.create<EmbeddingOp>(
+      builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input, weight});
+
+  // Test EmbeddingOp interface constraints
+  auto constraintsExp = embedding.getOpConstraints(
+      getInputLayouts(embedding), OpConfig(/*outputLayout=*/nullptr));
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 16384);
+    EXPECT_EQ(peakSize, 525312);
+    EXPECT_EQ(outputSize, 262144);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  // Test EmbeddingOp runtime
+  auto runtimeExp = embedding.getOpRuntime(getInputLayouts(embedding),
+                                           OpConfig(/*outputLayout=*/nullptr));
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, CacheOpConstraintsTest) {
   opConstraintsCache().clear();
   opRuntimeCache().clear();


### PR DESCRIPTION
### Ticket
I didn't create an issue since this was a quick fix.
@rpavlovicTT brought this issue up today. He was getting `segfault` with constraint APIs of `embeddingOp` when the output layout was `null`.

### Problem description
`embeddingOp` didn't handle the case where `outputLayout` is `nullptr`.

### What's changed
- This PR adds a fix to `embeddingOp`'s constraint APIs to handle `null` output layout.
- It also adds a UT that tests this case.

### Checklist
- [X] New/Existing tests provide coverage for changes
