### PR TITLE
Switch -mavx -mavx2 to -march=x86-64-v3

### DIFF
--- a/runtime/lib/ttnn/debug/CMakeLists.txt
+++ b/runtime/lib/ttnn/debug/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(TTRuntimeTTNNDebug
 )
 set_property(TARGET TTRuntimeTTNNDebug PROPERTY CXX_STANDARD 20)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(TTRuntimeTTNNDebug PUBLIC -mavx -mavx2)
+  target_compile_options(TTRuntimeTTNNDebug PUBLIC -march=x86-64-v3)
 endif()
 target_include_directories(TTRuntimeTTNNDebug PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -75,7 +75,7 @@ add_library(TTRuntimeTTNNOps
 
 set_property(TARGET TTRuntimeTTNNOps PROPERTY CXX_STANDARD 20)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(TTRuntimeTTNNOps PUBLIC -mavx -mavx2)
+  target_compile_options(TTRuntimeTTNNOps PUBLIC -march=x86-64-v3)
 endif()
 target_include_directories(TTRuntimeTTNNOps PRIVATE
   ${PROJECT_SOURCE_DIR}/runtime/lib/ttnn

--- a/runtime/lib/ttnn/types/CMakeLists.txt
+++ b/runtime/lib/ttnn/types/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(TTRuntimeTTNNTypes
 )
 set_property(TARGET TTRuntimeTTNNTypes PROPERTY CXX_STANDARD 20)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(TTRuntimeTTNNTypes PUBLIC -mavx -mavx2)
+  target_compile_options(TTRuntimeTTNNTypes PUBLIC -march=x86-64-v3)
 endif()
 target_include_directories(TTRuntimeTTNNTypes PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include

--- a/runtime/lib/ttnn/utils/CMakeLists.txt
+++ b/runtime/lib/ttnn/utils/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(TTRuntimeTTNNUtils
 )
 set_property(TARGET TTRuntimeTTNNUtils PROPERTY CXX_STANDARD 20)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(TTRuntimeTTNNUtils PUBLIC -mavx -mavx2)
+  target_compile_options(TTRuntimeTTNNUtils PUBLIC -march=x86-64-v3)
 endif()
 target_include_directories(TTRuntimeTTNNUtils PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(TTRuntimeTTNNTestLib
 )
 set_property(TARGET TTRuntimeTTNNTestLib PROPERTY CXX_STANDARD 20)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(TTRuntimeTTNNTestLib PUBLIC -mavx -mavx2)
+  target_compile_options(TTRuntimeTTNNTestLib PUBLIC -march=x86-64-v3)
 endif()
 target_include_directories(TTRuntimeTTNNTestLib PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -177,7 +177,7 @@ set_target_properties(ttnn-dylib PROPERTIES PUBLIC_HEADER ttnn-dylib.h)
 set_target_properties(ttnn-dylib PROPERTIES INSTALL_RPATH "$ORIGIN:${METAL_LIB_DIR}")
 set_target_properties(ttnn-dylib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
-  target_compile_options(ttnn-dylib PRIVATE -mavx -mavx2)
+  target_compile_options(ttnn-dylib PRIVATE -march=x86-64-v3)
 endif()
 
 target_precompile_headers(ttnn-dylib PRIVATE ttnn-precompiled.hpp)


### PR DESCRIPTION
### Ticket
none

### Problem description
-mavx2 does not enable some additional x86 ISA features that can help performance. Using -march=x86-64-v3 ensures that all of the Haswell-era ISA features are used by the compiler.

Per the x86-64 psABI, here is the complete list of features mandated by x86-64-v3:
- AVX
- AVX2
- BMI1
- BMI2
- F16C
- FMA
- LZCNT
- MOVBE
- OSXSAVE

### What's changed
Change compiler flags in cmake

### Checklist
- [ ] New/Existing tests provide coverage for changes
