### PR TITLE
Rename namespace `op_model::ttnn` to `ttnn::op_model`

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -35,7 +35,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
                      some operations this may be different from the requested output layout
                 If the op is illegal, returns an Error with a string describing the failure.
             }],
-            /*retTy=*/"llvm::Expected<mlir::tt::op_model::ttnn::OpConstraints>",
+            /*retTy=*/"llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>",
             /*methodName=*/"getOpConstraints",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config),
             /*methodBody=*/"",

--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -11,7 +11,7 @@
 #include "llvm/ADT/ArrayRef.h"
 
 #include <type_traits>
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 namespace conversion {
 ::tt::tt_metal::DataType getDataType(const ttcore::DataType dataType);
 ttcore::DataType getDataType(const ::tt::tt_metal::DataType dataType);
@@ -19,61 +19,50 @@ ttcore::DataType getDataType(const ::tt::tt_metal::DataType dataType);
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape);
 llvm::SmallVector<int64_t> getShape(const ::ttnn::Shape &shape);
 
-const std::array<uint32_t, 2>
-getShardShape(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+const std::array<uint32_t, 2> getShardShape(const TTNNLayoutAttr &layout);
 
-::tt::tt_metal::Layout
-getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::Layout getPageLayout(const TTNNLayoutAttr &layout);
 
-::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::Layout layout);
+::tt::tt_metal::Layout getPageLayout(Layout layout);
 
 ::tt::tt_metal::CoreRangeSet
-getCoreRangeSet(const mlir::tt::ttnn::CoreRangeSetAttr &coreRangeSetAttr);
+getCoreRangeSet(const CoreRangeSetAttr &coreRangeSetAttr);
 
-::tt::tt_metal::CoreRangeSet
-getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::CoreRangeSet getCoreRangeSet(const TTNNLayoutAttr &layout);
 
-::tt::tt_metal::ShardOrientation getShardOrientation(
-    const mlir::tt::ttnn::ShardOrientationAttr &shardOrientationAttr);
+::tt::tt_metal::ShardOrientation
+getShardOrientation(const ShardOrientationAttr &shardOrientationAttr);
 
-::tt::tt_metal::ShardMode
-getShardMode(const mlir::tt::ttnn::ShardModeAttr &shardModeAttr);
+::tt::tt_metal::ShardMode getShardMode(const ShardModeAttr &shardModeAttr);
 
 std::optional<::tt::tt_metal::ShardSpec>
-getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+getShardSpec(const TTNNLayoutAttr &layout);
 
-::tt::tt_metal::ShardSpec
-getShardSpec(const mlir::tt::ttnn::ShardSpecAttr &shardSpecAttr);
+::tt::tt_metal::ShardSpec getShardSpec(const ShardSpecAttr &shardSpecAttr);
 
-::tt::tt_metal::BufferType
-getBufferType(const mlir::tt::ttnn::BufferType &bufferType);
+::tt::tt_metal::BufferType getBufferType(const BufferType &bufferType);
 
-::tt::tt_metal::BufferType
-getBufferType(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::BufferType getBufferType(const TTNNLayoutAttr &layout);
 
-mlir::tt::ttnn::BufferType
-getBufferType(const ::tt::tt_metal::BufferType bufferType);
+BufferType getBufferType(const ::tt::tt_metal::BufferType bufferType);
 
-::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
-    const mlir::tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr);
+::tt::tt_metal::TensorMemoryLayout
+getTensorMemoryLayout(const TensorMemoryLayoutAttr memLayoutAttr);
 
-mlir::tt::ttnn::TensorMemoryLayout
+TensorMemoryLayout
 getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout);
 
-::tt::tt_metal::MemoryConfig
-getMemoryConfig(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::MemoryConfig getMemoryConfig(const TTNNLayoutAttr &layout);
 
-::tt::tt_metal::ShardSpec
-getShardSpec(const mlir::tt::ttnn::ShardSpecAttr &shardSpecAttr);
+::tt::tt_metal::ShardSpec getShardSpec(const ShardSpecAttr &shardSpecAttr);
 
 ::tt::tt_metal::MemoryConfig
-getMemoryConfig(const mlir::tt::ttnn::MemoryConfigAttr &memConfigAttr);
+getMemoryConfig(const MemoryConfigAttr &memConfigAttr);
 
-::tt::tt_metal::TensorLayout
-getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::TensorLayout getTensorLayout(const TTNNLayoutAttr &layout);
 
 ::ttnn::TensorSpec getTensorSpec(const ::llvm::ArrayRef<int64_t> shape,
-                                 const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+                                 const TTNNLayoutAttr &layout);
 
 /**
  * @brief Perform various validity checks on a converted TensorSpec
@@ -98,8 +87,8 @@ bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
 ::ttsl::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec);
 
-std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
-    const std::optional<mlir::tt::ttnn::Conv2dConfigAttr> &conv2dConfig);
+std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>
+getConv2dConfig(const std::optional<Conv2dConfigAttr> &conv2dConfig);
 
 template <typename To, std::size_t N, typename From>
 std::array<To, N> convertLLVMArrayRefToStdArray(::llvm::ArrayRef<From> vec) {
@@ -137,17 +126,16 @@ llvm::SmallVector<int64_t>
 getLogicalGridShape(const ::tt::tt_metal::MemoryConfig &memoryConfig,
                     const llvm::ArrayRef<int64_t> &gridPhyCores);
 
-mlir::tt::ttnn::TTNNLayoutAttr
-getLayoutAttrFromTensorSpec(MLIRContext *context,
-                            const ::ttnn::TensorSpec &tensorSpec,
-                            llvm::ArrayRef<int64_t> deviceGrid);
+TTNNLayoutAttr getLayoutAttrFromTensorSpec(MLIRContext *context,
+                                           const ::ttnn::TensorSpec &tensorSpec,
+                                           llvm::ArrayRef<int64_t> deviceGrid);
 
-std::optional<::ttnn::DeviceComputeKernelConfig> getDeviceComputeKernelConfig(
-    const std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-        &deviceComputeKernelConfig);
+std::optional<::ttnn::DeviceComputeKernelConfig>
+getDeviceComputeKernelConfig(const std::optional<DeviceComputeKernelConfigAttr>
+                                 &deviceComputeKernelConfig);
 
 } // namespace conversion
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL
 #endif // TTMLIR_OPMODEL_TTNN_CONVERSION_H

--- a/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
+++ b/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
@@ -18,7 +18,7 @@ class MeshDevice;
 } // namespace tt_metal
 } // namespace tt
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 // Singleton class to manage the device context, ensuring the device remains
 // active while compiler is running multiple graph traces without real
@@ -50,7 +50,7 @@ private:
   void openDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
   void closeDevice();
 };
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_ENABLE_OPMODEL
 #endif // TTMLIR_OPMODEL_TTNN_SINGLETONDEVICECONTEXT_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
@@ -7,7 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 /*
  * OpConstraints struct is used to store the constraints of an operation.
@@ -36,6 +36,6 @@ struct OpConstraints {
         outputLayout(nullptr) {}
 };
 
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPCONSTRAINTS_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -5,7 +5,6 @@
 #ifndef TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H
 #define TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H
 
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
@@ -14,24 +13,22 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr layout,
-                                 mlir::tt::ttcore::GridAttr maxGrid);
+                                 TTNNLayoutAttr layout,
+                                 ttcore::GridAttr maxGrid);
 
 // Calculate the output tensor type of the prepared weights for a conv2d op.
-mlir::RankedTensorType
-getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op);
+mlir::RankedTensorType getPreparedConv2dWeightsOutputTensor(Conv2dOp *op);
 
 //===----------------------------------------------------------------------===//
 // Device
 //===----------------------------------------------------------------------===//
 
 namespace Device {
-llvm::Expected<bool>
-getDeviceConstraints(mlir::tt::ttcore::GridAttr workerGrid);
+llvm::Expected<bool> getDeviceConstraints(ttcore::GridAttr workerGrid);
 }; // namespace Device
 
 template <typename OpTy>
@@ -44,61 +41,50 @@ struct OpModel;
 template <typename OpT>
 struct UnaryEltwiseOpModel {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 template <>
-struct OpModel<mlir::tt::ttnn::ReluOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::ReluOp> {};
+struct OpModel<ReluOp> : UnaryEltwiseOpModel<ReluOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::SqrtOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::SqrtOp> {};
+struct OpModel<SqrtOp> : UnaryEltwiseOpModel<SqrtOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::SinOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::SinOp> {};
+struct OpModel<SinOp> : UnaryEltwiseOpModel<SinOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::CosOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::CosOp> {};
+struct OpModel<CosOp> : UnaryEltwiseOpModel<CosOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::TanhOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp> {};
+struct OpModel<TanhOp> : UnaryEltwiseOpModel<TanhOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LogOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp> {};
+struct OpModel<LogOp> : UnaryEltwiseOpModel<LogOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::ReciprocalOp>
-    : UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp> {};
+struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::SigmoidOp> {
+struct OpModel<SigmoidOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -106,17 +92,15 @@ struct OpModel<mlir::tt::ttnn::SigmoidOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ExpOp> {
+struct OpModel<ExpOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -125,81 +109,61 @@ struct OpModel<mlir::tt::ttnn::ExpOp> {
 
 template <typename OpT>
 struct BinaryEltwiseOpModel {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShapeA,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                   llvm::ArrayRef<int64_t> inputShapeB,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+               TTNNLayoutAttr outputLayout);
 };
 
 template <>
-struct OpModel<mlir::tt::ttnn::AddOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::AddOp> {};
+struct OpModel<AddOp> : BinaryEltwiseOpModel<AddOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::MultiplyOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::MultiplyOp> {};
+struct OpModel<MultiplyOp> : BinaryEltwiseOpModel<MultiplyOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::SubtractOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::SubtractOp> {};
+struct OpModel<SubtractOp> : BinaryEltwiseOpModel<SubtractOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::MaximumOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::MaximumOp> {};
+struct OpModel<MaximumOp> : BinaryEltwiseOpModel<MaximumOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::MinimumOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::MinimumOp> {};
+struct OpModel<MinimumOp> : BinaryEltwiseOpModel<MinimumOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::DivideOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::DivideOp> {};
+struct OpModel<DivideOp> : BinaryEltwiseOpModel<DivideOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::EqualOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::EqualOp> {};
+struct OpModel<EqualOp> : BinaryEltwiseOpModel<EqualOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::NotEqualOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::NotEqualOp> {};
+struct OpModel<NotEqualOp> : BinaryEltwiseOpModel<NotEqualOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::GreaterEqualOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::GreaterEqualOp> {};
+struct OpModel<GreaterEqualOp> : BinaryEltwiseOpModel<GreaterEqualOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::GreaterThanOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::GreaterThanOp> {};
+struct OpModel<GreaterThanOp> : BinaryEltwiseOpModel<GreaterThanOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LessEqualOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::LessEqualOp> {};
+struct OpModel<LessEqualOp> : BinaryEltwiseOpModel<LessEqualOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LessThanOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::LessThanOp> {};
+struct OpModel<LessThanOp> : BinaryEltwiseOpModel<LessThanOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LogicalAndOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalAndOp> {};
+struct OpModel<LogicalAndOp> : BinaryEltwiseOpModel<LogicalAndOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LogicalOrOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalOrOp> {};
+struct OpModel<LogicalOrOp> : BinaryEltwiseOpModel<LogicalOrOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::LogicalXorOp>
-    : BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalXorOp> {};
+struct OpModel<LogicalXorOp> : BinaryEltwiseOpModel<LogicalXorOp> {};
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops
@@ -207,31 +171,23 @@ struct OpModel<mlir::tt::ttnn::LogicalXorOp>
 
 template <typename OpT>
 struct TernaryEltwiseOpModel {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShapeA,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                   llvm::ArrayRef<int64_t> inputShapeB,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                   llvm::ArrayRef<int64_t> inputShapeC,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutC,
-                   llvm::ArrayRef<int64_t> outputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+      TTNNLayoutAttr inputLayoutB, llvm::ArrayRef<int64_t> inputShapeC,
+      TTNNLayoutAttr inputLayoutC, llvm::ArrayRef<int64_t> outputShape,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-               llvm::ArrayRef<int64_t> inputShapeC,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutC,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+               llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
                llvm::ArrayRef<int64_t> outputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               TTNNLayoutAttr outputLayout);
 };
 
 template <>
-struct OpModel<mlir::tt::ttnn::WhereOp>
-    : TernaryEltwiseOpModel<mlir::tt::ttnn::WhereOp> {};
+struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 //===----------------------------------------------------------------------===//
 // Reduction Ops
@@ -239,44 +195,39 @@ struct OpModel<mlir::tt::ttnn::WhereOp>
 
 template <typename OpT>
 struct ReductionOpModel {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, std::optional<llvm::ArrayRef<int64_t>> dimArg,
+      bool keepDim, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               TTNNLayoutAttr outputLayout);
 };
 
 template <>
-struct OpModel<mlir::tt::ttnn::MeanOp>
-    : ReductionOpModel<mlir::tt::ttnn::MeanOp> {};
+struct OpModel<MeanOp> : ReductionOpModel<MeanOp> {};
 
 template <>
-struct OpModel<mlir::tt::ttnn::SumOp>
-    : ReductionOpModel<mlir::tt::ttnn::SumOp> {};
+struct OpModel<SumOp> : ReductionOpModel<SumOp> {};
 
 //===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::SoftmaxOp> {
+struct OpModel<SoftmaxOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, const int dimArg,
+                   TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             const int dimArg,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -284,19 +235,16 @@ struct OpModel<mlir::tt::ttnn::SoftmaxOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ReshapeOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   llvm::ArrayRef<int64_t> outputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<ReshapeOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> outputShape,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> outputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -304,21 +252,18 @@ struct OpModel<mlir::tt::ttnn::ReshapeOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::SliceOp> {
+struct OpModel<SliceOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
-                   llvm::ArrayRef<int64_t> step,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
+                   llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
-               llvm::ArrayRef<int64_t> step,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -326,19 +271,17 @@ struct OpModel<mlir::tt::ttnn::SliceOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::TypecastOp> {
+struct OpModel<TypecastOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   mlir::tt::ttcore::DataTypeAttr dtype,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
+                   TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::tt::ttcore::DataTypeAttr dtype,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             ttcore::DataTypeAttr dtype,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -346,19 +289,16 @@ struct OpModel<mlir::tt::ttnn::TypecastOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ToLayoutOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   std::optional<mlir::tt::ttcore::DataType> outputDtype,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<ToLayoutOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, std::optional<ttcore::DataType> outputDtype,
+      TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               std::optional<mlir::tt::ttcore::DataType> outputDtype,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               std::optional<ttcore::DataType> outputDtype,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -366,19 +306,17 @@ struct OpModel<mlir::tt::ttnn::ToLayoutOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ToMemoryConfigOp> {
+struct OpModel<ToMemoryConfigOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   mlir::tt::ttnn::MemoryConfigAttr memoryConfig,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, MemoryConfigAttr memoryConfig,
+                   TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::tt::ttnn::MemoryConfigAttr memoryConfig,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             MemoryConfigAttr memoryConfig,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -386,17 +324,17 @@ struct OpModel<mlir::tt::ttnn::ToMemoryConfigOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ConcatOp> {
+struct OpModel<ConcatOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-                   std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts,
-                   const int dim, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+                   TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-               std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts,
-               const int dim, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -404,17 +342,17 @@ struct OpModel<mlir::tt::ttnn::ConcatOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::TransposeOp> {
+struct OpModel<TransposeOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+  getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0,
-                   const int dim1, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
+                   TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0,
-               const int dim1, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             const int dim0, const int dim1,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -422,27 +360,21 @@ struct OpModel<mlir::tt::ttnn::TransposeOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::LinearOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShapeA,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                   llvm::ArrayRef<int64_t> inputShapeB,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                   std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                   std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-                   bool transposeB);
+struct OpModel<LinearOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+      TTNNLayoutAttr inputLayoutB,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+      bool transposeA, bool transposeB);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
                std::optional<llvm::ArrayRef<int64_t>> biasShape,
-               std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-               bool transposeB);
+               std::optional<TTNNLayoutAttr> biasLayout,
+               TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB);
 };
 
 //===----------------------------------------------------------------------===//
@@ -450,23 +382,17 @@ struct OpModel<mlir::tt::ttnn::LinearOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::MatmulOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShapeA,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                   llvm::ArrayRef<int64_t> inputShapeB,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-                   bool transposeB);
+struct OpModel<MatmulOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
+      bool transposeB);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-               bool transposeB);
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+               TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB);
 };
 
 //===----------------------------------------------------------------------===//
@@ -474,40 +400,33 @@ struct OpModel<mlir::tt::ttnn::MatmulOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::Conv2dOp> {
+struct OpModel<Conv2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape,
-      mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+      TTNNLayoutAttr weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-      uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-      uint32_t input_height, uint32_t input_width,
-      llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      uint32_t groups,
-      std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-      std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-          deviceComputeKernelConfig,
-      mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               llvm::ArrayRef<int64_t> weightShape,
-               mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-               std::optional<llvm::ArrayRef<int64_t>> biasShape,
-               std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-               uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-               uint32_t input_height, uint32_t input_width,
-               llvm::ArrayRef<int32_t> kernel_size,
-               llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-               llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-               std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-               std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-                   deviceComputeKernelConfig,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -515,37 +434,31 @@ struct OpModel<mlir::tt::ttnn::Conv2dOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ConvTranspose2dOp> {
+struct OpModel<ConvTranspose2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape,
-      mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+      TTNNLayoutAttr weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-      uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-      uint32_t input_height, uint32_t input_width,
-      llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
-      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-      std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-      mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+      uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               llvm::ArrayRef<int64_t> weightShape,
-               mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-               std::optional<llvm::ArrayRef<int64_t>> biasShape,
-               std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-               uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-               uint32_t input_height, uint32_t input_width,
-               llvm::ArrayRef<int32_t> kernel_size,
-               llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-               llvm::ArrayRef<int32_t> output_padding,
-               llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-               std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+      uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -553,23 +466,22 @@ struct OpModel<mlir::tt::ttnn::ConvTranspose2dOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::MaxPool2dOp> {
+struct OpModel<MaxPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
-      int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
+      int32_t inputWidth, int32_t inputChannels,
       llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
       llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      bool ceilMode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+      bool ceilMode, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
-               int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
-               llvm::ArrayRef<int32_t> kernelSize,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+               int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
                llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
                llvm::ArrayRef<int32_t> dilation, bool ceilMode,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -577,16 +489,18 @@ struct OpModel<mlir::tt::ttnn::MaxPool2dOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::ClampScalarOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
-      llvm::APFloat max, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<ClampScalarOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, llvm::APFloat min,
+                   llvm::APFloat max, TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
-               llvm::APFloat max, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             llvm::APFloat min,
+                                             llvm::APFloat max,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -594,19 +508,16 @@ struct OpModel<mlir::tt::ttnn::ClampScalarOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::PermuteOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<PermuteOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> permutation,
+      llvm::APFloat padValue, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+               TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -614,17 +525,18 @@ struct OpModel<mlir::tt::ttnn::PermuteOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::UpsampleOp> {
-  static llvm::Expected<OpConstraints> getOpConstraints(
-      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-      mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
-      llvm::StringRef mode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<UpsampleOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
+                   llvm::StringRef mode, TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               mlir::Attribute scaleFactor, llvm::StringRef mode,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             mlir::Attribute scaleFactor,
+                                             llvm::StringRef mode,
+                                             TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
@@ -632,22 +544,17 @@ struct OpModel<mlir::tt::ttnn::UpsampleOp> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<mlir::tt::ttnn::EmbeddingOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                   llvm::ArrayRef<int64_t> weightShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+struct OpModel<EmbeddingOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+      TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-               llvm::ArrayRef<int64_t> weightShape,
-               mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+               TTNNLayoutAttr outputLayout);
 };
 
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -23,7 +23,7 @@ template <typename ValueT>
 class TTNNOpModelCache;
 
 // Singleton accessor functions.
-TTNNOpModelCache<op_model::ttnn::OpConstraints> &opConstraintsCache();
+TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache();
 TTNNOpModelCache<size_t> &opRuntimeCache();
 
 // A cache for TTNN operation model results. This cache stores the results of
@@ -33,7 +33,7 @@ template <typename ValueT>
 class TTNNOpModelCache {
   // It is important to define the singleton accessor functions to prevent
   // multiple instances of the cache to be created.
-  friend TTNNOpModelCache<op_model::ttnn::OpConstraints> &opConstraintsCache();
+  friend TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache();
   friend TTNNOpModelCache<size_t> &opRuntimeCache();
 
 public:
@@ -157,12 +157,12 @@ private:
 };
 
 // Singleton accessor implementations
-inline TTNNOpModelCache<op_model::ttnn::OpConstraints> &opConstraintsCache() {
+inline TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache() {
   // According to C++11 standards:
   //  §6.7 [stmt.dcl] p4 If control enters the declaration concurrently while
   //  the variable is being initialized, the concurrent execution shall wait for
   //  completion of the initialization.
-  static TTNNOpModelCache<op_model::ttnn::OpConstraints> instance;
+  static TTNNOpModelCache<op_model::OpConstraints> instance;
   return instance;
 }
 

--- a/lib/Dialect/TTNN/Analysis/LegalTensorLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalTensorLayoutAnalysis.cpp
@@ -32,8 +32,7 @@ static bool tensorShapeCompatibleWithShard(RankedTensorType tensorType,
 
   llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
-  if (!op_model::ttnn::isLayoutLegalForTensorShape(tensorShape, layout,
-                                                   maxGrid)) {
+  if (!op_model::isLayoutLegalForTensorShape(tensorShape, layout, maxGrid)) {
     return false;
   }
 

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -861,7 +861,7 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
 
   assert(inputUnderCheckFound && "Input under check not found");
 
-  llvm::Expected<op_model::ttnn::OpConstraints> l1UsageExp =
+  llvm::Expected<op_model::OpConstraints> l1UsageExp =
       backend.getOpConstraints(inputLayouts, consumerConfig);
 
   if (!l1UsageExp) {

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -22,10 +22,9 @@ namespace mlir::tt::ttnn {
 
 namespace detail {
 llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
-  auto deviceAttr = mlir::tt::ttcore::lookupDevice(op);
+  auto deviceAttr = ttcore::lookupDevice(op);
   assert(deviceAttr);
-  return op_model::ttnn::Device::getDeviceConstraints(
-      deviceAttr.getWorkerGrid());
+  return op_model::Device::getDeviceConstraints(deviceAttr.getWorkerGrid());
 }
 
 llvm::SmallVector<int64_t>
@@ -46,7 +45,7 @@ convertOptionalArrayAttrToSmallVec(std::optional<mlir::ArrayAttr> arrayAttr) {
 }
 
 template <typename OpT>
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                       const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -60,8 +59,8 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpConstraints, op, deviceGrid,
-      inputShape, inputs[0], opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
+      inputs[0], opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -72,13 +71,13 @@ getUnaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpRuntime, op, inputShape, inputs[0],
-      opConfig.outputLayout);
+  return opRuntimeCache().getOrCompute(op_model::OpModel<OpT>::getOpRuntime, op,
+                                       inputShape, inputs[0],
+                                       opConfig.outputLayout);
 }
 
 template <typename OpT>
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                        const OpConfig &opConfig) {
   assert(inputs.size() == 2);
@@ -94,8 +93,8 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpConstraints, op, deviceGrid,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
+      inputs[0], inputShapeB, inputs[1], opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -107,13 +106,13 @@ getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = op.getLhs().getType().getShape();
   const auto inputShapeB = op.getRhs().getType().getShape();
 
-  return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpRuntime, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], opConfig.outputLayout);
+  return opRuntimeCache().getOrCompute(op_model::OpModel<OpT>::getOpRuntime, op,
+                                       inputShapeA, inputs[0], inputShapeB,
+                                       inputs[1], opConfig.outputLayout);
 }
 
 template <typename OpT>
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   assert(inputs.size() == 3);
@@ -131,9 +130,9 @@ getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpConstraints, op, deviceGrid,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], inputShapeC, inputs[2],
-      outputShape, opConfig.outputLayout);
+      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
+      inputs[0], inputShapeB, inputs[1], inputShapeC, inputs[2], outputShape,
+      opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -147,14 +146,14 @@ getTernaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeC = op.getThird().getType().getShape();
   const auto outputShape = op.getType().getShape();
 
-  return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpRuntime, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], inputShapeC, inputs[2], outputShape,
-      opConfig.outputLayout);
+  return opRuntimeCache().getOrCompute(op_model::OpModel<OpT>::getOpRuntime, op,
+                                       inputShapeA, inputs[0], inputShapeB,
+                                       inputs[1], inputShapeC, inputs[2],
+                                       outputShape, opConfig.outputLayout);
 }
 
 template <typename OpT>
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -166,9 +165,8 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpConstraints, op, deviceGrid,
-      inputShape, inputs[0],
-      detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
+      op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
+      inputs[0], detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
 }
 
@@ -179,7 +177,7 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<OpT>::getOpRuntime, op, inputShape, inputs[0],
+      op_model::OpModel<OpT>::getOpRuntime, op, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
 }
@@ -189,7 +187,7 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -205,7 +203,7 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SqrtOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -221,7 +219,7 @@ SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SinOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -237,7 +235,7 @@ SinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 CosOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -253,7 +251,7 @@ CosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TanhOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -269,7 +267,7 @@ TanhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LogOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -285,7 +283,7 @@ LogOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ReciprocalOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ReciprocalOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -301,7 +299,7 @@ ReciprocalOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SigmoidOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SigmoidOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -317,7 +315,7 @@ SigmoidOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ExpOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ExpOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -333,7 +331,7 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AddOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -349,7 +347,7 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MultiplyOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -365,7 +363,7 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SubtractOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SubtractOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -381,7 +379,7 @@ SubtractOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MaximumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MaximumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -397,7 +395,7 @@ MaximumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MinimumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MinimumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -413,7 +411,7 @@ MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // DivideOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 DivideOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -429,7 +427,7 @@ DivideOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 EqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -445,7 +443,7 @@ EqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NotEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 NotEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -461,7 +459,7 @@ NotEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GreaterEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 GreaterEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -477,7 +475,7 @@ GreaterEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GreaterThanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 GreaterThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -493,7 +491,7 @@ GreaterThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LessEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LessEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -509,7 +507,7 @@ LessEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LessThanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LessThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -525,7 +523,7 @@ LessThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalAndOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LogicalAndOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -541,7 +539,7 @@ LogicalAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalOrOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LogicalOrOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -557,7 +555,7 @@ LogicalOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalXorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LogicalXorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
   return detail::getBinaryOpConstraints(*this, inputs, opConfig);
@@ -573,7 +571,7 @@ LogicalXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // WhereOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 WhereOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getTernaryOpConstraints(*this, inputs, opConfig);
@@ -589,7 +587,7 @@ WhereOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MeanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return getReductionOpConstraints(*this, inputs, opConfig);
@@ -605,7 +603,7 @@ MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return getReductionOpConstraints(*this, inputs, opConfig);
@@ -621,7 +619,7 @@ SumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -635,9 +633,8 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getDimension(),
-      opConfig.outputLayout);
+      op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getDimension(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -648,15 +645,15 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getDimension(), opConfig.outputLayout);
+      op_model::OpModel<SoftmaxOp>::getOpRuntime, *this, inputShape, inputs[0],
+      getDimension(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // ReshapeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -673,9 +670,8 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], outputShape,
-      opConfig.outputLayout);
+      op_model::OpModel<ReshapeOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -687,15 +683,15 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getResult().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpRuntime, *this,
-      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+      op_model::OpModel<ReshapeOp>::getOpRuntime, *this, inputShape, inputs[0],
+      outputShape, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // SliceOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SliceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -710,9 +706,8 @@ SliceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SliceOp>::getOpConstraints, *this,
-      deviceGrid, inputShape, inputs[0],
-      detail::convertArrayAttrToSmallVec(getBegins()),
+      op_model::OpModel<SliceOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }
@@ -725,8 +720,8 @@ SliceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SliceOp>::getOpRuntime, *this,
-      inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
+      op_model::OpModel<SliceOp>::getOpRuntime, *this, inputShape, inputs[0],
+      detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }
@@ -735,7 +730,7 @@ SliceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TypecastOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -750,9 +745,8 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getDtypeAttr(),
-      opConfig.outputLayout);
+      op_model::OpModel<TypecastOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getDtypeAttr(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -763,15 +757,15 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getDtypeAttr(), opConfig.outputLayout);
+      op_model::OpModel<TypecastOp>::getOpRuntime, *this, inputShape, inputs[0],
+      getDtypeAttr(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // ToLayoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -788,9 +782,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getDtype(),
-      opConfig.outputLayout);
+      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getDtype(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -802,15 +795,15 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getDtype(), opConfig.outputLayout);
+      op_model::OpModel<ToLayoutOp>::getOpRuntime, *this, inputShape, inputs[0],
+      getDtype(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -825,10 +818,8 @@ ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<
-          mlir::tt::ttnn::ToMemoryConfigOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getMemoryConfig(),
-      opConfig.outputLayout);
+      op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getMemoryConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -839,15 +830,15 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpRuntime,
-      *this, inputShape, inputs[0], getMemoryConfig(), opConfig.outputLayout);
+      op_model::OpModel<ToMemoryConfigOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getMemoryConfig(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == getInputs().size());
@@ -867,8 +858,8 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConcatOp>::getOpConstraints,
-      *this, deviceGrid, inputShapes, inputs, getDim(), opConfig.outputLayout);
+      op_model::OpModel<ConcatOp>::getOpConstraints, *this, deviceGrid,
+      inputShapes, inputs, getDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -884,15 +875,15 @@ ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConcatOp>::getOpRuntime, *this,
-      inputShapes, inputs, getDim(), opConfig.outputLayout);
+      op_model::OpModel<ConcatOp>::getOpRuntime, *this, inputShapes, inputs,
+      getDim(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -907,9 +898,8 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getDim0(), getDim1(),
-      opConfig.outputLayout);
+      op_model::OpModel<TransposeOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -920,15 +910,15 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
+      op_model::OpModel<TransposeOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // LinearOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
@@ -937,7 +927,7 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = getB().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -952,9 +942,9 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LinearOp>::getOpConstraints,
-      *this, deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1],
-      biasShape, biasLayout, opConfig.outputLayout, false, false);
+      op_model::OpModel<LinearOp>::getOpConstraints, *this, deviceGrid,
+      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
+      opConfig.outputLayout, false, false);
 }
 
 llvm::Expected<size_t>
@@ -966,7 +956,7 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = getB().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -974,16 +964,16 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LinearOp>::getOpRuntime, *this,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
-      opConfig.outputLayout, false, false);
+      op_model::OpModel<LinearOp>::getOpRuntime, *this, inputShapeA, inputs[0],
+      inputShapeB, inputs[1], biasShape, biasLayout, opConfig.outputLayout,
+      false, false);
 }
 
 //===----------------------------------------------------------------------===//
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 2);
@@ -999,9 +989,9 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MatmulOp>::getOpConstraints,
-      *this, deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1],
-      opConfig.outputLayout, false, false);
+      op_model::OpModel<MatmulOp>::getOpConstraints, *this, deviceGrid,
+      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
+      false, false);
 }
 
 llvm::Expected<size_t>
@@ -1013,9 +1003,8 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = getB().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MatmulOp>::getOpRuntime, *this,
-      inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      false, false);
+      op_model::OpModel<MatmulOp>::getOpRuntime, *this, inputShapeA, inputs[0],
+      inputShapeB, inputs[1], opConfig.outputLayout, false, false);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1024,7 +1013,7 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 // If a config has been specified, use that. Otherwise, use the op property.
 static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
-                                     mlir::tt::ttnn::Conv2dOp op) {
+                                     Conv2dOp op) {
   assert((std::holds_alternative<Conv2dAttrs>(attrs) ||
           std::holds_alternative<UninitializedAttrs>(attrs)) &&
          "Please create a Conv2dAttrs or leave it to be uninitialized.");
@@ -1042,7 +1031,7 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
@@ -1050,7 +1039,7 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -1066,11 +1055,11 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::Conv2dOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], weightShape, inputs[1],
-      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getGroups(), attr.conv2dConfig,
+      op_model::OpModel<Conv2dOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), attr.conv2dConfig,
       attr.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
@@ -1082,7 +1071,7 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -1091,12 +1080,11 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::Conv2dOp>::getOpRuntime, *this,
-      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), attr.conv2dConfig,
-      attr.deviceComputeKernelConfig, opConfig.outputLayout);
+      op_model::OpModel<Conv2dOp>::getOpRuntime, *this, inputShape, inputs[0],
+      weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getDilation(), getGroups(),
+      attr.conv2dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1106,7 +1094,7 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // If a config has been specified, use that. Otherwise, use the op property.
 static Conv2dAttrs
 unpackConvTranspose2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
-                           mlir::tt::ttnn::ConvTranspose2dOp op) {
+                           ConvTranspose2dOp op) {
   assert((std::holds_alternative<Conv2dAttrs>(attrs) ||
           std::holds_alternative<UninitializedAttrs>(attrs)) &&
          "Please create a Conv2dAttrs or leave it to be uninitialized.");
@@ -1124,7 +1112,7 @@ unpackConvTranspose2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                      nullptr};
 }
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
@@ -1132,7 +1120,7 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -1151,13 +1139,12 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       unpackConvTranspose2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<
-          mlir::tt::ttnn::ConvTranspose2dOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], weightShape, inputs[1],
-      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getOutputPadding(), getDilation(), getGroups(),
-      conv2dAttrs.conv2dConfig, opConfig.outputLayout);
+      op_model::OpModel<ConvTranspose2dOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getOutputPadding(), getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1168,7 +1155,7 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
-  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+  std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
     biasShape = getBias().getType().getShape();
@@ -1180,19 +1167,19 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       unpackConvTranspose2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpRuntime,
-      *this, inputShape, inputs[0], weightShape, inputs[1], biasShape,
-      biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getOutputPadding(), getDilation(), getGroups(),
-      conv2dAttrs.conv2dConfig, opConfig.outputLayout);
+      op_model::OpModel<ConvTranspose2dOp>::getOpRuntime, *this, inputShape,
+      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
+      getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // MaxPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -1207,11 +1194,10 @@ MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getBatchSize(),
-      getInputHeight(), getInputWidth(), getChannels(), getKernelSize(),
-      getStride(), getPadding(), getDilation(), getCeilMode(),
-      opConfig.outputLayout);
+      op_model::OpModel<MaxPool2dOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
+      getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
+      getCeilMode(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1222,8 +1208,8 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
+      op_model::OpModel<MaxPool2dOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
       getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
       getCeilMode(), opConfig.outputLayout);
 }
@@ -1232,7 +1218,7 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -1247,9 +1233,8 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getMin(), getMax(),
-      opConfig.outputLayout);
+      op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getMin(), getMax(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1260,15 +1245,15 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpRuntime,
-      *this, inputShape, inputs[0], getMin(), getMax(), opConfig.outputLayout);
+      op_model::OpModel<ClampScalarOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getMin(), getMax(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // PermuteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -1283,8 +1268,8 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::PermuteOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getPermutation(), getPadValue(),
+      op_model::OpModel<PermuteOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getPermutation(), getPadValue(),
       opConfig.outputLayout);
 }
 
@@ -1296,16 +1281,15 @@ PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::PermuteOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getPermutation(), getPadValue(),
-      opConfig.outputLayout);
+      op_model::OpModel<PermuteOp>::getOpRuntime, *this, inputShape, inputs[0],
+      getPermutation(), getPadValue(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // UpsampleOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -1320,8 +1304,8 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::UpsampleOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getScaleFactor(), getMode(),
+      op_model::OpModel<UpsampleOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getScaleFactor(), getMode(),
       opConfig.outputLayout);
 }
 
@@ -1333,16 +1317,15 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::UpsampleOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getScaleFactor(), getMode(),
-      opConfig.outputLayout);
+      op_model::OpModel<UpsampleOp>::getOpRuntime, *this, inputShape, inputs[0],
+      getScaleFactor(), getMode(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 2);
@@ -1358,9 +1341,8 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], weightShape, inputs[1],
-      opConfig.outputLayout);
+      op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], weightShape, inputs[1], opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1372,8 +1354,8 @@ EmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto weightShape = getWeight().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpRuntime, *this,
-      inputShape, inputs[0], weightShape, inputs[1], opConfig.outputLayout);
+      op_model::OpModel<EmbeddingOp>::getOpRuntime, *this, inputShape,
+      inputs[0], weightShape, inputs[1], opConfig.outputLayout);
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
@@ -125,7 +125,7 @@ public:
     // runtime.
     // This will be removed once we switch to virtual device:
     // https://github.com/tenstorrent/tt-metal/issues/14000
-    mlir::tt::op_model::ttnn::SingletonDeviceContext::closeInstance();
+    op_model::SingletonDeviceContext::closeInstance();
 #endif
   }
 
@@ -133,7 +133,7 @@ private:
   ::mlir::RankedTensorType getPreparedWeightsType(ttnn::Conv2dOp conv2dOp) {
     // We use graph capture to retrieve the output type of the PrepareConv2dOp
     // for now until metal exposes an API.
-    return op_model::ttnn::getPreparedConv2dWeightsOutputTensor(&conv2dOp);
+    return op_model::getPreparedConv2dWeightsOutputTensor(&conv2dOp);
   }
 
   ::mlir::RankedTensorType getPreparedBiasType(ttnn::Conv2dOp conv2dOp) {

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -16,7 +16,7 @@
 #include <optional>
 #include <stdexcept>
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 namespace conversion {
 
@@ -79,8 +79,7 @@ llvm::SmallVector<int64_t> getShape(const ::ttnn::Shape &shape) {
   return llvm::SmallVector<int64_t>(shape.cbegin(), shape.cend());
 }
 
-const std::array<uint32_t, 2>
-getShardShape(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+const std::array<uint32_t, 2> getShardShape(const TTNNLayoutAttr &layout) {
   const auto layoutShardTile = layout.getScalarShardShape();
 
   if (layoutShardTile.size() != 2) {
@@ -103,28 +102,26 @@ getShardShape(const llvm::ArrayRef<int64_t> &shapeAttr) {
   return shape;
 }
 
-::tt::tt_metal::Layout
-getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+::tt::tt_metal::Layout getPageLayout(const TTNNLayoutAttr &layout) {
   return layout.isTiled() ? ::tt::tt_metal::Layout::TILE
                           : ::tt::tt_metal::Layout::ROW_MAJOR;
 }
 
-::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::Layout layout) {
+::tt::tt_metal::Layout getPageLayout(Layout layout) {
   switch (layout) {
-  case ::mlir::tt::ttnn::Layout::RowMajor:
+  case Layout::RowMajor:
     return ::tt::tt_metal::Layout::ROW_MAJOR;
-  case ::mlir::tt::ttnn::Layout::Tile:
+  case Layout::Tile:
     return ::tt::tt_metal::Layout::TILE;
-  case ::mlir::tt::ttnn::Layout::Invalid:
+  case Layout::Invalid:
     return ::tt::tt_metal::Layout::INVALID;
   }
 }
 
 ::tt::tt_metal::CoreRangeSet
-getCoreRangeSet(const mlir::tt::ttnn::CoreRangeSetAttr &coreRangeSetAttr) {
+getCoreRangeSet(const CoreRangeSetAttr &coreRangeSetAttr) {
   std::set<::tt::tt_metal::CoreRange> coreRangeSet;
-  for (const mlir::tt::ttnn::CoreRangeAttr &coreRange :
-       coreRangeSetAttr.getCoreRanges()) {
+  for (const CoreRangeAttr &coreRange : coreRangeSetAttr.getCoreRanges()) {
     coreRangeSet.insert(
         ::tt::tt_metal::CoreRange(CoreCoord(coreRange.getStartCoord().getX(),
                                             coreRange.getStartCoord().getY()),
@@ -134,8 +131,7 @@ getCoreRangeSet(const mlir::tt::ttnn::CoreRangeSetAttr &coreRangeSetAttr) {
   return ::tt::tt_metal::CoreRangeSet(coreRangeSet);
 }
 
-::tt::tt_metal::CoreRangeSet
-getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+::tt::tt_metal::CoreRangeSet getCoreRangeSet(const TTNNLayoutAttr &layout) {
   std::set<::tt::tt_metal::CoreRange> coreRangeSet;
   assert(layout.getGrid().getMapping().isEmpty() == false);
   for (const auto &[loc, size] : ttcore::utils::toCoreRangeSet(
@@ -148,7 +144,7 @@ getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 }
 
 std::optional<::tt::tt_metal::ShardSpec>
-getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+getShardSpec(const TTNNLayoutAttr &layout) {
   if (layout.getIgnorePhysicalLayout()) {
     return std::nullopt;
   }
@@ -164,28 +160,26 @@ getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
                                    ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
 }
 
-::tt::tt_metal::ShardOrientation getShardOrientation(
-    const mlir::tt::ttnn::ShardOrientationAttr &shardOrientationAttr) {
+::tt::tt_metal::ShardOrientation
+getShardOrientation(const ShardOrientationAttr &shardOrientationAttr) {
   switch (shardOrientationAttr.getValue()) {
-  case mlir::tt::ttnn::ShardOrientation::RowMajor:
+  case ShardOrientation::RowMajor:
     return ::tt::tt_metal::ShardOrientation::ROW_MAJOR;
-  case mlir::tt::ttnn::ShardOrientation::ColMajor:
+  case ShardOrientation::ColMajor:
     return ::tt::tt_metal::ShardOrientation::COL_MAJOR;
   }
 }
 
-::tt::tt_metal::ShardMode
-getShardMode(const mlir::tt::ttnn::ShardModeAttr &shardModeAttr) {
+::tt::tt_metal::ShardMode getShardMode(const ShardModeAttr &shardModeAttr) {
   switch (shardModeAttr.getValue()) {
-  case mlir::tt::ttnn::ShardMode::Physical:
+  case ShardMode::Physical:
     return ::tt::tt_metal::ShardMode::PHYSICAL;
-  case mlir::tt::ttnn::ShardMode::Logical:
+  case ShardMode::Logical:
     return ::tt::tt_metal::ShardMode::LOGICAL;
   }
 }
 
-::tt::tt_metal::ShardSpec
-getShardSpec(const mlir::tt::ttnn::ShardSpecAttr &shardSpecAttr) {
+::tt::tt_metal::ShardSpec getShardSpec(const ShardSpecAttr &shardSpecAttr) {
   ::tt::tt_metal::CoreRangeSet coreRangeSet =
       getCoreRangeSet(shardSpecAttr.getCoreRangeSet());
   std::array<uint32_t, 2> shape =
@@ -196,79 +190,75 @@ getShardSpec(const mlir::tt::ttnn::ShardSpecAttr &shardSpecAttr) {
   return ::tt::tt_metal::ShardSpec(coreRangeSet, shape, orientation, mode);
 }
 
-::tt::tt_metal::BufferType
-getBufferType(const mlir::tt::ttnn::BufferType &bufferType) {
+::tt::tt_metal::BufferType getBufferType(const BufferType &bufferType) {
   switch (bufferType) {
-  case mlir::tt::ttnn::BufferType::DRAM:
+  case BufferType::DRAM:
     return ::tt::tt_metal::BufferType::DRAM;
-  case mlir::tt::ttnn::BufferType::L1:
+  case BufferType::L1:
     return ::tt::tt_metal::BufferType::L1;
-  case mlir::tt::ttnn::BufferType::SystemMemory:
+  case BufferType::SystemMemory:
     return ::tt::tt_metal::BufferType::SYSTEM_MEMORY;
-  case mlir::tt::ttnn::BufferType::L1Small:
+  case BufferType::L1Small:
     return ::tt::tt_metal::BufferType::L1_SMALL;
-  case mlir::tt::ttnn::BufferType::Trace:
+  case BufferType::Trace:
     return ::tt::tt_metal::BufferType::TRACE;
   }
 }
 
-::tt::tt_metal::BufferType
-getBufferType(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+::tt::tt_metal::BufferType getBufferType(const TTNNLayoutAttr &layout) {
   auto bufferType = layout.getBufferType();
   return getBufferType(bufferType);
 }
 
-mlir::tt::ttnn::BufferType
-getBufferType(const ::tt::tt_metal::BufferType bufferType) {
+BufferType getBufferType(const ::tt::tt_metal::BufferType bufferType) {
   switch (bufferType) {
   case ::tt::tt_metal::BufferType::DRAM:
-    return mlir::tt::ttnn::BufferType::DRAM;
+    return BufferType::DRAM;
   case ::tt::tt_metal::BufferType::L1:
-    return mlir::tt::ttnn::BufferType::L1;
+    return BufferType::L1;
   case ::tt::tt_metal::BufferType::SYSTEM_MEMORY:
-    return mlir::tt::ttnn::BufferType::SystemMemory;
+    return BufferType::SystemMemory;
   case ::tt::tt_metal::BufferType::L1_SMALL:
-    return mlir::tt::ttnn::BufferType::L1Small;
+    return BufferType::L1Small;
   case ::tt::tt_metal::BufferType::TRACE:
-    return mlir::tt::ttnn::BufferType::Trace;
+    return BufferType::Trace;
   }
 }
 
-::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
-    const mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout) {
+::tt::tt_metal::TensorMemoryLayout
+getTensorMemoryLayout(const TensorMemoryLayout tensorMemoryLayout) {
   switch (tensorMemoryLayout) {
-  case mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
+  case TensorMemoryLayout::Interleaved:
     return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
-  case mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
+  case TensorMemoryLayout::HeightSharded:
     return ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED;
-  case mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
+  case TensorMemoryLayout::WidthSharded:
     return ::tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED;
-  case mlir::tt::ttnn::TensorMemoryLayout::BlockSharded:
+  case TensorMemoryLayout::BlockSharded:
     return ::tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED;
   }
 }
-mlir::tt::ttnn::TensorMemoryLayout
+TensorMemoryLayout
 getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout) {
   switch (memLayout) {
   case ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED:
-    return mlir::tt::ttnn::TensorMemoryLayout::Interleaved;
+    return TensorMemoryLayout::Interleaved;
   case ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
-    return mlir::tt::ttnn::TensorMemoryLayout::HeightSharded;
+    return TensorMemoryLayout::HeightSharded;
   case ::tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
-    return mlir::tt::ttnn::TensorMemoryLayout::WidthSharded;
+    return TensorMemoryLayout::WidthSharded;
   case ::tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED:
-    return mlir::tt::ttnn::TensorMemoryLayout::BlockSharded;
+    return TensorMemoryLayout::BlockSharded;
   }
 }
 
-::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
-    const mlir::tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
+::tt::tt_metal::TensorMemoryLayout
+getTensorMemoryLayout(const TensorMemoryLayoutAttr memLayoutAttr) {
   auto tensorMemoryLayout = memLayoutAttr.getValue();
   return getTensorMemoryLayout(tensorMemoryLayout);
 }
 
-::tt::tt_metal::MemoryConfig
-getMemoryConfig(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+::tt::tt_metal::MemoryConfig getMemoryConfig(const TTNNLayoutAttr &layout) {
   auto tensorMemoryLayout = getTensorMemoryLayout(layout.getMemLayout());
   auto bufferType = getBufferType(layout);
 
@@ -278,7 +268,7 @@ getMemoryConfig(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 }
 
 ::tt::tt_metal::MemoryConfig
-getMemoryConfig(const mlir::tt::ttnn::MemoryConfigAttr &memConfigAttr) {
+getMemoryConfig(const MemoryConfigAttr &memConfigAttr) {
   // Get tensor memory layout if available, otherwise use INTERLEAVED as default
   ::tt::tt_metal::TensorMemoryLayout tensorMemoryLayout =
       ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
@@ -304,15 +294,14 @@ getMemoryConfig(const mlir::tt::ttnn::MemoryConfigAttr &memConfigAttr) {
                                       shardSpec);
 }
 
-::tt::tt_metal::TensorLayout
-getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+::tt::tt_metal::TensorLayout getTensorLayout(const TTNNLayoutAttr &layout) {
   return ::tt::tt_metal::TensorLayout(getDataType(layout.getDataType()),
                                       getPageLayout(layout),
                                       getMemoryConfig(layout));
 }
 
 ::ttnn::TensorSpec getTensorSpec(const ::llvm::ArrayRef<int64_t> shape,
-                                 const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+                                 const TTNNLayoutAttr &layout) {
   assert(!layout.getIgnorePhysicalLayout() &&
          "TensorSpecs cannot be created without physical layouts");
   return ::ttnn::TensorSpec(getShape(shape), getTensorLayout(layout));
@@ -351,8 +340,8 @@ convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec) {
   return ::ttsl::SmallVector<int>(vec.begin(), vec.end());
 }
 
-std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
-    const std::optional<mlir::tt::ttnn::Conv2dConfigAttr> &conv2dConfig) {
+std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>
+getConv2dConfig(const std::optional<Conv2dConfigAttr> &conv2dConfig) {
   if (!conv2dConfig) {
     return std::nullopt;
   }
@@ -441,29 +430,28 @@ std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
 
 // sgholamiTT: I was on the fence for publicly exposing this API. Right now
 // there's no clear usecase for it other than conversion from
-// mlir::tt::ttnn::MathFidelity to ::ttnn::MathFidelity. Therefore, I decided to
+// MathFidelity to ::ttnn::MathFidelity. Therefore, I decided to
 // not expose it for now. Subject to change in the future.
-MathFidelity getMathFidelity(mlir::tt::ttnn::MathFidelity mathFidelity) {
+::MathFidelity getMathFidelity(MathFidelity mathFidelity) {
   switch (mathFidelity) {
-  case mlir::tt::ttnn::MathFidelity::LoFi:
-    return MathFidelity::LoFi;
-  case mlir::tt::ttnn::MathFidelity::HiFi2:
-    return MathFidelity::HiFi2;
-  case mlir::tt::ttnn::MathFidelity::HiFi3:
-    return MathFidelity::HiFi3;
-  case mlir::tt::ttnn::MathFidelity::HiFi4:
-    return MathFidelity::HiFi4;
+  case MathFidelity::LoFi:
+    return ::MathFidelity::LoFi;
+  case MathFidelity::HiFi2:
+    return ::MathFidelity::HiFi2;
+  case MathFidelity::HiFi3:
+    return ::MathFidelity::HiFi3;
+  case MathFidelity::HiFi4:
+    return ::MathFidelity::HiFi4;
   }
 }
 
-std::optional<::ttnn::DeviceComputeKernelConfig> getDeviceComputeKernelConfig(
-    const std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-        &deviceComputeKernelConfig) {
+std::optional<::ttnn::DeviceComputeKernelConfig>
+getDeviceComputeKernelConfig(const std::optional<DeviceComputeKernelConfigAttr>
+                                 &deviceComputeKernelConfig) {
   if (!deviceComputeKernelConfig || !deviceComputeKernelConfig.has_value()) {
     return std::nullopt;
   }
-  mlir::tt::ttnn::DeviceComputeKernelConfigAttr devConfig =
-      deviceComputeKernelConfig.value();
+  DeviceComputeKernelConfigAttr devConfig = deviceComputeKernelConfig.value();
 
   // Note: Currently, we only support creating WormholeComputeKernelConfig.
   // If we need to support GrayskullComputeKernelConfig in the future, we
@@ -517,10 +505,9 @@ getLogicalGridShape(const ::tt::tt_metal::MemoryConfig &memoryConfig,
   return {gridPhyCores[0], gridPhyCores[1]};
 }
 
-mlir::tt::ttnn::TTNNLayoutAttr
-getLayoutAttrFromTensorSpec(MLIRContext *context,
-                            const ::ttnn::TensorSpec &tensorSpec,
-                            llvm::ArrayRef<int64_t> deviceGrid) {
+TTNNLayoutAttr getLayoutAttrFromTensorSpec(MLIRContext *context,
+                                           const ::ttnn::TensorSpec &tensorSpec,
+                                           llvm::ArrayRef<int64_t> deviceGrid) {
   llvm::SmallVector<int64_t> shape;
   if (tensorSpec.logical_shape().size() > 0) {
     shape = getShape(tensorSpec.logical_shape());
@@ -532,35 +519,34 @@ getLayoutAttrFromTensorSpec(MLIRContext *context,
 
   Type elementType;
   if (tensorSpec.layout() == ::tt::tt_metal::Layout::TILE) {
-    elementType = mlir::tt::ttcore::TileType::get(
-        context,
-        {tensorSpec.page_config().get_tile().get_height(),
-         tensorSpec.page_config().get_tile().get_width()},
-        getDataType(tensorSpec.data_type()));
+    elementType =
+        ttcore::TileType::get(context,
+                              {tensorSpec.page_config().get_tile().get_height(),
+                               tensorSpec.page_config().get_tile().get_width()},
+                              getDataType(tensorSpec.data_type()));
   } else {
     elementType =
         dataTypeToElementType(context, getDataType(tensorSpec.data_type()));
   }
 
-  mlir::tt::ttnn::BufferType bufferType =
+  BufferType bufferType =
       getBufferType(tensorSpec.memory_config().buffer_type());
-  auto memoryLayoutAttr = mlir::tt::ttnn::TensorMemoryLayoutAttr::get(
+  auto memoryLayoutAttr = TensorMemoryLayoutAttr::get(
       context,
       getTensorMemoryLayout(tensorSpec.memory_config().memory_layout()));
 
   ttcore::GridAttr gridAttr = ttcore::GridAttr::get(context);
   if (isL1BufferType(bufferType)) {
-    gridAttr = mlir::tt::ttcore::GridAttr::get(
+    gridAttr = ttcore::GridAttr::get(
         context, getLogicalGridShape(tensorSpec.memory_config(), deviceGrid),
-        ::mlir::tt::ttnn::optimizer_utils::
-            createSingleDeviceVirtualToPhysicalAffineMap(
-                context, memoryLayoutAttr.getValue(), deviceGrid));
+        optimizer_utils::createSingleDeviceVirtualToPhysicalAffineMap(
+            context, memoryLayoutAttr.getValue(), deviceGrid));
   }
 
-  return mlir::tt::ttnn::TTNNLayoutAttr::get(
-      context, shape, elementType, bufferType, gridAttr, memoryLayoutAttr);
+  return TTNNLayoutAttr::get(context, shape, elementType, bufferType, gridAttr,
+                             memoryLayoutAttr);
 }
 
 } // namespace conversion
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -8,7 +8,7 @@
 #include "Constants.h"
 #include "ttmlir/OpModel/TTNN/MetalHeaders.h"
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 // todo(arminaleTT): look into dynamically adjusting this
 // getOpRuntime() uses trace capture to run and measure the runtime of an op.
@@ -68,5 +68,5 @@ void SingletonDeviceContext::closeDevice() {
   }
 }
 
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -32,7 +32,7 @@
 
 #endif // TTMLIR_ENABLE_OPMODEL
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
 namespace operation {
@@ -152,7 +152,7 @@ namespace detail {
  * grid size.
  */
 void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
-               mlir::tt::ttcore::GridAttr workerGrid) {
+               ttcore::GridAttr workerGrid) {
   // metal CoreCoord holds x,y
   // GridAttr holds shape {y,x}
   if ((static_cast<size_t>(workerGrid.getShape()[1]) != computeGridSize.x) ||
@@ -172,8 +172,7 @@ void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
  */
 llvm::Expected<::ttnn::TensorSpec>
 convertToTensorSpec(::tt::tt_metal::distributed::MeshDevice *device,
-                    ::llvm::ArrayRef<int64_t> shape,
-                    ::mlir::tt::ttnn::TTNNLayoutAttr layout) {
+                    llvm::ArrayRef<int64_t> shape, TTNNLayoutAttr layout) {
   const ::ttnn::TensorSpec spec = conversion::getTensorSpec(shape, layout);
   if (conversion::validateTensorSpec(
           spec, device->compute_with_storage_grid_size())) {
@@ -189,7 +188,7 @@ convertToTensorSpec(::tt::tt_metal::distributed::MeshDevice *device,
  * may be a nullptr. Returns std::nullopt if layout is nullptr
  */
 std::optional<::tt::tt_metal::MemoryConfig>
-getNullableMemoryConfig(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
+getNullableMemoryConfig(TTNNLayoutAttr layout) {
   if (!layout) {
     return std::nullopt;
   }
@@ -201,7 +200,7 @@ getNullableMemoryConfig(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
  * may be a nullptr. Returns std::nullopt if layout is nullptr
  */
 std::optional<::tt::tt_metal::DataType>
-getNullableDataType(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
+getNullableDataType(TTNNLayoutAttr layout) {
   if (!layout) {
     return std::nullopt;
   }
@@ -210,55 +209,55 @@ getNullableDataType(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
 
 template <typename OpTy>
 auto getOpSymbol() {
-  if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::ReluOp>) {
+  if constexpr (std::is_same_v<OpTy, ReluOp>) {
     return ::ttnn::relu;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::SqrtOp>) {
+  } else if constexpr (std::is_same_v<OpTy, SqrtOp>) {
     return ::ttnn::sqrt;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::SinOp>) {
+  } else if constexpr (std::is_same_v<OpTy, SinOp>) {
     return ::ttnn::sin;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::CosOp>) {
+  } else if constexpr (std::is_same_v<OpTy, CosOp>) {
     return ::ttnn::cos;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::TanhOp>) {
+  } else if constexpr (std::is_same_v<OpTy, TanhOp>) {
     return ::ttnn::tanh;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LogOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LogOp>) {
     return ::ttnn::log;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::ReciprocalOp>) {
+  } else if constexpr (std::is_same_v<OpTy, ReciprocalOp>) {
     return ::ttnn::reciprocal;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::AddOp>) {
+  } else if constexpr (std::is_same_v<OpTy, AddOp>) {
     return ::ttnn::add;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::MultiplyOp>) {
+  } else if constexpr (std::is_same_v<OpTy, MultiplyOp>) {
     return ::ttnn::multiply;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::SubtractOp>) {
+  } else if constexpr (std::is_same_v<OpTy, SubtractOp>) {
     return ::ttnn::subtract;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::DivideOp>) {
+  } else if constexpr (std::is_same_v<OpTy, DivideOp>) {
     return ::ttnn::divide;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::EqualOp>) {
+  } else if constexpr (std::is_same_v<OpTy, EqualOp>) {
     return ::ttnn::eq;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::NotEqualOp>) {
+  } else if constexpr (std::is_same_v<OpTy, NotEqualOp>) {
     return ::ttnn::ne;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::GreaterEqualOp>) {
+  } else if constexpr (std::is_same_v<OpTy, GreaterEqualOp>) {
     return ::ttnn::ge;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::GreaterThanOp>) {
+  } else if constexpr (std::is_same_v<OpTy, GreaterThanOp>) {
     return ::ttnn::gt;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LessEqualOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LessEqualOp>) {
     return ::ttnn::le;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LessThanOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LessThanOp>) {
     return ::ttnn::lt;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LogicalAndOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LogicalAndOp>) {
     return ::ttnn::logical_and;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LogicalOrOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LogicalOrOp>) {
     return ::ttnn::logical_or;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::LogicalXorOp>) {
+  } else if constexpr (std::is_same_v<OpTy, LogicalXorOp>) {
     return ::ttnn::logical_xor;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::MaximumOp>) {
+  } else if constexpr (std::is_same_v<OpTy, MaximumOp>) {
     return ::ttnn::maximum;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::MinimumOp>) {
+  } else if constexpr (std::is_same_v<OpTy, MinimumOp>) {
     return ::ttnn::minimum;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::WhereOp>) {
+  } else if constexpr (std::is_same_v<OpTy, WhereOp>) {
     return ::ttnn::where;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::MeanOp>) {
+  } else if constexpr (std::is_same_v<OpTy, MeanOp>) {
     return ::ttnn::mean;
-  } else if constexpr (std::is_same_v<OpTy, mlir::tt::ttnn::SumOp>) {
+  } else if constexpr (std::is_same_v<OpTy, SumOp>) {
     return ::ttnn::sum;
   } else {
     static_assert(ttmlir::utils::always_false(),
@@ -270,8 +269,8 @@ auto getOpSymbol() {
 #endif // TTMLIR_ENABLE_OPMODEL
 
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr layout,
-                                 mlir::tt::ttcore::GridAttr maxGrid) {
+                                 TTNNLayoutAttr layout,
+                                 ttcore::GridAttr maxGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Conversion to TensorSpec may throw if the layout is invalid, in which case
   // we return false.
@@ -311,7 +310,7 @@ createHostBuffer(uint32_t numElements, ::tt::tt_metal::DataType dataType) {
 // Allocate a ttnn tensor with the given shape and data type.
 static ::tt::tt_metal::Tensor
 createMetalHostTensor(llvm::ArrayRef<int64_t> shape,
-                      ::mlir::tt::ttcore::DataType dataType) {
+                      ttcore::DataType dataType) {
   // Calculate total volume of the tensor
   uint32_t volume = 1;
   for (size_t i = 0; i < shape.size(); i++) {
@@ -335,18 +334,15 @@ createMetalHostTensor(llvm::ArrayRef<int64_t> shape,
 // and input memory config.
 static llvm::Expected<::ttnn::TensorSpec>
 getPrepareConv2dWeightsOpOutputTensorSpec(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout, uint32_t in_channels,
-    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
-    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig, bool hasBias,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig, bool hasBias,
     bool transpose) {
-  if (weightLayout.getBufferType() !=
-      mlir::tt::ttnn::BufferType::SystemMemory) {
+  if (weightLayout.getBufferType() != BufferType::SystemMemory) {
     llvm::report_fatal_error("Conv2d weight tensor assumed to be on host.");
   }
 
@@ -427,17 +423,15 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
 // Returns the output tensor spec of the prepared bias for a conv2d op.
 static llvm::Expected<::ttnn::TensorSpec>
 getPrepareConv2dBiasOpOutputTensorSpec(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> biasShape,
-    mlir::tt::ttnn::TTNNLayoutAttr biasLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout,
     ::tt::tt_metal::DataType weightsDtype, uint32_t in_channels,
     uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
     uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig) {
-  if (biasLayout.getBufferType() != mlir::tt::ttnn::BufferType::SystemMemory) {
+    std::optional<Conv2dConfigAttr> conv2dConfig) {
+  if (biasLayout.getBufferType() != BufferType::SystemMemory) {
     llvm::report_fatal_error("Conv2d bias tensor assumed to be on host.");
   }
 
@@ -502,15 +496,12 @@ getPrepareConv2dBiasOpOutputTensorSpec(
 
 #endif // TTMLIR_ENABLE_OPMODEL
 
-mlir::RankedTensorType
-getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op) {
+mlir::RankedTensorType getPreparedConv2dWeightsOutputTensor(Conv2dOp *op) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto input = op->getInput().getType();
   auto weight = op->getWeight().getType();
-  auto inputLayout =
-      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(input.getEncoding());
-  auto weightLayout =
-      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(weight.getEncoding());
+  auto inputLayout = mlir::cast<TTNNLayoutAttr>(input.getEncoding());
+  auto weightLayout = mlir::cast<TTNNLayoutAttr>(weight.getEncoding());
 
   llvm::Expected<::ttnn::TensorSpec> outputTensorSpec =
       getPrepareConv2dWeightsOpOutputTensorSpec(
@@ -547,8 +538,7 @@ getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op) {
 // Device
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<bool>
-Device::getDeviceConstraints(mlir::tt::ttcore::GridAttr workerGrid) {
+llvm::Expected<bool> Device::getDeviceConstraints(ttcore::GridAttr workerGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   try {
     detail::checkGrid(SingletonDeviceContext::getInstance()
@@ -569,9 +559,8 @@ Device::getDeviceConstraints(mlir::tt::ttcore::GridAttr workerGrid) {
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -598,10 +587,10 @@ llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
 }
 
 template <typename OpTy>
-llvm::Expected<size_t> UnaryEltwiseOpModel<OpTy>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t>
+UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                        TTNNLayoutAttr inputLayout,
+                                        TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -627,22 +616,20 @@ llvm::Expected<size_t> UnaryEltwiseOpModel<OpTy>::getOpRuntime(
 }
 
 // Explicit template instantiation for UnaryEltwiseOpModel.
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReluOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SqrtOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SinOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CosOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp>;
-template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp>;
+template struct UnaryEltwiseOpModel<ReluOp>;
+template struct UnaryEltwiseOpModel<SqrtOp>;
+template struct UnaryEltwiseOpModel<SinOp>;
+template struct UnaryEltwiseOpModel<CosOp>;
+template struct UnaryEltwiseOpModel<TanhOp>;
+template struct UnaryEltwiseOpModel<LogOp>;
+template struct UnaryEltwiseOpModel<ReciprocalOp>;
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::SigmoidOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -673,10 +660,10 @@ OpModel<mlir::tt::ttnn::SigmoidOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SigmoidOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t>
+OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                 TTNNLayoutAttr inputLayout,
+                                 TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -709,10 +696,9 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SigmoidOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ExpOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::ExpOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<ExpOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -741,10 +727,10 @@ llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::ExpOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ExpOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t>
+OpModel<ExpOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                             TTNNLayoutAttr inputLayout,
+                             TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -778,11 +764,9 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ExpOp>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -822,11 +806,9 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
 
 template <typename OpTy>
 llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -864,21 +846,21 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
 }
 
 // Explicit template instantiation for BinaryEltwiseOpModel.
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::AddOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::MultiplyOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::SubtractOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::MaximumOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::MinimumOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::DivideOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::EqualOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::NotEqualOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::GreaterEqualOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::GreaterThanOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LessEqualOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LessThanOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalAndOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalOrOp>;
-template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalXorOp>;
+template struct BinaryEltwiseOpModel<AddOp>;
+template struct BinaryEltwiseOpModel<MultiplyOp>;
+template struct BinaryEltwiseOpModel<SubtractOp>;
+template struct BinaryEltwiseOpModel<MaximumOp>;
+template struct BinaryEltwiseOpModel<MinimumOp>;
+template struct BinaryEltwiseOpModel<DivideOp>;
+template struct BinaryEltwiseOpModel<EqualOp>;
+template struct BinaryEltwiseOpModel<NotEqualOp>;
+template struct BinaryEltwiseOpModel<GreaterEqualOp>;
+template struct BinaryEltwiseOpModel<GreaterThanOp>;
+template struct BinaryEltwiseOpModel<LessEqualOp>;
+template struct BinaryEltwiseOpModel<LessThanOp>;
+template struct BinaryEltwiseOpModel<LogicalAndOp>;
+template struct BinaryEltwiseOpModel<LogicalOrOp>;
+template struct BinaryEltwiseOpModel<LogicalXorOp>;
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops
@@ -887,13 +869,10 @@ template struct BinaryEltwiseOpModel<mlir::tt::ttnn::LogicalXorOp>;
 template <typename OpTy>
 llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    llvm::ArrayRef<int64_t> inputShapeC,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutC,
-    llvm::ArrayRef<int64_t> outputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+    TTNNLayoutAttr inputLayoutB, llvm::ArrayRef<int64_t> inputShapeC,
+    TTNNLayoutAttr inputLayoutC, llvm::ArrayRef<int64_t> outputShape,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -938,14 +917,10 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
 
 template <typename OpTy>
 llvm::Expected<size_t> TernaryEltwiseOpModel<OpTy>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    llvm::ArrayRef<int64_t> inputShapeC,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutC,
-    llvm::ArrayRef<int64_t> outputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -988,7 +963,7 @@ llvm::Expected<size_t> TernaryEltwiseOpModel<OpTy>::getOpRuntime(
 }
 
 // Explicit template instantiation for TernaryEltwiseOpModel.
-template struct TernaryEltwiseOpModel<mlir::tt::ttnn::WhereOp>;
+template struct TernaryEltwiseOpModel<WhereOp>;
 
 //===----------------------------------------------------------------------===//
 // Reduction Ops
@@ -996,10 +971,9 @@ template struct TernaryEltwiseOpModel<mlir::tt::ttnn::WhereOp>;
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, std::optional<llvm::ArrayRef<int64_t>> dimArg,
+    bool keepDim, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1035,10 +1009,9 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
 
 template <typename OpTy>
 llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1072,17 +1045,15 @@ llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
 }
 
 // Explicit template instantiation for ReductionOpModel.
-template struct ReductionOpModel<mlir::tt::ttnn::MeanOp>;
-template struct ReductionOpModel<mlir::tt::ttnn::SumOp>;
+template struct ReductionOpModel<MeanOp>;
+template struct ReductionOpModel<SumOp>;
 
 //===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, const int dimArg, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1108,10 +1079,10 @@ OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t>
+OpModel<SoftmaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                 TTNNLayoutAttr inputLayout, const int dimArg,
+                                 TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1139,12 +1110,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ReshapeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ReshapeOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> outputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> outputShape,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1170,11 +1139,9 @@ OpModel<mlir::tt::ttnn::ReshapeOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ReshapeOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> outputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1202,12 +1169,11 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ReshapeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SliceOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::SliceOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
+llvm::Expected<OpConstraints> OpModel<SliceOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
     llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1243,11 +1209,10 @@ OpModel<mlir::tt::ttnn::SliceOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SliceOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
-    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<SliceOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1284,12 +1249,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SliceOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // TypecastOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::TypecastOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttcore::DataTypeAttr dtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1316,11 +1279,9 @@ OpModel<mlir::tt::ttnn::TypecastOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::TypecastOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttcore::DataTypeAttr dtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1349,12 +1310,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::TypecastOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, std::optional<ttcore::DataType> outputDtype,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1387,11 +1346,9 @@ OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<ToLayoutOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1427,12 +1384,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ToMemoryConfigOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::MemoryConfigAttr memoryConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, MemoryConfigAttr memoryConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1458,11 +1413,9 @@ OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::MemoryConfigAttr memoryConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<ToMemoryConfigOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    MemoryConfigAttr memoryConfig, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1490,12 +1443,11 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ConcatOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ConcatOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid,
+llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid,
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-    std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts, const int dim,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1527,10 +1479,10 @@ OpModel<mlir::tt::ttnn::ConcatOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ConcatOp>::getOpRuntime(
+llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-    std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts, const int dim,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1564,11 +1516,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ConcatOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1594,10 +1545,9 @@ OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1625,16 +1575,13 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::LinearOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+    TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-    bool transposeB) {
+    std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+    bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1679,15 +1626,12 @@ OpModel<mlir::tt::ttnn::LinearOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::LinearOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-    bool transposeB) {
+    std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+    bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1734,13 +1678,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::MatmulOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
     bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1779,13 +1720,10 @@ OpModel<mlir::tt::ttnn::MatmulOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::MatmulOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShapeA,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-    bool transposeB) {
+llvm::Expected<size_t> OpModel<MatmulOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1825,23 +1763,19 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::MatmulOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::Conv2dOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+    TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-    std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-        deviceComputeKernelConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
@@ -1912,22 +1846,18 @@ OpModel<mlir::tt::ttnn::Conv2dOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::Conv2dOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-    std::optional<mlir::tt::ttnn::DeviceComputeKernelConfigAttr>
-        deviceComputeKernelConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
 
   // Prepare weight tensor first.
@@ -1999,21 +1929,18 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::Conv2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ConvTranspose2dOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpConstraints(
+llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+    TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
-    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
@@ -2074,20 +2001,17 @@ OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
-    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::ttnn::TensorSpec> preparedWeightExp =
@@ -2149,14 +2073,13 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MaxPool2D
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, int32_t batchSize, int32_t inputHeight,
+    int32_t inputWidth, int32_t inputChannels,
     llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
     llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool ceilMode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    bool ceilMode, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2197,13 +2120,13 @@ OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool ceilMode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<MaxPool2dOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2245,11 +2168,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampScalar
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
-    llvm::APFloat max, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::APFloat min, llvm::APFloat max,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2280,10 +2202,9 @@ OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
-    llvm::APFloat max, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::APFloat min, llvm::APFloat max, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2316,12 +2237,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Permute
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::PermuteOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> permutation,
+    llvm::APFloat padValue, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2353,11 +2272,10 @@ OpModel<mlir::tt::ttnn::PermuteOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::PermuteOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2392,11 +2310,10 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::PermuteOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Upsample
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::UpsampleOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
-    llvm::StringRef mode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
+    llvm::StringRef mode, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2439,10 +2356,10 @@ OpModel<mlir::tt::ttnn::UpsampleOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::UpsampleOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
-    llvm::StringRef mode, mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<UpsampleOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute scaleFactor, llvm::StringRef mode,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2498,10 +2415,9 @@ struct EmbeddingOpArgs {
 llvm::Expected<EmbeddingOpArgs>
 getEmbeddingOpArgs(::tt::tt_metal::distributed::MeshDevice *device,
                    llvm::ArrayRef<int64_t> inputShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                   TTNNLayoutAttr inputLayout,
                    llvm::ArrayRef<int64_t> weightShape,
-                   mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+                   TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout) {
   auto inputSpecExp =
       detail::convertToTensorSpec(device, inputShape, inputLayout);
   if (!inputSpecExp) {
@@ -2530,13 +2446,10 @@ getEmbeddingOpArgs(::tt::tt_metal::distributed::MeshDevice *device,
 }
 #endif // TTMLIR_ENABLE_OPMODEL
 
-llvm::Expected<OpConstraints>
-OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> weightShape,
+    TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2571,12 +2484,10 @@ OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape,
-    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+llvm::Expected<size_t> OpModel<EmbeddingOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2610,4 +2521,4 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <tuple>
 
-namespace mlir::tt::op_model::ttnn {
+namespace mlir::tt::ttnn::op_model {
 
 class OpModelTest : public OpModelFixture {};
 
@@ -27,8 +27,8 @@ namespace detail {
 namespace {
 struct TestTensor {
   llvm::SmallVector<int64_t> shape;
-  mlir::tt::ttnn::TensorMemoryLayout layout;
-  mlir::tt::ttnn::BufferType bufferType;
+  TensorMemoryLayout layout;
+  BufferType bufferType;
   std::optional<llvm::SmallVector<int64_t>> virtualGrid = std::nullopt;
 };
 
@@ -42,24 +42,22 @@ struct ExpectedResult {
 
 const TestTensor interleavedN300X1024Dram = {
     {OpModelFixture::workerCoresN300, 1024},
-    mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-    mlir::tt::ttnn::BufferType::DRAM};
+    TensorMemoryLayout::Interleaved,
+    BufferType::DRAM};
 const TestTensor interleavedN300X1024L1 = {
     {OpModelFixture::workerCoresN300, 1024},
-    mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-    mlir::tt::ttnn::BufferType::L1};
+    TensorMemoryLayout::Interleaved,
+    BufferType::L1};
 
-const TestTensor interleaved2048X2048Dram = {
-    {2048, 2048},
-    mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-    mlir::tt::ttnn::BufferType::DRAM,
-    llvm::SmallVector<int64_t>{8, 8}};
+const TestTensor interleaved2048X2048Dram = {{2048, 2048},
+                                             TensorMemoryLayout::Interleaved,
+                                             BufferType::DRAM,
+                                             llvm::SmallVector<int64_t>{8, 8}};
 
-const TestTensor inerleaved2048X2048L1 = {
-    {2048, 2048},
-    mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-    mlir::tt::ttnn::BufferType::L1,
-    llvm::SmallVector<int64_t>{8, 8}};
+const TestTensor inerleaved2048X2048L1 = {{2048, 2048},
+                                          TensorMemoryLayout::Interleaved,
+                                          BufferType::L1,
+                                          llvm::SmallVector<int64_t>{8, 8}};
 } // namespace detail
 
 // ==== Unary Eltwise Ops Starts ====
@@ -80,12 +78,12 @@ protected:
     const auto [expectedLegal, expectedCbSize, expectedPeakSize,
                 expectedOutputSize] = std::get<2>(params);
 
-    const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+    const TTNNLayoutAttr inputLayout = CreateTiledLayout(
         inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
-    const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+    const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-    auto constraintsExp = op_model::ttnn::OpModel<OpTy>::getOpConstraints(
+    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
         CreateWorkerGrid(), inputShape, inputLayout, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
     // which llvm::Expected<T> does not have
@@ -102,8 +100,8 @@ protected:
       llvm::consumeError(constraintsExp.takeError());
     }
 
-    auto runtimeExp = op_model::ttnn::OpModel<OpTy>::getOpRuntime(
-        inputShape, inputLayout, outputLayout);
+    auto runtimeExp =
+        OpModel<OpTy>::getOpRuntime(inputShape, inputLayout, outputLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
     if (expectedLegal) {
       EXPECT_TRUE(runtimeExp.get() > 0);
@@ -114,16 +112,15 @@ protected:
 };
 
 // Type aliases for unary operations
-using OpModelReluParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::ReluOp>;
-using OpModelSqrtParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::SqrtOp>;
-using OpModelSigmoidParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::SigmoidOp>;
-using OpModelSinParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::SinOp>;
-using OpModelCosParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::CosOp>;
-using OpModelExpParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::ExpOp>;
-using OpModelTanhParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::TanhOp>;
-using OpModelLogParam = OpModelUnaryEltwiseParam<mlir::tt::ttnn::LogOp>;
-using OpModelReciprocalParam =
-    OpModelUnaryEltwiseParam<mlir::tt::ttnn::ReciprocalOp>;
+using OpModelReluParam = OpModelUnaryEltwiseParam<ReluOp>;
+using OpModelSqrtParam = OpModelUnaryEltwiseParam<SqrtOp>;
+using OpModelSigmoidParam = OpModelUnaryEltwiseParam<SigmoidOp>;
+using OpModelSinParam = OpModelUnaryEltwiseParam<SinOp>;
+using OpModelCosParam = OpModelUnaryEltwiseParam<CosOp>;
+using OpModelExpParam = OpModelUnaryEltwiseParam<ExpOp>;
+using OpModelTanhParam = OpModelUnaryEltwiseParam<TanhOp>;
+using OpModelLogParam = OpModelUnaryEltwiseParam<LogOp>;
+using OpModelReciprocalParam = OpModelUnaryEltwiseParam<ReciprocalOp>;
 
 TEST_P(OpModelReluParam, ReluOp) { RunTest(); }
 TEST_P(OpModelSqrtParam, SqrtOp) { RunTest(); }
@@ -151,33 +148,29 @@ const std::initializer_list<
                         detail::interleavedN300X1024L1,
                         detail::ExpectedResult{true, 8192, 2048, 2048}),
         std::make_tuple(
-            detail::TestTensor{
-                {14 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1},
-            detail::TestTensor{
-                {14 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
             detail::ExpectedResult{true, 0, 14 * 32 * 32 * 2,
                                    14 * 32 * 32 * 2}),
         std::make_tuple(
             detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            detail::TestTensor{
-                {14 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1},
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
             detail::ExpectedResult{false}),
         std::make_tuple(
-            detail::TestTensor{
-                {14 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1},
             detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::L1},
             detail::ExpectedResult{false})};
 
 INSTANTIATE_TEST_SUITE_P(ReluTests, OpModelReluParam,
@@ -231,12 +224,12 @@ protected:
     const auto [expectedLegal, expectedCbSize, expectedPeakSize,
                 expectedOutputSize] = std::get<4>(params);
 
-    const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+    const TTNNLayoutAttr inputLayout = CreateTiledLayout(
         inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
-    const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+    const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-    auto constraintsExp = op_model::ttnn::OpModel<OpTy>::getOpConstraints(
+    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
         CreateWorkerGrid(), inputShape, inputLayout, dimArg, keepDim,
         outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
@@ -253,7 +246,7 @@ protected:
       llvm::consumeError(constraintsExp.takeError());
     }
 
-    auto runtimeExp = op_model::ttnn::OpModel<OpTy>::getOpRuntime(
+    auto runtimeExp = OpModel<OpTy>::getOpRuntime(
         inputShape, inputLayout, dimArg, keepDim, outputLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
     if (expectedLegal) {
@@ -265,8 +258,8 @@ protected:
 };
 
 // Type aliases for reduction operations
-using OpModelSumParam = OpModelReductionParam<mlir::tt::ttnn::SumOp>;
-using OpModelMeanParam = OpModelReductionParam<mlir::tt::ttnn::MeanOp>;
+using OpModelSumParam = OpModelReductionParam<SumOp>;
+using OpModelMeanParam = OpModelReductionParam<MeanOp>;
 
 TEST_P(OpModelSumParam, SumOp) { RunTest(); }
 TEST_P(OpModelMeanParam, MeanOp) { RunTest(); }
@@ -301,20 +294,16 @@ INSTANTIATE_TEST_SUITE_P(MeanTests, OpModelMeanParam, reductionParams);
 TEST_F(OpModelTest, SoftmaxInterleaved) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayout_dram = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayout_l1 = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_dram, -1,
-          inputLayout_dram);
+  auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cb_size, peak_size, output_size, outputLayoutReadBack] =
       constraintsExp.get();
@@ -322,55 +311,46 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   EXPECT_EQ(output_size, 0);
   EXPECT_EQ(peak_size, 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_dram, -1,
-          inputLayout_l1);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 137216);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 2048);
   EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_l1, -1,
-          inputLayout_dram);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_l1, -1, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 137216);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_l1, -1, inputLayout_l1);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_l1, -1, inputLayout_l1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 137216);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 2048);
   EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_dram, -1,
-          inputLayout_dram);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_dram, -1, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 137216);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  std::vector<std::tuple<mlir::tt::ttnn::TTNNLayoutAttr,
-                         mlir::tt::ttnn::TTNNLayoutAttr>>
-      layout_combinations = {{inputLayout_dram, inputLayout_dram},
-                             {inputLayout_l1, inputLayout_dram},
-                             {inputLayout_dram, inputLayout_l1},
-                             {inputLayout_l1, inputLayout_l1}};
+  std::vector<std::tuple<TTNNLayoutAttr, TTNNLayoutAttr>> layout_combinations =
+      {{inputLayout_dram, inputLayout_dram},
+       {inputLayout_l1, inputLayout_dram},
+       {inputLayout_dram, inputLayout_l1},
+       {inputLayout_l1, inputLayout_l1}};
   for (const auto &[input_layout, output_layout] : layout_combinations) {
-    auto runtimeExp =
-        op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpRuntime(
-            tensorShape, input_layout, -1, output_layout);
+    auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
+        tensorShape, input_layout, -1, output_layout);
     EXPECT_TRUE(static_cast<bool>(runtimeExp));
     EXPECT_TRUE(runtimeExp.get() > 0);
   }
@@ -379,42 +359,37 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
 TEST_F(OpModelTest, Reshape) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1 = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAM,
-          {workerCoresN300 * 4, 256}, layoutDRAM);
+  auto constraintsExp = OpModel<ReshapeOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, {workerCoresN300 * 4, 256},
+      layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 5120);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpRuntime(
-          tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutDRAM);
+  auto runtimeExp = OpModel<ReshapeOp>::getOpRuntime(
+      tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAM,
-          {workerCoresN300 * 4, 256}, layoutL1);
+  constraintsExp = OpModel<ReshapeOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, {workerCoresN300 * 4, 256},
+      layoutL1);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 5120);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 2048);
   EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
 
-  runtimeExp = op_model::ttnn::OpModel<mlir::tt::ttnn::ReshapeOp>::getOpRuntime(
+  runtimeExp = OpModel<ReshapeOp>::getOpRuntime(
       tensorShape, layoutDRAM, {workerCoresN300 * 4, 256}, layoutL1);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
@@ -424,9 +399,8 @@ TEST_F(OpModelTest, Slice) {
   const llvm::SmallVector<int64_t> inputTensorShape = {1, 56, 56, 96};
   const llvm::SmallVector<int64_t> outputTensorShape = {1, 28, 56, 95};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
-      CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
+      inputTensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
   llvm::SmallVector<int64_t> begins = {0, 0, 0, 0};
   llvm::SmallVector<int64_t> ends = {1, 56, 56, 95};
   llvm::SmallVector<int64_t> step = {1, 2, 1, 1};
@@ -434,19 +408,17 @@ TEST_F(OpModelTest, Slice) {
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SliceOp>::getOpConstraints(
-          CreateWorkerGrid(), inputTensorShape, layoutDRAM, begins, ends, step,
-          layoutDRAM);
+  auto constraintsExp = OpModel<SliceOp>::getOpConstraints(
+      CreateWorkerGrid(), inputTensorShape, layoutDRAM, begins, ends, step,
+      layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SliceOp>::getOpRuntime(
-          inputTensorShape, layoutDRAM, begins, ends, step, layoutDRAM);
+  auto runtimeExp = OpModel<SliceOp>::getOpRuntime(
+      inputTensorShape, layoutDRAM, begins, ends, step, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -454,22 +426,18 @@ TEST_F(OpModelTest, Slice) {
 TEST_F(OpModelTest, ToLayout) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAMTiled =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAMRowMajor =
-      CreateRowMajorLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1RowMajorHS =
-      CreateRowMajorLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                           mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
+  const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutDRAMRowMajor = CreateRowMajorLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1RowMajorHS = CreateRowMajorLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-          layoutDRAMRowMajor);
+  auto constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
+      layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
@@ -477,29 +445,25 @@ TEST_F(OpModelTest, ToLayout) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime(
-          tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
+  auto runtimeExp = OpModel<ToLayoutOp>::getOpRuntime(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-          layoutL1RowMajorHS);
+  constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
+      layoutL1RowMajorHS);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime(
-          tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS);
+  runtimeExp = OpModel<ToLayoutOp>::getOpRuntime(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-          layoutDRAMRowMajor);
+  constraintsExp = OpModel<ToLayoutOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
+      layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
@@ -507,9 +471,8 @@ TEST_F(OpModelTest, ToLayout) {
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
 
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToLayoutOp>::getOpRuntime(
-          tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
+  runtimeExp = OpModel<ToLayoutOp>::getOpRuntime(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -520,98 +483,77 @@ TEST_F(OpModelTest, ToMemoryConfig) {
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutL1Tiled =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayoutDRAMTiled =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  mlir::tt::ttnn::MemoryConfigAttr memoryConfig =
-      mlir::tt::ttnn::MemoryConfigAttr::get(
-          &context, outputLayoutDRAMTiled.getMemLayout(),
-          mlir::tt::ttnn::BufferTypeAttr::get(
-              &context, outputLayoutDRAMTiled.getBufferType()),
-          std::nullopt /*shardSpec*/);
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::
-          getOpConstraints(CreateWorkerGrid(), tensorShape, inputLayoutL1Tiled,
-                           memoryConfig, outputLayoutDRAMTiled);
+  const TTNNLayoutAttr inputLayoutL1Tiled = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outputLayoutDRAMTiled = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  MemoryConfigAttr memoryConfig = MemoryConfigAttr::get(
+      &context, outputLayoutDRAMTiled.getMemLayout(),
+      BufferTypeAttr::get(&context, outputLayoutDRAMTiled.getBufferType()),
+      std::nullopt /*shardSpec*/);
+  auto constraintsExp = OpModel<ToMemoryConfigOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayoutL1Tiled, memoryConfig,
+      outputLayoutDRAMTiled);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_GT(opCstr.cbL1PeakSize, 0);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpRuntime(
-          tensorShape, inputLayoutL1Tiled, memoryConfig, outputLayoutDRAMTiled);
+  auto runtimeExp = OpModel<ToMemoryConfigOp>::getOpRuntime(
+      tensorShape, inputLayoutL1Tiled, memoryConfig, outputLayoutDRAMTiled);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  auto coreRangeSetAttr = ::mlir::tt::ttnn::CoreRangeSetAttr::get(
-      &context,
-      ::llvm::ArrayRef<mlir::tt::ttnn::CoreRangeAttr>{
-          ::mlir::tt::ttnn::CoreRangeAttr::get(
-              &context, ::mlir::tt::ttnn::CoreCoordAttr::get(&context, 0, 0),
-              ::mlir::tt::ttnn::CoreCoordAttr::get(&context, 7, 0))});
-  mlir::tt::ttnn::ShardSpecAttr shardSpec = mlir::tt::ttnn::ShardSpecAttr::get(
-      &context, coreRangeSetAttr,
-      ::mlir::tt::ttnn::ShapeAttr::get(&context, {64, 128}),
-      ::mlir::tt::ttnn::ShardOrientationAttr::get(
-          &context, ::mlir::tt::ttnn::ShardOrientation::RowMajor),
-      ::mlir::tt::ttnn::ShardModeAttr::get(
-          &context, ::mlir::tt::ttnn::ShardMode::Physical),
+  auto coreRangeSetAttr = CoreRangeSetAttr::get(
+      &context, llvm::ArrayRef<CoreRangeAttr>{CoreRangeAttr::get(
+                    &context, CoreCoordAttr::get(&context, 0, 0),
+                    CoreCoordAttr::get(&context, 7, 0))});
+  ShardSpecAttr shardSpec = ShardSpecAttr::get(
+      &context, coreRangeSetAttr, ShapeAttr::get(&context, {64, 128}),
+      ShardOrientationAttr::get(&context, ShardOrientation::RowMajor),
+      ShardModeAttr::get(&context, ShardMode::Physical),
       /*physical_shard_shape=*/nullptr);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayoutL1Tiled =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
-  memoryConfig = mlir::tt::ttnn::MemoryConfigAttr::get(
+  const TTNNLayoutAttr outputLayoutL1Tiled = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
+  memoryConfig = MemoryConfigAttr::get(
       &context, outputLayoutL1Tiled.getMemLayout(),
-      mlir::tt::ttnn::BufferTypeAttr::get(&context,
-                                          outputLayoutL1Tiled.getBufferType()),
+      BufferTypeAttr::get(&context, outputLayoutL1Tiled.getBufferType()),
       shardSpec);
-  constraintsExp = op_model::ttnn::OpModel<
-      mlir::tt::ttnn::ToMemoryConfigOp>::getOpConstraints(CreateWorkerGrid(),
-                                                          tensorShape,
-                                                          inputLayoutL1Tiled,
-                                                          memoryConfig,
-                                                          outputLayoutL1Tiled);
+  constraintsExp = OpModel<ToMemoryConfigOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayoutL1Tiled, memoryConfig,
+      outputLayoutL1Tiled);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 8192);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 16384);
   EXPECT_EQ(opCstr.outputL1BufferSize, 16384);
 
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ToMemoryConfigOp>::getOpRuntime(
-          tensorShape, inputLayoutL1Tiled, memoryConfig, outputLayoutL1Tiled);
+  runtimeExp = OpModel<ToMemoryConfigOp>::getOpRuntime(
+      tensorShape, inputLayoutL1Tiled, memoryConfig, outputLayoutL1Tiled);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
 
 TEST_F(OpModelTest, Concat) {
   const llvm::SmallVector<int64_t> inputTensorShape = {workerCoresN300, 1024};
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
-      CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1Interleaved =
-      CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
+      inputTensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
+      inputTensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConcatOp>::getOpConstraints(
-          CreateWorkerGrid(), {inputTensorShape, inputTensorShape},
-          {layoutL1Interleaved, layoutL1Interleaved}, 0, layoutDRAM);
+  auto constraintsExp = OpModel<ConcatOp>::getOpConstraints(
+      CreateWorkerGrid(), {inputTensorShape, inputTensorShape},
+      {layoutL1Interleaved, layoutL1Interleaved}, 0, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 4096);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConcatOp>::getOpRuntime(
-          {inputTensorShape, inputTensorShape},
-          {layoutL1Interleaved, layoutL1Interleaved}, 0, layoutDRAM);
+  auto runtimeExp = OpModel<ConcatOp>::getOpRuntime(
+      {inputTensorShape, inputTensorShape},
+      {layoutL1Interleaved, layoutL1Interleaved}, 0, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -619,60 +561,50 @@ TEST_F(OpModelTest, Concat) {
 TEST_F(OpModelTest, Transpose) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1Interleaved =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1WSharded =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::WidthSharded);
+  const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
 
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1, layoutDRAM);
+  auto constraintsExp = OpModel<TransposeOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 8192);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime(
-          tensorShape, layoutDRAM, 0, 1, layoutDRAM);
+  auto runtimeExp = OpModel<TransposeOp>::getOpRuntime(tensorShape, layoutDRAM,
+                                                       0, 1, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1,
-          layoutL1Interleaved);
+  constraintsExp = OpModel<TransposeOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, 1, layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 8192);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 2048);
   EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
 
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime(
-          tensorShape, layoutDRAM, 0, 1, layoutL1Interleaved);
+  runtimeExp = OpModel<TransposeOp>::getOpRuntime(tensorShape, layoutDRAM, 0, 1,
+                                                  layoutL1Interleaved);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, 1,
-          layoutL1WSharded);
+  constraintsExp = OpModel<TransposeOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, 1,
+      layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TransposeOp>::getOpRuntime(
-          tensorShape, layoutL1Interleaved, 0, 1, layoutL1WSharded);
+  runtimeExp = OpModel<TransposeOp>::getOpRuntime(
+      tensorShape, layoutL1Interleaved, 0, 1, layoutL1WSharded);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 }
@@ -681,49 +613,41 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_hs =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_i =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayout_l1_hs = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
+  const TTNNLayoutAttr inputLayout_l1_i = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2,
-          inputLayout_l1_hs);
+  auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2,
+      inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 24576);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 32768);
   EXPECT_EQ(opCstr.outputL1BufferSize, 32768);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2,
-          inputLayout_l1_i);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_l1_hs, -2, inputLayout_l1_i);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 24576);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 32768);
   EXPECT_EQ(opCstr.outputL1BufferSize, 32768);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayout_l1_i, -2,
-          inputLayout_l1_hs);
+  constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayout_l1_i, -2, inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 24576);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 32768);
   EXPECT_EQ(opCstr.outputL1BufferSize, 32768);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::SoftmaxOp>::getOpRuntime(
-          tensorShape, inputLayout_l1_i, -2, inputLayout_l1_hs);
+  auto runtimeExp = OpModel<SoftmaxOp>::getOpRuntime(
+      tensorShape, inputLayout_l1_i, -2, inputLayout_l1_hs);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
@@ -732,50 +656,43 @@ TEST_F(OpModelTest, Typecast) {
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutDRAMIBF16 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutL1HSBF16 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutDRAMIF32 = CreateTiledLayout(
-      tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-      mlir::tt::ttnn::TensorMemoryLayout::Interleaved, std::nullopt,
-      GetPhysicalGridSize(), builder.getF32Type());
+  const TTNNLayoutAttr inputLayoutDRAMIBF16 = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayoutL1HSBF16 = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::HeightSharded);
+  const TTNNLayoutAttr inputLayoutDRAMIF32 = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      std::nullopt, GetPhysicalGridSize(), builder.getF32Type());
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
-          ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
-          inputLayoutDRAMIF32);
+  auto constraintsExp = OpModel<TypecastOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      inputLayoutDRAMIF32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 12288);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpRuntime(
-          tensorShape, inputLayoutDRAMIBF16,
-          ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
-          inputLayoutDRAMIF32);
+  auto runtimeExp = OpModel<TypecastOp>::getOpRuntime(
+      tensorShape, inputLayoutDRAMIBF16,
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      inputLayoutDRAMIF32);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
-  constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpConstraints(
-          CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
-          ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
-          inputLayoutL1HSBF16);
+  constraintsExp = OpModel<TypecastOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      inputLayoutL1HSBF16);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
-  runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::TypecastOp>::getOpRuntime(
-          tensorShape, inputLayoutDRAMIBF16,
-          ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
-          inputLayoutL1HSBF16);
+  runtimeExp = OpModel<TypecastOp>::getOpRuntime(
+      tensorShape, inputLayoutDRAMIBF16,
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      inputLayoutL1HSBF16);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 }
@@ -803,14 +720,14 @@ protected:
     const auto [expectedLegal, expectedCbSize, expectedPeakSize,
                 expectedOutputSize] = GetParam().expectedResult;
 
-    const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+    const TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
         inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
-    const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+    const TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
         inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
-    const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+    const TTNNLayoutAttr outputLayout = CreateTiledLayout(
         outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-    auto constraintsExp = op_model::ttnn::OpModel<OpTy>::getOpConstraints(
+    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
         CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
         inputLayoutB, outputLayout);
     // Manually cast to bool because EXPECT_TRUE requires a const bool operator
@@ -828,9 +745,8 @@ protected:
       llvm::consumeError(constraintsExp.takeError());
     }
 
-    llvm::Expected<size_t> runtimeExp =
-        op_model::ttnn::OpModel<OpTy>::getOpRuntime(
-            inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout);
+    llvm::Expected<size_t> runtimeExp = OpModel<OpTy>::getOpRuntime(
+        inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
     if (expectedLegal) {
       EXPECT_TRUE(runtimeExp.get() > 0);
@@ -841,33 +757,21 @@ protected:
 };
 
 // Type aliases for binary operations
-using OpModelAddParam = OpModelBinaryEltwiseParam<mlir::tt::ttnn::AddOp>;
-using OpModelMultiplyParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::MultiplyOp>;
-using OpModelSubtractParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::SubtractOp>;
-using OpModelMaximumParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::MaximumOp>;
-using OpModelMinimumParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::MinimumOp>;
-using OpModelDivideParam = OpModelBinaryEltwiseParam<mlir::tt::ttnn::DivideOp>;
-using OpModelEqualParam = OpModelBinaryEltwiseParam<mlir::tt::ttnn::EqualOp>;
-using OpModelNotEqualParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::NotEqualOp>;
-using OpModelGreaterEqualParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::GreaterEqualOp>;
-using OpModelGreaterThanParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::GreaterThanOp>;
-using OpModelLessEqualParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::LessEqualOp>;
-using OpModelLessThanParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::LessThanOp>;
-using OpModelLogicalAndParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::LogicalAndOp>;
-using OpModelLogicalOrParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::LogicalOrOp>;
-using OpModelLogicalXorParam =
-    OpModelBinaryEltwiseParam<mlir::tt::ttnn::LogicalXorOp>;
+using OpModelAddParam = OpModelBinaryEltwiseParam<AddOp>;
+using OpModelMultiplyParam = OpModelBinaryEltwiseParam<MultiplyOp>;
+using OpModelSubtractParam = OpModelBinaryEltwiseParam<SubtractOp>;
+using OpModelMaximumParam = OpModelBinaryEltwiseParam<MaximumOp>;
+using OpModelMinimumParam = OpModelBinaryEltwiseParam<MinimumOp>;
+using OpModelDivideParam = OpModelBinaryEltwiseParam<DivideOp>;
+using OpModelEqualParam = OpModelBinaryEltwiseParam<EqualOp>;
+using OpModelNotEqualParam = OpModelBinaryEltwiseParam<NotEqualOp>;
+using OpModelGreaterEqualParam = OpModelBinaryEltwiseParam<GreaterEqualOp>;
+using OpModelGreaterThanParam = OpModelBinaryEltwiseParam<GreaterThanOp>;
+using OpModelLessEqualParam = OpModelBinaryEltwiseParam<LessEqualOp>;
+using OpModelLessThanParam = OpModelBinaryEltwiseParam<LessThanOp>;
+using OpModelLogicalAndParam = OpModelBinaryEltwiseParam<LogicalAndOp>;
+using OpModelLogicalOrParam = OpModelBinaryEltwiseParam<LogicalOrOp>;
+using OpModelLogicalXorParam = OpModelBinaryEltwiseParam<LogicalXorOp>;
 
 TEST_P(OpModelAddParam, AddOp) { RunTest(); }
 TEST_P(OpModelMultiplyParam, MultiplyOp) { RunTest(); }
@@ -915,37 +819,37 @@ const std::initializer_list<BinaryEltwiseParam> binaryEltwiseParams = {
      detail::interleavedN300X1024L1,
      detail::ExpectedResult{true, 12288, 2048, 2048}},
     {detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                        mlir::tt::ttnn::BufferType::L1,
+                        TensorMemoryLayout::HeightSharded,
+                        BufferType::L1,
                         llvm::SmallVector<int64_t>{8, 1}},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                        mlir::tt::ttnn::BufferType::DRAM},
+                        TensorMemoryLayout::Interleaved,
+                        BufferType::DRAM},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                        mlir::tt::ttnn::BufferType::L1,
+                        TensorMemoryLayout::HeightSharded,
+                        BufferType::L1,
                         llvm::SmallVector<int64_t>{8, 1}},
      detail::ExpectedResult{true, 4096, 262144, 262144}},
     {detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                        mlir::tt::ttnn::BufferType::L1,
+                        TensorMemoryLayout::HeightSharded,
+                        BufferType::L1,
                         llvm::SmallVector<int64_t>{8, 1}},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                        mlir::tt::ttnn::BufferType::DRAM},
+                        TensorMemoryLayout::Interleaved,
+                        BufferType::DRAM},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                        mlir::tt::ttnn::BufferType::DRAM},
+                        TensorMemoryLayout::Interleaved,
+                        BufferType::DRAM},
      detail::ExpectedResult{true, 8192, 0, 0}},
     {detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                        mlir::tt::ttnn::BufferType::DRAM},
+                        TensorMemoryLayout::Interleaved,
+                        BufferType::DRAM},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                        mlir::tt::ttnn::BufferType::DRAM},
+                        TensorMemoryLayout::Interleaved,
+                        BufferType::DRAM},
      detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                        mlir::tt::ttnn::BufferType::L1,
+                        TensorMemoryLayout::HeightSharded,
+                        BufferType::L1,
                         llvm::SmallVector<int64_t>{8, 1}},
      detail::ExpectedResult{true, 8192, 262144, 262144}}};
 
@@ -1037,19 +941,18 @@ TEST_P(OpModelLinearParam, LinearParam) {
   const auto [expectedLegal, expectedCbSize, expectedPeakSize,
               expectedOutputSize] = std::get<5>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
       inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
       inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
-  const mlir::tt::ttnn::TTNNLayoutAttr biasLayout = CreateTiledLayout(
+  const TTNNLayoutAttr biasLayout = CreateTiledLayout(
       biasShape, biasBufferType, biasTensorLayout, biasVirtualGrid);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LinearOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
-          inputLayoutB, biasShape, biasLayout, outputLayout, false, false);
+  auto constraintsExp = OpModel<LinearOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
+      biasShape, biasLayout, outputLayout, false, false);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
@@ -1065,17 +968,16 @@ TEST_P(OpModelLinearParam, LinearParam) {
     llvm::consumeError(constraintsExp.takeError());
   }
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LinearOp>::getOpRuntime(
-          inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
-          biasLayout, outputLayout, false, false);
+  auto runtimeExp = OpModel<LinearOp>::getOpRuntime(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
+      biasLayout, outputLayout, false, false);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (expectedLegal) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
     llvm::consumeError(runtimeExp.takeError());
   }
-  mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
+  SingletonDeviceContext::resetInstance();
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1133,139 +1035,131 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     LinearShardedTests, OpModelLinearParam,
     ::testing::Values(
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 430144, 229376, 114688}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 544832, 0, 0}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{
-                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 430144, 229376, 114688}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{false}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{false}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 544832, 0, 0}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                            TensorMemoryLayout::HeightSharded, BufferType::L1,
+                            llvm::SmallVector<int64_t>{56, 1}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{false}),
         std::make_tuple(
             detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-                               mlir::tt::ttnn::BufferType::L1,
+                               TensorMemoryLayout::WidthSharded, BufferType::L1,
                                llvm::SmallVector<int64_t>{1, 56}},
             detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::DRAM,
                                llvm::SmallVector<int64_t>{7, 8}},
             detail::TestTensor{{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::DRAM,
                                llvm::SmallVector<int64_t>{7, 8}},
             detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-                               mlir::tt::ttnn::BufferType::L1,
+                               TensorMemoryLayout::WidthSharded, BufferType::L1,
                                llvm::SmallVector<int64_t>{1, 56}},
             llvm::SmallVector<int64_t>{7, 8},
             detail::ExpectedResult{true, 8256, 4096, 2048}),
-        std::make_tuple(
-            detail::TestTensor{
-                {56 * 32, 1 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{
-                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 114688, 229376, 114688})));
+        std::make_tuple(detail::TestTensor{{56 * 32, 1 * 32},
+                                           TensorMemoryLayout::HeightSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{56, 1}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                            TensorMemoryLayout::Interleaved, BufferType::DRAM,
+                            llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                            TensorMemoryLayout::HeightSharded, BufferType::L1,
+                            llvm::SmallVector<int64_t>{56, 1}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 114688, 229376, 114688})));
 
 class OpModelMatmulParam
     : public OpModelTest,
@@ -1288,17 +1182,16 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
   const auto [expectedLegal, expectedCbSize, expectedPeakSize,
               expectedOutputSize] = std::get<4>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
       inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
       inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MatmulOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
-          inputLayoutB, outputLayout, false, false);
+  auto constraintsExp = OpModel<MatmulOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
+      outputLayout, false, false);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
@@ -1315,9 +1208,8 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
   }
 
   auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MatmulOp>::getOpRuntime(
-          inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout,
-          false, false);
+      OpModel<MatmulOp>::getOpRuntime(inputShapeA, inputLayoutA, inputShapeB,
+                                      inputLayoutB, outputLayout, false, false);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (expectedLegal) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -1373,113 +1265,105 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     MatmulShardedTests, OpModelMatmulParam,
     ::testing::Values(
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 430144, 114688, 114688}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 262144, 401408,
-                                   401408}), // matmul bug shards to less cores
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 544832, 0, 0}),
-        std::make_tuple(
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-                               mlir::tt::ttnn::BufferType::L1,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{
-                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 430144, 114688, 114688}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{false}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{
+                            true, 262144, 401408,
+                            401408}), // matmul bug shards to less cores
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 544832, 0, 0}),
+        std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::BlockSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                            TensorMemoryLayout::HeightSharded, BufferType::L1,
+                            llvm::SmallVector<int64_t>{56, 1}},
+                        detail::TestTensor{{56 * 32, 56 * 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM,
+                                           llvm::SmallVector<int64_t>{7, 8}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{false}),
         std::make_tuple(
             detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-                               mlir::tt::ttnn::BufferType::L1,
+                               TensorMemoryLayout::WidthSharded, BufferType::L1,
                                llvm::SmallVector<int64_t>{1, 56}},
             detail::TestTensor{{56 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::DRAM,
                                llvm::SmallVector<int64_t>{7, 8}},
             detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-                               mlir::tt::ttnn::BufferType::L1,
+                               TensorMemoryLayout::WidthSharded, BufferType::L1,
                                llvm::SmallVector<int64_t>{1, 56}},
             llvm::SmallVector<int64_t>{7, 8},
             detail::ExpectedResult{true, 8256, 2048, 2048}),
-        std::make_tuple(
-            detail::TestTensor{
-                {56 * 32, 1 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM,
-                               llvm::SmallVector<int64_t>{7, 8}},
-            detail::TestTensor{
-                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{56, 1}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{true, 114688, 114688, 114688})));
+        std::make_tuple(detail::TestTensor{{56 * 32, 1 * 32},
+                                           TensorMemoryLayout::HeightSharded,
+                                           BufferType::L1,
+                                           llvm::SmallVector<int64_t>{56, 1}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                            TensorMemoryLayout::Interleaved, BufferType::DRAM,
+                            llvm::SmallVector<int64_t>{7, 8}},
+                        detail::TestTensor{
+                            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                            TensorMemoryLayout::HeightSharded, BufferType::L1,
+                            llvm::SmallVector<int64_t>{56, 1}},
+                        llvm::SmallVector<int64_t>{7, 8},
+                        detail::ExpectedResult{true, 114688, 114688, 114688})));
 
 class OpModelConv2dParam
     : public OpModelTest,
@@ -1522,13 +1406,13 @@ TEST_P(OpModelConv2dParam, Conv2d) {
   const auto [expectedLegal, expectedCbSize, expectedPeakSize,
               expectedOutputSize] = std::get<13>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateRowMajorLayout(
+  const TTNNLayoutAttr inputLayout = CreateRowMajorLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid,
       GetPhysicalGridSize(), builder.getF32Type());
-  const mlir::tt::ttnn::TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
+  const TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
       weightShape, weightBufferType, weightTensorLayout, weightVirtualGrid,
       GetPhysicalGridSize(), builder.getF32Type());
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   // Device hangs otherwise.
@@ -1537,20 +1421,19 @@ TEST_P(OpModelConv2dParam, Conv2d) {
   // This is not configurable, as the backend doesn't support it for now.
   // But this test shows that this information is parsed and passes to the
   // backend correctly.
-  ::mlir::tt::ttnn::DeviceComputeKernelConfigAttr deviceConfig =
-      ::mlir::tt::ttnn::DeviceComputeKernelConfigAttr::get(
-          &context, /*mathFidelity=*/::mlir::tt::ttnn::MathFidelity::LoFi,
+  DeviceComputeKernelConfigAttr deviceConfig =
+      DeviceComputeKernelConfigAttr::get(
+          &context, /*mathFidelity=*/MathFidelity::LoFi,
           /*mathApproxMode=*/::mlir::BoolAttr::get(&context, true),
           /*fp32DestAccEn=*/::mlir::BoolAttr::get(&context, true),
           /*packerL1Acc=*/::mlir::BoolAttr::get(&context, true),
           /*dstFullSyncEn=*/::mlir::BoolAttr::get(&context, true));
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::Conv2dOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, weightShape,
-          weightLayout, std::nullopt, std::nullopt, in_channels, out_channels,
-          batch_size, input_height, input_width, kernel_size, stride, padding,
-          dilation, groups, std::nullopt, deviceConfig, outputLayout);
+  auto constraintsExp = OpModel<Conv2dOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
+      std::nullopt, std::nullopt, in_channels, out_channels, batch_size,
+      input_height, input_width, kernel_size, stride, padding, dilation, groups,
+      std::nullopt, deviceConfig, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -1567,12 +1450,11 @@ TEST_P(OpModelConv2dParam, Conv2d) {
   // Device hangs otherwise.
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::Conv2dOp>::getOpRuntime(
-          inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
-          std::nullopt, in_channels, out_channels, batch_size, input_height,
-          input_width, kernel_size, stride, padding, dilation, groups,
-          std::nullopt, deviceConfig, outputLayout);
+  auto runtimeExp = OpModel<Conv2dOp>::getOpRuntime(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, dilation, groups, std::nullopt,
+      deviceConfig, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
@@ -1588,34 +1470,34 @@ TEST_P(OpModelConv2dParam, Conv2d) {
 INSTANTIATE_TEST_SUITE_P(
     Conv2dTests, OpModelConv2dParam,
     ::testing::Values(
-        std::make_tuple(
-            detail::TestTensor{{1, 1, 50176, 3},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{64, 3, 7, 7},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::SystemMemory},
-            detail::TestTensor{{1, 1, 12544, 64},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
-            llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{3, 3},
-            llvm::SmallVector<int32_t>{1, 1}, 1,
-            detail::ExpectedResult{true, 229440, 190568, 0}),
-        std::make_tuple(
-            detail::TestTensor{{1, 1, 50176, 3},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{64, 3, 9, 7},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::SystemMemory},
-            detail::TestTensor{{1, 1, 12544, 64},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
-            llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{3, 3},
-            llvm::SmallVector<int32_t>{1, 1}, 1,
-            detail::ExpectedResult{false, 0, 0, 0})));
+        std::make_tuple(detail::TestTensor{{1, 1, 50176, 3},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{64, 3, 7, 7},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::SystemMemory},
+                        detail::TestTensor{{1, 1, 12544, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
+                        llvm::SmallVector<int32_t>{2, 2},
+                        llvm::SmallVector<int32_t>{3, 3},
+                        llvm::SmallVector<int32_t>{1, 1}, 1,
+                        detail::ExpectedResult{true, 229440, 190568, 0}),
+        std::make_tuple(detail::TestTensor{{1, 1, 50176, 3},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{64, 3, 9, 7},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::SystemMemory},
+                        detail::TestTensor{{1, 1, 12544, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
+                        llvm::SmallVector<int32_t>{2, 2},
+                        llvm::SmallVector<int32_t>{3, 3},
+                        llvm::SmallVector<int32_t>{1, 1}, 1,
+                        detail::ExpectedResult{false, 0, 0, 0})));
 
 class OpModelConvTranspose2dParam
     : public OpModelTest,
@@ -1661,24 +1543,23 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
   const auto [expectedLegal, expectedCbSize, expectedPeakSize,
               expectedOutputSize] = std::get<14>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout =
+  const TTNNLayoutAttr inputLayout =
       CreateRowMajorLayout(inputShape, inputBufferType, inputTensorLayout,
                            inputVirtualGrid, GetPhysicalGridSize());
-  const mlir::tt::ttnn::TTNNLayoutAttr weightLayout =
+  const TTNNLayoutAttr weightLayout =
       CreateRowMajorLayout(weightShape, weightBufferType, weightTensorLayout,
                            weightVirtualGrid, GetPhysicalGridSize());
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   // Device hangs otherwise.
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp = op_model::ttnn::
-      OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, weightShape,
-          weightLayout, std::nullopt, std::nullopt, in_channels, out_channels,
-          batch_size, input_height, input_width, kernel_size, stride, padding,
-          output_padding, dilation, groups, std::nullopt, outputLayout);
+  auto constraintsExp = OpModel<ConvTranspose2dOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, weightShape, weightLayout,
+      std::nullopt, std::nullopt, in_channels, out_channels, batch_size,
+      input_height, input_width, kernel_size, stride, padding, output_padding,
+      dilation, groups, std::nullopt, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
@@ -1694,12 +1575,11 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
   // Device hangs otherwise.
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ConvTranspose2dOp>::getOpRuntime(
-          inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
-          std::nullopt, in_channels, out_channels, batch_size, input_height,
-          input_width, kernel_size, stride, padding, output_padding, dilation,
-          groups, std::nullopt, outputLayout);
+  auto runtimeExp = OpModel<ConvTranspose2dOp>::getOpRuntime(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, output_padding, dilation,
+      groups, std::nullopt, outputLayout);
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
@@ -1716,14 +1596,14 @@ INSTANTIATE_TEST_SUITE_P(
     ConvTranspose2dTests, OpModelConvTranspose2dParam,
     ::testing::Values(std::make_tuple(
         detail::TestTensor{{1, 1, 50176, 3},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::DRAM},
+                           TensorMemoryLayout::Interleaved,
+                           BufferType::DRAM},
         detail::TestTensor{{3, 64, 7, 7},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::SystemMemory},
+                           TensorMemoryLayout::Interleaved,
+                           BufferType::SystemMemory},
         detail::TestTensor{{1, 1, 12544, 64},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::DRAM},
+                           TensorMemoryLayout::Interleaved,
+                           BufferType::DRAM},
         3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
         llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{3, 3},
         llvm::SmallVector<int32_t>{0, 0}, llvm::SmallVector<int32_t>{1, 1}, 1,
@@ -1767,18 +1647,17 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
   const auto ceilMode = std::get<10>(params);
   const auto expectedLegal = std::get<11>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, batchSize, inputHeight,
-          inputWidth, inputChannels, kernelSize, stride, padding, dilation,
-          ceilMode, outputLayout);
+  auto constraintsExp = OpModel<MaxPool2dOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, batchSize, inputHeight,
+      inputWidth, inputChannels, kernelSize, stride, padding, dilation,
+      ceilMode, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -1798,11 +1677,10 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::MaxPool2dOp>::getOpRuntime(
-          inputShape, inputLayout, batchSize, inputHeight, inputWidth,
-          inputChannels, kernelSize, stride, padding, dilation, ceilMode,
-          outputLayout);
+  auto runtimeExp = OpModel<MaxPool2dOp>::getOpRuntime(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -1814,36 +1692,36 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
 INSTANTIATE_TEST_SUITE_P(
     MaxPool2DTests, OpModelMaxPool2DParam,
     ::testing::Values(
-        std::make_tuple(
-            detail::TestTensor{{1, 1, 128 * 128, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{1, 1, 64 * 64, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            1, 128, 128, 32, llvm::SmallVector<int32_t>{2, 2},
-            llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{0, 0},
-            llvm::SmallVector<int32_t>{1, 1}, false, true),
-        std::make_tuple(
-            detail::TestTensor{{1, 1, 256 * 256, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{1, 1, 64 * 128, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            1, 256, 256, 32, llvm::SmallVector<int32_t>{3, 3},
-            llvm::SmallVector<int32_t>{4, 2}, llvm::SmallVector<int32_t>{0, 0},
-            llvm::SmallVector<int32_t>{1, 1}, false, true),
-        std::make_tuple(
-            detail::TestTensor{{1, 1, 17 * 21, 22},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{1, 1, 5 * 11, 22},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            1, 256, 256, 22, llvm::SmallVector<int32_t>{3, 3},
-            llvm::SmallVector<int32_t>{4, 2}, llvm::SmallVector<int32_t>{0, 0},
-            llvm::SmallVector<int32_t>{1, 1}, false, false)));
+        std::make_tuple(detail::TestTensor{{1, 1, 128 * 128, 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{1, 1, 64 * 64, 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        1, 128, 128, 32, llvm::SmallVector<int32_t>{2, 2},
+                        llvm::SmallVector<int32_t>{2, 2},
+                        llvm::SmallVector<int32_t>{0, 0},
+                        llvm::SmallVector<int32_t>{1, 1}, false, true),
+        std::make_tuple(detail::TestTensor{{1, 1, 256 * 256, 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{1, 1, 64 * 128, 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        1, 256, 256, 32, llvm::SmallVector<int32_t>{3, 3},
+                        llvm::SmallVector<int32_t>{4, 2},
+                        llvm::SmallVector<int32_t>{0, 0},
+                        llvm::SmallVector<int32_t>{1, 1}, false, true),
+        std::make_tuple(detail::TestTensor{{1, 1, 17 * 21, 22},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{1, 1, 5 * 11, 22},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        1, 256, 256, 22, llvm::SmallVector<int32_t>{3, 3},
+                        llvm::SmallVector<int32_t>{4, 2},
+                        llvm::SmallVector<int32_t>{0, 0},
+                        llvm::SmallVector<int32_t>{1, 1}, false, false)));
 
 class OpModelClampScalarParam : public OpModelTest,
                                 public testing::WithParamInterface<
@@ -1864,17 +1742,16 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
   const auto maxVal = llvm::APFloat(std::get<3>(params));
   const auto expectedLegal = std::get<4>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, minVal, maxVal,
-          outputLayout);
+  auto constraintsExp = OpModel<ClampScalarOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, minVal, maxVal,
+      outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -1894,9 +1771,8 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::ClampScalarOp>::getOpRuntime(
-          inputShape, inputLayout, minVal, maxVal, outputLayout);
+  auto runtimeExp = OpModel<ClampScalarOp>::getOpRuntime(
+      inputShape, inputLayout, minVal, maxVal, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -1905,16 +1781,15 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ClampScalarTests, OpModelClampScalarParam,
-    ::testing::Values(std::make_tuple(
-        detail::TestTensor{{1, 1, 128 * 128, 32},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::DRAM},
-        detail::TestTensor{{1, 1, 128 * 128, 32},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::L1},
-        1.0, 5.0, true)));
+INSTANTIATE_TEST_SUITE_P(ClampScalarTests, OpModelClampScalarParam,
+                         ::testing::Values(std::make_tuple(
+                             detail::TestTensor{{1, 1, 128 * 128, 32},
+                                                TensorMemoryLayout::Interleaved,
+                                                BufferType::DRAM},
+                             detail::TestTensor{{1, 1, 128 * 128, 32},
+                                                TensorMemoryLayout::Interleaved,
+                                                BufferType::L1},
+                             1.0, 5.0, true)));
 
 class OpModelPermuteParam
     : public OpModelTest,
@@ -1936,17 +1811,16 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
   const auto padValue = llvm::APFloat(std::get<3>(params));
   const auto expectedLegal = std::get<4>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::PermuteOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, permutation, padValue,
-          outputLayout);
+  auto constraintsExp = OpModel<PermuteOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, permutation, padValue,
+      outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -1966,9 +1840,8 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::PermuteOp>::getOpRuntime(
-          inputShape, inputLayout, permutation, padValue, outputLayout);
+  auto runtimeExp = OpModel<PermuteOp>::getOpRuntime(
+      inputShape, inputLayout, permutation, padValue, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -1980,30 +1853,28 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
 INSTANTIATE_TEST_SUITE_P(
     PermuteTests, OpModelPermuteParam,
     ::testing::Values(
-        std::make_tuple(
-            detail::TestTensor{{1, 64, 128, 256},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{1, 256, 64, 128},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            llvm::SmallVector<int64_t>{0, 3, 1, 2}, 0.0f, true),
-        std::make_tuple(
-            detail::TestTensor{{2, 1280, 8, 8},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{8, 8, 2, 1280},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            llvm::SmallVector<int64_t>{2, 3, 0, 1}, 0.0f, true),
-        std::make_tuple(
-            detail::TestTensor{{1, 2, 32, 64},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{1, 2, 64, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1},
-            llvm::SmallVector<int64_t>{0, -3, -1, -2}, 0.0f, true)));
+        std::make_tuple(detail::TestTensor{{1, 64, 128, 256},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{1, 256, 64, 128},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        llvm::SmallVector<int64_t>{0, 3, 1, 2}, 0.0f, true),
+        std::make_tuple(detail::TestTensor{{2, 1280, 8, 8},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{8, 8, 2, 1280},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        llvm::SmallVector<int64_t>{2, 3, 0, 1}, 0.0f, true),
+        std::make_tuple(detail::TestTensor{{1, 2, 32, 64},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::DRAM},
+                        detail::TestTensor{{1, 2, 64, 32},
+                                           TensorMemoryLayout::Interleaved,
+                                           BufferType::L1},
+                        llvm::SmallVector<int64_t>{0, -3, -1, -2}, 0.0f,
+                        true)));
 
 class OpModelUpsampleParam : public OpModelTest,
                              public testing::WithParamInterface<
@@ -2025,18 +1896,17 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
   const auto mode = std::get<3>(params);
   const auto expectedLegal = std::get<4>(params);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateRowMajorLayout(
+  const TTNNLayoutAttr inputLayout = CreateRowMajorLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
 
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateRowMajorLayout(
+  const TTNNLayoutAttr outputLayout = CreateRowMajorLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::UpsampleOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, scaleFactor, mode,
-          outputLayout);
+  auto constraintsExp = OpModel<UpsampleOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, scaleFactor, mode,
+      outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -2056,9 +1926,8 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::UpsampleOp>::getOpRuntime(
-          inputShape, inputLayout, scaleFactor, mode, outputLayout);
+  auto runtimeExp = OpModel<UpsampleOp>::getOpRuntime(
+      inputShape, inputLayout, scaleFactor, mode, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -2070,12 +1939,10 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
 INSTANTIATE_TEST_SUITE_P(
     UpsampleTests, OpModelUpsampleParam,
     ::testing::Values(std::make_tuple(
-        detail::TestTensor{{2, 128, 8, 8},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::DRAM},
-        detail::TestTensor{{2, 256, 16, 8},
-                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                           mlir::tt::ttnn::BufferType::DRAM},
+        detail::TestTensor{
+            {2, 128, 8, 8}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {2, 256, 16, 8}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
         2, "nearest", true)));
 
 // ==== EmbeddingOp Tests ====
@@ -2097,18 +1964,17 @@ protected:
     llvm::SmallVector<int64_t> outputShape = {inputShape[0], inputShape[1],
                                               weightShape[1]};
 
-    const mlir::tt::ttnn::TTNNLayoutAttr inputTiledLayout = CreateTiledLayout(
+    const TTNNLayoutAttr inputTiledLayout = CreateTiledLayout(
         inputShape, inputBufferType, inputLayout, inputVirtualGrid);
-    const mlir::tt::ttnn::TTNNLayoutAttr weightTiledLayout = CreateTiledLayout(
+    const TTNNLayoutAttr weightTiledLayout = CreateTiledLayout(
         weightShape, weightBufferType, weightLayout, weightVirtualGrid);
-    const mlir::tt::ttnn::TTNNLayoutAttr outputTiledLayout = CreateTiledLayout(
-        outputShape, mlir::tt::ttnn::BufferType::L1,
-        mlir::tt::ttnn::TensorMemoryLayout::Interleaved, std::nullopt);
+    const TTNNLayoutAttr outputTiledLayout =
+        CreateTiledLayout(outputShape, BufferType::L1,
+                          TensorMemoryLayout::Interleaved, std::nullopt);
 
-    auto constraintsExp =
-        op_model::ttnn::OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpConstraints(
-            CreateWorkerGrid(), inputShape, inputTiledLayout, weightShape,
-            weightTiledLayout, outputTiledLayout);
+    auto constraintsExp = OpModel<EmbeddingOp>::getOpConstraints(
+        CreateWorkerGrid(), inputShape, inputTiledLayout, weightShape,
+        weightTiledLayout, outputTiledLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
@@ -2123,17 +1989,16 @@ protected:
     }
 
     // Test runtime using the interface directly
-    auto runtimeExp =
-        op_model::ttnn::OpModel<mlir::tt::ttnn::EmbeddingOp>::getOpRuntime(
-            inputShape, inputTiledLayout, weightShape, weightTiledLayout,
-            outputTiledLayout);
+    auto runtimeExp = OpModel<EmbeddingOp>::getOpRuntime(
+        inputShape, inputTiledLayout, weightShape, weightTiledLayout,
+        outputTiledLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
     if (expectedLegal) {
       EXPECT_GT(runtimeExp.get(), 0);
     } else {
       llvm::consumeError(runtimeExp.takeError());
     }
-  } // namespace mlir::tt::op_model::ttnn
+  }
 };
 
 TEST_P(OpModelEmbeddingParam, EmbeddingParam) { RunTest(); }
@@ -2143,40 +2008,34 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple(
             // Input: [batch=1, seq_len=1024]
-            detail::TestTensor{{1, 1024},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {1, 1024}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
             // Weight: [vocab_size=256, hidden_size=128]
-            detail::TestTensor{{256, 128},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {256, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
             detail::ExpectedResult{true, 16384, 8192, 4096}),
         std::make_tuple(
             // Input: [batch=2, seq_len=512] (sharded)
             detail::TestTensor{{2, 512},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::L1,
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::L1,
                                llvm::SmallVector<int64_t>{2, 1}},
             // Weight: [vocab_size=512, hidden_size=256]
-            detail::TestTensor{{512, 256},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {512, 256}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
             detail::ExpectedResult{true, 32768, 16384, 8192})));
 
 TEST_F(OpModelTest, Where) {
   const llvm::SmallVector<int64_t> inputTensorShape = {workerCoresN300, 1024};
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout =
-      CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout =
-      CreateTiledLayout(inputTensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputTensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      inputTensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::WhereOp>::getOpConstraints(
-          CreateWorkerGrid(), inputTensorShape, inputLayout, inputTensorShape,
-          inputLayout, inputTensorShape, inputLayout, inputTensorShape,
-          outputLayout);
+  auto constraintsExp = OpModel<WhereOp>::getOpConstraints(
+      CreateWorkerGrid(), inputTensorShape, inputLayout, inputTensorShape,
+      inputLayout, inputTensorShape, inputLayout, inputTensorShape,
+      outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
       constraintsExp.get();
@@ -2184,12 +2043,11 @@ TEST_F(OpModelTest, Where) {
   EXPECT_EQ(peakSize, 10240);
   EXPECT_EQ(outputSize, 2048);
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::WhereOp>::getOpRuntime(
-          inputTensorShape, inputLayout, inputTensorShape, inputLayout,
-          inputTensorShape, inputLayout, inputTensorShape, outputLayout);
+  auto runtimeExp = OpModel<WhereOp>::getOpRuntime(
+      inputTensorShape, inputLayout, inputTensorShape, inputLayout,
+      inputTensorShape, inputLayout, inputTensorShape, outputLayout);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_GT(runtimeExp.get(), 0);
 }
 
-} // namespace mlir::tt::op_model::ttnn
+} // namespace mlir::tt::ttnn::op_model


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4245

### Problem description
Namespace `op_model::ttnn` clearly violates hierarchical order, as `op_model` belongs to `ttnn`, not vice-versa. This has led to the necessity to specify a fully qualified name for all types in `ttnn` namespace.

### What's changed
Changed the order to `ttnn::op_model`. Changed fully qualified names to unqualified (or partially qualified in case of types belonging to `ttcore` ns).

Thanks @rpavlovicTT for suggesting this change.

### Checklist
- [x] New/Existing tests provide coverage for changes
