### PR TITLE
Add binary_dest_reuse_tiles and its init op to ttkernel op

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -397,6 +397,42 @@ def TTKernel_ReduceTileOp : TTKernel_FPUOp<"reduce_tile", [TTKernel_BinaryOpTrai
     }];
 }
 
+def TTKernel_BinaryDestReuseTilesInitOp : TTKernel_InitOp<"binary_dest_reuse_tiles_init"> {
+    let summary = "Init function for binary_dest_reuse_tiles operation.";
+    let description = [{
+      Please refer to documentation for any_init.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         TTKernel_EltwiseBinaryTypeAttr:$eltwise_binary_type,
+                         TTKernel_EltwiseBinaryReuseDestTypeAttr:$eltwise_binary_reuse_dest_type);
+}
+
+def TTKernel_BinaryDestReuseTilesOp : TTKernel_FPUOp<"binary_dest_reuse_tiles", [TTKernel_BinaryOpTrait]> {
+    let summary = "Performs element-wise binary operations with operand in DST register and "
+                   "another operand in CB at a given index.";
+    let description = [{
+      Performs element-wise binary operations, such as multiply, add, or sub of tiles.
+      If binary_reuse_dest = EltwiseBinaryReuseDestType::DST_TO_SRCA, then the tile specified by idst will be loaded from
+      the DST register buffer into SRCA. The binary operation will operate on SRCA & SRCB inputs, and the result will be
+      written back to the DST register buffer specified by idst. Similar to DST_TO_SRCA, if binary_reuse_dest =
+      EltwiseBinaryReuseDestType::DST_TO_SRCB, then tile specified by idst will be loaded from the DST into SRCB register
+      buffer.
+
+      EltwiseBinaryReuseDestType::DST_TO_SRCA and EltwiseBinaryReuseDestType::DST_TO_SRCB assume that another operation has
+      populated the dest register, otherwise dest will contain zeroes.
+
+      The DST register buffer must be in acquired state via *acquire_dst* call.
+      This call is blocking and is only available on the compute engine.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         IndexLike:$in_tile_index,
+                         IndexLike:$dst_index,
+                         TTKernel_EltwiseBinaryTypeAttr:$eltwise_binary_type,
+                         TTKernel_EltwiseBinaryReuseDestTypeAttr:$eltwise_binary_reuse_dest_type);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel SFPU operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -93,6 +93,34 @@ def TTKernel_CBPort : I32EnumAttr<"CBPort", "TTKernel Circular Buffer Ports",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
+def TTKernel_EltwiseBinaryAdd : I32EnumAttrCase<"Add", 0, "add">;
+def TTKernel_EltwiseBinarySub : I32EnumAttrCase<"Sub", 1, "sub">;
+def TTKernel_EltwiseBinaryMul : I32EnumAttrCase<"Mul", 2, "mul">;
+
+def TTKernel_EltwiseBinaryType : I32EnumAttr<"EltwiseBinaryType", "TTKernel Elementwise Binary Types",
+                          [
+                            TTKernel_EltwiseBinaryAdd,
+                            TTKernel_EltwiseBinarySub,
+                            TTKernel_EltwiseBinaryMul
+                          ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
+def TTKernel_EltwiseBinaryReuseDestNone : I32EnumAttrCase<"None", 0, "none">;
+def TTKernel_EltwiseBinaryReuseDestToSrcA : I32EnumAttrCase<"DestToSrcA", 1, "dest_to_src_a">;
+def TTKernel_EltwiseBinaryReuseDestToSrcB : I32EnumAttrCase<"DestToSrcB", 2, "dest_to_src_b">;
+
+def TTKernel_EltwiseBinaryReuseDestType : I32EnumAttr<"EltwiseBinaryReuseDestType", "TTKernel Elementwise Binary Reuse Destination Types",
+                          [
+                            TTKernel_EltwiseBinaryReuseDestNone,
+                            TTKernel_EltwiseBinaryReuseDestToSrcA,
+                            TTKernel_EltwiseBinaryReuseDestToSrcB
+                          ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
 def TTKernel_ReduceSum : I32EnumAttrCase<"Sum", 0, "reduce_sum">;
 def TTKernel_ReduceMax : I32EnumAttrCase<"Max", 1, "reduce_max">;
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -262,6 +262,28 @@ public:
     return name;
   }
 
+  template <typename EltwiseBinaryReuseDestOp>
+  std::pair<StringRef, StringRef>
+  getEltwiseBinaryTypeAndReuseDestType(EltwiseBinaryReuseDestOp op) const {
+    StringRef eltwiseBinaryType = "EltwiseBinaryType::ELWADD";
+    if (op.getEltwiseBinaryTypeAttr().getValue() ==
+        ttkernel::EltwiseBinaryType::Mul)
+      eltwiseBinaryType = "EltwiseBinaryType::ELWMUL";
+    else if (op.getEltwiseBinaryTypeAttr().getValue() ==
+             ttkernel::EltwiseBinaryType::Sub)
+      eltwiseBinaryType = "EltwiseBinaryType::ELWSUB";
+
+    StringRef eltwiseBinaryReuseDestType = "EltwiseBinaryReuseDestType::NONE";
+    if (op.getEltwiseBinaryReuseDestTypeAttr().getValue() ==
+        ttkernel::EltwiseBinaryReuseDestType::DestToSrcA)
+      eltwiseBinaryReuseDestType = "EltwiseBinaryReuseDestType::DEST_TO_SRCA";
+    else if (op.getEltwiseBinaryReuseDestTypeAttr().getValue() ==
+             ttkernel::EltwiseBinaryReuseDestType::DestToSrcB)
+      eltwiseBinaryReuseDestType = "EltwiseBinaryReuseDestType::DEST_TO_SRCB";
+
+    return {eltwiseBinaryType, eltwiseBinaryReuseDestType};
+  }
+
   template <typename ReduceKindOp>
   std::pair<StringRef, StringRef> getReduceTypeAndDim(ReduceKindOp op) const {
     StringRef reduceType =
@@ -326,6 +348,30 @@ public:
           datatypeToDataformatEnumValue(builder, op.getInDtype()));
       template_args.push_back(
           datatypeToDataformatEnumValue(builder, op.getOutDtype()));
+      return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp,
+                                        ttkernel::BinaryDestReuseTilesInitOp> ||
+                         std::is_same_v<SourceOp,
+                                        ttkernel::BinaryDestReuseTilesOp>) {
+      SmallVector<Attribute, 4> template_args;
+      StringRef binaryType, binaryReuseDestType;
+      if (std::is_same_v<SourceOp, ttkernel::BinaryDestReuseTilesInitOp>) {
+        auto binaryReuseDestInitOp =
+            mlir::cast<ttkernel::BinaryDestReuseTilesInitOp>(op);
+        std::tie(binaryType, binaryReuseDestType) =
+            getEltwiseBinaryTypeAndReuseDestType<
+                ttkernel::BinaryDestReuseTilesInitOp>(binaryReuseDestInitOp);
+      } else {
+        auto binaryReuseDestOp =
+            mlir::cast<ttkernel::BinaryDestReuseTilesOp>(op);
+        std::tie(binaryType, binaryReuseDestType) =
+            getEltwiseBinaryTypeAndReuseDestType<
+                ttkernel::BinaryDestReuseTilesOp>(binaryReuseDestOp);
+      }
+      template_args.push_back(
+          emitc::OpaqueAttr::get(op.getContext(), binaryType));
+      template_args.push_back(
+          emitc::OpaqueAttr::get(op.getContext(), binaryReuseDestType));
       return ArrayAttr::get(op.getContext(), template_args);
     }
     return ArrayAttr();
@@ -729,6 +775,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::BinaryOpInitCommonOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::BinaryDestReuseTilesInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::BinaryDestReuseTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitShortOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulTilesOp>,

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -348,6 +348,78 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_init_add_none
+    func.func @binary_dest_reuse_tiles_init_add_none() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles_init"(%[[IN_CB]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWADD">, #emitc.opaque<"EltwiseBinaryReuseDestType::NONE">]}
+      "ttkernel.binary_dest_reuse_tiles_init"(%in_cb) <{eltwise_binary_type = #ttkernel.eltwise_binary_type<add>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<none>}> : (!cb0_tiles) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_init_mul_dest_to_srca
+    func.func @binary_dest_reuse_tiles_init_mul_dest_to_srca() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles_init"(%[[IN_CB]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWMUL">, #emitc.opaque<"EltwiseBinaryReuseDestType::DEST_TO_SRCA">]}
+      "ttkernel.binary_dest_reuse_tiles_init"(%in_cb) <{eltwise_binary_type = #ttkernel.eltwise_binary_type<mul>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<dest_to_src_a>}> : (!cb0_tiles) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_init_sub_dest_to_srcb
+    func.func @binary_dest_reuse_tiles_init_sub_dest_to_srcb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles_init"(%[[IN_CB]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWSUB">, #emitc.opaque<"EltwiseBinaryReuseDestType::DEST_TO_SRCB">]}
+      "ttkernel.binary_dest_reuse_tiles_init"(%in_cb) <{eltwise_binary_type = #ttkernel.eltwise_binary_type<sub>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<dest_to_src_b>}> : (!cb0_tiles) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_add_none
+    func.func @binary_dest_reuse_tiles_add_none() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
+      %in_tile_index = arith.constant 1 : i32
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWADD">, #emitc.opaque<"EltwiseBinaryReuseDestType::NONE">]}
+      "ttkernel.binary_dest_reuse_tiles"(%in_cb, %in_tile_index, %dst_index) <{
+        eltwise_binary_type = #ttkernel.eltwise_binary_type<add>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<none>
+        }> : (!cb0_tiles, i32, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_mul_dest_to_srca
+    func.func @binary_dest_reuse_tiles_mul_dest_to_srca() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
+      %in_tile_index = arith.constant 1 : i32
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWMUL">, #emitc.opaque<"EltwiseBinaryReuseDestType::DEST_TO_SRCA">]}
+      "ttkernel.binary_dest_reuse_tiles"(%in_cb, %in_tile_index, %dst_index) <{
+        eltwise_binary_type = #ttkernel.eltwise_binary_type<mul>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<dest_to_src_a>
+        }> : (!cb0_tiles, i32, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @binary_dest_reuse_tiles_sub_dest_to_srcb
+    func.func @binary_dest_reuse_tiles_sub_dest_to_srcb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
+      %in_tile_index = arith.constant 1 : i32
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      %dst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "binary_dest_reuse_tiles"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"EltwiseBinaryType::ELWSUB">, #emitc.opaque<"EltwiseBinaryReuseDestType::DEST_TO_SRCB">]}
+      "ttkernel.binary_dest_reuse_tiles"(%in_cb, %in_tile_index, %dst_index) <{
+        eltwise_binary_type = #ttkernel.eltwise_binary_type<sub>, eltwise_binary_reuse_dest_type = #ttkernel.eltwise_binary_reuse_dest_type<dest_to_src_b>
+        }> : (!cb0_tiles, i32, i32) -> ()
+      return
+    }
+
   } // module
 
   //===----------------------------------------------------------------------===//


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add binary_dest_reuse_tiles and its init op to ttkernel op

### What's changed
Add binary_dest_reuse_tiles and its init op to ttkernel op.
Also, add lowering to emitc for these ops.

### Checklist
- [ ] New/Existing tests provide coverage for changes
