### PR TITLE
Adding claude local files to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ third_party/tt-metal
 .DS_STORE
 .vscode/*
 .cache
+.claude/*
 *pycache*
 *.egg-info
 cluster_descriptor.yaml


### PR DESCRIPTION
Add .claude/ directory to .gitignore

Adds the .claude/ directory to the project's gitignore file to prevent local Claude Code configuration files from being tracked in version control.