### PR TITLE
Fixing generate default functions linking

### DIFF
--- a/lib/Dialect/StableHLO/Utils/GSPMDUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/GSPMDUtils.cpp
@@ -435,7 +435,7 @@ determineGSPMDShardingDims(llvm::SmallVector<int64_t> &shardShape,
 }
 
 // Generate default GSPMDMeshSharding.
-llvm::Expected<GSPMDMeshSharding> generateDefault() {
+llvm::Expected<GSPMDMeshSharding> GSPMDMeshSharding::generateDefault() {
   return GSPMDMeshSharding{mlir::tt::ttcore::MeshShardDirection::FullToShard,
                            mlir::tt::ttcore::MeshShardType::Identity,
                            /*shardShape=*/llvm::SmallVector<int64_t>{},

--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -505,7 +505,7 @@ llvm::Expected<bool> parseSdySharding(mlir::sdy::TensorShardingAttr sdySharding,
 }
 
 // Generate default ShardyMeshSharding.
-llvm::Expected<ShardyMeshSharding> generateDefault() {
+llvm::Expected<ShardyMeshSharding> ShardyMeshSharding::generateDefault() {
   return ShardyMeshSharding{
       mlir::tt::ttcore::MeshShardDirection::FullToShard,
       mlir::tt::ttcore::MeshShardType::Identity,


### PR DESCRIPTION
There has been an issue with the `generateDefault` function for `ShardySharding` and `GSPMDSharding` classes. Putting a quick fix so it is usable from `tt-xla`.