### PR TITLE
Escape `%` characters in  `ttrt` `argparse` help str

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -314,7 +314,7 @@ class Run:
             type=int,
             default=1,
             choices=None,
-            help="Random ones vs zeroes density, 1 = 100% ones, 2 = 50% ones, 3 = 33% ones, etc.",
+            help="Random ones vs zeroes density, 1 = 100%% ones, 2 = 50%% ones, 3 = 33%% ones, etc.",
         )
         Run.register_arg(
             name="--fabric-config",


### PR DESCRIPTION
### Ticket
Closes #4228 

### Problem description
`ttrt run -h` was errring out due to unescaped `%` chars in a `help` str.

### What's changed
`%`s have been escaped