### PR TITLE
FIX: comment out not used optimization policies

### DIFF
--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -15,8 +15,8 @@ OPTIMIZER_DISABLED_POLICY = "Optimizer Disabled"
 OPTIMIZATION_POLICIES = {
     OPTIMIZER_DISABLED_POLICY: False,
     "DF Sharding": optimizer_overrides.MemoryLayoutAnalysisPolicyType.DFSharding,
-    "Greedy L1 Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.GreedyL1Interleaved,
-    "BF Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.BFInterleaved,
+    # "Greedy L1 Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.GreedyL1Interleaved,
+    # "BF Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.BFInterleaved,
 }
 
 


### PR DESCRIPTION
### Ticket
Based on this comment: https://github.com/tenstorrent/model-explorer/issues/38#issuecomment-3127653114

### Problem description
`tt-explorer` lists optimization policies that are not actively supported.

### What's changed
Comment out the two optimization policies that are not actively supported so they will not be sent to the UI.

### Checklist
- [x] New/Existing tests provide coverage for changes
