### PR TITLE
Add constraints for most unary eltwise ops.

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -288,7 +288,9 @@ def TTNN_CeilOp : TTNN_ElementwiseUnaryOp<"ceil",
     }];
 }
 
-def TTNN_SignOp: TTNN_ElementwiseUnaryOp<"sign"> {
+def TTNN_SignOp: TTNN_ElementwiseUnaryOp<"sign",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise sign operation.";
     let description = [{
       Returns the sign of the `operand` element-wise and produces a `result`
@@ -318,14 +320,18 @@ def TTNN_ExpOp : TTNN_ElementwiseUnaryOp<"exp",
     }];
 }
 
-def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf"> {
+def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise erf op.";
     let description = [{
         Eltwise erf operation. Calculates erf(x) for each element of the input tensor.
       }];
 }
 
-def TTNN_ErfcOp : TTNN_ElementwiseUnaryOp<"erfc"> {
+def TTNN_ErfcOp : TTNN_ElementwiseUnaryOp<"erfc",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise erfc op.";
     let description = [{
         Eltwise erfc operation. Calculates erfc(x) for each element of the input tensor.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -279,7 +279,9 @@ def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt"> {
     }];
 }
 
-def TTNN_CeilOp : TTNN_ElementwiseUnaryOp<"ceil"> {
+def TTNN_CeilOp : TTNN_ElementwiseUnaryOp<"ceil",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise ceil.";
     let description = [{
       Eltwise ceil operation.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -263,7 +263,9 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where", [ExplicateOperandBroadcast
     }];
 }
 
-def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs"> {
+def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise absolute.";
     let description = [{
       Eltwise absolute operation.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -338,28 +338,36 @@ def TTNN_ErfcOp : TTNN_ElementwiseUnaryOp<"erfc",
       }];
 }
 
-def TTNN_FloorOp: TTNN_ElementwiseUnaryOp<"floor"> {
+def TTNN_FloorOp: TTNN_ElementwiseUnaryOp<"floor",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise floor op.";
     let description = [{
       Eltwise floor operation.
     }];
 }
 
-def TTNN_GeluOp: TTNN_ElementwiseUnaryOp<"gelu"> {
+def TTNN_GeluOp: TTNN_ElementwiseUnaryOp<"gelu",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
   let summary = "Eltwise GELU.";
   let description = [{
     Eltwise GELU operation.
   }];
 }
 
-def TTNN_IsFiniteOp: TTNN_ElementwiseUnaryOp<"isfinite"> {
+def TTNN_IsFiniteOp: TTNN_ElementwiseUnaryOp<"isfinite",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise isfinite op.";
     let description = [{
       Eltwise isfinite operation.
     }];
 }
 
-def TTNN_LogicalNotOp: TTNN_ElementwiseUnaryOp<"logical_not"> {
+def TTNN_LogicalNotOp: TTNN_ElementwiseUnaryOp<"logical_not",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise logical not op.";
     let description = [{
       Eltwise logical not operation.
@@ -379,21 +387,27 @@ def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
     }];
 }
 
-def TTNN_NegOp : TTNN_ElementwiseUnaryOp<"neg"> {
+def TTNN_NegOp : TTNN_ElementwiseUnaryOp<"neg",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise negate.";
     let description = [{
       Eltwise negate operation.
     }];
 }
 
-def TTNN_TanOp: TTNN_ElementwiseUnaryOp<"tan"> {
+def TTNN_TanOp: TTNN_ElementwiseUnaryOp<"tan",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise tan op.";
     let description = [{
       Eltwise tan operation.
     }];
 }
 
-def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan"> {
+def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise arctangent op.";
     let description = [{
       Performs an elementwise arctangent (`atan`) operation on the input tensor.
@@ -465,7 +479,9 @@ def TTNN_SqrtOp : TTNN_ElementwiseUnaryOp<"sqrt",
     }];
 }
 
-def TTNN_RsqrtOp : TTNN_ElementwiseUnaryOp<"rsqrt"> {
+def TTNN_RsqrtOp : TTNN_ElementwiseUnaryOp<"rsqrt",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise rsqrt.";
     let description = [{
       Eltwise rsqrt operation.
@@ -490,7 +506,9 @@ def TTNN_LogOp : TTNN_ElementwiseUnaryOp<"log",
     }];
 }
 
-def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p"> {
+def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise log1p operation.";
     let description = [{
         Performs element-wise logarithm plus one operation on `operand` tensor and
@@ -502,7 +520,9 @@ def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p"> {
       }];
 }
 
-def TTNN_Expm1Op: TTNN_ElementwiseUnaryOp<"expm1"> {
+def TTNN_Expm1Op: TTNN_ElementwiseUnaryOp<"expm1",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
   let description = [{
     Performs element-wise exponential minus one operation on `operand` tensor
     and stores the result in the output tensor.
@@ -537,7 +557,9 @@ class TTNN_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> tra
     ];
 }
 
-def TTNN_LeakyReluOp : TTNN_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
+def TTNN_LeakyReluOp : TTNN_ElementwiseUnaryWithFloatParameterOp<"leaky_relu",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise leaky relu operation.";
     let description = [{
       The Leaky ReLU (Rectified Linear Unit) operation computes an element-wise

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -60,6 +60,9 @@ template <>
 struct OpModel<SinOp> : UnaryEltwiseOpModel<SinOp> {};
 
 template <>
+struct OpModel<AbsOp> : UnaryEltwiseOpModel<AbsOp> {};
+
+template <>
 struct OpModel<CosOp> : UnaryEltwiseOpModel<CosOp> {};
 
 template <>

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -72,6 +72,9 @@ template <>
 struct OpModel<LogOp> : UnaryEltwiseOpModel<LogOp> {};
 
 template <>
+struct OpModel<CeilOp> : UnaryEltwiseOpModel<CeilOp> {};
+
+template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -75,6 +75,9 @@ template <>
 struct OpModel<CeilOp> : UnaryEltwiseOpModel<CeilOp> {};
 
 template <>
+struct OpModel<SignOp> : UnaryEltwiseOpModel<SignOp> {};
+
+template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
 //===----------------------------------------------------------------------===//
@@ -109,6 +112,37 @@ struct OpModel<ExpOp> {
                                              TTNNLayoutAttr outputLayout);
 };
 
+//===----------------------------------------------------------------------===//
+// ErfOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<ErfOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+               TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
+// ErfcOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<ErfcOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+               TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+};
 //===----------------------------------------------------------------------===//
 // Binary Eltwise Ops
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -104,68 +104,71 @@ struct OpModel<Expm1Op> : UnaryEltwiseOpModel<Expm1Op> {};
 template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
+template <typename OpT>
+struct UnaryEltwiseWithFastApproxModeOpModel {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
+};
+
+template <>
+struct OpModel<mlir::tt::ttnn::RsqrtOp>
+    : UnaryEltwiseWithFastApproxModeOpModel<mlir::tt::ttnn::RsqrtOp> {};
+
+template <>
+struct OpModel<mlir::tt::ttnn::GeluOp>
+    : UnaryEltwiseWithFastApproxModeOpModel<mlir::tt::ttnn::GeluOp> {};
+
+template <>
+struct OpModel<mlir::tt::ttnn::ExpOp>
+    : UnaryEltwiseWithFastApproxModeOpModel<mlir::tt::ttnn::ExpOp> {};
+
+template <>
+struct OpModel<mlir::tt::ttnn::ErfOp>
+    : UnaryEltwiseWithFastApproxModeOpModel<mlir::tt::ttnn::ErfOp> {};
+
+template <>
+struct OpModel<mlir::tt::ttnn::ErfcOp>
+    : UnaryEltwiseWithFastApproxModeOpModel<mlir::tt::ttnn::ErfcOp> {};
+
 //===----------------------------------------------------------------------===//
 // SigmoidOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<SigmoidOp> {
+struct OpModel<mlir::tt::ttnn::SigmoidOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
+  getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                                             TTNNLayoutAttr inputLayout,
-                                             TTNNLayoutAttr outputLayout);
-};
-
-//===----------------------------------------------------------------------===//
-// ExpOp
-//===----------------------------------------------------------------------===//
-
-template <>
-struct OpModel<ExpOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                                             TTNNLayoutAttr inputLayout,
-                                             TTNNLayoutAttr outputLayout);
-};
-
-//===----------------------------------------------------------------------===//
-// ErfOp
-//===----------------------------------------------------------------------===//
-
-template <>
-struct OpModel<ErfOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+               mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//
-// ErfcOp
+// LeakyReluOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<ErfcOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+struct OpModel<mlir::tt::ttnn::LeakyReluOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+      mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-               TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+               mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+               mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -78,6 +78,30 @@ template <>
 struct OpModel<SignOp> : UnaryEltwiseOpModel<SignOp> {};
 
 template <>
+struct OpModel<FloorOp> : UnaryEltwiseOpModel<FloorOp> {};
+
+template <>
+struct OpModel<IsFiniteOp> : UnaryEltwiseOpModel<IsFiniteOp> {};
+
+template <>
+struct OpModel<LogicalNotOp> : UnaryEltwiseOpModel<LogicalNotOp> {};
+
+template <>
+struct OpModel<NegOp> : UnaryEltwiseOpModel<NegOp> {};
+
+template <>
+struct OpModel<TanOp> : UnaryEltwiseOpModel<TanOp> {};
+
+template <>
+struct OpModel<AtanOp> : UnaryEltwiseOpModel<AtanOp> {};
+
+template <>
+struct OpModel<Log1pOp> : UnaryEltwiseOpModel<Log1pOp> {};
+
+template <>
+struct OpModel<Expm1Op> : UnaryEltwiseOpModel<Expm1Op> {};
+
+template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
 //===----------------------------------------------------------------------===//
@@ -143,6 +167,7 @@ struct OpModel<ErfcOp> {
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 };
+
 //===----------------------------------------------------------------------===//
 // Binary Eltwise Ops
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -248,6 +248,22 @@ AbsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// CeilOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+CeilOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+CeilOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -312,6 +312,166 @@ ErfcOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// FloorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+FloorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+FloorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// GeluOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+GeluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+GeluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// IsFiniteOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+IsFiniteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+IsFiniteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalNotOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LogicalNotOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+LogicalNotOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// NegOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+NegOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+NegOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// TanOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+TanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+TanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// AtanOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+AtanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+AtanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// RsqrtOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+RsqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+RsqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Log1pOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+Log1pOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+Log1pOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Expm1Op - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+Expm1Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+Expm1Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -405,6 +565,42 @@ llvm::Expected<size_t>
 ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
   return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// LeakyReluOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  return opConstraintsCache().getOrCompute(
+      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpConstraints,
+      *this, deviceGrid, inputShape, inputs[0], getParameter(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+LeakyReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpRuntime, *this,
+      inputShape, inputs[0], getParameter(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -232,6 +232,22 @@ SinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// AbsOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+AbsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+AbsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -235,7 +235,7 @@ SinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AbsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 AbsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -251,7 +251,7 @@ AbsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CeilOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 CeilOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -267,7 +267,7 @@ CeilOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SignOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 SignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -283,7 +283,7 @@ SignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ErfOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ErfOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -299,7 +299,7 @@ ErfOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ErfcOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 ErfcOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -315,7 +315,7 @@ ErfcOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FloorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 FloorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -331,7 +331,7 @@ FloorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GeluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 GeluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -347,7 +347,7 @@ GeluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // IsFiniteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 IsFiniteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -363,7 +363,7 @@ IsFiniteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalNotOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LogicalNotOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -379,7 +379,7 @@ LogicalNotOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NegOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 NegOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -395,7 +395,7 @@ NegOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 TanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -411,7 +411,7 @@ TanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AtanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 AtanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -427,7 +427,7 @@ AtanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RsqrtOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 RsqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -443,7 +443,7 @@ RsqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Log1pOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 Log1pOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -459,7 +459,7 @@ Log1pOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Expm1Op - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 Expm1Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getUnaryOpConstraints(*this, inputs, opConfig);
@@ -571,7 +571,7 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LeakyReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::ttnn::OpConstraints>
+llvm::Expected<op_model::OpConstraints>
 LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 1);
@@ -586,9 +586,8 @@ LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpConstraints,
-      *this, deviceGrid, inputShape, inputs[0], getParameter(),
-      opConfig.outputLayout);
+      op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], getParameter(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -599,8 +598,8 @@ LeakyReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpRuntime, *this,
-      inputShape, inputs[0], getParameter(), opConfig.outputLayout);
+      op_model::OpModel<LeakyReluOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getParameter(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -264,6 +264,54 @@ CeilOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// SignOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+SignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+SignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// ErfOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+ErfOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+ErfOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// ErfcOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+ErfcOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+ErfcOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -215,6 +215,8 @@ auto getOpSymbol() {
     return ::ttnn::sqrt;
   } else if constexpr (std::is_same_v<OpTy, SinOp>) {
     return ::ttnn::sin;
+  } else if constexpr (std::is_same_v<OpTy, AbsOp>) {
+    return ::ttnn::abs;
   } else if constexpr (std::is_same_v<OpTy, CosOp>) {
     return ::ttnn::cos;
   } else if constexpr (std::is_same_v<OpTy, TanhOp>) {
@@ -616,13 +618,14 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }
 
 // Explicit template instantiation for UnaryEltwiseOpModel.
-template struct UnaryEltwiseOpModel<ReluOp>;
-template struct UnaryEltwiseOpModel<SqrtOp>;
-template struct UnaryEltwiseOpModel<SinOp>;
-template struct UnaryEltwiseOpModel<CosOp>;
-template struct UnaryEltwiseOpModel<TanhOp>;
-template struct UnaryEltwiseOpModel<LogOp>;
-template struct UnaryEltwiseOpModel<ReciprocalOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReluOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SqrtOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SinOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::AbsOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CosOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp>;
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -625,6 +625,7 @@ template struct UnaryEltwiseOpModel<mlir::tt::ttnn::AbsOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CosOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CeilOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp>;
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -219,6 +219,8 @@ auto getOpSymbol() {
     return ::ttnn::abs;
   } else if constexpr (std::is_same_v<OpTy, CeilOp>) {
     return ::ttnn::ceil;
+  } else if constexpr (std::is_same_v<OpTy, SignOp>) {
+    return ::ttnn::sign;
   } else if constexpr (std::is_same_v<OpTy, CosOp>) {
     return ::ttnn::cos;
   } else if constexpr (std::is_same_v<OpTy, TanhOp>) {
@@ -629,7 +631,15 @@ template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CeilOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SignOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::FloorOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::IsFiniteOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogicalNotOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::NegOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::AtanOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::Log1pOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::Expm1Op>;
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp
@@ -831,6 +841,7 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ErfOp>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
 // ErfcOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::ErfcOp>::getOpConstraints(
@@ -891,6 +902,200 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ErfcOp>::getOpRuntime(
   };
 
   return operation::getOpRuntime(erfcOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// GeluOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::GeluOp>::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto geluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::gelu, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     geluOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<mlir::tt::ttnn::GeluOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto geluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::gelu, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpRuntime(geluOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// RsqrtOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints>
+OpModel<mlir::tt::ttnn::RsqrtOp>::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto geluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::gelu, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     geluOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<mlir::tt::ttnn::RsqrtOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto geluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::gelu, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpRuntime(geluOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LeakyReluOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints>
+OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Create query closure
+  auto leakyReluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::leaky_relu, device, inputSpec, slope.convertToFloat(),
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     leakyReluOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Create query closure
+  auto leakyReluOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::leaky_relu, device, inputSpec, slope.convertToFloat(),
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpRuntime(leakyReluOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -217,6 +217,8 @@ auto getOpSymbol() {
     return ::ttnn::sin;
   } else if constexpr (std::is_same_v<OpTy, AbsOp>) {
     return ::ttnn::abs;
+  } else if constexpr (std::is_same_v<OpTy, CeilOp>) {
+    return ::ttnn::ceil;
   } else if constexpr (std::is_same_v<OpTy, CosOp>) {
     return ::ttnn::cos;
   } else if constexpr (std::is_same_v<OpTy, TanhOp>) {
@@ -626,6 +628,7 @@ template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CosOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::TanhOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::LogOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::CeilOp>;
+template struct UnaryEltwiseOpModel<mlir::tt::ttnn::SignOp>;
 template struct UnaryEltwiseOpModel<mlir::tt::ttnn::ReciprocalOp>;
 
 //===----------------------------------------------------------------------===//
@@ -757,6 +760,137 @@ OpModel<ExpOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   };
 
   return operation::getOpRuntime(expOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// ErfOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::ErfOp>::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto erfOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::erf, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     erfOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ErfOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto erfOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::erf, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpRuntime(erfOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+// ErfcOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> OpModel<mlir::tt::ttnn::ErfcOp>::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto erfcOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::erfc, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     erfcOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<mlir::tt::ttnn::ErfcOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Add default parameters
+  bool fastApproxMode = false;
+
+  // Create query closure
+  auto erfcOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::erfc, device, inputSpec, fastApproxMode,
+        detail::getNullableMemoryConfig(outputLayout));
+  };
+
+  return operation::getOpRuntime(erfcOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -121,6 +121,7 @@ using OpModelExpParam = OpModelUnaryEltwiseParam<ExpOp>;
 using OpModelTanhParam = OpModelUnaryEltwiseParam<TanhOp>;
 using OpModelLogParam = OpModelUnaryEltwiseParam<LogOp>;
 using OpModelReciprocalParam = OpModelUnaryEltwiseParam<ReciprocalOp>;
+using OpModelAbsParam = OpModelUnaryEltwiseParam<AbsOp>;
 
 TEST_P(OpModelReluParam, ReluOp) { RunTest(); }
 TEST_P(OpModelSqrtParam, SqrtOp) { RunTest(); }
@@ -130,6 +131,7 @@ TEST_P(OpModelCosParam, CosOp) { RunTest(); }
 TEST_P(OpModelExpParam, ExpOp) { RunTest(); }
 TEST_P(OpModelTanhParam, TanhOp) { RunTest(); }
 TEST_P(OpModelLogParam, LogOp) { RunTest(); }
+TEST_P(OpModelAbsParam, AbsOp) { RunTest(); }
 TEST_P(OpModelReciprocalParam, ReciprocalOp) { RunTest(); }
 
 const std::initializer_list<
@@ -195,6 +197,9 @@ INSTANTIATE_TEST_SUITE_P(TanhTests, OpModelTanhParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(LogTests, OpModelLogParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(AbsTests, OpModelAbsParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(ReciprocalTests, OpModelReciprocalParam,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -122,6 +122,7 @@ using OpModelTanhParam = OpModelUnaryEltwiseParam<TanhOp>;
 using OpModelLogParam = OpModelUnaryEltwiseParam<LogOp>;
 using OpModelReciprocalParam = OpModelUnaryEltwiseParam<ReciprocalOp>;
 using OpModelAbsParam = OpModelUnaryEltwiseParam<AbsOp>;
+using OpModelCeilParam = OpModelUnaryEltwiseParam<CeilOp>;
 
 TEST_P(OpModelReluParam, ReluOp) { RunTest(); }
 TEST_P(OpModelSqrtParam, SqrtOp) { RunTest(); }
@@ -132,6 +133,7 @@ TEST_P(OpModelExpParam, ExpOp) { RunTest(); }
 TEST_P(OpModelTanhParam, TanhOp) { RunTest(); }
 TEST_P(OpModelLogParam, LogOp) { RunTest(); }
 TEST_P(OpModelAbsParam, AbsOp) { RunTest(); }
+TEST_P(OpModelCeilParam, CeilOp) { RunTest(); }
 TEST_P(OpModelReciprocalParam, ReciprocalOp) { RunTest(); }
 
 const std::initializer_list<
@@ -200,6 +202,9 @@ INSTANTIATE_TEST_SUITE_P(LogTests, OpModelLogParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(AbsTests, OpModelAbsParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(CeilTests, OpModelCeilParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(ReciprocalTests, OpModelReciprocalParam,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -125,6 +125,18 @@ using OpModelCeilParam = OpModelUnaryEltwiseParam<CeilOp>;
 using OpModelSignParam = OpModelUnaryEltwiseParam<SignOp>;
 using OpModelErfParam = OpModelUnaryEltwiseParam<ErfOp>;
 using OpModelErfcParam = OpModelUnaryEltwiseParam<ErfcOp>;
+using OpModelFloorParam = OpModelUnaryEltwiseParam<FloorOp>;
+using OpModelGeluParam = OpModelUnaryEltwiseParam<GeluOp>;
+using OpModelIsFiniteParam =
+    OpModelUnaryEltwiseParam<IsFiniteOp>;
+using OpModelLogicalNotParam =
+    OpModelUnaryEltwiseParam<LogicalNotOp>;
+using OpModelNegParam = OpModelUnaryEltwiseParam<NegOp>;
+using OpModelTanParam = OpModelUnaryEltwiseParam<TanOp>;
+using OpModelAtanParam = OpModelUnaryEltwiseParam<AtanOp>;
+using OpModelRsqrtParam = OpModelUnaryEltwiseParam<RsqrtOp>;
+using OpModelLog1pParam = OpModelUnaryEltwiseParam<Log1pOp>;
+using OpModelExpm1Param = OpModelUnaryEltwiseParam<Expm1Op>;
 using OpModelReciprocalParam =
     OpModelUnaryEltwiseParam<ReciprocalOp>;
 
@@ -141,7 +153,17 @@ TEST_P(OpModelCeilParam, CeilOp) { RunTest(); }
 TEST_P(OpModelSignParam, SignOp) { RunTest(); }
 TEST_P(OpModelErfParam, ErfOp) { RunTest(); }
 TEST_P(OpModelErfcParam, ErfcOp) { RunTest(); }
+TEST_P(OpModelFloorParam, FloorOp) { RunTest(); }
 TEST_P(OpModelReciprocalParam, ReciprocalOp) { RunTest(); }
+TEST_P(OpModelGeluParam, GeluOp) { RunTest(); }
+TEST_P(OpModelIsFiniteParam, IsFiniteOp) { RunTest(); }
+TEST_P(OpModelLogicalNotParam, LogicalNotOp) { RunTest(); }
+TEST_P(OpModelNegParam, NegOp) { RunTest(); }
+TEST_P(OpModelTanParam, TanOp) { RunTest(); }
+TEST_P(OpModelAtanParam, AtanOp) { RunTest(); }
+TEST_P(OpModelRsqrtParam, RsqrtOp) { RunTest(); }
+TEST_P(OpModelLog1pParam, Log1pOp) { RunTest(); }
+TEST_P(OpModelExpm1Param, Expm1Op) { RunTest(); }
 
 const std::initializer_list<
     std::tuple<detail::TestTensor, detail::TestTensor, detail::ExpectedResult>>
@@ -221,6 +243,36 @@ INSTANTIATE_TEST_SUITE_P(ErfTests, OpModelErfParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(ErfcTests, OpModelErfcParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(FloorTests, OpModelFloorParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(GeluTests, OpModelGeluParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(IsFiniteTests, OpModelIsFiniteParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(LogicalNotTests, OpModelLogicalNotParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(NegTests, OpModelNegParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(TanTests, OpModelTanParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(AtanTests, OpModelAtanParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(RsqrtTests, OpModelRsqrtParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(Log1pTests, OpModelLog1pParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(Expm1Tests, OpModelExpm1Param,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(ReciprocalTests, OpModelReciprocalParam,
@@ -1718,36 +1770,104 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
 INSTANTIATE_TEST_SUITE_P(
     MaxPool2DTests, OpModelMaxPool2DParam,
     ::testing::Values(
-        std::make_tuple(detail::TestTensor{{1, 1, 128 * 128, 32},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::DRAM},
-                        detail::TestTensor{{1, 1, 64 * 64, 32},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::L1},
-                        1, 128, 128, 32, llvm::SmallVector<int32_t>{2, 2},
-                        llvm::SmallVector<int32_t>{2, 2},
-                        llvm::SmallVector<int32_t>{0, 0},
-                        llvm::SmallVector<int32_t>{1, 1}, false, true),
-        std::make_tuple(detail::TestTensor{{1, 1, 256 * 256, 32},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::DRAM},
-                        detail::TestTensor{{1, 1, 64 * 128, 32},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::L1},
-                        1, 256, 256, 32, llvm::SmallVector<int32_t>{3, 3},
-                        llvm::SmallVector<int32_t>{4, 2},
-                        llvm::SmallVector<int32_t>{0, 0},
-                        llvm::SmallVector<int32_t>{1, 1}, false, true),
-        std::make_tuple(detail::TestTensor{{1, 1, 17 * 21, 22},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::DRAM},
-                        detail::TestTensor{{1, 1, 5 * 11, 22},
-                                           TensorMemoryLayout::Interleaved,
-                                           BufferType::L1},
-                        1, 256, 256, 22, llvm::SmallVector<int32_t>{3, 3},
-                        llvm::SmallVector<int32_t>{4, 2},
-                        llvm::SmallVector<int32_t>{0, 0},
-                        llvm::SmallVector<int32_t>{1, 1}, false, false)));
+        std::make_tuple(
+            detail::TestTensor{{1, 1, 128 * 128, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{1, 1, 64 * 64, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            1, 128, 128, 32, llvm::SmallVector<int32_t>{2, 2},
+            llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{0, 0},
+            llvm::SmallVector<int32_t>{1, 1}, false, true),
+        std::make_tuple(
+            detail::TestTensor{{1, 1, 256 * 256, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{1, 1, 64 * 128, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            1, 256, 256, 32, llvm::SmallVector<int32_t>{3, 3},
+            llvm::SmallVector<int32_t>{4, 2}, llvm::SmallVector<int32_t>{0, 0},
+            llvm::SmallVector<int32_t>{1, 1}, false, true),
+        std::make_tuple(
+            detail::TestTensor{{1, 1, 17 * 21, 22},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{1, 1, 5 * 11, 22},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            1, 256, 256, 22, llvm::SmallVector<int32_t>{3, 3},
+            llvm::SmallVector<int32_t>{4, 2}, llvm::SmallVector<int32_t>{0, 0},
+            llvm::SmallVector<int32_t>{1, 1}, false, false)));
+
+class OpModelLeakyReluParam : public OpModelTest,
+                              public testing::WithParamInterface<
+                                  std::tuple<detail::TestTensor, // input
+                                             detail::TestTensor, // output
+                                             float,              // slope
+                                             bool // expected legal
+                                             >> {};
+
+TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
+  auto params = GetParam();
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<1>(params);
+  const auto slope = llvm::APFloat(std::get<2>(params));
+  const auto expectedLegal = std::get<3>(params);
+
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  SingletonDeviceContext::resetInstance();
+
+  auto constraintsExp =
+      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpConstraints(
+          CreateWorkerGrid(), inputShape, inputLayout, slope, outputLayout);
+  if (!constraintsExp) {
+    std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
+              << std::endl;
+  }
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+
+  if (constraintsExp) {
+    const auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
+        constraintsExp.get();
+    EXPECT_GT(cbSize, 0);
+    EXPECT_GT(peakSize, 0);
+    EXPECT_GT(outputSize, 0);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  SingletonDeviceContext::resetInstance();
+
+  auto runtimeExp =
+      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpRuntime(
+          inputShape, inputLayout, slope, outputLayout);
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LeakyReluTests, OpModelLeakyReluParam,
+    ::testing::Values(std::make_tuple(
+        detail::TestTensor{{1, 1, 128 * 128, 32},
+                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                           mlir::tt::ttnn::BufferType::DRAM},
+        detail::TestTensor{{1, 1, 128 * 128, 32},
+                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                           mlir::tt::ttnn::BufferType::L1},
+        1.0, true)));
 
 class OpModelClampScalarParam : public OpModelTest,
                                 public testing::WithParamInterface<

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -127,18 +127,15 @@ using OpModelErfParam = OpModelUnaryEltwiseParam<ErfOp>;
 using OpModelErfcParam = OpModelUnaryEltwiseParam<ErfcOp>;
 using OpModelFloorParam = OpModelUnaryEltwiseParam<FloorOp>;
 using OpModelGeluParam = OpModelUnaryEltwiseParam<GeluOp>;
-using OpModelIsFiniteParam =
-    OpModelUnaryEltwiseParam<IsFiniteOp>;
-using OpModelLogicalNotParam =
-    OpModelUnaryEltwiseParam<LogicalNotOp>;
+using OpModelIsFiniteParam = OpModelUnaryEltwiseParam<IsFiniteOp>;
+using OpModelLogicalNotParam = OpModelUnaryEltwiseParam<LogicalNotOp>;
 using OpModelNegParam = OpModelUnaryEltwiseParam<NegOp>;
 using OpModelTanParam = OpModelUnaryEltwiseParam<TanOp>;
 using OpModelAtanParam = OpModelUnaryEltwiseParam<AtanOp>;
 using OpModelRsqrtParam = OpModelUnaryEltwiseParam<RsqrtOp>;
 using OpModelLog1pParam = OpModelUnaryEltwiseParam<Log1pOp>;
 using OpModelExpm1Param = OpModelUnaryEltwiseParam<Expm1Op>;
-using OpModelReciprocalParam =
-    OpModelUnaryEltwiseParam<ReciprocalOp>;
+using OpModelReciprocalParam = OpModelUnaryEltwiseParam<ReciprocalOp>;
 
 TEST_P(OpModelReluParam, ReluOp) { RunTest(); }
 TEST_P(OpModelSqrtParam, SqrtOp) { RunTest(); }
@@ -1825,9 +1822,8 @@ TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpConstraints(
-          CreateWorkerGrid(), inputShape, inputLayout, slope, outputLayout);
+  auto constraintsExp = op_model::OpModel<LeakyReluOp>::getOpConstraints(
+      CreateWorkerGrid(), inputShape, inputLayout, slope, outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
               << std::endl;
@@ -1847,9 +1843,8 @@ TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp =
-      op_model::ttnn::OpModel<mlir::tt::ttnn::LeakyReluOp>::getOpRuntime(
-          inputShape, inputLayout, slope, outputLayout);
+  auto runtimeExp = op_model::OpModel<LeakyReluOp>::getOpRuntime(
+      inputShape, inputLayout, slope, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -120,9 +120,13 @@ using OpModelCosParam = OpModelUnaryEltwiseParam<CosOp>;
 using OpModelExpParam = OpModelUnaryEltwiseParam<ExpOp>;
 using OpModelTanhParam = OpModelUnaryEltwiseParam<TanhOp>;
 using OpModelLogParam = OpModelUnaryEltwiseParam<LogOp>;
-using OpModelReciprocalParam = OpModelUnaryEltwiseParam<ReciprocalOp>;
 using OpModelAbsParam = OpModelUnaryEltwiseParam<AbsOp>;
 using OpModelCeilParam = OpModelUnaryEltwiseParam<CeilOp>;
+using OpModelSignParam = OpModelUnaryEltwiseParam<SignOp>;
+using OpModelErfParam = OpModelUnaryEltwiseParam<ErfOp>;
+using OpModelErfcParam = OpModelUnaryEltwiseParam<ErfcOp>;
+using OpModelReciprocalParam =
+    OpModelUnaryEltwiseParam<ReciprocalOp>;
 
 TEST_P(OpModelReluParam, ReluOp) { RunTest(); }
 TEST_P(OpModelSqrtParam, SqrtOp) { RunTest(); }
@@ -134,6 +138,9 @@ TEST_P(OpModelTanhParam, TanhOp) { RunTest(); }
 TEST_P(OpModelLogParam, LogOp) { RunTest(); }
 TEST_P(OpModelAbsParam, AbsOp) { RunTest(); }
 TEST_P(OpModelCeilParam, CeilOp) { RunTest(); }
+TEST_P(OpModelSignParam, SignOp) { RunTest(); }
+TEST_P(OpModelErfParam, ErfOp) { RunTest(); }
+TEST_P(OpModelErfcParam, ErfcOp) { RunTest(); }
 TEST_P(OpModelReciprocalParam, ReciprocalOp) { RunTest(); }
 
 const std::initializer_list<
@@ -205,6 +212,15 @@ INSTANTIATE_TEST_SUITE_P(AbsTests, OpModelAbsParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(CeilTests, OpModelCeilParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(SignTests, OpModelSignParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(ErfTests, OpModelErfParam,
+                         ::testing::ValuesIn(unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(ErfcTests, OpModelErfcParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(ReciprocalTests, OpModelReciprocalParam,

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1687,7 +1687,7 @@ TEST_F(OpModelBase, LeakyReluOp) {
       builder.getUnknownLoc(), outputType, input, slopeAPF);
   leakyReluOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
-  op_model::ttnn::SingletonDeviceContext::resetInstance();
+  op_model::SingletonDeviceContext::resetInstance();
 
   auto constraintsExp = getOpConstraints(leakyReluOp.getOperation());
   if (!constraintsExp) {
@@ -1700,7 +1700,7 @@ TEST_F(OpModelBase, LeakyReluOp) {
   EXPECT_EQ(peakSize, 2048);
   EXPECT_EQ(outputSize, 2048);
 
-  op_model::ttnn::SingletonDeviceContext::resetInstance();
+  op_model::SingletonDeviceContext::resetInstance();
 
   auto runtimeExp = getOpRuntime(leakyReluOp.getOperation());
   if (runtimeExp) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -223,6 +223,10 @@ const auto createAbs = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<AbsOp>(loc, type, ops).getOperation();
 };
+const auto createCeil = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<CeilOp>(loc, type, ops).getOperation();
+};
 const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
@@ -230,10 +234,15 @@ const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
 //===---------------------------------------------------------===
 // Define the test parameters
 const std::vector<UnaryOpTestParams> unaryOpTestParams = {
-    {"Relu", createRelu, expected}, {"Sin", createSin, expected},
-    {"Cos", createCos, expected},   {"Exp", createExp, expected},
-    {"Tanh", createTanh, expected}, {"Log", createLog, expected},
-    {"Abs", createAbs, expected},   {"Reciprocal", createReciprocal, expected}};
+    {"Relu", createRelu, expected},
+    {"Sin", createSin, expected},
+    {"Cos", createCos, expected},
+    {"Exp", createExp, expected},
+    {"Tanh", createTanh, expected},
+    {"Log", createLog, expected},
+    {"Abs", createAbs, expected},
+    {"Ceil", createCeil, expected},
+    {"Reciprocal", createReciprocal, expected}};
 
 // Instantiate the test suite
 INSTANTIATE_TEST_SUITE_P(

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -239,6 +239,46 @@ const auto createErfc = [](OpBuilder &b, Location loc, Type type,
                            ValueRange ops) {
   return b.create<ErfcOp>(loc, type, ops).getOperation();
 };
+const auto createFloor = [](OpBuilder &b, Location loc, Type type,
+                            ValueRange ops) {
+  return b.create<FloorOp>(loc, type, ops).getOperation();
+};
+const auto createGelu = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<GeluOp>(loc, type, ops).getOperation();
+};
+const auto createIsFinite = [](OpBuilder &b, Location loc, Type type,
+                               ValueRange ops) {
+  return b.create<IsFiniteOp>(loc, type, ops).getOperation();
+};
+const auto createLogicalNot = [](OpBuilder &b, Location loc, Type type,
+                                 ValueRange ops) {
+  return b.create<LogicalNotOp>(loc, type, ops).getOperation();
+};
+const auto createNeg = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<NegOp>(loc, type, ops).getOperation();
+};
+const auto createTan = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<TanOp>(loc, type, ops).getOperation();
+};
+const auto createAtan = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<AtanOp>(loc, type, ops).getOperation();
+};
+const auto createRsqrt = [](OpBuilder &b, Location loc, Type type,
+                            ValueRange ops) {
+  return b.create<RsqrtOp>(loc, type, ops).getOperation();
+};
+const auto createLog1p = [](OpBuilder &b, Location loc, Type type,
+                            ValueRange ops) {
+  return b.create<Log1pOp>(loc, type, ops).getOperation();
+};
+const auto createExpm1 = [](OpBuilder &b, Location loc, Type type,
+                            ValueRange ops) {
+  return b.create<Expm1Op>(loc, type, ops).getOperation();
+};
 const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
@@ -246,12 +286,28 @@ const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
 //===---------------------------------------------------------===
 // Define the test parameters
 const std::vector<UnaryOpTestParams> unaryOpTestParams = {
-    {"Relu", createRelu, expected}, {"Sin", createSin, expected},
-    {"Cos", createCos, expected},   {"Exp", createExp, expected},
-    {"Tanh", createTanh, expected}, {"Log", createLog, expected},
-    {"Abs", createAbs, expected},   {"Ceil", createCeil, expected},
-    {"Sign", createSign, expected}, {"Erf", createErf, expected},
-    {"Erfc", createErfc, expected}, {"Reciprocal", createReciprocal, expected}};
+    {"Relu", createRelu, expected},
+    {"Sin", createSin, expected},
+    {"Cos", createCos, expected},
+    {"Exp", createExp, expected},
+    {"Tanh", createTanh, expected},
+    {"Log", createLog, expected},
+    {"Abs", createAbs, expected},
+    {"Ceil", createCeil, expected},
+    {"Sign", createSign, expected},
+    {"Erf", createErf, expected},
+    {"Erfc", createErfc, expected},
+    {"Floor", createFloor, expected},
+    {"Reciprocal", createReciprocal, expected},
+    {"Gelu", createGelu, expected},
+    {"IsFinite", createIsFinite, expected},
+    {"LogicalNot", createLogicalNot, expected},
+    {"Neg", createNeg, expected},
+    {"Tan", createTan, expected},
+    {"Atan", createAtan, expected},
+    {"Rsqrt", createRsqrt, expected},
+    {"Log1p", createLog1p, expected},
+    {"Expm1", createExpm1, expected}};
 
 // Instantiate the test suite
 INSTANTIATE_TEST_SUITE_P(
@@ -1607,6 +1663,46 @@ TEST_F(OpModelBase, maxPool2DOp) {
   op_model::SingletonDeviceContext::resetInstance();
 
   auto runtimeExp = getOpRuntime(maxPool2DOp.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, LeakyReluOp) {
+  // Create LeakyReluOp with flattened input tensor
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  // Input param
+  float slope = 0.01f;
+
+  // Convert float value to APFloat object
+  llvm::APFloat slopeAPF(slope);
+
+  LeakyReluOp leakyReluOp = builder.create<LeakyReluOp>(
+      builder.getUnknownLoc(), outputType, input, slopeAPF);
+  leakyReluOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  op_model::ttnn::SingletonDeviceContext::resetInstance();
+
+  auto constraintsExp = getOpConstraints(leakyReluOp.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+  const auto &[cbSize, peakSize, outputSize, outputLayout] =
+      constraintsExp.get();
+  EXPECT_EQ(cbSize, 8192);
+  EXPECT_EQ(peakSize, 2048);
+  EXPECT_EQ(outputSize, 2048);
+
+  op_model::ttnn::SingletonDeviceContext::resetInstance();
+
+  auto runtimeExp = getOpRuntime(leakyReluOp.getOperation());
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -219,6 +219,10 @@ const auto createLog = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<LogOp>(loc, type, ops).getOperation();
 };
+const auto createAbs = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<AbsOp>(loc, type, ops).getOperation();
+};
 const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
@@ -226,13 +230,10 @@ const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
 //===---------------------------------------------------------===
 // Define the test parameters
 const std::vector<UnaryOpTestParams> unaryOpTestParams = {
-    {"Relu", createRelu, expected},
-    {"Sin", createSin, expected},
-    {"Cos", createCos, expected},
-    {"Exp", createExp, expected},
-    {"Tanh", createTanh, expected},
-    {"Log", createLog, expected},
-    {"Reciprocal", createReciprocal, expected}};
+    {"Relu", createRelu, expected}, {"Sin", createSin, expected},
+    {"Cos", createCos, expected},   {"Exp", createExp, expected},
+    {"Tanh", createTanh, expected}, {"Log", createLog, expected},
+    {"Abs", createAbs, expected},   {"Reciprocal", createReciprocal, expected}};
 
 // Instantiate the test suite
 INSTANTIATE_TEST_SUITE_P(

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -227,6 +227,18 @@ const auto createCeil = [](OpBuilder &b, Location loc, Type type,
                            ValueRange ops) {
   return b.create<CeilOp>(loc, type, ops).getOperation();
 };
+const auto createSign = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<SignOp>(loc, type, ops).getOperation();
+};
+const auto createErf = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<ErfOp>(loc, type, ops).getOperation();
+};
+const auto createErfc = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<ErfcOp>(loc, type, ops).getOperation();
+};
 const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
@@ -234,15 +246,12 @@ const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
 //===---------------------------------------------------------===
 // Define the test parameters
 const std::vector<UnaryOpTestParams> unaryOpTestParams = {
-    {"Relu", createRelu, expected},
-    {"Sin", createSin, expected},
-    {"Cos", createCos, expected},
-    {"Exp", createExp, expected},
-    {"Tanh", createTanh, expected},
-    {"Log", createLog, expected},
-    {"Abs", createAbs, expected},
-    {"Ceil", createCeil, expected},
-    {"Reciprocal", createReciprocal, expected}};
+    {"Relu", createRelu, expected}, {"Sin", createSin, expected},
+    {"Cos", createCos, expected},   {"Exp", createExp, expected},
+    {"Tanh", createTanh, expected}, {"Log", createLog, expected},
+    {"Abs", createAbs, expected},   {"Ceil", createCeil, expected},
+    {"Sign", createSign, expected}, {"Erf", createErf, expected},
+    {"Erfc", createErfc, expected}, {"Reciprocal", createReciprocal, expected}};
 
 // Instantiate the test suite
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Ticket
#4195 

Added constraints API for almost all unary eltwise ops.

The only ones pending are `cbrtOp` and `BitwiseNotOp`. I will add them in a later PR as they need the test files to be updated slightly.
