### PR TITLE
Remove duplicated workaround around reduce_scatter

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
@@ -56,7 +56,8 @@ TTNNReduceScatterWorkarounds::matchAndRewrite(ttnn::ReduceScatterOp op,
 
   // Create 4D output tensor type
   RankedTensorType paddedOutputType =
-      RankedTensorType::Builder(outputType).setShape(paddedOutputShape);
+      ttnn::utils::RankedTensorTypeFactory::create(outputType,
+                                                   paddedOutputShape);
 
   // Create the reduce scatter operation on 4D tensors with adjusted
   // scatter_dim

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -468,24 +468,19 @@ public:
   }
 };
 
-//
 // Two workarounds are implemented here to avoid issues in ttnn
 //
 // 1. all_reduce ops are broken down into reduce_scatter and all_gather ops
 // because current support of all_reduce in TTNN is not stable.
-// 2. reduce_scatter op in TTNN currently does not support two dimensional
-// tensor correctly. As a temporary workaround, we insert reshape ops front
-// and back to make the tensor as four dimensional tensor.
-// 3. It doesn't really matter which tensor dimension we do the
+// 2. It doesn't really matter which tensor dimension we do the
 // reduce scatter and the all gather on but they must be equal to each other
 // and within the constraints of the rank of the tensor.
-// 3-1. It turned out that using any dimension other than 3 generates
+// 2-1. It turned out that using any dimension other than 3 generates
 // incorrect output under the current ttnn implementation. Temporarily use
 // dimension == 3.
-// 4. We also need to
-// make sure the tensor dimension we select is divisible by the number of
-// devices along the cluster axis dimension we want to perform the all
-// reduce on.
+// 3. We also need to make sure the tensor dimension we select is divisible by
+// the number of devices along the cluster axis dimension we want to perform the
+// all reduce on.
 class TTNNAllReduceWorkarounds : public OpRewritePattern<ttnn::AllReduceOp> {
 public:
   using OpRewritePattern<ttnn::AllReduceOp>::OpRewritePattern;
@@ -532,14 +527,14 @@ public:
     inputTypeShape[dimension] =
         inputTypeShape[dimension] / meshShape[clusterAxis];
     auto scatteredInputType =
-        RankedTensorType::Builder(inputType).setShape(inputTypeShape);
+        ttnn::utils::RankedTensorTypeFactory::create(inputType, inputTypeShape);
 
     // Create a new reducer scatter op.
     ttnn::ReduceScatterOp reduceScatterOp =
         rewriter.create<ttnn::ReduceScatterOp>(
             ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
-            Type(scatteredInputType), op.getInput(), deviceValue,
-            op.getReduceType(), dimension, clusterAxis);
+            scatteredInputType, op.getInput(), deviceValue, op.getReduceType(),
+            dimension, clusterAxis);
     reduceScatterOp->setAttr("decomposed_from_all_reduce",
                              rewriter.getUnitAttr());
 
@@ -570,7 +565,8 @@ private:
         rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(
             expandedInputShape.begin(), expandedInputShape.end()));
     RankedTensorType reshapedInputType =
-        RankedTensorType::Builder(inputType).setShape(expandedInputShape);
+        ttnn::utils::RankedTensorTypeFactory::create(inputType,
+                                                     expandedInputShape);
 
     ttnn::ReshapeOp leadingReshapeOp = rewriter.create<ttnn::ReshapeOp>(
         ttmlir::utils::appendLocationSuffix(loc, "_reshape"), reshapedInputType,
@@ -580,8 +576,8 @@ private:
     // Create a new all gather op.
     expandedInputShape[0] = meshShape[clusterAxis];
     RankedTensorType allGatherOutputType =
-        RankedTensorType::Builder(reshapedInputType)
-            .setShape(expandedInputShape);
+        ttnn::utils::RankedTensorTypeFactory::create(reshapedInputType,
+                                                     expandedInputShape);
     ttnn::AllGatherOp allGatherOp = rewriter.create<ttnn::AllGatherOp>(
         ttmlir::utils::appendLocationSuffix(loc, "_allGather"),
         allGatherOutputType, leadingReshapeOp.getResult(), deviceValue, 0,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -523,95 +523,29 @@ public:
       }
     }
 
-    // TODO(wooseoklee): Once it supports two dimensional tensor
-    // (https://github.com/tenstorrent/tt-metal/issues/15010), we can remove
-    // this workaround solution.
-    if (inputTypeShape.size() < 4) {
-      // We need to expand the current inputShape size to a tensor with
-      // rank=4. We do this by adding leading 1's to the inputShape to create
-      // a new shape with rank=4.
-      uint32_t requiredOnesInput = 4 - inputTypeShape.size();
-      llvm::SmallVector<int64_t> reshapedInputShape(requiredOnesInput, 1);
-      reshapedInputShape.append(inputTypeShape);
+    // TODO(wooseoklee): Once ttnn supports all_reduce op
+    // (https://github.com/tenstorrent/tt-metal/issues/13835), we can
+    // convert directly to ttnn.all_reduce.
 
-      ArrayAttr reshapedInputShapeAttr =
-          rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(
-              reshapedInputShape.begin(), reshapedInputShape.end()));
-      auto reshapedInputType =
-          RankedTensorType::Builder(inputType).setShape(reshapedInputShape);
+    // Determine the shape of its input tensor. The new tensor
+    // shape at the scatter_dim will be tensor_shape[scatter_dim] =
+    // original_tensor_shape / num_devices.
+    inputTypeShape[dimension] =
+        inputTypeShape[dimension] / meshShape[clusterAxis];
+    auto scatteredInputType =
+        RankedTensorType::Builder(inputType).setShape(inputTypeShape);
 
-      // Create a new reshape op.
-      ttnn::ReshapeOp preReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-          ttmlir::utils::appendLocationSuffix(loc, "_preReshape"),
-          Type(reshapedInputType), op.getInput(), reshapedInputShapeAttr,
-          /* memory_config */ nullptr);
+    // Create a new reducer scatter op.
+    ttnn::ReduceScatterOp reduceScatterOp =
+        rewriter.create<ttnn::ReduceScatterOp>(
+            ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
+            Type(scatteredInputType), op.getInput(), deviceValue,
+            op.getReduceType(), dimension, clusterAxis);
 
-      // Determine new dimension since entire tensor shape got shifted.
-      dimension = dimension + requiredOnesInput;
-
-      // Determine the shape of its input tensor. The new tensor
-      // shape at the scatter_dim will be tensor_shape[scatter_dim] =
-      // original_tensor_shape / num_devices.
-      reshapedInputShape[dimension] =
-          reshapedInputShape[dimension] / meshShape[clusterAxis];
-      auto scatteredInputType =
-          RankedTensorType::Builder(inputType).setShape(reshapedInputShape);
-
-      // Create a new reduce scatter op.
-      ttnn::ReduceScatterOp reduceScatterOp =
-          rewriter.create<ttnn::ReduceScatterOp>(
-              ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
-              Type(scatteredInputType), preReshapeOp.getResult(), deviceValue,
-              op.getReduceType(), dimension, clusterAxis);
-
-      // We need to reshape the output to tensor rank=4 as well.
-      RankedTensorType outputType = mlir::cast<RankedTensorType>(op.getType());
-      llvm::SmallVector<int64_t> outputTypeShape(outputType.getShape());
-
-      uint32_t requiredOnesOutput = 4 - outputTypeShape.size();
-      llvm::SmallVector<int64_t> reshapedOutputShape(requiredOnesOutput, 1);
-      reshapedOutputShape.append(outputTypeShape);
-
-      auto reshapedOutputType =
-          RankedTensorType::Builder(outputType).setShape(reshapedOutputShape);
-      ArrayAttr reshapedOutputShapeAttr =
-          rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(
-              outputTypeShape.begin(), outputTypeShape.end()));
-
-      // Create a new all gather op.
-      ttnn::AllGatherOp allGatherOp = rewriter.create<ttnn::AllGatherOp>(
-          ttmlir::utils::appendLocationSuffix(loc, "_allGather"),
-          Type(reshapedOutputType), reduceScatterOp.getResult(), deviceValue,
-          dimension, clusterAxis);
-
-      rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
-          op, Type(outputType), allGatherOp.getResult(),
-          reshapedOutputShapeAttr, /* memory_config */ nullptr);
-    } else {
-      // TODO(wooseoklee): Once ttnn supports all_reduce op
-      // (https://github.com/tenstorrent/tt-metal/issues/13835), we can
-      // convert directly to ttnn.all_reduce.
-
-      // Determine the shape of its input tensor. The new tensor
-      // shape at the scatter_dim will be tensor_shape[scatter_dim] =
-      // original_tensor_shape / num_devices.
-      inputTypeShape[dimension] =
-          inputTypeShape[dimension] / meshShape[clusterAxis];
-      auto scatteredInputType =
-          RankedTensorType::Builder(inputType).setShape(inputTypeShape);
-
-      // Create a new reducer scatter op.
-      ttnn::ReduceScatterOp reduceScatterOp =
-          rewriter.create<ttnn::ReduceScatterOp>(
-              ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
-              Type(scatteredInputType), op.getInput(), deviceValue,
-              op.getReduceType(), dimension, clusterAxis);
-
-      // Replace all_reduce op with all_gather op.
-      rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
-          op, op.getType(), reduceScatterOp.getResult(), deviceValue, dimension,
-          clusterAxis);
-    }
+    // Replace all_reduce op with all_gather op.
+    rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
+        op, op.getType(), reduceScatterOp.getResult(), deviceValue, dimension,
+        clusterAxis);
     return success();
   }
 

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
@@ -12,8 +12,8 @@ module attributes {} {
     %1 = "ttir.all_reduce"(%arg0, %0) <{all_gather_dim = 0 : si32, cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 0 : si32}> : (tensor<4096x16384xf32>, tensor<4096x16384xf32>) -> tensor<4096x16384xf32>
     // CHECK: = "ttnn.reshape"
     // CHECK: "ttnn.reduce_scatter"
-    // CHECK: "ttnn.all_gather"
     // CHECK: = "ttnn.reshape"
+    // CHECK: "ttnn.all_gather"
     return %1 : tensor<4096x16384xf32>
   }
 }
@@ -28,8 +28,8 @@ module attributes {} {
     %1 = "ttir.all_reduce"(%arg0, %0) <{all_gather_dim = 0 : si32, cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 0 : si32}> : (tensor<1x1x4096x16384xf32>, tensor<1x1x4096x16384xf32>) -> tensor<1x1x4096x16384xf32>
     // CHECK-NOT: = "ttnn.reshape"
     // CHECK: "ttnn.reduce_scatter"
-    // CHECK: "ttnn.all_gather"
     // CHECK-NOT: = "ttnn.reshape"
+    // CHECK: "ttnn.all_gather"
     return %1 : tensor<1x1x4096x16384xf32>
   }
 }
@@ -44,9 +44,9 @@ module attributes {} {
     %1 = "ttir.all_reduce"(%arg0, %0) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 0 : si32}> : (tensor<4096x16384xf32>, tensor<4096x16384xf32>) -> tensor<4096x16384xf32>
     // CHECK-NOT: = "ttnn.reshape"
     // CHECK-NOT: "ttnn.reduce_scatter"
+    // CHECK-NOT: = "ttnn.reshape"
     // CHECK-NOT: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.all_reduce"
-    // CHECK-NOT: = "ttnn.reshape"
     return %1 : tensor<4096x16384xf32>
   }
 }
@@ -61,9 +61,9 @@ module attributes {} {
     %1 = "ttir.all_reduce"(%arg0, %0) <{all_gather_dim = 0 : si32, cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 0 : si32}> : (tensor<1x1x4096x16384xf32>, tensor<1x1x4096x16384xf32>) -> tensor<1x1x4096x16384xf32>
     // CHECK-NOT: = "ttnn.reshape"
     // CHECK-NOT: "ttnn.reduce_scatter"
+    // CHECK-NOT: = "ttnn.reshape"
     // CHECK-NOT: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.all_reduce"
-    // CHECK-NOT: = "ttnn.reshape"
     return %1 : tensor<1x1x4096x16384xf32>
   }
 }


### PR DESCRIPTION
### Ticket
closes #4236 

### Problem description
here are two separate workaround implementations - one for Reduce Scatter and another for All Reduce - that contain almost identical logic. This duplication makes the codebase harder to maintain and increases the risk of inconsistencies.

### What's changed
Removed redundant workaround in All Reduce
 - The special-case code that handled dim < 4 tensors inside the All Reduce workaround has been deleted.
 - All Reduce is now transformed only by decomposing it into Reduce Scatter + All Gather, without altering tensor ranks or layouts.
 - Centralized handling of dim < 4 Reduce Scatter
 - Any dim < 4 tensors produced by the All Reduce decomposition are now handled exclusively by the existing Reduce Scatter workaround.
Updated Reduce Scatter workaround implementation
 - Updated the implementation so that 4-D Reduce Scatter outputs are constructed with RankedTensorTypeFactory, ensuring the resulting tensors have the correct layout.

### Checklist
- [ ] New/Existing tests provide coverage for changes
