### PR TITLE
Fix SmallVector to Span conversion

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1227,13 +1227,16 @@ OpModel<mlir::tt::ttnn::SliceOp>::getOpConstraints(
   ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
+  ::ttsl::Span<const int> beginsSpan = ::ttsl::make_span(beginsVec);
+  ::ttsl::Span<const int> endsSpan = ::ttsl::make_span(endsVec);
+  ::ttsl::Span<const int> stepSpan = ::ttsl::make_span(stepVec);
+
   // Create query closure
   auto sliceOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
+        ::ttnn::slice, device, inputSpec, beginsSpan, endsSpan, stepSpan,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt,
         std::nullopt);
-    // conversion::getShape(outputShape), std::nullopt);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
@@ -1267,10 +1270,14 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::SliceOp>::getOpRuntime(
   ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
+  ::ttsl::Span<const int> beginsSpan = ::ttsl::make_const_span(beginsVec);
+  ::ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
+  ::ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
+
   // Create query closure
   auto sliceOpQuery = [=]() {
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
+        ::ttnn::slice, device, inputSpec, beginsSpan, endsSpan, stepSpan,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt,
         std::nullopt);
   };

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -20,7 +20,11 @@ void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
   ::ttsl::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
   ::ttsl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
 
-  ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
+  ::ttsl::Span<const int32_t> beginsSpan = ::ttsl::make_const_span(begins);
+  ::ttsl::Span<const int32_t> endsSpan = ::ttsl::make_const_span(ends);
+  ::ttsl::Span<const int32_t> stepSpan = ::ttsl::make_const_span(step);
+
+  ::ttnn::Tensor out = ::ttnn::slice(in, beginsSpan, endsSpan, stepSpan);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }


### PR DESCRIPTION
### Problem description
After changes to tt_stl in tt-metal, the following error began to occur: no matching conversion for functional-style cast from 'const ttnn::SmallVector<int>' (aka 'const SmallVector<int, 8UL>') to 'tt::stl::Span<const int>' (aka 'span<const int, 18446744073709551615UL>')

### What's changed
The conversion was broken in ttnn::slice. As a workaround, we convert a ttnn::SmallVector to ttsl::Span which matches another overload of ttnn::slice.