### PR TITLE
Fix PermuteOp flatbuffer serialization to respect memory layout changes

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -838,17 +838,14 @@ createOp(FlatbufferObjectCache &cache, PermuteOp op) {
           getOperandThroughDPSOps(op.getInput()));
   flatbuffers::Offset<flatbuffers::Vector<int64_t>> permutation =
       toFlatbuffer(cache, op.getPermutation());
-  std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
-      op.getMemoryConfig();
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
   float padValue = op.getPadValue().convertToFloat();
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedSize);
 
   auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
-  return ::tt::target::ttnn::CreatePermuteOp(
-      *cache.fbb, input, permutation,
-      memoryConfig ? toFlatbuffer(cache, memoryConfig.value()) : 0, padValue,
-      output);
+  return ::tt::target::ttnn::CreatePermuteOp(*cache.fbb, input, permutation,
+                                             memoryConfig, padValue, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::BatchNormOp>


### PR DESCRIPTION
### Ticket

### Problem description

### What's changed
This PR updates the PermuteOp flatbuffer serialization to use getMemoryConfigIfNeeded(cache, op) instead of directly accessing op.getMemoryConfig(). The getMemoryConfigIfNeeded function:

1. First attempts to get the memory config from the op's explicit attribute
2. If that's null, derives the memory config from the output tensor's layout information