### PR TITLE
Ignore `third_party/ttnn-python`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .local
 **/build
+
+# Third party dirs generatd/fetched by CMake
 third_party/tt-metal
+third_party/ttnn-python
+
 .DS_STORE
 .vscode/*
 .cache


### PR DESCRIPTION
Some time ago we started generating `third_party/ttnn-python` as part of the build, but never ignored it. This change ignores it.