### PR TITLE
Add RMS norm operation across TTIR and TTNN dialects

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -5,6 +5,6 @@
 
 # Calculate hash from the following files. This hash is used to tag the docker images.
 # Any change in these files will result in a new docker image build
-DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/patches/shardy.patch env/patches/shardy_roundtrip.patch env/patches/llvm.patch"
+DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/patches/shardy.patch env/patches/shardy_roundtrip.patch env/patches/llvm.patch test/python/requirements.txt"
 DOCKERFILE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES | sha256sum | cut -d ' ' -f 1)
 echo dt-$DOCKERFILE_HASH

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2067,6 +2067,58 @@ def TTIR_BatchNormOp : TTIR_DPSOp<"batch_norm"> {
   let hasVerifier = 1;
 }
 
+def TTIR_RMSNormOp : TTIR_DPSOp<"rms_norm", [AttrSizedOperandSegments]> {
+  let summary = "RMS normalization operation";
+  let description = [{
+    Performs RMS (Root Mean Square) normalization on the input tensor. This operation
+    normalizes the input tensor by computing the root mean square of elements across
+    the specified dimensions and dividing by that value, optionally scaling and
+    shifting the result.
+
+    Inputs:
+    - `input` (Tensor): The input tensor to be normalized.
+    - `weight` (Optional Tensor): The scale parameter (gamma). If provided, the normalized
+      result is element-wise multiplied by this weight.
+    - `bias` (Optional Tensor): The shift parameter (beta). If provided, this bias is
+      added to the scaled result.
+
+    Attributes:
+    - `normalized_shape` specifies the dimensions over which to normalize. Typically
+      the last few dimensions of the input tensor.
+    - `epsilon` is a small constant added for numerical stability (default: 1e-05).
+
+    Output:
+    - `result` (Tensor): The RMS normalized output tensor.
+
+    Example:
+    ```mlir
+      // RMS normalization over last dimension (shape: [2, 4, 8] -> normalize over [8])
+      %result = ttir.rms_norm(%input, %weight, %bias, %output,
+                             normalized_shape = [8], epsilon = 1e-05) :
+            (tensor<2x4x8xf32>, tensor<2x4x8xf32>, tensor<8xf32>, tensor<8xf32>) -> tensor<2x4x8xf32>
+
+      // RMS normalization over last two dimensions (shape: [2, 4, 8] -> normalize over [4, 8])
+      %result = ttir.rms_norm(%input, %weight, %bias, %output,
+                             normalized_shape = [4, 8], epsilon = 1e-05) :
+            (tensor<2x4x8xf32>, tensor<2x4x8xf32>, tensor<4x8xf32>) -> tensor<2x4x8xf32>
+    ```
+
+    Mathematical definition: rms_norm(x, weight, bias, epsilon) =
+      (x / sqrt(mean(x^2, dims=normalized_dims) + epsilon)) * weight + bias
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       Optional<AnyRankedTensor>:$weight,
+                       Optional<AnyRankedTensor>:$bias,
+                       AnyRankedTensor:$output,
+                       DenseI64ArrayAttr:$normalized_shape,
+                       DefaultValuedAttr<F32Attr, "1e-05">:$epsilon);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
     TTIR_NamedOp<mnemonic, traits> {
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1633,6 +1633,28 @@ def TTNN_BatchNormOp : TTNN_Op<"batch_norm", [AttrSizedOperandSegments,
     let hasVerifier = 1;
 }
 
+def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, HasMemoryConfigTrait]> {
+    let summary = "RMS normalization op.";
+    let description = [{
+      RMS (Root Mean Square) normalization operation over the input tensor.
+      Normalizes the input by computing the root mean square of elements and
+      dividing by that value, optionally scaling and shifting the result.
+
+      This operation performs normalization over the last dimension of the input tensor,
+      matching the TTNN runtime implementation.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         Optional<AnyRankedTensor>:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         DefaultValuedAttr<F32Attr, "1e-12">:$epsilon,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar", [HasMemoryConfigTrait,
       DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -21,3 +21,12 @@ table BatchNormOp {
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
 }
+
+table RMSNormOp {
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  epsilon: float;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -78,6 +78,7 @@ union OpType {
   ReduceScatterOp,
   RepeatInterleaveOp,
   RepeatOp,
+  RMSNormOp,
   ReshapeOp,
   SliceOp,
   SoftmaxOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -937,6 +937,45 @@ public:
 };
 } // namespace
 
+namespace {
+class RMSNormOpConversionPattern : public OpConversionPattern<ttir::RMSNormOp> {
+public:
+  using OpConversionPattern<ttir::RMSNormOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::RMSNormOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+
+    // TTNN RMS norm only supports normalization over the last dimension.
+    // We need to validate that the normalized_shape matches this constraint.
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    ArrayRef<int64_t> normalizedShape = adaptor.getNormalizedShape();
+
+    // For now, TTNN only support normalization over the last dimension (most
+    // common case).
+    if (normalizedShape.size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "TTNN RMS norm currently only supports normalization over the "
+              "last dimension");
+    }
+
+    if (normalizedShape[0] != inputShape.back()) {
+      return rewriter.notifyMatchFailure(
+          op, "TTNN RMS norm requires normalized_shape to match the last "
+              "dimension of input shape");
+    }
+
+    rewriter.replaceOpWithNewOp<ttnn::RMSNormOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getWeight(), adaptor.getBias(),
+        adaptor.getEpsilon(), /*memoryConfig*/ nullptr);
+    return success();
+  }
+};
+} // namespace
+
 // ANCHOR: adding_an_op_matmul_op_rewriter
 namespace {
 class MatmulOpConversionPattern : public OpConversionPattern<ttir::MatmulOp> {
@@ -1864,6 +1903,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ConstantOpConversionPattern,
            LinearOpConversionPattern,
            BatchNormOpConversionPattern,
+           RMSNormOpConversionPattern,
            MatmulOpConversionPattern,
            Conv2dOpConversionPattern,
            ConvTranspose2dOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2281,6 +2281,40 @@ public:
 };
 } // namespace
 
+// RMSNormOp conversion pattern
+//
+namespace {
+class RMSNormOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::RMSNormOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::RMSNormOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::RMSNormOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::RMSNormOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getEpsilon()),
+        emitter.emit(srcOp.getWeight()),
+        emitter.emit(srcOp.getBias()),
+        emitter.emit(/* residual_input_tensor= */ std::nullopt),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
+        emitter.emit(/* program_config= */ std::nullopt),
+        emitter.emit(/* compute_kernel_config= */ std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // PermuteOp conversion pattern
 //
 namespace {
@@ -2535,8 +2569,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
                DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
-               MorehCumSumOpConversionPattern, BatchNormOpConversionPattern>(
-      typeConverter, ctx);
+               MorehCumSumOpConversionPattern, BatchNormOpConversionPattern,
+               RMSNormOpConversionPattern>(typeConverter, ctx);
 
   // CCL ops
   //

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2137,6 +2137,60 @@ mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// RMSNormOp
+//===----------------------------------------------------------------------===//
+::mlir::LogicalResult mlir::tt::ttnn::RMSNormOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType outputType = getResult().getType();
+
+  // Input and output must have the same shape.
+  if (inputType.getShape() != outputType.getShape()) {
+    return emitOpError("input and output must have the same shape");
+  }
+
+  // For 0D tensors, weight and bias validation is different.
+  if (inputType.getRank() == 0) {
+    // For 0D tensors, weight and bias should also be 0D if present.
+    if (getWeight()) {
+      RankedTensorType weightType = getWeight().getType();
+      if (weightType.getRank() != 0) {
+        return emitOpError("weight tensor must be 0D for 0D input tensor");
+      }
+    }
+    if (getBias()) {
+      RankedTensorType biasType = getBias().getType();
+      if (biasType.getRank() != 0) {
+        return emitOpError("bias tensor must be 0D for 0D input tensor");
+      }
+    }
+    return success();
+  }
+
+  // For non-0D tensors, get the last dimension size for weight/bias validation.
+  int64_t lastDimSize = inputType.getShape().back();
+
+  // Verify weight tensor shape if present.
+  if (getWeight()) {
+    RankedTensorType weightType = getWeight().getType();
+    if (weightType.getRank() != 1 || weightType.getShape()[0] != lastDimSize) {
+      return emitOpError("weight tensor must be 1D with size matching the last "
+                         "dimension of input");
+    }
+  }
+
+  // Verify bias tensor shape if present.
+  if (getBias()) {
+    RankedTensorType biasType = getBias().getType();
+    if (biasType.getRank() != 1 || biasType.getShape()[0] != lastDimSize) {
+      return emitOpError("bias tensor must be 1D with size matching the last "
+                         "dimension of input");
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // AllGatherOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -880,6 +880,37 @@ createOp(FlatbufferObjectCache &cache, BatchNormOp op) {
       weight, bias, memoryConfig, output);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::RMSNormOp>
+createOp(FlatbufferObjectCache &cache, RMSNormOp op) {
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getInput()));
+
+  // Handle optional weight and bias operands
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> weight = 0;
+  if (op.getWeight()) {
+    weight = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getWeight()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> bias = 0;
+  if (op.getBias()) {
+    bias = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getBias()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> output =
+      cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                        kHostAllocatedSize);
+
+  ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
+      getMemoryConfigIfNeeded(cache, op);
+
+  return ::tt::target::ttnn::CreateRMSNormOp(*cache.fbb, input, weight, bias,
+                                             op.getEpsilon().convertToFloat(),
+                                             memoryConfig, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::UpsampleOp>
 createOp(FlatbufferObjectCache &cache, UpsampleOp op) {
   flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
@@ -2327,6 +2358,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto batchNormOp = dyn_cast<BatchNormOp>(op); batchNormOp) {
     return createOperation(cache, createOp(cache, batchNormOp), debugString,
+                           locInfo);
+  }
+  if (auto rmsNormOp = dyn_cast<RMSNormOp>(op); rmsNormOp) {
+    return createOperation(cache, createOp(cache, rmsNormOp), debugString,
                            locInfo);
   }
   if (auto constantOp = dyn_cast<ConstantOp>(op); constantOp) {

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -38,6 +38,7 @@
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/moreh/moreh_cumsum/moreh_cumsum.hpp"
 #include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
+#include "ttnn/operations/normalization/rmsnorm/rmsnorm.hpp"
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
 #include "ttnn/operations/pool/generic/generic_pools.hpp"
 #include "ttnn/operations/pool/upsample/upsample.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/mlir_native/func_call.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/moreh/moreh_cumsum.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/batch_norm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/normalization/rms_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/softmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/pool2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/upsample.cpp

--- a/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/normalization/rms_norm.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::rms_norm {
+void run(const ::tt::target::ttnn::RMSNormOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
+
+  // Handle optional weight and bias parameters
+  std::optional<::ttnn::Tensor> weight = std::nullopt;
+  if (op->weight()) {
+    weight = tensorPool.getTTNNTensorAndValidate(op->weight());
+  }
+
+  std::optional<::ttnn::Tensor> bias = std::nullopt;
+  if (op->bias()) {
+    bias = tensorPool.getTTNNTensorAndValidate(op->bias());
+  }
+
+  float epsilon = op->epsilon();
+
+  // Handle optional memory config
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+
+  // Call TTNN RMS norm operation
+  ::ttnn::Tensor output = ::ttnn::rms_norm(
+      input, epsilon, weight, bias,
+      /*residual_input_tensor=*/std::nullopt, // Not used in our implementation
+      memoryConfig,
+      /*program_config=*/std::nullopt,       // Use default
+      /*compute_kernel_config=*/std::nullopt // Use default
+  );
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
+}
+} // namespace tt::runtime::ttnn::operations::rms_norm

--- a/runtime/lib/ttnn/operations/normalization/rms_norm.h
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_RMS_NORM_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_RMS_NORM_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::rms_norm {
+void run(const ::tt::target::ttnn::RMSNormOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::rms_norm
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -52,6 +52,7 @@
 #include "operations/mlir_native/func_call.h"
 #include "operations/moreh/moreh_cumsum.h"
 #include "operations/normalization/batch_norm.h"
+#include "operations/normalization/rms_norm.h"
 #include "operations/normalization/softmax.h"
 #include "operations/pool/pool2d.h"
 #include "operations/pool/upsample.h"
@@ -276,6 +277,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::RepeatOp: {
     return operations::data_movement::run(op->type_as_RepeatOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::RMSNormOp: {
+    return operations::rms_norm::run(op->type_as_RMSNormOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::RepeatInterleaveOp: {
     return operations::data_movement::run(op->type_as_RepeatInterleaveOp(),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1105,6 +1105,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_BatchNormOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::RMSNormOp: {
+    tensorRef = opContext.type_as_RMSNormOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::AllGatherOp: {
     tensorRef = opContext.type_as_AllGatherOp()->out();
     break;
@@ -1363,6 +1367,16 @@ getOpInputRefs(OpContext opContextHandle,
                   opContext.type_as_BatchNormOp()->running_var(),
                   opContext.type_as_BatchNormOp()->weight(),
                   opContext.type_as_BatchNormOp()->bias()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::RMSNormOp: {
+    tensorRefs = {opContext.type_as_RMSNormOp()->input()};
+    if (opContext.type_as_RMSNormOp()->weight()) {
+      tensorRefs.push_back(opContext.type_as_RMSNormOp()->weight());
+    }
+    if (opContext.type_as_RMSNormOp()->bias()) {
+      tensorRefs.push_back(opContext.type_as_RMSNormOp()->bias());
+    }
     break;
   }
   case ::tt::target::ttnn::OpType::AllGatherOp: {

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,4 +1,4 @@
 lit
 pytest
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.3.0
+torch==2.5.0

--- a/test/ttmlir/Dialect/TTIR/ttir_rms_norm_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ttir_rms_norm_negative.mlir
@@ -1,0 +1,73 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for TTIR RMSNormOp
+
+// CHECK: error: 'ttir.rms_norm' op input and output must have the same shape
+func.func @rms_norm_shape_mismatch(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x16xf32> {
+  %0 = ttir.empty() : tensor<2x4x16xf32>
+  %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64: 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<2x4x8xf32>, tensor<2x4x16xf32>) -> tensor<2x4x16xf32>
+  return %1 : tensor<2x4x16xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op normalized_shape cannot be empty
+func.func @rms_norm_empty_normalized_shape(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op normalized_shape has more dimensions than input tensor
+func.func @rms_norm_normalized_shape_too_large(%arg0: tensor<2x4xf32>) -> tensor<2x4xf32> {
+  %0 = ttir.empty() : tensor<2x4xf32>
+  %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64: 2, 4, 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<2x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
+  return %1 : tensor<2x4xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op normalized_shape dimensions must match trailing dimensions of input tensor
+func.func @rms_norm_normalized_shape_mismatch(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64: 4, 16>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op normalized_shape dimensions must match trailing dimensions of input tensor
+func.func @rms_norm_normalized_shape_single_dim_mismatch(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64: 16>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<2x4x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op weight tensor shape must match normalized_shape
+func.func @rms_norm_weight_shape_mismatch(%arg0: tensor<2x4x8xf32>, %arg1: tensor<16xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %arg1, %0) <{normalized_shape = array<i64: 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 1>}> : (tensor<2x4x8xf32>, tensor<16xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op bias tensor shape must match normalized_shape
+func.func @rms_norm_bias_shape_mismatch(%arg0: tensor<2x4x8xf32>, %arg1: tensor<8xf32>, %arg2: tensor<4xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %arg1, %arg2, %0) <{normalized_shape = array<i64: 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<2x4x8xf32>, tensor<8xf32>, tensor<4xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op weight tensor shape must match normalized_shape
+func.func @rms_norm_weight_multidim_shape_mismatch(%arg0: tensor<2x4x8xf32>, %arg1: tensor<4x16xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %arg1, %0) <{normalized_shape = array<i64: 4, 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 1>}> : (tensor<2x4x8xf32>, tensor<4x16xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttir.rms_norm' op bias tensor shape must match normalized_shape
+func.func @rms_norm_bias_multidim_shape_mismatch(%arg0: tensor<2x4x8xf32>, %arg1: tensor<4x8xf32>, %arg2: tensor<2x8xf32>) -> tensor<2x4x8xf32> {
+  %0 = ttir.empty() : tensor<2x4x8xf32>
+  %1 = "ttir.rms_norm"(%arg0, %arg1, %arg2, %0) <{normalized_shape = array<i64: 4, 8>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<2x4x8xf32>, tensor<4x8xf32>, tensor<2x8xf32>, tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/rms_norm/simple_rms_norm.mlir
+++ b/test/ttmlir/Dialect/TTNN/rms_norm/simple_rms_norm.mlir
@@ -1,0 +1,42 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // Test basic RMS norm with normalization over last dimension [1024]
+  func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = ttir.empty() : tensor<512x1024xbf16>
+    // CHECK: "ttnn.rms_norm"
+
+    %1 = "ttir.rms_norm"(%arg0, %0) <{normalized_shape = array<i64: 1024>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %1 : tensor<512x1024xbf16>
+  }
+
+  // Test RMS norm with weight
+  func.func @forward_with_weight(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = ttir.empty() : tensor<512x1024xbf16>
+    %1 = ttir.empty() : tensor<1024xbf16>
+    // CHECK: "ttnn.rms_norm"
+    %2 = "ttir.rms_norm"(%arg0, %1, %0) <{normalized_shape = array<i64: 1024>, epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 1>}> : (tensor<512x1024xbf16>, tensor<1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %2 : tensor<512x1024xbf16>
+  }
+
+  // Test RMS norm with bias
+  func.func @forward_with_bias(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = ttir.empty() : tensor<512x1024xbf16>
+    %1 = ttir.empty() : tensor<1024xbf16>
+    // CHECK: "ttnn.rms_norm"
+    %2 = "ttir.rms_norm"(%arg0, %1, %0) <{normalized_shape = array<i64: 1024>, epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<512x1024xbf16>, tensor<1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %2 : tensor<512x1024xbf16>
+  }
+
+  // Test RMS norm with weight and bias
+  func.func @forward_with_weight_and_bias(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = ttir.empty() : tensor<512x1024xbf16>
+    %1 = ttir.empty() : tensor<1024xbf16>
+    %2 = ttir.empty() : tensor<1024xbf16>
+    // CHECK: "ttnn.rms_norm"
+
+    %3 = "ttir.rms_norm"(%arg0, %1, %2, %0) <{normalized_shape = array<i64: 1024>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<512x1024xbf16>, tensor<1024xbf16>, tensor<1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %3 : tensor<512x1024xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/ttnn_rms_norm_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttnn_rms_norm_negative.mlir
@@ -1,0 +1,64 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for TTNN RMSNormOp
+
+// CHECK: error: 'ttnn.rms_norm' op input and output must have the same shape
+func.func @rms_norm_shape_mismatch(%arg0: tensor<2x4x8xf32>) -> tensor<2x4x16xf32> {
+  %1 = "ttnn.rms_norm"(%arg0) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 0, 0>}> : (tensor<2x4x8xf32>) -> tensor<2x4x16xf32>
+  return %1 : tensor<2x4x16xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op weight tensor must be 0D for 0D input tensor
+func.func @rms_norm_0d_input_weight_not_0d(%arg0: tensor<f32>, %arg1: tensor<1xf32>) -> tensor<f32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<f32>, tensor<1xf32>) -> tensor<f32>
+  return %1 : tensor<f32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op bias tensor must be 0D for 0D input tensor
+func.func @rms_norm_0d_input_bias_not_0d(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<1xf32>) -> tensor<f32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1, %arg2) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<f32>, tensor<f32>, tensor<1xf32>) -> tensor<f32>
+  return %1 : tensor<f32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op weight tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_weight_wrong_rank(%arg0: tensor<2x4x8xf32>, %arg1: tensor<2x8xf32>) -> tensor<2x4x8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<2x4x8xf32>, tensor<2x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op weight tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_weight_wrong_size(%arg0: tensor<2x4x8xf32>, %arg1: tensor<16xf32>) -> tensor<2x4x8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<2x4x8xf32>, tensor<16xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op bias tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_bias_wrong_rank(%arg0: tensor<2x4x8xf32>, %arg1: tensor<8xf32>, %arg2: tensor<2x8xf32>) -> tensor<2x4x8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1, %arg2) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<2x4x8xf32>, tensor<8xf32>, tensor<2x8xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op bias tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_bias_wrong_size(%arg0: tensor<2x4x8xf32>, %arg1: tensor<8xf32>, %arg2: tensor<4xf32>) -> tensor<2x4x8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1, %arg2) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<2x4x8xf32>, tensor<8xf32>, tensor<4xf32>) -> tensor<2x4x8xf32>
+  return %1 : tensor<2x4x8xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op weight tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_weight_0d_for_nonzero_input(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<8xf32>, tensor<f32>) -> tensor<8xf32>
+  return %1 : tensor<8xf32>
+}
+
+// -----
+// CHECK: error: 'ttnn.rms_norm' op bias tensor must be 1D with size matching the last dimension of input
+func.func @rms_norm_bias_0d_for_nonzero_input(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>, %arg2: tensor<f32>) -> tensor<8xf32> {
+  %1 = "ttnn.rms_norm"(%arg0, %arg1, %arg2) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<8xf32>, tensor<8xf32>, tensor<f32>) -> tensor<8xf32>
+  return %1 : tensor<8xf32>
+}

--- a/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+module {
+  func.func public @rms_norm(%arg0: tensor<2x4xf32>, %arg1: tensor<4xf32>) -> tensor<2x4xf32> {
+    %0 = ttir.empty() : tensor<2x4xf32>
+    %1 = "ttir.rms_norm"(%arg0, %arg1, %0) <{normalized_shape = array<i64: 4>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 1>}> : (tensor<2x4xf32>, tensor<4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
+    return %1 : tensor<2x4xf32>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/rms_norm/rms_norm.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/rms_norm/rms_norm.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+module @rms_norm {
+  func.func public @test_rms_norm(%arg0: tensor<2x4xf32>, %arg1: tensor<4xf32>) -> tensor<2x4xf32> {
+    %0 = ttir.empty() : tensor<2x4xf32>
+    // CHECK: ttnn.rms_norm
+    %1 = "ttir.rms_norm"(%arg0, %arg1, %0) <{normalized_shape = array<i64: 4>, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 1>}> : (tensor<2x4xf32>, tensor<4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
+    return %1 : tensor<2x4xf32>
+  }
+}

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -332,6 +332,50 @@ def batch_norm_golden(
     return result
 
 
+def rms_norm_golden(
+    input: torch.Tensor,
+    weight: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    normalized_shape: List[int] = None,
+    epsilon: float = 1e-5,
+) -> torch.Tensor:
+    """
+    Custom golden function for RMS normalization operation.
+    Parameters
+    ----------
+    input : torch.Tensor
+        Input tensor to RMS normalization operation
+    weight : torch.Tensor, optional
+        Weight tensor for scaling (default: None)
+    bias : torch.Tensor, optional
+        Bias tensor for shifting (default: None)
+    normalized_shape : List[int], optional
+        Shape of the input tensor to normalize (default: None)
+    epsilon : float, optional
+        Small value to avoid division by zero (default: 1e-5)
+    Returns
+    -------
+    torch.Tensor
+        RMS normalized output tensor
+    """
+    # Convert to float for computation
+    input_float = input.float()
+
+    rms_norm = torch.nn.functional.rms_norm(
+        input_float,
+        normalized_shape=normalized_shape,
+        weight=weight,
+        eps=epsilon,
+    )
+
+    # Apply bias (shift) if provided
+    if bias is not None:
+        rms_norm = rms_norm + bias.float()
+
+    # Convert back to original dtype
+    return rms_norm.to(input.dtype)
+
+
 def argmax_golden(input_tensor, dim_arg, keep_dim=False):
     """
     Custom golden function for argmax.
@@ -2133,6 +2177,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.EmbeddingOp: embedding_golden,
     ttir.Upsample2dOp: upsample2d_golden,
     ttir.BatchNormOp: batch_norm_golden,
+    ttir.RMSNormOp: rms_norm_golden,
     # Type operations
     ttir.TypecastOp: torch.Tensor.type,
     # Tensor creation

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -133,7 +133,6 @@ class TTIRBuilder(Builder):
             op_golden_function = builder_golden.get_golden_function(
                 op_ttir_function, **golden_kwargs
             )
-
             if (
                 not isinstance(organize_golden_args(inputs), torch.Tensor)
                 and organize_golden_args(inputs) == 0
@@ -4786,4 +4785,77 @@ class TTIRBuilder(Builder):
             [input],
             golden_kwargs=kwargs,
             ttir_kwargs=kwargs,
+        )
+
+    def rms_norm(
+        self,
+        in0: Operand,
+        normalized_shape: List[int],
+        weight: Optional[Operand] = None,
+        bias: Optional[Operand] = None,
+        epsilon: float = 1e-5,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpView:
+        """
+        Creates ``ttir.rms_norm``.
+
+        *RMS normalization operation.*
+
+        Performs RMS (Root Mean Square) normalization on the input tensor. This operation
+        normalizes the input tensor by computing the root mean square of elements across
+        the specified dimensions and dividing by that value, optionally scaling and
+        shifting the result.
+
+        Mathematical definition: rms_norm(x, weight, bias, epsilon) =
+          (x / sqrt(mean(x^2, dims=normalized_dims) + epsilon)) * weight + bias
+
+        Parameters
+        ----------
+        in0 : Operand
+            Input tensor to be normalized
+        normalized_shape : List[int]
+            Shape over which to normalize (typically the last few dimensions)
+        weight : Optional[Operand], optional
+            Scale parameter (gamma) tensor with shape matching normalized_shape
+        bias : Optional[Operand], optional
+            Shift parameter (beta) tensor with shape matching normalized_shape
+        epsilon : float, optional
+            Small constant for numerical stability (default: 1e-5)
+        unit_attrs : Optional[List[str]], optional
+            Optional list of unit attributes
+
+        Returns
+        -------
+        (*OpView*)
+        """
+        # Prepare TTIR kwargs:
+        ttir_kwargs = {
+            "normalized_shape": normalized_shape,
+            "epsilon": epsilon,
+        }
+
+        golden_kwargs = {
+            "normalized_shape": normalized_shape,
+            "epsilon": epsilon,
+        }
+
+        if weight is not None:
+            ttir_kwargs["weight"] = weight
+            golden_kwargs["weight"] = self._get_golden_tensor(weight)
+        if bias is not None:
+            ttir_kwargs["bias"] = bias
+            golden_kwargs["bias"] = self._get_golden_tensor(bias)
+
+        return self._op_proxy(
+            ttir.RMSNormOp,
+            [in0],
+            golden_kwargs=golden_kwargs,
+            ttir_kwargs=ttir_kwargs,
+            organize_ttir_args=lambda i, o, _: (
+                self._get_type(o),
+                i[0],
+                o,
+            ),
+            organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
+            unit_attrs=unit_attrs,
         )

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -30,6 +30,7 @@
 #include "operations/matmul/matmul.hpp"
 #include "operations/moreh/moreh_cumsum/moreh_cumsum.hpp"
 #include "operations/normalization/batch_norm/batch_norm.hpp"
+#include "operations/normalization/rmsnorm/rmsnorm.hpp"
 #include "operations/normalization/softmax/softmax.hpp"
 #include "operations/pool/generic/generic_pools.hpp"
 #include "operations/pool/upsample/upsample.hpp"


### PR DESCRIPTION
### Ticket
Closes #4262

### Problem description
The tt-mlir compiler was missing support for RMS (Root Mean Square) normalization operations, which are commonly used in modern neural network architectures like transformers. Without this operation, users could not compile models that utilize RMS normalization layers.

### What's changed
- Added TTIR RMSNormOp: New operation definition in TTIR dialect with support for normalized_shape, epsilon, optional weight/bias parameters, and comprehensive verification.
- Added TTNN RMSNormOp: Corresponding operation in TTNN dialect with memory config support and proper verification.
- Implemented conversion pipeline: Complete conversion from TTIR to TTNN with validation that normalized_shape matches TTNN's constraint of last-dimension normalization
- Added flatbuffer serialization: Full support for serializing RMS norm operations to flatbuffer format with proper handling of optional parameters
- Implemented runtime support: Complete runtime implementation including operation execution, tensor pool management, and proper handling of optional weight/bias tensors
- Added comprehensive tests: Test coverage across all levels - dialect verification, conversion pipeline, EmitC generation, and silicon execution tests

The implementation supports the full RMS normalization formula:
```
rms_norm(x, weight, bias, epsilon) = (x / sqrt(mean(x^2, dims=normalized_dims) + epsilon)) * weight + bias
```
with proper handling of optional weight and bias parameters.

### Checklist
- [x] New/Existing tests provide coverage for changes
