### PR TITLE
[PyKernel] Attributes node implementation

### DIFF
--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -411,7 +411,7 @@ def test_attributes():
     # TEST: Define variables
     # CHECK: %[[BANK_ID:.*]] = arith.constant
     bank_id = 1
-    args = TensorAccessorArgs(2,0)
+    args = TensorAccessorArgs(2, 0)
 
     # TEST: Check member function is called correctly
     # CHECK: %[[TA:.*]] = ttkernel.TensorAccessor({{.*}})
@@ -420,6 +420,7 @@ def test_attributes():
     # CHECK: ttkernel.tensor_accessor_get_noc_addr(%[[TA]], %[[BANK_ID]], {{.*}})
     noc_addr = ta.get_noc_addr(bank_id, 0)
     return
+
 
 test_assign()
 test_ifstmt()

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -405,6 +405,22 @@ def test_array_with_expressions():
     return
 
 
+@ttkernel_compile(optimize=False)
+def test_attributes():
+    # CHECK-LABEL: func.func @test_attributes
+    # TEST: Define variables
+    # CHECK: %[[BANK_ID:.*]] = arith.constant
+    bank_id = 1
+    args = TensorAccessorArgs(2,0)
+
+    # TEST: Check member function is called correctly
+    # CHECK: %[[TA:.*]] = ttkernel.TensorAccessor({{.*}})
+    ta = TensorAccessor(args, 0, 1024)
+
+    # CHECK: ttkernel.tensor_accessor_get_noc_addr(%[[TA]], %[[BANK_ID]], {{.*}})
+    noc_addr = ta.get_noc_addr(bank_id, 0)
+    return
+
 test_assign()
 test_ifstmt()
 test_for()
@@ -418,3 +434,4 @@ test_array_iteration()
 test_array_additional()
 test_multidim_arrays()
 test_array_with_expressions()
+test_attributes()

--- a/tools/pykernel/CMakeLists.txt
+++ b/tools/pykernel/CMakeLists.txt
@@ -8,6 +8,7 @@ declare_mlir_python_sources(TTPykernelSources
         ast.py
         op.py
         types.py
+        kernel_types.py
 )
 
 add_mlir_python_modules(TTPykernelModules

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -619,7 +619,7 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Function calls
     def visit_Call(self, node):
-        def _load_func_arg(func_arg): 
+        def _load_func_arg(func_arg):
             if not func_arg:
                 raise ValueError(f"Function argument not found for {node.func.id}")
             if hasattr(func_arg, "type") and isinstance(
@@ -652,7 +652,7 @@ class TTKernelCompiler(ast.NodeVisitor):
             for arg in node.args:
                 func_arg = _load_func_arg(self.visit(arg))
                 func_args.append(func_arg)
-            self.visit(node.func, func_args=func_args) # visit_Attribute
+            self.visit(node.func, func_args=func_args)  # visit_Attribute
 
     # Expressions
     def visit_Expr(self, node):
@@ -917,7 +917,7 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     def visit_Attribute(self, node, func_args=[]):
         # regex match for ttkernel.* and check if it has a PyKernelAttrBase subclass
-        pattern = r'ttkernel\.[a-zA-Z_][a-zA-Z0-9_]*'
+        pattern = r"ttkernel\.[a-zA-Z_][a-zA-Z0-9_]*"
         mlir_value = self.var_exists(node.value.id)[node.value.id]
         match = re.search(pattern, str(mlir_value.type)).group()
         if match and ClassRegistry.exists(match):
@@ -926,7 +926,9 @@ class TTKernelCompiler(ast.NodeVisitor):
             attr_class = ClassRegistry.get(match)()
             attr_class.emit_mlir(node.attr, func_args)
         else:
-            raise ValueError(f"{node.value.id} has no attributes. Did you define a PyKernelAttributesBase subclass?")
+            raise ValueError(
+                f"{node.value.id} has no attributes. Did you define a PyKernelAttributesBase subclass?"
+            )
         return
 
     def visit_List(self, node):
@@ -1036,11 +1038,11 @@ class TTKernelCompiler(ast.NodeVisitor):
                 # Create a verbatim Op here to store the comment
                 source_code = self.get_source_comment(node)
                 emitc.verbatim(source_code, [])
-            
+
             # Figure out which node to visit. Not using super().visit() in order to pass kwargs.
-            method_name = 'visit_' + node.__class__.__name__
+            method_name = "visit_" + node.__class__.__name__
             visitor = getattr(self, method_name, self.generic_visit)
-            
+
             return visitor(node, **kwargs)
         else:
             raise NotImplementedError(f"visit {type(node).__name__} not supported")

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -7,12 +7,14 @@ import inspect
 import functools
 import textwrap
 import os
+import re
 
 from ttmlir.ir import *
 from ttmlir.dialects import ttcore, ttkernel, func, scf, arith, memref, emitc
 from ttmlir.passes import ttkernel_to_cpp, pykernel_compile_pipeline
 
 from .types import *
+from .kernel_types import *
 
 
 def get_supported_nodes():
@@ -617,6 +619,17 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Function calls
     def visit_Call(self, node):
+        def _load_func_arg(func_arg): 
+            if not func_arg:
+                raise ValueError(f"Function argument not found for {node.func.id}")
+            if hasattr(func_arg, "type") and isinstance(
+                func_arg.type, memref.MemRefType
+            ):
+                func_arg = memref.LoadOp(
+                    func_arg, arith.ConstantOp(IndexType.get(self.ctx), 0)
+                )
+            return func_arg
+
         if not isinstance(node.func, ast.Attribute):
             # if not an Attribute, it's just a kernel api call.
             assert (
@@ -630,22 +643,16 @@ class TTKernelCompiler(ast.NodeVisitor):
             assert len(node.args) == len(args_as_attr)
             for arg, as_attr in zip(node.args, args_as_attr):
                 arg._ttkernel_as_attr = as_attr
-                func_arg = self.visit(arg)
-                if not func_arg:
-                    raise ValueError(f"Function argument not found for {node.func.id}")
-
-                if hasattr(func_arg, "type") and isinstance(
-                    func_arg.type, memref.MemRefType
-                ):
-                    func_arg = memref.LoadOp(
-                        func_arg, arith.ConstantOp(IndexType.get(self.ctx), 0)
-                    )
-
+                func_arg = _load_func_arg(self.visit(arg))
                 func_args.append(func_arg)
 
-            return func(*func_args)  # how do i make sure the types are correct?
+            return func(*func_args)  # type checking will occur downstream
         else:
-            self.visit(node.func)
+            func_args = []
+            for arg in node.args:
+                func_arg = _load_func_arg(self.visit(arg))
+                func_args.append(func_arg)
+            self.visit(node.func, func_args=func_args) # visit_Attribute
 
     # Expressions
     def visit_Expr(self, node):
@@ -908,12 +915,19 @@ class TTKernelCompiler(ast.NodeVisitor):
             idx = arith.IndexCastOp(IndexType.get(self.ctx), idx)
             return memref.LoadOp(arr, idx)
 
-    def visit_Attribute(self, node):
-        # TODO(vtang): Unsure how to get the lvalue type of operand w emitc pybinds rn
-        # emitc::LValueType::get(adaptor.getDataFormat().getType())
-        # operand_lvalue = emitc.LValueType.get()
-        # emitc.member(IntegerType.get_signless(32, self.ctx), node.attr, operand)
-        raise NotImplementedError("Attributes not supported yet")
+    def visit_Attribute(self, node, func_args=[]):
+        # regex match for ttkernel.* and check if it has a PyKernelAttrBase subclass
+        pattern = r'ttkernel\.[a-zA-Z_][a-zA-Z0-9_]*'
+        mlir_value = self.var_exists(node.value.id)[node.value.id]
+        match = re.search(pattern, str(mlir_value.type)).group()
+        if match and ClassRegistry.exists(match):
+            # Instantiate class and call its emit_mlir method.
+            func_args = [mlir_value] + func_args
+            attr_class = ClassRegistry.get(match)()
+            attr_class.emit_mlir(node.attr, func_args)
+        else:
+            raise ValueError(f"{node.value.id} has no attributes. Did you define a PyKernelAttributesBase subclass?")
+        return
 
     def visit_List(self, node):
         # Snoop List for nested loops and get size
@@ -1012,7 +1026,7 @@ class TTKernelCompiler(ast.NodeVisitor):
                 f"constant type {type(node.value).__name__} not implemented"
             )
 
-    def visit(self, node: ast.AST):
+    def visit(self, node: ast.AST, **kwargs):
         if any(
             isinstance(node, supported_node) for supported_node in self.supported_nodes
         ):
@@ -1022,7 +1036,12 @@ class TTKernelCompiler(ast.NodeVisitor):
                 # Create a verbatim Op here to store the comment
                 source_code = self.get_source_comment(node)
                 emitc.verbatim(source_code, [])
-            return super().visit(node)
+            
+            # Figure out which node to visit. Not using super().visit() in order to pass kwargs.
+            method_name = 'visit_' + node.__class__.__name__
+            visitor = getattr(self, method_name, self.generic_visit)
+            
+            return visitor(node, **kwargs)
         else:
             raise NotImplementedError(f"visit {type(node).__name__} not supported")
 

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -7,7 +7,6 @@ import inspect
 import functools
 import textwrap
 import os
-import re
 
 from ttmlir.ir import *
 from ttmlir.dialects import ttcore, ttkernel, func, scf, arith, memref, emitc

--- a/tools/pykernel/kernel_types.py
+++ b/tools/pykernel/kernel_types.py
@@ -4,23 +4,26 @@
 
 from ttmlir.dialects import ttkernel
 
+
 class ClassRegistry:
     _registry = {}
-    
+
     @classmethod
     def register(cls, mlir_type):
         def decorator(attr_class):
             cls._registry[mlir_type] = attr_class
             return attr_class
+
         return decorator
-    
+
     @classmethod
     def get(cls, mlir_type):
         return cls._registry.get(mlir_type)
-    
+
     @classmethod
     def exists(cls, mlir_type):
         return mlir_type in cls._registry
+
 
 class PyKernelClassBase:
     def __init__(self):
@@ -41,6 +44,7 @@ class PyKernelClassBase:
         else:
             raise ValueError(f"Member {member} not found in {self.__class__.__name__}")
 
+
 @ClassRegistry.register("ttkernel.TensorAccessor")
 class TensorAccessor(PyKernelClassBase):
     def __init__(self):
@@ -60,4 +64,6 @@ class TensorAccessor(PyKernelClassBase):
         return func(*args)
 
     def _emit_member_variable_mlir(self, member_variable):
-        raise NotImplementedError("TensorAccessorAttributes does not have member variables")
+        raise NotImplementedError(
+            "TensorAccessorAttributes does not have member variables"
+        )

--- a/tools/pykernel/kernel_types.py
+++ b/tools/pykernel/kernel_types.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ttmlir.dialects import ttkernel
+
+class ClassRegistry:
+    _registry = {}
+    
+    @classmethod
+    def register(cls, mlir_type):
+        def decorator(attr_class):
+            cls._registry[mlir_type] = attr_class
+            return attr_class
+        return decorator
+    
+    @classmethod
+    def get(cls, mlir_type):
+        return cls._registry.get(mlir_type)
+    
+    @classmethod
+    def exists(cls, mlir_type):
+        return mlir_type in cls._registry
+
+class PyKernelClassBase:
+    def __init__(self):
+        self.member_functions = {}
+        self.member_variables = {}
+
+    def _emit_member_function_mlir(self, member_function, args):
+        raise NotImplementedError("emit_mlir must be implemented in subclass")
+
+    def _emit_member_variable_mlir(self, member_variable):
+        raise NotImplementedError("emit_mlir must be implemented in subclass")
+
+    def emit_mlir(self, member, args):
+        if member in self.member_functions:
+            return self._emit_member_function_mlir(member, args)
+        elif member in self.member_variables:
+            return self._emit_member_variable_mlir(member)
+        else:
+            raise ValueError(f"Member {member} not found in {self.__class__.__name__}")
+
+@ClassRegistry.register("ttkernel.TensorAccessor")
+class TensorAccessor(PyKernelClassBase):
+    def __init__(self):
+        self.member_functions = {
+            "get_noc_addr": ttkernel.tensor_accessor_get_noc_addr,
+            "get_shard_noc_addr": ttkernel.tensor_accessor_get_shard_noc_addr,
+            "get_bank_and_offset": ttkernel.tensor_accessor_get_bank_and_offset,
+            "is_local_bank": ttkernel.tensor_accessor_is_local_bank,
+            "is_local_addr": ttkernel.tensor_accessor_is_local_addr,
+            "is_local_page": ttkernel.tensor_accessor_is_local_page,
+            "is_local_shard": ttkernel.tensor_accessor_is_local_shard,
+        }
+        self.member_variables = {}
+
+    def _emit_member_function_mlir(self, member_function, args):
+        func = self.member_functions[member_function]
+        return func(*args)
+
+    def _emit_member_variable_mlir(self, member_variable):
+        raise NotImplementedError("TensorAccessorAttributes does not have member variables")

--- a/tools/pykernel/op.py
+++ b/tools/pykernel/op.py
@@ -307,18 +307,3 @@ class PyKernelOp:
         program = cached_info["program_descriptor"]
 
         return self.ttnn.generic_op(tensors, program)
-
-class PyKernelAttributesBase:
-    def __init__(self):
-        self.member_functions = {}
-        self.member_variables = {}
-
-    def _emit_member_function_mlir(self, member_function):
-        raise NotImplementedError("emit_mlir must be implemented in subclass")
-
-    def _emit_member_variable_mlir(self, member_variable):
-        raise NotImplementedError("emit_mlir must be implemented in subclass")
-
-    def emit_mlir(self, member):
-        # call emit_member_function_mlir or emit_member_variable_mlir based on type
-        raise NotImplementedError("emit_mlir must be implemented in subclass")

--- a/tools/pykernel/op.py
+++ b/tools/pykernel/op.py
@@ -307,3 +307,18 @@ class PyKernelOp:
         program = cached_info["program_descriptor"]
 
         return self.ttnn.generic_op(tensors, program)
+
+class PyKernelAttributesBase:
+    def __init__(self):
+        self.member_functions = {}
+        self.member_variables = {}
+
+    def _emit_member_function_mlir(self, member_function):
+        raise NotImplementedError("emit_mlir must be implemented in subclass")
+
+    def _emit_member_variable_mlir(self, member_variable):
+        raise NotImplementedError("emit_mlir must be implemented in subclass")
+
+    def emit_mlir(self, member):
+        # call emit_member_function_mlir or emit_member_variable_mlir based on type
+        raise NotImplementedError("emit_mlir must be implemented in subclass")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4160)

### Problem description
Currently, if we want to access member functions, we call the ttkernel op, so it lowers properly: 
```
noc_addr = tensor_accessor_get_noc_addr(...)
```

Instead, want to be do something like below in python and have it lower properly to the right ttkernel function
```
addr_gen = TensorAccessor(...)
noc_addr = addr_gen.get_noc_addr(...)
```
Both of the above will map to `ttkernel.tensor_accessor_get_nocc_addr` but the latter is just better..

### What's changed
- `PyKernelClassBase` as a base class for any future kernel types
- `TensorAccessor` to provide access to member functions used by TensorAccessor in kernels
- `ClassRegistry` as a way to map to the right PyKernelClass based on the mlir stored in the ast symbol table.
- `visit_Attribute` ast node implementation
- base `visit` method in ast no longer calls `super.visit()`, instead allows passing kwargs through.
  - this is only used for `visit_Attribute` method right now.
- unit test for changes

Notes:
- none of existing programming examples actually makes use of TensorAccessor member functions yet.

### Checklist
- [x] New/Existing tests provide coverage for changes
