### PR TITLE
[WIP, #2394] better asserts lib

### DIFF
--- a/include/ttmlir/Asserts.h
+++ b/include/ttmlir/Asserts.h
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_ASSERTS_H
+#define TTMLIR_ASSERTS_H
+
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <type_traits>
+
+// ............................................................................
+namespace ttmlir::utils::asserts {
+
+// The TT_debug*() family of macros are meant to be elided in "release" builds
+// and are meant to be used in tight loops and similar situations where
+// invariant checking overhead should be remoed from the final product.
+//
+// These debug macros are enabled when TT_ASSERT_ENABLE_DEBUG_CHECKS is defined
+// which by default happens when TTMLIR_ENABLE_DEBUG_LOGS is defined.
+
+#ifdef TTMLIR_ENABLE_DEBUG_LOGS
+#define TT_ASSERT_ENABLE_DEBUG_CHECKS
+#endif // TTMLIR_ENABLE_DEBUG_LOGS
+
+// The default behavior for a triggered assert is to print a message (to
+// TT_ASSERT_REPORT_STREAM()) and std::abort the process. Redefine
+// TT_ASSERT_FAILURE() to call a different function (or throw an exception, or
+// do nothing) to customize this behavior.
+
+#if !defined(TT_ASSERT_FAILURE)
+#define TT_ASSERT_FAILURE() ::std::abort()
+#endif // TT_ASSERT_FAILURE
+
+// Redefine TT_ASSERT_REPORT_STREAM() to an expression that will return a
+// reference to an I/O stream that is to receive the triggered assert message
+// just before TT_ASSERT_FAILURE() action is taken. The default is
+// `::llvm::errs()`.
+
+#if !defined(TT_ASSERT_REPORT_STREAM)
+#define TT_ASSERT_REPORT_STREAM() ::llvm::errs()
+#endif // TT_ASSERT_REPORT_STREAM
+
+// ............................................................................
+namespace impl {
+
+// clang-format off
+
+#define TT_IMPL_ASSERT_LOC_INFO       __FILE__,__LINE__,__PRETTY_FUNCTION__
+
+#define TT_ASSERT_UNLIKELY(condition) __builtin_expect (static_cast<bool>(condition), 0)
+
+#define TT_ASSERT_STRINGIZE(x)        TT_IMPL_STRINGIZE(x)
+#define TT_IMPL_STRINGIZE(x)          #x
+
+// clang-format on
+
+template <typename T>
+struct always_false : std::false_type {};
+
+// ............................................................................
+
+template <typename T, typename = void>
+struct UnsignedCast {
+  // Specializing for non-integral types in order to generate nicer compiler
+  // error messages.
+  static_assert(always_false<T>::value,
+                "range asserts are only supported for integral types");
+};
+
+template <typename T>
+struct UnsignedCast<T, std::enable_if_t<std::is_integral_v<T>>> {
+  static auto evaluate(T x) -> std::make_unsigned_t<T> {
+    return static_cast<std::make_unsigned_t<T>>(x);
+  }
+};
+// ............................................................................
+
+template <typename T, typename Stream, typename = void>
+struct is_streamable : std::false_type {};
+
+template <typename T, typename Stream>
+struct is_streamable<
+    T, Stream,
+    std::void_t<decltype(std::declval<Stream &>() << std::declval<T>())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct has_to_string : std::false_type {};
+
+template <typename T>
+struct has_to_string<T, std::void_t<decltype(to_string(std::declval<T>()))>>
+    : std::true_type {};
+
+// ............................................................................
+
+// A hook for printing values in assertion failure messages (e.g. strings/chars
+// could be printed as quoted strings, etc).
+template <typename T, typename Stream, typename = void>
+struct PrintAdaptor {
+  static constexpr bool enabled = false;
+  static void evaluate(Stream &os, T &&obj) {
+    static_assert(
+        always_false<T>::value,
+        "assert condition contains an expression type that isn't printable "
+        "(wrap in parentheses to disable expression decomposition)");
+  }
+};
+
+template <typename T, typename Stream>
+struct PrintAdaptor<T, Stream,
+                    std::enable_if_t<is_streamable<T, Stream>::value>> {
+  static constexpr bool enabled = true;
+  static void evaluate(Stream &os, T &&obj) { os << obj; }
+};
+
+template <typename T, typename Stream>
+struct PrintAdaptor<T, Stream,
+                    std::enable_if_t<not is_streamable<T, Stream>::value and
+                                     has_to_string<T>::value>> {
+  static constexpr bool enabled = true;
+  static void evaluate(Stream &os, T &&obj) {
+    using std::to_string;
+    os << to_string(obj);
+  }
+};
+
+// llvm raw streams have ambiguous overloads for std::nullptr_t.
+template <typename T, typename Stream>
+
+struct PrintAdaptor<
+    T, Stream,
+    std::enable_if_t<std::is_null_pointer_v<std::remove_reference_t<T>>>> {
+  static constexpr bool enabled = true;
+  static void evaluate(Stream &os, T &&obj) { os << "nullptr"; }
+};
+
+} // namespace impl
+
+template <typename T, typename Stream>
+inline constexpr bool is_printable_v = impl::PrintAdaptor<T, Stream>::enabled;
+
+template <typename T, typename Stream>
+void print(Stream &os, T &&obj) {
+  impl::PrintAdaptor<T, Stream>::evaluate(os, std::forward<T>(obj));
+}
+// ............................................................................
+// clang-format off
+
+enum class BinaryOp {
+    eq,   // ==
+    ne,   // !=
+    lt,   // <
+    le,   // <=
+    gt,   // >
+    ge,   // >=
+    undefined
+};
+
+static inline constexpr const char * kBinaryOpName[] { "==", "!=", "<", "<=", ">", ">=", "UNDEFINED"};
+
+// clang-format on
+// ............................................................................
+
+template <typename LHS, typename RHS, BinaryOp Op>
+struct BinaryExpr {
+  LHS m_lhs;
+  RHS m_rhs;
+  bool m_result;
+
+  template <typename Stream>
+  void prefix(Stream &os, const char *file, int line, const char *func,
+              const char *condition) const {
+    os << file << ':' << line << ": " << func << ": Assertion `" << condition
+       << "` failed";
+    if constexpr (is_printable_v<LHS, Stream> && is_printable_v<RHS, Stream>) {
+      os << ", was `";
+      print(os, m_lhs);
+      os << ' ' << kBinaryOpName[llvm::to_underlying(Op)] << ' ';
+      print(os, m_rhs);
+      os << '`';
+    }
+  }
+
+  // Supports `TT_assert()`.
+  template <typename Stream>
+  void report(Stream &os, const char *file, int line, const char *func,
+              const char *condition) const {
+    prefix(os, file, line, func, condition);
+    os << '\n';
+  }
+
+  // Supports `TT_assertv()`.
+  template <typename Stream>
+  void report(Stream &os, const char *file, int line, const char *func,
+              const char *condition, const std::string &message) const {
+    prefix(os, file, line, func, condition);
+    os << ", " << message << '\n';
+  }
+
+  // Intercept chained expressions.
+
+#define TT_IMPL_ASSERT_CHAINED_OP_HANDLER(op)                                  \
+  template <typename T>                                                        \
+  auto operator op(T) -> BinaryExpr<LHS, RHS, Op> const {                      \
+    static_assert(                                                             \
+        impl::always_false<T>::value,                                          \
+        "chained comparisons are not supported inside assertions (e.g., wrap " \
+        "`x < y && a < b` inside parentheses, e.g. `(x < y && a < b)`)");      \
+  }
+
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(==)
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(!=)
+
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(<)
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(<=)
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(>)
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(>=)
+
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(&&)
+  TT_IMPL_ASSERT_CHAINED_OP_HANDLER(||)
+
+#undef TT_IMPL_ASSERT_CHAINED_OP_HANDLER
+};
+// ............................................................................
+
+template <typename LHS>
+struct ExprLHS {
+  explicit constexpr ExprLHS(LHS lhs) : m_lhs{lhs} {}
+
+  // Intercept binary expr cases.
+
+#define TT_IMPL_ASSERT_BINARY_OP_HANDLER(op, bop)                              \
+  template <typename RHS>                                                      \
+  constexpr friend auto operator op(ExprLHS &&lhs, RHS &&rhs)                  \
+      -> BinaryExpr<LHS, RHS, BinaryOp::bop> {                                 \
+    return {lhs.m_lhs, rhs, static_cast<bool>(lhs.m_lhs op rhs)};              \
+  }
+
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(==, eq)
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(!=, ne)
+
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(<, lt)
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(<=, le)
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(>, gt)
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(>=, ge)
+
+#undef TT_IMPL_ASSERT_BINARY_OP_HANDLER
+
+  // TODO(vroubtsov) |, &, ^ ?
+
+#define TT_IMPL_ASSERT_BINARY_OP_HANDLER(op)                                   \
+  template <typename RHS>                                                      \
+  constexpr friend auto operator op(ExprLHS &&lhs, RHS &&rhs)                  \
+      -> BinaryExpr<LHS, RHS, BinaryOp::undefined> {                           \
+    static_assert(impl::always_false<RHS>::value,                              \
+                  "operators ||, && are not supported inside TT_assert() "     \
+                  "assertions: wrap condition in parentheses");                \
+  }
+
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(||)
+  TT_IMPL_ASSERT_BINARY_OP_HANDLER(&&)
+
+#undef TT_IMPL_ASSERT_BINARY_OP_HANDLER
+
+  // Intercept unary expr cases.
+
+  template <typename Stream>
+  void prefix(Stream &os, const char *file, int line, const char *func,
+              const char *condition) const {
+    os << file << ':' << line << ": " << func << ": Assertion `" << condition
+       << "` failed";
+  }
+
+  // Supports `TT_assert()`.
+  template <typename Stream>
+  void report(Stream &os, const char *file, int line, const char *func,
+              const char *condition) const {
+    prefix(os, file, line, func, condition);
+    os << '\n';
+  }
+
+  // Supports `TT_assertv()`.
+  template <typename Stream>
+  void report(Stream &os, const char *file, int line, const char *func,
+              const char *condition, const std::string &message) const {
+    prefix(os, file, line, func, condition);
+    os << ", " << message << '\n';
+  }
+
+  LHS m_lhs;
+
+}; // end of class
+// ............................................................................
+
+struct ExprDecomposer {
+
+  template <typename T>
+  constexpr friend auto operator<=(ExprDecomposer &&, T &&lhs)
+      -> ExprLHS<const T &> {
+    return ExprLHS<const T &>{lhs};
+  }
+
+}; // end of class
+// ............................................................................
+
+template <typename T>
+decltype(auto) unsigned_cast(T x) {
+  return impl::UnsignedCast<T>::evaluate(x);
+}
+
+// These macro names spellings are intentional, they are intended to show up
+// in assert failure messages.
+
+// Single-branch `a <= x < b` check.
+#define in_open_range(x, a, b)                                                 \
+  (::ttmlir::utils::asserts::unsigned_cast((x) - (a)) <                        \
+   ::ttmlir::utils::asserts::unsigned_cast((b) - (a)))
+
+// Single-branch `a < x < b` check.
+#define in_exclusive_range(x, a, b)                                            \
+  (::ttmlir::utils::asserts::unsigned_cast((x) - (a)-1) <                      \
+   ::ttmlir::utils::asserts::unsigned_cast((b) - (a)-1))
+
+// Single-branch `a <= x <= b` check.
+#define in_inclusive_range(x, a, b)                                            \
+  (::ttmlir::utils::asserts::unsigned_cast((x) - (a)) <=                       \
+   ::ttmlir::utils::asserts::unsigned_cast((b) - (a)))
+
+// ............................................................................
+// clang-format off
+
+#define TT_assert(condition)                                                  \
+  do {                                                                        \
+    if (!TT_ASSERT_UNLIKELY(condition)) {                                     \
+      (::ttmlir::utils::asserts::ExprDecomposer { } <= condition )            \
+        .report(TT_ASSERT_REPORT_STREAM(), TT_IMPL_ASSERT_LOC_INFO, #condition); \
+      TT_ASSERT_FAILURE();                                                    \
+    }                                                                         \
+  } while (false)                                                             \
+  /* */
+
+// TODO(vroubtsov) for now, 'message' is required; in c++20 there will be
+// a standard-compliant way to make it optional and to nicely merge
+// TT_assert and TT_assertv into a single macro; there doesn't seem to be
+// a way to do this in c++17 without enabling gcc/clang extensions.
+
+#define TT_assertv(condition, /* message[, args...] */...)                    \
+  do {                                                                        \
+    if (!TT_ASSERT_UNLIKELY(condition)) {                                     \
+      (::ttmlir::utils::asserts::ExprDecomposer { } <= condition )            \
+        .report(TT_ASSERT_REPORT_STREAM(), TT_IMPL_ASSERT_LOC_INFO, #condition, \
+                llvm::formatv(__VA_ARGS__).str());                            \
+      TT_ASSERT_FAILURE();                                                    \
+    }                                                                         \
+  } while (false)                                                             \
+  /* */
+
+// ............................................................................
+
+// a <= x < b
+#define TT_assert_open_range(x, a, b) \
+  TT_assertv(in_open_range(x, a, b), "{} ({}) is not in [{}, {})", TT_ASSERT_STRINGIZE(x), x, a, b)
+
+// 0 <= x < b, convenience shortcut.
+#define TT_assert_limit(x, limit) \
+  TT_assertv(in_open_range(x, 0, limit), "{} ({}) is not in [0, {})", TT_ASSERT_STRINGIZE(x), x, limit)
+
+// a < x < b
+#define TT_assert_exclusive_range(x, a, b) \
+  TT_assertv(in_exclusive_range(x, a, b), "{} ({}) is not in ({}, {})", TT_ASSERT_STRINGIZE(x), x, a, b)
+
+// a <= x <= b
+#define TT_assert_inclusive_range(x, a, b) \
+  TT_assertv(in_inclusive_range(x, a, b), "{} ({}) is not in [{}, {}]", TT_ASSERT_STRINGIZE(x), x, a, b)
+
+// ............................................................................
+
+#ifdef TT_ASSERT_ENABLE_DEBUG_CHECKS
+
+# define TT_debug(condition)                            TT_assert(condition)
+# define TT_debugv(condition, /* message[, args] */...) TT_assertv(condition, __VA_ARGS__)
+
+# define TT_debug_open_range(x, a, b)                   TT_assert_open_range(x, a, b)
+# define TT_debug_limit(x, limit)                       TT_assert_limit(x, limit)
+# define TT_debug_exclusive_range(x, a, b)              TT_assert_exclusive_range(x, a, b)
+# define TT_debug_inclusive_range(x, a, b)              TT_assert_inclusive_range(x, a, b)
+
+#else // !TT_ASSERT_ENABLE_DEBUG_CHECKS
+
+# define TT_debug(condition)                            ((void)0)
+# define TT_debugv(condition, /* message[, args] */...) ((void)0)
+
+# define TT_debug_open_range(x, a, b)                   ((void)0)
+# define TT_debug_limit(x, limit)                       ((void)0)
+# define TT_debug_exclusive_range(x, a, b)              ((void)0)
+# define TT_debug_inclusive_range(x, a, b)              ((void)0)
+
+#endif // TT_ASSERT_ENABLE_DEBUG_CHECKS
+
+// clang-format on
+// ............................................................................
+
+} // namespace ttmlir::utils::asserts
+#endif // TTMLIR_ASSERTS_H

--- a/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
+++ b/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h"
 
+#include "ttmlir/Asserts.h"
 #include "ttmlir/Support/Logger.h"
 
 #include "llvm/ADT/IntervalTree.h"
@@ -16,8 +17,6 @@
 namespace mlir::tt::ttir {
 
 // Define some local convenience macros.
-
-#define TT_assert(condition, msg) assert((condition) && msg)
 
 #define TT_ALLOC_DEBUG(/* fmt, args */...)                                     \
   TTMLIR_DEBUG(ttmlir::LogComponent::Allocator, __VA_ARGS__)
@@ -32,9 +31,9 @@ using IndexT = std::int32_t;
 
 void AllocationPlanner::Context::add(AllocSizeT size, SequenceT first,
                                      SequenceT last) {
-  TT_assert(size > 0, "expected positive size");
-  TT_assert(0 <= first && 0 <= last, "expected non-negative op positions");
-  TT_assert(first <= last, "expected first <= last");
+  TT_assertv(size > 0, "expected positive size: {}", size);
+  TT_assert((0 <= first && 0 <= last));
+  TT_assert(first <= last);
 
   [[maybe_unused]] const auto &r =
       records.emplace_back(Record{-1, size, first, last});
@@ -129,7 +128,8 @@ PlannerImpl<AllocationPlanner::Algorithm::Greedy>::allocate(
     pq.pop();
     Record &record = records[i];
     TT_ALLOC_TRACE("record #{}: {}", i, record);
-    TT_assert(record.offset < 0, "record should not be marked allocated yet");
+    TT_assertv(record.offset < 0,
+               "record should not be marked allocated yet: {}", record);
 
     AllocSizeT gapBest = std::numeric_limits<AllocSizeT>::max();
     AllocSizeT offsetPrev = 0;
@@ -137,7 +137,7 @@ PlannerImpl<AllocationPlanner::Algorithm::Greedy>::allocate(
 
     for (const auto &[kOffset, k] : allocatedOrderedByOffset) {
       const Record &allocatedRecord = records[k];
-      TT_assert(kOffset >= 0 && kOffset == allocatedRecord.offset,
+      TT_debugv((kOffset >= 0 && kOffset == allocatedRecord.offset),
                 "iterating over allocated records");
 
       const SequenceT maxFirst = std::max(record.first, allocatedRecord.first);
@@ -223,7 +223,7 @@ AllocationPlanner::Stats AllocationPlanner::verify(const Context &context) {
   for (IndexT i = 0; i < n; ++i) {
     const Record &record = context[i];
 
-    TT_assert(record.offset >= 0, "unallocated record");
+    TT_assertv(record.offset >= 0, "unallocated record: {}", record);
     AllocSizeT load = record.size;
 
     const auto conflicts = iv.getContaining(record.first);
@@ -238,7 +238,8 @@ AllocationPlanner::Stats AllocationPlanner::verify(const Context &context) {
             std::max(record.offset, conflict.offset) <
             std::min(record.offset + record.size,
                      conflict.offset + conflict.size);
-        TT_assert(!memOverlap, "memory overlap");
+        TT_assertv(!memOverlap, "memory overlap b/w {} and {}", record,
+                   conflict);
 
         load += conflict.size;
       }
@@ -252,9 +253,8 @@ AllocationPlanner::Stats AllocationPlanner::verify(const Context &context) {
     maxSize = std::max(maxSize, record.size);
   }
 
-  TT_assert(maxLoad > 0, "should have seen positive max load");
-  TT_assert(maxLoad <= memUsage,
-            "inconsistent max load/mem usage metrics inferred");
+  TT_assert(maxLoad > 0);
+  TT_assert(maxLoad <= memUsage);
 
   TT_ALLOC_DEBUG(
       "verified allocation plan with {} record(s): max alloc size {}, mem "

--- a/test/unittests/Support/CMakeLists.txt
+++ b/test/unittests/Support/CMakeLists.txt
@@ -1,8 +1,15 @@
 add_mlir_unittest(TTMLIRSupportTests
   LoggerTest.cpp
-  )
+  TestAsserts.cpp
+  DeathTestAsserts.cpp
+)
+
+target_include_directories(TTMLIRSupportTests
+  PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../
+)
 
 target_link_libraries(TTMLIRSupportTests
   PRIVATE
-  MLIRSupport
-  )
+    MLIRSupport
+)

--- a/test/unittests/Support/DeathTestAsserts.cpp
+++ b/test/unittests/Support/DeathTestAsserts.cpp
@@ -1,0 +1,130 @@
+
+#include "ttmlir/Asserts.h"
+
+#include "testing/Utils.h"
+
+#include <string>
+#include <string_view>
+
+// A subset of "TestAsserts.cpp" test suite to verify that assert
+// failure messages are seen in stderr when the process terminates.
+
+#define TT_STANDARD_ASSERT_MSG_PREFIX(condition)                               \
+  "Assertion `" #condition "` failed"                                          \
+  ".*"
+
+TEST(AssertsDeathTest, BinaryExprDecomposition) {
+  ASSERT_DEATH(
+      {
+        int32_t x = 1;
+        int32_t y = 2;
+        TT_assert(x == y);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(x == y) "1 == 2");
+  ASSERT_DEATH(
+      {
+        int32_t x = 1;
+        int32_t y = 2;
+        TT_assert(x > y);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(x > y) "1 > 2");
+  ASSERT_DEATH(
+      {
+        int32_t x = 1;
+        int32_t y = 2;
+        TT_assert(y <= x);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(y <= x) "2 <= 1");
+  // With custom formatted context.
+  ASSERT_DEATH(
+      {
+        int32_t x = 1;
+        int32_t y = 2;
+        TT_assertv(x == y, "x-y was {}", x - y);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(x == y) "x-y was -1");
+  // Strings and views.
+  ASSERT_DEATH(
+      {
+        std::string s = "hello";
+        TT_assert(s != "hello");
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(s != "hello") "hello != hello");
+  ASSERT_DEATH(
+      {
+        using namespace std::literals;
+
+        auto sa = "abcdef"sv;
+        const std::string sb = "asdf";
+        TT_assert(sa == sb);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(sa == sb) "abcdef == asdf");
+  // Chars.
+  ASSERT_DEATH(
+      {
+        int8_t a = 'A';
+        char b = 'B';
+        int8_t c = b;
+        TT_assertv(a == b,
+                   "hmm, I think a, b, and c were {}, {}, and {}, respectively",
+                   a, b, c);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(
+          a == b) "hmm, I think a, b, and c were A, B, and B, respectively");
+  // llvm streams have issues printing std::nullptr_t, but TT_assert*()s don't.
+  ASSERT_DEATH(
+      {
+        int32_t x = 42;
+        void *y = &x;
+        TT_assert(y == nullptr);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(y == nullptr) "0x.+ == nullptr");
+}
+
+TEST(AssertsDeathTest, IntegralRangeChecks) {
+  ASSERT_DEATH(
+      {
+        int32_t y = 20;
+        TT_assert_limit(y, 20);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(
+          in_open_range\\(y, 0, 20\\)) "y \\(20\\) is not in \\[0, 20\\)");
+  ASSERT_DEATH(
+      {
+        int32_t y = 2;
+        TT_assert_open_range(y, 0, 2);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(
+          in_open_range\\(y, 0, 2\\)) "y \\(2\\) is not in \\[0, 2\\)");
+  ASSERT_DEATH(
+      {
+        int32_t y = 2;
+        TT_assert_inclusive_range(y, 0, 1);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(
+          in_inclusive_range\\(y, 0, 1\\)) "y \\(2\\) is not in \\[0, 1\\]");
+  ASSERT_DEATH(
+      {
+        int32_t y = 2;
+        TT_assert_exclusive_range(y, 2, 3);
+      },
+      TT_STANDARD_ASSERT_MSG_PREFIX(
+          in_exclusive_range\\(y, 2, 3\\)) "y \\(2\\) is not in \\(2, 3\\)");
+}
+
+// Check that TT_debug* asserts are elided when TTMLIR_ENABLE_DEBUG_LOGS is
+// undefined.
+
+TEST(AssertsDeathTest, MacroElision) {
+#if !defined(TTMLIR_ENABLE_DEBUG_LOGS)
+  // These should be elided and not abort the process.
+
+  TT_debug(2 < 1);
+  TT_debug_limit(10, 1);
+
+  TT_debugv(2 + 2 != 4, "was hoping against hope");
+
+#endif // TTMLIR_ENABLE_DEBUG_LOGS
+}
+
+#undef TT_STANDARD_ASSERT_MSG_PREFIX

--- a/test/unittests/Support/TestAsserts.cpp
+++ b/test/unittests/Support/TestAsserts.cpp
@@ -1,0 +1,315 @@
+
+#include "llvm/Support/raw_ostream.h"
+
+#include "testing/Utils.h"
+
+#include <memory>
+#include <string>
+
+// The tests here check that customizing TT_ASSERT_REPORT_STREAM() and
+// TT_ASSERT_FAILURE() can be used to avoid aborting the process on an assert
+// failure and/or to re-route failure messaging to a custom stream.
+//
+// For that reason, we must define a few things before #including "Asserts.h" in
+// the translation unit.
+//
+// See "DeathTestAsserts.cpp" for a version of this test suite using "default"
+// assert behavior.
+
+namespace {
+struct MockErrStream {
+
+  MockErrStream() : os(std::make_unique<llvm::raw_string_ostream>(msg)) {}
+
+  llvm::raw_ostream &out() { return (*os); }
+
+  void reset() {
+    os->flush();
+    msg.clear();
+    os = std::make_unique<llvm::raw_string_ostream>(msg);
+  }
+
+  std::string msg;
+  std::unique_ptr<llvm::raw_string_ostream> os;
+};
+} // namespace
+
+inline MockErrStream &stream() {
+  static MockErrStream instance;
+
+  return instance;
+}
+
+#define TT_ASSERT_REPORT_STREAM() stream().out()
+#define TT_ASSERT_FAILURE() ((void)0)
+#include "ttmlir/Asserts.h"
+
+#include <regex>
+#include <string_view>
+
+class AssertsTest : public testing::Test {
+protected:
+  AssertsTest() : mocks(&stream()) {}
+
+  const std::string &msg() { return mocks->msg; }
+
+  void check(const std::string &re) {
+    ASSERT_TRUE(std::regex_search(msg(), std::regex(re)))
+        << "expected to find [" << re << "] in assertion message [" << msg()
+        << "]";
+  }
+
+  void reset() { mocks->reset(); }
+
+  MockErrStream *mocks;
+};
+
+#define TT_STANDARD_ASSERT_MSG_PREFIX(condition)                               \
+  "Assertion `" #condition "` failed"                                          \
+  ".*"
+
+TEST_F(AssertsTest, BinaryExprDecomposition) {
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    TT_assert(x == y);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(x == y));
+    check("1 == 2");
+  }
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    TT_assert(x > y);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(x > y));
+    check("1 > 2");
+  }
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    TT_assert(y <= x);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(y <= x));
+    check("2 <= 1");
+  }
+  // With custom formatted context.
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    TT_assertv(x == y, "x-y was {}", x - y);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(x == y));
+    check("x-y was -1");
+  }
+  // Strings and views.
+  {
+    reset();
+
+    std::string s = "hello";
+    TT_assert(s != "hello");
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(s != "hello"));
+    // check("s != \"hello\"");
+    check("hello != hello");
+  }
+  {
+    reset();
+
+    using namespace std::literals;
+
+    auto sa = "abcdef"sv;
+    const std::string sb = "asdf";
+    TT_assert(sa == sb);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(sa == sb));
+    check("abcdef == asdf");
+  }
+  // Chars.
+  {
+    reset();
+
+    // TODO(vroubtsov) better consistency handling 1-byte int types (e.g,
+    // uint8_t).
+
+    int8_t a = 'A';
+    char b = 'B';
+    int8_t c = b;
+    TT_assertv(a == b,
+               "hmm, I think a, b, and c were {}, {}, and {}, respectively", a,
+               b, c);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(a == b));
+    check("hmm, I think a, b, and c were A, B, and B, respectively");
+  }
+  // llvm streams have issues printing std::nullptr_t, but TT_assert*()s don't.
+  {
+    reset();
+
+    int32_t x = 42;
+    void *y = &x;
+    TT_assert(y == nullptr);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(y == nullptr));
+    check("0x.+ == nullptr");
+  }
+}
+
+TEST_F(AssertsTest, IntegralRangeChecks) {
+  {
+    reset();
+
+    int32_t y = 20;
+    TT_assert_limit(y, 20);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(in_open_range\\(y, 0, 20\\)));
+    check(R"(y \(20\) is not in \[0, 20\))");
+  }
+  {
+    reset();
+
+    int32_t y = 20;
+
+    // These don't get triggered.
+
+    TT_assert_open_range(y, 20, 21);
+    TT_assert_inclusive_range(y, 20, 20);
+    TT_assert_exclusive_range(y, 19, 21);
+
+    ASSERT_TRUE(msg().empty());
+  }
+  {
+    reset();
+
+    int32_t y = 2;
+    TT_assert_open_range(y, 0, 2);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(in_open_range\\(y, 0, 2\\)));
+    check(R"(y \(2\) is not in \[0, 2\))");
+  }
+  {
+    reset();
+
+    int32_t y = 2;
+    TT_assert_inclusive_range(y, 0, 1);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(in_inclusive_range\\(y, 0, 1\\)));
+    check(R"(y \(2\) is not in \[0, 1\])");
+  }
+  {
+    reset();
+
+    int32_t y = 2;
+    TT_assert_exclusive_range(y, 2, 3);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(in_exclusive_range\\(y, 2, 3\\)));
+    check(R"(y \(2\) is not in \(2, 3\))");
+  }
+}
+
+TEST_F(AssertsTest, ChainedExprRecipes) {
+  // Recipe for chained expressions (automatic decomposition isn't supported).
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    int32_t z = 3;
+    TT_assert((x > y && y < z));
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(\\(x > y && y < z\\)));
+  }
+  // Custom context is another way to see runtime values.
+  {
+    reset();
+
+    int32_t x = 1;
+    int32_t y = 2;
+    int32_t z = 3;
+    TT_assertv((x > y && y < z), "was {} > {} && {} < {}", x, y, y, z);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX(\\(x > y && y < z\\)));
+    check("was 1 > 2 && 2 < 3");
+  }
+}
+
+namespace {
+
+struct PrintableType {
+  int32_t x;
+  int32_t y;
+
+  friend bool operator<(const PrintableType &lhs, const PrintableType &rhs) {
+    return (lhs.x < rhs.x) && (lhs.y < rhs.y);
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const PrintableType &obj) {
+    return os << "{x = " << obj.x << ", y = " << obj.y << '}';
+  }
+};
+
+struct NonprintableType {
+  int32_t x;
+  int32_t y;
+
+  friend bool operator==(const NonprintableType &lhs,
+                         const NonprintableType &rhs) {
+    return (lhs.x == rhs.x) && (lhs.y == rhs.y);
+  }
+};
+
+} // namespace
+
+// TODO(vroubtsov) ideally, implementing either to_string or operator<<
+// should make the type usable both for decomposed messages and custom
+// context suffixes, but right now that works only for operator<<
+
+TEST_F(AssertsTest, CustomPrintableTypes) {
+  {
+    reset();
+
+    PrintableType small{123, 456};
+    PrintableType big{1230, 4560};
+    TT_assert(big < small);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX((big < small)));
+    check(R"(\{x = 1230, y = 4560\} < \{x = 123, y = 456\})");
+  }
+  {
+    reset();
+
+    PrintableType small{123, 456};
+    PrintableType big{1230, 4560};
+    TT_assertv(big < small, "something's wrong with {} and {}", big, small);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX((big < small)));
+    check(
+        R"(something's wrong with \{x = 1230, y = 4560\} and \{x = 123, y = 456\})");
+  }
+}
+
+// Types that can't be printed in a discoverable way should still compile
+// and the assert message will still contain the stringified `condition`.
+
+TEST_F(AssertsTest, NonprintableTypes) {
+  {
+    reset();
+
+    NonprintableType one{123, 456};
+    NonprintableType another{1230, 4560};
+    TT_assert(one == another);
+
+    check(TT_STANDARD_ASSERT_MSG_PREFIX((one == another)));
+  }
+}
+
+#undef TT_STANDARD_ASSERT_MSG_PREFIX


### PR DESCRIPTION
### Ticket
This is WIP for #2394, been working on this in the background and would like to run some tests in CI. Converted Allocator and AllocationPlanner code to these asserts as a real world usage check.

### Problem description
TODO need docs

### What's changed
TODO "binary expr decomposition'' is inspired by Catch2 test asserts.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] test/unittests/Support/TestAsserts.cpp
- [x] test/unittests/Support/DeathTestAsserts.cpp
