### PR TITLE
Early out when dilation != 1 in maxpool2d

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1590,7 +1590,8 @@ class TTNN_PoolingOp<string mnemonic, list<Trait> traits = []> :
 
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
+        llvm::ArrayRef<int32_t> dilation = getDilation();
+        return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds(dilation);
       }
     }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -215,7 +215,8 @@ private:
 class TTNNOperandsWorkaroundsFactory {
 public:
   // Create workarounds for pooling 2d ops (max_pool2d, avg_pool2d) operands.
-  static TTNNOperandsWorkarounds createPool2DOpOperandsWorkarounds();
+  static TTNNOperandsWorkarounds
+  createPool2DOpOperandsWorkarounds(llvm::ArrayRef<int32_t> dilation);
 
   // Create workarounds for embedding op operands.
   static TTNNOperandsWorkarounds createEmbeddingOpOperandsWorkarounds();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -863,14 +863,6 @@ verifyPoolingOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 
 // MaxPool2dOp verification
 ::mlir::LogicalResult mlir::tt::ttnn::MaxPool2dOp::verify() {
-  // Until dilation > 1 is supported, error out early:
-  // https://github.com/tenstorrent/tt-metal/issues/25845
-  if (getDilation()[0] != 1 || getDilation()[1] != 1) {
-    return emitOpError()
-           << "Dilation must be 1 in both dims for MaxPool2dOp. "
-              "See https://github.com/tenstorrent/tt-metal/issues/25845";
-  }
-
   return verifyPoolingOp([&]() { return emitOpError(); }, getInput().getType(),
                          getKernelSize(), getInputHeight(), getInputWidth(),
                          getBatchSize(), getChannels(), getOperationName());

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -863,6 +863,14 @@ verifyPoolingOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 
 // MaxPool2dOp verification
 ::mlir::LogicalResult mlir::tt::ttnn::MaxPool2dOp::verify() {
+  // Until dilation > 1 is supported, error out early:
+  // https://github.com/tenstorrent/tt-metal/issues/25845
+  if (getDilation()[0] != 1 || getDilation()[1] != 1) {
+    return emitOpError()
+           << "Dilation must be 1 in both dims for MaxPool2dOp. "
+              "See https://github.com/tenstorrent/tt-metal/issues/25845";
+  }
+
   return verifyPoolingOp([&]() { return emitOpError(); }, getInput().getType(),
                          getKernelSize(), getInputHeight(), getInputWidth(),
                          getBatchSize(), getChannels(), getOperationName());

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -98,7 +98,15 @@ TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(Operation *op) {
 // type, so the bf16 workaround is applied to both the input and output
 // operands.
 TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds() {
+TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds(
+    llvm::ArrayRef<int32_t> dilation) {
+  // Until dilation > 1 is supported, error out early:
+  // https://github.com/tenstorrent/tt-metal/issues/25845
+  assert(dilation.size() == 2 && "Dilation must be a 2D array");
+  if (dilation[0] != 1 || dilation[1] != 1) {
+    assert(false && "Dilation must be 1x1 for now");
+  }
+
   wa::TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
   rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =


### PR DESCRIPTION
### Ticket
#4314 

### Problem description
A [recent TT-NN change](https://github.com/tenstorrent/tt-metal/commit/a79ebb853cd0a57fad00c44bae8160f62c750652) introduced asserts that `dilation == 1` in maxpool2d op. The op never previously worked with `dilation != 1` and might've executed to end without errors by chance.

### What's changed
Added verification to early error out (model compile-time), instead of failing in runtime.

### Checklist
- [ ] New/Existing tests provide coverage for changes
