### PR TITLE
[EmitC] Pass MeshDevice object properly to TTNN ops

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1482,11 +1482,28 @@ public:
       return emit(std::nullopt);
     }
 
-    if constexpr (std::is_same_v<TargetTy, ::ttnn::distributed::MeshDevice *> ||
-                  std::is_same_v<TargetTy, ::ttnn::distributed::MeshDevice>) {
+    if constexpr (std::is_same_v<TargetTy, ::ttnn::distributed::MeshDevice *>) {
       unsigned index = getOperandIndex(device);
       operands.push_back(adaptor.getOperands()[index]);
 
+      return rewriter.getIndexAttr(index);
+    } else if constexpr (std::is_same_v<TargetTy,
+                                        ::ttnn::distributed::MeshDevice>) {
+      unsigned index = getOperandIndex(device);
+      mlir::Value deviceValueFromOperandsList = adaptor.getOperands()[index];
+
+      // ttnn::distributed::MeshDevice does not support copy/move constructor.
+      // So a reference variable is created to be used as function argument.
+      // ::ttnn::distributed::MeshDevice& deviceRef = *devicePtr;
+      emitc::ApplyOp meshDeviceOp = rewriter.create<emitc::ApplyOp>(
+          op.getLoc(),
+          emitc::OpaqueType::get(rewriter.getContext(),
+                                 TypeNameV<TargetTy> +
+                                     "&"), // ::ttnn::distributed::MeshDevice&
+          "*",                             // Dereference operator
+          deviceValueFromOperandsList);
+
+      operands.push_back(meshDeviceOp.getResult());
       return rewriter.getIndexAttr(index);
     } else if constexpr (std::is_same_v<TargetTy,
                                         ::ttnn::operations::creation::detail::


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/4321

### Problem description
EmitC conversion generates same code for `ttnn::distributed::MeshDevice` and `ttnn::distributed::MeshDevice *` which causes compilation to fail.

### What's changed
Create a `ttnn::distributed::MeshDevice &` variable to access the `MeshDevice *ptr` and pass it to the TTNN ops.
Note: TTNN API has deleted `copy` and `move` constructors for `MeshDevice`; so other solutions requiring copy/move do not work.

### Checklist
- [ ] New/Existing tests provide coverage for changes
