### PR TITLE
Adding bfp8_b type to ttcore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .local
 **/build
 third_party/tt-metal
+third_party/ttnn-python
 .DS_STORE
 .vscode/*
 .cache

--- a/include/ttmlir/Dialect/TTCore/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTCore/IR/CMakeLists.txt
@@ -4,6 +4,12 @@ add_mlir_doc(TTCoreOps TTCoreOp src/autogen/md/Dialect/ -gen-op-doc)
 add_mlir_doc(TTCoreOpsTypes TTCoreAttr src/autogen/md/Dialect/ -gen-attrdef-doc)
 add_mlir_doc(TTCoreOpsTypes TTCoreType src/autogen/md/Dialect/ -gen-typedef-doc)
 
+set(LLVM_TARGET_DEFINITIONS TTCoreTypeInterfaces.td)
+mlir_tablegen(TTCoreTypeInterfaces.h.inc -gen-type-interface-decls)
+mlir_tablegen(TTCoreTypeInterfaces.cpp.inc -gen-type-interface-defs)
+add_public_tablegen_target(TTCoreTypeInterfacesIncGen)
+add_dependencies(mlir-headers TTCoreTypeInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS TTCoreAttrInterfaces.td)
 mlir_tablegen(TTCoreAttrInterfaces.h.inc -gen-attr-interface-decls)
 mlir_tablegen(TTCoreAttrInterfaces.cpp.inc -gen-attr-interface-defs)

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
@@ -10,9 +10,18 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
 
+#include <numeric>
+
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.h.inc"
 
-#include <numeric>
+#include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.h.inc"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreTypeInterfaces.h.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsAttrDefs.h.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h.inc"
 
 namespace mlir::tt::ttcore {
 struct PhysGridResultIdx {
@@ -126,6 +135,10 @@ inline std::optional<DataType> elementTypeToDataTypeImpl(Type elementType) {
     return DataType::BFloat16;
   }
 
+  if (isa<ttcore::BFloat8BType>(elementType)) {
+    return DataType::BFP_BFloat8;
+  }
+
   if (auto floatType = dyn_cast<mlir::FloatType>(elementType)) {
     switch (floatType.getWidth()) {
     // Treat f64 as f32.
@@ -169,7 +182,7 @@ inline Type dataTypeToElementType(mlir::MLIRContext *context, DataType dtype) {
   case DataType::BFP_Float8:
     return Float16Type::get(context);
   case DataType::BFP_BFloat8:
-    return BFloat16Type::get(context);
+    return ttcore::BFloat8BType::get(context);
   case DataType::BFP_Float4:
     return Float16Type::get(context);
   case DataType::BFP_BFloat4:
@@ -301,18 +314,6 @@ inline uint8_t getNumberOfBits(const DataType dtype) {
     return 2;
   }
 }
-
-} // namespace mlir::tt::ttcore
-
-#include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.h.inc"
-
-#define GET_ATTRDEF_CLASSES
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsAttrDefs.h.inc"
-
-#define GET_TYPEDEF_CLASSES
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h.inc"
-
-namespace mlir::tt::ttcore {
 
 mlir::AffineMap collapsedLinearAffineMap(
     mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape,

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -8,6 +8,7 @@
 include "ttmlir/Dialect/TTCore/IR/TTCoreBase.td"
 include "ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td"
 include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td"
+include "ttmlir/Dialect/TTCore/IR/TTCoreTypeInterfaces.td"
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
@@ -554,6 +555,13 @@ def TTCore_Tile : TTCore_Type<"Tile", "tile", [MemRefElementTypeInterface]> {
     }];
 
     let genVerifyDecl = 1;
+}
+
+def TT_BFloat8B : TTCore_Type<"BFloat8B", "bfp8_b", [BlockTypeInterface, MemRefElementTypeInterface]> {
+  let summary = "This is MLIR type representation of bfp8_b type in TT.";
+  let description = [{
+    This is MLIR type representation of bfp8_b type in TT.
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreTypeInterfaces.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreTypeInterfaces.td
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TT_TTTYPEINTERFACES_TD
+#define TTMLIR_TTMLIR_DIALECT_TT_TTTYPEINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+def BlockTypeInterface : TypeInterface<"BlockType"> {
+  let cppNamespace = "::mlir::tt";
+  let description = [{
+    Interface used to tag all block types. Intent is to use this interface
+    to check if a type is a block type, similar to how we check if type is a
+    FloatType without needing to know the specific type.
+  }];
+}
+
+#endif // TTMLIR_TTMLIR_DIALECT_TT_TTTYPEINTERFACES_TD

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -517,6 +517,10 @@ def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::M
     "This pass walks through the graph and normalizes the element types into a list of supported types. This is useful for lowering
         to a target that only supports a subset of the element types.
   }];
+
+  list<Option> options = [
+    Option<"enableBfp8Type", "enable-bfp8-type", "bool", "false", "When enabled this pass will convert all bfloat16 types into bfp8_b types.">,
+  ];
 }
 
 def TTIRFlattenSlidingWindow: Pass<"ttir-flatten-sliding-window", "::mlir::ModuleOp">

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
@@ -9,6 +9,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.td"
+include "ttmlir/Dialect/TTNN/IR/TTNNTraits.td"
 
 //===----------------------------------------------------------------------===//
 // TTNN dialect definition.
@@ -46,7 +47,7 @@ def TTNN_Dialect : Dialect {
 //===----------------------------------------------------------------------===//
 
 class TTNN_Op<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [Pure, TTNN_WorkaroundInterface] # traits>;
+        Op<TTNN_Dialect, mnemonic, [Pure, TTNN_WorkaroundInterface, CheckBFloat8BTrait] # traits>;
 
 class TTNN_InplaceOp<string mnemonic, list<Trait> traits = []> :
         Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemWrite]>, TTNN_WorkaroundInterface] # traits>;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -10,7 +10,6 @@ include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td"
-include "ttmlir/Dialect/TTNN/IR/TTNNTraits.td"
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_IR_TTNNTRAITS_H
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/OpDefinition.h"
 
@@ -83,53 +84,48 @@ public:
   }
 };
 
-class HasOutputDTypeTraitBase {
-public:
-  static constexpr ::llvm::StringLiteral getOutputDTypeAttributeName() {
-    return "output_dtype";
-  }
-};
-
 template <typename ConcreteType>
 class HasOutputDTypeTrait
-    : public mlir::OpTrait::TraitBase<ConcreteType, HasOutputDTypeTrait>,
-      public HasOutputDTypeTraitBase {
+    : public mlir::OpTrait::TraitBase<ConcreteType, HasOutputDTypeTrait> {
 public:
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
     // Check if the operation defines output data type attribute.
     auto attributeNames = ConcreteType::getAttributeNames();
     if (std::find(attributeNames.begin(), attributeNames.end(),
-                  getOutputDTypeAttributeName()) == attributeNames.end()) {
+                  ttmlir::utils::g_outputDtypeAttrName) ==
+        attributeNames.end()) {
       return op->emitOpError(
           "Operation must define output data type attribute.");
     }
 
     // Retrieve output layout.
-    RankedTensorType output =
-        mlir::cast<RankedTensorType>(op->getResult(0).getType());
-    TTNNLayoutAttr outputLayoutAttr =
-        mlir::dyn_cast_or_null<TTNNLayoutAttr>(output.getEncoding());
+    for (auto result : op->getResults()) {
+      RankedTensorType output = mlir::cast<RankedTensorType>(result.getType());
+      TTNNLayoutAttr outputLayoutAttr =
+          mlir::dyn_cast_if_present<TTNNLayoutAttr>(output.getEncoding());
 
-    // If output layout isn't present, skip the verification.
-    if (!outputLayoutAttr) {
-      return mlir::success();
-    }
+      // If output layout isn't present, skip the verification.
+      if (!outputLayoutAttr) {
+        return mlir::success();
+      }
 
-    // Retrieve output data type attribute.
-    auto outputDTypeAttr =
-        op->getAttrOfType<ttcore::DataTypeAttr>(getOutputDTypeAttributeName());
-    if (!outputDTypeAttr) {
-      return op->emitOpError("Output data type attribute is not defined for op "
-                             "that has output layout attribute.");
-    }
+      // Retrieve output data type attribute.
+      auto outputDTypeAttr = op->getAttrOfType<ttcore::DataTypeAttr>(
+          ttmlir::utils::g_outputDtypeAttrName);
+      if (!outputDTypeAttr) {
+        return op->emitOpError(
+            "Output data type attribute is not defined for op "
+            "that has output layout attribute.");
+      }
 
-    // Compare output data type attribute with output tensor data type.
-    if (outputDTypeAttr.getValue() != outputLayoutAttr.getDataType()) {
-      return op->emitOpError()
-             << "Output tensor layout data type "
-             << DataTypeEnumToString(outputLayoutAttr.getDataType())
-             << " must match output data type attribute "
-             << DataTypeEnumToString(outputDTypeAttr.getValue());
+      // Compare output data type attribute with output tensor data type.
+      if (outputDTypeAttr.getValue() != outputLayoutAttr.getDataType()) {
+        return op->emitOpError()
+               << "Output tensor layout data type "
+               << DataTypeEnumToString(outputLayoutAttr.getDataType())
+               << " must match output data type attribute "
+               << DataTypeEnumToString(outputDTypeAttr.getValue());
+      }
     }
 
     return mlir::success();
@@ -139,9 +135,48 @@ public:
 template <typename ConcreteType>
 class ExplicateOperandBroadcastsTrait
     : public mlir::OpTrait::TraitBase<ConcreteType,
-                                      ExplicateOperandBroadcastsTrait> {
+                                      ExplicateOperandBroadcastsTrait> {};
+
+// BFloat8B is tile type so we need some way to check if op which returns
+// it has correct layout information in encoding.
+template <typename ConcreteType>
+class CheckBFloat8BTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, CheckBFloat8BTrait> {
 public:
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    if (op->getNumResults() == 0) {
+      return mlir::success();
+    }
+
+    for (auto result : op->getResults()) {
+      auto resultType = mlir::dyn_cast<RankedTensorType>(result.getType());
+      if (!resultType) {
+        continue;
+      }
+
+      Type elementType = resultType.getElementType();
+      if (!mlir::isa<ttcore::BFloat8BType>(elementType)) {
+        continue;
+      }
+
+      TTNNLayoutAttr layoutAttr =
+          mlir::cast<TTNNLayoutAttr>(resultType.getEncoding());
+      Type scalarElementType = layoutAttr.getScalarElementType();
+      if (elementType != scalarElementType) {
+        return op->emitOpError()
+               << "Output element type must match the scalar "
+                  "element type from encoding."
+               << " Element type: " << elementType
+               << ", Scalar element type: " << scalarElementType << ".";
+      }
+
+      if (layoutAttr.getLayout() != Layout::Tile) {
+        return op->emitOpError()
+               << "BFloat8B type is only supported in Tile layout, but got "
+               << stringifyLayout(layoutAttr.getLayout()) << ".";
+      }
+    }
+
     return mlir::success();
   }
 };

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -29,4 +29,11 @@ def ExplicateOperandBroadcastsTrait : NativeOpTrait<"ExplicateOperandBroadcastsT
   let cppNamespace = "::mlir::tt::ttnn";
 }
 
+// BFloat8B is tile type so we need some way to check if op which returns
+// it has correct layout information in encoding.
+def CheckBFloat8BTrait : NativeOpTrait<"CheckBFloat8BTrait">
+{
+  let cppNamespace = "mlir::tt::ttnn";
+}
+
 #endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -270,6 +270,11 @@ struct TTIRToTTNNBackendPipelineOptions
           "Set to enable quantized data type conversion pass. "
           "Leave empty to disable the pass."),
       llvm::cl::init(32)};
+
+  Option<bool> enableBfp8Type{
+      *this, "enable-bfp8-type",
+      llvm::cl::desc("Enables conversion from bfloat16 to bfp8_b."),
+      llvm::cl::init(false)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -30,6 +30,7 @@ constexpr inline llvm::StringLiteral g_conv2dWeightAttrName =
     "ttir.conv2d_weight";
 constexpr inline llvm::StringLiteral g_cpuHoistFuncCallAttrName =
     "ttir.cpu_hoist_call";
+constexpr inline llvm::StringLiteral g_outputDtypeAttrName = "output_dtype";
 
 template <typename T>
 T alignUp(T ptr, T alignment) {

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -27,6 +27,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.cpp.inc"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.cpp.inc"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreTypeInterfaces.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.cpp.inc"

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -14,15 +14,26 @@ namespace mlir::tt::ttir {
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
-class ElementTypeConverter : public TypeConverter {
+class ElementTypeConverter : public mlir::TypeConverter {
 public:
-  ElementTypeConverter() {
-    addConversion([](RankedTensorType type) -> std::optional<RankedTensorType> {
+  void init(bool enableBfp8Type) {
+    addConversion([enableBfp8Type](mlir::RankedTensorType type)
+                      -> std::optional<mlir::RankedTensorType> {
       Type elementType = type.getElementType();
 
       // Skip quantized types - don't modify them.
-      if (isa<quant::QuantizedType>(elementType)) {
+      if (mlir::isa<quant::QuantizedType>(elementType)) {
         return type;
+      }
+
+      if (mlir::isa<ttcore::BFloat8BType>(elementType)) {
+        return type;
+      }
+
+      if (enableBfp8Type && mlir::isa<mlir::BFloat16Type>(elementType)) {
+        return mlir::RankedTensorType::get(
+            type.getShape(), ttcore::BFloat8BType::get(type.getContext()),
+            type.getEncoding());
       }
 
       elementType = mlir::tt::ttcore::toTTMLIRSupportedDataType(elementType);
@@ -30,8 +41,8 @@ public:
         return {};
       }
 
-      return RankedTensorType::get(type.getShape(), elementType,
-                                   type.getEncoding());
+      return mlir::RankedTensorType::get(type.getShape(), elementType,
+                                         type.getEncoding());
     });
   }
 };
@@ -40,15 +51,18 @@ public:
 // We need more sophisticated rewriting of the constant op,
 // since current logic doesn't rely on the type converter and
 // doesn't support DenseResourceElementsAttr conversion.
-class ConstantOpAttrRewriter : public OpRewritePattern<tt::ttir::ConstantOp> {
+class ConstantOpAttrRewriter
+    : public mlir::OpRewritePattern<tt::ttir::ConstantOp> {
 public:
-  using OpRewritePattern<tt::ttir::ConstantOp>::OpRewritePattern;
+  using mlir::OpRewritePattern<tt::ttir::ConstantOp>::OpRewritePattern;
 
-  ConstantOpAttrRewriter(const TypeConverter &converter, MLIRContext *ctx)
+  ConstantOpAttrRewriter(const mlir::TypeConverter &converter,
+                         mlir::MLIRContext *ctx)
       : OpRewritePattern(ctx), converter(converter) {}
 
-  LogicalResult matchAndRewrite(tt::ttir::ConstantOp op,
-                                PatternRewriter &rewriter) const override {
+  mlir::LogicalResult
+  matchAndRewrite(tt::ttir::ConstantOp op,
+                  mlir::PatternRewriter &rewriter) const override {
     if (auto newAttr = rebuildElementsAttr(op.getValue())) {
       if (newAttr == op.getValue()) {
         return failure();
@@ -63,7 +77,7 @@ public:
   }
 
 private:
-  TypeConverter converter;
+  mlir::TypeConverter converter;
 
   mlir::ElementsAttr rebuildElementsAttr(mlir::ElementsAttr attr) const {
     auto elementType = attr.getElementType();
@@ -73,14 +87,14 @@ private:
     // Skip rewriting if type is already supported or if the attribute is
     // DenseResourceElementsAttr (conversion not supported yet).
     if (newType.getElementType() == elementType ||
-        isa<DenseResourceElementsAttr>(attr)) {
+        mlir::isa<mlir::DenseResourceElementsAttr>(attr)) {
       return attr;
     }
 
-    if (isa<IntegerType>(elementType)) {
+    if (mlir::isa<mlir::IntegerType>(elementType)) {
       return rebuildIntAttr(attr, newType);
     }
-    if (isa<FloatType>(elementType)) {
+    if (mlir::isa<mlir::FloatType>(elementType)) {
       return rebuildFloatAttr(attr, newType);
     }
 
@@ -129,39 +143,43 @@ private:
   }
 };
 
-struct ElementTypeNormalization
+class ElementTypeNormalization
     : public impl::ElementTypeNormalizationBase<ElementTypeNormalization> {
   using impl::ElementTypeNormalizationBase<
       ElementTypeNormalization>::ElementTypeNormalizationBase;
 
+public:
   void runOnOperation() final {
+    // Command line options are parsed after the pass is created
+    // so we can't initialize the converter in the constructor.
+    converter.init(enableBfp8Type);
+
     // Check that all types are supported by TTMLIR.
     if (!checkSupportedTypes()) {
       signalPassFailure();
       return;
     }
 
-    RewritePatternSet patterns(&getContext());
+    mlir::RewritePatternSet patterns(&getContext());
     patterns.add<UniformTypeRewriter>(converter, &getContext());
     patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    if (failed(
+            mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
       return;
     }
   }
 
 private:
-  ElementTypeConverter converter;
-
-  bool isLegal(Type type) const {
+  bool isLegal(mlir::Type type) const {
     return converter.convertType(type) != nullptr;
   }
 
-  bool isLegal(Operation *op) const {
-    auto isTypeLegal = [this](Type type) { return isLegal(type); };
+  bool isLegal(mlir::Operation *op) const {
+    auto isTypeLegal = [this](mlir::Type type) { return isLegal(type); };
 
     // Special handling for function signature
-    if (auto funcOp = llvm::dyn_cast<func::FuncOp>(op)) {
+    if (auto funcOp = mlir::dyn_cast<mlir::func::FuncOp>(op)) {
       return llvm::all_of(funcOp.getArgumentTypes(), isTypeLegal) &&
              llvm::all_of(funcOp.getResultTypes(), isTypeLegal);
     }
@@ -173,19 +191,21 @@ private:
 
   // Check that all operations in module are using supported types.
   bool checkSupportedTypes() {
-    ModuleOp moduleOp = getOperation();
-    WalkResult walkResult =
-        moduleOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    mlir::ModuleOp moduleOp = getOperation();
+    mlir::WalkResult walkResult =
+        moduleOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
           if (!isLegal(op)) {
             op->emitOpError("Unsupported type.");
-            return WalkResult::interrupt();
+            return mlir::WalkResult::interrupt();
           }
 
-          return WalkResult::advance();
+          return mlir::WalkResult::advance();
         });
 
     return !walkResult.wasInterrupted();
   }
+
+  ElementTypeConverter converter;
 };
 } // namespace
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -145,7 +145,10 @@ void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
   pm.addPass(mlir::createCanonicalizerPass());
   // Element type normalization should be the first pass in the pipeline.
-  pm.addPass(ttir::createElementTypeNormalization());
+  ttir::ElementTypeNormalizationOptions elementTypeNormalizationOptions;
+  elementTypeNormalizationOptions.enableBfp8Type = options.enableBfp8Type;
+  pm.addPass(
+      ttir::createElementTypeNormalization(elementTypeNormalizationOptions));
   // Create DeviceModule to wrap all ops.
   pm.addPass(ttcore::createTTCoreWrapDeviceModulePass());
   // Create CPUModuleOp to wrap hoisted ops (if any).

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -370,8 +370,7 @@ public:
           if (op->hasTrait<HasOutputDTypeTrait>()) {
             ttcore::DataTypeAttr newDataTypeAttr = ttcore::DataTypeAttr::get(
                 op->getContext(), layoutAttr.getDataType());
-            op->setAttr(HasOutputDTypeTraitBase::getOutputDTypeAttributeName(),
-                        newDataTypeAttr);
+            op->setAttr(ttmlir::utils::g_outputDtypeAttrName, newDataTypeAttr);
           }
 
           // Update DPS operand layout as well.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -208,8 +208,7 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
       ttcore::DataTypeAttr updatedDataTypeAttr =
           rewriter.getAttr<ttcore::DataTypeAttr>(
               outputWorkaroundResults.tensorDataTypeResult.targetValue);
-      op->setAttr(HasOutputDTypeTraitBase::getOutputDTypeAttributeName(),
-                  updatedDataTypeAttr);
+      op->setAttr(ttmlir::utils::g_outputDtypeAttrName, updatedDataTypeAttr);
     }
 
     if ((outputWorkaroundResults.tensorBufferTypeResult.isModified() ||

--- a/test/ttmlir/Dialect/TTNN/element_type_normalization/block_type_conversion.mlir
+++ b/test/ttmlir/Dialect/TTNN/element_type_normalization/block_type_conversion.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-bfp8-type=true" %s | FileCheck %s
+
+module  {
+  // CHECK-LABEL: @forward(
+  // CHECK-SAME: tensor<32x32x!ttcore.bfp8_b
+  // CHECK-SAME: tensor<32x32x!ttcore.bfp8_b
+  // CHECK-SAME: -> tensor<32x32x!ttcore.bfp8_b
+  func.func @forward(%arg0 : tensor<32x32xbf16>, %arg1 : tensor<32x32xbf16>) ->tensor<32x32xbf16> {
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: tensor<32x32x!ttcore.bfp8_b
+    // CHECK-SAME: tensor<32x32x!ttcore.bfp8_b
+    // CHECK-SAME: -> tensor<32x32x!ttcore.bfp8_b
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %1 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/element_type_normalization/block_type_normalization_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/element_type_normalization/block_type_normalization_negative.mlir
@@ -1,0 +1,23 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32x!ttcore.bfp8_b, #system_memory>>
+module {
+  // CHECK: error: 'ttnn.add' op BFloat8B type is only supported in Tile layout, but got row_major.
+  func.func @forward(%arg0 : tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>) -> tensor<32x32x!ttcore.bfp8_b> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>, tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>) -> tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>
+    return %0 : tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module {
+  // CHECK: error: 'ttnn.add' op Output element type must match the scalar element type from encoding. Element type: '!ttcore.bfp8_b', Scalar element type: 'bf16'.
+  func.func @forward(%arg0 : tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>) -> tensor<32x32x!ttcore.bfp8_b> {
+    %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>, tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>) -> tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>
+    return %0 : tensor<32x32x!ttcore.bfp8_b, #ttnn_layout>
+  }
+}


### PR DESCRIPTION
This PR introduces bfp8_b type into ttcore.
Change is very small so, so there isn't really additional context that needs to be conveyed.

To add silicon test,  we would have to special case how we handle output in bfp8 which I would like to avoid. Instead ideal solution would be to leave inputs/output in bfloat16 and typecast on input/output, which requires greater refactor.