### PR TITLE
Move decomposed_from_all_reduce attribute to Utils.h

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -32,6 +32,8 @@ constexpr inline llvm::StringLiteral g_cpuHoistFuncCallAttrName =
     "ttir.cpu_hoist_call";
 constexpr inline llvm::StringLiteral g_skipQdqCommuteAttrName =
     "ttir.skip_qdq_commute";
+constexpr inline llvm::StringLiteral g_decomposedFromAllReduceAttrName =
+    "ttir.decomposed_from_all_reduce";
 
 template <typename T>
 T alignUp(T ptr, T alignment) {

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -376,7 +376,7 @@ public:
 
     // If the input to the allGather is from a allReduce workaround, we skip
     // this workaround, as it will produce incorrect results.
-    if (op->hasAttr("decomposed_from_all_reduce")) {
+    if (op->hasAttr(ttmlir::utils::g_decomposedFromAllReduceAttrName)) {
       return failure();
     }
 
@@ -535,14 +535,15 @@ public:
             ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
             scatteredInputType, op.getInput(), deviceValue, op.getReduceType(),
             dimension, clusterAxis);
-    reduceScatterOp->setAttr("decomposed_from_all_reduce",
+    reduceScatterOp->setAttr(ttmlir::utils::g_decomposedFromAllReduceAttrName,
                              rewriter.getUnitAttr());
 
     // Replace all_reduce op with all_gather op.
     auto allGatherOp = rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
         op, op.getType(), reduceScatterOp.getResult(), deviceValue, dimension,
         clusterAxis);
-    allGatherOp->setAttr("decomposed_from_all_reduce", rewriter.getUnitAttr());
+    allGatherOp->setAttr(ttmlir::utils::g_decomposedFromAllReduceAttrName,
+                         rewriter.getUnitAttr());
     return success();
   }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4236

### Problem description
The raw string "decomposed_from_all_reduce" was duplicated in multiple places.
However, we already have a centralized location for discardable attribute definitions.

### What's changed
Moved the "decomposed_from_all_reduce" attribute definition into ttmlir/Utils.h to avoid duplication and improve maintainability.

### Checklist
- [ ] New/Existing tests provide coverage for changes
