### PR TITLE
Fix prepare dtype usage

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1325,7 +1325,7 @@ def TTNN_MatmulOp : TTNN_Op<"matmul",
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
-def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [HasOutputDTypeTrait]> {
+def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
     let summary = "Prepares conv2d weights so that they can be consumed by the conv2d op.";
 
     let arguments = (ins AnyRankedTensor:$weight_tensor,
@@ -1353,7 +1353,7 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [HasOutputDT
     let hasVerifier = 1;
 }
 
-def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias", [HasOutputDTypeTrait]> {
+def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias"> {
     let summary = "Prepares conv2d bias so that it can be consumed by the conv2d op.";
 
     let arguments = (ins AnyRankedTensor:$bias_tensor,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -223,6 +223,7 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
   let assemblyFormat = "`<` $bufferType (`,` $tensorMemoryLayout^ )? (`,` $shardSpec^ )? `>`";
 
   let extraClassDeclaration = [{
+    static MemoryConfigAttr get(ttnn::TTNNLayoutAttr layout, ttcore::GridAttr deviceGrid);
     llvm::ArrayRef<int64_t> getShardShape(bool convertTileToScalar = true) const;
     MemoryConfigAttr withBufferType(BufferType bufferType);
     MemoryConfigAttr withMemoryLayout(TensorMemoryLayout memLayout);

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -618,6 +618,22 @@ llvm::LogicalResult TTNNLayoutAttr::verify(
   return status;
 }
 
+// Construct a new MemoryConfigAttr
+//
+// This function creates new MemoryConfigAttr from given TTNNLayoutAttr.
+//
+// param layoutAttr The TTNNLayoutAttr to create MemoryConfigAttr from.
+// param deviceGrid Device grid to use for sharding spec.
+// return The constructed MemoryConfigAttr.
+MemoryConfigAttr MemoryConfigAttr::get(TTNNLayoutAttr layoutAttr,
+                                       mlir::tt::ttcore::GridAttr deviceGrid) {
+  BufferTypeAttr bufferTypeAttr =
+      mlir::cast<BufferTypeAttr>(layoutAttr.getMemref().getMemorySpace());
+  return MemoryConfigAttr::get(
+      layoutAttr.getContext(), layoutAttr.getMemLayout(), bufferTypeAttr,
+      utils::createShardSpecIfNeeded(layoutAttr, deviceGrid));
+}
+
 // Construct a new MemoryConfig
 //
 // This function creates a deep copy of the current MemoryConfigAttr and

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
@@ -91,7 +91,7 @@ public:
               conv2dOp.getPaddingAttr(), conv2dOp.getDilationAttr(),
               rewriter.getBoolAttr(conv2dOp.getBias() != nullptr),
               conv2dOp.getGroupsAttr(), conv2dOp.getDevice(), inputDtypeAttr,
-              outputDtypeAttr, conv2dOp.getConv2dConfigAttr());
+              outputDtypeAttr, conv2dConfig);
 
       ttnn::PrepareConv2dBiasOp prepareConv2dBiasOp;
       if (conv2dOp.getBias()) {

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeightsAndBias.cpp
@@ -30,32 +30,53 @@ public:
     IRRewriter rewriter(&getContext());
 
     moduleOp.walk([&](ttnn::Conv2dOp conv2dOp) {
-      rewriter.setInsertionPoint(conv2dOp);
-      mlir::RankedTensorType inputType = conv2dOp.getInput().getType();
-      ttnn::TTNNLayoutAttr inputLayoutAttr =
-          mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
-      ttcore::GridAttr deviceGrid =
-          ttcore::lookupDevice(moduleOp).getWorkerGrid();
-      ttnn::MemoryConfigAttr inputMemConfigAttr =
-          rewriter.getAttr<ttnn::MemoryConfigAttr>(
-              inputLayoutAttr.getMemLayout(),
-              rewriter.getAttr<ttnn::BufferTypeAttr>(
-                  inputLayoutAttr.getBufferType()),
-              utils::createShardSpecIfNeeded(inputLayoutAttr, deviceGrid));
-      auto inputDtypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
-          &getContext(), inputLayoutAttr.getDataType());
-
-      mlir::RankedTensorType weightType = conv2dOp.getWeight().getType();
-      ttnn::TTNNLayoutAttr weightLayoutAttr =
-          mlir::cast<ttnn::TTNNLayoutAttr>(weightType.getEncoding());
-      auto weightDtypeAttr = rewriter.getAttr<ttcore::DataTypeAttr>(
-          weightLayoutAttr.getDataType());
+      ttnn::TTNNLayoutAttr weightLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+          conv2dOp.getWeight().getType().getEncoding());
       assert(weightLayoutAttr.getBufferType() ==
                  ttnn::BufferType::SystemMemory &&
              weightLayoutAttr.getLayout() == ttnn::Layout::RowMajor &&
              "Weight must be in system memory and row-major layout when "
              "calling TTNNPrepareConv2dWeightsAndBias pass.");
 
+      ttnn::TTNNLayoutAttr biasLayoutAttr;
+      if (conv2dOp.getBias()) {
+        biasLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+            conv2dOp.getBias().getType().getEncoding());
+        assert(biasLayoutAttr.getBufferType() ==
+                   ttnn::BufferType::SystemMemory &&
+               biasLayoutAttr.getLayout() == ttnn::Layout::RowMajor &&
+               "Bias must be in system memory and row-major layout when "
+               "calling TTNNPrepareConv2dWeightsAndBias pass");
+      }
+
+      ttnn::TTNNLayoutAttr inputLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+          conv2dOp.getInput().getType().getEncoding());
+      ttnn::TTNNLayoutAttr outputLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+          conv2dOp.getResult().getType().getEncoding());
+
+      ttcore::GridAttr deviceGrid =
+          ttcore::lookupDevice(moduleOp).getWorkerGrid();
+      ttnn::MemoryConfigAttr inputMemConfigAttr =
+          ttnn::MemoryConfigAttr::get(inputLayoutAttr, deviceGrid);
+
+      // Input and output dtype attr on prepare api is used to specify
+      // input/output dtype for the conv2d operation.
+      auto inputDtypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
+          &getContext(), inputLayoutAttr.getDataType());
+      auto outputDtypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
+          &getContext(), outputLayoutAttr.getDataType());
+
+      // When weight dtype is set in conv2d config prepare API will typecast the
+      // output into desired dtype. Until we have some different use case we
+      // will put prepared bias/weight into the same dtype as input.
+      auto conv2dConfig = conv2dOp.getConv2dConfigAttr()
+                              ? conv2dOp.getConv2dConfigAttr()
+                              : Conv2dConfigAttr::get(&getContext());
+      conv2dConfig =
+          conv2dConfig.withWeightsDtype(ttcore::elementTypeToDataType(
+              inputLayoutAttr.getScalarElementType()));
+
+      rewriter.setInsertionPoint(conv2dOp);
       ttnn::PrepareConv2dWeightsOp prepareConv2dWeightsOp =
           rewriter.create<ttnn::PrepareConv2dWeightsOp>(
               ttmlir::utils::appendLocationSuffix(conv2dOp.getLoc(),
@@ -70,30 +91,10 @@ public:
               conv2dOp.getPaddingAttr(), conv2dOp.getDilationAttr(),
               rewriter.getBoolAttr(conv2dOp.getBias() != nullptr),
               conv2dOp.getGroupsAttr(), conv2dOp.getDevice(), inputDtypeAttr,
-              weightDtypeAttr, conv2dOp.getConv2dConfigAttr());
+              outputDtypeAttr, conv2dOp.getConv2dConfigAttr());
 
       ttnn::PrepareConv2dBiasOp prepareConv2dBiasOp;
       if (conv2dOp.getBias()) {
-        mlir::RankedTensorType biasType = conv2dOp.getBias().getType();
-        ttnn::TTNNLayoutAttr biasLayoutAttr =
-            mlir::cast<ttnn::TTNNLayoutAttr>(biasType.getEncoding());
-        auto biasDtypeAttr = rewriter.getAttr<ttcore::DataTypeAttr>(
-            biasLayoutAttr.getDataType());
-        assert(biasLayoutAttr.getBufferType() ==
-                   ttnn::BufferType::SystemMemory &&
-               biasLayoutAttr.getLayout() == ttnn::Layout::RowMajor &&
-               "Bias must be in system memory and row-major layout when "
-               "calling TTNNPrepareConv2dWeightsAndBias pass");
-
-        // PrepareConv2dBias requires Conv2dConfig to be created and weights
-        // dtype to be set.
-        auto conv2dConfig = conv2dOp.getConv2dConfigAttr()
-                                ? conv2dOp.getConv2dConfigAttr()
-                                : Conv2dConfigAttr::get(&getContext());
-        conv2dConfig =
-            conv2dConfig.withWeightsDtype(ttcore::elementTypeToDataType(
-                conv2dOp.getWeight().getType().getElementType()));
-
         prepareConv2dBiasOp = rewriter.create<ttnn::PrepareConv2dBiasOp>(
             ttmlir::utils::appendLocationSuffix(conv2dOp.getLoc(),
                                                 "_prepare_conv2d_bias"),
@@ -105,7 +106,8 @@ public:
             conv2dOp.getInputWidthAttr(), conv2dOp.getKernelSizeAttr(),
             conv2dOp.getStrideAttr(), conv2dOp.getPaddingAttr(),
             conv2dOp.getDilationAttr(), conv2dOp.getGroupsAttr(),
-            conv2dOp.getDevice(), inputDtypeAttr, biasDtypeAttr, conv2dConfig);
+            conv2dOp.getDevice(), inputDtypeAttr, outputDtypeAttr,
+            conv2dConfig);
       }
 
       // Update only the weight and bias since PrepareConv2dWeightsOp and

--- a/test/ttmlir/Dialect/TTNN/conv/prepare_conv2d_weights/prepare_conv2d_weights_and_bias.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/prepare_conv2d_weights/prepare_conv2d_weights_and_bias.mlir
@@ -1,0 +1,27 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @conv2d_prepare_weight_and_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xf32>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: "ttnn.prepare_conv2d_weights"
+    // CHECK-SAME: weights_dtype = bf16
+    // CHECK-SAME: input_dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<bf16>
+
+    // CHECK: "ttnn.prepare_conv2d_bias"
+    // CHECK-SAME: weights_dtype = bf16
+    // CHECK-SAME: input_dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<bf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xf32>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %4: tensor<1x30x30x64xbf16>
+  }
+}


### PR DESCRIPTION
`output_dtype` attribute on prepare conv/bias should be used to indicate to prepare api what is the output dtype of conv operation itself, wheres our code uses it to specify the output dtype of prepare operation.
To tell ttnn to which dtype output of prepare should be we need to use `weights_dtype`.
 
This fix sets `weights_dtype` on prepare apis to the same type as input so that after prepare bias, weight and input are in same dtype.
`input_dtype/output_dtype` on prepare APIs is updated to dtype of input tensor and dtype of conv result respectively.

fixes #4180 