### PR TITLE
Change the ArgMax workaround to allow int32 inputs

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -904,7 +904,7 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::
-          createArgMaxOpOperandsWorkarounds();
+          createArgMaxOpOperandsWorkarounds(getInput().getType());
     }
   }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -270,7 +270,8 @@ public:
   static TTNNOperandsWorkarounds createTanhOpOperandsWorkarounds();
 
   // Create workarounds for ArgMax op operands.
-  static TTNNOperandsWorkarounds createArgMaxOpOperandsWorkarounds();
+  static TTNNOperandsWorkarounds
+  createArgMaxOpOperandsWorkarounds(mlir::RankedTensorType inputType);
 
   // Create workarounds for pad op operands.
   static TTNNOperandsWorkarounds

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -523,9 +523,7 @@ TTNNOperandsWorkaroundsFactory::createTanhOpOperandsWorkarounds() {
 }
 
 // Factory method to create a set of workarounds for ArgMax op operands.
-// Input tensor can have BFLOAT16 or INT32 data type and must use ROW_MAJOR
-// layout. No need for data type workaround for output tensor; only layout
-// workaround is required to match original layout. tt-metal specs:
+// Both input and output must be in ROW_MAJOR layout.
 // https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.argmax.html
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds(
@@ -533,20 +531,8 @@ TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds(
   wa::TTNNOperandWorkarounds inputWorkaround;
   inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
 
-  mlir::Type inputElementType = inputType.getElementType();
-  mlir::tt::ttcore::DataType inputDataType =
-      mlir::tt::ttcore::elementTypeToDataType(inputElementType);
-
-  if (inputDataType != mlir::tt::ttcore::DataType::BFloat16 &&
-      inputDataType != mlir::tt::ttcore::DataType::Int32) {
-    inputWorkaround.tensorDataTypeWorkaround =
-        mlir::tt::ttcore::DataType::BFloat16;
-  }
-
   wa::TTNNOperandWorkarounds outputWorkaround;
   outputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
-  outputWorkaround.tensorDataTypeWorkaround =
-      mlir::tt::ttcore::DataType::UInt32;
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(inputWorkaround)

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -533,12 +533,10 @@ TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds(
   wa::TTNNOperandWorkarounds inputWorkaround;
   inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
 
-  // Check if input data type is already bfloat16 or int32
   mlir::Type inputElementType = inputType.getElementType();
   mlir::tt::ttcore::DataType inputDataType =
       mlir::tt::ttcore::elementTypeToDataType(inputElementType);
 
-  // Only apply data type workaround if input is not already bfloat16 or int32
   if (inputDataType != mlir::tt::ttcore::DataType::BFloat16 &&
       inputDataType != mlir::tt::ttcore::DataType::Int32) {
     inputWorkaround.tensorDataTypeWorkaround =


### PR DESCRIPTION
### Ticket


### Problem description
Argmax in metal was changed to enable int32 inputs, as per https://github.com/tenstorrent/tt-metal/issues/25012

### What's changed
Loosened the workaround to allow either bf16 or int32 inputs to remain in the original dtype.

### Checklist
- [X] New/Existing tests provide coverage for changes
