### PR TITLE
Adding Dynamic Slice

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3812,14 +3812,14 @@ def TTIR_PadOp: TTIR_NamedOp<"pad"> {
     let hasVerifier = 1;
 }
 
-def TTIR_SliceOp: TTIR_NamedOp<"slice"> {
-    let summary = "Tensor slice operation.";
+def TTIR_SliceStaticOp: TTIR_NamedOp<"slice_static"> {
+    let summary = "Tensor slice operation with constant parameters.";
     let description = [{
-      The `slice` operation extracts a sub-tensor (slice) from the input tensor across one or more dimensions.
+      The `slice_static` operation extracts a sub-tensor (slice) from the input tensor across one or more dimensions.
 
       This operation selects a subset of elements from the input tensor based on the specified begin, end, and
       step indices for each dimension. It's similar to Python's slicing notation `tensor[begin:end:step]` but
-      extended to multiple dimensions.
+      extended to multiple dimensions. The `begins` and `ends` parameters are attributes with fixed values.
 
       Example:
       ```mlir
@@ -3830,7 +3830,7 @@ def TTIR_SliceOp: TTIR_NamedOp<"slice"> {
                                       //  [9,  10, 11, 12],
                                       //  [13, 14, 15, 16]]
       %output = ttir.empty() : tensor<2x2xf32>  // Output tensor shape
-      %result = ttir.slice(%input, %output) {
+      %result = ttir.slice_static(%input, %output) {
           begins = [1, 1],  // Start indices for each dimension
           ends = [3, 3],    // End indices for each dimension (exclusive)
           step = [1, 1]     // Step size for each dimension
@@ -3842,7 +3842,7 @@ def TTIR_SliceOp: TTIR_NamedOp<"slice"> {
       // Extract elements with a step of 2
       %input = ... : tensor<5xf32>  // Input tensor with values: [1, 2, 3, 4, 5]
       %output = ttir.empty() : tensor<3xf32>  // Output tensor shape
-      %result = ttir.slice(%input, %output) {
+      %result = ttir.slice_static(%input, %output) {
           begins = [0],  // Start index
           ends = [5],    // End index (exclusive)
           step = [2]     // Step size
@@ -3871,6 +3871,70 @@ def TTIR_SliceOp: TTIR_NamedOp<"slice"> {
                          I32ArrayAttr:$begins,
                          I32ArrayAttr:$ends,
                          I32ArrayAttr:$step);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
+def TTIR_SliceDynamicOp: TTIR_NamedOp<"slice_dynamic"> {
+    let summary = "Tensor slice operation with dynamic parameters.";
+    let description = [{
+      The `slice_dynamic` operation extracts a sub-tensor (slice) from the input tensor across one or more dimensions.
+
+      This operation selects a subset of elements from the input tensor based on the specified begin, end, and
+      step indices for each dimension. It's similar to Python's slicing notation `tensor[begin:end:step]` but
+      extended to multiple dimensions. The `begins` and `ends` parameters are tensor inputs determined at runtime.
+
+      Example:
+      ```mlir
+      // Extract a 2x2 slice from a 4x4 tensor with dynamic begin/end indices
+      %input = ... : tensor<4x4xf32>  // Input tensor with values:
+                                      // [[1,  2,  3,  4],
+                                      //  [5,  6,  7,  8],
+                                      //  [9,  10, 11, 12],
+                                      //  [13, 14, 15, 16]]
+      %begins = ... : tensor<2xi32>   // Tensor with values [1, 1]
+      %ends = ... : tensor<2xi32>     // Tensor with values [3, 3]
+      %output = ttir.empty() : tensor<2x2xf32>  // Output tensor shape
+      %result = ttir.slice_dynamic(%input, %begins, %ends, %output) {
+          step = [1, 1]     // Step size for each dimension
+      } : tensor<4x4xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2x2xf32> -> tensor<2x2xf32>
+      // Result:
+      // [[6,  7],
+      //  [10, 11]]
+
+      // Extract elements with a step of 2 using dynamic indices
+      %input = ... : tensor<5xf32>    // Input tensor with values: [1, 2, 3, 4, 5]
+      %begins = ... : tensor<1xi32>   // Tensor with values [0]
+      %ends = ... : tensor<1xi32>     // Tensor with values [5]
+      %output = ttir.empty() : tensor<3xf32>  // Output tensor shape
+      %result = ttir.slice_dynamic(%input, %begins, %ends, %output) {
+          step = [2]        // Step size
+      } : tensor<5xf32>, tensor<1xi32>, tensor<1xi32>, tensor<3xf32> -> tensor<3xf32>
+      // Result: [1, 3, 5]
+      ```
+
+      Inputs:
+      - `input` (Tensor): The input tensor to slice.
+      - `begins` (Tensor): The starting indices for the slice in each dimension.
+      - `ends` (Tensor): The ending indices (exclusive) for the slice in each dimension.
+
+      Attributes:
+      - `step` (Array of Integer): The step sizes for the slice in each dimension.
+
+      Outputs:
+      - `result` (Tensor): The sliced tensor.
+
+      Note: The `begins` and `ends` tensors must have the same length as the rank of the input tensor.
+      The output tensor shape may contain dynamic dimensions when slice parameters are runtime-determined.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$begins,
+                         AnyRankedTensor:$ends,
+                         AnyRankedTensor:$output,
+                         OptionalAttr<I32ArrayAttr>:$step);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1247,12 +1247,9 @@ def TTNN_SliceStaticOp: TTNN_Op<"slice_static",
 
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
-            getResult().getType().getEncoding());
-        ::mlir::ArrayAttr begins = getBegins();
         ::mlir::ArrayAttr step = getStep();
         return wa::TTNNOperandsWorkaroundsFactory::
-            createSliceStaticOpOperandsWorkarounds(layoutAttr, begins, step);
+            createSliceStaticOpOperandsWorkarounds(step);
       }
     }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1236,6 +1236,7 @@ def TTNN_SliceStaticOp: TTNN_Op<"slice_static",
     let description = [{
       Extract a portion of a tensor based on the specified start (`begins`), stop (`ends`), and step
       indices for each dimension. The `begins` and `ends` parameters are attributes with fixed values.
+      Maps to ttnn::slice.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
@@ -1260,7 +1261,7 @@ def TTNN_SliceDynamicOp: TTNN_Op<"slice_dynamic"> {
     let summary = "Dynamic slice op.";
     let description = [{
       Extract a portion of a tensor based on the specified start (`begins`), stop (`ends`), and step
-      indices for each dimension.
+      indices for each dimension. Maps to ttnn::slice.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1229,13 +1229,13 @@ def TTNN_PadOp: TTNN_Op<"pad"> {
   }];
 }
 
-def TTNN_SliceOp: TTNN_Op<"slice",
+def TTNN_SliceStaticOp: TTNN_Op<"slice_static",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Slice op.";
     let description = [{
       Extract a portion of a tensor based on the specified start (`begins`), stop (`ends`), and step
-      indices for each dimension.
+      indices for each dimension. The `begins` and `ends` parameters are attributes with fixed values.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
@@ -1252,7 +1252,32 @@ def TTNN_SliceOp: TTNN_Op<"slice",
         ::mlir::ArrayAttr begins = getBegins();
         ::mlir::ArrayAttr step = getStep();
         return wa::TTNNOperandsWorkaroundsFactory::
-            createSliceOpOperandsWorkarounds(layoutAttr, begins, step);
+            createSliceStaticOpOperandsWorkarounds(layoutAttr, begins, step);
+      }
+    }];
+
+    let hasVerifier = 1;
+}
+
+def TTNN_SliceDynamicOp: TTNN_Op<"slice_dynamic"> {
+    let summary = "Dynamic slice op.";
+    let description = [{
+      Extract a portion of a tensor based on the specified start (`begins`), stop (`ends`), and step
+      indices for each dimension.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$begins,
+                         AnyRankedTensor:$ends,
+                         OptionalAttr<I32ArrayAttr>:$step);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        ::mlir::ArrayAttr step = getStepAttr();
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createSliceDynamicOpOperandsWorkarounds(step);
       }
     }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -243,9 +243,7 @@ public:
 
   // Create workarounds for slice op operands.
   static TTNNOperandsWorkarounds
-  createSliceStaticOpOperandsWorkarounds(ttnn::TTNNLayoutAttr layoutAttr,
-                                         mlir::ArrayAttr begins,
-                                         mlir::ArrayAttr step);
+  createSliceStaticOpOperandsWorkarounds(mlir::ArrayAttr step);
 
   // Create workarounds for dynamic slice op operands.
   static TTNNOperandsWorkarounds

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -243,9 +243,13 @@ public:
 
   // Create workarounds for slice op operands.
   static TTNNOperandsWorkarounds
-  createSliceOpOperandsWorkarounds(ttnn::TTNNLayoutAttr layoutAttr,
-                                   mlir::ArrayAttr begins,
-                                   mlir::ArrayAttr step);
+  createSliceStaticOpOperandsWorkarounds(ttnn::TTNNLayoutAttr layoutAttr,
+                                         mlir::ArrayAttr begins,
+                                         mlir::ArrayAttr step);
+
+  // Create workarounds for dynamic slice op operands.
+  static TTNNOperandsWorkarounds
+  createSliceDynamicOpOperandsWorkarounds(mlir::ArrayAttr step);
 
   // Workaround for tensor creation that is modeled as ConstantOp in TTNN
   // dialect.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -339,11 +339,11 @@ struct OpModel<ReshapeOp> {
 };
 
 //===----------------------------------------------------------------------===//
-// SliceOp
+// SliceStaticOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<SliceOp> {
+struct OpModel<SliceStaticOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,

--- a/include/ttmlir/Target/TTNN/operations/data_movement.fbs
+++ b/include/ttmlir/Target/TTNN/operations/data_movement.fbs
@@ -48,12 +48,32 @@ table ReshapeOp {
   memory_config: tt.target.ttnn.MemoryConfig;
 }
 
-table SliceOp {
-  in: tt.target.ttnn.TensorRef;
-  out: tt.target.ttnn.TensorRef;
+enum SliceOpType : uint32 {
+  SliceStaticOp,
+  SliceDynamicOp
+}
+
+table SliceStaticOpParams {
   begins: [int64];
   ends: [int64];
+}
+
+table SliceDynamicOpParams {
+  begins: tt.target.ttnn.TensorRef;
+  ends: tt.target.ttnn.TensorRef;
+}
+
+union SliceOpParams {
+  SliceStaticOpParams,
+  SliceDynamicOpParams
+}
+
+table SliceOp {
+  type: SliceOpType;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   step: [int64];
+  params: SliceOpParams;
 }
 
 table SortOp {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2173,6 +2173,9 @@ public:
 };
 } // namespace
 
+// NOTE: StableHLO Dynamic Slice Op clamps start indices to ensure validity,
+// but we don't. Would add multiple ops (worse perf) and doesn't appear in test
+// models.
 namespace {
 class StableHLOToTTIRDynamicSliceOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::DynamicSliceOp> {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2225,18 +2225,14 @@ public:
 
     // Create an add op that adds the slice sizes to start indices to get end
     // indices.
-    auto endIndices = ttir::utils::createDPSOp<mlir::tt::ttir::AddOp>(
+    auto endIndicesTensor = ttir::utils::createDPSOp<mlir::tt::ttir::AddOp>(
         rewriter, srcOp.getLoc(), startIndicesTensorType.getShape(),
         startIndexElementType, startIndicesTensorType.getEncoding(),
         startIndicesTensor, sliceSizesConstant);
 
-    ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType(),
-        outputType.getEncoding());
-
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::SliceDynamicOp>(
-        srcOp, outputType, adaptor.getOperand(), startIndicesTensor, endIndices,
-        outputTensor, ArrayAttr());
+    ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::SliceDynamicOp>(
+        rewriter, srcOp, outputType, adaptor.getOperand(), startIndicesTensor,
+        endIndicesTensor, ArrayAttr());
 
     return success();
   }

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -1498,13 +1498,14 @@ public:
 } // namespace
 
 namespace {
-// Conversion pattern for ttir.slice operation.
-class SliceOpConversionPattern : public OpConversionPattern<ttir::SliceOp> {
+// Conversion pattern for ttir.slice_static operation.
+class SliceStaticOpConversionPattern
+    : public OpConversionPattern<ttir::SliceStaticOp> {
 public:
-  using OpConversionPattern<ttir::SliceOp>::OpConversionPattern;
+  using OpConversionPattern<ttir::SliceStaticOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ttir::SliceOp op, OpAdaptor adaptor,
+  matchAndRewrite(ttir::SliceStaticOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value input = adaptor.getInput();
     Value output = adaptor.getOutput(); // Get the output buffer
@@ -1667,7 +1668,7 @@ void populateTTIRToLinalgPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
       ElementwiseBinaryOpConversionPattern<ttir::PowOp, linalg::PowFOp>,
       ElementwiseOpConversionPattern<ttir::SqrtOp, linalg::SqrtOp>,
       SoftmaxOpConversionPattern, EmptyOpConversionPattern,
-      PermuteOpConversionPattern, SliceOpConversionPattern,
+      PermuteOpConversionPattern, SliceStaticOpConversionPattern,
       ConstantOpConversionPattern, EmbeddingOpConversionPattern,
       ReluOpConversionPattern>(typeConverter, ctx);
 }

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -65,7 +65,7 @@ struct IndexToSliceConversionPattern
       }
     }
 
-    auto newOp = rewriter.create<ttir::SliceOp>(
+    auto newOp = rewriter.create<ttir::SliceStaticOp>(
         op.getLoc(), op.getType(), adaptor.getInput(), adaptor.getOutput(),
         rewriter.getArrayAttr(begins), rewriter.getArrayAttr(ends),
         rewriter.getArrayAttr(steps));
@@ -1463,9 +1463,9 @@ public:
 };
 } // namespace
 
-// IndexSelectOp is converted to a series of SliceOp and potentially a ConcatOp
-// if the sliced dimension is sliced multiple times. For example, if the input
-// tensor is
+// IndexSelectOp is converted to a series of SliceStaticOp and potentially a
+// ConcatOp if the sliced dimension is sliced multiple times. For example, if
+// the input tensor is
 //    [[[1, 2, 3],
 //      [4, 5, 6],
 //      [7, 8, 9],
@@ -1549,7 +1549,7 @@ public:
       begins[dim] = newBegin;
       ends[dim] = newEnd;
 
-      auto newOp = ttir::utils::createDPSOp<ttir::SliceOp>(
+      auto newOp = ttir::utils::createDPSOp<ttir::SliceStaticOp>(
           rewriter, op.getLoc(), resultShape, inputType.getElementType(),
           inputType.getEncoding(), adaptor.getInput(),
           rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1839,18 +1839,18 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
   }
 
   // Verify that begins and ends are 1D tensors.
-  size_t begins_rank = static_cast<size_t>(beginsType.getRank());
-  size_t ends_rank = static_cast<size_t>(endsType.getRank());
-  if (begins_rank != 1 || ends_rank != 1) {
+  size_t beginsRank = static_cast<size_t>(beginsType.getRank());
+  size_t endsRank = static_cast<size_t>(endsType.getRank());
+  if (beginsRank != 1 || endsRank != 1) {
     return emitOpError("Begins and ends must be 1D tensors");
   }
 
   // Verify that the input rank matches number of elements in begins, ends, and
   // step.
-  auto input_rank = inputType.getRank();
+  auto inputRank = inputType.getRank();
 
-  if (input_rank != beginsShape[0] || input_rank != endsShape[0] ||
-      (stepAttr && static_cast<size_t>(input_rank) != stepAttr.size())) {
+  if (inputRank != beginsShape[0] || inputRank != endsShape[0] ||
+      (stepAttr && static_cast<size_t>(inputRank) != stepAttr.size())) {
     return emitOpError("Begins, ends, and step must have the same "
                        "number of elements as the input tensor rank");
   }
@@ -1870,7 +1870,7 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
 
   if (stepAttr) {
     // Verify that step isn't zero for any dimension.
-    for (auto i = 0; i < input_rank; ++i) {
+    for (auto i = 0; i < inputRank; ++i) {
       int32_t step = ::mlir::cast<::mlir::IntegerAttr>(stepAttr[i]).getInt();
       if (step == 0) {
         return emitOpError("Step value for dimension " + std::to_string(i) +

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -1072,12 +1072,12 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// SliceOp - TTNN Op Model Interface
+// SliceStaticOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<op_model::OpConstraints>
-SliceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
+SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -1090,22 +1090,22 @@ SliceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceOp>::getOpConstraints, *this, deviceGrid,
+      op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, deviceGrid,
       inputShape, inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
-SliceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig) {
+SliceStaticOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
 
   return opRuntimeCache().getOrCompute(
-      op_model::OpModel<SliceOp>::getOpRuntime, *this, inputShape, inputs[0],
-      detail::convertArrayAttrToSmallVec(getBegins()),
+      op_model::OpModel<SliceStaticOp>::getOpRuntime, *this, inputShape,
+      inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
       detail::convertArrayAttrToSmallVec(getEnds()),
       detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1292,11 +1292,11 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttnn::ReshapeOp op) {
 }
 
 //===----------------------------------------------------------------------===//
-// SliceOp
+// SliceStaticOp
 //===----------------------------------------------------------------------===//
 
-// SliceOp verification
-::mlir::LogicalResult mlir::tt::ttnn::SliceOp::verify() {
+// SliceStaticOp verification
+::mlir::LogicalResult mlir::tt::ttnn::SliceStaticOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
   ::mlir::ArrayAttr begins = getBeginsAttr();
@@ -1408,6 +1408,69 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttnn::ReshapeOp op) {
                            << " of the output tensor: expected size "
                            << expectedDimSize << ", but got "
                            << outputType.getDimSize(i);
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SliceDynamicOp
+//===----------------------------------------------------------------------===//
+
+// SliceDynamicOp verification
+::mlir::LogicalResult mlir::tt::ttnn::SliceDynamicOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType beginsType = getBegins().getType();
+  ::llvm::ArrayRef<int64_t> beginsShape = beginsType.getShape();
+  ::mlir::RankedTensorType endsType = getEnds().getType();
+  ::llvm::ArrayRef<int64_t> endsShape = endsType.getShape();
+  ::mlir::ArrayAttr stepAttr = getStepAttr();
+  ::mlir::RankedTensorType outputType = getResult().getType();
+
+  // Verify that the input is at least 1D tensor.
+  if (inputType.getRank() < 1) {
+    return emitOpError("Input must be at least a 1D tensor");
+  }
+
+  // Verify that begins and ends are 1D tensors.
+  size_t begins_rank = static_cast<size_t>(beginsType.getRank());
+  size_t ends_rank = static_cast<size_t>(endsType.getRank());
+  if (begins_rank != 1 || ends_rank != 1) {
+    return emitOpError("Begins and ends must be 1D tensors");
+  }
+
+  // Verify that the input rank matches number of elements in begins, ends, and
+  // step.
+  auto input_rank = inputType.getRank();
+
+  if (input_rank != beginsShape[0] || input_rank != endsShape[0] ||
+      (stepAttr && static_cast<size_t>(input_rank) != stepAttr.size())) {
+    return emitOpError("Begins, ends, and step must have the same "
+                       "number of elements as the input tensor rank");
+  }
+
+  // Validate that the output tensor has the same element type as the input
+  // tensor.
+  if (inputType.getElementType() != outputType.getElementType()) {
+    return emitOpError(
+        "Output tensor must have the same element type as the input tensor");
+  }
+
+  // Verify the output tensor rank.
+  if (inputType.getRank() != outputType.getRank()) {
+    return emitOpError(
+        "Output tensor must have the same rank as the input tensor");
+  }
+
+  if (stepAttr) {
+    // Verify that step isn't zero for any dimension.
+    for (auto i = 0; i < input_rank; ++i) {
+      int32_t step = ::mlir::cast<::mlir::IntegerAttr>(stepAttr[i]).getInt();
+      if (step == 0) {
+        return emitOpError("Step value for dimension " + std::to_string(i) +
+                           " cannot be zero");
+      }
     }
   }
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -240,6 +240,7 @@ TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
 
 // Factory method to create a set of workarounds for slice op input operands.
 // ttnn::SliceStaticOp requires bfloat16 data type for strided slice.
+// Tracking issue: https://github.com/tenstorrent/tt-metal/issues/26691.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSliceStaticOpOperandsWorkarounds(
     mlir::ArrayAttr step) {
@@ -250,18 +251,19 @@ TTNNOperandsWorkaroundsFactory::createSliceStaticOpOperandsWorkarounds(
     return intAttr.getInt() > 1;
   });
 
-  TTNNOperandWorkarounds BF16Workaround;
+  TTNNOperandWorkarounds bF16Workaround;
   if (isStridedSliceOp) {
-    BF16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+    bF16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addInputOperandWorkaround(BF16Workaround)
-      .addOutputOperandWorkaround(BF16Workaround);
+      .addInputOperandWorkaround(bF16Workaround)
+      .addOutputOperandWorkaround(bF16Workaround);
 }
 
 // Factory method to create a set of workarounds for dynamic slice op input
 // operands. ttnn::SliceDynamicOp requires bfloat16 data type for strided slice.
 // ttnn::SliceDynamicOp requires uint32 for begins and ends operands.
+// Tracking issue: https://github.com/tenstorrent/tt-metal/issues/26691.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSliceDynamicOpOperandsWorkarounds(
     mlir::ArrayAttr step) {
@@ -275,18 +277,18 @@ TTNNOperandsWorkaroundsFactory::createSliceDynamicOpOperandsWorkarounds(
     });
   }
 
-  TTNNOperandWorkarounds BF16Workaround;
+  TTNNOperandWorkarounds bF16Workaround;
   if (isStridedSliceOp) {
-    BF16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+    bF16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
   }
-  TTNNOperandWorkarounds UInt32Workaround;
-  UInt32Workaround.tensorDataTypeWorkaround = ttcore::DataType::UInt32;
+  TTNNOperandWorkarounds uInt32Workaround;
+  uInt32Workaround.tensorDataTypeWorkaround = ttcore::DataType::UInt32;
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addInputOperandWorkaround(BF16Workaround)
-      .addInputOperandWorkaround(UInt32Workaround)
-      .addInputOperandWorkaround(UInt32Workaround)
-      .addOutputOperandWorkaround(BF16Workaround);
+      .addInputOperandWorkaround(bF16Workaround)
+      .addInputOperandWorkaround(uInt32Workaround)
+      .addInputOperandWorkaround(uInt32Workaround)
+      .addOutputOperandWorkaround(bF16Workaround);
 }
 
 // ConstantOp is not a TTNN (lib) operation, but it is used to create TTNN

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.cpp
@@ -82,12 +82,12 @@ LogicalResult UpsampleOpBilinearPaddingRewritePattern::matchAndRewrite(
       srcOp.getLoc(), upsampledPaddedType, padOp, srcOp.getScaleFactorAttr(),
       srcOp.getModeAttr(), /*memory_config=*/nullptr);
 
-  // Create SliceOp to remove padding from the upsampled result.
+  // Create SliceStaticOp to remove padding from the upsampled result.
   SmallVector<int32_t> begins(/*size=*/DIM_COUNT, /*value=*/0);
   SmallVector<int32_t> ends(outputType.getShape());
   SmallVector<int32_t> steps(/*size=*/DIM_COUNT, /*value=*/1);
 
-  auto sliceOp = rewriter.create<ttnn::SliceOp>(
+  auto sliceOp = rewriter.create<ttnn::SliceStaticOp>(
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "slice"), outputType,
       paddedUpsampleOp, rewriter.getI32ArrayAttr(begins),
       rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1349,9 +1349,9 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
-// SliceOp
+// SliceStaticOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<SliceOp>::getOpConstraints(
+llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
     llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
@@ -1394,7 +1394,7 @@ llvm::Expected<OpConstraints> OpModel<SliceOp>::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> OpModel<SliceOp>::getOpRuntime(
+llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
     llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1684,7 +1684,7 @@ createSliceOp(FlatbufferObjectCache &cache, SliceOp op) {
         ::tt::target::ttnn::CreateSliceStaticOpParams(*cache.fbb, begins, ends)
             .Union();
   } else {
-    llvm_unreachable("unhandled SliceOp");
+    llvm_unreachable("Unhandled SliceOp");
   }
 
   auto in = cache.at<::tt::target::ttnn::TensorRef>(

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -11,13 +11,16 @@
 #include <cstdint>
 
 namespace tt::runtime::ttnn::operations::data_movement {
-void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.getTensorPool();
+static void runSliceStaticOp(const ::tt::target::ttnn::SliceOp *op,
+                             ProgramTensorPool &tensorPool) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::ttsl::SmallVector<int32_t> begins(op->begins()->begin(),
-                                      op->begins()->end());
-  ::ttsl::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
+  ::ttsl::SmallVector<int32_t> begins(
+      op->params_as<target::ttnn::SliceStaticOpParams>()->begins()->begin(),
+      op->params_as<target::ttnn::SliceStaticOpParams>()->begins()->end());
+  ::ttsl::SmallVector<int32_t> ends(
+      op->params_as<target::ttnn::SliceStaticOpParams>()->ends()->begin(),
+      op->params_as<target::ttnn::SliceStaticOpParams>()->ends()->end());
   ::ttsl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
 
   ttsl::Span<const int32_t> beginsSpan(begins.data(), begins.size());
@@ -28,4 +31,40 @@ void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
+
+static void runSliceDynamicOp(const ::tt::target::ttnn::SliceOp *op,
+                              ProgramTensorPool &tensorPool) {
+  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
+
+  const ::ttnn::Tensor &begins = tensorPool.getTTNNTensorAndValidate(
+      op->params_as<target::ttnn::SliceDynamicOpParams>()->begins());
+  const ::ttnn::Tensor &ends = tensorPool.getTTNNTensorAndValidate(
+      op->params_as<target::ttnn::SliceDynamicOpParams>()->ends());
+
+  std::optional<::ttsl::SmallVector<uint32_t>> step;
+  if (op->step() && op->step()->size() > 0) {
+    step = ::ttsl::SmallVector<uint32_t>();
+    step->resize(op->step()->size());
+    std::transform(op->step()->begin(), op->step()->end(), step->begin(),
+                   [](int32_t v) { return static_cast<uint32_t>(v); });
+  }
+
+  ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  switch (op->type()) {
+  case ::tt::target::ttnn::SliceOpType::SliceStaticOp:
+    runSliceStaticOp(op, tensorPool);
+    break;
+  case ::tt::target::ttnn::SliceOpType::SliceDynamicOp:
+    runSliceDynamicOp(op, tensorPool);
+    break;
+  }
+}
+
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/tools/chisel/chisel/utils/mapping.py
+++ b/runtime/tools/chisel/chisel/utils/mapping.py
@@ -483,7 +483,7 @@ ttir_to_torch_mapping = {
         custom_update_cache,
         {"batch_offset": "batch_offset"},
     ),
-    "ttir.slice": OpMapping(
+    "ttir.slice_static": OpMapping(
         custom_slice,
         {"begins": "begins", "ends": "ends", "step": "step"},
         unpack_inputs=False,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/slice_dynamic_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/slice_dynamic_op.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module @jit_dynamic_slice attributes {} {
+    func.func @dynamic_slice(%arg0: tensor<32x64xf32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> (tensor<8x8xf32> {jax.result_info = "result"}) {
+    // CHECK: = "ttir.concat"
+    // CHECK: = "ttir.constant"
+    // CHECK: = "ttir.add"
+    // CHECK: = ttir.empty
+    // CHECK: = "ttir.slice_dynamic"
+    %0 = stablehlo.dynamic_slice %arg0, %arg1, %arg2, sizes = [8, 8] : (tensor<32x64xf32>, tensor<i32>, tensor<i32>) -> tensor<8x8xf32>
+    return %0 : tensor<8x8xf32>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/slice_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/slice_op.mlir
@@ -4,7 +4,7 @@
 module @jit_eltwise_subtract attributes {} {
   func.func @slice_op(%arg0: tensor<32x64xf32>) -> tensor<8x8xf32> {
   // CHECK: = ttir.empty
-  // CHECK: = "ttir.slice"
+  // CHECK: = "ttir.slice_static"
   %result = "stablehlo.slice"(%arg0) {
     start_indices = array<i64: 0, 16>,
     limit_indices = array<i64: 16, 32>,

--- a/test/ttmlir/Dialect/TTIR/Decomposition/select_decomposition_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/select_decomposition_tests.mlir
@@ -4,7 +4,7 @@
 module attributes {} {
   func.func @select_identity(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.slice"
+    // CHECK: %{{[0-9]+}} = "ttir.slice_static"
     %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
@@ -13,10 +13,10 @@ module attributes {} {
   func.func @select_multi_slice(%arg0: tensor<4x2x64x128xf32>) -> tensor<4x2x64x32xf32> {
     %0 = ttir.empty() : tensor<4x2x64x32xf32>
 
-    // CHECK: %{{[0-9]+}} = "ttir.slice"
-    // CHECK: %{{[0-9]+}} = "ttir.slice"
-    // CHECK: %{{[0-9]+}} = "ttir.slice"
-    // CHECK: %{{[0-9]+}} = "ttir.slice"
+    // CHECK: %{{[0-9]+}} = "ttir.slice_static"
+    // CHECK: %{{[0-9]+}} = "ttir.slice_static"
+    // CHECK: %{{[0-9]+}} = "ttir.slice_static"
+    // CHECK: %{{[0-9]+}} = "ttir.slice_static"
     // CHECK: %{{[0-9]+}} = "ttir.concat"
     %1 = "ttir.index_select"(%arg0, %0) <{dim = -1: si32, begin = 0: si32, length = 4: si32, stride = 16: si32}>  :
         (tensor<4x2x64x128xf32>, tensor<4x2x64x32xf32>) -> tensor<4x2x64x32xf32>

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_permute_slice.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_permute_slice.mlir
@@ -3,7 +3,7 @@
 
 module {
   func.func @test_permute_concat_commute_downwards(%arg0: tensor<1x160x160x160xbf16>) -> tensor<1x160x160x80xbf16> {
-    // CHECK: %[[CONCAT:[0-9]+]] = "ttir.slice"(%arg0,
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttir.slice_static"(%arg0,
     // CHECK: begins = [0 : i32, 80 : i32, 0 : i32, 0 : i32]
     // CHECK: ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32]
     // CHECK: step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]
@@ -14,7 +14,7 @@ module {
     %0 = ttir.empty() : tensor<1x160x160x160xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x160x160x160xbf16>, tensor<1x160x160x160xbf16>) -> tensor<1x160x160x160xbf16>
     %2 = ttir.empty() : tensor<1x160x160x80xbf16>
-    %3 = "ttir.slice"(%1, %2) <{begins = [0 : i32, 0 : i32, 0 : i32, 80 : i32], ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x160x160x160xbf16>, tensor<1x160x160x80xbf16>) -> tensor<1x160x160x80xbf16>
+    %3 = "ttir.slice_static"(%1, %2) <{begins = [0 : i32, 0 : i32, 0 : i32, 80 : i32], ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x160x160x160xbf16>, tensor<1x160x160x80xbf16>) -> tensor<1x160x160x80xbf16>
     return %3 : tensor<1x160x160x80xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_permute_slice.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_permute_slice.mlir
@@ -4,12 +4,12 @@
 module {
   func.func @test_permute_concat_commute_upwards(%arg0: tensor<1x160x160x160xbf16>) -> tensor<1x160x160x80xbf16> {
     // CHECK: %[[PERMUTE1:[0-9]+]] = "ttir.permute"(%arg0, %{{[0-9]+}}) <{permutation = array<i64: 0, 2, 3, 1>}>
-    // CHECK: %[[CONCAT:[0-9]+]] = "ttir.slice"(%[[PERMUTE1]]
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttir.slice_static"(%[[PERMUTE1]]
     // CHECK: begins = [0 : i32, 0 : i32, 0 : i32, 80 : i32]
     // CHECK: ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32]
     // CHECK: step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]
     %0 = tensor.empty() : tensor<1x80x160x160xbf16>
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0 : i32, 80 : i32, 0 : i32, 0 : i32], ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x160x160x160xbf16>, tensor<1x80x160x160xbf16>) -> tensor<1x80x160x160xbf16>
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0 : i32, 80 : i32, 0 : i32, 0 : i32], ends = [1 : i32, 160 : i32, 160 : i32, 160 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x160x160x160xbf16>, tensor<1x80x160x160xbf16>) -> tensor<1x80x160x160xbf16>
     %2 = tensor.empty() : tensor<1x160x160x80xbf16>
     %3 = "ttir.permute"(%1, %2) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x80x160x160xbf16>, tensor<1x160x160x80xbf16>) -> tensor<1x160x160x80xbf16>
     return %3 : tensor<1x160x160x80xbf16>

--- a/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_negative.mlir
@@ -1,7 +1,7 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for dynamic slice operation
 
-// Verify that the parsing fails if input is not at least a 1D tensor
+// Verify that the parsing fails if input is not at least a 1D tensor.
 module attributes {} {
   func.func @slice_negative_invalid_shape(%arg0: tensor<bf16>, %arg1 : tensor<1xi32>, %arg2 : tensor<1xi32>) -> tensor<1xbf16> {
     %0 = ttir.empty() : tensor<1xbf16>
@@ -11,7 +11,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if begins is not a 1D tensor
+// Verify that the parsing fails if begins is not a 1D tensor.
 // -----
 module attributes {} {
   func.func @slice_negative_invalid_begins(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2x1xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
@@ -22,7 +22,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if ends is not a 1D tensor
+// Verify that the parsing fails if ends is not a 1D tensor.
 // -----
 module attributes {} {
   func.func @slice_negative_invalid_ends(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2x1xi32>) -> tensor<64x32xbf16> {
@@ -33,7 +33,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the ends size is not equal to the input tensor rank
+// Verify that the parsing fails if the ends size is not equal to the input tensor rank.
 // -----
 module attributes {} {
   func.func @slice_negative_invalid_ends_shape(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<3xi32>) -> tensor<64x32xbf16> {
@@ -44,7 +44,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the step size is not equal to the input tensor rank
+// Verify that the parsing fails if the step size is not equal to the input tensor rank.
 // -----
 module attributes {} {
   func.func @slice_negative_invalid_step(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
@@ -55,7 +55,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the output type is not equal to the input tensor type
+// Verify that the parsing fails if the output type is not equal to the input tensor type.
 // -----
 module attributes {} {
   func.func @slice_negative_invalid_output_datatype(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xf32> {
@@ -66,7 +66,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the output rank is not equal to the input tensor rank
+// Verify that the parsing fails if the output rank is not equal to the input tensor rank.
 // -----
 module attributes {} {
   func.func @slice_negative_input_output_rank_missmatch(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32x1xbf16> {
@@ -77,7 +77,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the step value is equal to zero
+// Verify that the parsing fails if the step value is equal to zero.
 // -----
 module attributes {} {
   func.func @slice_negative_step_is_zero(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {

--- a/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_negative.mlir
@@ -1,0 +1,89 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for dynamic slice operation
+
+// Verify that the parsing fails if input is not at least a 1D tensor
+module attributes {} {
+  func.func @slice_negative_invalid_shape(%arg0: tensor<bf16>, %arg1 : tensor<1xi32>, %arg2 : tensor<1xi32>) -> tensor<1xbf16> {
+    %0 = ttir.empty() : tensor<1xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Input must be at least a 1D tensor
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32]}> : (tensor<bf16>, tensor<1xi32>, tensor<1xi32>, tensor<1xbf16>) -> tensor<1xbf16>
+    return %1 : tensor<1xbf16>
+  }
+}
+
+// Verify that the parsing fails if begins is not a 1D tensor
+// -----
+module attributes {} {
+  func.func @slice_negative_invalid_begins(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2x1xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Begins and ends must be 1D tensors
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2x1xi32>, tensor<2xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+}
+
+// Verify that the parsing fails if ends is not a 1D tensor
+// -----
+module attributes {} {
+  func.func @slice_negative_invalid_ends(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2x1xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Begins and ends must be 1D tensors
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2x1xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+}
+
+// Verify that the parsing fails if the ends size is not equal to the input tensor rank
+// -----
+module attributes {} {
+  func.func @slice_negative_invalid_ends_shape(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<3xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Begins, ends, and step must have the same number of elements as the input tensor rank
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<3xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+}
+
+// Verify that the parsing fails if the step size is not equal to the input tensor rank
+// -----
+module attributes {} {
+  func.func @slice_negative_invalid_step(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Begins, ends, and step must have the same number of elements as the input tensor rank
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+}
+
+// Verify that the parsing fails if the output type is not equal to the input tensor type
+// -----
+module attributes {} {
+  func.func @slice_negative_invalid_output_datatype(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xf32> {
+    %0 = ttir.empty() : tensor<64x32xf32>
+    // CHECK: error: 'ttir.slice_dynamic' op Output tensor must have the same element type as the input tensor
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+    return %1 : tensor<64x32xf32>
+  }
+}
+
+// Verify that the parsing fails if the output rank is not equal to the input tensor rank
+// -----
+module attributes {} {
+  func.func @slice_negative_input_output_rank_missmatch(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32x1xbf16> {
+    %0 = ttir.empty() : tensor<64x32x1xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Output tensor must have the same rank as the input tensor
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<64x32x1xbf16>) -> tensor<64x32x1xbf16>
+    return %1 : tensor<64x32x1xbf16>
+  }
+}
+
+// Verify that the parsing fails if the step value is equal to zero
+// -----
+module attributes {} {
+  func.func @slice_negative_step_is_zero(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: error: 'ttir.slice_dynamic' op Step value for dimension 1 cannot be zero
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 0: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_dynamic_tests_positive.mlir
@@ -1,0 +1,59 @@
+// RUN: ttmlir-opt -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module attributes {} {
+  func.func @slice_1d(%arg0: tensor<64xbf16>, %arg1 : tensor<1xi32>, %arg2 : tensor<1xi32>) -> tensor<32xbf16> {
+    %0 = ttir.empty() : tensor<32xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32]}> : (tensor<64xbf16>, tensor<1xi32>, tensor<1xi32>, tensor<32xbf16>) -> tensor<32xbf16>
+    return %1 : tensor<32xbf16>
+  }
+
+  func.func @slice_1d_step(%arg0: tensor<64xbf16>, %arg1 : tensor<1xi32>, %arg2 : tensor<1xi32>) -> tensor<16xbf16> {
+    %0 = ttir.empty() : tensor<16xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [4: i32]}> : (tensor<64xbf16>, tensor<1xi32>, tensor<1xi32>, tensor<16xbf16>) -> tensor<16xbf16>
+    return %1 : tensor<16xbf16>
+  }
+
+  func.func @slice_2d(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<64x32xbf16> {
+    %0 = ttir.empty() : tensor<64x32xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    return %1 : tensor<64x32xbf16>
+  }
+
+  func.func @slice_2d_step(%arg0: tensor<128x64xbf16>, %arg1 : tensor<2xi32>, %arg2 : tensor<2xi32>) -> tensor<32x16xbf16> {
+    %0 = ttir.empty() : tensor<32x16xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [2: i32, 4: i32]}> : (tensor<128x64xbf16>, tensor<2xi32>, tensor<2xi32>, tensor<32x16xbf16>) -> tensor<32x16xbf16>
+    return %1 : tensor<32x16xbf16>
+  }
+
+  func.func @slice_3d(%arg0: tensor<3x128x64xbf16>, %arg1 : tensor<3xi32>, %arg2 : tensor<3xi32>) -> tensor<1x64x64xbf16> {
+    %0 = ttir.empty() : tensor<1x64x64xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<3xi32>, tensor<3xi32>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
+    return %1 : tensor<1x64x64xbf16>
+  }
+
+  func.func @slice_3d_step(%arg0: tensor<3x128x64xbf16>, %arg1 : tensor<3xi32>, %arg2 : tensor<3xi32>) -> tensor<2x32x32xbf16> {
+    %0 = ttir.empty() : tensor<2x32x32xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [2: i32, 4: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<3xi32>, tensor<3xi32>, tensor<2x32x32xbf16>) -> tensor<2x32x32xbf16>
+    return %1 : tensor<2x32x32xbf16>
+  }
+
+  func.func @slice_4d(%arg0: tensor<10x3x128x64xbf16>, %arg1 : tensor<4xi32>, %arg2 : tensor<4xi32>) -> tensor<5x3x32x64xbf16> {
+    %0 = ttir.empty() : tensor<5x3x32x64xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32, 1: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4xi32>, tensor<4xi32>, tensor<5x3x32x64xbf16>) -> tensor<5x3x32x64xbf16>
+    return %1 : tensor<5x3x32x64xbf16>
+  }
+
+  func.func @slice_4d_step(%arg0: tensor<10x3x128x64xbf16>, %arg1 : tensor<4xi32>, %arg2 : tensor<4xi32>) -> tensor<4x1x16x32xbf16> {
+    %0 = ttir.empty() : tensor<4x1x16x32xbf16>
+    // CHECK: = "ttir.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [3: i32, -2: i32, 8: i32, 2: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4xi32>, tensor<4xi32>, tensor<4x1x16x32xbf16>) -> tensor<4x1x16x32xbf16>
+    return %1 : tensor<4x1x16x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_tests_negative.mlir
@@ -5,8 +5,8 @@
 module attributes {} {
   func.func @slice_negative_invalid_shape(%arg0: tensor<bf16>) -> tensor<1xbf16> {
     %0 = ttir.empty() : tensor<1xbf16>
-    // CHECK: error: 'ttir.slice' op Input must be at least a 1D tensor
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32], ends = [0: i32], step = [1: i32]}> : (tensor<bf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    // CHECK: error: 'ttir.slice_static' op Input must be at least a 1D tensor
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32], ends = [0: i32], step = [1: i32]}> : (tensor<bf16>, tensor<1xbf16>) -> tensor<1xbf16>
     return %1 : tensor<1xbf16>
   }
 }
@@ -16,8 +16,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_begins(%arg0: tensor<3x128x64xbf16>) -> tensor<1x64x64xbf16> {
     %0 = ttir.empty() : tensor<1x64x64xbf16>
-    // CHECK: error: 'ttir.slice' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
+    // CHECK: error: 'ttir.slice_static' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
     return %1 : tensor<1x64x64xbf16>
   }
 }
@@ -27,8 +27,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_ends(%arg0: tensor<3x128x64xbf16>) -> tensor<1x64x64xbf16> {
     %0 = ttir.empty() : tensor<1x64x64xbf16>
-    // CHECK: error: 'ttir.slice' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
+    // CHECK: error: 'ttir.slice_static' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
     return %1 : tensor<1x64x64xbf16>
   }
 }
@@ -38,8 +38,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_step(%arg0: tensor<3x128x64xbf16>) -> tensor<1x64x64xbf16> {
     %0 = ttir.empty() : tensor<1x64x64xbf16>
-    // CHECK: error: 'ttir.slice' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
+    // CHECK: error: 'ttir.slice_static' op Begins, ends, and step attributes must have the same number of elements as the input tensor rank
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
     return %1 : tensor<1x64x64xbf16>
   }
 }
@@ -49,8 +49,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_output_datatype(%arg0: tensor<3x128x64xbf16>) -> tensor<1x64x64xf32> {
     %0 = ttir.empty() : tensor<1x64x64xf32>
-    // CHECK: error: 'ttir.slice' op Output tensor must have the same element type as the input tensor
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xf32>) -> tensor<1x64x64xf32>
+    // CHECK: error: 'ttir.slice_static' op Output tensor must have the same element type as the input tensor
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xf32>) -> tensor<1x64x64xf32>
     return %1 : tensor<1x64x64xf32>
   }
 }
@@ -60,8 +60,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_input_output_rank_missmatch(%arg0: tensor<3x128x64xbf16>) -> tensor<1x1x64x64xbf16> {
     %0 = ttir.empty() : tensor<1x1x64x64xbf16>
-    // CHECK: error: 'ttir.slice' op Output tensor must have the same rank as the input tensor
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
+    // CHECK: error: 'ttir.slice_static' op Output tensor must have the same rank as the input tensor
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [0: i32, 63: i32, 63: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
     return %1 : tensor<1x1x64x64xbf16>
   }
 }
@@ -71,8 +71,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_begin_negative(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op Invalid begin index for dimension 2. Expected value in range [-128, 128), got -129. Input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, -129: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op Invalid begin index for dimension 2. Expected value in range [-128, 128), got -129. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, -129: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -82,8 +82,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_end_positive(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op Invalid end index for dimension 3. Expected value in range [-64, 64], got 65. Input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 65: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op Invalid end index for dimension 3. Expected value in range [-64, 64], got 65. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 65: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -93,8 +93,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_end_negative(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op Invalid end index for dimension 3. Expected value in range [-64, 64], got -65. Input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, -65: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op Invalid end index for dimension 3. Expected value in range [-64, 64], got -65. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, -65: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -104,8 +104,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_step_is_zero(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op Step value for dimension 3 cannot be zero
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 0: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op Step value for dimension 3 cannot be zero
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 0: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -115,8 +115,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_begin_greater_than_end_positive_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op For positive step, begin index must be less than or equal to end index for dimension 0. Got begin: 9, end: 0, step: 3, input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [9: i32, 0: i32, 0: i32, 32: i32], ends = [0: i32, 3: i32, 32: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op For positive step, begin index must be less than or equal to end index for dimension 0. Got begin: 9, end: 0, step: 3, input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [9: i32, 0: i32, 0: i32, 32: i32], ends = [0: i32, 3: i32, 32: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -125,8 +125,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_begin_greater_than_end_positive_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x8x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x8x8xbf16>
-    // CHECK: error: 'ttir.slice' op For positive step, begin index must be less than or equal to end index for dimension 2. Got begin: 96 (-32), end: 32 (-96), step: 8, input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, -32: i32, 32: i32], ends = [10: i32, 3: i32, -96: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x8x8xbf16>) -> tensor<4x1x8x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op For positive step, begin index must be less than or equal to end index for dimension 2. Got begin: 96 (-32), end: 32 (-96), step: 8, input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, -32: i32, 32: i32], ends = [10: i32, 3: i32, -96: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x8x8xbf16>) -> tensor<4x1x8x8xbf16>
     return %1 : tensor<4x1x8x8xbf16>
   }
 }
@@ -136,8 +136,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_begin_less_than_end_negative_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op For negative step, begin index must be greater than or equal to end index for dimension 1. Got begin: 0 (-3), end: 2 (-1), step: -3, input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, -3: i32, 0: i32, 32: i32], ends = [10: i32, -1: i32, 32: i32, 128: i32], step = [3: i32, -3: i32, 8: i32, 8: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op For negative step, begin index must be greater than or equal to end index for dimension 1. Got begin: 0 (-3), end: 2 (-1), step: -3, input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, -3: i32, 0: i32, 32: i32], ends = [10: i32, -1: i32, 32: i32, 128: i32], step = [3: i32, -3: i32, 8: i32, 8: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
     return %1 : tensor<4x1x16x8xbf16>
   }
 }
@@ -146,8 +146,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_begin_less_than_end_negative_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<5x1x16x8xbf16> {
     %0 = ttir.empty() : tensor<5x1x16x8xbf16>
-    // CHECK: error: 'ttir.slice' op For negative step, begin index must be greater than or equal to end index for dimension 0. Got begin: 0, end: 10, step: -2, input shape: (10, 3, 128, 64)
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [-2: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<5x1x16x8xbf16>) -> tensor<5x1x16x8xbf16>
+    // CHECK: error: 'ttir.slice_static' op For negative step, begin index must be greater than or equal to end index for dimension 0. Got begin: 0, end: 10, step: -2, input shape: (10, 3, 128, 64)
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [-2: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<5x1x16x8xbf16>) -> tensor<5x1x16x8xbf16>
     return %1 : tensor<5x1x16x8xbf16>
   }
 }
@@ -157,8 +157,8 @@ module attributes {} {
 module attributes {} {
   func.func @slice_negative_invalid_output_shape(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x16xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x16xbf16>
-    // CHECK: error: 'ttir.slice' op Mismatch in dimension 3 of the output tensor: expected size 8, but got 16
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x16xbf16>) -> tensor<4x1x16x16xbf16>
+    // CHECK: error: 'ttir.slice_static' op Mismatch in dimension 3 of the output tensor: expected size 8, but got 16
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x16xbf16>) -> tensor<4x1x16x16xbf16>
     return %1 : tensor<4x1x16x16xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/slice/slice_tests_positive.mlir
@@ -3,57 +3,57 @@
 module attributes {} {
   func.func @slice_1d(%arg0: tensor<64xbf16>) -> tensor<32xbf16> {
     %0 = ttir.empty() : tensor<32xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32], ends = [32: i32], step = [1: i32]}> : (tensor<64xbf16>, tensor<32xbf16>) -> tensor<32xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32], ends = [32: i32], step = [1: i32]}> : (tensor<64xbf16>, tensor<32xbf16>) -> tensor<32xbf16>
     return %1 : tensor<32xbf16>
   }
 
   func.func @slice_1d_step(%arg0: tensor<64xbf16>) -> tensor<16xbf16> {
     %0 = ttir.empty() : tensor<16xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32], ends = [64: i32], step = [4: i32]}> : (tensor<64xbf16>, tensor<16xbf16>) -> tensor<16xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32], ends = [64: i32], step = [4: i32]}> : (tensor<64xbf16>, tensor<16xbf16>) -> tensor<16xbf16>
     return %1 : tensor<16xbf16>
   }
 
   func.func @slice_2d(%arg0: tensor<128x64xbf16>) -> tensor<64x32xbf16> {
     %0 = ttir.empty() : tensor<64x32xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32], ends = [64: i32, 32: i32], step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32], ends = [64: i32, 32: i32], step = [1: i32, 1: i32]}> : (tensor<128x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
     return %1 : tensor<64x32xbf16>
   }
 
   func.func @slice_2d_step(%arg0: tensor<128x64xbf16>) -> tensor<32x16xbf16> {
     %0 = ttir.empty() : tensor<32x16xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [64: i32, 0: i32], ends = [128: i32, 64: i32], step = [2: i32, 4: i32]}> : (tensor<128x64xbf16>, tensor<32x16xbf16>) -> tensor<32x16xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [64: i32, 0: i32], ends = [128: i32, 64: i32], step = [2: i32, 4: i32]}> : (tensor<128x64xbf16>, tensor<32x16xbf16>) -> tensor<32x16xbf16>
     return %1 : tensor<32x16xbf16>
   }
 
   func.func @slice_3d(%arg0: tensor<3x128x64xbf16>) -> tensor<1x64x64xbf16> {
     %0 = ttir.empty() : tensor<1x64x64xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [1: i32, 64: i32, 64: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [1: i32, 64: i32, 64: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<1x64x64xbf16>) -> tensor<1x64x64xbf16>
     return %1 : tensor<1x64x64xbf16>
   }
 
   func.func @slice_3d_step(%arg0: tensor<3x128x64xbf16>) -> tensor<2x32x32xbf16> {
     %0 = ttir.empty() : tensor<2x32x32xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 32: i32], ends = [3: i32, 128: i32, 64: i32], step = [2: i32, 4: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<2x32x32xbf16>) -> tensor<2x32x32xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 32: i32], ends = [3: i32, 128: i32, 64: i32], step = [2: i32, 4: i32, 1: i32]}> : (tensor<3x128x64xbf16>, tensor<2x32x32xbf16>) -> tensor<2x32x32xbf16>
     return %1 : tensor<2x32x32xbf16>
   }
 
   func.func @slice_4d(%arg0: tensor<10x3x128x64xbf16>) -> tensor<5x3x32x64xbf16> {
     %0 = ttir.empty() : tensor<5x3x32x64xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [3: i32, 0: i32, 32: i32, 0: i32], ends = [8: i32, 3: i32, 64: i32, 64: i32], step = [1: i32, 1: i32, 1: i32, 1: i32]}> : (tensor<10x3x128x64xbf16>, tensor<5x3x32x64xbf16>) -> tensor<5x3x32x64xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [3: i32, 0: i32, 32: i32, 0: i32], ends = [8: i32, 3: i32, 64: i32, 64: i32], step = [1: i32, 1: i32, 1: i32, 1: i32]}> : (tensor<10x3x128x64xbf16>, tensor<5x3x32x64xbf16>) -> tensor<5x3x32x64xbf16>
     return %1 : tensor<5x3x32x64xbf16>
   }
 
   func.func @slice_4d_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x32xbf16> {
     %0 = ttir.empty() : tensor<4x1x16x32xbf16>
-    // CHECK: = "ttir.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 2: i32, 0: i32, -64: i32], ends = [10: i32, 0: i32, -1: i32, -1: i32], step = [3: i32, -2: i32, 8: i32, 2: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x32xbf16>) -> tensor<4x1x16x32xbf16>
+    // CHECK: = "ttir.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 2: i32, 0: i32, -64: i32], ends = [10: i32, 0: i32, -1: i32, -1: i32], step = [3: i32, -2: i32, 8: i32, 2: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x32xbf16>) -> tensor<4x1x16x32xbf16>
     return %1 : tensor<4x1x16x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
@@ -11,13 +11,13 @@ module attributes {} {
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<4x32x32xf32
     // CHECK-SAME: -> tensor<4x32x32xbf16
-    // CHECK: %[[SLICE:[0-9]+]] = "ttnn.slice"(%[[ARG0]])
+    // CHECK: %[[SLICE:[0-9]+]] = "ttnn.slice_static"(%[[ARG0]])
     // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32]
     // CHECK-SAME: ends = [2 : i32, 16 : i32, 16 : i32]
     // CHECK-SAME: step = [1 : i32, 1 : i32, 2 : i32]}
     // CHECK-SAME: tensor<4x32x32xbf16
     // CHECK-SAME: -> tensor<2x16x8xbf16
-    %0 = "ttnn.slice"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [2 : i32, 16 : i32, 16 : i32], step = [1 : i32, 1 : i32, 2 : i32]}> : (tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1>
+    %0 = "ttnn.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [2 : i32, 16 : i32, 16 : i32], step = [1 : i32, 1 : i32, 2 : i32]}> : (tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1>
     // CHECK: "ttnn.to_layout"(%[[SLICE]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: tensor<2x16x8xbf16

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_bilinear_workaround.mlir
@@ -19,7 +19,7 @@ module {
     // CHECK: %[[TO_TILE:.*]] = "ttnn.to_layout"(%[[UPSAMPLE]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<tile>
-    // CHECK: "ttnn.slice"(%[[TO_TILE]])
+    // CHECK: "ttnn.slice_static"(%[[TO_TILE]])
     // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32]
     // CHECK-SAME: ends = [1 : i32, 16 : i32, 16 : i32, 30 : i32]
     %1 = "ttnn.upsample"(%arg0) <{mode = "bilinear", scale_factor = 2 : si32}> : (tensor<1x8x8x30xf32, #layout_tile_interleaved>) -> tensor<1x16x16x30xf32, #layout_tile_interleaved_out>

--- a/test/ttmlir/Dialect/TTNN/simple_slice.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_slice.mlir
@@ -3,8 +3,8 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>
-    // CHECK: = "ttnn.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
     return %1 : tensor<2x16x16xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// This test assumes the difference in values of %arg2 and %arg1 will match output shape
+// This test assumes the difference in values of %arg2 and %arg1 will match output shape.
 module attributes {} {
   func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xi32>, %arg2: tensor<3xi32>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>

--- a/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// This test assumes the difference in values of %arg2 and %arg1 will match output shape
+module attributes {} {
+  func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xi32>, %arg2: tensor<3xi32>) -> tensor<2x16x16xbf16> {
+    %0 = ttir.empty() : tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xi32>, tensor<3xi32>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    return %1 : tensor<2x16x16xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
@@ -5,6 +5,6 @@
 
 func.func @slice(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
     return %1 : tensor<2x16x16xbf16>
 }

--- a/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+// UNSUPPORTED: true
+func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xui32>, %arg2: tensor<3xui32>) -> tensor<2x16x16xbf16> {
+    %0 = ttir.empty() : tensor<2x16x16xbf16>
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xui32>, tensor<3xui32>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    return %1 : tensor<2x16x16xbf16>
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/slice_dynamic.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/slice_dynamic.mlir
@@ -5,6 +5,7 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
+// UNSUPPORTED: true
 module @mod_slice_dynamic attributes {} {
     func.func @dynamic_slice(%arg0: tensor<32x64xf32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> (tensor<8x8xf32> {jax.result_info = "result"}) {
     // CHECK: = "ttnn.reshape"

--- a/test/ttmlir/Silicon/StableHLO/n150/slice_dynamic.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/slice_dynamic.mlir
@@ -1,0 +1,18 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s -o %t.mlir --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%"
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module @mod_slice_dynamic attributes {} {
+    func.func @dynamic_slice(%arg0: tensor<32x64xf32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> (tensor<8x8xf32> {jax.result_info = "result"}) {
+    // CHECK: = "ttnn.reshape"
+    // CHECK: = "ttnn.reshape"
+    // CHECK: = "ttnn.concat"
+    // CHECK: = "ttnn.add"
+    // CHECK: = "ttnn.slice_dynamic"
+    %0 = stablehlo.dynamic_slice %arg0, %arg1, %arg2, sizes = [8, 8] : (tensor<32x64xf32>, tensor<i32>, tensor<i32>) -> tensor<8x8xf32>
+    return %0 : tensor<8x8xf32>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
@@ -8,7 +8,7 @@
 module @mod_slice attributes {} {
   func.func public @test_slice(%arg0: tensor<32x64xbf16>) -> tensor<8x8xbf16> {
     // CHECK-LABEL: func.func public @test_slice
-    // CHECK: ttnn.slice
+    // CHECK: ttnn.slice_static
     // CHECK-SAME: begins = [0 : i32, 16 : i32],
     // CHECK-SAME: ends = [16 : i32, 32 : i32],
     // CHECK-SAME: step = [2 : i32, 2 : i32]
@@ -24,7 +24,7 @@ module @mod_slice attributes {} {
 
   func.func public @test_slice_f32(%arg0: tensor<32x64xf32>) -> (tensor<16x16xf32>) {
     // CHECK-LABEL: @test_slice_f32(
-    // CHECK: ttnn.slice
+    // CHECK: ttnn.slice_static
     // CHECK-SAME: begins = [0 : i32, 16 : i32],
     // CHECK-SAME: ends = [16 : i32, 32 : i32],
     // CHECK-SAME: step = [1 : i32, 1 : i32]
@@ -36,7 +36,7 @@ module @mod_slice attributes {} {
 
   func.func public @test_slice_non_tilize(%arg0: tensor<32x64xf32>) -> (tensor<14x14xf32>) {
     // CHECK-LABEL: @test_slice_non_tilize(
-    // CHECK: ttnn.slice
+    // CHECK: ttnn.slice_static
     // CHECK-SAME: begins = [0 : i32, 16 : i32],
     // CHECK-SAME: ends = [14 : i32, 30 : i32],
     // CHECK-SAME: step = [1 : i32, 1 : i32]
@@ -48,7 +48,7 @@ module @mod_slice attributes {} {
 
   func.func public @test_slice_strided(%arg0: tensor<32x64xf32>) -> (tensor<8x8xf32>) {
     // CHECK-LABEL: @test_slice_strided(
-    // CHECK: ttnn.slice
+    // CHECK: ttnn.slice_static
     // CHECK-SAME: begins = [0 : i32, 16 : i32],
     // CHECK-SAME: ends = [16 : i32, 32 : i32],
     // CHECK-SAME: step = [2 : i32, 2 : i32]
@@ -64,7 +64,7 @@ module @mod_slice attributes {} {
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<1x128x128x192xf32
     // CHECK-SAME:-> tensor<1x128x128x192xbf16
-    // CHECK: ttnn.slice
+    // CHECK: ttnn.slice_static
     // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32],
     // CHECK-SAME: ends = [1 : i32, 128 : i32, 128 : i32, 192 : i32],
     // CHECK-SAME: step = [1 : i32, 2 : i32, 1 : i32, 1 : i32]

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice.mlir
@@ -4,16 +4,16 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>
-    // CHECK: = "ttnn.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
     return %1 : tensor<2x16x16xbf16>
   }
 
   func.func @test_slice_empty(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x8x0xbf16> {
     // CHECK-LABEL: @test_slice_empty
     %0 = ttir.empty() : tensor<4x1x8x0xbf16>
-    // CHECK: %{{[0-9]+}} = "ttnn.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 32: i32, 128: i32], ends = [10: i32, 3: i32, 64: i32, 128: i32], step = [3: i32, 3: i32, 4: i32, 8: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x8x0xbf16>) -> tensor<4x1x8x0xbf16>
+    // CHECK: %{{[0-9]+}} = "ttnn.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 32: i32, 128: i32], ends = [10: i32, 3: i32, 64: i32, 128: i32], step = [3: i32, 3: i32, 4: i32, 8: i32]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x8x0xbf16>) -> tensor<4x1x8x0xbf16>
     return %1 : tensor<4x1x8x0xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
 
 module attributes {} {
-  // Assuming the difference in values of %arg2 (ends) and %arg1 (begins) will match output shape
+  // Assuming the difference in values of %arg2 (ends) and %arg1 (begins) will match output shape.
   func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xui32>, %arg2: tensor<3xui32>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>
     // CHECK: = "ttnn.slice_dynamic"
@@ -11,7 +11,7 @@ module attributes {} {
     return %1 : tensor<2x16x16xbf16>
   }
 
-  // Using constant op to make sure ends and begins match output shape
+  // Using constant op to make sure ends and begins match output shape.
   func.func @dynamic_slice1(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = "ttir.constant"() <{value = dense<1> : tensor<3xui32>}> : () -> tensor<3xui32>
     %1 = "ttir.constant"() <{value = dense<[3, 17, 17]> : tensor<3xui32>}> : () -> tensor<3xui32>

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module attributes {} {
+  // Assuming the difference in values of %arg2 (ends) and %arg1 (begins) will match output shape
+  func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xui32>, %arg2: tensor<3xui32>) -> tensor<2x16x16xbf16> {
+    %0 = ttir.empty() : tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xui32>, tensor<3xui32>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    return %1 : tensor<2x16x16xbf16>
+  }
+
+  // Using constant op to make sure ends and begins match output shape
+  func.func @dynamic_slice1(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
+    %0 = "ttir.constant"() <{value = dense<1> : tensor<3xui32>}> : () -> tensor<3xui32>
+    %1 = "ttir.constant"() <{value = dense<[3, 17, 17]> : tensor<3xui32>}> : () -> tensor<3xui32>
+    %2 = ttir.empty() : tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_dynamic"
+    %3 = "ttir.slice_dynamic"(%arg0, %0, %1, %2) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xui32>, tensor<3xui32>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    return %3 : tensor<2x16x16xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/slice/simple_slice_dynamic.mlir
@@ -3,14 +3,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
 
 module attributes {} {
-  // Assuming the difference in values of %arg2 (ends) and %arg1 (begins) will match output shape.
-  func.func @dynamic_slice(%arg0: tensor<4x32x32xbf16>, %arg1: tensor<3xui32>, %arg2: tensor<3xui32>) -> tensor<2x16x16xbf16> {
-    %0 = ttir.empty() : tensor<2x16x16xbf16>
-    // CHECK: = "ttnn.slice_dynamic"
-    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2, %0) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xui32>, tensor<3xui32>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
-    return %1 : tensor<2x16x16xbf16>
-  }
-
   // Using constant op to make sure ends and begins match output shape.
   func.func @dynamic_slice1(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = "ttir.constant"() <{value = dense<1> : tensor<3xui32>}> : () -> tensor<3xui32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_slice.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_slice.mlir
@@ -4,8 +4,8 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
     %0 = ttir.empty() : tensor<2x16x16xbf16>
-    // CHECK: = "ttnn.slice"
-    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    // CHECK: = "ttnn.slice_static"
+    %1 = "ttir.slice_static"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
     return %1 : tensor<2x16x16xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_index.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_index.mlir
@@ -4,7 +4,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<4x32x32xbf16>) -> tensor<4x32x16xbf16> {
     %0 = ttir.empty() : tensor<4x32x16xbf16>
-    // CHECK: = "ttnn.slice"
+    // CHECK: = "ttnn.slice_static"
     %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = 0: i32, end = 32: i32, step = 2: i32}> : (tensor<4x32x32xbf16>, tensor<4x32x16xbf16>) -> tensor<4x32x16xbf16>
     return %1 : tensor<4x32x16xbf16>
   }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -558,7 +558,7 @@ TEST_F(OpModelTest, Slice) {
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
-  auto constraintsExp = OpModel<SliceOp>::getOpConstraints(
+  auto constraintsExp = OpModel<SliceStaticOp>::getOpConstraints(
       CreateWorkerGrid(), inputTensorShape, layoutDRAM, begins, ends, step,
       layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
@@ -567,7 +567,7 @@ TEST_F(OpModelTest, Slice) {
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
 
-  auto runtimeExp = OpModel<SliceOp>::getOpRuntime(
+  auto runtimeExp = OpModel<SliceStaticOp>::getOpRuntime(
       inputTensorShape, layoutDRAM, begins, ends, step, layoutDRAM);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1028,8 +1028,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   op_model::SingletonDeviceContext::resetInstance();
 }
 
-TEST_F(OpModelBase, SliceOpInterface) {
-  // create SliceOp
+TEST_F(OpModelBase, SliceStaticOpInterface) {
+  // create SliceStaticOp
   llvm::SmallVector<int64_t> tensorShapeA = {1, 56, 56, 96};
   llvm::SmallVector<int64_t> tensorShapeO = {1, 28, 56, 95};
 
@@ -1040,15 +1040,15 @@ TEST_F(OpModelBase, SliceOpInterface) {
   llvm::SmallVector<int64_t> endsArray = {1, 56, 56, 95};
   llvm::SmallVector<int64_t> stepArray = {1, 2, 1, 1};
 
-  auto sliceOp = builder.create<SliceOp>(
+  auto sliceStaticOp = builder.create<SliceStaticOp>(
       builder.getUnknownLoc(), output.getType(), mlir::ValueRange{input});
 
-  sliceOp.setBeginsAttr(builder.getI64ArrayAttr(beginsArray));
-  sliceOp.setEndsAttr(builder.getI64ArrayAttr(endsArray));
-  sliceOp.setStepAttr(builder.getI64ArrayAttr(stepArray));
+  sliceStaticOp.setBeginsAttr(builder.getI64ArrayAttr(beginsArray));
+  sliceStaticOp.setEndsAttr(builder.getI64ArrayAttr(endsArray));
+  sliceStaticOp.setStepAttr(builder.getI64ArrayAttr(stepArray));
 
-  // test SliceOp interface
-  auto constraintsExp = getOpConstraints(sliceOp.getOperation());
+  // test SliceStaticOp interface
+  auto constraintsExp = getOpConstraints(sliceStaticOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto &[cbSize, peakSize, outputSize, outputLayout] = l1;
@@ -1060,7 +1060,7 @@ TEST_F(OpModelBase, SliceOpInterface) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
 
-  auto runtimeExp = getOpRuntime(sliceOp.getOperation());
+  auto runtimeExp = getOpRuntime(sliceStaticOp.getOperation());
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -2125,7 +2125,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.PadOp: pad_golden,
     ttir.IndexSelectOp: select_golden,
     ttir.IndexOp: index_golden,
-    ttir.SliceOp: slice_golden,
+    ttir.SliceStaticOp: slice_golden,
     ttir.GatherOp: gather_golden,
     # Neural network operations
     ttir.SoftmaxOp: softmax_golden,

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -4449,7 +4449,7 @@ class TTIRBuilder(Builder):
 
         # Use op_proxy
         return self._op_proxy(
-            ttir.SliceOp,
+            ttir.SliceStaticOp,
             [in0],
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], o),
             output_shape=output_shape,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2309

### Problem description
Dynamic slice op had no support in tt-mlir.

### What's changed
- Renamed slice op to slice static op
- Added dynamic slice op to TTIR and TTNN dialects
- Added StableHLO -> TTIR conversion: individual start indices tensors are concatenated into one begins tensor, and slice sizes are added to it to make an ends tensor
- Removed outdated (static) slice op row major workaround:
https://github.com/tenstorrent/tt-metal/issues/17351

### Notes
- Dynamic slice through StableHLO hits this issue because of concatenation:
https://github.com/tenstorrent/tt-metal/issues/22541
https://github.com/tenstorrent/tt-metal/issues/20205

### Checklist
- [x] New/Existing tests provide coverage for changes
