### PR TITLE
Generate golden tensors for graphs with CCL ops using the TTIR builder

### DIFF
--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -14,13 +14,6 @@ from builder.base.builder_utils import compile_ttir_to_flatbuffer
 pytestmark = pytest.mark.llmbox
 
 
-def pseudo_golden_all_gather(
-    input_tensor: torch.Tensor,
-):
-    output_tensor = input_tensor.clone()
-    return output_tensor
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -45,10 +38,6 @@ def pseudo_golden_all_gather(
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_gather(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_gather(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -75,12 +64,9 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         mesh_name="mesh",
         mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
         test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
-
-
-def pseudo_golden_all_reduce(input_tensor: torch.Tensor):
-    shards = torch.chunk(input_tensor, 4, dim=3)
-    return sum(shards)
 
 
 @pytest.mark.parametrize(
@@ -102,10 +88,6 @@ def pseudo_golden_all_reduce(input_tensor: torch.Tensor):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_reduce(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_reduce(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -133,14 +115,6 @@ def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
         mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
         test_base=request.node.name,
     )
-
-
-def pseudo_golden_reduce_scatter(
-    input_tensor: torch.Tensor,
-    scatter_dim: int,
-):
-    shards = torch.chunk(input_tensor, 4, dim=scatter_dim)
-    return sum(shards)
 
 
 @pytest.mark.parametrize(
@@ -172,10 +146,6 @@ def pseudo_golden_reduce_scatter(
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
     def reduce_scatter(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_reduce_scatter(input, 3)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -206,29 +176,6 @@ def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-def pseudo_golden_collective_permute(
-    input_tensor: torch.Tensor,
-    source_target_pairs: List[Tuple[int, int]],
-):
-    # sharding
-    shards = [
-        chunk
-        for shard in torch.chunk(input_tensor, 2, dim=2)
-        for chunk in torch.chunk(shard, 4, dim=3)
-    ]
-
-    # permute
-    permuted = [torch.zeros_like(shard) for shard in shards]
-    for src, tgt in source_target_pairs:
-        permuted[tgt] = shards[src]
-
-    # unsharding
-    return torch.cat(
-        [torch.cat(permuted[i : i + 4], dim=3) for i in range(0, len(permuted), 4)],
-        dim=2,
-    )
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -248,11 +195,7 @@ def pseudo_golden_collective_permute(
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
     def collective_permute(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
         pairs = [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
-        golden_output = pseudo_golden_collective_permute(input, pairs)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -315,11 +258,6 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_2x4(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.matmul(input, weight)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -386,11 +324,6 @@ def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_matmul_1x8(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_1x8(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.matmul(input, weight)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -448,10 +381,6 @@ def test_matmul_1x8(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -497,10 +426,6 @@ def test_neg_2x4(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_cluster_0(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -546,10 +471,6 @@ def test_neg_2x4_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_cluster_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_cluster_1(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -595,10 +516,6 @@ def test_neg_2x4_cluster_1(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_reversed_cluster(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_reversed_cluster(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -644,10 +561,6 @@ def test_neg_2x4_reversed_cluster(shape: Shape, mesh_shape: Tuple[int, int], req
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_reversed_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_reversed_cluster_0(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -694,10 +607,6 @@ def test_neg_2x4_reversed_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], r
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_neg_1x8_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x8_dim_3(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -744,10 +653,6 @@ def test_neg_1x8_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_neg_1x8_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x8_dim_1(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -794,11 +699,6 @@ def test_neg_1x8_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def eltwise_multidevice(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.add(input, weight)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -843,12 +743,6 @@ def test_matmul_and_binary_op(
     shapes: List[Shape], mesh_shape: Tuple[int, int], request
 ):
     def matmul_test(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        bias = builder._get_golden_tensor(in2)
-        golden_output = torch.add(torch.matmul(input, weight), bias)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -900,11 +794,6 @@ def test_matmul_and_binary_op(
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_matmul_and_unary_op(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_test(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.neg(torch.matmul(input, weight))
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -960,17 +849,6 @@ def test_matmul_and_binary_op_2(
     def matmul_test(
         in0: Operand, in1: Operand, in2: Operand, in3: Operand, builder: TTIRBuilder
     ):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        input_2 = builder._get_golden_tensor(in2)
-        weight_2 = builder._get_golden_tensor(in3)
-        golden_output = torch.add(
-            torch.matmul(input, weight), torch.matmul(input_2, weight_2)
-        )
-        builder.set_graph_input_output(
-            [input, weight, input_2, weight_2], [golden_output]
-        )
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -1040,45 +918,6 @@ def test_matmul_and_binary_op_2(
     )
 
 
-def pseudo_golden_all_to_all(
-    input: torch.Tensor,
-    split_dim: int,
-    concat_dim: int,
-    mesh_shape: Tuple[int, int],
-    shard_dims: Tuple[int, int],
-    replica_groups: Tuple[
-        Tuple[
-            int,
-        ]
-    ],
-):
-    # sharding
-    shards = [input]
-    for dim_size, shard_dim in zip(mesh_shape, shard_dims):
-        temp_shards = []
-        for shard in shards:
-            temp_shards.extend(torch.chunk(shard, dim_size, dim=shard_dim))
-        shards = temp_shards
-    # all_to_all
-    output_shards: List[torch.Tensor] = [None] * len(shards)
-    for group in replica_groups:
-        size = len(group)
-        split_sets = [torch.chunk(shards[r], size, dim=split_dim) for r in group]
-        for dst_idx, r in enumerate(group):
-            output_shards[r] = torch.cat(
-                [split_sets[src_idx][dst_idx] for src_idx in range(size)],
-                dim=concat_dim,
-            )
-    # unsharding
-    for dim_size, shard_dim in zip(reversed(mesh_shape), reversed(shard_dims)):
-        temp_shards = []
-        for i in range(0, len(output_shards), dim_size):
-            concat_shard = torch.cat(output_shards[i : i + dim_size], dim=shard_dim)
-            temp_shards.append(concat_shard)
-        output_shards = temp_shards
-    return output_shards[0]
-
-
 def all_to_all_test(
     input_shape: Shape,
     split_dim,
@@ -1091,17 +930,6 @@ def all_to_all_test(
     request,
 ):
     def all_to_all(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_to_all(
-            input,
-            split_dim=split_dim,
-            concat_dim=concat_dim,
-            mesh_shape=mesh_shape,
-            shard_dims=shard_dims,
-            replica_groups=replica_groups,
-        )
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -1217,33 +1045,6 @@ def test_all_to_all_4d(
     )
 
 
-def pseudo_golden_collective_broadcast(
-    input_tensor: torch.Tensor,
-    mesh_shape: Tuple[int, int],
-    replica_groups: List[Tuple[int, int]],
-):
-    # sharding
-    shards = [
-        chunk
-        for shard in torch.chunk(input_tensor, mesh_shape[0], dim=2)
-        for chunk in torch.chunk(shard, mesh_shape[1], dim=3)
-    ]
-
-    # permute
-    for group in replica_groups:
-        for device in group:
-            shards[device] = shards[group[0]]
-
-    # unsharding
-    return torch.cat(
-        [
-            torch.cat(shards[i : i + mesh_shape[1]], dim=3)
-            for i in range(0, len(shards), mesh_shape[1])
-        ],
-        dim=2,
-    )
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -1268,11 +1069,6 @@ def test_collective_broadcast(
     shard_shape = (1, 1) + mesh_shape
 
     def collective_broadcast(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_collective_broadcast(
-            input, mesh_shape, replica_groups
-        )
-        builder.set_graph_input_output([input], [golden_output])
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -15,13 +15,6 @@ from builder.base.builder_utils import compile_ttir_to_flatbuffer
 pytestmark = pytest.mark.n300
 
 
-def pseudo_golden_all_gather(
-    input_tensor: torch.Tensor,
-):
-    output_tensor = input_tensor.clone()
-    return output_tensor
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -47,10 +40,6 @@ def pseudo_golden_all_gather(
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_gather(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_gather(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -82,12 +71,6 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-def pseudo_golden_all_reduce(input_tensor: torch.Tensor):
-    shard_1, shard_2 = torch.chunk(input_tensor, 2, dim=3)
-    output_tensor = shard_1 + shard_2
-    return output_tensor
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -114,10 +97,6 @@ def pseudo_golden_all_reduce(input_tensor: torch.Tensor):
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_reduce(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_reduce(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -150,15 +129,6 @@ def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-def pseudo_golden_reduce_scatter(
-    input_tensor: torch.Tensor,
-    scatter_dim: int,
-):
-    shard_1, shard_2 = torch.chunk(input_tensor, 2, dim=scatter_dim)
-    output_tensor = shard_1 + shard_2
-    return output_tensor
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -187,10 +157,6 @@ def pseudo_golden_reduce_scatter(
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
     def reduce_scatter(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_reduce_scatter(input, 3)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -223,18 +189,6 @@ def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-def pseudo_golden_collective_permute(
-    input_tensor: torch.Tensor,
-    source_target_pairs: List[Tuple[int, int]],
-):
-    shards = list(torch.chunk(input_tensor, 2, dim=3))
-    permuted_tensor = shards.copy()
-    for source, target in source_target_pairs:
-        permuted_tensor[target] = shards[source]
-    result_tensor = torch.cat(permuted_tensor, dim=3)
-    return result_tensor
-
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -249,10 +203,6 @@ def pseudo_golden_collective_permute(
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
     def collective_permute(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_collective_permute(input, [(0, 1), (1, 0)])
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -300,11 +250,6 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_matmul_1x2(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_1x2(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.matmul(input, weight)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -369,10 +314,6 @@ def test_matmul_1x2(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_neg_1x2_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x2_dim_3(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -425,10 +366,6 @@ def test_neg_1x2_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_neg_1x2_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x2_dim_1(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = torch.neg(input)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -476,11 +413,6 @@ def test_neg_1x2_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def eltwise_multidevice(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.add(input, weight)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -527,12 +459,6 @@ def test_matmul_and_binary_op(
     shapes: List[Shape], mesh_shape: Tuple[int, int], request
 ):
     def matmul_test(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        bias = builder._get_golden_tensor(in2)
-        golden_output = torch.add(torch.matmul(input, weight), bias)
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -584,11 +510,6 @@ def test_matmul_and_binary_op(
 @pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_matmul_and_unary_op(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_test(in0: Operand, in1: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        golden_output = torch.neg(torch.matmul(input, weight))
-        builder.set_graph_input_output([input, weight], [golden_output])
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -644,17 +565,6 @@ def test_matmul_and_binary_op_2(
     def matmul_test(
         in0: Operand, in1: Operand, in2: Operand, in3: Operand, builder: TTIRBuilder
     ):
-        input = builder._get_golden_tensor(in0)
-        weight = builder._get_golden_tensor(in1)
-        input_2 = builder._get_golden_tensor(in2)
-        weight_2 = builder._get_golden_tensor(in3)
-        golden_output = torch.add(
-            torch.matmul(input, weight), torch.matmul(input_2, weight_2)
-        )
-        builder.set_graph_input_output(
-            [input, weight, input_2, weight_2], [golden_output]
-        )
-
         sharded_in0 = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -724,45 +634,6 @@ def test_matmul_and_binary_op_2(
     )
 
 
-def pseudo_golden_all_to_all(
-    input: torch.Tensor,
-    split_dim: int,
-    concat_dim: int,
-    mesh_shape: Tuple[int, int],
-    shard_dims: Tuple[int, int],
-    replica_groups: Tuple[
-        Tuple[
-            int,
-        ]
-    ],
-):
-    # sharding
-    shards = [input]
-    for dim_size, shard_dim in zip(mesh_shape, shard_dims):
-        temp_shards = []
-        for shard in shards:
-            temp_shards.extend(torch.chunk(shard, dim_size, dim=shard_dim))
-        shards = temp_shards
-    # all_to_all
-    output_shards: List[torch.Tensor] = [None] * len(shards)
-    for group in replica_groups:
-        size = len(group)
-        split_sets = [torch.chunk(shards[r], size, dim=split_dim) for r in group]
-        for dst_idx, r in enumerate(group):
-            output_shards[r] = torch.cat(
-                [split_sets[src_idx][dst_idx] for src_idx in range(size)],
-                dim=concat_dim,
-            )
-    # unsharding
-    for dim_size, shard_dim in zip(reversed(mesh_shape), reversed(shard_dims)):
-        temp_shards = []
-        for i in range(0, len(output_shards), dim_size):
-            concat_shard = torch.cat(output_shards[i : i + dim_size], dim=shard_dim)
-            temp_shards.append(concat_shard)
-        output_shards = temp_shards
-    return output_shards[0]
-
-
 def all_to_all_test(
     input_shape: Shape,
     split_dim,
@@ -775,17 +646,6 @@ def all_to_all_test(
     request,
 ):
     def all_to_all(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = pseudo_golden_all_to_all(
-            input,
-            split_dim=split_dim,
-            concat_dim=concat_dim,
-            mesh_shape=mesh_shape,
-            shard_dims=shard_dims,
-            replica_groups=replica_groups,
-        )
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",
@@ -920,10 +780,6 @@ def test_collective_broadcast(
     shape: Shape, mesh_shape: Tuple[int, int], replica_groups, request
 ):
     def collective_broadcast(in0: Operand, builder: TTIRBuilder):
-        input = builder._get_golden_tensor(in0)
-        golden_output = golden_collective_broadcast(input, replica_groups)
-        builder.set_graph_input_output([input], [golden_output])
-
         sharded = builder.mesh_shard(
             in0,
             shard_direction="#ttcore.shard_direction<full_to_shard>",

--- a/tools/builder/CMakeLists.txt
+++ b/tools/builder/CMakeLists.txt
@@ -8,6 +8,7 @@ declare_mlir_python_sources(BuilderSources
     base/builder.py
     base/builder_golden.py
     base/builder_utils.py
+    base/sharded_tensor.py
 
     # ttir subpackage files
     ttir/__init__.py

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -13,6 +13,7 @@ import re
 from ttmlir.ir import *
 from ttmlir.dialects import tensor, quant
 from ttmlir.passes import GoldenTensor, DataType
+from builder.base.sharded_tensor import ShardedTensor, TensorLike
 
 # ----- Public APIs -----
 
@@ -29,11 +30,11 @@ class TypeInfo:
 
 @dataclass(frozen=True)
 class Golden:
-    tensor: torch.Tensor
+    tensor: TensorLike
     seed: Optional[int] = None
 
     def contiguous(self) -> Golden:
-        return Golden(self.tensor.contiguous())
+        return Golden(self.tensor.contiguous(), self.seed)
 
 
 class GoldenCheckLevel(Enum):
@@ -80,6 +81,11 @@ class Builder:
                 if re.match(r"^(input|output)_[0-9]+$", name) is None:
                     # It means this is not graph level golden.
                     continue
+            if isinstance(golden_tensor.tensor, ShardedTensor):
+                # Skip multi-device tensors (i.e., ShardedTensor).
+                # We cannot bring them back to the host until we unshard/collect,
+                # so we skip them when building the golden map.
+                continue
             golden_tensor = golden_tensor.contiguous()
             data_type = self._get_datatype_from_torch_dtype(golden_tensor.tensor.dtype)
             golden_info[name] = GoldenTensor(

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -13,7 +13,7 @@ import re
 from ttmlir.ir import *
 from ttmlir.dialects import tensor, quant
 from ttmlir.passes import GoldenTensor, DataType
-from builder.base.sharded_tensor import ShardedTensor, TensorLike
+from builder.base.sharded_tensor import ShardedTensor
 
 # ----- Public APIs -----
 
@@ -30,7 +30,7 @@ class TypeInfo:
 
 @dataclass(frozen=True)
 class Golden:
-    tensor: TensorLike
+    tensor: Union[torch.Tensor, ShardedTensor]
     seed: Optional[int] = None
 
     def contiguous(self) -> Golden:

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -24,7 +24,7 @@ from ttmlir.ir import (
     DenseI32ArrayAttr,
     DenseI64ArrayAttr,
 )
-from builder.base.sharded_tensor import ShardedTensor, TensorLike
+from builder.base.sharded_tensor import ShardedTensor
 
 
 def unpack_mlir_attr(attr):
@@ -1721,19 +1721,19 @@ def _unsharding(
 
 
 def mesh_shard_golden(
-    input: TensorLike,
+    input: Union[torch.Tensor, ShardedTensor],
     mesh_shape: Tuple[int, int],
     shard_type: Attribute,
     shard_direction: Attribute,
     shard_shape: Tuple[int, int],
     shard_dims: List[int],
-) -> TensorLike:
+) -> Union[torch.Tensor, ShardedTensor]:
     """
-    Return a TensorLike which was sharded or unsharded by mesh_shard.
+    Return a tensor which was sharded or unsharded by mesh_shard.
 
     Parameters
     ----------
-    input : TensorLike
+    input : Union[torch.Tensor, ShardedTensor]
         Input tensor to be sharded or ShardedTensor to be unsharded
     mesh_shape : Tuple[int, int]
         Shape of the device mesh
@@ -1749,7 +1749,7 @@ def mesh_shard_golden(
     Returns
     -------
     ShardedTensor
-        TensorLike which was sharded or unsharded by mesh_shard.
+        Union[torch.Tensor, ShardedTensor] which was sharded or unsharded by mesh_shard.
     """
     shard_direction_str = str(shard_direction).lower()
     shard_type_str = str(shard_type).lower()

--- a/tools/builder/base/sharded_tensor.py
+++ b/tools/builder/base/sharded_tensor.py
@@ -33,7 +33,24 @@ _SAFE_TENSOR_ATTRS = {
 
 
 class ShardedTensor:
-    """A logical tensor split into equal-shaped shards."""
+    """
+    ShardedTensor is a utility class for managing golden tensors produced by the TTIR Builder.
+
+    What is the purpose of this class?
+      - It organizes and manipulates golden tensors for TTIR Builder workflows.
+      - It represents tensors that are sharded across multiple devices.
+
+    How does this class simulate sharded tensors across multiple TT devices?
+      - ShardedTensor simulates a multi-device tensor by storing a list of torch.Tensor objects, each representing a shard.
+      - The `shard_shape` argument specifies the arrangement of these shards, as if each shard resides on a different TT device.
+      - All shards must have the same shape, dtype, and device.
+
+    How is this class compatible with torch.* operations?
+      - For read-only tensor attributes (like shape, dtype, device, etc.), ShardedTensor forwards attribute access to the first shard.
+      - For torch.* operations, the class implements the `__torch_function__` protocol.
+      - When a torch function is called on a ShardedTensor, the function is applied independently to each shard.
+      - The results are collected into a new ShardedTensor.
+    """
 
     # ------------------------------------------------------------
     # internal helpers (static)

--- a/tools/builder/base/sharded_tensor.py
+++ b/tools/builder/base/sharded_tensor.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import itertools
+import operator
+from functools import reduce
+from typing import Any, Iterable, Iterator, List, Tuple, Union, Dict
+
+import torch
+
+# Names that are safe to forward to the first shard.
+_SAFE_TENSOR_ATTRS = {
+    "shape",
+    "dtype",
+    "device",
+    "layout",
+    "requires_grad",
+    "is_cuda",
+    "is_floating_point",
+    "is_complex",
+    "ndim",
+    "dim",
+    "size",
+    "stride",
+    "storage_offset",
+    "numel",
+    "element_size",
+    "is_contiguous",
+    "is_pinned",
+}
+
+
+class ShardedTensor:
+    """A logical tensor split into equal-shaped shards."""
+
+    # ------------------------------------------------------------
+    # internal helpers (static)
+    # ------------------------------------------------------------
+    @staticmethod
+    def _ravel_index(idx: Tuple[int, ...], shape: Tuple[int, ...]) -> int:
+        """Row-major flatten of an n-D index."""
+        flat, stride = 0, 1
+        for size, i in zip(reversed(shape), reversed(idx)):
+            flat += i * stride
+            stride *= size
+        return flat
+
+    @staticmethod
+    def _walk_tree(*trees) -> Iterable:
+        """Yield leaves in a nested structure."""
+        for tree in trees:
+            if isinstance(tree, (list, tuple)):
+                for v in tree:
+                    yield from ShardedTensor._walk_tree(v)
+            elif isinstance(tree, dict):
+                for v in tree.values():
+                    yield from ShardedTensor._walk_tree(v)
+            else:
+                yield tree
+
+    # ------------------------------------------------------------
+    # constructor
+    # ------------------------------------------------------------
+    def __init__(self, shards: List[torch.Tensor], shard_shape: Tuple[int, ...]):
+        if not shards:
+            raise ValueError("shards must be non-empty")
+        if reduce(operator.mul, shard_shape, 1) != len(shards):
+            raise ValueError("product(shard_shape) must equal len(shards)")
+
+        first = shards[0]
+        for t in shards[1:]:
+            if t.shape != first.shape:
+                raise ValueError("all shards must share the same shape")
+            if t.dtype != first.dtype:
+                raise ValueError("all shards must share the same dtype")
+            if t.device != first.device:
+                raise ValueError("all shards must share the same device")
+
+        self._shards: List[torch.Tensor] = shards
+        self._shard_shape: Tuple[int, ...] = shard_shape
+
+    # ------------------------------------------------------------
+    # attribute forwarding
+    # ------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        if name in _SAFE_TENSOR_ATTRS:
+            return getattr(self._shards[0], name)
+        raise AttributeError(
+            f"'ShardedTensor' has no attribute '{name}'. "
+            "For mutating ops call torch.* directly."
+        )
+
+    # ------------------------------------------------------------
+    # torch dispatch
+    # ------------------------------------------------------------
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if not any(issubclass(t, cls) for t in types):
+            return NotImplemented
+
+        st_inputs = [a for a in cls._walk_tree(args, kwargs) if isinstance(a, cls)]
+        shard_counts = {len(st._shards) for st in st_inputs}
+        if len(shard_counts) != 1:
+            raise RuntimeError("all ShardedTensors must have the same shard count")
+        n = shard_counts.pop()
+
+        def _take(obj, i: int):
+            if isinstance(obj, cls):
+                return obj._shards[i]
+            if isinstance(obj, (list, tuple)):
+                return type(obj)(_take(v, i) for v in obj)
+            if isinstance(obj, dict):
+                return {k: _take(v, i) for k, v in obj.items()}
+            return obj
+
+        out_shards = [func(*_take(args, i), **_take(kwargs, i)) for i in range(n)]
+
+        if all(isinstance(o, torch.Tensor) for o in out_shards):
+            ref = out_shards[0]
+            if all(
+                (o.shape, o.dtype, o.device) == (ref.shape, ref.dtype, ref.device)
+                for o in out_shards[1:]
+            ):
+                return cls(out_shards, st_inputs[0]._shard_shape)
+
+        return out_shards
+
+    # ------------------------------------------------------------
+    # public api
+    # ------------------------------------------------------------
+    @property
+    def shards(self) -> List[torch.Tensor]:
+        return self._shards
+
+    def shard_at(self, idx: int) -> torch.Tensor:
+        return self._shards[idx]
+
+    @property
+    def shard_shape(self) -> Tuple[int, ...]:
+        return self._shard_shape
+
+    def clone(self) -> "ShardedTensor":
+        return ShardedTensor([t.clone() for t in self._shards], self._shard_shape)
+
+    def contiguous(self) -> "ShardedTensor":
+        return ShardedTensor([t.contiguous() for t in self._shards], self._shard_shape)
+
+    def grouped_shards(self, axis: int) -> List[Dict[int, torch.Tensor]]:
+        """Group shards that vary along *axis* while other coordinates are fixed."""
+        rank = len(self._shard_shape)
+        if axis < 0:
+            axis += rank
+        if not 0 <= axis < rank:
+            raise ValueError("axis out of range")
+
+        other_axes = [a for a in range(rank) if a != axis]
+        groups: List[Dict[int, torch.Tensor]] = []
+        for fixed in itertools.product(
+            *[range(self._shard_shape[a]) for a in other_axes]
+        ):
+            group: Dict[int, torch.Tensor] = {}
+            for v in range(self._shard_shape[axis]):
+                coord = list(fixed)
+                coord.insert(axis, v)
+                idx = self._ravel_index(tuple(coord), self._shard_shape)
+                group[idx] = self._shards[idx]
+            groups.append(group)
+        return groups
+
+    # ------------------------------------------------------------
+    # misc dunders
+    # ------------------------------------------------------------
+    def __len__(self) -> int:
+        return self._shards[0].size(0)
+
+    def __iter__(self) -> Iterator:
+        return iter(self._shards[0])
+
+    def __repr__(self) -> str:
+        return (
+            "ShardedTensor("
+            f"{len(self._shards)} shards, "
+            f"shard_shape={self._shard_shape}, "
+            f"tensor_shape={tuple(self._shards[0].shape)}, "
+            f"dtype={self._shards[0].dtype}, "
+            f"device={self._shards[0].device})"
+        )
+
+
+TensorLike = Union[torch.Tensor, ShardedTensor]

--- a/tools/builder/base/sharded_tensor.py
+++ b/tools/builder/base/sharded_tensor.py
@@ -206,6 +206,3 @@ class ShardedTensor:
             f"dtype={self._shards[0].dtype}, "
             f"device={self._shards[0].device})"
         )
-
-
-TensorLike = Union[torch.Tensor, ShardedTensor]

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -190,27 +190,6 @@ class TTIRBuilder(Builder):
     ) -> OpView:
         return self._op_proxy(op_ttir_function, inputs, unit_attrs)
 
-    def _ccl_proxy(
-        self,
-        op_ttir_function: Callable,
-        inputs: List[Operand],
-        kwargs: dict = {},
-    ) -> OpView:
-        self.golden_check_level = GoldenCheckLevel.GRAPH_LEVEL
-        return self._op_proxy(
-            op_ttir_function=op_ttir_function,
-            inputs=inputs,
-            organize_golden_args=lambda i: (
-                [self._get_golden_tensor(i[0]), self.mesh_shape]
-            ),
-            organize_ttir_args=lambda i, o, shape: (
-                self._get_type(o),
-                i[0],
-                o,
-            ),
-            ttir_kwargs=kwargs,
-        )
-
     # ----- Public Op Generators ----
 
     def get_dimension_size(
@@ -4520,16 +4499,18 @@ class TTIRBuilder(Builder):
         -------
         (*OpView*)
         """
-        kwargs = {
+        ttir_kwargs = {
             "shard_type": Attribute.parse(shard_type),
             "shard_direction": Attribute.parse(shard_direction),
             "shard_shape": shard_shape,
             "shard_dims": shard_dims,
         }
-        return self._ccl_proxy(
+        golden_kwargs = dict(ttir_kwargs, mesh_shape=self.mesh_shape)
+        return self._op_proxy(
             ttir.MeshShardOp,
             [input],
-            kwargs,
+            ttir_kwargs=ttir_kwargs,
+            golden_kwargs=golden_kwargs,
         )
 
     def all_gather(
@@ -4581,10 +4562,11 @@ class TTIRBuilder(Builder):
         (*OpView*)
         """
         kwargs = {"all_gather_dim": all_gather_dim, "cluster_axis": cluster_axis}
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.AllGatherOp,
             [input],
-            kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )
 
     def all_reduce(
@@ -4617,10 +4599,11 @@ class TTIRBuilder(Builder):
             "reduce_type": Attribute.parse(reduce_type),
             "cluster_axis": cluster_axis,
         }
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.AllReduceOp,
             [input],
-            kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )
 
     def reduce_scatter(
@@ -4657,10 +4640,11 @@ class TTIRBuilder(Builder):
             "scatter_dim": scatter_dim,
             "cluster_axis": cluster_axis,
         }
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.ReduceScatterOp,
             [input],
-            kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )
 
     def collective_permute(
@@ -4696,10 +4680,11 @@ class TTIRBuilder(Builder):
         kwargs = {
             "source_target_pairs": source_target_pairs,
         }
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.CollectivePermuteOp,
             [input],
-            kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )
 
     def all_to_all(
@@ -4749,10 +4734,11 @@ class TTIRBuilder(Builder):
             "split_count": split_count,
             "replica_groups": replica_groups,
         }
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.AllToAllOp,
             [input],
-            kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )
 
     def collective_broadcast(
@@ -4783,8 +4769,9 @@ class TTIRBuilder(Builder):
         kwargs = {
             "replica_groups": replica_groups,
         }
-        return self._ccl_proxy(
+        return self._op_proxy(
             ttir.CollectiveBroadcastOp,
             [input],
-            kwargs=kwargs,
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
         )

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 import inspect
 from dataclasses import dataclass
-from typing import List, Optional, Union, Tuple, Callable, Dict, Any
+from typing import List, Optional, Union, Tuple, Callable, Dict, Any, Sequence
 import torch
 from enum import Enum, auto
 import re
@@ -135,7 +135,7 @@ class TTIRBuilder(Builder):
 
             golden = (
                 Golden(golden_output[0])
-                if not isinstance(golden_output, torch.Tensor)
+                if isinstance(golden_output, Sequence)
                 else Golden(golden_output)
             )
 


### PR DESCRIPTION
### Ticket
closes #4339
closes #4173

### Problem description
The TTIR builder cannot currently generate golden tensors for graphs that include CCL operations.


### What's changed
Introduced ShardedTensor — a class for multi-device tensors that:
 - stores a List[torch.Tensor]
 - provides access to a tensor on a specific device
 - provides access to tensors grouped by cluster_axis
 - supports most torch.* functions by applying them shard-wise

Updated TTIR golden library to work with ShardedTensor.
Removed ccl_proxy; replaced calls with op_proxy.
Updated multi-device test cases to use TTIR Builder generated goldens instead of pseudo goldens.

### Checklist
- [x] New/Existing tests provide coverage for changes
