### PR TITLE
#4333: Added support for shardy dialect in stablehlo builder.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,7 +152,7 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /test/pykernel/ @xanderchin @vprajapati-tt @vtangTT
 
 # TTIRBuilder
-/tools/ttir-builder @ctodTT @tapspatel
+/tools/builder @ctodTT @tapspatel
 
 # tt-explorer
 /tools/explorer/ @tenstorrent/forge-developers-mlir-explorer

--- a/docs/src/builder/stablehlo-builder.md
+++ b/docs/src/builder/stablehlo-builder.md
@@ -54,3 +54,52 @@ module {
   }
 }
 ```
+
+## Creating a StableHLO module with Shardy annotations
+
+`StableHLOBuilder` allows you to attach shardy annotations to the generated mlir graph.
+
+### Example
+
+```python
+from builder.base.builder import Operand
+from builder.stablehlo.stablehlo_builder import StableHLOBuilder
+from builder.stablehlo.stablehlo_utils import build_stablehlo_module
+
+shapes = [(32, 32), (32, 32)]
+
+def model(in0: Operand, in1: Operand, shlo_builder: StableHLOBuilder):
+    tensor_sharding_attr = shlo_builder.tensor_sharding_attr(
+        mesh_name="mesh",
+        dimension_shardings=[
+            shlo_builder.dimension_sharding_attr(
+                axes=[shlo_builder.axis_ref_attr(name="x")],
+                is_closed=True,
+            ),
+            shlo_builder.dimension_sharding_attr(
+                axes=[shlo_builder.axis_ref_attr(name="y")],
+                is_closed=False,
+            )
+        ]
+    )
+
+    shlo_builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
+    return shlo_builder.add(in0, in1)
+
+module, shlo_builder = build_stablehlo_module(model, shapes)
+```
+
+#### Returns
+
+An MLIR module containing shardy annotations.
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=1, "y"=8]>
+  func.func @model(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = sdy.sharding_constraint %arg0 <@mesh, [{"x"}, {"y", ?}]> : tensor<32x32xf32>
+    %1 = stablehlo.add %arg0, %arg1 : tensor<32x32xf32>
+    return %1 : tensor<32x32xf32>
+  }
+}
+```

--- a/tools/builder/stablehlo/stablehlo_utils.py
+++ b/tools/builder/stablehlo/stablehlo_utils.py
@@ -8,8 +8,9 @@ import subprocess
 import torch
 import pytest
 from typing import Callable, List, Optional, Tuple, Union, Literal, Dict
+from collections import OrderedDict
 
-from ttmlir.dialects import func
+from ttmlir.dialects import func, sdy
 
 from builder.base.builder import *
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
@@ -31,50 +32,12 @@ def build_stablehlo_module(
     fn: Callable,
     inputs_shapes: List[Shape],
     inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
+    mesh_name: str = "mesh",
+    mesh_dict: OrderedDict[str, int] = OrderedDict([("x", 1), ("y", 1)]),
     module_dump: bool = False,
     base: Optional[str] = None,
     output_root: str = ".",
 ):
-    """
-    Define a MLIR module specified as a python function.
-
-    It will wrap `fn` in a MLIR FuncOp and then wrap that in a MLIR
-    module, and finally tie arguments of that FuncOp to test function inputs. It will
-    also pass a `StableHLOBuilder` object as the last argument of test function.
-
-    Parameters
-    ----------
-    fn : Callable
-        Python function to be converted to MLIR
-
-    inputs_shapes : *List[Shape]*
-        Shapes of the respective ranked tensor inputs of the test function.
-
-    inputs_types: *Optional[List[Union[torch.dtype, TypeInfo]]]*
-        Data types of the input tensors
-
-    module_dump : bool
-        Set to True to print out generated MLIR module.
-
-    base : *Optional[str]*
-        Output file name
-
-    output_root: str = ".",
-        Output file path
-
-    Returns
-    -------
-    Module
-        MLIR module containing MLIR op graph defined by `fn`
-
-    Example
-    -------
-    >>> def test_add(in0: Operand, in1: Operand, builder: StableHLOBuilder):
-    ...     return builder.add(in0, in1)
-    ...
-    >>> build_stablehlo_module(test_add, ((32, 32), (32, 32)))
-    """
-
     ctx = Context()
 
     # Grab the location of the test function in python for later debugging
@@ -112,6 +75,15 @@ def build_stablehlo_module(
 
         # Wrap everything in a mlir module.
         module = Module.create()
+        module.body.append(
+            stablehlo_builder.mesh(
+                mesh_name=mesh_name,
+                mesh_attr=stablehlo_builder._create_mesh_attr_from_ordered_dict(
+                    mesh_dict
+                ),
+            )
+        )
+
         with InsertionPoint(module.body):
             # Wrap everything in a mlir function.
             @func.func(*fn_input_types, name=fn.__name__)


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/4333

This PR adds shardy support into stablehlo builder. It allows users to generate stablehlo graphs with shardy ops and attribute indentations. For example

```
from builder.base.builder import Operand
from builder.stablehlo.stablehlo_builder import StableHLOBuilder
from builder.stablehlo.stablehlo_utils import build_stablehlo_module

shapes = [(32, 32), (32, 32)]

def model(in0: Operand, in1: Operand, shlo_builder: StableHLOBuilder):
    tensor_sharding_attr = shlo_builder.tensor_sharding_attr(
        mesh_name="mesh",
        dimension_shardings=[
            shlo_builder.dimension_sharding_attr(
                axes=[shlo_builder.axis_ref_attr(name="x")],
                is_closed=True,
            ),
            shlo_builder.dimension_sharding_attr(
                axes=[shlo_builder.axis_ref_attr(name="y")],
                is_closed=False,
            )
        ]
    )

    shlo_builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
    return shlo_builder.add(in0, in1)

module, shlo_builder = build_stablehlo_module(model, shapes)
```

produces the following mlir module
```
module {
  sdy.mesh @mesh = <["x"=1, "y"=8]>
  func.func @model(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
    %0 = sdy.sharding_constraint %arg0 <@mesh, [{"x"}, {"y", ?}]> : tensor<32x32xf32>
    %1 = stablehlo.add %arg0, %arg1 : tensor<32x32xf32>
    return %1 : tensor<32x32xf32>
  }
}
```