### PR TITLE
ttrt read quick bug fix

### DIFF
--- a/runtime/tools/ttrt/ttrt/binary/__init__.py
+++ b/runtime/tools/ttrt/ttrt/binary/__init__.py
@@ -49,5 +49,5 @@ def program_outputs_as_dict(bin, index):
     return json_string_as_dict(bin.get_program_outputs_as_json(index))
 
 
-def program_mlir_as_dict(bin, index):
-    return json_string_as_dict(bin.get_program_mlir_as_json(index))
+def mlir_as_dict(bin, index):
+    return json_string_as_dict(bin.get_mlir_as_json())


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`ttrt.binary` has an incorrectly named function. 

### What's changed
Corrected function name

### Checklist
- [ ] New/Existing tests provide coverage for changes
