### PR TITLE
Add ttnn.unsqueeze_to_4D op to TTNN IR (#4266)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1194,6 +1194,27 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape", [HasMemoryConfigTrait,
     let hasVerifier = 1;
 }
 
+def TTNN_UnsqueezeTo4DOp : TTNN_Op<"unsqueeze_to_4D", [HasMemoryConfigTrait,
+      DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
+    let summary = "Unsqueezes to 4D op.";
+    let description = [{
+      Transforms a tensor of any rank to a 4D tensor by adding dimensions of size 1.
+
+      Examples:
+      - Input shape [32, 128] -> Output shape [1, 1, 32, 128]
+      - Input shape [8, 32, 128] -> Output shape [1, 8, 32, 128]
+      - Input shape [2, 8, 32, 128] -> Output shape [2, 8, 32, 128]
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_RepeatOp : TTNN_Op<"repeat"> {
     let summary = "Repeat op.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -308,6 +308,23 @@ struct OpModel<ReshapeOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// UnsqueezeTo4DOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<UnsqueezeTo4DOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> outputShape,
+      TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               llvm::ArrayRef<int64_t> outputShape,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // SliceOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/data_movement.fbs
+++ b/include/ttmlir/Target/TTNN/operations/data_movement.fbs
@@ -48,6 +48,12 @@ table ReshapeOp {
   memory_config: tt.target.ttnn.MemoryConfig;
 }
 
+table UnsqueezeTo4DOp {
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  memory_config: tt.target.ttnn.MemoryConfig;
+}
+
 table SliceOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -75,6 +75,7 @@ union OpType {
   RepeatInterleaveOp,
   RepeatOp,
   ReshapeOp,
+  UnsqueezeTo4DOp,
   SliceOp,
   SoftmaxOp,
   SortOp,

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -960,6 +960,43 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// UnsqueezeTo4DOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+UnsqueezeTo4DOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape = getResult().getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<UnsqueezeTo4DOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+UnsqueezeTo4DOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape = getResult().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<UnsqueezeTo4DOp>::getOpRuntime, *this, inputShape, inputs[0],
+      outputShape, opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // SliceOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/ttir_to_ttnn_conversion.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/ttir_to_ttnn_conversion.mlir
@@ -1,0 +1,55 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// Test that TTIR unsqueeze operations are correctly converted to ttnn.unsqueeze_to_4D when appropriate.
+
+module {
+  // CHECK-LABEL: func.func @unsqueeze_2d_to_4d_conversion
+  func.func @unsqueeze_2d_to_4d_conversion(%arg0: tensor<32x128xbf16>) -> tensor<1x1x32x128xbf16> {
+    // Chained unsqueezes are not converted optimaly. Ideally, we'd just use one operations, but 
+    // this is an edge case. 
+    // TODO: look into folding these into one unsqueeze in the future. 
+    
+    // First unsqueeze to 3D at dim 0
+    %0 = ttir.empty() : tensor<1x32x128xbf16>
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = 0 : si32}> : (tensor<32x128xbf16>, tensor<1x32x128xbf16>) -> tensor<1x32x128xbf16>
+    
+    // Then unsqueeze to 4D at dim 0
+    %2 = ttir.empty() : tensor<1x1x32x128xbf16>
+    %3 = "ttir.unsqueeze"(%1, %2) <{dim = 0 : si32}> : (tensor<1x32x128xbf16>, tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    
+    // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"
+    // CHECK-SAME: (tensor<32x128xbf16, {{.*}}>) -> tensor<1x32x128xbf16, {{.*}}>
+    // CHECK: %[[UNSQUEEZE:.*]] = "ttnn.unsqueeze_to_4D"
+    // CHECK-SAME: (tensor<1x32x128xbf16, {{.*}}>) -> tensor<1x1x32x128xbf16, {{.*}}>
+    return %3 : tensor<1x1x32x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_3d_to_4d_conversion
+  func.func @unsqueeze_3d_to_4d_conversion(%arg0: tensor<8x32x128xbf16>) -> tensor<1x8x32x128xbf16> {
+    %0 = ttir.empty() : tensor<1x8x32x128xbf16>
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = 0 : si32}> : (tensor<8x32x128xbf16>, tensor<1x8x32x128xbf16>) -> tensor<1x8x32x128xbf16>
+    
+    // CHECK: %[[C:.*]] = "ttnn.unsqueeze_to_4D"
+    // CHECK-SAME: (tensor<8x32x128xbf16, {{.*}}>) -> tensor<1x8x32x128xbf16, {{.*}}>
+    return %1 : tensor<1x8x32x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_not_to_4d_uses_reshape
+  func.func @unsqueeze_not_to_4d_uses_reshape(%arg0: tensor<32x128xbf16>) -> tensor<1x32x128xbf16> {
+    %0 = ttir.empty() : tensor<1x32x128xbf16>
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = 0 : si32}> : (tensor<32x128xbf16>, tensor<1x32x128xbf16>) -> tensor<1x32x128xbf16>
+    
+    // CHECK-NOT: ttnn.unsqueeze_to_4D
+    // CHECK: ttnn.reshape
+    return %1 : tensor<1x32x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_middle_dim_uses_reshape
+  func.func @unsqueeze_middle_dim_uses_reshape(%arg0: tensor<8x32x128xbf16>) -> tensor<8x1x32x128xbf16> {
+    %0 = ttir.empty() : tensor<8x1x32x128xbf16>
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = 1 : si32}> : (tensor<8x32x128xbf16>, tensor<8x1x32x128xbf16>) -> tensor<8x1x32x128xbf16>
+    
+    // CHECK-NOT: ttnn.unsqueeze_to_4D
+    // CHECK: ttnn.reshape
+    return %1 : tensor<8x1x32x128xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/unsqueeze_to_4D_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/unsqueeze_to_4D_negative.mlir
@@ -1,0 +1,50 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Test negative cases for ttnn.unsqueeze_to_4D operation.
+
+module {
+  func.func @output_not_4d(%arg0: tensor<32x128xbf16>) -> tensor<1x32x128xbf16> {
+    // CHECK: error: 'ttnn.unsqueeze_to_4D' op Output tensor must be 4D, but has rank 3
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<1x32x128xbf16>
+    return %0 : tensor<1x32x128xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @input_rank_too_high(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4xbf16> {
+    // CHECK: error: 'ttnn.unsqueeze_to_4D' op Input tensor rank 5 is greater than 4
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4xbf16>
+    return %0 : tensor<1x2x3x4xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @dimension_mismatch(%arg0: tensor<32x128xbf16>) -> tensor<1x1x64x64xbf16> {
+    // CHECK: error: 'ttnn.unsqueeze_to_4D' op Input dimension 0 with size 32 does not match output dimension 2 with size 64
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<1x1x64x64xbf16>
+    return %0 : tensor<1x1x64x64xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @leading_dim_not_one(%arg0: tensor<32x128xbf16>) -> tensor<2x1x32x128xbf16> {
+    // CHECK: error: 'ttnn.unsqueeze_to_4D' op Leading dimension 0 must be 1, but is 2
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<2x1x32x128xbf16>
+    return %0 : tensor<2x1x32x128xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @element_count_mismatch(%arg0: tensor<32x128xbf16>) -> tensor<1x1x32x256xbf16> {
+    // CHECK: error: 'ttnn.unsqueeze_to_4D' op Input dimension 1 with size 128 does not match output dimension 3 with size 256
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<1x1x32x256xbf16>
+    return %0 : tensor<1x1x32x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/unsqueeze_to_4D_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/unsqueeze_to_4D/unsqueeze_to_4D_positive.mlir
@@ -1,0 +1,36 @@
+// RUN: ttmlir-opt %s | FileCheck %s
+// Test positive cases for ttnn.unsqueeze_to_4D operation.
+
+module {
+  // CHECK-LABEL: func.func @unsqueeze_2d_to_4d
+  func.func @unsqueeze_2d_to_4d(%arg0: tensor<32x128xbf16>) -> tensor<1x1x32x128xbf16> {
+    // CHECK: %[[C:.*]] = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    // CHECK: return %[[C]] : tensor<1x1x32x128xbf16>
+    return %0 : tensor<1x1x32x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_3d_to_4d
+  func.func @unsqueeze_3d_to_4d(%arg0: tensor<8x32x128xbf16>) -> tensor<1x8x32x128xbf16> {
+    // CHECK: %[[C:.*]] = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<8x32x128xbf16>) -> tensor<1x8x32x128xbf16>
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<8x32x128xbf16>) -> tensor<1x8x32x128xbf16>
+    // CHECK: return %[[C]] : tensor<1x8x32x128xbf16>
+    return %0 : tensor<1x8x32x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_1d_to_4d
+  func.func @unsqueeze_1d_to_4d(%arg0: tensor<128xbf16>) -> tensor<1x1x1x128xbf16> {
+    // CHECK: %[[C:.*]] = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<128xbf16>) -> tensor<1x1x1x128xbf16>
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<128xbf16>) -> tensor<1x1x1x128xbf16>
+    // CHECK: return %[[C]] : tensor<1x1x1x128xbf16>
+    return %0 : tensor<1x1x1x128xbf16>
+  }
+
+  // CHECK-LABEL: func.func @unsqueeze_4d_to_4d
+  func.func @unsqueeze_4d_to_4d(%arg0: tensor<2x8x32x128xbf16>) -> tensor<2x8x32x128xbf16> {
+    // CHECK: %[[C:.*]] = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<2x8x32x128xbf16>) -> tensor<2x8x32x128xbf16>
+    %0 = "ttnn.unsqueeze_to_4D"(%arg0) : (tensor<2x8x32x128xbf16>) -> tensor<2x8x32x128xbf16>
+    // CHECK: return %[[C]] : tensor<2x8x32x128xbf16>
+    return %0 : tensor<2x8x32x128xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Add ttnn.unsqueeze_to_4D op to TTNN IR](https://github.com/tenstorrent/tt-mlir/issues/4266)

### Problem description
Add support for ttnn.unsqueeze_to_4D operation to TTNN IR as part of LLM-specific ops onboarding for Llama3.2 architecture. This op unsqueezes tensors to 4D shape, which is often required for compatibility with various tensor operations in LLM computations.

Examples:
 * Input shape [32, 128] -> Output shape [1, 1, 32, 128]
 * Input shape [8, 32, 128] -> Output shape [1, 8, 32, 128]
 * Input shape [2, 8, 32, 128] -> Output shape [2, 8, 32, 128]

### What's changed
 * Added new operation.
 * Added positive, negative, and conversion tests (with the help of Claude 🤖).
 * Updated existing pattern matching to dispatch out to new op when possible.

### Checklist
- [ ] Address TODOs and REVIEW COMMENTs 
- [ ] Add more conversion tests
- [ ] Add integration tests
- [ ] Add runtime support (hacked with reshape right now)
- [ ] Add TTNNToEmitC and fix failing tests
- [ ] Investigate folding 
- [ ] Are python bindings needed?
