### PR TITLE
Add constraints for min, max reduction ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -795,7 +795,8 @@ def TTNN_Atan2Op :  TTNN_ElementwiseBinaryCompositeOp<"atan2"> {
     }];
 }
 
-class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemonic, traits> {
+class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemonic,
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits> {
   let summary = "Reduction op.";
   let description = [{
     Reduction op.
@@ -817,18 +818,14 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
   let hasVerifier = 1;
 }
 
-def TTNN_SumOp : TTNN_ReductionOp<"sum",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_SumOp : TTNN_ReductionOp<"sum"> {
     let summary = "Sum reduction op.";
     let description = [{
       Sum reduction op.
     }];
 }
 
-def TTNN_MeanOp : TTNN_ReductionOp<"mean",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_MeanOp : TTNN_ReductionOp<"mean"> {
   let summary = "Mean reduction op.";
   let description = [{
     Mean reduction op.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -272,6 +272,12 @@ struct OpModel<MeanOp> : ReductionOpModel<MeanOp> {};
 template <>
 struct OpModel<SumOp> : ReductionOpModel<SumOp> {};
 
+template <>
+struct OpModel<MaxOp> : ReductionOpModel<MaxOp> {};
+
+template <>
+struct OpModel<MinOp> : ReductionOpModel<MinOp> {};
+
 //===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -872,6 +872,38 @@ MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// MaxOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+MaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getReductionOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+MaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// MinOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+MinOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getReductionOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+MinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // SumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -289,6 +289,10 @@ auto getOpSymbol() {
     return ::ttnn::where;
   } else if constexpr (std::is_same_v<OpTy, MeanOp>) {
     return ::ttnn::mean;
+  } else if constexpr (std::is_same_v<OpTy, MaxOp>) {
+    return ::ttnn::max;
+  } else if constexpr (std::is_same_v<OpTy, MinOp>) {
+    return ::ttnn::min;
   } else if constexpr (std::is_same_v<OpTy, SumOp>) {
     return ::ttnn::sum;
   } else {
@@ -1151,6 +1155,8 @@ llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
 // Explicit template instantiation for ReductionOpModel.
 template struct ReductionOpModel<MeanOp>;
 template struct ReductionOpModel<SumOp>;
+template struct ReductionOpModel<MaxOp>;
+template struct ReductionOpModel<MinOp>;
 
 //===----------------------------------------------------------------------===//
 // SoftmaxOp

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -322,7 +322,7 @@ protected:
       // Must clean up the error
       llvm::consumeError(constraintsExp.takeError());
     }
-
+    SingletonDeviceContext::resetInstance();
     auto runtimeExp = OpModel<OpTy>::getOpRuntime(
         inputShape, inputLayout, dimArg, keepDim, outputLayout);
     EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
@@ -337,9 +337,13 @@ protected:
 // Type aliases for reduction operations
 using OpModelSumParam = OpModelReductionParam<SumOp>;
 using OpModelMeanParam = OpModelReductionParam<MeanOp>;
+using OpModelMaxParam = OpModelReductionParam<MaxOp>;
+using OpModelMinParam = OpModelReductionParam<MinOp>;
 
 TEST_P(OpModelSumParam, SumOp) { RunTest(); }
 TEST_P(OpModelMeanParam, MeanOp) { RunTest(); }
+TEST_P(OpModelMaxParam, MaxOp) { RunTest(); }
+TEST_P(OpModelMinParam, MinOp) { RunTest(); }
 
 // Test parameters for reduction operations
 static const auto reductionParams = ::testing::Values(
@@ -367,6 +371,10 @@ static const auto reductionParams = ::testing::Values(
 INSTANTIATE_TEST_SUITE_P(SumTests, OpModelSumParam, reductionParams);
 
 INSTANTIATE_TEST_SUITE_P(MeanTests, OpModelMeanParam, reductionParams);
+
+INSTANTIATE_TEST_SUITE_P(MaxTests, OpModelMaxParam, reductionParams);
+
+INSTANTIATE_TEST_SUITE_P(MinTests, OpModelMinParam, reductionParams);
 
 TEST_F(OpModelTest, SoftmaxInterleaved) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -322,6 +322,8 @@ protected:
       // Must clean up the error
       llvm::consumeError(constraintsExp.takeError());
     }
+    // TODO(tt-metal #25772): Need to reset device here otherwise hangs. Remove
+    // once fixed.
     SingletonDeviceContext::resetInstance();
     auto runtimeExp = OpModel<OpTy>::getOpRuntime(
         inputShape, inputLayout, dimArg, keepDim, outputLayout);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -827,6 +827,30 @@ TEST_F(OpModelBase, MeanOpInterface) {
       &OpModelBase::getOpConstraints, &OpModelBase::getOpRuntime);
 }
 
+TEST_F(OpModelBase, MaxOpInterface) {
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 1024};
+  auto input = createEmptyTensor(tensorShapeA);
+  auto output = createEmptyTensor(tensorShapeO);
+
+  testReductionOp<MaxOp>(
+      this, builder, input, output.getType(), /*expectedCbSize=*/12288,
+      /*expectedPeakSize=*/2048, /*expectedOutputSize=*/2048,
+      &OpModelBase::getOpConstraints, &OpModelBase::getOpRuntime);
+}
+
+TEST_F(OpModelBase, MinOpInterface) {
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 1024};
+  auto input = createEmptyTensor(tensorShapeA);
+  auto output = createEmptyTensor(tensorShapeO);
+
+  testReductionOp<MinOp>(
+      this, builder, input, output.getType(), /*expectedCbSize=*/12288,
+      /*expectedPeakSize=*/69632, /*expectedOutputSize=*/2048,
+      &OpModelBase::getOpConstraints, &OpModelBase::getOpRuntime);
+}
+
 TEST_F(OpModelBase, SumOpInterface) {
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
   llvm::SmallVector<int64_t> tensorShapeO = {2048, 1024};


### PR DESCRIPTION
### Ticket
#4198

Constraints for `min` and `max` reduction ops.

The ordering of tests in `TestOpModelLib.cpp` causes `min` `getOpRuntime()` to hang on the final test. As a temporary workaround, I added `SingletonDeviceContext::resetInstance();` before `getOpRuntime()`. We will eventually remove all resets (Issues: #4316, https://github.com/tenstorrent/tt-metal/issues/25772).