### PR TITLE
sort the files for ttrt runs and pytest

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -487,6 +487,8 @@ class FileManager:
             except Exception as e:
                 raise Exception(f"an unexpected error occurred: {e}")
 
+        # Sort files alphabetically to ensure consistent ordering.
+        ttnn_files.sort()
         return ttnn_files
 
     def find_ttmetal_binary_paths(self, path):
@@ -517,6 +519,8 @@ class FileManager:
             except Exception as e:
                 raise Exception(f"an unexpected error occurred: {e}")
 
+        # Sort files alphabetically to ensure consistent ordering.
+        ttmetal_files.sort()
         return ttmetal_files
 
     def find_ttsys_binary_paths(self, path):
@@ -547,6 +551,8 @@ class FileManager:
             except Exception as e:
                 raise Exception(f"an unexpected error occurred: {e}")
 
+        # Sort files alphabetically to ensure consistent ordering.
+        ttsys_files.sort()
         return ttsys_files
 
 

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -123,6 +123,9 @@ def pytest_collection_modifyitems(config, items):
     # Update the items list (collected tests)
     items[:] = valid_items
 
+    # Sort tests alphabetically by their nodeid to ensure consistent ordering.
+    items.sort(key=lambda x: x.nodeid)
+
     # Report deselected items to pytest
     if deselected:
         config.hook.pytest_deselected(items=deselected)


### PR DESCRIPTION
### Problem description
Currently `ttrt` will run files in order they are created. Pytest will run tests sequentially based on ordering in test/python/golden/test_ttir_ops.py
### What's changed
Sorted ttrt runs alphabetically for easier debugging. Also sorted pytest. 