### PR TITLE
Removing full workaround and updating tests

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1842,12 +1842,6 @@ def TTNN_FullOp : TTNN_CreationOp<"full"> {
     OpBuilder<(ins "Type": $resultType, "Attribute": $fillValue, "Value": $device)>
   ];
 
-  let extraClassDeclaration = [{
-    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-      auto outputType = getType();
-      return wa::TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(outputType);
-    }
-  }];
 }
 
 def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "result"]>]> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -230,10 +230,6 @@ public:
   static TTNNOperandsWorkarounds
   createZerosOpOperandsWorkarounds(RankedTensorType outputType);
 
-  // Create workarounds for full op operands.
-  static TTNNOperandsWorkarounds
-  createFullOpOperandsWorkarounds(RankedTensorType outputType);
-
   // Create workarounds for mesh shard op operands.
   static TTNNOperandsWorkarounds
   createMeshShardOpOperandsWorkarounds(ttcore::MeshShardType shardType);

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -194,23 +194,6 @@ TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
       .addOutputOperandWorkaround(fullOpOutputWorkarounds);
 }
 
-// Factory method to create a set of workarounds for full op output operand.
-// ttnn::full does not support output dtype int32. If the output data type of
-// full is int32, we override to float32 and typecast separately.
-TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
-    RankedTensorType outputType) {
-  wa::TTNNOperandWorkarounds fullOpOutputWorkarounds;
-  mlir::tt::ttcore::DataType dataType =
-      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType());
-  if (dataType == mlir::tt::ttcore::DataType::Int32) {
-    fullOpOutputWorkarounds.tensorDataTypeWorkaround =
-        mlir::tt::ttcore::DataType::Float32;
-  }
-  return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addOutputOperandWorkaround(fullOpOutputWorkarounds);
-}
-
 // Factory method to create a set of workarounds for mesh shard op input
 // operand. ttnn::MeshShardOp supports host tensors only
 TTNNOperandsWorkarounds

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1142,15 +1142,6 @@ static AttrType getAttrFromConstantChain(mlir::Value tensorVal,
                                                 expectedTypeMsg);
     }
   }
-  if constexpr (std::is_same_v<AttrType, int32_t>) {
-    // typecast first op for per-tensor zp
-    if (auto typeCastOp = firstInput.getDefiningOp<ttnn::TypecastOp>()) {
-      firstInput = typeCastOp.getInput();
-    } else {
-      llvm_unreachable(
-          "Expected ttnn.typecast as defining op for per-tensor zp.");
-    }
-  }
   ttnn::FullOp fullOp =
       mlir::dyn_cast<ttnn::FullOp>(firstInput.getDefiningOp());
   assert(fullOp &&

--- a/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
@@ -21,8 +21,6 @@ module attributes {} {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: %{{[0-9]+}} = "ttnn.typecast"
     // CHECK-SAME: -> tensor<64x128xsi32
     return %0 : tensor<64x128xi32>
   }
@@ -70,8 +68,6 @@ module attributes {} {
   func.func @test_full_int() -> tensor<64x128xi32> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fill_value = 1 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: %{{[0-9]+}} = "ttnn.typecast"
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     return %0 : tensor<64x128xi32>

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_dequantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_dequantize.mlir
@@ -7,13 +7,8 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
-    // CHECK: "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
-    // CHECK-SAME: -> tensor<1xsi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.dequantize"
     // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>,
@@ -33,10 +28,6 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
-    // CHECK: "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
-    // CHECK-SAME: -> tensor<3xsi32,
     // CHECK: "ttnn.dequantize"
     // CHECK-SAME: axis = 0 : i32
     // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<f32>

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_quantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_quantize.mlir
@@ -6,10 +6,8 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.quantize"
     // CHECK-SAME: {output_dtype = #ttcore.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x224x224xf32
@@ -28,7 +26,6 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.quantize"
     // CHECK-SAME: axis = 1 : i32
     // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<si32>

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_requantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_requantize.mlir
@@ -6,13 +6,10 @@ module {
     %0 = ttir.empty() : tensor<1x3x320x320x!quant.uniform<i32:f32, 0.2>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-01 : f32
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
-    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.requantize"
     // CHECK-SAME: {output_dtype = #ttcore.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x320x320x!quant.uniform<i32:f32, 1.000000e-01>,
@@ -33,7 +30,6 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.requantize"
     // CHECK-SAME: <{axis = 1 : i32, output_dtype = #ttcore.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x320x320x!quant.uniform<i32:f32:1, {1.000000e-01,2.000000e-01,3.000000e-01}>,

--- a/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
@@ -5,7 +5,7 @@ module attributes {} {
     %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
     // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}})
     // CHECK-SAME: fill_value = 21 : i32
-    // CHECK-SAME: -> tensor<1xf32
+    // CHECK-SAME: -> tensor<1xsi32
     return %0 : tensor<1xi32>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/tensor/full.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/full.mlir
@@ -7,3 +7,8 @@ func.func @full_float() -> tensor<64x128xbf16> {
   %0 = "ttir.full"() <{shape = array<i32: 64, 128>, fill_value = 3.0 : f32}> : () -> tensor<64x128xbf16>
   return %0 : tensor<64x128xbf16>
 }
+
+func.func @full_int() -> tensor<64x128xi32> {
+  %0 = "ttir.full"() <{shape = array<i32: 64, 128>, fill_value = 3 : i32}> : () -> tensor<64x128xi32>
+  return %0 : tensor<64x128xi32>
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
@@ -10,8 +10,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<f32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.constant dense<3> : tensor<i32>
     return %0 : tensor<i32>
@@ -21,8 +19,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<f32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.constant dense<0> : tensor<i32>
     return %0 : tensor<i32>
@@ -32,8 +28,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
@@ -43,8 +37,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi32>
     return %0 : tensor<64x128xi32>

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
@@ -10,8 +10,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<f32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.constant dense<3> : tensor<i64>
     return %0 : tensor<i64>
@@ -21,8 +19,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<f32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.constant dense<0> : tensor<i64>
     return %0 : tensor<i64>
@@ -32,8 +28,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi64>
     return %0 : tensor<64x128xi64>
@@ -43,8 +37,6 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<64x128xf32
-    // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi64>
     return %0 : tensor<64x128xi64>

--- a/test/ttmlir/Silicon/StableHLO/n150/get_dimension_size_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/get_dimension_size_op.mlir
@@ -10,7 +10,7 @@ module @jit_get_dimension_size attributes {} {
     // CHECK-LABEL: func.func public @test_get_dimension_size
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 128 : i32
-    // CHECK-SAME: -> tensor<f32
+    // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<64x128xf32>) -> tensor<i32>
     return %0 : tensor<i32>
   }
@@ -19,7 +19,7 @@ module @jit_get_dimension_size attributes {} {
     // CHECK-LABEL: func.func public @test_get_dimension_size_f64
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 128 : i32
-    // CHECK-SAME: -> tensor<f32
+    // CHECK-SAME: -> tensor<si32
     %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<64x128xf64>) -> tensor<i32>
     return %0 : tensor<i32>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/get_dimension_size/get_dimension_size.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/get_dimension_size/get_dimension_size.mlir
@@ -6,6 +6,6 @@ func.func @get_dimension_size(%arg0: tensor<13x21x1x3xf32>) -> tensor<1xi32> {
   %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x1x3xf32>) -> tensor<1xi32>
   // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}})
   // CHECK-SAME: fill_value = 21 : i32
-  // CHECK-SAME: -> tensor<1xf32
+  // CHECK-SAME: -> tensor<1xsi32
   return %0 : tensor<1xi32>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_dequantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_dequantize.mlir
@@ -9,9 +9,6 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
-    // CHECK: "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<1xsi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_quantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_quantize.mlir
@@ -8,7 +8,7 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: -> tensor<1xsi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_requantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_requantize.mlir
@@ -11,7 +11,7 @@ func.func @requantize_per_tensor_scales_per_tensor_zps(%arg0: tensor<1x3x320x320
     // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: -> tensor<1xi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_dequantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_dequantize.mlir
@@ -9,9 +9,6 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
-    // CHECK: "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<1xsi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02
@@ -35,9 +32,6 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
-    // CHECK: "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<3xsi32,
     // CHECK: "ttnn.dequantize"
     // CHECK-SAME: axis = 0 : i32

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_quantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_quantize.mlir
@@ -8,7 +8,7 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: -> tensor<1xsi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -30,7 +30,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
+    // CHECK-SAME: -> tensor<3xsi32,
     // CHECK: "ttnn.quantize"
     // CHECK-SAME: axis = 1 : i32
     // CHECK-SAME: output_dtype = #ttcore.supportedDataTypes<si32>

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_requantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_requantize.mlir
@@ -11,7 +11,7 @@ module {
     // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: -> tensor<1xi32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -35,7 +35,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xf32,
+    // CHECK-SAME: -> tensor<3xi32,
     // CHECK: "ttnn.requantize"
     // CHECK-SAME: <{axis = 1 : i32, output_dtype = #ttcore.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x320x320x!quant.uniform<i32:f32:1, {1.000000e-01,2.000000e-01,3.000000e-01}>,


### PR DESCRIPTION
### Problem description
TTNN Full op supports int32 output.

### What's changed
Removed workaround and updated FileChecks in relevant tests. No builder test for Full, so nothing to update there. 