### PR TITLE
Restrict sharding to conv2d only

### DIFF
--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -92,10 +92,8 @@ void DFShardingPolicy::run() {
 
         // Consider sharding only if we found at least single legal config for
         // the current op.
-        bool validForSharding =
-            llvm::isa<ttnn::AddOp, ttnn::SubtractOp, ttnn::MultiplyOp,
-                      ttnn::ReluOp, ttnn::Conv2dOp>(currentOp) &&
-            legalConfigs.lookup(currentOp).size() > 0;
+        bool validForSharding = llvm::isa<ttnn::Conv2dOp>(currentOp) &&
+                                legalConfigs.lookup(currentOp).size() > 0;
 
         if (validForSharding) {
           OpL1MemSpec shardSpec;


### PR DESCRIPTION
Due to a new PCC regression that probably occurs in an eltwise sharded op, sharding is restricted to conv2d only as a temporary workaround.

Metal issue for the problem will be created as a follow-up.
