### PR TITLE
Ignore builder artifact dir `ttnn-standalone`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test/lit.site.cfg.py
 /ttir/
 /ttnn/
 /ttmetal/
+/ttnn-standalone/
 
 # TTNN and TTMetal flatbuffers
 *.ttnn


### PR DESCRIPTION
Need to ignore `ttnn-standalone`, an artifact dir from builder tests.