### PR TITLE
Uplift third_party/tt-metal to e46b29077a1dfb00cd4b57a8ce9e018b059dd84a 2025-08-06

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1217,11 +1217,6 @@ struct EmitCTypeConverter<::ttnn::operations::conv::conv2d::Conv2dConfig> {
           << EmitCTypeConverter<bool>::convert(attr.getEnableSplitReader());
       firstElement = false;
     }
-    if (attr.getEnableSubblockPadding()) {
-      rso << (firstElement ? "" : ", ") << ".enable_subblock_padding = "
-          << EmitCTypeConverter<bool>::convert(attr.getEnableSubblockPadding());
-      firstElement = false;
-    }
     if (attr.getInPlace()) {
       rso << (firstElement ? "" : ", ") << ".in_place = "
           << EmitCTypeConverter<bool>::convert(attr.getInPlace());

--- a/include/ttmlir/Dialect/TTNN/Analysis/Conv2dConfigSearchSpace.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/Conv2dConfigSearchSpace.h
@@ -35,7 +35,6 @@ struct Conv2dConfigSearchSpace {
   llvm::SmallVector<bool> enableActDoubleBuffer;
   llvm::SmallVector<bool> enableWeightsDoubleBuffer;
   llvm::SmallVector<bool> enableSplitReader;
-  llvm::SmallVector<bool> enableSubblockPadding;
 
   // Constructor: All fields are empty by default.
   Conv2dConfigSearchSpace() = default;
@@ -74,9 +73,6 @@ struct Conv2dConfigSearchSpace {
   bool isEnableSplitReaderSetForSearch() const {
     return !enableSplitReader.empty();
   }
-  bool isEnableSubblockPaddingSetForSearch() const {
-    return !enableSubblockPadding.empty();
-  }
 
   // Helper to check if any field has been set with search values
   bool isAnyFieldSetForSearch() const {
@@ -90,8 +86,7 @@ struct Conv2dConfigSearchSpace {
            isTransposeShardsSetForSearch() || isOutputLayoutSetForSearch() ||
            isEnableActDoubleBufferSetForSearch() ||
            isEnableWeightsDoubleBufferSetForSearch() ||
-           isEnableSplitReaderSetForSearch() ||
-           isEnableSubblockPaddingSetForSearch();
+           isEnableSplitReaderSetForSearch();
   }
 };
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -461,7 +461,6 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
     - `enable_act_double_buffer`: Enable activation double buffering for increased performance at cost of higher L1 usage (default: false)
     - `enable_weights_double_buffer`: Enable weights double buffering when using block sharding for increased performance at cost of higher L1 usage (default: false)
     - `enable_split_reader`: Enable dual concurrent reader kernels instead of one. Only for height sharding, requires act_block_h >= 64 (default: false)
-    - `enable_subblock_padding`: Enable subblock padding optimization (default: false)
     - `in_place`: Re-use input tensor storage when creating output tensor (default: false)
 
     Example:
@@ -482,7 +481,6 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
       enable_act_double_buffer = false,
       enable_weights_double_buffer = false,
       enable_split_reader = false,
-      enable_subblock_padding = false,
       in_place = false
     >
     ```
@@ -503,7 +501,6 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
                         OptionalParameter<"BoolAttr">:$enable_act_double_buffer,
                         OptionalParameter<"BoolAttr">:$enable_weights_double_buffer,
                         OptionalParameter<"BoolAttr">:$enable_split_reader,
-                        OptionalParameter<"BoolAttr">:$enable_subblock_padding,
                         OptionalParameter<"BoolAttr">:$in_place);
 
   let builders = [
@@ -528,7 +525,6 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
     Conv2dConfigAttr withEnableActDoubleBuffer(bool value) const;
     Conv2dConfigAttr withEnableWeightsDoubleBuffer(bool value) const;
     Conv2dConfigAttr withEnableSplitReader(bool value) const;
-    Conv2dConfigAttr withEnableSubblockPadding(bool value) const;
     Conv2dConfigAttr withInPlace(bool value) const;
     bool hasActivation() const;
     bool hasWeightsDtype() const;
@@ -547,7 +543,6 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
     bool hasEnableActDoubleBuffer() const;
     bool hasEnableWeightsDoubleBuffer() const;
     bool hasEnableSplitReader() const;
-    bool hasEnableSubblockPadding() const;
     bool hasInPlace() const;
   }];
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -93,7 +93,7 @@ struct TTIRToTTNNBackendPipelineOptions
   // optimizerPassEnabled (enable-optimizer) is true.
   //
   // Full Example:
-  // override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false
+  // override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false
   // Partial Example:
   // "conv2d_1=enable_weights_double_buffer#true:activation#none,conv2d_2=dtype#bf16"
   //
@@ -116,7 +116,6 @@ struct TTIRToTTNNBackendPipelineOptions
   // * enable_act_double_buffer: [true, false]
   // * enable_weights_double_buffer: [true, false]
   // * enable_split_reader: [true, false]
-  // * enable_subblock_padding: [true, false]
   //
   // For more details on parameter values see conv2d_op.hpp in tt-metal.
   //

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -48,7 +48,6 @@ struct Conv2dConfigOverrideParams {
   std::optional<bool> enableActDoubleBuffer = std::nullopt;
   std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
   std::optional<bool> enableSplitReader = std::nullopt;
-  std::optional<bool> enableSubblockPadding = std::nullopt;
 
   bool empty() const {
     return !weightsDtype.has_value() && !activation.has_value() &&
@@ -60,7 +59,7 @@ struct Conv2dConfigOverrideParams {
            !coreGrid.has_value() && !transposeShards.has_value() &&
            !outputLayout.has_value() && !enableActDoubleBuffer.has_value() &&
            !enableWeightsDoubleBuffer.has_value() &&
-           !enableSplitReader.has_value() && !enableSubblockPadding.has_value();
+           !enableSplitReader.has_value();
   }
 
   bool fullConfigOverride() const {
@@ -72,7 +71,7 @@ struct Conv2dConfigOverrideParams {
            coreGrid.has_value() && transposeShards.has_value() &&
            outputLayout.has_value() && enableActDoubleBuffer.has_value() &&
            enableWeightsDoubleBuffer.has_value() &&
-           enableSplitReader.has_value() && enableSubblockPadding.has_value();
+           enableSplitReader.has_value();
   }
 
   friend llvm::raw_ostream &
@@ -89,8 +88,7 @@ struct Conv2dConfigOverrideParams {
        << ":output_layout#" << params.outputLayout
        << ":enable_act_double_buffer#" << params.enableActDoubleBuffer
        << ":enable_weights_double_buffer#" << params.enableWeightsDoubleBuffer
-       << ":enable_split_reader#" << params.enableSplitReader
-       << ":enable_subblock_padding#" << params.enableSubblockPadding;
+       << ":enable_split_reader#" << params.enableSplitReader;
     return os;
   }
 };

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -20,7 +20,6 @@ table Conv2dConfig {
   enable_act_double_buffer: bool = null;
   enable_weights_double_buffer: bool = null;
   enable_split_reader: bool = null;
-  enable_subblock_padding: bool = null;
   in_place: bool = null;
 }
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -760,7 +760,6 @@ toFlatbuffer(FlatbufferObjectCache &cache, ttnn::Conv2dConfigAttr config) {
       toFlatbuffer(cache, config.getEnableActDoubleBuffer()),
       toFlatbuffer(cache, config.getEnableWeightsDoubleBuffer()),
       toFlatbuffer(cache, config.getEnableSplitReader()),
-      toFlatbuffer(cache, config.getEnableSubblockPadding()),
       toFlatbuffer(cache, config.getInPlace()));
 }
 

--- a/lib/Dialect/TTNN/Analysis/Conv2dConfigSearchSpace.cpp
+++ b/lib/Dialect/TTNN/Analysis/Conv2dConfigSearchSpace.cpp
@@ -166,16 +166,6 @@ Conv2dConfigGenerator::Conv2dConfigGenerator(
           return attr.withEnableSplitReader(info.getCurrentBool());
         });
   }
-  if (searchSpace.isEnableSubblockPaddingSetForSearch() &&
-      !baseConfig.hasEnableSubblockPadding()) {
-    activeSearchFields.emplace_back(
-        Conv2dConfigGeneratorSearchFieldInfo(searchSpace.enableSubblockPadding),
-        [](Conv2dConfigAttr attr,
-           const Conv2dConfigGeneratorSearchFieldInfo &info)
-            -> Conv2dConfigAttr {
-          return attr.withEnableSubblockPadding(info.getCurrentBool());
-        });
-  }
 
   // Initialize isDone to true if there are no active search fields.
   isDone = activeSearchFields.empty();

--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -112,11 +112,6 @@ applyConv2dConfigOverrides(ttnn::Conv2dOp op,
         conv2dConfigAttr.withEnableSplitReader(*overrides.enableSplitReader);
   }
 
-  if (overrides.enableSubblockPadding.has_value()) {
-    conv2dConfigAttr = conv2dConfigAttr.withEnableSubblockPadding(
-        *overrides.enableSubblockPadding);
-  }
-
   TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                "Conv2d config after overrides: {}", conv2dConfigAttr);
 

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -731,7 +731,6 @@ struct Conv2dConfigAttrParams {
   mlir::BoolAttr enableActDoubleBuffer;
   mlir::BoolAttr enableWeightsDoubleBuffer;
   mlir::BoolAttr enableSplitReader;
-  mlir::BoolAttr enableSubblockPadding;
   mlir::BoolAttr inPlace;
 
   Conv2dConfigAttrParams() = delete;
@@ -789,8 +788,6 @@ public:
         getOrDefaultBool(attr.getEnableWeightsDoubleBuffer(), ctx, partial);
     enableSplitReader =
         getOrDefaultBool(attr.getEnableSplitReader(), ctx, partial);
-    enableSubblockPadding =
-        getOrDefaultBool(attr.getEnableSubblockPadding(), ctx, partial);
     inPlace = getOrDefaultBool(attr.getInPlace(), ctx, partial);
   }
 
@@ -800,8 +797,7 @@ public:
         reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
         reshardIfNotOptimal, overrideShardingConfig, shardLayout, coreGrid,
         transposeShards, outputLayout, enableActDoubleBuffer,
-        enableWeightsDoubleBuffer, enableSplitReader, enableSubblockPadding,
-        inPlace);
+        enableWeightsDoubleBuffer, enableSplitReader, inPlace);
   }
 };
 
@@ -823,7 +819,6 @@ Conv2dConfigAttr Conv2dConfigAttr::getEmpty(::mlir::MLIRContext *context) {
                                /*enableActDoubleBuffer=*/nullptr,
                                /*enableWeightsDoubleBuffer=*/nullptr,
                                /*enableSplitReader=*/nullptr,
-                               /*enableSubblockPadding=*/nullptr,
                                /*inPlace=*/nullptr);
 }
 
@@ -928,12 +923,6 @@ Conv2dConfigAttr Conv2dConfigAttr::withEnableSplitReader(bool value) const {
   return params.buildConv2dConfig(getContext());
 }
 
-Conv2dConfigAttr Conv2dConfigAttr::withEnableSubblockPadding(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.enableSubblockPadding = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
-}
-
 Conv2dConfigAttr Conv2dConfigAttr::withInPlace(bool value) const {
   Conv2dConfigAttrParams params(*this);
   params.inPlace = BoolAttr::get(getContext(), value);
@@ -996,10 +985,6 @@ bool Conv2dConfigAttr::hasEnableWeightsDoubleBuffer() const {
 
 bool Conv2dConfigAttr::hasEnableSplitReader() const {
   return getEnableSplitReader() != nullptr;
-}
-
-bool Conv2dConfigAttr::hasEnableSubblockPadding() const {
-  return getEnableSubblockPadding() != nullptr;
 }
 
 bool Conv2dConfigAttr::hasInPlace() const { return getInPlace() != nullptr; }

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -48,7 +48,7 @@ bool parseBool(StringRef param, bool &result) {
 } // namespace
 
 // Full Example:
-// conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false
+// conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false
 // Partial Example:
 // conv2d_1=enable_weights_double_buffer#true:activation#none,conv2d_2=dtype#bf16
 bool Conv2dConfigOverrideParser::parse(
@@ -242,17 +242,6 @@ bool Conv2dConfigOverrideParser::parse(
           return true;
         }
         params.enableSplitReader = enableSplitReader;
-      } else if (paramName == "enable_subblock_padding") {
-        bool enableSubblockPadding;
-        if (parseBool(paramValue, enableSubblockPadding)) {
-          opt.error("Invalid enable_subblock_padding: " + paramValue);
-          return true;
-        }
-        if (params.enableSubblockPadding.has_value()) {
-          opt.error("Duplicate enable_subblock_padding: " + paramValue);
-          return true;
-        }
-        params.enableSubblockPadding = enableSubblockPadding;
       } else {
         opt.error("Invalid override parameter: " + paramName);
         return true;
@@ -325,10 +314,6 @@ std::string Conv2dConfigOverrideParser::toString(
     if (params.enableSplitReader.has_value()) {
       rso << "enable_split_reader#"
           << (params.enableSplitReader.value() ? "true" : "false") << ":";
-    }
-    if (params.enableSubblockPadding.has_value()) {
-      rso << "enable_subblock_padding#"
-          << (params.enableSubblockPadding.value() ? "true" : "false") << ":";
     }
     rso.flush();
     // Remove the last ':' if there are parameters

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -420,11 +420,6 @@ getConv2dConfig(const std::optional<Conv2dConfigAttr> &conv2dConfig) {
         conv2dConfig->getEnableSplitReader().getValue();
   }
 
-  if (conv2dConfig->getEnableSubblockPadding()) {
-    config.enable_subblock_padding =
-        conv2dConfig->getEnableSubblockPadding().getValue();
-  }
-
   return config;
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -14,8 +14,8 @@ namespace mlir::tt::ttnn::op_model {
 // getOpRuntime() uses trace capture to run and measure the runtime of an op.
 // This requires the device to be opened with sufficient trace region size. This
 // number is currently set based on manual testing of supported ops to
-// accommodate the highest required trace buffer size (400384B)
-static constexpr size_t opModelDefaultTraceRegionSize = 500000;
+// accommodate the highest required trace buffer size (2004992B)
+static constexpr size_t opModelDefaultTraceRegionSize = 5000000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
   openDevice(traceRegionSize);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -404,11 +404,9 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
   // Create query closure
   auto prepareConv2dWeightsOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        &::ttnn::operations::conv::conv2d::prepare_conv_weights<
-            ::tt::tt_metal::distributed::MeshDevice>,
-        device, weightTensor, inputSpec.memory_config(), inputSpec.layout(),
-        "OIHW", in_channels, out_channels, batch_size, input_height,
-        input_width,
+        &::ttnn::operations::conv::conv2d::prepare_conv_weights, device,
+        weightTensor, inputSpec.memory_config(), inputSpec.layout(), "OIHW",
+        in_channels, out_channels, batch_size, input_height, input_width,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToMultiSizeStdArray<uint32_t, 2, 4>(
@@ -423,8 +421,7 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
   auto prepareConvTranspose2dWeightsOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         &::ttnn::operations::conv::conv_transpose2d::
-            prepare_conv_transpose2d_weights<
-                ::tt::tt_metal::distributed::MeshDevice>,
+            prepare_conv_transpose2d_weights,
         device, weightTensor, inputSpec.memory_config(), inputSpec.layout(),
         "IOHW", in_channels, out_channels, batch_size, input_height,
         input_width,
@@ -490,8 +487,7 @@ getPrepareConv2dBiasOpOutputTensorSpec(
   std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>
       conv2dConfigConverted = conversion::getConv2dConfig(conv2dConfig);
 
-  auto prepare_fn = &::ttnn::operations::conv::conv2d::prepare_conv_bias<
-      ::tt::tt_metal::distributed::MeshDevice>;
+  auto prepare_fn = &::ttnn::operations::conv::conv2d::prepare_conv_bias;
   // Create query closure
   auto prepareConv2dBiasOpQuery = [=]() {
     ::ttnn::operations::conv::conv2d::Conv2dConfig localConfig;

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -241,9 +241,6 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
                   enableWeightsDoubleBuffer)
       .def_rw("enable_split_reader",
               &mlir::tt::ttnn::Conv2dConfigOverrideParams::enableSplitReader)
-      .def_rw(
-          "enable_subblock_padding",
-          &mlir::tt::ttnn::Conv2dConfigOverrideParams::enableSubblockPadding)
       .def("set_weights_dtype_from_str",
            [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
               const std::string &value) {
@@ -340,11 +337,6 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
            [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
               const std::string &value) {
              obj.enableSplitReader = (value == "True");
-           })
-      .def("set_enable_subblock_padding_from_str",
-           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
-              const std::string &value) {
-             obj.enableSubblockPadding = (value == "True");
            })
       .def("empty", &mlir::tt::ttnn::Conv2dConfigOverrideParams::empty);
 }

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -176,8 +176,7 @@ void populateTTNNModule(nb::module_ &m) {
              tt::ttnn::CoreRangeSetAttr coreGrid, BoolAttr transposeShards,
              std::optional<tt::ttnn::Layout> outputLayout,
              BoolAttr enableActDoubleBuffer, BoolAttr enableWeightsDoubleBuffer,
-             BoolAttr enableSplitReader, BoolAttr enableSubblockPadding,
-             BoolAttr inPlace) {
+             BoolAttr enableSplitReader, BoolAttr inPlace) {
             MLIRContext *context = unwrap(ctx);
 
             return wrap(tt::ttnn::Conv2dConfigAttr::get(
@@ -185,8 +184,7 @@ void populateTTNNModule(nb::module_ &m) {
                 reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
                 reshardIfNotOptimal, overrideShardingConfig, shardLayout,
                 coreGrid, transposeShards, outputLayout, enableActDoubleBuffer,
-                enableWeightsDoubleBuffer, enableSplitReader,
-                enableSubblockPadding, inPlace));
+                enableWeightsDoubleBuffer, enableSplitReader, inPlace));
           })
       .def_prop_ro("weights_dtype_as_int",
                    [](tt::ttnn::Conv2dConfigAttr self)
@@ -302,14 +300,6 @@ void populateTTNNModule(nb::module_ &m) {
                        return nb::none();
                      }
                      return self.getEnableSplitReader().getValue();
-                   })
-      .def_prop_ro("enable_subblock_padding",
-                   [](tt::ttnn::Conv2dConfigAttr self)
-                       -> std::variant<nb::object, bool> {
-                     if (!self.getEnableSubblockPadding()) {
-                       return nb::none();
-                     }
-                     return self.getEnableSubblockPadding().getValue();
                    })
       .def_prop_ro("in_place",
                    [](tt::ttnn::Conv2dConfigAttr self)

--- a/runtime/lib/ttnn/operations/conv/prepare_conv2d_bias.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv2d_bias.cpp
@@ -62,15 +62,14 @@ void run(const ::tt::target::ttnn::PrepareConv2dBiasOp *op,
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out =
-      ::ttnn::operations::conv::conv2d::prepare_conv_bias<::ttnn::MeshDevice>(
-          weightTensor, *inputMemoryConfig,
-          ::tt::runtime::ttnn::utils::toTTNNLayout(op->input_tensor_layout()),
-          op->in_channels(), op->out_channels(), op->batch_size(),
-          op->input_height(), op->input_width(), kernelSize, stride, padding,
-          dilation, op->groups(), &targetDevice, inputDtype, outputDtype,
-          conv2dConfig,
-          /*compute_config_=*/std::nullopt);
+  ::ttnn::Tensor out = ::ttnn::operations::conv::conv2d::prepare_conv_bias(
+      weightTensor, *inputMemoryConfig,
+      ::tt::runtime::ttnn::utils::toTTNNLayout(op->input_tensor_layout()),
+      op->in_channels(), op->out_channels(), op->batch_size(),
+      op->input_height(), op->input_width(), kernelSize, stride, padding,
+      dilation, op->groups(), &targetDevice, inputDtype, outputDtype,
+      conv2dConfig,
+      /*compute_config_=*/std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
@@ -62,8 +62,7 @@ void run(const ::tt::target::ttnn::PrepareConv2dWeightsOp *op,
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  ::ttnn::Tensor out = ::ttnn::operations::conv::conv2d::prepare_conv_weights<
-      ::ttnn::MeshDevice>(
+  ::ttnn::Tensor out = ::ttnn::operations::conv::conv2d::prepare_conv_weights(
       weightTensor, *inputMemoryConfig,
       ::tt::runtime::ttnn::utils::toTTNNLayout(op->input_tensor_layout()),
       op->weights_format()->str(), op->in_channels(), op->out_channels(),

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -321,10 +321,6 @@ createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *config) {
     conv2dConfig.enable_split_reader = *config->enable_split_reader();
   }
 
-  if (config->enable_subblock_padding()) {
-    conv2dConfig.enable_subblock_padding = *config->enable_subblock_padding();
-  }
-
   if (config->in_place()) {
     conv2dConfig.in_place = *config->in_place();
   }

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
@@ -24,7 +24,7 @@ module {
     %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
           <{
             batch_size = 1 : i32,
-            conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, activation = "relu", deallocate_activation = false, reallocate_halo_output = false, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, shard_layout = height_sharded, transpose_shards = false, output_layout = tile, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>,
+            conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, activation = "relu", deallocate_activation = false, reallocate_halo_output = false, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, shard_layout = height_sharded, transpose_shards = false, output_layout = tile, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false>,
             dilation = array<i32: 1, 1>,
             groups = 1 : i32,
             in_channels = 64 : i32,

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=false override-conv2d-config=conv2d_1=weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=false override-conv2d-config=conv2d_1=weights_dtype#bf16:activation#relu:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
@@ -18,7 +18,6 @@ module {
     // CHECK-SAME: enable_act_double_buffer = false
     // CHECK-SAME: enable_weights_double_buffer = false
     // CHECK-SAME: enable_split_reader = false
-    // CHECK-SAME: enable_subblock_padding = false
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 1, 1>,

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
@@ -28,7 +28,6 @@
   enable_act_double_buffer = false,
   enable_weights_double_buffer = false,
   enable_split_reader = false,
-  enable_subblock_padding = false,
   in_place = false
 >
 

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
@@ -26,7 +26,6 @@
   enable_act_double_buffer = false,
   enable_weights_double_buffer = false,
   enable_split_reader = false,
-  enable_subblock_padding = false,
   in_place = false
 >
 

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
@@ -25,7 +25,6 @@
   enable_act_double_buffer = false,
   enable_weights_double_buffer = false,
   enable_split_reader = false,
-  enable_subblock_padding = false,
   in_place = false
 >
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1580,7 +1580,7 @@ INSTANTIATE_TEST_SUITE_P(
                         llvm::SmallVector<int32_t>{2, 2},
                         llvm::SmallVector<int32_t>{3, 3},
                         llvm::SmallVector<int32_t>{1, 1}, 1,
-                        detail::ExpectedResult{false, 0, 0, 0})));
+                        detail::ExpectedResult{true, 0, 0, 0})));
 
 class OpModelConvTranspose2dParam
     : public OpModelTest,

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1387,7 +1387,6 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       /*enable_act_double_buffer=*/BoolAttr::get(&context, false),
       /*enable_weights_double_buffer=*/BoolAttr::get(&context, false),
       /*enable_split_reader=*/BoolAttr::get(&context, false),
-      /*enable_subblock_padding=*/BoolAttr::get(&context, false),
       /*in_place=*/BoolAttr::get(&context, false));
 
   OpModel backend = dyn_cast<OpModel>(conv2d.getOperation());
@@ -1427,7 +1426,6 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       /*enable_act_double_buffer=*/BoolAttr::get(&context, true),
       /*enable_weights_double_buffer=*/BoolAttr::get(&context, true),
       /*enable_split_reader=*/BoolAttr::get(&context, false),
-      /*enable_subblock_padding=*/BoolAttr::get(&context, false),
       /*in_place=*/BoolAttr::get(&context, false));
 
   constraintsExp = backend.getOpConstraints(
@@ -1575,7 +1573,6 @@ TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
       /*enable_act_double_buffer=*/BoolAttr::get(&context, true),
       /*enable_weights_double_buffer=*/BoolAttr::get(&context, true),
       /*enable_split_reader=*/BoolAttr::get(&context, false),
-      /*enable_subblock_padding=*/BoolAttr::get(&context, false),
       /*in_place=*/BoolAttr::get(&context, false));
 
   OpModel backend = dyn_cast<OpModel>(convTranspose2d.getOperation());

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -46,8 +46,7 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
                     "output_layout#row_major:"
                     "enable_act_double_buffer#false:"
                     "enable_weights_double_buffer#false:"
-                    "enable_split_reader#false:"
-                    "enable_subblock_padding#false";
+                    "enable_split_reader#false";
 
   bool result = parser.parse(OverrideConv2dConfigOption,
                              "override-conv2d-config", arg, parsedOverride);
@@ -84,8 +83,6 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
   ASSERT_FALSE(params.enableWeightsDoubleBuffer.value());
   ASSERT_TRUE(params.enableSplitReader.has_value());
   ASSERT_FALSE(params.enableSplitReader.value());
-  ASSERT_TRUE(params.enableSubblockPadding.has_value());
-  ASSERT_FALSE(params.enableSubblockPadding.value());
 }
 
 TEST_F(Conv2dConfigOverrideTest, ParsePartialConv2dConfigOverride) {
@@ -114,7 +111,6 @@ TEST_F(Conv2dConfigOverrideTest, ParsePartialConv2dConfigOverride) {
   ASSERT_FALSE(params.enableActDoubleBuffer.has_value());
   ASSERT_FALSE(params.enableWeightsDoubleBuffer.has_value());
   ASSERT_FALSE(params.enableSplitReader.has_value());
-  ASSERT_FALSE(params.enableSubblockPadding.has_value());
 }
 
 TEST_F(Conv2dConfigOverrideTest, ParseMultipleOps) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -39,7 +39,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${CPM_SOURCE_CACHE}/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0
   ${CPM_SOURCE_CACHE}/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
   ${CPM_SOURCE_CACHE}/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include
-  ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+  ${CPM_SOURCE_CACHE}/enchantum/2fb7ab238e36c101b9848892ddb6382276b65837/enchantum/include
   ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
   ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
   ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
@@ -182,7 +182,7 @@ install(
   DIRECTORY
     ${CPM_SOURCE_CACHE}/boost
     ${CPM_SOURCE_CACHE}/fmt
-    ${CPM_SOURCE_CACHE}/magic_enum
+    ${CPM_SOURCE_CACHE}/enchantum
     ${CPM_SOURCE_CACHE}/nlohmann_json
     ${CPM_SOURCE_CACHE}/reflect
     ${CPM_SOURCE_CACHE}/spdlog

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "8e131829e4f91371a8dd59c0c4a6fa83ce13a87e")
+set(TT_METAL_VERSION "e46b29077a1dfb00cd4b57a8ce9e018b059dd84a")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -124,10 +124,6 @@ def settings_to_overrides(settings, artifacts_dir):
                         conv2d_config_override.set_enable_split_reader_from_str(
                             attr["value"]
                         )
-                    case "enable_subblock_padding":
-                        conv2d_config_override.set_enable_subblock_padding_from_str(
-                            attr["value"]
-                        )
                     case _:
                         raise ValueError(f"Invalid override attribute: {attr['key']}")
             if not output_layout_override.empty():

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -623,18 +623,6 @@ def parse_conv2d_config(attr):
             },
         )
     )
-    result.append(
-        utils.make_editable_kv(
-            graph_builder.KeyValue(
-                key="enable_subblock_padding",
-                value=str(conv2d_config.enable_subblock_padding),
-            ),
-            editable={
-                "input_type": "value_list",
-                "options": ["True", "False"],
-            },
-        )
-    )
 
     return result
 

--- a/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
+++ b/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
@@ -60,7 +60,7 @@ set(INCLUDE_DIRS
     # TODO: Remove these when ttmetal removes the dependencies from public facing headers
     ${CPM_SOURCE_CACHE}/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0
     ${CPM_SOURCE_CACHE}/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include
-    ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+    ${CPM_SOURCE_CACHE}/enchantum/2fb7ab238e36c101b9848892ddb6382276b65837/enchantum/include
     ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
     ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
@@ -80,7 +80,7 @@ set(INCLUDE_DIRS
     ${METAL_SRC_DIR}/tt_stl
     ${METAL_SRC_DIR}/tt_stl/tt_stl
     ${METAL_SRC_DIR}/tt_metal/third_party/fmt
-    ${METAL_SRC_DIR}/tt_metal/third_party/magic_enum
+    ${METAL_SRC_DIR}/tt_metal/third_party/enchantum
     ${METAL_SRC_DIR}/tt_metal/third_party/taskflow
     ${METAL_SRC_DIR}/tt_metal/third_party/tracy/public
     ${METAL_SRC_DIR}/tt_metal/third_party/umd

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -80,7 +80,7 @@ set(INCLUDE_DIRS
     # TODO: Remove these when ttmetal removes the dependencies from public facing headers
     ${CPM_SOURCE_CACHE}/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0
     ${CPM_SOURCE_CACHE}/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include
-    ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+    ${CPM_SOURCE_CACHE}/enchantum/2fb7ab238e36c101b9848892ddb6382276b65837/enchantum/include
     ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
     ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
@@ -100,7 +100,7 @@ set(INCLUDE_DIRS
     ${METAL_SRC_DIR}/tt_stl
     ${METAL_SRC_DIR}/tt_stl/tt_stl
     ${METAL_SRC_DIR}/tt_metal/third_party/fmt
-    ${METAL_SRC_DIR}/tt_metal/third_party/magic_enum
+    ${METAL_SRC_DIR}/tt_metal/third_party/enchantum
     ${METAL_SRC_DIR}/tt_metal/third_party/taskflow
     ${METAL_SRC_DIR}/tt_metal/third_party/tracy/public
     ${METAL_SRC_DIR}/tt_metal/third_party/umd


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the e46b29077a1dfb00cd4b57a8ce9e018b059dd84a

- Remove usage of enable_subblock_padding after removed in metal commit 0f76e02a3c
- Remove templated calls to conv APIs after metal commit ec7c1d1397
- Include enchantum via cpm after metal commit 27b6da1b4e
- Increase traceregionsize since requirements increased after metal commit a2de6f9eb9
- Update conv op config legality after metal commit d6330b1014

Bisect note:
- Metal commit `fa5351012a` breaks build for tt-mlir since it consumes a new dependency enchantum using fetchcontent instead of CPM, resolved by metal commit `27b6da1b4e`