### PR TITLE
Added PyKernel Deps on Build

### DIFF
--- a/test/pykernel/demo/CMakeLists.txt
+++ b/test/pykernel/demo/CMakeLists.txt
@@ -7,23 +7,8 @@ if(NOT TTMLIR_ENABLE_PYKERNEL)
     message(WARNING "TTMLIR_ENABLE_PYKERNEL must be ON to build the PyKernel demo")
 endif()
 
-find_program(GREP_EXEC grep REQUIRED)
-set(GREP_PATTERN [[^(git\+|^-r|^#)]])
-set(METAL_REQUIREMENTS_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/python_env/requirements-dev.txt)
-
-# Define a target for the demo depending on Runtime and Python Bindings
-add_custom_target(pykernel-demo
-    COMMENT "Setting up and running PyKernel demo"
-    COMMAND ${GREP_EXEC} -vE '${GREP_PATTERN}' ${METAL_REQUIREMENTS_PATH} > ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt
-    DEPENDS TTMLIRRuntime TTMLIRPythonModules)
-
-add_custom_command(TARGET pykernel-demo
-    COMMENT "Installing Requirements for Demo"
-    COMMAND PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install -r ${CMAKE_CURRENT_BINARY_DIR}/requirements.txt
-)
-
 # Run the test
-add_custom_command(TARGET pykernel-demo
+add_custom_target(pykernel-demo
     COMMENT "Running Pykernel Tests"
     COMMAND pytest ${CMAKE_CURRENT_SOURCE_DIR}/test.py
 )

--- a/tools/pykernel/CMakeLists.txt
+++ b/tools/pykernel/CMakeLists.txt
@@ -15,3 +15,20 @@ add_mlir_python_modules(TTPykernelModules
     INSTALL_PREFIX "python_packages/pykernel"
     DECLARED_SOURCES TTPykernelSources
 )
+
+
+# Include the Logic Here to install PyKernel dependencies (to run)
+
+find_program(GREP_EXEC grep REQUIRED)
+set(GREP_PATTERN [[^(git\+|^-r|^#)]])
+set(METAL_REQUIREMENTS_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/python_env/requirements-dev.txt)
+
+# Set extra build dependencies here that might be filtered out from the requirements-dev.txt
+set(PYKERNEL_EXTRA_PIP_PACKAGES graphviz)
+
+add_custom_command(TARGET TTPykernelModules POST_BUILD
+    COMMENT "Setting up PyKernel dependencies"
+    COMMAND ${GREP_EXEC} -vE '${GREP_PATTERN}' ${METAL_REQUIREMENTS_PATH} > ${CMAKE_CURRENT_BINARY_DIR}/pykernel_requirements.txt
+    COMMAND PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install -r ${CMAKE_CURRENT_BINARY_DIR}/pykernel_requirements.txt
+    COMMAND PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install ${PYKERNEL_EXTRA_PIP_PACKAGES}
+)

--- a/tools/pykernel/CMakeLists.txt
+++ b/tools/pykernel/CMakeLists.txt
@@ -32,3 +32,6 @@ add_custom_command(TARGET TTPykernelModules POST_BUILD
     COMMAND PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install -r ${CMAKE_CURRENT_BINARY_DIR}/pykernel_requirements.txt
     COMMAND PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install ${PYKERNEL_EXTRA_PIP_PACKAGES}
 )
+
+# Add dependency to ensure tt-metal is downloaded before the command runs
+add_dependencies(TTPykernelModules tt-metal-download)


### PR DESCRIPTION
### Ticket
- PR closes #4385 

### Problem description
- Devs facing build complications, especially with `graphviz` and pykernel deps. 

### What's changed
- Automatically install `pip` dependencies when configuring `pykernel` (eg: when build flag is set).
- "Newest" `ttnn` is dependent on the hash code in the ExternalProject config for `tt-metal`, but it will always build the "newest" `_ttnn.so` and add it to PYTHONPATH w/ `source env/activate`.
