### PR TITLE
D2M: fix ArrayRef use-after-free

### DIFF
--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -211,7 +211,7 @@ protected:
 
   // Default memory spaces for {inputs, outputs}.
   std::array<ttcore::MemorySpace, 2> memorySpaces;
-  mlir::ArrayRef<int64_t> targetGridShape;
+  llvm::SmallVector<int64_t> targetGridShape;
 
   static constexpr std::array<int64_t, 2> s_expectedInputGridShape{1, 1};
 };


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The target grid shape is a temporary SmallVector created in `populateTTIRToTTIRGenericPatterns`, it goes away once the function returns. But currently `TTIRNamedRewriterCommon` holds a const ref of it, this makes ASan unhappy.

### What's changed
Obtain a copy of the array.

### Checklist
- [x] New/Existing tests provide coverage for changes
