### PR TITLE
Add constraints for Cbrt and BitwiseNot

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -135,7 +135,8 @@ def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
 }
 
 class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [HasMemoryConfigTrait] # traits> {
+    TTNN_Op<mnemonic, [HasMemoryConfigTrait,
+    DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -263,36 +264,28 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where", [ExplicateOperandBroadcast
     }];
 }
 
-def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs"> {
     let summary = "Eltwise absolute.";
     let description = [{
       Eltwise absolute operation.
     }];
 }
 
-def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt"> {
     let summary = "Eltwise cubic root.";
     let description = [{
       Eltwise cubic root operation.
     }];
 }
 
-def TTNN_CeilOp : TTNN_ElementwiseUnaryOp<"ceil",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_CeilOp : TTNN_ElementwiseUnaryOp<"ceil"> {
     let summary = "Eltwise ceil.";
     let description = [{
       Eltwise ceil operation.
     }];
 }
 
-def TTNN_SignOp: TTNN_ElementwiseUnaryOp<"sign",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_SignOp: TTNN_ElementwiseUnaryOp<"sign"> {
     let summary = "Eltwise sign operation.";
     let description = [{
       Returns the sign of the `operand` element-wise and produces a `result`
@@ -304,81 +297,63 @@ def TTNN_SignOp: TTNN_ElementwiseUnaryOp<"sign",
     }];
 }
 
-def TTNN_CosOp : TTNN_ElementwiseUnaryOp<"cos",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_CosOp : TTNN_ElementwiseUnaryOp<"cos"> {
     let summary = "Eltwise cosine.";
     let description = [{
       Eltwise cosine operation.
     }];
 }
 
-def TTNN_ExpOp : TTNN_ElementwiseUnaryOp<"exp",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_ExpOp : TTNN_ElementwiseUnaryOp<"exp"> {
     let summary = "Eltwise exponential.";
     let description = [{
       Eltwise exponential operation.
     }];
 }
 
-def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf"> {
     let summary = "Eltwise erf op.";
     let description = [{
         Eltwise erf operation. Calculates erf(x) for each element of the input tensor.
       }];
 }
 
-def TTNN_ErfcOp : TTNN_ElementwiseUnaryOp<"erfc",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_ErfcOp : TTNN_ElementwiseUnaryOp<"erfc"> {
     let summary = "Eltwise erfc op.";
     let description = [{
         Eltwise erfc operation. Calculates erfc(x) for each element of the input tensor.
       }];
 }
 
-def TTNN_FloorOp: TTNN_ElementwiseUnaryOp<"floor",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_FloorOp: TTNN_ElementwiseUnaryOp<"floor"> {
     let summary = "Eltwise floor op.";
     let description = [{
       Eltwise floor operation.
     }];
 }
 
-def TTNN_GeluOp: TTNN_ElementwiseUnaryOp<"gelu",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_GeluOp: TTNN_ElementwiseUnaryOp<"gelu"> {
   let summary = "Eltwise GELU.";
   let description = [{
     Eltwise GELU operation.
   }];
 }
 
-def TTNN_IsFiniteOp: TTNN_ElementwiseUnaryOp<"isfinite",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_IsFiniteOp: TTNN_ElementwiseUnaryOp<"isfinite"> {
     let summary = "Eltwise isfinite op.";
     let description = [{
       Eltwise isfinite operation.
     }];
 }
 
-def TTNN_LogicalNotOp: TTNN_ElementwiseUnaryOp<"logical_not",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_LogicalNotOp: TTNN_ElementwiseUnaryOp<"logical_not"> {
     let summary = "Eltwise logical not op.";
     let description = [{
       Eltwise logical not operation.
     }];
 }
 
-def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
     let summary = "Eltwise bitwise NOT.";
     let description = [{
         Performs element-wise NOT of tensor `operand` and produces a `result` tensor.
@@ -391,27 +366,21 @@ def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not",
     }];
 }
 
-def TTNN_NegOp : TTNN_ElementwiseUnaryOp<"neg",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_NegOp : TTNN_ElementwiseUnaryOp<"neg"> {
     let summary = "Eltwise negate.";
     let description = [{
       Eltwise negate operation.
     }];
 }
 
-def TTNN_TanOp: TTNN_ElementwiseUnaryOp<"tan",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_TanOp: TTNN_ElementwiseUnaryOp<"tan"> {
     let summary = "Eltwise tan op.";
     let description = [{
       Eltwise tan operation.
     }];
 }
 
-def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan"> {
     let summary = "Eltwise arctangent op.";
     let description = [{
       Performs an elementwise arctangent (`atan`) operation on the input tensor.
@@ -430,9 +399,7 @@ def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan",
     }];
 }
 
-def TTNN_TanhOp: TTNN_ElementwiseUnaryOp<"tanh",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_TanhOp: TTNN_ElementwiseUnaryOp<"tanh"> {
     let summary = "Eltwise tanh op.";
 
     let extraClassDeclaration = [{
@@ -447,72 +414,56 @@ def TTNN_TanhOp: TTNN_ElementwiseUnaryOp<"tanh",
     }];
 }
 
-def TTNN_ReciprocalOp : TTNN_ElementwiseUnaryOp<"reciprocal",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_ReciprocalOp : TTNN_ElementwiseUnaryOp<"reciprocal"> {
     let summary = "Eltwise reciprocal.";
     let description = [{
       Eltwise reciprocal operation.
     }];
 }
 
-def TTNN_ReluOp : TTNN_ElementwiseUnaryOp<"relu",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_ReluOp : TTNN_ElementwiseUnaryOp<"relu"> {
     let summary = "Eltwise ReLU.";
     let description = [{
       Eltwise ReLU operation.
     }];
 }
 
-def TTNN_SinOp : TTNN_ElementwiseUnaryOp<"sin",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_SinOp : TTNN_ElementwiseUnaryOp<"sin"> {
     let summary = "Eltwise sine.";
     let description = [{
       Eltwise sine operation.
     }];
 }
 
-def TTNN_SqrtOp : TTNN_ElementwiseUnaryOp<"sqrt",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_SqrtOp : TTNN_ElementwiseUnaryOp<"sqrt"> {
     let summary = "Eltwise sqrt.";
     let description = [{
       Eltwise sqrt operation.
     }];
 }
 
-def TTNN_RsqrtOp : TTNN_ElementwiseUnaryOp<"rsqrt",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_RsqrtOp : TTNN_ElementwiseUnaryOp<"rsqrt"> {
     let summary = "Eltwise rsqrt.";
     let description = [{
       Eltwise rsqrt operation.
     }];
 }
 
-def TTNN_SigmoidOp : TTNN_ElementwiseUnaryOp<"sigmoid",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_SigmoidOp : TTNN_ElementwiseUnaryOp<"sigmoid"> {
     let summary = "Eltwise sigmoid.";
     let description = [{
       Eltwise sigmoid operation.
     }];
 }
 
-def TTNN_LogOp : TTNN_ElementwiseUnaryOp<"log",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_LogOp : TTNN_ElementwiseUnaryOp<"log"> {
     let summary = "Eltwise logarithm.";
     let description = [{
       Eltwise logarithm operation.
     }];
 }
 
-def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p"> {
     let summary = "Eltwise log1p operation.";
     let description = [{
         Performs element-wise logarithm plus one operation on `operand` tensor and
@@ -524,9 +475,7 @@ def TTNN_Log1pOp: TTNN_ElementwiseUnaryOp<"log1p",
       }];
 }
 
-def TTNN_Expm1Op: TTNN_ElementwiseUnaryOp<"expm1",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
-      > {
+def TTNN_Expm1Op: TTNN_ElementwiseUnaryOp<"expm1"> {
   let description = [{
     Performs element-wise exponential minus one operation on `operand` tensor
     and stores the result in the output tensor.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -272,7 +272,9 @@ def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs",
     }];
 }
 
-def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt"> {
+def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise cubic root.";
     let description = [{
       Eltwise cubic root operation.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -376,7 +376,9 @@ def TTNN_LogicalNotOp: TTNN_ElementwiseUnaryOp<"logical_not",
     }];
 }
 
-def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
+def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise bitwise NOT.";
     let description = [{
         Performs element-wise NOT of tensor `operand` and produces a `result` tensor.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -107,6 +107,9 @@ struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 template <>
 struct OpModel<CbrtOp> : UnaryEltwiseOpModel<CbrtOp> {};
 
+template <>
+struct OpModel<BitwiseNotOp> : UnaryEltwiseOpModel<BitwiseNotOp> {};
+
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
   static llvm::Expected<OpConstraints>

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -104,6 +104,9 @@ struct OpModel<Expm1Op> : UnaryEltwiseOpModel<Expm1Op> {};
 template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
+template <>
+struct OpModel<CbrtOp> : UnaryEltwiseOpModel<CbrtOp> {};
+
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
   static llvm::Expected<OpConstraints>

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -533,6 +533,22 @@ ReciprocalOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// CbrtOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+CbrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+CbrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // SigmoidOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -549,6 +549,22 @@ CbrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// BitwiseNotOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+BitwiseNotOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+BitwiseNotOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // SigmoidOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -255,6 +255,8 @@ auto getOpSymbol() {
     return ::ttnn::log;
   } else if constexpr (std::is_same_v<OpTy, ReciprocalOp>) {
     return ::ttnn::reciprocal;
+  } else if constexpr (std::is_same_v<OpTy, CbrtOp>) {
+    return ::ttnn::cbrt;
   } else if constexpr (std::is_same_v<OpTy, AddOp>) {
     return ::ttnn::add;
   } else if constexpr (std::is_same_v<OpTy, MultiplyOp>) {
@@ -727,6 +729,7 @@ template struct UnaryEltwiseOpModel<NegOp>;
 template struct UnaryEltwiseOpModel<TanOp>;
 template struct UnaryEltwiseOpModel<AtanOp>;
 template struct UnaryEltwiseOpModel<ReciprocalOp>;
+template struct UnaryEltwiseOpModel<CbrtOp>;
 template struct UnaryEltwiseOpModel<Log1pOp>;
 template struct UnaryEltwiseOpModel<Expm1Op>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<ErfOp>;

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -257,6 +257,8 @@ auto getOpSymbol() {
     return ::ttnn::reciprocal;
   } else if constexpr (std::is_same_v<OpTy, CbrtOp>) {
     return ::ttnn::cbrt;
+  } else if constexpr (std::is_same_v<OpTy, BitwiseNotOp>) {
+    return ::ttnn::bitwise_not;
   } else if constexpr (std::is_same_v<OpTy, AddOp>) {
     return ::ttnn::add;
   } else if constexpr (std::is_same_v<OpTy, MultiplyOp>) {
@@ -730,6 +732,7 @@ template struct UnaryEltwiseOpModel<TanOp>;
 template struct UnaryEltwiseOpModel<AtanOp>;
 template struct UnaryEltwiseOpModel<ReciprocalOp>;
 template struct UnaryEltwiseOpModel<CbrtOp>;
+template struct UnaryEltwiseOpModel<BitwiseNotOp>;
 template struct UnaryEltwiseOpModel<Log1pOp>;
 template struct UnaryEltwiseOpModel<Expm1Op>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<ErfOp>;

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -131,36 +131,10 @@ protected:
     const auto [expectedLegal, expectedCbSize, expectedPeakSize,
                 expectedOutputSize] = std::get<2>(params);
 
-    TTNNLayoutAttr inputLayout;
-    TTNNLayoutAttr outputLayout;
-
-    // BitwiseNot requires Int32 data type - create layouts manually
-    auto int32DataType = ttcore::DataType::Int32;
-    auto tileType = ttcore::TileType::get(&context, {32, 32}, int32DataType);
-    auto grid = CreateGrid(&context, inputBufferType, inputTensorLayout,
-                           inputVirtualGrid.value_or(GetVirtualGridShape(
-                               inputShape, inputTensorLayout)),
-                           GetPhysicalGridSize());
-    auto memLayoutAttr =
-        inputBufferType == BufferType::SystemMemory
-            ? TensorMemoryLayoutAttr{}
-            : TensorMemoryLayoutAttr::get(&context, inputTensorLayout);
-
-    inputLayout = TTNNLayoutAttr::get(&context, inputShape, tileType,
-                                      inputBufferType, grid, memLayoutAttr);
-
-    auto outputGrid = CreateGrid(&context, outputBufferType, outputTensorLayout,
-                                 outputVirtualGrid.value_or(GetVirtualGridShape(
-                                     outputShape, outputTensorLayout)),
-                                 GetPhysicalGridSize());
-    auto outputMemLayoutAttr =
-        outputBufferType == BufferType::SystemMemory
-            ? TensorMemoryLayoutAttr{}
-            : TensorMemoryLayoutAttr::get(&context, outputTensorLayout);
-
-    outputLayout =
-        TTNNLayoutAttr::get(&context, outputShape, tileType, outputBufferType,
-                            outputGrid, outputMemLayoutAttr);
+    const TTNNLayoutAttr inputLayout = CreateTiledLayoutInt32(
+        inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+    const TTNNLayoutAttr outputLayout = CreateTiledLayoutInt32(
+        outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
         CreateWorkerGrid(), inputShape, inputLayout, outputLayout);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -193,6 +193,7 @@ TEST_P(UnaryOpModelTest, TestOpInterfaceNullOutput) {
 }
 
 const ExpectedResult expected{true, 8192, 2048, 2048};
+const ExpectedResult cbrtExpected{true, 12288, 6144, 2048};
 
 //===---------------------------------------------------------===
 const auto createRelu = [](OpBuilder &b, Location loc, Type type,
@@ -283,6 +284,11 @@ const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
 };
+const auto createCbrt = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<CbrtOp>(loc, type, ops).getOperation();
+};
+
 //===---------------------------------------------------------===
 // Define the test parameters
 const std::vector<UnaryOpTestParams> unaryOpTestParams = {
@@ -299,6 +305,7 @@ const std::vector<UnaryOpTestParams> unaryOpTestParams = {
     {"Erfc", createErfc, expected},
     {"Floor", createFloor, expected},
     {"Reciprocal", createReciprocal, expected},
+    {"Cbrt", createCbrt, cbrtExpected},
     {"Gelu", createGelu, expected},
     {"IsFinite", createIsFinite, expected},
     {"LogicalNot", createLogicalNot, expected},

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -482,6 +482,57 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.testName;
     });
 
+// Separate test for BitwiseNot with integer data types
+TEST_F(OpModelBase, BitwiseNotOpInterface) {
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  // Create TTNNLayoutAttr with Int32 data type manually
+  // (CreateTiledLayout only supports FloatType, not IntegerType)
+  auto int32DataType = ttcore::DataType::Int32;
+  auto tileType = ttcore::TileType::get(&context, {32, 32}, int32DataType);
+  auto bufferType = BufferType::L1;
+  auto grid = ttcore::GridAttr::get(&context, {8, 8});
+  auto memLayout =
+      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
+
+  auto int32Layout = TTNNLayoutAttr::get(&context, tensorShape, tileType,
+                                         bufferType, grid, memLayout);
+
+  // Create tensors with the proper Int32 layout
+  auto intType = builder.getIntegerType(32);
+  auto inputType = createRankedTensorType(tensorShape, intType, int32Layout);
+  auto outputType = createRankedTensorType(tensorShape, intType, int32Layout);
+
+  // Create input tensor using OnesOp with Int32 layout
+  auto input = builder.create<OnesOp>(builder.getUnknownLoc(), inputType,
+                                      ShapeAttr::get(&context, tensorShape),
+                                      nullptr, nullptr, nullptr, nullptr);
+
+  auto bitwiseNot = builder.create<BitwiseNotOp>(
+      builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input});
+
+  // Test BitwiseNot interface
+  auto constraintsExp = getOpConstraints(bitwiseNot.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 16384);
+    EXPECT_EQ(peakSize, 4096);
+    EXPECT_EQ(outputSize, 4096);
+  } else {
+    FAIL() << "Missing L1 constraints for BitwiseNot; Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = getOpRuntime(bitwiseNot.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << "Runtime test failed for BitwiseNot; Error="
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, SqrtOpInterface) {
   // create SqrtOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -111,6 +111,33 @@ public:
         memLayoutAttr);
   }
 
+  mlir::tt::ttnn::TTNNLayoutAttr CreateTiledLayoutInt32(
+      const llvm::ArrayRef<int64_t> &tensorShape,
+      const mlir::tt::ttnn::BufferType &bufferType,
+      const mlir::tt::ttnn::TensorMemoryLayout &tensorMemoryLayout,
+      const std::optional<llvm::SmallVector<int64_t>> &virtualGrid =
+          std::nullopt,
+      const llvm::SmallVector<int64_t> physicalGrid = GetPhysicalGridSize()) {
+    const auto &virtualGridSelected =
+        virtualGrid.has_value()
+            ? virtualGrid.value()
+            : GetVirtualGridShape(tensorShape, tensorMemoryLayout);
+
+    auto memLayoutAttr = bufferType == mlir::tt::ttnn::BufferType::SystemMemory
+                             ? mlir::tt::ttnn::TensorMemoryLayoutAttr{}
+                             : mlir::tt::ttnn::TensorMemoryLayoutAttr::get(
+                                   &context, tensorMemoryLayout);
+    auto int32DataType = mlir::tt::ttcore::DataType::Int32;
+    auto tileType =
+        mlir::tt::ttcore::TileType::get(&context, {32, 32}, int32DataType);
+
+    return mlir::tt::ttnn::TTNNLayoutAttr::get(
+        &context, tensorShape, tileType, bufferType,
+        CreateGrid(&context, bufferType, tensorMemoryLayout,
+                   virtualGridSelected, physicalGrid),
+        memLayoutAttr);
+  }
+
   mlir::tt::ttnn::TTNNLayoutAttr CreateRowMajorLayout(
       const llvm::ArrayRef<int64_t> &tensorShape,
       const mlir::tt::ttnn::BufferType &bufferType,


### PR DESCRIPTION
### Ticket
#4195

Added constraints for `CbrtOp` and `BitwiseNotOp`.

Testing in `TestOpModelLib.cpp`:
Both of these ops have different memory usage compared to the rest of the unary ops. In the case of `BitwiseNot` the memory numbers are doubled. For `Cbrt`, `expectedCbSize` becomes (*1.25 + 2048), and `expectedPeakSize` becomes 3x. Instead of refactoring the testing framework to be able to set these values, and given that we will eventually changes EQ to GE/LE (#4288), I added `EXPECT_EQ_OR_GE()` that uses GE given a flag. GE test is used for both `Cbrt` and `BitwiseNot`.

`BitwiseNot` only works with int32. Because of this, I created `CreateTiledLayoutInt32()` and `RunTestInt32()` to be used for `BitwiseNot` and in case any other future op is like this.
