### PR TITLE
Add dump tensors flag to ttrt

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -1139,8 +1139,8 @@ class Run:
                         for tensor in program.output_tensors:
                             self.logging.debug(f"{tensor}\n")
 
-                        # Dump the perf data before deallocating buffers
-                        device.dump_device_profile_results()
+                        # Read the perf data before deallocating buffers
+                        device.read_device_profiler_results()
 
                         # if golden comparison is enabled, check golden results json file to see if test passed
                         if not self["--disable-golden"]:


### PR DESCRIPTION
### Ticket
NA

### Problem description
Sometimes I want to interact with inputs/outputs of a program via python to verify golden by hand, etc.

### What's changed
Add flag to dump inputs/outputs to .pt files in `/tmp`

### Checklist
- [ ] New/Existing tests provide coverage for changes
