### PR TITLE
[TTNNWorkaround] SortOp indices

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1101,6 +1101,13 @@ def TTNN_SortOp : TTNN_Op<"sort"> {
   let results = (outs AnyRankedTensor:$values,
                       AnyRankedTensor:$indices);
 
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return
+        wa::TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(*this);
+    }
+  }];
+
   let hasVerifier = 1;
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -286,6 +286,10 @@ public:
   static TTNNOperandsWorkarounds
   createReduceProdOpOperandsWorkarounds(mlir::Type elementType,
                                         bool allDimensions);
+
+  // Create workarounds for sort op operands.
+  static TTNNOperandsWorkarounds
+  createSortOpOperandsWorkarounds(mlir::Operation *op);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -14,6 +14,12 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include <optional>
 
+// TODO (azecevic): Forward declaration is a temporary solution to avoid
+// circular dependency issue. https://github.com/tenstorrent/tt-mlir/issues/4405
+namespace mlir::tt::ttnn {
+class SortOp;
+} // namespace mlir::tt::ttnn
+
 namespace mlir::tt::ttnn::wa {
 using TensorLayoutWorkaround = std::optional<Layout>;
 using TensorBufferTypeWorkaround = std::optional<BufferType>;
@@ -289,7 +295,7 @@ public:
 
   // Create workarounds for sort op operands.
   static TTNNOperandsWorkarounds
-  createSortOpOperandsWorkarounds(mlir::Operation *op);
+  createSortOpOperandsWorkarounds(ttnn::SortOp op);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2028,8 +2028,8 @@ mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
   auto indicesType =
       mlir::cast<RankedTensorType>(getResults().back().getType());
   auto elementType = indicesType.getElementType();
-  if (!elementType.isInteger(16)) {
-    return emitOpError("Expected data type for indices is i16 but got ")
+  if (!isa<IntegerType>(elementType)) {
+    return emitOpError("Expected integer data type for indices but got ")
            << elementType;
   }
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -638,9 +638,8 @@ TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds(
 // Issue page: https://github.com/tenstorrent/tt-mlir/issues/4405
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(
-    mlir::Operation *op) {
-  ttnn::SortOp sortOp = mlir::cast<ttnn::SortOp>(op);
-  auto indicesElementType = sortOp.getIndices().getType().getElementType();
+    ttnn::SortOp op) {
+  auto indicesElementType = op.getIndices().getType().getElementType();
 
   TTNNOperandWorkarounds datatypeWorkaround;
   if (!(indicesElementType.isInteger(16) &&

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sort_workaround.mlir
@@ -1,0 +1,21 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func public @test_sort_datatype_workaround(%arg0: tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xsi32>) {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = ttir.empty() : tensor<64x128xsi32>
+    // CHECK-LABEL: func.func public @test_sort_datatype_workaround
+    // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.sort"
+    // CHECK-SAME: <{descending = false, dim = -1 : si8, stable = false}>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> (tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xui16,
+    %2, %3 = "ttir.sort"(%arg0, %0, %1) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xsi32>) -> (tensor<64x128xbf16>, tensor<64x128xsi32>)
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<64x128xui16,
+    // CHECK-SAME: -> tensor<64x128xsi32,
+    return %2, %3 : tensor<64x128xbf16>, tensor<64x128xsi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/sort/sort_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/sort/sort_tests_negative.mlir
@@ -12,7 +12,7 @@ module {
 // -----
 module {
   func.func @test_sort(%arg0: tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xbf16>) {
-    // CHECK: error: 'ttnn.sort' op Expected data type for indices is i16 but got 'bf16'
+    // CHECK: error: 'ttnn.sort' op Expected integer data type for indices but got 'bf16'
     %1, %2 = "ttnn.sort"(%arg0) <{dim = -1 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xbf16>)
     return %1, %2 : tensor<64x128xbf16>, tensor<64x128xbf16>
   }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/4405

### Problem description
ttnn::sort generates indices of type uint16. If ttir.sort generates indices with different type then runtime crashes due to mismatch in generated and expected data type.

### What's changed
Add datatype workaround for SortOp indices.

### Checklist
- [X] New/Existing tests provide coverage for changes
