### PR TITLE
[D2M] Fix bug in wait() and remove unnecessary commands

### DIFF
--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -37,10 +37,6 @@ table DeallocateBufferCommand {
   ref: BufferRef;
 }
 
-table CreateEventCommand {
-  ref: EventRef;
-}
-
 table EnqueueRecordEventCommand {
   ref: EventRef;
 }
@@ -50,10 +46,6 @@ table EnqueueWaitForEventCommand {
 }
 
 table EventSynchronizeCommand {
-  ref: EventRef;
-}
-
-table EventQueryCommand {
   ref: EventRef;
 }
 
@@ -80,11 +72,9 @@ union CommandType {
   EnqueueReadBufferCommand,
   CreateBufferCommand,
   DeallocateBufferCommand,
-  CreateEventCommand,
   EnqueueRecordEventCommand,
   EnqueueWaitForEventCommand,
   EventSynchronizeCommand,
-  EventQueryCommand,
   MemrefCopyCommand,
   CpuCommand,
   FinishCommand,

--- a/runtime/include/tt/runtime/workarounds.h
+++ b/runtime/include/tt/runtime/workarounds.h
@@ -13,8 +13,7 @@ struct Env {
   static const Env &get(bool swapBinaryOperands = true,
                         bool readUpdateIndexFromDeviceForKVCache = true,
                         bool traceImplicitFromDevice = true,
-                        bool blackholeWorkarounds = true,
-                        bool d2mReturnEvent = false);
+                        bool blackholeWorkarounds = true);
 
   // TODO(bug #1124): We're currently swapping the operands for binary ops
   // in runtime if the lhs operand is smaller (and requires broadcast onto the
@@ -40,22 +39,15 @@ struct Env {
   // host for now.
   bool blackholeWorkarounds;
 
-  // TODO(bug #4181): d2mReturnEvent is to create MeshEvent at
-  // EnqueueReturnCommand. This is currently set to false due to the issue in
-  // tt metal MeshEvent and should be removed once the issue is fixed.
-  bool d2mReturnEvent;
-
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool traceImplicitFromDevice, bool blackholeWorkarounds,
-                bool d2mReturnEvent)
+                bool traceImplicitFromDevice, bool blackholeWorkarounds)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
         traceImplicitFromDevice(traceImplicitFromDevice),
-        blackholeWorkarounds(blackholeWorkarounds),
-        d2mReturnEvent(d2mReturnEvent) {}
+        blackholeWorkarounds(blackholeWorkarounds) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -69,8 +61,6 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << "traceImplicitFromDevice: " << env.traceImplicitFromDevice << "\n";
   os << "\t"
      << "blackholeWorkarounds: " << env.blackholeWorkarounds << "\n";
-  os << "\t"
-     << "d2mReturnEvent: " << env.d2mReturnEvent << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -7,11 +7,10 @@
 namespace tt::runtime::workaround {
 const Env &Env::get(bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool traceImplicitFromDevice, bool blackholeWorkarounds,
-                    bool d2mReturnEvent) {
-  static const Env config(
-      swapBinaryOperands, readUpdateIndexFromDeviceForKVCache,
-      traceImplicitFromDevice, blackholeWorkarounds, d2mReturnEvent);
+                    bool traceImplicitFromDevice, bool blackholeWorkarounds) {
+  static const Env config(swapBinaryOperands,
+                          readUpdateIndexFromDeviceForKVCache,
+                          traceImplicitFromDevice, blackholeWorkarounds);
   return config;
 }
 } // namespace tt::runtime::workaround

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -365,10 +365,11 @@ void setFabricConfig(FabricConfig config) {
 }
 
 void wait(Event event) {
-  std::shared_ptr<tt_metal::Event> eventPtr =
-      event.asSharedPtr<tt_metal::Event>(DeviceRuntime::TTMetal);
+  std::shared_ptr<tt_metal::distributed::MeshEvent> eventPtr =
+      event.asSharedPtr<tt_metal::distributed::MeshEvent>(
+          DeviceRuntime::TTMetal);
   if (eventPtr) {
-    tt_metal::EventSynchronize(eventPtr);
+    tt_metal::distributed::EventSynchronize(*eventPtr);
   }
 }
 

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -191,13 +191,6 @@ class Run:
             help="disable blackhole workarounds",
         )
         Run.register_arg(
-            name="--enable-d2m-return-event",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="enable d2m return event",
-        )
-        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -575,7 +568,6 @@ class Run:
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-trace-implicit-from-device"],
                 not self["--disable-blackhole-workarounds"],
-                self["--enable-d2m-return-event"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             tracy_program_metadata = {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4181

### Problem description
There was a bug in waiting ttmetal MeshEvent at return time, leading to hanging. It turns out that current wait() uses single device EventSynchronize while it is supposed to use distributed::EventSynchronize(). 

### What's changed
1. Fix bug in D2M wait() to use MeshEvent and distributed::EventSynchronize().
2. Remove some unnecessary commands as we migrate to MeshEvent from Event.

### Checklist
- [X] Existing tests provide coverage for changes
