### PR TITLE
Adding golden infrastructure and sdy ops to stablehlo-builder

### DIFF
--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -14,6 +14,8 @@ from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 from builder.base.builder_utils import compile_stablehlo_to_flatbuffer
 from test_utils import Marks, shape_str
 
+pytestmark = pytest.mark.n300
+
 
 def sharding_constraint(
     in0: Operand,
@@ -60,6 +62,7 @@ def test_sharding_constraint(
         base=request.node.name,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
+        mesh_dict=OrderedDict([("x", 1), ("y", 2)]),
     )
 
 
@@ -85,6 +88,7 @@ def reshard(
             ),
         ],
     )
+
     builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
     out_sharding = builder.tensor_sharding_attr(
         mesh_name="mesh",
@@ -103,6 +107,7 @@ def reshard(
             ),
         ],
     )
+    print(f"out_sharding: {out_sharding}")
     return builder.reshard(in0, sharding=out_sharding)
 
 
@@ -127,6 +132,7 @@ def test_reshard(
         base=request.node.name,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
+        mesh_dict=OrderedDict([("x", 1), ("y", 2)]),
     )
 
 
@@ -201,4 +207,5 @@ def test_manual_computation(
         base=request.node.name,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
+        mesh_dict=OrderedDict([("x", 1), ("y", 2)]),
     )

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -9,13 +9,8 @@ from conftest import x86_only
 
 from builder.base.builder import Operand, Shape, TypeInfo
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
-from builder.base.builder_utils import build_stablehlo_module
+from builder.base.builder_utils import compile_stablehlo_to_flatbuffer
 from test_utils import Marks, shape_str
-
-from ttmlir.passes import (
-    stablehlo_pipeline,
-    stablehlo_to_ttir_pipeline,
-)
 
 
 def add(
@@ -41,11 +36,11 @@ def test_binary_ops(
     dtype: torch.dtype,
     request,
 ):
-    module, shlo_builder = build_stablehlo_module(
+    compile_stablehlo_to_flatbuffer(
         test_fn,
-        [shape, shape],
-        [dtype, dtype],
+        inputs_shapes=[shape, shape],
+        inputs_types=[dtype, dtype],
+        base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
-
-    stablehlo_pipeline(module)
-    stablehlo_to_ttir_pipeline(module)

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -11,7 +11,7 @@ from enum import Enum, auto
 import re
 
 from ttmlir.ir import *
-from ttmlir.dialects import tensor, quant
+from ttmlir.dialects import ttir, tensor, quant
 from ttmlir.passes import GoldenTensor, DataType
 
 # ----- Public APIs -----
@@ -381,3 +381,17 @@ class Builder:
 
     def _organize_eltwise_golden(self, inputs: List[Operand]):
         return [self._get_golden_tensor(inp) for inp in inputs]
+
+    def _empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
+        dtype = data_type if data_type is not None else self._get_default_dtype()
+        return self._create_empty_from_tensor_type(
+            shape, self._create_ranked_tensor_type(shape, dtype)
+        )
+
+    def _create_empty_from_tensor_type(
+        self, shape: Shape, tensor_type: RankedTensorType
+    ) -> OpView:
+        with self._ctx, self._loc:
+            op = ttir.EmptyOp(tensor_type)
+            self._generate_and_store_random_golden(op)
+            return op

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -14,7 +14,7 @@ comparison with TTIR or StableHLO operation results.
 from typing import Dict, Callable, Any, Optional, Union, List, Tuple
 import torch
 import torch.nn.functional
-from ttmlir.dialects import ttir, stablehlo
+from ttmlir.dialects import ttir, stablehlo, sdy
 from ttmlir.ir import Attribute
 
 
@@ -1165,6 +1165,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # Operations with parameter transformations
     ttir.LeakyReluOp: torch.nn.functional.leaky_relu,
     stablehlo.AddOp: torch.add,
+    sdy.ReshardOp: torch.tensor,
 }
 
 

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -22,6 +22,7 @@ from ttmlir.passes import (
     translate_to_cpp,
     MLIRModuleLogger,
     stablehlo_pipeline,
+    stablehlo_to_ttir_pipeline,
 )
 
 from builder.base.builder import *
@@ -32,7 +33,7 @@ from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 
 
 def _get_target_path(output_path, filename, target):
-    target_dir = os.path.join(output_path, target)
+    target_dir = os.path.join(output_path, "builder-artifacts", target)
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
     return os.path.join(target_dir, filename)
@@ -75,9 +76,6 @@ def _run_ttir_pipeline(
     mesh_dict: OrderedDict[str, int] = OrderedDict([("x", 1), ("y", 1)]),
     argument_types_string: Optional[str] = None,
 ):
-    if pipeline_options is None:
-        pipeline_options = []
-
     if argument_types_string:
         tt_populate_argument_types(module, argument_types_string)
         pipeline_options.append("enable-const-eval=true")
@@ -116,7 +114,7 @@ def build_ttir_module(
     module_dump: bool = False,
     base: Optional[str] = None,
     output_root: str = ".",
-) -> Tuple[Module, TTIRBuilder]:
+):
     """
     Define a MLIR module specified as a python function.
 
@@ -144,9 +142,6 @@ def build_ttir_module(
     module_dump : bool
         Set to True to print out generated MLIR module.
 
-    golden_dump : bool
-        Set to True to dump golden info to flatbuffer file.
-
     base : *Optional[str]*
         Output file name
 
@@ -155,8 +150,8 @@ def build_ttir_module(
 
     Returns
     -------
-    Module
-        MLIR module containing MLIR op graph defined by `fn`
+    Tuple[Module, TTIRBuilder]
+        A tuple containing the MLIR module and the TTIRBuilder instance
 
     Example
     -------
@@ -243,11 +238,11 @@ def build_ttir_module(
                 ttir_builder.set_graph_input_output(input_goldens, output_goldens)
                 return result
 
-        print(f"`{fn.__name__}` sucessfully transformed into a MLIR module.")
+        print(f"`{fn.__name__}` successfully transformed into a MLIR module.")
 
         base = fn.__name__ if base is None else base
 
-        filename = _get_target_path(output_root, base + "_ttir.mlir", "ttir")
+        filename = _get_target_path(output_root, base + "_ttir.mlir", base)
 
         if module_dump:
             with open(filename, "w") as f:
@@ -262,7 +257,7 @@ def compile_ttir_to_flatbuffer(
     inputs_shapes: List[Shape],
     inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
     system_desc_path: str = "ttrt-artifacts/system_desc.ttsys",
-    test_base: str = "test",
+    base: str = "test",
     output_root: str = ".",
     target: Literal["ttnn", "ttmetal", "ttnn-standalone"] = "ttnn",
     mesh_name: str = "mesh",
@@ -298,7 +293,7 @@ def compile_ttir_to_flatbuffer(
         `len(inputs_shapes) == len(inputs_types)` must be true.
         Default is None.
 
-    test_base : str
+    base : str
         The string to be used as the base name for dumped files throughout the
         process. If `None` is provided, then the `__name__` of `fn` will be used.
 
@@ -307,9 +302,20 @@ def compile_ttir_to_flatbuffer(
         exist, it will be created.
 
     target : *Literal["ttnn", "ttmetal", "ttnn-standalone"]*
-        Either "ttnn" or "ttmetal". This controls which backend to use.
+        Either "ttnn", "ttmetal", or "ttnn-standalone". This controls which backend to use.
 
-    argument_types_string : *Optional[str]*
+    mesh_name : *str*, optional
+        Name of the mesh to be used in the module. Default is "mesh".
+
+    mesh_dict : *OrderedDict[str, int]*, optional
+        Dictionary that defines the mesh shape, e.g. OrderedDict([("x", 1), ("y", 1)]).
+        Default is OrderedDict([("x", 1), ("y", 1)]).
+
+    module_dump : bool, optional
+        Set to True to print out generated TTIR MLIR module. Default is True.
+
+    argument_types_string : *Optional[str]*, optional
+        String defining argument types for constant evaluation. Default is None.
 
     custom_pipeline : *Union[Callable, str]*, optional
         Pipeline function to run.
@@ -318,113 +324,51 @@ def compile_ttir_to_flatbuffer(
         - A Callable: custom_pipeline(module, options)
         - A str: "ttir-lower-to-layout,ttir-bufferization-pipeline"
 
-    mesh_name : *str*
-        Name of the mesh to be used in the module. Default is "mesh".
+    system_desc_path : str, optional
+        Path to the system descriptor file. Default is "ttrt-artifacts/system_desc.ttsys".
 
-    mesh_dict : *OrderedDict[str, int]*
-        Dictionary that defines the mesh shape, e.g. OrderedDict([("x", 1), ("y", 1)]).
-
-    module_dump : bool
-        Set to True to print out generated TTIR MLIR module.
-        Default is False.
-
-    pipeline_options : *Optional[List[str]]*
-        Pipeline options to be added to the pass
+    pipeline_options : *Optional[List[str]]*, optional
+        Pipeline options to be added to the pass. Default is None.
 
     print_ir : *Union[bool, str]*, optional
         Set to True to print IR to stdout. Set to dir path to print IR after
-        each pass to its own file under that directory.
-        Default is False.
+        each pass to its own file under that directory. Default is False.
 
     Returns
     -------
     str
         The path to the generated TT{Metal,NN} MLIR file.
     """
-
     if inputs_types is not None:
         if len(inputs_shapes) != len(inputs_types):
             raise ValueError("inputs_shapes and inputs_types must have the same length")
-
-    if type(custom_pipeline) is str:
-        custom_pipeline = _create_custom_ttir_pipeline_fn(
-            custom_pipeline, print_ir=print_ir
-        )
-
-    if pipeline_options is None:
-        pipeline_options = []
-
-    pipeline_fn: Callable
-    to_target: Callable
-    mlir_suffix: str
-    target_extension: str
-
-    if target == "ttnn":
-        pipeline_fn = (
-            custom_pipeline if custom_pipeline else ttir_to_ttnn_backend_pipeline
-        )
-        to_target = ttnn_to_flatbuffer_file
-        mlir_suffix = "_ttnn.mlir"
-        target_extension = "ttnn"
-    elif target == "ttmetal":
-        pipeline_fn = (
-            custom_pipeline if custom_pipeline else ttir_to_ttmetal_backend_pipeline
-        )
-        to_target = ttmetal_to_flatbuffer_file
-        mlir_suffix = "_ttm.mlir"
-        target_extension = "ttm"
-    elif target == "ttnn-standalone":
-        ttir_to_ttnn_emitc_pipeline = _create_custom_ttir_pipeline_fn(
-            "ttir-to-emitc-pipeline", print_ir=print_ir
-        )
-        pipeline_fn = (
-            custom_pipeline if custom_pipeline else ttir_to_ttnn_emitc_pipeline
-        )
-        to_target = _emitc_to_executable
-        mlir_suffix = "_ttnn.mlir"
-        target_extension = "cpp"
-    else:
-        raise ValueError("Unsupported target: " + target)
 
     # Compile model to TTIR MLIR
     module, builder = build_ttir_module(
         fn,
         inputs_shapes,
         inputs_types,
+        base=base,
         mesh_name=mesh_name,
         mesh_dict=mesh_dict,
         module_dump=module_dump,
         output_root=output_root,
     )
 
-    output_file_mlir = _get_target_path(output_root, test_base + mlir_suffix, target)
-    output_file_fbb = ".".join([output_file_mlir, target_extension])
-
-    # Compile TTIR MLIR -> TT{Metal,NN} MLIR
-    module = _run_ttir_pipeline(
+    return compile_ttir_module_to_flatbuffer(
         module,
-        pipeline_fn,
-        pipeline_options=pipeline_options,
-        dump_to_file=module_dump,
-        output_file_name=output_file_mlir,
+        builder,
         system_desc_path=system_desc_path,
+        base=base,
+        output_root=output_root,
+        target=target,
         mesh_dict=mesh_dict,
+        module_dump=module_dump,
         argument_types_string=argument_types_string,
+        custom_pipeline=custom_pipeline,
+        pipeline_options=pipeline_options,
+        print_ir=print_ir,
     )
-    print(f"{target} pipeline ran successfully.")
-
-    module_logger = MLIRModuleLogger()
-    module_logger.attach_context(module.context)
-
-    # Compile TT{Metal,NN} MLIR -> flatbuffer
-    to_target(
-        module,
-        output_file_fbb,
-        builder.golden_map,
-        module_logger.module_log if module_logger.module_log else [],
-    )
-    print(f"{target} flatbuffer created successfully at: {output_file_fbb}")
-    return output_file_mlir
 
 
 def build_stablehlo_module(
@@ -436,7 +380,7 @@ def build_stablehlo_module(
     module_dump: bool = False,
     base: Optional[str] = None,
     output_root: str = ".",
-) -> Tuple[Module, StableHLOBuilder]:
+):
     """
     Define a MLIR module specified as a python function.
 
@@ -472,8 +416,8 @@ def build_stablehlo_module(
 
     Returns
     -------
-    Module
-        MLIR module containing MLIR op graph defined by `fn`
+    Tuple[Module, StableHLOBuilder]
+        A tuple containing the MLIR module and the StableHLOBuilder instance
 
     Example
     -------
@@ -564,11 +508,13 @@ def build_stablehlo_module(
                 stablehlo_builder.set_graph_input_output(input_goldens, output_goldens)
                 return result
 
-        print(f"`{fn.__name__}` sucessfully transformed into a MLIR module.")
+        stablehlo_pipeline(module)
+
+        print(f"`{fn.__name__}` successfully transformed into a MLIR module.")
 
         base = fn.__name__ if base is None else base
 
-        filename = _get_target_path(output_root, base + "_shlo.mlir", "shlo")
+        filename = _get_target_path(output_root, base + "_shlo.mlir", base)
 
         if module_dump:
             with open(filename, "w") as f:
@@ -576,3 +522,261 @@ def build_stablehlo_module(
                 print(module)
 
         return module, stablehlo_builder
+
+
+def compile_stablehlo_to_flatbuffer(
+    fn: Callable,
+    inputs_shapes: List[Shape],
+    inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
+    system_desc_path: str = "ttrt-artifacts/system_desc.ttsys",
+    base: str = "test",
+    output_root: str = ".",
+    target: Literal["ttnn", "ttmetal", "ttnn-standalone"] = "ttnn",
+    mesh_name: str = "mesh",
+    mesh_dict: OrderedDict[str, int] = OrderedDict([("x", 1), ("y", 1)]),
+    module_dump: bool = True,
+    argument_types_string: Optional[str] = None,
+    custom_pipeline: Optional[Union[Callable, str]] = None,
+    pipeline_options: Optional[List[str]] = None,
+    print_ir: Union[bool, str] = False,
+):
+    """
+    Compiles a StableHLO function to flatbuffer format.
+
+    This function compiles a StableHLO function through the complete pipeline:
+    StableHLO -> TTIR -> TT{Metal,NN} -> Flatbuffer. It first builds a StableHLO
+    module, runs the stablehlo pipeline and conversion to TTIR, then compiles
+    the TTIR module to the target flatbuffer format.
+
+    Parameters
+    ----------
+    fn : Callable
+        The StableHLO function to compile
+
+    inputs_shapes : List[Shape]
+        Shapes of the respective ranked tensor inputs of the test function
+
+    inputs_types : Optional[List[Union[torch.dtype, TypeInfo]]], optional
+        The dtypes to use for the inputs to `fn`
+
+    system_desc_path : str, optional
+        Path to the system descriptor file
+
+    base : str, optional
+        The string to be used as the base name for dumped files
+
+    output_root : str, optional
+        The path to dump all generated files under
+
+    target : Literal["ttnn", "ttmetal", "ttnn-standalone"], optional
+        The target backend to use. Default is "ttnn"
+
+    mesh_name : str, optional
+        Name of the mesh to be used in the module
+
+    mesh_dict : OrderedDict[str, int], optional
+        Dictionary that defines the mesh shape
+
+    module_dump : bool, optional
+        Set to True to print out generated MLIR modules
+
+    argument_types_string : Optional[str], optional
+        String defining argument types for constant evaluation
+
+    custom_pipeline : Optional[Union[Callable, str]], optional
+        Custom pipeline function or string to run instead of default pipeline
+
+    pipeline_options : Optional[List[str]], optional
+        Additional pipeline options to pass to the pipeline
+
+    print_ir : Union[bool, str], optional
+        Set to True to print IR to stdout or to a directory path
+
+    Returns
+    -------
+    str
+        The path to the generated TT{Metal,NN} MLIR file.
+
+    Raises
+    ------
+    ValueError
+        If inputs_shapes and inputs_types have different lengths
+    """
+    if inputs_types is not None:
+        if len(inputs_shapes) != len(inputs_types):
+            raise ValueError("inputs_shapes and inputs_types must have the same length")
+
+    # Compile model to StableHLO and run stablehlo pipeline to TTIR MLIR
+    module, builder = build_stablehlo_module(
+        fn,
+        inputs_shapes,
+        inputs_types,
+        base=base,
+        mesh_name=mesh_name,
+        mesh_dict=mesh_dict,
+        module_dump=module_dump,
+        output_root=output_root,
+    )
+
+    stablehlo_to_ttir_pipeline(module)
+    print(module)
+    builder.populate_goldens()
+
+    filename = _get_target_path(output_root, base + "_ttir.mlir", base)
+    if module_dump:
+        with open(filename, "w") as f:
+            f.write(str(module))
+
+    return compile_ttir_module_to_flatbuffer(
+        module,
+        builder,
+        system_desc_path=system_desc_path,
+        base=base,
+        output_root=output_root,
+        target=target,
+        mesh_dict=mesh_dict,
+        module_dump=module_dump,
+        argument_types_string=argument_types_string,
+        custom_pipeline=custom_pipeline,
+        pipeline_options=pipeline_options,
+        print_ir=print_ir,
+    )
+
+
+def compile_ttir_module_to_flatbuffer(
+    module: Module,
+    builder: Union[TTIRBuilder, StableHLOBuilder],
+    system_desc_path: str = "ttrt-artifacts/system_desc.ttsys",
+    base: str = "test",
+    output_root: str = ".",
+    target: Literal["ttnn", "ttmetal", "ttnn-standalone"] = "ttnn",
+    mesh_dict: OrderedDict[str, int] = OrderedDict([("x", 1), ("y", 1)]),
+    module_dump: bool = True,
+    argument_types_string: Optional[str] = None,
+    custom_pipeline: Optional[Union[Callable, str]] = None,
+    pipeline_options: Optional[List[str]] = None,
+    print_ir: Union[bool, str] = False,
+):
+    """
+    Compiles a TTIR MLIR module to flatbuffer format.
+
+    This function takes an existing TTIR MLIR module and compiles it through
+    the backend pipeline to generate a flatbuffer file. It supports multiple
+    targets including TTNN, TTMetal, and TTNN-standalone.
+
+    Parameters
+    ----------
+    module : Module
+        The TTIR MLIR module to compile
+
+    builder : Union[TTIRBuilder, StableHLOBuilder]
+        The builder instance containing golden reference values
+
+    system_desc_path : str, optional
+        Path to the system descriptor file. Default is "ttrt-artifacts/system_desc.ttsys"
+
+    base : str, optional
+        The string to be used as the base name for dumped files. Default is "test"
+
+    output_root : str, optional
+        The path to dump all generated files under
+
+    target : Literal["ttnn", "ttmetal", "ttnn-standalone"], optional
+        The target backend to use. Default is "ttnn"
+
+    mesh_dict : OrderedDict[str, int], optional
+        Dictionary that defines the mesh shape. Default is OrderedDict([("x", 1), ("y", 1)])
+
+    module_dump : bool, optional
+        Set to True to print out generated MLIR modules
+
+    argument_types_string : Optional[str], optional
+        String defining argument types for constant evaluation
+
+    custom_pipeline : Optional[Union[Callable, str]], optional
+        Custom pipeline function or string to run instead of default pipeline
+
+    pipeline_options : Optional[List[str]], optional
+        Additional pipeline options to pass to the pipeline
+
+    print_ir : Union[bool, str], optional
+        Set to True to print IR to stdout or to a directory path. Default is False
+
+    Returns
+    -------
+    str
+        The path to the generated target MLIR file
+
+    Raises
+    ------
+    ValueError
+        If an unsupported target is specified
+    """
+    if type(custom_pipeline) is str:
+        custom_pipeline = _create_custom_ttir_pipeline_fn(
+            custom_pipeline, print_ir=print_ir
+        )
+
+    if pipeline_options is None:
+        pipeline_options = []
+
+    pipeline_fn: Callable
+    to_target: Callable
+    mlir_suffix: str
+    target_extension: str
+
+    if target == "ttnn":
+        pipeline_fn = (
+            custom_pipeline if custom_pipeline else ttir_to_ttnn_backend_pipeline
+        )
+        to_target = ttnn_to_flatbuffer_file
+        mlir_suffix = "_ttnn.mlir"
+        target_extension = "ttnn"
+    elif target == "ttmetal":
+        pipeline_fn = (
+            custom_pipeline if custom_pipeline else ttir_to_ttmetal_backend_pipeline
+        )
+        to_target = ttmetal_to_flatbuffer_file
+        mlir_suffix = "_ttm.mlir"
+        target_extension = "ttm"
+    elif target == "ttnn-standalone":
+        ttir_to_ttnn_emitc_pipeline = _create_custom_ttir_pipeline_fn(
+            "ttir-to-emitc-pipeline", print_ir=print_ir
+        )
+        pipeline_fn = (
+            custom_pipeline if custom_pipeline else ttir_to_ttnn_emitc_pipeline
+        )
+        to_target = _emitc_to_executable
+        mlir_suffix = "_ttnn.mlir"
+        target_extension = "cpp"
+    else:
+        raise ValueError("Unsupported target: " + target)
+
+    output_file_mlir = _get_target_path(output_root, base + mlir_suffix, base)
+    output_file_fbb = ".".join([output_file_mlir, target_extension])
+
+    # Compile TTIR MLIR -> TT{Metal,NN} MLIR
+    module = _run_ttir_pipeline(
+        module,
+        pipeline_fn,
+        pipeline_options=pipeline_options,
+        dump_to_file=module_dump,
+        output_file_name=output_file_mlir,
+        system_desc_path=system_desc_path,
+        mesh_dict=mesh_dict,
+        argument_types_string=argument_types_string,
+    )
+    print(f"{target} pipeline ran successfully.")
+
+    module_logger = MLIRModuleLogger()
+    module_logger.attach_context(module.context)
+
+    # Compile TT{Metal,NN} MLIR -> flatbuffer
+    to_target(
+        module,
+        output_file_fbb,
+        builder.golden_map,
+        module_logger.module_log if module_logger.module_log else [],
+    )
+    print(f"{target} flatbuffer created successfully at: {output_file_fbb}")
+    return output_file_mlir

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -449,7 +449,6 @@ class StableHLOBuilder(Builder):
         (*sdy.ReshardOp*)
             A reshard operation that redistributes the input tensor according to the specified sharding
         """
-        # return sdy.ReshardOp(in0, sharding)
         return self._op_proxy(
             sdy.ReshardOp,
             [in0],

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -64,20 +64,6 @@ class TTIRBuilder(Builder):
 
     # ----- Private methods ----
 
-    def _empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
-        dtype = data_type if data_type is not None else self._default_type
-        return self._create_empty_from_tensor_type(
-            shape, self._create_ranked_tensor_type(shape, dtype)
-        )
-
-    def _create_empty_from_tensor_type(
-        self, shape: Shape, tensor_type: RankedTensorType
-    ) -> OpView:
-        with self._ctx, self._loc:
-            op = ttir.EmptyOp(tensor_type)
-            self._generate_and_store_random_golden(op)
-            return op
-
     def _organize_eltwise_ttir(
         self, inputs: List[Operand], output: OpView, _: Optional[Shape]
     ):


### PR DESCRIPTION
### Ticket
Closes [#4377 ](https://github.com/tenstorrent/tt-mlir/issues/4377)

### Problem description
`stablehlo-builder` doesn't have support for golden checks

### What's changed
Added support in `StableHLOBuilder` for storing information required to create golden tensors and `populate_goldens()` to add in golden tensors after module is lowered into ttir.
Restructured `builder_utils.py`. Added `compile_stablehlo_to_flatbuffer()` and `compile_ttir_module_to_flatbuffer()` for use after ttir modules are built.  
Added various functions to build `sdy` ops and attributes: `tensor_sharding_per_value_attr`, `manual_axes_attr`, `manual_computation`, `reshard`
Added tests.

_Documentation to come_
### Checklist
- [ ] New/Existing tests provide coverage for changes
