### PR TITLE
[Utils] Updated generateReshape to accept location parameter

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -15,16 +15,14 @@ namespace mlir::tt::ttir_to_ttnn::utils {
 mlir::tt::ttnn::ReshapeOp
 generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
                 llvm::ArrayRef<int64_t> newShape,
-                mlir::PatternRewriter &rewriter,
-                llvm::StringRef locSuffix = "_reshape");
+                mlir::PatternRewriter &rewriter, mlir::Location newLoc);
 
 // Generates a reshape operation for the given input tensor that returns 4D
 // tensor. Assumes that the input tensor is 4D. First 3 dimensions are flattened
 // into 3rd dimension and 4th dimension is kept as is.
 mlir::tt::ttnn::ReshapeOp
 generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
-                   mlir::PatternRewriter &rewriter,
-                   llvm::StringRef locSuffix = "_flatten");
+                   mlir::PatternRewriter &rewriter, mlir::Location newLoc);
 } // namespace mlir::tt::ttir_to_ttnn::utils
 
 #endif

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -17,16 +17,12 @@ namespace ttir_to_ttnn::utils {
 ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
                                 ArrayRef<int64_t> newShape,
                                 PatternRewriter &rewriter,
-                                llvm::StringRef locSuffix) {
+                                mlir::Location newLoc) {
   // With reshape op, the output layout changes due to new output shape, hence
   // we need to create a new output layout attribute with the new shape.
   RankedTensorType inputType = input.getType();
   RankedTensorType outputType =
       ttnn::utils::RankedTensorTypeFactory::create(inputType, newShape);
-
-  // Add suffix to keep the location name unique.
-  Location newLoc =
-      ttmlir::utils::appendLocationSuffix(input.getLoc(), locSuffix);
 
   llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
   return rewriter.create<ttnn::ReshapeOp>(newLoc, outputType, input,
@@ -36,14 +32,14 @@ ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
 
 ttnn::ReshapeOp
 generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
-                   PatternRewriter &rewriter, llvm::StringRef locSuffix) {
+                   PatternRewriter &rewriter, mlir::Location newLoc) {
   llvm::ArrayRef<int64_t> shape = input.getType().getShape();
 
   assert(shape.size() == 4 && "Must have 4-dim tensor as conv2d input");
 
   llvm::SmallVector<int64_t> newShape = {1, 1, shape[0] * shape[1] * shape[2],
                                          shape[3]};
-  return generateReshape(input, newShape, rewriter, locSuffix);
+  return generateReshape(input, newShape, rewriter, newLoc);
 }
 
 } // namespace ttir_to_ttnn::utils

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
@@ -42,7 +43,8 @@ ArgMaxOpRewritePattern::matchAndRewrite(ttnn::ArgMaxOp srcOp,
 
   // Create reshape op to unsqueeze input tensor to 4D.
   ReshapeOp preReshapeOp = ttir_to_ttnn::utils::generateReshape(
-      srcOp.getInput(), reshapeOutputShape, rewriter);
+      srcOp.getInput(), reshapeOutputShape, rewriter,
+      ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_reshapeInput"));
 
   // Create output layout attribute with new output tensor shape and create new
   // output type.
@@ -66,7 +68,8 @@ ArgMaxOpRewritePattern::matchAndRewrite(ttnn::ArgMaxOp srcOp,
 
   // Create ttnn.reshape op after performing ttnn.argmax op.
   ReshapeOp postReshapeOp = ttir_to_ttnn::utils::generateReshape(
-      argMaxOp, outputType.getShape(), rewriter);
+      argMaxOp, outputType.getShape(), rewriter,
+      ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_reshapeOutput"));
 
   rewriter.replaceOp(srcOp, postReshapeOp);
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
@@ -32,7 +33,8 @@ CumSumOpRankRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
   adaptedShape.append(additionalAxes, 1);
 
   ReshapeOp adaptedInput = ttir_to_ttnn::utils::generateReshape(
-      srcOp.getInput(), adaptedShape, rewriter, "_reshapeInput");
+      srcOp.getInput(), adaptedShape, rewriter,
+      ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_reshapeInput"));
 
   RankedTensorType outputType = srcOp.getResult().getType();
   RankedTensorType adaptedOutputType =
@@ -44,7 +46,7 @@ CumSumOpRankRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
 
   ReshapeOp cumsumOutput = ttir_to_ttnn::utils::generateReshape(
       adaptedCumSumOp, srcOp.getResult().getType().getShape(), rewriter,
-      "_reshapeOutput");
+      ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_reshapeOutput"));
   rewriter.replaceOp(srcOp, cumsumOutput);
 
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
@@ -34,7 +35,8 @@ LogicalResult EmbeddingOpSqueezeWeightRewritePattern::matchAndRewrite(
 
   // Create reshape op to squeeze weight tensor to 4D.
   ReshapeOp reshapeWeightOp = ttir_to_ttnn::utils::generateReshape(
-      srcOp.getWeight(), adaptedWeightShape, rewriter);
+      srcOp.getWeight(), adaptedWeightShape, rewriter,
+      ttmlir::utils::appendLocationSuffix(srcOp->getLoc(), "_reshape"));
 
   rewriter.modifyOpInPlace(
       srcOp, [&]() { srcOp.getWeightMutable().assign(reshapeWeightOp); });


### PR DESCRIPTION
### Problem description
When creating a reshape function using generateReshape from utils, the newly created reshape will always inherit the location from the input. This is not always desirable because sometimes we want to reshape the input to a certain operation and inherit the location from that operation, not the input.

This posed a problem when using the Chisle tool for golden verification because Chisle uses locations to track the relationship between ops in the TTNN dialect and the TTIR dialect from which they originated, for which we have custom golden implementations.

### What's changed
Updated the function to accept a location and changed its usage to adhere to the new signature.

### Checklist
- [ ] New/Existing tests provide coverage for changes
