### PR TITLE
[TTNNWorkaround] ConcatOp with one dimensional input tensors

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPRESHAPEREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPRESHAPEREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+// ConcatOp crashes if the inputs are 1 dimensional tensors.
+// tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/22541
+
+// This workaround adds one additional dimension to all the input tensor (using
+// reshape) to make input tensors 2 dimensional and reshaped back after
+// concatenation.
+class ConcatOpReshapeRewritePattern : public OpRewritePattern<ttnn::ConcatOp> {
+public:
+  using OpRewritePattern<ttnn::ConcatOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::ConcatOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPRESHAPEREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/ConcatOpDecompositionRewritePattern.cpp
         Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
+        Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+LogicalResult ConcatOpReshapeRewritePattern::matchAndRewrite(
+    ttnn::ConcatOp srcOp, PatternRewriter &rewriter) const {
+  int64_t dim = srcOp.getDim();
+  mlir::RankedTensorType outputType = srcOp.getResult().getType();
+  int64_t rank = outputType.getRank();
+
+  // Workaround required for 1 dimensional tensors only.
+  if (rank != 1) {
+    return failure();
+  }
+
+  // Apply workaround: reshape inputs by adding an extra dimension.
+  llvm::SmallVector<mlir::Value> reshapedInputs;
+  for (auto input : srcOp.getInputs()) {
+    auto typedInput = dyn_cast<mlir::TypedValue<mlir::RankedTensorType>>(input);
+    llvm::SmallVector<int64_t> newShape(typedInput.getType().getShape());
+    newShape.push_back(1);
+
+    reshapedInputs.push_back(ttir_to_ttnn::utils::generateReshape(
+        typedInput, newShape, rewriter, srcOp.getLoc()));
+  }
+
+  // Create output type with extra dimension.
+  llvm::SmallVector<int64_t> newOutputShape(outputType.getShape());
+  newOutputShape.push_back(1);
+
+  RankedTensorType newOutputType =
+      utils::RankedTensorTypeFactory::create(outputType, newOutputShape);
+
+  // Create new concat op with reshaped inputs and new output type.
+  auto newConcatOp = rewriter.create<ttnn::ConcatOp>(
+      srcOp->getLoc(), newOutputType, reshapedInputs, dim,
+      /*memory_config=*/nullptr);
+
+  // Reshape back to the original output shape.
+  auto result = ttir_to_ttnn::utils::generateReshape(
+      newConcatOp, outputType.getShape(), rewriter, srcOp.getLoc());
+
+  rewriter.replaceOp(srcOp, result);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpDecompositionRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.h"
@@ -671,6 +672,7 @@ public:
       patterns.add<
           TTNNAllReduceWorkarounds, TTNNAllGatherWorkarounds,
           workarounds::decomposition::ConcatOpDecompositionRewritePattern,
+          workarounds::decomposition::ConcatOpReshapeRewritePattern,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::CumSumOpDimRewritePattern,
           workarounds::decomposition::CumSumOpRankRewritePattern,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -25,4 +25,33 @@ module {
     // CHECK-SAME: -> tensor<2x54xsi32
     return %1 : tensor<2x54xsi32>
   }
+
+  func.func public @test_concat_reshape_workaround(%arg0: tensor<53xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xf32>) -> tensor<55xf32> {
+    %0 = ttir.empty() : tensor<55xf32>
+    // CHECK-LABEL: @test_concat_reshape_workaround
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.reshape"(%arg0)
+    // CHECK-SAME: <{shape = [53 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<53xf32,
+    // CHECK-SAME: -> tensor<53x1xf32,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.reshape"(%arg1)
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<1xf32,
+    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK: %[[ARG2:[0-9]+]] = "ttnn.reshape"(%arg2)
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<1xf32,
+    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
+    // CHECK-SAME: {dim = 0 : si32}
+    // CHECK-SAME: tensor<53x1xf32,
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: -> tensor<55x1xf32,
+    %1 = "ttir.concat"(%arg0, %arg1, %arg2, %0) <{dim = 0 : si32}> : (tensor<53xf32>, tensor<1xf32>, tensor<1xf32>, tensor<55xf32>) -> tensor<55xf32>
+    // CHECK: %{{[0-9]+}} = "ttnn.reshape"(%[[CONCAT]])
+    // CHECK-SAME: {shape = [55 : i32]}
+    // CHECK-SAME: tensor<55x1xf32,
+    // CHECK-SAME: -> tensor<55xf32,
+    return %1 : tensor<55xf32>
+  }
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/4425

### Problem description
ttnn::concat op crashes for 1D inputs

### What's changed
Add a reshape workaround for 1D inputs.

### Checklist
- [X] New/Existing tests provide coverage for changes
