### PR TITLE
Add folder for TTNN Reshape Op #4428

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1194,6 +1194,8 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape", [HasMemoryConfigTrait,
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+
+    let hasFolder = 1;
 }
 
 def TTNN_RepeatOp : TTNN_Op<"repeat"> {

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test_ttnn.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test_ttnn.mlir
@@ -1,0 +1,39 @@
+// RUN: ttmlir-opt --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_device_tile_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout_device_tile_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout_device_tile_bf16 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module {
+  // Test case to verify the folding of reshape operation.
+  func.func @identity_reshape(%arg0: tensor<64x128xf32, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile_bf16> {
+    // Verify that we fold the reshape when we reshape to the identical shape.
+    // CHECK-NOT: ttnn.reshape
+    // CHECK: return %arg0 : tensor<64x128xf32, #ttnn_layout>
+    %0 = "ttnn.reshape"(%arg0) <{shape = [64 : i32, 128 : i32]}> : (tensor<64x128xf32, #ttnn_layout_device_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile_bf16>
+    return %0 : tensor<64x128xf32, #ttnn_layout_device_tile_bf16>
+  }
+
+  // Test case to verify consecutive reshape op folding.
+  func.func @consecutive_reshape(%arg0: tensor<64x128xf32, #ttnn_layout_device_tile_f32>) -> tensor<8192xf32, #ttnn_layout_device_tile_f32> {
+    // Verify that we fold two consecutive reshape ops into a single one.
+    // CHECK: ttnn.reshape
+    // CHECK-NOT: ttnn.reshape
+    // CHECK-NEXT: return
+    %0 = "ttnn.reshape"(%arg0) <{shape = [32 : i32, 256 : i32]}> : (tensor<64x128xf32, #ttnn_layout_device_tile_f32>) -> tensor<32x256xf32, #ttnn_layout_device_tile_f32>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32]}> : (tensor<32x256xf32, #ttnn_layout_device_tile_f32>) -> tensor<8192xf32, #ttnn_layout_device_tile_f32>
+    return %1 : tensor<8192xf32, #ttnn_layout_device_tile_f32>
+  }
+
+  // Test case to verify that we do not fold consecutive reshape ops if the first reshape has more than a single use.
+  func.func @consecutive_reshape_multiple_uses(%arg0: tensor<64x128xf32, #ttnn_layout_device_tile_f32>) -> (tensor<8192xf32, #ttnn_layout_device_tile_f32>, tensor<32x256xf32, #ttnn_layout_device_tile_f32>) {
+    // Verify that both reshapes exists.
+    // CHECK: ttnn.reshape
+    // CHECK: ttnn.reshape
+    // CHECK: ttnn.add
+    %0 = "ttnn.reshape"(%arg0) <{shape = [32 : i32, 256 : i32]}> : (tensor<64x128xf32, #ttnn_layout_device_tile_f32>) -> tensor<32x256xf32, #ttnn_layout_device_tile_f32>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32]}> : (tensor<32x256xf32, #ttnn_layout_device_tile_f32>) -> tensor<8192xf32, #ttnn_layout_device_tile_f32>
+    %2 = "ttnn.add"(%0, %0) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<32x256xf32, #ttnn_layout_device_tile_f32>, tensor<32x256xf32, #ttnn_layout_device_tile_f32>) -> tensor<32x256xf32, #ttnn_layout_device_tile_f32>
+    return %1, %2 : tensor<8192xf32, #ttnn_layout_device_tile_f32>, tensor<32x256xf32, #ttnn_layout_device_tile_f32>
+  }
+}


### PR DESCRIPTION
### Ticket
#4428 

### Problem description
TTIR Fusing and TTNN decompositions might create reshape operations that should have been folded. There is reshape op folding in TTIR, but there isn't reshape op folding in TTNN.

### What's changed
Added Reshape Op folding in TTNN and added a test file.

### Checklist
- [X] New/Existing tests provide coverage for changes
