### PR TITLE
[tt-alchemist] Add "--pipeline-options" option to generate APIs

### DIFF
--- a/tools/tt-alchemist/csrc/include/tt_alchemist.hpp
+++ b/tools/tt-alchemist/csrc/include/tt_alchemist.hpp
@@ -36,11 +36,13 @@ public:
 
   // Generate a standalone solution with the generated C++ code
   bool generateCpp(const std::string &input_file, const std::string &output_dir,
-                   bool is_local = true);
+                   bool is_local = true,
+                   const std::string &pipeline_options = "");
 
   // Generate a standalone solution with the generated Python code
   bool generatePython(const std::string &input_file,
-                      const std::string &output_dir, bool is_local = true);
+                      const std::string &output_dir, bool is_local = true,
+                      const std::string &pipeline_options = "");
 
 private:
   TTAlchemist();

--- a/tools/tt-alchemist/csrc/lib/generate_cpp.cpp
+++ b/tools/tt-alchemist/csrc/lib/generate_cpp.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
 #include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
 
@@ -26,7 +27,8 @@ namespace fs = std::filesystem;
 namespace tt::alchemist {
 
 bool TTAlchemist::generateCpp(const std::string &input_file,
-                              const std::string &output_dir, bool is_local) {
+                              const std::string &output_dir, bool is_local,
+                              const std::string &pipeline_options) {
   // Check if input file exists
   //
   if (!fs::exists(input_file)) {
@@ -45,8 +47,34 @@ bool TTAlchemist::generateCpp(const std::string &input_file,
   }
 
   mlir::PassManager pm(&context);
-  mlir::tt::ttnn::createTTIRToEmitCPipeline(
-      pm, mlir::tt::ttnn::TTIRToEmitCPipelineOptions());
+
+  // Parse pipeline options if provided
+  if (!pipeline_options.empty()) {
+    // Use the registered pipeline with options
+    const auto *pipeline =
+        mlir::PassPipelineInfo::lookup("ttir-to-emitc-pipeline");
+    if (!pipeline) {
+      std::cout << "Failed to find ttir-to-emitc-pipeline" << std::endl;
+      return false;
+    }
+
+    std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
+        [](const llvm::Twine &msg) {
+          std::cout << "Pipeline error: " << msg.str() << std::endl;
+          return mlir::failure();
+        };
+
+    if (mlir::failed(
+            pipeline->addToPipeline(pm, pipeline_options, err_handler))) {
+      std::cout << "Failed to add pipeline with options: " << pipeline_options
+                << std::endl;
+      return false;
+    }
+  } else {
+    // Use default options
+    mlir::tt::ttnn::createTTIRToEmitCPipeline(
+        pm, mlir::tt::ttnn::TTIRToEmitCPipelineOptions());
+  }
 
   if (mlir::failed(pm.run(module.get()))) {
     std::cout << "Failed to run TTIR to EmitC pipeline" << std::endl;
@@ -132,10 +160,11 @@ extern "C" {
 // Generate a standalone solution
 bool tt_alchemist_TTAlchemist_generateCpp(void *instance,
                                           const char *input_file,
-                                          const char *output_dir,
-                                          bool is_local) {
+                                          const char *output_dir, bool is_local,
+                                          const char *pipeline_options) {
   auto *alchemist = static_cast<tt::alchemist::TTAlchemist *>(instance);
-  return alchemist->generateCpp(input_file, output_dir, is_local);
+  return alchemist->generateCpp(input_file, output_dir, is_local,
+                                pipeline_options ? pipeline_options : "");
 }
 
 } // extern "C"

--- a/tools/tt-alchemist/csrc/lib/tt_alchemist.cpp
+++ b/tools/tt-alchemist/csrc/lib/tt_alchemist.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
 
 namespace tt::alchemist {
 
@@ -41,6 +42,9 @@ TTAlchemist::TTAlchemist() {
   context.loadDialect<mlir::func::FuncDialect>();
   context.loadDialect<mlir::emitc::EmitCDialect>();
   context.loadDialect<mlir::LLVM::LLVMDialect>();
+
+  // Register TTNN pipelines to make them available for lookup
+  mlir::tt::ttnn::registerTTNNPipelines();
 }
 
 } // namespace tt::alchemist

--- a/tools/tt-alchemist/include/tt-alchemist/tt_alchemist_c_api.hpp
+++ b/tools/tt-alchemist/include/tt-alchemist/tt_alchemist_c_api.hpp
@@ -29,12 +29,14 @@ tt_alchemist_TTAlchemist_modelToPython(void *instance, const char *input_file);
 // Generate a standalone solution
 TT_ALCHEMIST_EXPORT bool
 tt_alchemist_TTAlchemist_generateCpp(void *instance, const char *input_file,
-                                     const char *output_dir, bool is_local);
+                                     const char *output_dir, bool is_local,
+                                     const char *pipeline_options);
 
 // Generate a standalone solution
 TT_ALCHEMIST_EXPORT bool
 tt_alchemist_TTAlchemist_generatePython(void *instance, const char *input_file,
-                                        const char *output_dir, bool is_local);
+                                        const char *output_dir, bool is_local,
+                                        const char *pipeline_options);
 
 #ifdef __cplusplus
 }

--- a/tools/tt-alchemist/python/tt_alchemist/api.py
+++ b/tools/tt-alchemist/python/tt_alchemist/api.py
@@ -52,6 +52,7 @@ class TTAlchemistAPI:
             ctypes.c_char_p,  # input_file
             ctypes.c_char_p,  # output_dir
             ctypes.c_bool,  # is_local
+            ctypes.c_char_p,  # pipeline_options
         ]
         self.lib.tt_alchemist_TTAlchemist_generateCpp.restype = ctypes.c_bool
 
@@ -60,6 +61,7 @@ class TTAlchemistAPI:
             ctypes.c_char_p,  # input_file
             ctypes.c_char_p,  # output_dir
             ctypes.c_bool,  # is_local
+            ctypes.c_char_p,  # pipeline_options
         ]
         self.lib.tt_alchemist_TTAlchemist_generatePython.restype = ctypes.c_bool
 
@@ -107,7 +109,7 @@ class TTAlchemistAPI:
             self.instance_ptr, input_file.encode("utf-8")
         )
 
-    def generate_cpp(self, input_file, output_dir, local=True):
+    def generate_cpp(self, input_file, output_dir, local=True, pipeline_options=""):
         """Generate a solution with the generated C++ code.
 
         This generates a directory with all necessary files to build and run the generated code,
@@ -118,6 +120,7 @@ class TTAlchemistAPI:
             output_dir: Path to the output directory where the solution will be generated.
             local: Whether to generate for local execution (True) or standalone deployment (False).
                    Local mode uses development environment libraries, standalone bundles all dependencies.
+            pipeline_options: Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc').
 
         Returns:
             bool: True if successful, False otherwise.
@@ -127,9 +130,10 @@ class TTAlchemistAPI:
             input_file.encode("utf-8"),
             output_dir.encode("utf-8"),
             local,
+            pipeline_options.encode("utf-8"),
         )
 
-    def generate_python(self, input_file, output_dir, local=True):
+    def generate_python(self, input_file, output_dir, local=True, pipeline_options=""):
         """Generate a solution with the generated Python code.
 
         This generates a directory with all necessary files to build and run the generated code,
@@ -140,6 +144,7 @@ class TTAlchemistAPI:
             output_dir: Path to the output directory where the solution will be generated.
             local: Whether to generate for local execution (True) or standalone deployment (False).
                    Local mode uses development environment libraries, standalone bundles all dependencies.
+            pipeline_options: Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc').
 
         Returns:
             bool: True if successful, False otherwise.
@@ -149,6 +154,7 @@ class TTAlchemistAPI:
             input_file.encode("utf-8"),
             output_dir.encode("utf-8"),
             local,
+            pipeline_options.encode("utf-8"),
         )
 
 
@@ -179,7 +185,7 @@ def model_to_python(input_file):
     return api.model_to_python(input_file)
 
 
-def generate_cpp(input_file, output_dir, local=True):
+def generate_cpp(input_file, output_dir, local=True, pipeline_options=""):
     """Generate a solution with the generated C++ code.
 
     This generates a directory with all necessary files to build and run the generated code,
@@ -190,15 +196,16 @@ def generate_cpp(input_file, output_dir, local=True):
         output_dir: Path to the output directory where the solution will be generated.
         local: Whether to generate for local execution (True) or standalone deployment (False).
                Local mode uses development environment libraries, standalone bundles all dependencies.
+        pipeline_options: Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc').
 
     Returns:
         bool: True if successful, False otherwise.
     """
     api = TTAlchemistAPI.get_instance()
-    return api.generate_cpp(input_file, output_dir, local)
+    return api.generate_cpp(input_file, output_dir, local, pipeline_options)
 
 
-def generate_python(input_file, output_dir, local=True):
+def generate_python(input_file, output_dir, local=True, pipeline_options=""):
     """Generate a solution with the generated Python code.
 
     This generates a directory with all necessary files to build and run the generated code,
@@ -209,9 +216,10 @@ def generate_python(input_file, output_dir, local=True):
         output_dir: Path to the output directory where the solution will be generated.
         local: Whether to generate for local execution (True) or standalone deployment (False).
                Local mode uses development environment libraries, standalone bundles all dependencies.
+        pipeline_options: Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc').
 
     Returns:
         bool: True if successful, False otherwise.
     """
     api = TTAlchemistAPI.get_instance()
-    return api.generate_python(input_file, output_dir, local)
+    return api.generate_python(input_file, output_dir, local, pipeline_options)

--- a/tools/tt-alchemist/python/tt_alchemist/cli.py
+++ b/tools/tt-alchemist/python/tt_alchemist/cli.py
@@ -78,8 +78,13 @@ def model_to_python_cmd(input_file, verbose):
     flag_value="standalone",
     help="Generate for standalone execution",
 )
+@click.option(
+    "--pipeline-options",
+    default="",
+    help="Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc')",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-def generate_cpp_cmd(input_file, output_dir, mode, verbose):
+def generate_cpp_cmd(input_file, output_dir, mode, pipeline_options, verbose):
     """Generate standalone solution with the generated C++ code.
 
     This generates a directory with all necessary files to build and run the
@@ -93,7 +98,7 @@ def generate_cpp_cmd(input_file, output_dir, mode, verbose):
             )
 
         is_local = mode == "local"
-        success = generate_cpp(input_file, output_dir, is_local)
+        success = generate_cpp(input_file, output_dir, is_local, pipeline_options)
         if success:
             click.echo(f"Successfully generated {mode} solution in: {output_dir}")
             return 0
@@ -128,8 +133,13 @@ def generate_cpp_cmd(input_file, output_dir, mode, verbose):
     flag_value="standalone",
     help="Generate for standalone execution",
 )
+@click.option(
+    "--pipeline-options",
+    default="",
+    help="Pipeline options string (e.g., 'enable-optimizer=true system-desc-path=/path/to/desc')",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-def generate_python_cmd(input_file, output_dir, mode, verbose):
+def generate_python_cmd(input_file, output_dir, mode, pipeline_options, verbose):
     """Generate standalone solution with the generated Python code.
 
     This generates a directory with all necessary files to build and run the
@@ -143,7 +153,7 @@ def generate_python_cmd(input_file, output_dir, mode, verbose):
             )
 
         is_local = mode == "local"
-        success = generate_python(input_file, output_dir, is_local)
+        success = generate_python(input_file, output_dir, is_local, pipeline_options)
         if success:
             click.echo(f"Successfully generated {mode} solution in: {output_dir}")
             return 0


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4424

### Problem description
In emitc/emitpy paths, using ttmlir-opt/ttmlir-translate tools directly allows users to specify various pipeline options, like "enable-optimizer=true". Using tt-alchemist, users don't have this option.

### What's changed
Added the option to specify pipeline options via `--pipeline-options` option arg. Both cpp and python paths.

### Checklist
- [ ] New/Existing tests provide coverage for changes
