### PR TITLE
Add quantizable to unaryop interface

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -508,7 +508,7 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where"> {
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, [TwoOperands, TTIR_ElementwiseUnary] # traits> {
+    TTIR_ElementwiseOp<mnemonic, [TwoOperands, TTIR_ElementwiseUnary, TTIR_QuantizableOpInterface] # traits> {
     let summary = "Base class for elementwise operations with one input tensor.";
     let description = [{
       A base class for elementwise operations that apply a unary function to a single input tensor.

--- a/include/ttmlir/Dialect/TTIR/Utils/QuantUtils.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/QuantUtils.h
@@ -131,7 +131,6 @@ inline mlir::quant::QuantizedType computeOutputScalesAndZeroPoint(
     // Check if the weight axis is the same as the required weight axis.
     if (requiredWeightAxis &&
         perAxisType.getQuantizedDimension() != *requiredWeightAxis) {
-      emitError(loc, "Per-axis weight axis must be kernel_output_feature.");
       return nullptr;
     }
     // Check if the number of per-axis weight scales is the same as the required
@@ -139,8 +138,6 @@ inline mlir::quant::QuantizedType computeOutputScalesAndZeroPoint(
     if (requiredAxisSize &&
         static_cast<int64_t>(perAxisType.getScales().size()) !=
             *requiredAxisSize) {
-      emitError(loc,
-                "Number of per-axis weight scales must equal output channels.");
       return nullptr;
     }
 


### PR DESCRIPTION
### Problem description
#4363 included Maximum -> Relu lowering in TTIRFusing which precedes QuantDequantConversion in the TTIR pass pipeline. This required Relu to also possess the QuantizableOpInterface.

### What's changed
Added QuantizableOpInterface to all unary ops (including Relu).
Removed emitError (breaking pipeline) in lieu of sandwich for improper QDQ convolution.
Updated QDQ test to invoke full TTIR -> TTNN pipeline to catch future regressions earlier.
