### PR TITLE
Add conversion from `stablehlo.custom_call(@mhlo.erf)` to `ttir.erf`, add `gelu` fusion pattern

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2550,8 +2550,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto funcName = adaptor.getCallTargetName();
     if (funcName != "mhlo.erf") {
-      return rewriter.notifyMatchFailure(srcOp, "Unsupported function name: " +
-                                                    funcName);
+      return failure();
     }
 
     ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ErfOp>(

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2554,7 +2554,12 @@ public:
     }
 
     if (adaptor.getOperands().size() != 1 || srcOp.getResults().size() != 1) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          srcOp, "Erf op must have exactly one operand and one result. Got " +
+                     std::to_string(adaptor.getOperands().size()) +
+                     " operands "
+                     "and " +
+                     std::to_string(srcOp.getResults().size()) + " results.");
     }
 
     ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ErfOp>(

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2548,7 +2548,7 @@ public:
   matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
                   mlir::stablehlo::CustomCallOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto funcName = adaptor.getCallTargetName();
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
     if (funcName != "mhlo.erf") {
       return failure();
     }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2553,9 +2553,15 @@ public:
       return failure();
     }
 
+    if (adaptor.getOperands().size() != 1 || srcOp.getResults().size() != 1) {
+      return failure();
+    }
+
     ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ErfOp>(
-        rewriter, srcOp, cast<RankedTensorType>(srcOp.getResult(0).getType()),
-        srcOp.getOperand(0));
+        rewriter, srcOp,
+        cast<RankedTensorType>(
+            getTypeConverter()->convertType(srcOp.getResult(0).getType())),
+        adaptor.getOperands()[0]);
 
     return success();
   }

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1388,6 +1388,7 @@ private:
 };
 } // namespace
 
+namespace {
 // This pattern fuses: 0.5 * x * gaussianCDF(x), where gaussian CDF is the
 // cumulative distribution function of a gaussian distribution (or an
 // approximation of one)
@@ -1833,6 +1834,7 @@ private:
     } while (true);
   }
 };
+} // namespace
 
 class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
 public:

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1707,8 +1707,7 @@ private:
       }
 
       APFloat powerValue = dyn_cast<FloatAttr>(power.getFillValue()).getValue();
-      if (powerValue.convertToFloat() - 3.0 > 1.5e-3 ||
-          powerValue.convertToFloat() - 3.0 < -1.5e-3) {
+      if (!checkFloatIsNear(powerValue.convertToFloat(), 3.0)) {
         return nullptr;
       }
 
@@ -1762,7 +1761,7 @@ private:
       return nullptr;
     }
     APFloat value = dyn_cast<FloatAttr>(one.getFillValue()).getValue();
-    if (!value.isExactlyValue(1.0)) {
+    if (!checkFloatIsNear(value.convertToFloat(), 1.0)) {
       return nullptr;
     }
 
@@ -1797,6 +1796,11 @@ private:
     return scalingArgument;
   }
 
+  bool checkFloatIsNear(double value, double trueValue) const {
+    return value / trueValue - 1.0 <= 1.5e-3 &&
+           value / trueValue - 1.0 >= -1.5e-3;
+  }
+
   // This function will return true if the Value 'val' is a FullOp (or the
   // result of tms beginning with a FullOp), with the fill_value near 'scalar'.
   // It allows for a en error of 1.5%
@@ -1804,8 +1808,7 @@ private:
     if (FullOp fullOp = getFullOpThroughTMChain(val)) {
       if (isa<FloatAttr>(fullOp.getFillValue())) {
         APFloat value = dyn_cast<FloatAttr>(fullOp.getFillValue()).getValue();
-        if (value.convertToFloat() / scalar - 1.0 <= 1.5e-3 &&
-            value.convertToFloat() / scalar - 1.0 >= -1.5e-3) {
+        if (checkFloatIsNear(value.convertToFloat(), scalar)) {
           return true;
         }
       }

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1455,6 +1455,7 @@ public:
       // gaussianCDFType is Tanh.
       //     - For now, we will always use the default erf version. This should
       //       be OK as the tanh approximation is incredibly accurate.
+      // https://github.com/tenstorrent/tt-mlir/issues/4486
       (void)gaussianCDFType;
       ttir::utils::replaceOpWithNewDPSOp<ttir::GeluOp>(
           rewriter, op, op.getResult().getType(), geluInput);

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1493,7 +1493,7 @@ private:
   }
 
   // The gaussianCDF will be either 1 + erf(x/sqrt(2)) or 1 +
-  // tanh(2/sqrt(pi) * (x + 0.044715 * x^3)) if gelu approximation is true
+  // tanh(sqrt(2/pi) * (x + 0.044715 * x^3)) if gelu approximation is true
   std::tuple<GaussianCDFType, Value>
   getGaussianCDFTypeAndInput(Value gaussianCDFResult) const {
     if (Value gaussianCDFInput = getErfGaussianCDFInput(gaussianCDFResult)) {
@@ -1507,7 +1507,7 @@ private:
 
   Value getTanhGaussianCDFInput(Value gaussianCDFResult) const {
     // The final op in this pattern must be:
-    // 1 + tanh(2/sqrt(pi) * (x + 0.044715 * x^3))
+    // 1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))
     //   ^ this add
 
     AddOp gaussianCDFAdd = gaussianCDFResult.getDefiningOp<AddOp>();

--- a/test/ttmlir/Conversion/StableHLOToTTIR/unary/erf_mhlo_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/unary/erf_mhlo_op.mlir
@@ -1,0 +1,12 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module @erf_mhlo_op attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+  func.func @main(%arg0: tensor<32x32xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<32x32xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    // CHECK: %[[ERF:.*]] = "ttir.erf"(%arg0
+    // CHECK: return %[[ERF]]
+    %0 = stablehlo.custom_call @mhlo.erf(%arg0) {mhlo.attributes = {}, mhlo.version = 1 : i64} : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %0 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/gelu_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/gelu_fusing.mlir
@@ -1,0 +1,99 @@
+// RUN: ttmlir-opt --canonicalize --ttir-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  module @gelu_erf attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+    func.func @main(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+      // CHECK: %[[GELU:.*]] = "ttir.gelu"(%arg0
+      // CHECK: return %[[GELU]]
+      %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %1 = "ttir.constant"() <{value = dense<7.070310e-01> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %2 = "ttir.constant"() <{value = dense<5.000000e-01> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %3 = ttir.empty() : tensor<32x32xbf16>
+      %4 = "ttir.multiply"(%arg0, %2, %3) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %5 = ttir.empty() : tensor<32x32xbf16>
+      %6 = "ttir.multiply"(%arg0, %1, %5) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %7 = ttir.empty() : tensor<32x32xbf16>
+      %8 = "ttir.erf"(%6, %7) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %9 = ttir.empty() : tensor<32x32xbf16>
+      %10 = "ttir.add"(%8, %0, %9) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %11 = ttir.empty() : tensor<32x32xbf16>
+      %12 = "ttir.multiply"(%4, %10, %11) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      return %12 : tensor<32x32xbf16>
+    }
+  }
+  module @gelu_tanh attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+    func.func @main(%arg0: tensor<32x32xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<32x32xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+      // CHECK: %[[GELU:.*]] = "ttir.gelu"(%arg0
+      // CHECK: return %[[GELU]]
+      %0 = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %1 = "ttir.constant"() <{value = dense<4.467770e-02> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %2 = "ttir.constant"() <{value = dense<7.968750e-01> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %3 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %4 = "ttir.constant"() <{value = dense<5.000000e-01> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+      %5 = ttir.empty() : tensor<32x32xbf16>
+      %6 = "ttir.multiply"(%arg0, %4, %5) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %7 = ttir.empty() : tensor<32x32xbf16>
+      %8 = "ttir.pow"(%arg0, %0, %7) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %9 = ttir.empty() : tensor<32x32xbf16>
+      %10 = "ttir.multiply"(%8, %1, %9) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %11 = ttir.empty() : tensor<32x32xbf16>
+      %12 = "ttir.add"(%arg0, %10, %11) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %13 = ttir.empty() : tensor<32x32xbf16>
+      %14 = "ttir.multiply"(%12, %2, %13) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %15 = ttir.empty() : tensor<32x32xbf16>
+      %16 = "ttir.tanh"(%14, %15) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %17 = ttir.empty() : tensor<32x32xbf16>
+      %18 = "ttir.add"(%16, %3, %17) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %19 = ttir.empty() : tensor<32x32xbf16>
+      %20 = "ttir.multiply"(%6, %18, %19) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      return %20 : tensor<32x32xbf16>
+    }
+  }
+}
+
+module @gelu_tanh2 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+  func.func public @main(%arg0: tensor<32x32xf32> {mhlo.sharding = "{replicated}", ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<32x32xf32> {jax.result_info = "result", ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    // CHECK: %[[GELU:.*]] = "ttir.gelu"(%arg0
+    // CHECK: return %[[GELU]]
+    %0 = "ttir.constant"() <{value = dense<5.000000e-01> : tensor<f32>}> : () -> tensor<f32>
+    %1 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+    %2 = "ttir.constant"() <{value = dense<0.797884583> : tensor<f32>}> : () -> tensor<f32>
+    %3 = "ttir.constant"() <{value = dense<4.471500e-02> : tensor<f32>}> : () -> tensor<f32>
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.multiply"(%arg0, %arg0, %4) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.multiply"(%5, %arg0, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %8 = ttir.empty() : tensor<1x1xf32>
+    %9 = "ttir.reshape"(%3, %8) <{shape = [1 : i32, 1 : i32]}> : (tensor<f32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    %10 = ttir.empty() : tensor<32x32xf32>
+    %11 = "ttir.broadcast"(%9, %10) <{broadcast_dimensions = array<i64: 32, 32>}> : (tensor<1x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %12 = ttir.empty() : tensor<32x32xf32>
+    %13 = "ttir.multiply"(%11, %7, %12) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %14 = ttir.empty() : tensor<32x32xf32>
+    %15 = "ttir.add"(%arg0, %13, %14) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %16 = ttir.empty() : tensor<1x1xf32>
+    %17 = "ttir.reshape"(%2, %16) <{shape = [1 : i32, 1 : i32]}> : (tensor<f32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    %18 = ttir.empty() : tensor<32x32xf32>
+    %19 = "ttir.broadcast"(%17, %18) <{broadcast_dimensions = array<i64: 32, 32>}> : (tensor<1x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %20 = ttir.empty() : tensor<32x32xf32>
+    %21 = "ttir.multiply"(%19, %15, %20) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %22 = ttir.empty() : tensor<32x32xf32>
+    %23 = "ttir.tanh"(%21, %22) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %24 = ttir.empty() : tensor<1x1xf32>
+    %25 = "ttir.reshape"(%1, %24) <{shape = [1 : i32, 1 : i32]}> : (tensor<f32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    %26 = ttir.empty() : tensor<32x32xf32>
+    %27 = "ttir.broadcast"(%25, %26) <{broadcast_dimensions = array<i64: 32, 32>}> : (tensor<1x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %28 = ttir.empty() : tensor<32x32xf32>
+    %29 = "ttir.add"(%27, %23, %28) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %30 = ttir.empty() : tensor<1x1xf32>
+    %31 = "ttir.reshape"(%0, %30) <{shape = [1 : i32, 1 : i32]}> : (tensor<f32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    %32 = ttir.empty() : tensor<32x32xf32>
+    %33 = "ttir.broadcast"(%31, %32) <{broadcast_dimensions = array<i64: 32, 32>}> : (tensor<1x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %34 = ttir.empty() : tensor<32x32xf32>
+    %35 = "ttir.multiply"(%33, %29, %34) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %36 = ttir.empty() : tensor<32x32xf32>
+    %37 = "ttir.multiply"(%arg0, %35, %36) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %37 : tensor<32x32xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
N/a

### Problem description
- torch-xla will provide calls to `erf` in the form `stablehlo.custom_call(@mhlo.erf)`. We do not lower this yet
- Gelu is provided in a multitude of forms. These are some eltwise operations surrounding a call to `erf` or `tanh`

### What's changed
- Lower `stablehlo.custom_call(@mhlo.erf)` to `ttir.erf`
- Add fusion pattern, capable of fusing a few different forms of `gelu` as they are presented from torch-xla and jax
- Add test for SHLO lowering
- Add tests for `gelu` fusion.

**NOTE**: The `erf` based version of `gelu` as it is provided from jax lowers `erf` as a polynomial approximation. Unlike torch-xla which conveniently provides `stablehlo.custom_call(@mhlo.erf)`. tt-xla currently has a monkeypatch to return `gelu` as a composite call, which is lowered properly, thereby bypassing this issue. So, the fusion of the erf polynomial isn't urgent and may not even be necessary. 

### Checklist
- [X] New/Existing tests provide coverage for changes
