### PR TITLE
Adds unit test to validate accurate L1 footprint calculation for large conv2d ops

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1627,12 +1627,9 @@ TEST_F(OpModelTest, Conv2dL1InputDRAMOutput) {
                                               3}; // [top, bottom, left, right]
   const llvm::SmallVector<int32_t> dilation = {1, 1};
   const uint32_t groups = 1;
-  auto conv2dConfig = std::nullopt;
-  // Would be accurate according to debug logs in Resnet,
-  // but gives even more inaccurate results than the default here.
-  //   auto conv2dConfig = Conv2dConfigAttr::get(&context)
-  //                           .withWeightsDtype(ttcore::DataType::BFloat16)
-  //                           .withActivation(builder.getStringAttr("relu"));
+  auto conv2dConfig = Conv2dConfigAttr::get(&context)
+                          .withWeightsDtype(ttcore::DataType::BFloat16)
+                          .withActivation(builder.getStringAttr("relu"));
 
   // Device config
   DeviceComputeKernelConfigAttr deviceConfig =
@@ -1666,10 +1663,10 @@ TEST_F(OpModelTest, Conv2dL1InputDRAMOutput) {
 
     // Current values from ResNet for this conv2d operation:
     // - producerL1OutputUsage: 401408
-    // - cbSize: 233536 (in this test, it's 634944)
+    // - cbSize: 1839168
     // - peakSize: 889048
     // - outputSize: 0 (DRAM output, so no L1 usage)
-    // - l1UsageSize: 1523992 (in this test, it's 1925400)
+    // - l1UsageSize: 3129624
 
     // Memory validation logic from L1InterleavedFallbackAnalysis:
     // bool l1UsageValid = l1UsageSize < tensorL1UsageCap * usableL1CacheSize;


### PR DESCRIPTION
### Problem description
This PR adds a single unit test to simulate a real-world case observed in the first conv2d operation of Resnet benchmark model, where the operation’s overall memory footprint exceeds the L1 cache capacity during compile time.
In this scenario, the input is placed in L1, while the output resides in DRAM, but the intermediate computations still exceed the assumed maximum available L1 size.

The L1 fit calculation logic is described in detail within the test comments. It is important that this check is performed as accurately as possible at compile time, avoiding some of current possibly incorrect assumptions and instead directly using `getOpConstraints` results, to prevent failures later in runtime.
### What's changed
Added a unit test that:
- Mimics a large conv2d operation with L1 input and DRAM output.
- Demonstrates that the total op footprint (input + intermediates) can exceed L1 capacity with current calculations and gives ground to streamline these calculations to be simply a comparison of L1 capacity and one of the results of getOpConstraints.
- Provides guidance for consolidating L1 usage calculation within getOpConstraints for better accuracy and maintainability.

**Note:** The test isn't an exact simulation of the conv2d op that yields described case in running Resnet50, as only the `cbUsage` result of `getOpContraints` is different here compared to the one in the Resnet model, due to still unknown reasons. However in this test, that value is even larger, meaning it would still exceed L1 cache capacity as well as the one it is modeled after.
### Checklist
- [x] No functional changes outside of the new test.
