### PR TITLE
D2M: align up runtime input tensors to 32x32 tiles

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -74,7 +74,8 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
-                      std::uint32_t itemsize, ::tt::target::DataType dataType);
+                      std::uint32_t itemsize, ::tt::target::DataType dataType,
+                      const bool alignToTiles);
 
 // Creates multi-device host tensor with owned storage (buffers of the tensor
 // are on the host and their allocation/deallocation is owned by this tensor
@@ -99,9 +100,11 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize);
 
 inline ::tt::runtime::Tensor createOwnedHostTensor(const void *data,
-                                                   const TensorDesc &desc) {
+                                                   const TensorDesc &desc,
+                                                   const bool alignToTiles) {
   return ::tt::runtime::ttnn::createOwnedHostTensor(
-      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType,
+      alignToTiles);
 }
 
 inline ::tt::runtime::Tensor createBorrowedHostTensor(void *data,
@@ -192,7 +195,8 @@ void wait(const std::vector<::tt::runtime::Tensor> &tensors,
 
 std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
                                           bool untilize = false,
-                                          bool blocking = true);
+                                          bool blocking = true,
+                                          bool unalignToTiles = false);
 
 ::tt::runtime::Tensor toLayout(::tt::runtime::Tensor tensor, Device device,
                                Layout layout,

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -67,7 +67,8 @@ Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,
                              std::uint32_t itemsize,
-                             ::tt::target::DataType dataType);
+                             ::tt::target::DataType dataType,
+                             const bool alignToTiles);
 
 // Creates multi-device host tensor with owned storage (buffers of the tensor
 // are on the host and their allocation/deallocation is owned by this tensor
@@ -98,9 +99,11 @@ inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
                                                  desc.itemsize, desc.dataType);
 }
 
-inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
+inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc,
+                                    const bool alignToTiles) {
   return ::tt::runtime::createOwnedHostTensor(data, desc.shape, desc.stride,
-                                              desc.itemsize, desc.dataType);
+                                              desc.itemsize, desc.dataType,
+                                              alignToTiles);
 }
 
 inline Tensor createMultiDeviceHostTensor(
@@ -175,7 +178,7 @@ void wait(const std::vector<Tensor> &tensors,
 // Copies device tensor data to host tensor with owned storage, with option to
 // untilize data.
 std::vector<Tensor> toHost(Tensor tensor, bool untilize = false,
-                           bool blocking = true);
+                           bool blocking = true, bool unalignToTiles = false);
 
 Tensor toLayout(Tensor tensor, Device device, Layout layout,
                 std::optional<bool> retain = std::nullopt);

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -403,7 +403,7 @@ Flatbuffer Flatbuffer::loadFromPath(const char *path) {
   LOG_ASSERT(fbb.is_open(), "Failed to open file: ", path);
   std::streampos size = fbb.tellg();
   fbb.seekg(0, std::ios::beg);
-  auto buffer = ::tt::runtime::utils::malloc_shared(size);
+  auto buffer = ::tt::runtime::utils::mallocShared(size);
   fbb.read(static_cast<char *>(buffer.get()), size);
   return Flatbuffer(buffer);
 }
@@ -412,7 +412,7 @@ Flatbuffer Flatbuffer::loadFromMemory(const void *memory, size_t size) {
   // load a flatbuffer from memory
   LOG_ASSERT(memory != nullptr, "Memory pointer is null");
   LOG_ASSERT(size > 0, "Size must be greater than zero");
-  auto buffer = ::tt::runtime::utils::malloc_shared(size);
+  auto buffer = ::tt::runtime::utils::mallocShared(size);
   std::memcpy(buffer.get(), memory, size);
   return Flatbuffer(buffer);
 }

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -245,7 +245,7 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
   }
   uint8_t *buf = fbb.GetBufferPointer();
   auto size = fbb.GetSize();
-  auto handle = ::tt::runtime::utils::malloc_shared(size);
+  auto handle = ::tt::runtime::utils::mallocShared(size);
   std::memcpy(handle.get(), buf, size);
   return std::make_unique<::tt::runtime::SystemDesc>(handle);
 }

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -195,18 +195,19 @@ Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,
                              std::uint32_t itemsize,
-                             ::tt::target::DataType dataType) {
+                             ::tt::target::DataType dataType,
+                             const bool alignToTiles) {
   using RetType = Tensor;
   LOG_ASSERT(itemsize > 0);
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType {
-        return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
-                                                          itemsize, dataType);
+        return ::tt::runtime::ttnn::createOwnedHostTensor(
+            data, shape, stride, itemsize, dataType, alignToTiles);
       },
       [&]() -> RetType {
         return ::tt::runtime::ttmetal::createOwnedHostTensor(
-            data, TensorDesc(shape, stride, itemsize, dataType));
+            data, TensorDesc(shape, stride, itemsize, dataType), alignToTiles);
       });
 }
 
@@ -586,15 +587,18 @@ void wait(const std::vector<Tensor> &tensors, std::optional<uint8_t> cqId) {
       [&]() { ::tt::runtime::ttmetal::wait(tensors, cqId); });
 }
 
-std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
+std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking,
+                           bool unalignToTiles) {
   using RetType = std::vector<Tensor>;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType {
-        return ::tt::runtime::ttnn::toHost(tensor, untilize, blocking);
+        return ::tt::runtime::ttnn::toHost(tensor, untilize, blocking,
+                                           unalignToTiles);
       },
       [&]() -> RetType {
-        return ::tt::runtime::ttmetal::toHost(tensor, untilize, blocking);
+        return ::tt::runtime::ttmetal::toHost(tensor, untilize, blocking,
+                                              unalignToTiles);
       });
 }
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -231,7 +231,8 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
-                      std::uint32_t itemsize, ::tt::target::DataType dataType) {
+                      std::uint32_t itemsize, ::tt::target::DataType dataType,
+                      const bool alignToTiles) {
 
   ::tt::runtime::Tensor tensor = utils::createRuntimeTensorFromTTNN(
       createOwnedTTNNTensor(data, shape, stride, itemsize, dataType));
@@ -284,7 +285,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   std::transform(data.begin(), data.end(), std::back_inserter(tensorShards),
                  [&](const void *dataShard) -> ::tt::runtime::Tensor {
                    return createOwnedHostTensor(dataShard, shape, stride,
-                                                itemsize, dataType);
+                                                itemsize, dataType, false);
                  });
   return createMultiDeviceHostTensor(tensorShards, strategy, meshShape);
 }
@@ -747,7 +748,8 @@ void wait(const std::vector<::tt::runtime::Tensor> &tensors,
 }
 
 std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
-                                          bool untilize, bool blocking) {
+                                          bool untilize, bool blocking,
+                                          bool /*unalignToTiles*/) {
   const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper =
       tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN);
 

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -51,7 +51,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def_ro("shape", &tt::runtime::TensorDesc::shape)
       .def_ro("stride", &tt::runtime::TensorDesc::stride)
       .def_ro("item_size", &tt::runtime::TensorDesc::itemsize)
-      .def_ro("dtype", &tt::runtime::TensorDesc::dataType);
+      .def_ro("dtype", &tt::runtime::TensorDesc::dataType)
+      .def_ro("physical_shape_2D", &tt::runtime::TensorDesc::physicalShape2D);
 
   nb::class_<tt::runtime::MeshDeviceOptions>(m, "MeshDeviceOptions")
       .def(nb::init<>())
@@ -246,11 +247,13 @@ void registerRuntimeBindings(nb::module_ &m) {
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-         ::tt::target::DataType dataType) {
+         ::tt::target::DataType dataType, const bool alignToTiles = false) {
         return tt::runtime::createOwnedHostTensor(
             reinterpret_cast<const void *>(ptr), shape, stride, itemsize,
-            dataType);
+            dataType, alignToTiles);
       },
+      nb::arg("ptr"), nb::arg("shape"), nb::arg("stride"), nb::arg("itemsize"),
+      nb::arg("dataType"), nb::arg("alignToTiles") = false,
       "Create a tensor with owned memory");
   m.def(
       "create_empty_tensor",
@@ -306,7 +309,7 @@ void registerRuntimeBindings(nb::module_ &m) {
         nb::arg("mesh_device"), nb::arg("mesh_shape"), "Reshape a mesh device");
   m.def("to_host", &tt::runtime::toHost, nb::arg("tensor"),
         nb::arg("untilize") = false, nb::arg("blocking") = true,
-        "Copy the tensor to host");
+        nb::arg("unalign_to_tiles") = false, "Copy the tensor to host");
   m.def("to_layout", &tt::runtime::toLayout, nb::arg("tensor"),
         nb::arg("device"), nb::arg("layout"), nb::arg("retain") = nb::none(),
         "Create a copy of the tensor with the specified layout");

--- a/runtime/test/ttnn/python/device_agnostic/test_runtime_api.py
+++ b/runtime/test/ttnn/python/device_agnostic/test_runtime_api.py
@@ -10,6 +10,7 @@ from ttrt.common.util import *
 from ..utils import Helper, DeviceContext, assert_pcc, get_runtime_tensor_from_torch
 
 
+# TODO(wenbinlyuTT): create a TTMetal equivalent?
 @pytest.mark.parametrize("shape", [(64, 128)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_tensor_buffer_api(shape, dtype):

--- a/test/python/golden/test_metal_layout.py
+++ b/test/python/golden/test_metal_layout.py
@@ -46,13 +46,13 @@ def test_to_layout(
     ):
         to_device = builder.to_layout(
             in0,
-            output_type=builder.get_metal_tensor_layout(shape),
+            output_type=builder.get_metal_tensor_layout(shape, tiled=True),
             unit_attrs=unit_attrs,
             loc="to_device",
         )
         reblock = builder.to_layout(
             in0,
-            output_type=builder.get_metal_tensor_layout(shape),
+            output_type=builder.get_metal_tensor_layout(shape, tiled=True),
             unit_attrs=unit_attrs,
             loc="reblock",
         )

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2437,6 +2437,40 @@ def test_ternary_eltwise_ops_implicit_broadcast(
 
 
 @pytest.mark.parametrize(
+    "shape",
+    [
+        (5, 3),
+        (32, 1),
+        (31, 7),
+        (1, 32),
+        (13, 29),
+        (64, 1),
+        (61, 3),
+        (61, 37),
+        (1, 64),
+        (5, 67),
+        (43, 67),
+        (1, 3, 5),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_add_unaligned_shapes(shape: Shape, dtype: torch.dtype, target: str, request):
+    pipeline_options = []
+    compile_ttir_to_flatbuffer(
+        add,
+        [shape, shape],
+        [dtype, dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        pipeline_options=pipeline_options,
+    )
+
+
+@pytest.mark.parametrize(
     "test_fn,inputs_shapes,inputs_dtypes",
     [
         (transpose, [(64, 32)], None),

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -55,8 +55,9 @@ class TTIRBuilder(Builder):
 
         if tiled:
             elemType = ttcore.ir.TileType.get(ctx, 32, 32, ttcore.DataType.Float32)
-            device_shape[-2] //= 32
-            device_shape[-1] //= 32
+            # Use ceil-division so small shapes still allocate at least 1 tile.
+            device_shape[-2] = (device_shape[-2] + 31) // 32
+            device_shape[-1] = (device_shape[-1] + 31) // 32
 
         return RankedTensorType.get(
             device_shape, elemType, layout, Location.unknown(ctx)


### PR DESCRIPTION
### Ticket
Related-To: #3013 #3014 #3015 #3023

### Problem description
Currently when we pass a tensor from the runtime, its elements are assumed to be densely packed into a flat row-major storage.
This means that elements of a tensor with a non-tile-aligned shape end up in completely wrong locations in the DRAM and thus the CB.
Additionally, for tile-level broadcast and some other ops, zero-padding is required in the last two dimensions if they are not already tile-aligned.

### What's changed
- Core idea: implement the 'calling convention' that the input/output `Tensor`s of the executor are 32x32 tile-aligned zero-padded in the last two dimensions, and the decision of padding/unpadding is manually made where the runtime interfaces with torch etc.
- In `ttrt run`, detect if an input tensor needs padding and an output needs unpadding.
- Alignment & padding happens when `createOwnedHostTensor` is called, a bigger buffer is allocated and the original densely-packed data will be copied over according to an aligned physical 2D shape.
- Unpadding happens when `toHost` is called, it's the inverse of the padding step described above.
- Added a simple golden test that ensures the addition of irregular shapes work.

### Known issues
- This change isn't compatible with CPU hoisted ops yet, currently aligning & padding is disabled for the hoisted ops tests.
- Tensors over 2D doesn't work yet.

### Checklist
- [ ] New/Existing tests provide coverage for changes