### PR TITLE
Merge Conv2dConfig structures

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_CONV2DCONFIGPARAMS_H
+#define TTMLIR_DIALECT_TTNN_UTILS_CONV2DCONFIGPARAMS_H
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn {
+
+// Forward declaration
+class Conv2dConfigAttr;
+
+/// Unified configuration parameters for Conv2d operations.
+/// This class serves dual purposes:
+/// 1. As a mutable helper for Conv2dConfigAttr (immutable MLIR attribute)
+/// 2. As a flexible override container for selective parameter overriding
+///
+/// All fields are std::optional to support partial configuration and selective
+/// overrides.
+struct Conv2dConfigParams {
+  std::optional<ttcore::DataType> weightsDtype = std::nullopt;
+  std::optional<std::string> activation = std::nullopt;
+  std::optional<bool> deallocateActivation = std::nullopt;
+  std::optional<bool> reallocateHaloOutput = std::nullopt;
+  std::optional<uint32_t> actBlockHOverride = std::nullopt;
+  std::optional<uint32_t> actBlockWDiv = std::nullopt;
+  std::optional<bool> reshardIfNotOptimal = std::nullopt;
+  std::optional<bool> overrideShardingConfig = std::nullopt;
+  std::optional<TensorMemoryLayout> shardLayout = std::nullopt;
+  std::optional<CoreRangeSetAttr> coreGrid = std::nullopt;
+  std::optional<bool> transposeShards = std::nullopt;
+  std::optional<Layout> outputLayout = std::nullopt;
+  std::optional<bool> enableActDoubleBuffer = std::nullopt;
+  std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
+  std::optional<bool> enableSplitReader = std::nullopt;
+  std::optional<bool> inPlace = std::nullopt;
+
+  // Default constructor - all fields nullopt
+  Conv2dConfigParams() = default;
+
+  // Constructor from Conv2dConfigAttr (for mutability helper use case)
+  Conv2dConfigParams(const Conv2dConfigAttr &attr, bool partial = true);
+
+  // Constructor from another Conv2dConfigParams (for override merging)
+  Conv2dConfigParams(const Conv2dConfigParams &base,
+                     const Conv2dConfigParams &overrides);
+
+  // Conversion method to build MLIR attribute
+  Conv2dConfigAttr buildConv2dConfigAttr(::mlir::MLIRContext *ctx) const;
+
+  // Override application - merge another set of parameters into this one
+  void applyOverrides(const Conv2dConfigParams &overrides);
+
+  /// Check if all fields are unset (empty configuration)
+  bool empty() const {
+    return !weightsDtype.has_value() && !activation.has_value() &&
+           !deallocateActivation.has_value() &&
+           !reallocateHaloOutput.has_value() &&
+           !actBlockHOverride.has_value() && !actBlockWDiv.has_value() &&
+           !reshardIfNotOptimal.has_value() &&
+           !overrideShardingConfig.has_value() && !shardLayout.has_value() &&
+           !coreGrid.has_value() && !transposeShards.has_value() &&
+           !outputLayout.has_value() && !enableActDoubleBuffer.has_value() &&
+           !enableWeightsDoubleBuffer.has_value() &&
+           !enableSplitReader.has_value() && !inPlace.has_value();
+  }
+
+  /// Check if all fields are set (complete configuration)
+  bool fullConfigOverride() const {
+    return weightsDtype.has_value() && activation.has_value() &&
+           deallocateActivation.has_value() &&
+           reallocateHaloOutput.has_value() && actBlockHOverride.has_value() &&
+           actBlockWDiv.has_value() && reshardIfNotOptimal.has_value() &&
+           overrideShardingConfig.has_value() && shardLayout.has_value() &&
+           coreGrid.has_value() && transposeShards.has_value() &&
+           outputLayout.has_value() && enableActDoubleBuffer.has_value() &&
+           enableWeightsDoubleBuffer.has_value() &&
+           enableSplitReader.has_value() && inPlace.has_value();
+  }
+
+  // Individual field check methods
+  bool hasWeightsDtype() const { return weightsDtype.has_value(); }
+  bool hasActivation() const {
+    return activation.has_value() && activation.value() != "";
+  }
+  bool hasDeallocateActivation() const {
+    return deallocateActivation.has_value();
+  }
+  bool hasReallocateHaloOutput() const {
+    return reallocateHaloOutput.has_value();
+  }
+  bool hasActBlockHOverride() const { return actBlockHOverride.has_value(); }
+  bool hasActBlockWDiv() const { return actBlockWDiv.has_value(); }
+  bool hasReshardIfNotOptimal() const {
+    return reshardIfNotOptimal.has_value();
+  }
+  bool hasOverrideShardingConfig() const {
+    return overrideShardingConfig.has_value();
+  }
+  bool hasShardLayout() const { return shardLayout.has_value(); }
+  bool hasCoreGrid() const { return coreGrid.has_value(); }
+  bool hasTransposeShards() const { return transposeShards.has_value(); }
+  bool hasOutputLayout() const { return outputLayout.has_value(); }
+  bool hasEnableActDoubleBuffer() const {
+    return enableActDoubleBuffer.has_value();
+  }
+  bool hasEnableWeightsDoubleBuffer() const {
+    return enableWeightsDoubleBuffer.has_value();
+  }
+  bool hasEnableSplitReader() const { return enableSplitReader.has_value(); }
+  bool hasInPlace() const { return inPlace.has_value(); }
+
+  // Stream operator for debugging/logging
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const Conv2dConfigParams &params) {
+    os << "weights_dtype#" << params.weightsDtype << ":activation#"
+       << params.activation << ":deallocate_activation#"
+       << params.deallocateActivation << ":reallocate_halo_output#"
+       << params.reallocateHaloOutput << ":act_block_h_override#"
+       << params.actBlockHOverride << ":act_block_w_div#" << params.actBlockWDiv
+       << ":reshard_if_not_optimal#" << params.reshardIfNotOptimal
+       << ":override_sharding_config#" << params.overrideShardingConfig
+       << ":shard_layout#" << params.shardLayout << ":core_grid#"
+       << params.coreGrid << ":transpose_shards#" << params.transposeShards
+       << ":output_layout#" << params.outputLayout
+       << ":enable_act_double_buffer#" << params.enableActDoubleBuffer
+       << ":enable_weights_double_buffer#" << params.enableWeightsDoubleBuffer
+       << ":enable_split_reader#" << params.enableSplitReader << ":in_place#"
+       << params.inPlace;
+    return os;
+  }
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_UTILS_CONV2DCONFIGPARAMS_H

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h"
 
 #include "llvm/Support/CommandLine.h"
 
@@ -32,66 +33,7 @@ struct OptionNames {
   static constexpr StringRef tuplifyInputIfEmpty = "tuplify-input-if-empty";
 };
 
-struct Conv2dConfigOverrideParams {
-  std::optional<ttcore::DataType> weightsDtype = std::nullopt;
-  std::optional<std::string> activation = std::nullopt;
-  std::optional<bool> deallocateActivation = std::nullopt;
-  std::optional<bool> reallocateHaloOutput = std::nullopt;
-  std::optional<uint32_t> actBlockHOverride = std::nullopt;
-  std::optional<uint32_t> actBlockWDiv = std::nullopt;
-  std::optional<bool> reshardIfNotOptimal = std::nullopt;
-  std::optional<bool> overrideShardingConfig = std::nullopt;
-  std::optional<TensorMemoryLayout> shardLayout = std::nullopt;
-  std::optional<CoreRangeSetAttr> coreGrid = std::nullopt;
-  std::optional<bool> transposeShards = std::nullopt;
-  std::optional<Layout> outputLayout = std::nullopt;
-  std::optional<bool> enableActDoubleBuffer = std::nullopt;
-  std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
-  std::optional<bool> enableSplitReader = std::nullopt;
-
-  bool empty() const {
-    return !weightsDtype.has_value() && !activation.has_value() &&
-           !deallocateActivation.has_value() &&
-           !reallocateHaloOutput.has_value() &&
-           !actBlockHOverride.has_value() && !actBlockWDiv.has_value() &&
-           !reshardIfNotOptimal.has_value() &&
-           !overrideShardingConfig.has_value() && !shardLayout.has_value() &&
-           !coreGrid.has_value() && !transposeShards.has_value() &&
-           !outputLayout.has_value() && !enableActDoubleBuffer.has_value() &&
-           !enableWeightsDoubleBuffer.has_value() &&
-           !enableSplitReader.has_value();
-  }
-
-  bool fullConfigOverride() const {
-    return weightsDtype.has_value() && activation.has_value() &&
-           deallocateActivation.has_value() &&
-           reallocateHaloOutput.has_value() && actBlockHOverride.has_value() &&
-           actBlockWDiv.has_value() && reshardIfNotOptimal.has_value() &&
-           overrideShardingConfig.has_value() && shardLayout.has_value() &&
-           coreGrid.has_value() && transposeShards.has_value() &&
-           outputLayout.has_value() && enableActDoubleBuffer.has_value() &&
-           enableWeightsDoubleBuffer.has_value() &&
-           enableSplitReader.has_value();
-  }
-
-  friend llvm::raw_ostream &
-  operator<<(llvm::raw_ostream &os, const Conv2dConfigOverrideParams &params) {
-    os << "weights_dtype#" << params.weightsDtype << ":activation#"
-       << params.activation << ":deallocate_activation#"
-       << params.deallocateActivation << ":reallocate_halo_output#"
-       << params.reallocateHaloOutput << ":act_block_h_override#"
-       << params.actBlockHOverride << ":act_block_w_div#" << params.actBlockWDiv
-       << ":reshard_if_not_optimal#" << params.reshardIfNotOptimal
-       << ":override_sharding_config#" << params.overrideShardingConfig
-       << ":shard_layout#" << params.shardLayout << ":core_grid#"
-       << params.coreGrid << ":transpose_shards#" << params.transposeShards
-       << ":output_layout#" << params.outputLayout
-       << ":enable_act_double_buffer#" << params.enableActDoubleBuffer
-       << ":enable_weights_double_buffer#" << params.enableWeightsDoubleBuffer
-       << ":enable_split_reader#" << params.enableSplitReader;
-    return os;
-  }
-};
+using Conv2dConfigOverrideParams = Conv2dConfigParams;
 
 struct OutputLayoutOverrideParams {
   std::optional<SmallVector<int64_t, 2>> grid = std::nullopt;

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/Utils/CoreRangeSet.h"
+#include "ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
@@ -728,95 +729,6 @@ bool CoreRangeAttr::intersects(CoreRangeAttr other) const {
   return ::llvm::success();
 }
 
-// MLIR attributes are immutable, so we can't just modify arbitrary param of
-// Conv2dConfigAttr. Instead iwe will use this struct to store the params and
-// build a new Conv2dConfigAttr.
-struct Conv2dConfigAttrParams {
-  std::optional<mlir::tt::ttcore::DataType> weightsDtype;
-  mlir::StringAttr activation;
-  mlir::BoolAttr deallocateActivation;
-  mlir::BoolAttr reallocateHaloOutput;
-  std::optional<uint32_t> actBlockHOverride;
-  std::optional<uint32_t> actBlockWDiv;
-  mlir::BoolAttr reshardIfNotOptimal;
-  mlir::BoolAttr overrideShardingConfig;
-  std::optional<TensorMemoryLayout> shardLayout;
-  CoreRangeSetAttr coreGrid;
-  mlir::BoolAttr transposeShards;
-  std::optional<Layout> outputLayout;
-  mlir::BoolAttr enableActDoubleBuffer;
-  mlir::BoolAttr enableWeightsDoubleBuffer;
-  mlir::BoolAttr enableSplitReader;
-  mlir::BoolAttr inPlace;
-
-  Conv2dConfigAttrParams() = delete;
-
-private:
-  template <typename T>
-  std::optional<T> getOrDefaultOpt(std::optional<T> attr, T defaultValue,
-                                   bool partial) {
-    return attr.has_value()
-               ? attr.value()
-               : (partial ? std::nullopt : std::optional<T>(defaultValue));
-  }
-
-  mlir::BoolAttr getOrDefaultBool(mlir::BoolAttr attr, mlir::MLIRContext *ctx,
-                                  bool partial = true,
-                                  bool defaultValue = false) {
-    return attr ? attr
-                : (partial ? nullptr : mlir::BoolAttr::get(ctx, defaultValue));
-  }
-
-public:
-  // Constructor for Conv2dConfigAttrParams. Takes a Conv2dConfigAttr copies its
-  // properties into the struct. If a property is not set and partial is true,
-  // the property will be set to null. If a property is not set and partial is
-  // false, the property will be set to the default value.
-  Conv2dConfigAttrParams(Conv2dConfigAttr attr, bool partial = true) {
-    mlir::MLIRContext *ctx = attr.getContext();
-
-    weightsDtype = getOrDefaultOpt(
-        attr.getWeightsDtype(), mlir::tt::ttcore::DataType::BFloat16, partial);
-    activation = attr.getActivation()
-                     ? attr.getActivation()
-                     : (partial ? nullptr : mlir::StringAttr::get(ctx, ""));
-    deallocateActivation =
-        getOrDefaultBool(attr.getDeallocateActivation(), ctx, partial);
-    reallocateHaloOutput = getOrDefaultBool(attr.getReallocateHaloOutput(), ctx,
-                                            partial, /*defaultValue=*/true);
-    actBlockHOverride =
-        getOrDefaultOpt<uint32_t>(attr.getActBlockHOverride(), 0, partial);
-    actBlockWDiv =
-        getOrDefaultOpt<uint32_t>(attr.getActBlockWDiv(), 1, partial);
-    reshardIfNotOptimal =
-        getOrDefaultBool(attr.getReshardIfNotOptimal(), ctx, partial);
-    overrideShardingConfig =
-        getOrDefaultBool(attr.getOverrideShardingConfig(), ctx, partial);
-    shardLayout = getOrDefaultOpt(attr.getShardLayout(),
-                                  TensorMemoryLayout::HeightSharded, partial);
-    coreGrid = attr.getCoreGrid() ? attr.getCoreGrid() : CoreRangeSetAttr{};
-    transposeShards = getOrDefaultBool(attr.getTransposeShards(), ctx, partial);
-    outputLayout =
-        getOrDefaultOpt(attr.getOutputLayout(), Layout::Tile, partial);
-    enableActDoubleBuffer =
-        getOrDefaultBool(attr.getEnableActDoubleBuffer(), ctx, partial);
-    enableWeightsDoubleBuffer =
-        getOrDefaultBool(attr.getEnableWeightsDoubleBuffer(), ctx, partial);
-    enableSplitReader =
-        getOrDefaultBool(attr.getEnableSplitReader(), ctx, partial);
-    inPlace = getOrDefaultBool(attr.getInPlace(), ctx, partial);
-  }
-
-  Conv2dConfigAttr buildConv2dConfig(mlir::MLIRContext *ctx) const {
-    return Conv2dConfigAttr::get(
-        ctx, weightsDtype, activation, deallocateActivation,
-        reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
-        reshardIfNotOptimal, overrideShardingConfig, shardLayout, coreGrid,
-        transposeShards, outputLayout, enableActDoubleBuffer,
-        enableWeightsDoubleBuffer, enableSplitReader, inPlace);
-  }
-};
-
 // Returns empty configuration.
 Conv2dConfigAttr Conv2dConfigAttr::getEmpty(::mlir::MLIRContext *context) {
   return Conv2dConfigAttr::get(context,
@@ -841,108 +753,108 @@ Conv2dConfigAttr Conv2dConfigAttr::getEmpty(::mlir::MLIRContext *context) {
 // Returns default configuration.
 Conv2dConfigAttr Conv2dConfigAttr::get(::mlir::MLIRContext *context) {
   Conv2dConfigAttr convConfig = getEmpty(context);
-  return Conv2dConfigAttrParams(convConfig, /*partial=*/false)
-      .buildConv2dConfig(context);
+  return Conv2dConfigParams(convConfig, /*partial=*/false)
+      .buildConv2dConfigAttr(context);
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withActivation(StringRef activation) const {
-  Conv2dConfigAttrParams params(*this);
-  params.activation = StringAttr::get(getContext(), activation);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.activation = activation.str();
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr
 Conv2dConfigAttr::withWeightsDtype(mlir::tt::ttcore::DataType dtype) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.weightsDtype = dtype;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withDeallocateActivation(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.deallocateActivation = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.deallocateActivation = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withReallocateHaloOutput(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.reallocateHaloOutput = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.reallocateHaloOutput = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withActBlockHOverride(uint32_t value) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.actBlockHOverride = value;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withActBlockWDiv(uint32_t value) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.actBlockWDiv = value;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withReshardIfNotOptimal(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.reshardIfNotOptimal = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.reshardIfNotOptimal = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr
 Conv2dConfigAttr::withOverrideShardingConfig(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.overrideShardingConfig = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.overrideShardingConfig = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr
 Conv2dConfigAttr::withShardLayout(TensorMemoryLayout layout) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.shardLayout = layout;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withCoreGrid(CoreRangeSetAttr grid) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.coreGrid = grid;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withTransposeShards(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.transposeShards = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.transposeShards = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withOutputLayout(Layout layout) const {
-  Conv2dConfigAttrParams params(*this);
+  Conv2dConfigParams params(*this);
   params.outputLayout = layout;
-  return params.buildConv2dConfig(getContext());
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withEnableActDoubleBuffer(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.enableActDoubleBuffer = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.enableActDoubleBuffer = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr
 Conv2dConfigAttr::withEnableWeightsDoubleBuffer(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.enableWeightsDoubleBuffer = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.enableWeightsDoubleBuffer = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withEnableSplitReader(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.enableSplitReader = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.enableSplitReader = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 Conv2dConfigAttr Conv2dConfigAttr::withInPlace(bool value) const {
-  Conv2dConfigAttrParams params(*this);
-  params.inPlace = BoolAttr::get(getContext(), value);
-  return params.buildConv2dConfig(getContext());
+  Conv2dConfigParams params(*this);
+  params.inPlace = value;
+  return params.buildConv2dConfigAttr(getContext());
 }
 
 bool Conv2dConfigAttr::hasActivation() const {

--- a/lib/Dialect/TTNN/Utils/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(TTMLIRTTNNUtils
+  Conv2dConfigParams.cpp
   OptimizerOverrides.cpp
   OptimizerUtils.cpp
   PassOverrides.cpp

--- a/lib/Dialect/TTNN/Utils/Conv2dConfigParams.cpp
+++ b/lib/Dialect/TTNN/Utils/Conv2dConfigParams.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h"
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+namespace mlir::tt::ttnn {
+
+Conv2dConfigParams::Conv2dConfigParams(const Conv2dConfigAttr &attr,
+                                       bool partial) {
+  auto getOrDefaultOpt =
+      [partial](auto value,
+                auto defaultValue) -> std::optional<decltype(defaultValue)> {
+    return value.has_value()
+               ? value.value()
+               : (partial
+                      ? std::nullopt
+                      : std::optional<decltype(defaultValue)>(defaultValue));
+  };
+
+  auto getOrDefaultBool =
+      [partial](mlir::BoolAttr attr) -> std::optional<bool> {
+    return attr ? std::optional<bool>(attr.getValue())
+                : (partial ? std::nullopt : std::optional<bool>(false));
+  };
+
+  auto getOrDefaultString =
+      [partial](mlir::StringAttr attr) -> std::optional<std::string> {
+    return attr ? std::optional<std::string>(attr.getValue().str())
+                : (partial ? std::nullopt : std::optional<std::string>(""));
+  };
+
+  weightsDtype = getOrDefaultOpt(attr.getWeightsDtype(),
+                                 mlir::tt::ttcore::DataType::BFloat16);
+  activation = getOrDefaultString(attr.getActivation());
+  deallocateActivation = getOrDefaultBool(attr.getDeallocateActivation());
+  reallocateHaloOutput = getOrDefaultBool(attr.getReallocateHaloOutput());
+  actBlockHOverride = getOrDefaultOpt(attr.getActBlockHOverride(), uint32_t(0));
+  actBlockWDiv = getOrDefaultOpt(attr.getActBlockWDiv(), uint32_t(1));
+  reshardIfNotOptimal = getOrDefaultBool(attr.getReshardIfNotOptimal());
+  overrideShardingConfig = getOrDefaultBool(attr.getOverrideShardingConfig());
+  shardLayout =
+      getOrDefaultOpt(attr.getShardLayout(), TensorMemoryLayout::HeightSharded);
+  coreGrid = attr.getCoreGrid()
+                 ? std::optional<CoreRangeSetAttr>(attr.getCoreGrid())
+                 : std::nullopt;
+  transposeShards = getOrDefaultBool(attr.getTransposeShards());
+  outputLayout = getOrDefaultOpt(attr.getOutputLayout(), Layout::Tile);
+  enableActDoubleBuffer = getOrDefaultBool(attr.getEnableActDoubleBuffer());
+  enableWeightsDoubleBuffer =
+      getOrDefaultBool(attr.getEnableWeightsDoubleBuffer());
+  enableSplitReader = getOrDefaultBool(attr.getEnableSplitReader());
+  inPlace = getOrDefaultBool(attr.getInPlace());
+}
+
+Conv2dConfigParams::Conv2dConfigParams(const Conv2dConfigParams &base,
+                                       const Conv2dConfigParams &overrides) {
+  // Copy base values first, then apply overrides
+  *this = base;
+  applyOverrides(overrides);
+}
+
+Conv2dConfigAttr
+Conv2dConfigParams::buildConv2dConfigAttr(::mlir::MLIRContext *ctx) const {
+  auto toStringAttr =
+      [ctx](const std::optional<std::string> &str) -> mlir::StringAttr {
+    return str.has_value() ? mlir::StringAttr::get(ctx, str.value()) : nullptr;
+  };
+
+  auto toBoolAttr = [ctx](const std::optional<bool> &b) -> mlir::BoolAttr {
+    return b.has_value() ? mlir::BoolAttr::get(ctx, b.value()) : nullptr;
+  };
+
+  return Conv2dConfigAttr::get(
+      ctx, weightsDtype, toStringAttr(activation),
+      toBoolAttr(deallocateActivation), toBoolAttr(reallocateHaloOutput),
+      actBlockHOverride, actBlockWDiv, toBoolAttr(reshardIfNotOptimal),
+      toBoolAttr(overrideShardingConfig), shardLayout,
+      coreGrid.has_value() ? coreGrid.value() : CoreRangeSetAttr{},
+      toBoolAttr(transposeShards), outputLayout,
+      toBoolAttr(enableActDoubleBuffer), toBoolAttr(enableWeightsDoubleBuffer),
+      toBoolAttr(enableSplitReader), toBoolAttr(inPlace));
+}
+
+void Conv2dConfigParams::applyOverrides(const Conv2dConfigParams &overrides) {
+  if (overrides.weightsDtype.has_value()) {
+    weightsDtype = overrides.weightsDtype;
+  }
+  if (overrides.activation.has_value()) {
+    activation = overrides.activation;
+  }
+  if (overrides.deallocateActivation.has_value()) {
+    deallocateActivation = overrides.deallocateActivation;
+  }
+  if (overrides.reallocateHaloOutput.has_value()) {
+    reallocateHaloOutput = overrides.reallocateHaloOutput;
+  }
+  if (overrides.actBlockHOverride.has_value()) {
+    actBlockHOverride = overrides.actBlockHOverride;
+  }
+  if (overrides.actBlockWDiv.has_value()) {
+    actBlockWDiv = overrides.actBlockWDiv;
+  }
+  if (overrides.reshardIfNotOptimal.has_value()) {
+    reshardIfNotOptimal = overrides.reshardIfNotOptimal;
+  }
+  if (overrides.overrideShardingConfig.has_value()) {
+    overrideShardingConfig = overrides.overrideShardingConfig;
+  }
+  if (overrides.shardLayout.has_value()) {
+    shardLayout = overrides.shardLayout;
+  }
+  if (overrides.coreGrid.has_value()) {
+    coreGrid = overrides.coreGrid;
+  }
+  if (overrides.transposeShards.has_value()) {
+    transposeShards = overrides.transposeShards;
+  }
+  if (overrides.outputLayout.has_value()) {
+    outputLayout = overrides.outputLayout;
+  }
+  if (overrides.enableActDoubleBuffer.has_value()) {
+    enableActDoubleBuffer = overrides.enableActDoubleBuffer;
+  }
+  if (overrides.enableWeightsDoubleBuffer.has_value()) {
+    enableWeightsDoubleBuffer = overrides.enableWeightsDoubleBuffer;
+  }
+  if (overrides.enableSplitReader.has_value()) {
+    enableSplitReader = overrides.enableSplitReader;
+  }
+  if (overrides.inPlace.has_value()) {
+    inPlace = overrides.inPlace;
+  }
+}
+
+} // namespace mlir::tt::ttnn


### PR DESCRIPTION
### Ticket
Closes #3452

### Problem description

Currently we have multiple classes that store Conv2dConfig parameters:
- `Conv2dConfigAttr`
- `Conv2dConfigAttrParams`
- `Conv2dConfigOverrideParams`

First one is an immutable MLIR attribute and should not be changed.
Second one is a helper class used to overcome the immutability of the MLIR attribute when setting individual parameters.
Third one is a class for storing and parsing Conv2dConfig overrides.

Functionalities of second and third class can be merged into a single class. 

### What's changed
Merged `Conv2dConfigAttrParams` and `Conv2dConfigOverrideParams` classes into a single class called `Conv2dConfigParams` that has the functionality of both classes.