### PR TITLE
Add constraints API for most binary composite ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -628,7 +628,9 @@ def TTNN_LogicalXorOp : TTNN_ElementwiseBinaryOp<"logical_xor"> {
     }];
 }
 
-def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_and"> {
+def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_and",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise bitwise AND.";
     let description = [{
         Performs element-wise bitwise AND of two tensors `lhs` and `rhs`
@@ -642,7 +644,9 @@ def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_and"> {
     }];
 }
 
-def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_or"> {
+def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_or",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise bitwise OR.";
     let description = [{
         Performs element-wise bitwise OR of two tensors `lhs` and `rhs`
@@ -656,7 +660,9 @@ def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_or"> {
     }];
 }
 
-def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_xor"> {
+def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_xor",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise bitwise XOR.";
     let description = [{
         Performs element-wise bitwise XOR of two tensors `lhs` and `rhs`
@@ -715,7 +721,9 @@ def TTNN_RemainderOp : TTNN_ElementwiseBinaryCompositeOp<"remainder"> {
     }];
 }
 
-def TTNN_PowOp : TTNN_ElementwiseBinaryCompositeOp<"pow"> {
+def TTNN_PowOp : TTNN_ElementwiseBinaryCompositeOp<"pow",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise power OP.";
     let description = [{
       Performs element-wise exponentiation of lhs tensor by rhs tensor and produces a
@@ -732,7 +740,9 @@ def TTNN_PowOp : TTNN_ElementwiseBinaryCompositeOp<"pow"> {
     }];
 }
 
-def TTNN_Atan2Op :  TTNN_ElementwiseBinaryCompositeOp<"atan2"> {
+def TTNN_Atan2Op :  TTNN_ElementwiseBinaryCompositeOp<"atan2",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise atan2 OP.";
     let description = [{
       Performs element-wise atan2 operation on lhs and rhs tensor and produces a result

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -259,11 +259,10 @@ template <>
 struct OpModel<BitwiseXorOp> : BinaryCompositeOpModel<BitwiseXorOp> {};
 
 template <>
-struct OpModel<Atan2Op> : BinaryCompositeOpModel<Atan2Op> {}; // TEMPORARY
+struct OpModel<Atan2Op> : BinaryCompositeOpModel<Atan2Op> {};
 
 template <>
-struct OpModel<RemainderOp> : BinaryCompositeOpModel<RemainderOp> {
-}; // TEMPORARY
+struct OpModel<RemainderOp> : BinaryCompositeOpModel<RemainderOp> {};
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -188,6 +188,19 @@ struct BinaryEltwiseOpModel {
                TTNNLayoutAttr outputLayout);
 };
 
+template <typename OpT>
+struct BinaryBitwiseOpModel {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+      TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+      TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+               TTNNLayoutAttr outputLayout);
+};
+
 template <>
 struct OpModel<AddOp> : BinaryEltwiseOpModel<AddOp> {};
 
@@ -232,6 +245,24 @@ struct OpModel<LogicalOrOp> : BinaryEltwiseOpModel<LogicalOrOp> {};
 
 template <>
 struct OpModel<LogicalXorOp> : BinaryEltwiseOpModel<LogicalXorOp> {};
+
+template <>
+struct OpModel<PowOp> : BinaryEltwiseOpModel<PowOp> {};
+
+template <>
+struct OpModel<BitwiseAndOp> : BinaryBitwiseOpModel<BitwiseAndOp> {};
+
+template <>
+struct OpModel<BitwiseOrOp> : BinaryBitwiseOpModel<BitwiseOrOp> {};
+
+template <>
+struct OpModel<BitwiseXorOp> : BinaryBitwiseOpModel<BitwiseXorOp> {};
+
+template <>
+struct OpModel<Atan2Op> : BinaryBitwiseOpModel<Atan2Op> {}; // TEMPORARY
+
+template <>
+struct OpModel<RemainderOp> : BinaryBitwiseOpModel<RemainderOp> {}; // TEMPORARY
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -189,7 +189,7 @@ struct BinaryEltwiseOpModel {
 };
 
 template <typename OpT>
-struct BinaryBitwiseOpModel {
+struct BinaryCompositeOpModel {
   static llvm::Expected<OpConstraints> getOpConstraints(
       ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
       TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
@@ -250,19 +250,20 @@ template <>
 struct OpModel<PowOp> : BinaryEltwiseOpModel<PowOp> {};
 
 template <>
-struct OpModel<BitwiseAndOp> : BinaryBitwiseOpModel<BitwiseAndOp> {};
+struct OpModel<BitwiseAndOp> : BinaryCompositeOpModel<BitwiseAndOp> {};
 
 template <>
-struct OpModel<BitwiseOrOp> : BinaryBitwiseOpModel<BitwiseOrOp> {};
+struct OpModel<BitwiseOrOp> : BinaryCompositeOpModel<BitwiseOrOp> {};
 
 template <>
-struct OpModel<BitwiseXorOp> : BinaryBitwiseOpModel<BitwiseXorOp> {};
+struct OpModel<BitwiseXorOp> : BinaryCompositeOpModel<BitwiseXorOp> {};
 
 template <>
-struct OpModel<Atan2Op> : BinaryBitwiseOpModel<Atan2Op> {}; // TEMPORARY
+struct OpModel<Atan2Op> : BinaryCompositeOpModel<Atan2Op> {}; // TEMPORARY
 
 template <>
-struct OpModel<RemainderOp> : BinaryBitwiseOpModel<RemainderOp> {}; // TEMPORARY
+struct OpModel<RemainderOp> : BinaryCompositeOpModel<RemainderOp> {
+}; // TEMPORARY
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -261,9 +261,6 @@ struct OpModel<BitwiseXorOp> : BinaryCompositeOpModel<BitwiseXorOp> {};
 template <>
 struct OpModel<Atan2Op> : BinaryCompositeOpModel<Atan2Op> {};
 
-template <>
-struct OpModel<RemainderOp> : BinaryCompositeOpModel<RemainderOp> {};
-
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -712,6 +712,102 @@ MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// BitwiseAndOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+BitwiseAndOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+BitwiseAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// BitwiseOrOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+BitwiseOrOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+BitwiseOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// BitwiseXorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+BitwiseXorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+BitwiseXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Atan2Op - TTNN Op Model Interface - TEMPORARY
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+Atan2Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// RemainderOp - TTNN Op Model Interface - TEMPORARY
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+RemainderOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+RemainderOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// PowOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+PowOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+}
+
+llvm::Expected<size_t>
+PowOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
 // DivideOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -776,22 +776,6 @@ Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// RemainderOp - TTNN Op Model Interface - TEMPORARY
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-RemainderOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
-}
-
-llvm::Expected<size_t>
-RemainderOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getBinaryOpRuntime(*this, inputs, opConfig);
-}
-
-//===----------------------------------------------------------------------===//
 // PowOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -297,8 +297,6 @@ auto getOpSymbol() {
     return ::ttnn::bitwise_xor;
   } else if constexpr (std::is_same_v<OpTy, Atan2Op>) {
     return ::ttnn::atan2;
-  } else if constexpr (std::is_same_v<OpTy, RemainderOp>) {
-    return ::ttnn::remainder;
   } else if constexpr (std::is_same_v<OpTy, PowOp>) {
     return ::ttnn::pow;
   } else if constexpr (std::is_same_v<OpTy, WhereOp>) {
@@ -1065,7 +1063,6 @@ template struct BinaryCompositeOpModel<BitwiseAndOp>;
 template struct BinaryCompositeOpModel<BitwiseOrOp>;
 template struct BinaryCompositeOpModel<BitwiseXorOp>;
 template struct BinaryCompositeOpModel<Atan2Op>;
-template struct BinaryCompositeOpModel<RemainderOp>;
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -289,6 +289,18 @@ auto getOpSymbol() {
     return ::ttnn::maximum;
   } else if constexpr (std::is_same_v<OpTy, MinimumOp>) {
     return ::ttnn::minimum;
+  } else if constexpr (std::is_same_v<OpTy, BitwiseAndOp>) {
+    return ::ttnn::bitwise_and;
+  } else if constexpr (std::is_same_v<OpTy, BitwiseOrOp>) {
+    return ::ttnn::bitwise_or;
+  } else if constexpr (std::is_same_v<OpTy, BitwiseXorOp>) {
+    return ::ttnn::bitwise_xor;
+  } else if constexpr (std::is_same_v<OpTy, Atan2Op>) { // CHECK --PENDING
+    return ::ttnn::atan2;
+  } else if constexpr (std::is_same_v<OpTy, RemainderOp>) { // CHECK --PENDING
+    return ::ttnn::remainder;
+  } else if constexpr (std::is_same_v<OpTy, PowOp>) {
+    return ::ttnn::pow;
   } else if constexpr (std::is_same_v<OpTy, WhereOp>) {
     return ::ttnn::where;
   } else if constexpr (std::is_same_v<OpTy, MeanOp>) {
@@ -952,6 +964,85 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+template <typename OpTy>
+llvm::Expected<OpConstraints> BinaryBitwiseOpModel<OpTy>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
+    TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
+                                               device, inputSpecA, inputSpecB,
+                                               outputMemoryConfig);
+  };
+
+  return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
+                                     query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+template <typename OpTy>
+llvm::Expected<size_t> BinaryBitwiseOpModel<OpTy>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_runtime(detail::getOpSymbol<OpTy>(), device,
+                                           inputSpecA, inputSpecB,
+                                           outputMemoryConfig);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
 // Explicit template instantiation for BinaryEltwiseOpModel.
 template struct BinaryEltwiseOpModel<AddOp>;
 template struct BinaryEltwiseOpModel<MultiplyOp>;
@@ -968,6 +1059,13 @@ template struct BinaryEltwiseOpModel<LessThanOp>;
 template struct BinaryEltwiseOpModel<LogicalAndOp>;
 template struct BinaryEltwiseOpModel<LogicalOrOp>;
 template struct BinaryEltwiseOpModel<LogicalXorOp>;
+template struct BinaryEltwiseOpModel<PowOp>;
+// Bitwise Ops
+template struct BinaryBitwiseOpModel<BitwiseAndOp>;
+template struct BinaryBitwiseOpModel<BitwiseOrOp>;
+template struct BinaryBitwiseOpModel<BitwiseXorOp>;
+template struct BinaryBitwiseOpModel<Atan2Op>;
+template struct BinaryBitwiseOpModel<RemainderOp>;
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -295,9 +295,9 @@ auto getOpSymbol() {
     return ::ttnn::bitwise_or;
   } else if constexpr (std::is_same_v<OpTy, BitwiseXorOp>) {
     return ::ttnn::bitwise_xor;
-  } else if constexpr (std::is_same_v<OpTy, Atan2Op>) { // CHECK --PENDING
+  } else if constexpr (std::is_same_v<OpTy, Atan2Op>) {
     return ::ttnn::atan2;
-  } else if constexpr (std::is_same_v<OpTy, RemainderOp>) { // CHECK --PENDING
+  } else if constexpr (std::is_same_v<OpTy, RemainderOp>) {
     return ::ttnn::remainder;
   } else if constexpr (std::is_same_v<OpTy, PowOp>) {
     return ::ttnn::pow;
@@ -965,7 +965,7 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
 }
 
 template <typename OpTy>
-llvm::Expected<OpConstraints> BinaryBitwiseOpModel<OpTy>::getOpConstraints(
+llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
     TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout) {
@@ -1005,7 +1005,7 @@ llvm::Expected<OpConstraints> BinaryBitwiseOpModel<OpTy>::getOpConstraints(
 }
 
 template <typename OpTy>
-llvm::Expected<size_t> BinaryBitwiseOpModel<OpTy>::getOpRuntime(
+llvm::Expected<size_t> BinaryCompositeOpModel<OpTy>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout) {
@@ -1060,12 +1060,12 @@ template struct BinaryEltwiseOpModel<LogicalAndOp>;
 template struct BinaryEltwiseOpModel<LogicalOrOp>;
 template struct BinaryEltwiseOpModel<LogicalXorOp>;
 template struct BinaryEltwiseOpModel<PowOp>;
-// Bitwise Ops
-template struct BinaryBitwiseOpModel<BitwiseAndOp>;
-template struct BinaryBitwiseOpModel<BitwiseOrOp>;
-template struct BinaryBitwiseOpModel<BitwiseXorOp>;
-template struct BinaryBitwiseOpModel<Atan2Op>;
-template struct BinaryBitwiseOpModel<RemainderOp>;
+// BinaryCompositeOpModel
+template struct BinaryCompositeOpModel<BitwiseAndOp>;
+template struct BinaryCompositeOpModel<BitwiseOrOp>;
+template struct BinaryCompositeOpModel<BitwiseXorOp>;
+template struct BinaryCompositeOpModel<Atan2Op>;
+template struct BinaryCompositeOpModel<RemainderOp>;
 
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -885,9 +885,12 @@ protected:
     if (expectedLegal) {
       const auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
           constraintsExp.get();
-      EXPECT_EQ(cbSize, expectedCbSize);
-      EXPECT_EQ(peakSize, expectedPeakSize);
-      EXPECT_EQ(outputSize, expectedOutputSize);
+
+      bool useGreaterThan =
+          std::is_same_v<OpTy, Atan2Op> || std::is_same_v<OpTy, RemainderOp>;
+      EXPECT_EQ_OR_GE(cbSize, expectedCbSize, useGreaterThan);
+      EXPECT_EQ_OR_GE(peakSize, expectedPeakSize, useGreaterThan);
+      EXPECT_EQ_OR_GE(outputSize, expectedOutputSize, useGreaterThan);
       ExpectLayoutsEQ(outputLayout, outputLayoutReadBack);
     } else {
       // Must clean up the error

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1087,6 +1087,20 @@ generateBinaryBitwiseParams(std::initializer_list<BinaryEltwiseParam> values,
   return ::testing::ValuesIn(newValues);
 }
 
+::testing::internal::ParamGenerator<BinaryEltwiseParam>
+generateBinaryEltwiseParamsSameLayout(
+    std::initializer_list<BinaryEltwiseParam> values) {
+  std::vector<BinaryEltwiseParam> newValues;
+  for (const auto &v : values) {
+    newValues.emplace_back(v);
+    if ((newValues.back().inputA.layout != newValues.back().inputB.layout) ||
+        (newValues.back().inputA.layout != newValues.back().output.layout)) {
+      newValues.back().expectedResult.expectedLegal = false;
+    }
+  }
+  return ::testing::ValuesIn(newValues);
+}
+
 INSTANTIATE_TEST_SUITE_P(AddTests, OpModelAddParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));
 
@@ -1145,14 +1159,13 @@ INSTANTIATE_TEST_SUITE_P(BitwiseOrTests, OpModelBitwiseOrParam,
 INSTANTIATE_TEST_SUITE_P(BitwiseXorTests, OpModelBitwiseXorParam,
                          generateBinaryBitwiseParams(binaryEltwiseParams));
 
-INSTANTIATE_TEST_SUITE_P(Atan2Tests, OpModelAtan2Param,
-                         generateBinaryEltwiseParams(
-                             binaryEltwiseParams, /*extraCbRequirement=*/4096));
+INSTANTIATE_TEST_SUITE_P(
+    Atan2Tests, OpModelAtan2Param,
+    generateBinaryEltwiseParamsSameLayout(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(
     RemainderTests, OpModelRemainderParam,
-    generateBinaryEltwiseParams(binaryEltwiseParams,
-                                /*extraCbRequirement=*/20480));
+    generateBinaryEltwiseParamsSameLayout(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(PowTests, OpModelPowParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -903,6 +903,51 @@ protected:
       llvm::consumeError(runtimeExp.takeError());
     }
   }
+
+  void RunTestInt32() {
+    const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
+                inputVirtualGridA] = GetParam().inputA;
+    const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
+                inputVirtualGridB] = GetParam().inputB;
+    const auto [outputShape, outputTensorLayout, outputBufferType,
+                outputVirtualGrid] = GetParam().output;
+    const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+                expectedOutputSize] = GetParam().expectedResult;
+
+    const TTNNLayoutAttr inputLayoutA = CreateTiledLayoutInt32(
+        inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
+    const TTNNLayoutAttr inputLayoutB = CreateTiledLayoutInt32(
+        inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
+    const TTNNLayoutAttr outputLayout = CreateTiledLayoutInt32(
+        outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+    auto constraintsExp = OpModel<OpTy>::getOpConstraints(
+        CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB,
+        inputLayoutB, outputLayout);
+    // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+    // which llvm::Expected<T> does not have
+    EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+    if (expectedLegal) {
+      const auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
+          constraintsExp.get();
+      EXPECT_EQ(cbSize, expectedCbSize);
+      EXPECT_EQ(peakSize, expectedPeakSize);
+      EXPECT_EQ(outputSize, expectedOutputSize);
+      ExpectLayoutsEQ(outputLayout, outputLayoutReadBack);
+    } else {
+      // Must clean up the error
+      llvm::consumeError(constraintsExp.takeError());
+    }
+
+    llvm::Expected<size_t> runtimeExp = OpModel<OpTy>::getOpRuntime(
+        inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout);
+    EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+    if (expectedLegal) {
+      EXPECT_TRUE(runtimeExp.get() > 0);
+    } else {
+      llvm::consumeError(runtimeExp.takeError());
+    }
+  }
 };
 
 // Type aliases for binary operations
@@ -921,6 +966,12 @@ using OpModelLessThanParam = OpModelBinaryEltwiseParam<LessThanOp>;
 using OpModelLogicalAndParam = OpModelBinaryEltwiseParam<LogicalAndOp>;
 using OpModelLogicalOrParam = OpModelBinaryEltwiseParam<LogicalOrOp>;
 using OpModelLogicalXorParam = OpModelBinaryEltwiseParam<LogicalXorOp>;
+using OpModelPowParam = OpModelBinaryEltwiseParam<PowOp>;
+using OpModelBitwiseAndParam = OpModelBinaryEltwiseParam<BitwiseAndOp>;
+using OpModelBitwiseOrParam = OpModelBinaryEltwiseParam<BitwiseOrOp>;
+using OpModelBitwiseXorParam = OpModelBinaryEltwiseParam<BitwiseXorOp>;
+using OpModelAtan2Param = OpModelBinaryEltwiseParam<Atan2Op>;
+using OpModelRemainderParam = OpModelBinaryEltwiseParam<RemainderOp>;
 
 TEST_P(OpModelAddParam, AddOp) { RunTest(); }
 TEST_P(OpModelMultiplyParam, MultiplyOp) { RunTest(); }
@@ -937,6 +988,12 @@ TEST_P(OpModelLessThanParam, LessThanOp) { RunTest(); }
 TEST_P(OpModelLogicalAndParam, LogicalAndOp) { RunTest(); }
 TEST_P(OpModelLogicalOrParam, LogicalOrOp) { RunTest(); }
 TEST_P(OpModelLogicalXorParam, LogicalXorOp) { RunTest(); }
+TEST_P(OpModelBitwiseAndParam, BitwiseAndOp) { RunTestInt32(); }
+TEST_P(OpModelBitwiseOrParam, BitwiseOrOp) { RunTestInt32(); }
+TEST_P(OpModelBitwiseXorParam, BitwiseXorOp) { RunTestInt32(); }
+TEST_P(OpModelAtan2Param, Atan2Op) { RunTest(); }
+TEST_P(OpModelRemainderParam, RemainderOp) { RunTest(); }
+TEST_P(OpModelPowParam, PowOp) { RunTest(); }
 
 const std::initializer_list<BinaryEltwiseParam> binaryEltwiseParams = {
     {detail::interleavedN300X1024Dram, detail::interleavedN300X1024Dram,
@@ -1016,6 +1073,20 @@ generateBinaryEltwiseParams(std::initializer_list<BinaryEltwiseParam> values,
   return ::testing::ValuesIn(newValues);
 }
 
+::testing::internal::ParamGenerator<BinaryEltwiseParam>
+generateBinaryBitwiseParams(std::initializer_list<BinaryEltwiseParam> values,
+                            std::size_t extraCbRequirement = 0) {
+  // Memory requirements for bitwise ops are 2x compared to other binary ops
+  std::vector<BinaryEltwiseParam> newValues;
+  for (const auto &v : values) {
+    newValues.emplace_back(v);
+    newValues.back().expectedResult.expectedCbSize *= 2;
+    newValues.back().expectedResult.expectedPeakSize *= 2;
+    newValues.back().expectedResult.expectedOutputSize *= 2;
+  }
+  return ::testing::ValuesIn(newValues);
+}
+
 INSTANTIATE_TEST_SUITE_P(AddTests, OpModelAddParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));
 
@@ -1064,6 +1135,27 @@ INSTANTIATE_TEST_SUITE_P(LogicalOrTests, OpModelLogicalOrParam,
 INSTANTIATE_TEST_SUITE_P(LogicalXorTests, OpModelLogicalXorParam,
                          generateBinaryEltwiseParams(
                              binaryEltwiseParams, /*extraCbRequirement=*/4096));
+
+INSTANTIATE_TEST_SUITE_P(BitwiseAndTests, OpModelBitwiseAndParam,
+                         generateBinaryBitwiseParams(binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(BitwiseOrTests, OpModelBitwiseOrParam,
+                         generateBinaryBitwiseParams(binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(BitwiseXorTests, OpModelBitwiseXorParam,
+                         generateBinaryBitwiseParams(binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(Atan2Tests, OpModelAtan2Param,
+                         generateBinaryEltwiseParams(
+                             binaryEltwiseParams, /*extraCbRequirement=*/4096));
+
+INSTANTIATE_TEST_SUITE_P(
+    RemainderTests, OpModelRemainderParam,
+    generateBinaryEltwiseParams(binaryEltwiseParams,
+                                /*extraCbRequirement=*/20480));
+
+INSTANTIATE_TEST_SUITE_P(PowTests, OpModelPowParam,
+                         generateBinaryEltwiseParams(binaryEltwiseParams));
 
 // ==== Binary Eltwise Ops Ends ====
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -886,8 +886,7 @@ protected:
       const auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
           constraintsExp.get();
 
-      bool useGreaterThan =
-          std::is_same_v<OpTy, Atan2Op> || std::is_same_v<OpTy, RemainderOp>;
+      bool useGreaterThan = std::is_same_v<OpTy, Atan2Op>;
       EXPECT_EQ_OR_GE(cbSize, expectedCbSize, useGreaterThan);
       EXPECT_EQ_OR_GE(peakSize, expectedPeakSize, useGreaterThan);
       EXPECT_EQ_OR_GE(outputSize, expectedOutputSize, useGreaterThan);
@@ -974,7 +973,6 @@ using OpModelBitwiseAndParam = OpModelBinaryEltwiseParam<BitwiseAndOp>;
 using OpModelBitwiseOrParam = OpModelBinaryEltwiseParam<BitwiseOrOp>;
 using OpModelBitwiseXorParam = OpModelBinaryEltwiseParam<BitwiseXorOp>;
 using OpModelAtan2Param = OpModelBinaryEltwiseParam<Atan2Op>;
-using OpModelRemainderParam = OpModelBinaryEltwiseParam<RemainderOp>;
 
 TEST_P(OpModelAddParam, AddOp) { RunTest(); }
 TEST_P(OpModelMultiplyParam, MultiplyOp) { RunTest(); }
@@ -995,7 +993,6 @@ TEST_P(OpModelBitwiseAndParam, BitwiseAndOp) { RunTestInt32(); }
 TEST_P(OpModelBitwiseOrParam, BitwiseOrOp) { RunTestInt32(); }
 TEST_P(OpModelBitwiseXorParam, BitwiseXorOp) { RunTestInt32(); }
 TEST_P(OpModelAtan2Param, Atan2Op) { RunTest(); }
-TEST_P(OpModelRemainderParam, RemainderOp) { RunTest(); }
 TEST_P(OpModelPowParam, PowOp) { RunTest(); }
 
 const std::initializer_list<BinaryEltwiseParam> binaryEltwiseParams = {
@@ -1164,10 +1161,6 @@ INSTANTIATE_TEST_SUITE_P(BitwiseXorTests, OpModelBitwiseXorParam,
 
 INSTANTIATE_TEST_SUITE_P(
     Atan2Tests, OpModelAtan2Param,
-    generateBinaryEltwiseParamsSameLayout(binaryEltwiseParams));
-
-INSTANTIATE_TEST_SUITE_P(
-    RemainderTests, OpModelRemainderParam,
     generateBinaryEltwiseParamsSameLayout(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(PowTests, OpModelPowParam,

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -517,10 +517,6 @@ const auto createMin = [](OpBuilder &b, Location l, Type t, ValueRange r) {
 const auto createAtan2 = [](OpBuilder &b, Location l, Type t, ValueRange r) {
   return b.create<Atan2Op>(l, t, r).getOperation();
 };
-const auto createRemainder = [](OpBuilder &b, Location l, Type t,
-                                ValueRange r) {
-  return b.create<RemainderOp>(l, t, r).getOperation();
-};
 const auto createPow = [](OpBuilder &b, Location l, Type t, ValueRange r) {
   return b.create<PowOp>(l, t, r).getOperation();
 };
@@ -556,10 +552,7 @@ const std::vector<BinaryOpTestParams> binaryOpTestParams = {
     {"LogicalXor", createXor, binaryExpected_extraCb4096},
     {"Maximum", createMax, binaryExpected},
     {"Minimum", createMin, binaryExpected},
-    {"Atan2", createAtan2,
-     binaryExpected_extraCb4096_extraPeak30720}, // PENDING
-    {"Remainder", createRemainder,
-     binaryExpected_extraCb20480_extraPeak26624}, // PENDING
+    {"Atan2", createAtan2, binaryExpected_extraCb4096_extraPeak30720},
     {"Pow", createPow, binaryExpected}};
 
 // Define the test parameters for binary bitwise operations

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -584,48 +584,6 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.testName;
     });
 
-/*TEST_F(OpModelBase, BitwiseAndOpInterface) {
-  // create BitwiseAndOp
-  llvm::SmallVector<int64_t> tensorShapeA = {workerCoresN300, 1024};
-  llvm::SmallVector<int64_t> tensorShapeB = {workerCoresN300, 1024};
-
-  auto inputLayoutA = CreateTiledLayoutInt32(tensorShapeA, BufferType::DRAM,
-                                       TensorMemoryLayout::Interleaved);
-  auto inputLayoutB = CreateTiledLayoutInt32(tensorShapeB, BufferType::DRAM,
-                                       TensorMemoryLayout::Interleaved);
-  auto outputLayout = CreateTiledLayoutInt32(tensorShapeA, BufferType::DRAM,
-                                       TensorMemoryLayout::Interleaved);
-
-  auto inputA = createEmptyTensor(tensorShapeA, builder.getI32Type(),
-inputLayoutA); auto inputB = createEmptyTensor(tensorShapeB,
-builder.getI32Type(), inputLayoutB); auto outputType =
-createRankedTensorType(tensorShapeA, builder.getI32Type(), outputLayout);
-
-  auto bitwiseAnd =
-      builder.create<BitwiseAndOp>(builder.getUnknownLoc(), outputType,
-                                 mlir::ValueRange{inputA, inputB});
-
-  // test BitwiseAndOp interface using the created layouts
-  OpModel backend = dyn_cast<OpModel>(bitwiseAnd.getOperation());
-  auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(bitwiseAnd),
-OpConfig(outputLayout));
-
-  ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  auto constraints = constraintsExp.get();
-  EXPECT_EQ(constraints.cbL1PeakSize, 24576);
-  EXPECT_EQ(constraints.tensorL1PeakSize, 0);
-  EXPECT_EQ(constraints.outputL1BufferSize, 0);
-
-  auto runtimeExp = getOpRuntime(bitwiseAnd.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << "Runtime test failed for BitwiseAnd; Error="
-           << llvm::toString(runtimeExp.takeError());
-  }
-}*/
-
 // Separate test for BitwiseNot with integer data types
 TEST_F(OpModelBase, BitwiseNotOpInterface) {
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -463,8 +463,6 @@ const ExpectedResult binaryExpected_extraCb2048{true, 12288 + 2048, 2048, 2048};
 const ExpectedResult binaryExpected_extraCb4096{true, 12288 + 4096, 2048, 2048};
 const ExpectedResult binaryExpected_extraCb4096_extraPeak30720{
     true, 12288 + 4096, 2048 + 30720, 2048};
-const ExpectedResult binaryExpected_extraCb20480_extraPeak26624{
-    true, 12288 + 20480, 2048 + 26624, 2048};
 const ExpectedResult binaryBitwiseExpected{true, 12288 * 2, 0, 0};
 
 //===---------------------------------------------------------===


### PR DESCRIPTION
### Ticket
#4196 

Added constraints for `BitwiseAnd`, `BitwiseOr`, `BitwiseXor`, `Pow`, `Atan2`.
