### PR TITLE
Fix slice_sizes update logic in UpdateGlobalToLocalShapes pass

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
@@ -87,6 +87,14 @@ llvm::SmallVector<mlir::sdy::TensorShardingAttr>
 getOutShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
                     mlir::sdy::MeshOp &globalMeshOp);
 
+mlir::sdy::TensorShardingAttr
+getShardingForManualComputationArg(mlir::BlockArgument barg);
+
+mlir::sdy::TensorShardingAttr getShardingForOpResult(mlir::OpResult res);
+
+mlir::sdy::TensorShardingAttr getShardingAttr(mlir::Value v,
+                                              mlir::sdy::MeshOp globalMeshOp);
+
 // Calculate the updated shape based on the tensor sharding annotation.
 FailureOr<int64_t>
 calculateUpdatedDim(mlir::sdy::MeshAttr meshAttr,

--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -124,30 +124,53 @@ static FailureOr<mlir::OperationState> createNewOperationState(
             return mlir::success();
           })
           .Case<mlir::stablehlo::GatherOp>([&](auto gatherOp) {
+            // 1. Get the sharding for each operand dimension.
+            llvm::ArrayRef<mlir::sdy::DimensionShardingAttr>
+                operandDimShardings = shardy_utils::getShardingAttr(
+                                          gatherOp.getOperand(), globalMeshOp)
+                                          .getDimShardings();
+
+            // 2. Copy the current slice_sizes attribute.
             llvm::SmallVector<int64_t> newSliceSizes(gatherOp.getSliceSizes());
 
-            for (uint32_t i = 0; i < tensorShardings.size(); i++) {
-              llvm::ArrayRef<mlir::sdy::DimensionShardingAttr> dimShardings =
-                  tensorShardings[i].getDimShardings();
+            // 3. Get collapsed_slice_dims and start_index_map from the op.
+            auto collapsedSliceDims =
+                gatherOp.getDimensionNumbers().getCollapsedSliceDims();
+            auto startIndexMap =
+                gatherOp.getDimensionNumbers().getStartIndexMap();
 
-              for (const auto [index, dimShardingAttr] :
-                   llvm::enumerate(dimShardings)) {
+            // 4. For each dimension, update slice size if not in
+            // start_index_map.
+            for (auto [index, sliceSize] : llvm::enumerate(newSliceSizes)) {
+              // If this dimension is collapsed, it must be 1.
+              if (llvm::is_contained(collapsedSliceDims, index)) {
+                if (sliceSize != 1) {
+                  gatherOp->emitError("collapsed slice dims should be 1");
+                  return mlir::failure();
+                }
+                continue;
+              }
+
+              // If this dim is not indexed, its slice size should match the
+              // local (sharded) size of the operand. We use operandDimShardings
+              // to get the local shape for this dim.
+              if (!llvm::is_contained(startIndexMap, index)) {
                 FailureOr<int64_t> updatedSliceDim =
-                    shardy_utils::calculateUpdatedDim(globalMeshOp.getMesh(),
-                                                      dimShardingAttr,
-                                                      newSliceSizes[index]);
-
+                    shardy_utils::calculateUpdatedDim(
+                        globalMeshOp.getMesh(), operandDimShardings[index],
+                        newSliceSizes[index]);
                 if (failed(updatedSliceDim)) {
                   gatherOp->emitError(
                       "Could not apply propagated tensor shardings to "
                       "attribute dictionary for gather op");
                   return mlir::failure();
                 }
-
                 newSliceSizes[index] = *updatedSliceDim;
               }
             }
 
+            // 5. Update the slice_sizes attribute in the op's attribute
+            // dictionary.
             llvm::StringRef sliceSizesAttrName = "slice_sizes";
             assert(attrDict.contains(sliceSizesAttrName) &&
                    "Gather operation does not have slice sizes attribute. "

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/gather.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/gather.mlir
@@ -4,7 +4,7 @@
 
 sdy.mesh @mesh = <["model"=1, "batch"=2]>
 
-func.func @gather_simple(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<56xi64>) -> tensor<4x56x56x96xbf16> {
+func.func @gather_with_shard_on_operand_non_index_dim(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<56xi64>) -> tensor<4x56x56x96xbf16> {
   %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 4, 1, 56, 96>}> : (tensor<4x56x56x96xbf16>, tensor<56xi64>) -> tensor<4x56x56x96xbf16>
   return %0 : tensor<4x56x56x96xbf16>
 }
@@ -12,3 +12,37 @@ func.func @gather_simple(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sha
 // CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>]
 // CHECK: "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 2, 1, 56, 96>}> : (tensor<2x56x56x96xbf16>, tensor<56xi64>) -> tensor<2x56x56x96xbf16>
 // CHECK: sdy.return %1 : tensor<2x56x56x96xbf16>
+
+
+func.func @gather_with_shard_on_operand_index_dim(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<56x2xi64>) -> tensor<1x56x56x96xbf16> {
+  %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 56, 96>}> : (tensor<4x56x56x96xbf16>, tensor<56x2xi64>) -> tensor<1x56x56x96xbf16>
+  return %0 : tensor<1x56x56x96xbf16>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{}, {}]>] out_shardings=[<@mesh, [{}, {}, {}, {}]>]
+// CHECK: "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 56, 96>}> : (tensor<2x56x56x96xbf16>, tensor<56x2xi64>) -> tensor<1x56x56x96xbf16>
+// CHECK: %2 = "stablehlo.all_reduce"(%1) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense
+// CHECK-SAME: 0, 1
+// CHECK: %3 = stablehlo.add %arg4, %arg5 : tensor<bf16>
+// CHECK: stablehlo.return %3 : tensor<bf16>
+// CHECK: sdy.return %2 : tensor<1x56x56x96xbf16>
+
+
+func.func @gather_with_shard_on_start_indices_0(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {}, {}]>}, %arg1: tensor<56xi64> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}) -> tensor<4x56x56x96xbf16> {
+  %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 4, 1, 56, 96>}> : (tensor<4x56x56x96xbf16>, tensor<56xi64>) -> tensor<4x56x56x96xbf16>
+  return %0 : tensor<4x56x56x96xbf16>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}, {}, {}]>, <@mesh, [{"batch"}]>] out_shardings=[<@mesh, [{}, {"batch"}, {}, {}]>]
+// CHECK: "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 4, 1, 56, 96>}> : (tensor<4x56x56x96xbf16>, tensor<28xi64>) -> tensor<4x28x56x96xbf16>
+// CHECK: sdy.return %1 : tensor<4x28x56x96xbf16>
+
+
+func.func @gather_with_shard_on_start_indices_from_embedding_op(%arg0: tensor<131072x2048xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, %arg1: tensor<2x12xi64> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) -> tensor<2x12x2048xbf16> {
+  %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2048>}> : (tensor<131072x2048xbf16>, tensor<2x12xi64>) -> tensor<2x12x2048xbf16>
+  return %0 : tensor<2x12x2048xbf16>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"batch"}, {}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}]>]
+// CHECK: "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2048>}> : (tensor<131072x2048xbf16>, tensor<1x12xi64>) -> tensor<1x12x2048xbf16>
+// CHECK: sdy.return %1 : tensor<1x12x2048xbf16>


### PR DESCRIPTION
### Ticket
closes #4416 

### Problem description
The UpdateGlobalToLocalShapes pass failed to update the slice_sizes argument.
The pass previously updated slice_sizes based on output sharding. It should update them based on operand sharding instead.

### What's changed
- Fixed the update logic so that slice_sizes are updated based on operand sharding.
- Added a new Shardy utility function: getShardingAttr.

### Checklist
- [ ] New/Existing tests provide coverage for changes
