### PR TITLE
Reduce D2M codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,7 +98,6 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /include/ttmlir/Dialect/TTIR/IR/TTIRGeneric* @tenstorrent/forge-developers-mlir-d2m
 /include/ttmlir/Dialect/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
 /include/ttmlir/Dialect/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
-/lib/Dialect/TTIR/Transforms/ @tenstorrent/forge-developers-mlir-core
 /lib/Dialect/TTIR/Transforms/Generic*.cpp @tenstorrent/forge-developers-mlir-d2m
 /lib/Dialect/TTIR/Transforms/Allocate.cpp @tenstorrent/forge-developers-mlir-d2m
 /lib/Dialect/TTIR/Transforms/InsertDstRegisterAccess.cpp @tenstorrent/forge-developers-mlir-d2m


### PR DESCRIPTION
### Ticket
NA

### Problem description
D2M is codeowner on all TTIR transforms, but most TTIR transforms aren't related to D2M.

### What's changed
Reduce codeowner footprint to more fine-grained, file-by-file pattern

### Checklist
NA