### PR TITLE
Fix debug build

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -193,9 +193,6 @@ convertToOptionalTensorSpec(::tt::tt_metal::distributed::MeshDevice *device,
     auto retExp =
         detail::convertToTensorSpec(device, shape.value(), layout.value());
     if (!retExp) {
-      // This is a common pattern for preventing the function to return
-      // llvm::Expected when std::optional is needed (by consuming the error).
-      llvm::consumeError(retExp.takeError());
       assert(false && "Failed to convert to TensorSpec");
       return std::nullopt;
     }


### PR DESCRIPTION
There is a linker error in Debug build

```
ld.lld: error: undefined symbol: typeinfo for llvm::ErrorInfoBase
>>> referenced by TTNNOpModel.cpp
>>>        TTNNOpModel.cpp.o:(typeinfo for llvm::ErrorInfo<llvm::ErrorList, llvm::ErrorInfoBase>) in archive lib/OpModel/TTNN/libTTNNOpModelLib.a
>>> did you mean: vtable for llvm::ErrorInfoBase
>>> defined in: /opt/ttmlir-toolchain/lib/libLLVMSupport.a(Error.cpp.o)
clang++-17: error: linker command failed with exit co
```
