### PR TITLE
Optimize Docker Image Size and Speedup GDB Archive Download

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -58,7 +58,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
 # Install python packages
 RUN pip install cmake \
     sphinx \
-    sphinx-markdown-builder
+    sphinx-markdown-builder && \
+    rm -rf ~/.cache/pip
 
 # Install Googletest
 RUN git clone https://github.com/google/googletest.git -b release-1.12.1 && \

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -40,6 +40,8 @@ apt-get install -y \
 # Setup / install metal dependencies
 wget https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/{install_dependencies.sh,tt_metal/sfpi-version.sh}
 bash install_dependencies.sh --docker
+
+rm -rf /var/cache/apt /var/lib/apt/lists
 # ANCHOR_END: developer_dependencies
 EOT
 
@@ -50,7 +52,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     apt install -y libc++-17-dev libc++abi-17-dev && \
     ln -s /usr/bin/clang-17 /usr/bin/clang && \
     ln -s /usr/bin/clang++-17 /usr/bin/clang++ && \
-    ln -s /usr/bin/clangd-17 /usr/bin/clangd
+    ln -s /usr/bin/clangd-17 /usr/bin/clangd && \
+    rm -rf /var/cache/apt /var/lib/apt/lists
 
 # Install python packages
 RUN pip install cmake \

--- a/.github/Dockerfile.cibuildwheel
+++ b/.github/Dockerfile.cibuildwheel
@@ -17,9 +17,8 @@ RUN dnf install --refresh -y \
     hwloc-devel tbb-devel capstone-devel \
     yaml-cpp-devel boost-devel libcurl-devel \
     pandoc doxygen graphviz lcov perf \
-    xz
-
-RUN dnf clean all
+    xz && \
+    dnf clean all
 
 # Install Ninja
 ENV NINJA_VERSION="1.11.1"

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -27,7 +27,7 @@ RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
 # Install GDB 14.2
 RUN apt update && apt install libmpfr-dev -y && \
     rm -rf /var/cache/apt /var/lib/apt/lists && \
-    wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz && \
+    wget 'https://mirrors.ocf.berkeley.edu/gnu/gdb/gdb-14.2.tar.gz' && \
     tar -xvf gdb-14.2.tar.gz && \
     cd gdb-14.2 && \
     ./configure && \

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -17,14 +17,16 @@ RUN apt-get update && apt-get install -y \
     nano \
     tmux \
     psmisc \
-    bash-completion
+    bash-completion && \
+    rm -rf /var/cache/apt /var/lib/apt/lists
 
 # Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
     chmod -R 777 $TTMLIR_TOOLCHAIN_DIR
 
 # Install GDB 14.2
-RUN apt install libmpfr-dev -y && \
+RUN apt update && apt install libmpfr-dev -y && \
+    rm -rf /var/cache/apt /var/lib/apt/lists && \
     wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz && \
     tar -xvf gdb-14.2.tar.gz && \
     cd gdb-14.2 && \


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Docker images are needlessly carrying around cache for both apt and dnf.  Although the size itself is a small fraction of the total images, it's cheap to remove cache and considered best practice for image distribution.

Also, the official GDB mirror is slow, causing builds for **Dockerfile.ird** to spend a large percent of its time downloading the **gdb-14.2.tar.gz** archive.

### What's changed
Steps to remove cache for apt repos was added by removing the **/var/cache/apt** and **/var/lib/apt/lists** directories after install operations are complete.  Where needed **apt update** steps are added so updated lists are pulled where a local list would not exist.

The GDB mirror was updated from **ftp.gnu.org** to **mirrors.ocf.berkely.edu** to get about a 15x or higher improvement in download speed when pulling **gdb-14.2.tar.gz**.

### Checklist
- [x] New/Existing tests provide coverage for changes
