### PR TITLE
[D2M] Add Support for DRAM Interleaved Buffers in D2M Runtime

### DIFF
--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -13,6 +13,11 @@ table ShardSpecBuffer {
   tensor_shape_in_pages: Dim2d;
 }
 
+table InterleavedBufferConfig {
+  size: uint64;
+  page_size: uint64;
+}
+
 table ShardedBufferConfig {
   size: uint64;
   page_size: uint64;
@@ -36,9 +41,15 @@ table MetalBuffer {
   circular_buffer_config: CircularBufferConfig;
 }
 
+table MetalBufferInterleaved {
+  buffer_type: BufferType;
+  interleaved_buffer_config: InterleavedBufferConfig;
+}
+
 union BufferDetail {
   SystemBuffer,
-  MetalBuffer
+  MetalBuffer,
+  MetalBufferInterleaved
 }
 
 table BufferDesc {

--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -24,6 +24,11 @@ table ShardedBufferConfig {
   shard_spec_buffer: ShardSpecBuffer;
 }
 
+union BufferConfig {
+  ShardedBufferConfig,
+  InterleavedBufferConfig
+}
+
 table CircularBufferConfig {
   core_range_set: [Dim2dRange];
   total_size: uint64;
@@ -37,19 +42,13 @@ table SystemBuffer {
 
 table MetalBuffer {
   buffer_type: BufferType;
-  sharded_buffer_config: ShardedBufferConfig;
+  buffer_config: BufferConfig;
   circular_buffer_config: CircularBufferConfig;
-}
-
-table MetalBufferInterleaved {
-  buffer_type: BufferType;
-  interleaved_buffer_config: InterleavedBufferConfig;
 }
 
 union BufferDetail {
   SystemBuffer,
-  MetalBuffer,
-  MetalBufferInterleaved
+  MetalBuffer
 }
 
 table BufferDesc {

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -336,7 +336,7 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     if (isSharded) {
 
       flatbuffers::Offset<target::metal::ShardedBufferConfig>
-          shardedBufferConfig = createShardedBufferConfigForL1Memref(
+          shardedBufferConfig = memrefTypeToShardedBufferConfigFlatbuffer(
               cache, memref, device, elementShape);
 
       // only generate CircularBufferConfig for L1 memspace

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -287,6 +287,11 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
 
   for (const target::metal::CBRef *cbRef : *command->cbs()) {
     const target::metal::BufferDesc *bufferDesc = cbRef->buffer_ref()->desc();
+    // assume interleaved buffer configs don't have CB config
+    if (bufferDesc->buffer_detail_type() ==
+        target::metal::BufferDetail::MetalBufferInterleaved) {
+      continue;
+    }
     LOG_ASSERT(bufferDesc->buffer_detail_type() ==
                target::metal::BufferDetail::MetalBuffer);
     const target::metal::MetalBuffer *metalBuffer =

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -292,11 +292,10 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
     const target::metal::MetalBuffer *metalBuffer =
         bufferDesc->buffer_detail_as_MetalBuffer();
 
-    // Assume interleaved buffer configs don't have CB config
-    if (metalBuffer->buffer_config_type() ==
-        target::metal::BufferConfig::InterleavedBufferConfig) {
-      continue;
-    }
+    assert(metalBuffer->buffer_config_type() !=
+               target::metal::BufferConfig::InterleavedBufferConfig ||
+           !metalBuffer->circular_buffer_config() &&
+               "Interleaved buffer configs should not have a CB config");
 
     // skip init if CircularBufferConfig is not present
     if (!metalBuffer->circular_buffer_config()) {

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -287,15 +287,16 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
 
   for (const target::metal::CBRef *cbRef : *command->cbs()) {
     const target::metal::BufferDesc *bufferDesc = cbRef->buffer_ref()->desc();
-    // assume interleaved buffer configs don't have CB config
-    if (bufferDesc->buffer_detail_type() ==
-        target::metal::BufferDetail::MetalBufferInterleaved) {
-      continue;
-    }
     LOG_ASSERT(bufferDesc->buffer_detail_type() ==
                target::metal::BufferDetail::MetalBuffer);
     const target::metal::MetalBuffer *metalBuffer =
         bufferDesc->buffer_detail_as_MetalBuffer();
+
+    // Assume interleaved buffer configs don't have CB config
+    if (metalBuffer->buffer_config_type() ==
+        target::metal::BufferConfig::InterleavedBufferConfig) {
+      continue;
+    }
 
     // skip init if CircularBufferConfig is not present
     if (!metalBuffer->circular_buffer_config()) {

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -292,10 +292,10 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
     const target::metal::MetalBuffer *metalBuffer =
         bufferDesc->buffer_detail_as_MetalBuffer();
 
-    assert(metalBuffer->buffer_config_type() !=
-               target::metal::BufferConfig::InterleavedBufferConfig ||
-           !metalBuffer->circular_buffer_config() &&
-               "Interleaved buffer configs should not have a CB config");
+    assert((metalBuffer->buffer_config_type() !=
+                target::metal::BufferConfig::InterleavedBufferConfig ||
+            !metalBuffer->circular_buffer_config()) &&
+           "Interleaved buffer configs should not have a CB config");
 
     // skip init if CircularBufferConfig is not present
     if (!metalBuffer->circular_buffer_config()) {

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -108,15 +108,15 @@ createMeshBufferFromBufferRef(
 
   const target::metal::BufferDesc *bufferDesc = bufferRef->desc();
 
-  LOG_ASSERT(bufferDesc->buffer_detail_type() ==
-             target::metal::BufferDetail::MetalBuffer);
-  const target::metal::MetalBuffer *metalBuffer =
-      bufferDesc->buffer_detail_as_MetalBuffer();
-  const target::metal::ShardedBufferConfig *shardedBufferConfig =
-      metalBuffer->sharded_buffer_config();
-  const target::metal::ShardSpecBuffer *shardSpecBuffer =
-      shardedBufferConfig->shard_spec_buffer();
-  const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
+  if (bufferDesc->buffer_detail_type() ==
+      target::metal::BufferDetail::MetalBuffer) {
+    const target::metal::MetalBuffer *metalBuffer =
+        bufferDesc->buffer_detail_as_MetalBuffer();
+    const target::metal::ShardedBufferConfig *shardedBufferConfig =
+        metalBuffer->sharded_buffer_config();
+    const target::metal::ShardSpecBuffer *shardSpecBuffer =
+        shardedBufferConfig->shard_spec_buffer();
+    const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
 
     CoreRangeSet coreRangeSet =
         common::toCoreRangeSet(shardSpec->core_range_set());
@@ -137,14 +137,14 @@ createMeshBufferFromBufferRef(
     tt_metal::ShardSpecBuffer metalShardSpecBuffer(metalShardSpec, pageShape,
                                                    tensorShapeInPages);
 
-  LOG_ASSERT(metalBuffer->buffer_type() == target::BufferType::DRAM ||
-             metalBuffer->buffer_type() == target::BufferType::L1);
-  tt_metal::BufferType bufferType =
-      metalBuffer->buffer_type() == target::BufferType::DRAM
-          ? tt_metal::BufferType::DRAM
-          : tt_metal::BufferType::L1;
-  uint32_t address =
-      deviceAddressValidator(bufferRef->address(), metalBuffer->buffer_type());
+    LOG_ASSERT(metalBuffer->buffer_type() == target::BufferType::DRAM ||
+               metalBuffer->buffer_type() == target::BufferType::L1);
+    tt_metal::BufferType bufferType =
+        metalBuffer->buffer_type() == target::BufferType::DRAM
+            ? tt_metal::BufferType::DRAM
+            : tt_metal::BufferType::L1;
+    uint32_t address = deviceAddressValidator(bufferRef->address(),
+                                              metalBuffer->buffer_type());
 
     auto localShardShape = tt_metal::Shape2D{shardShape[0], shardShape[1]};
     auto distributedBufferShape =


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The TTMetal TTRT backend does not currently support DRAM interleaved buffers, and all DRAM buffers are assumed to be sharded. A partner wants to use DRAM interleaved buffers, and D2M will need to eventually support these buffers even if they are not the first choice.

### What's changed
- D2M memrefs are assumed to be DRAM interleaved if:
  - the memory space is set to DRAM, and
  - there is no `ShardLayoutAttr` (tt/ttcore.shard in the IR)
- For each DRAM interleaved buffer, create and serialize an `InterleavedBufferConfig` instead of a `ShardedBufferConfig` in `TTMetalToFlatbuffer`
- Modified the TTMetal flatbuffer schema to allow exactly one of `ShardedBufferConfig` or `InterleavedBufferConfig` for each serialized buffer
- Modified the TTMetal TTRT backend to check the type of `bufferConfig` in each buffer and call the correct `CreateMeshBuffer` with the correct config object type.

Note: Interleaved buffers must be single device and in DRAM. L1 interleaved or multi-device DRAM interleaved buffers are not supported

Note: **This PR does not add a ttir->TTMetal lowering for DRAM interleaved tensors.** The partner has their own lowering pathway into TTMetal

### Testing
Manually tested. CI testing to be discussed in D2M F2F as it would require checking in a TTMetal IR file

### Checklist
- [ ] New/Existing tests provide coverage for changes
