### PR TITLE
Remove redundant log from ttrt read

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/read.py
+++ b/runtime/tools/ttrt/ttrt/common/read.py
@@ -418,7 +418,6 @@ class Read:
                         for x in res
                     )
                 result.append(res)
-                self.logging.info(msg)
             except Exception as e:
                 raise Exception(
                     f"failed to process read for binary={binary.file_path} with exception {str(e)}"


### PR DESCRIPTION
Removed redundant log from ttrt read, since `--read-file` flag was added in #4274.
