### PR TITLE
Fix absence of `pytestmark` in new tests

### DIFF
--- a/test/python/golden/test_metal_dma.py
+++ b/test/python/golden/test_metal_dma.py
@@ -15,6 +15,8 @@ from builder.base.builder_utils import compile_ttir_to_flatbuffer
 
 from test_utils import Marks, shape_str
 
+pytestmark = pytest.mark.frontend("ttir")
+
 
 def compile_dma_test(test_func, shape, request):
 


### PR DESCRIPTION
### Problem description
#4407 got merged on a rebase and I missed adding `pytestmark` to a file to denote frontends. This is a single line straightforward fix that repairs the functionality of the reporting infrastructure

### What's changed
`pytestmark` added to `test/python/golden/test_metal_dma.py`

