### PR TITLE
Uplift third_party/tt-metal to 795135f0c9fde96c4fed761e274cf8d5ca053247 2025-08-21

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "708045f468fd90fcba3ef24ca48eef1f388c096d")
+set(TT_METAL_VERSION "795135f0c9fde96c4fed761e274cf8d5ca053247")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/tools/tt-alchemist/csrc/InstallComponents.cmake
+++ b/tools/tt-alchemist/csrc/InstallComponents.cmake
@@ -69,6 +69,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${TTMETAL_BUILD_DIR}/../tt_metal/third_party/tracy/public/tracy ${TTNN_INSTALL_DIR}/include/tracy
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${TTMETAL_BUILD_DIR}/../tt_metal/third_party/tracy/public/common ${TTNN_INSTALL_DIR}/include/common
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${TTMETAL_BUILD_DIR}/../tt_metal/third_party/tracy/public/client ${TTNN_INSTALL_DIR}/include/client
+  # Copy tt_stl headers (workaround for missing optional_reference.hpp)
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${TTMETAL_BUILD_DIR}/../tt_stl/tt_stl ${TTNN_INSTALL_DIR}/include/tt_stl
   # Copy op-related missing hpp files
   COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${TTMETAL_BUILD_DIR}/../ttnn/cpp/ttnn/operations -DDEST_DIR=${TTNN_INSTALL_DIR}/include/ttnn/operations -P ${CMAKE_CURRENT_SOURCE_DIR}/CopyHppFiles.cmake
   # Copy kernel-related missing hpp/cpp files (needed for kernel compilation in runtime)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 795135f0c9fde96c4fed761e274cf8d5ca053247

- Add workaround to copy tt_stl optional_references header after metal commit 09aae44c70
    - Follow up in https://github.com/tenstorrent/tt-mlir/issues/4601