### PR TITLE
#4532 Fix Parsing Error in tt-adaptor for Optional Attribute in conv2d_config

### DIFF
--- a/docs/src/tt-explorer/ui.md
+++ b/docs/src/tt-explorer/ui.md
@@ -42,7 +42,7 @@ This button invokes the `execute` function which will compile and execute the mo
 
 ## "Code" Button
 
-![Toolbar highlighting the "execute" button](../images/tt-explorer/execute.png)
+![Toolbar highlighting the "code" button](../images/tt-explorer/code.png)
 
 If the `Generate C++ Code` option is enabled, this button will become available to view and download the C++ code in a window within explorer.
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -575,15 +575,19 @@ def parse_conv2d_config(attr):
             },
         )
     )
+    output_layout = OVERRIDE_PARAMETER_DISABLED_STR
+    if conv2d_config.output_layout_as_int is not None:
+        output_layout = str(ttnn.Layout(conv2d_config.output_layout_as_int))
     result.append(
         utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="output_layout",
-                value=str(ttnn.Layout(conv2d_config.output_layout_as_int)),
+                value=output_layout,
             ),
             editable={
                 "input_type": "value_list",
-                "options": [str(o) for o in ttnn.Layout],
+                "options": [str(o) for o in ttnn.Layout]
+                + [OVERRIDE_PARAMETER_DISABLED_STR],
             },
         )
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4532

### Problem description
tt-adaptor tries to parse an optional attribute when it's actually not given in the IR, leading to a parsing error.

The IR has `conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, activation = "relu">`
But tt-adaptor also tries to parse value of `output_layout_as_int` from the config, causing the error.

### What's changed
- Do not attempt to create output layout enum if value is None
- Fix image for code button

### Checklist
- [ ] New/Existing tests provide coverage for changes
