### PR TITLE
Adding OnesLike and ZerosLike ops in ttmlir compiler

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -4970,6 +4970,67 @@ def TTIR_OnesOp : TTIR_NamedFullOp<"ones"> {
   }];
 }
 
+class TTIR_NamedFullLikeOp <string mnemonic, list<Trait> traits = []> :
+  TTIR_NamedOp<mnemonic, [SameOperandsAndResultType] # traits> {
+  let summary = "Base class that creates a tensor with the same properties as the input tensor, filled with a predefined constant value (e.g., zero or one).";
+  let description = [{
+    The `TTIR_NamedFullLikeOp` class serves as a base class for tensor creation operations that
+    generate tensors with the specified properties of an input tensor and fill them with predefined values.
+
+    This class is used by operations like `zeros_like` and `ones_like` that create tensors with a
+    properties derived from the input tensor (e.g. like shape, element type) and initialize all elements to the same value.
+
+    Attributes:
+    - `input` (Tensor): The input tensor to create a like tensor from.
+
+    Outputs:
+    - `result` (Tensor): The created tensor.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$output);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
+def TTIR_ZerosLikeOp : TTIR_NamedFullLikeOp<"zeros_like">
+{
+  let summary = "Creates a tensor filled with zeros with the same shape and type as the input tensor.";
+  let description = [{
+    The `zeros_like` operation creates a new tensor with the same shape and element type
+    as the input tensor, but with all elements initialized to zero.
+
+    Example:
+    ```mlir
+    // Input tensor %input
+    // [[2.3, 3.2],
+    //  [4.0, 5.0]]
+    %result = ttir.zeros_like (%input) : tensor<2x2xf32> -> tensor<2x2xf32>
+    // Result: [[0.0, 0.0],
+    //          [0.0, 0.0]]
+    ```
+  }];
+}
+
+def TTIR_OnesLikeOp : TTIR_NamedFullLikeOp<"ones_like">
+{
+  let summary = "Creates a tensor filled with ones with the same shape and type as the input tensor.";
+  let description = [{
+    The `ones_like` operation creates a new tensor with the same shape and element type
+    as the input tensor, but with all elements initialized to one.
+
+    Example:
+    ```mlir
+    // Input tensor %input
+    // [[2.3, 3.2],
+    //  [4.0, 5.0]]
+    %result = ttir.ones_like %input : tensor<2x2xf32> -> tensor<2x2xf32>
+    // Result: [[1.0, 1.0],
+    //          [1.0, 1.0]]
+    ```
+  }];
+}
+
 def TTIR_EmptyOp : TTIR_CreationOp<"empty",
   [DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
                                                       , "bufferizesToMemoryWrite"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1906,6 +1906,46 @@ def TTNN_OnesOp : TTNN_NamedFullOp<"ones"> {
   }];
 }
 
+class TTNN_NamedFullLikeOp <string mnemonic, list<Trait> traits = []> :
+TTNN_Op<mnemonic, [HasMemoryConfigTrait, HasOutputDTypeTrait] # traits> {
+  let summary = "Creates a tensor filled with a specific value, with the same properties as the input tensor.";
+  let description = [{
+    Tensor operation to create a tensor filled with a specific value, matching the shape and type of the input tensor.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       OptionalAttr<TTCore_DataTypeAttr>:$output_dtype,
+                       OptionalAttr<TTNN_LayoutAttr>:$layout,
+                       Optional<TTNN_Device>:$device,
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
+def TTNN_ZerosLikeOp : TTNN_NamedFullLikeOp<"zeros_like"> {
+  let summary = "Creates a tensor filled with zeros, with the same properties as the input tensor.";
+  let description = [{
+    Tensor operation to create a tensor filled with zeros, matching the shape and type of the input tensor.
+
+    Example:
+      %0 = "ttnn.zeros_like"(%1) : (tensor<64x28x28xbf16>) -> tensor<64x28x28xbf16>
+      // %0: [[[0, 0, 0, ..., 0], [0, 0, 0, ..., 0], ..., [0, 0, 0, ..., 0]]]
+  }];
+}
+
+def TTNN_OnesLikeOp : TTNN_NamedFullLikeOp<"ones_like"> {
+  let summary = "Creates a tensor filled with ones, with the same properties as the input tensor.";
+  let description = [{
+    Tensor operation to create a tensor filled with ones, matching the shape and type of the input tensor.
+
+    Example:
+      %0 = "ttnn.ones_like"(%1) : (tensor<64x28x28xbf16>) -> tensor<64x28x28xbf16>
+      // %0: [[[1, 1, 1, ..., 1], [1, 1, 1, ..., 1], ..., [1, 1, 1, ..., 1]]]
+  }];
+}
+
 def TTNN_FullOp : TTNN_CreationOp<"full",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -94,8 +94,7 @@ public:
     if (std::find(attributeNames.begin(), attributeNames.end(),
                   ttmlir::utils::g_outputDtypeAttrName) ==
         attributeNames.end()) {
-      return op->emitOpError(
-          "Operation must define output data type attribute.");
+      return op->emitOpError("must define output data type attribute.");
     }
 
     // Retrieve output layout.
@@ -114,14 +113,14 @@ public:
           ttmlir::utils::g_outputDtypeAttrName);
       if (!outputDTypeAttr) {
         return op->emitOpError(
-            "Output data type attribute is not defined for op "
+            "output data type attribute is not defined for op "
             "that has output layout attribute.");
       }
 
       // Compare output data type attribute with output tensor data type.
       if (outputDTypeAttr.getValue() != outputLayoutAttr.getDataType()) {
         return op->emitOpError()
-               << "Output tensor layout data type "
+               << "output tensor layout data type "
                << DataTypeEnumToString(outputLayoutAttr.getDataType())
                << " must match output data type attribute "
                << DataTypeEnumToString(outputDTypeAttr.getValue());

--- a/include/ttmlir/Target/TTNN/operations/creation.fbs
+++ b/include/ttmlir/Target/TTNN/operations/creation.fbs
@@ -64,3 +64,18 @@ table NamedFullOp {
   memcfg: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
 }
+
+enum NamedFullLikeOpType: uint32 {
+  Zeros,
+  Ones,
+}
+
+table NamedFullLikeOp {
+  type: NamedFullLikeOpType;
+  input: tt.target.ttnn.TensorRef;
+  dtype: tt.target.DataType = null;
+  layout: tt.target.TensorLayout = null;
+  device: tt.target.DeviceRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -65,6 +65,7 @@ union OpType {
   MeshShardOp,
   MorehCumSumOp,
   NamedFullOp,
+  NamedFullLikeOp,
   PadOp,
   PermuteOp,
   PointToPointOp,

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1022,7 +1022,7 @@ static ::mlir::LogicalResult namedOpVerify(Op op) {
   ArrayRef<int64_t> outputShape = output.getShape();
 
   if (shape != outputShape) {
-    return op.emitOpError("Output tensor shape must be ")
+    return op.emitOpError("output tensor shape must be ")
            << shape << ", but got " << outputShape;
   }
 
@@ -1035,6 +1035,43 @@ static ::mlir::LogicalResult namedOpVerify(Op op) {
 
 ::mlir::LogicalResult mlir::tt::ttnn::OnesOp::verify() {
   return namedOpVerify(*this);
+}
+
+//===----------------------------------------------------------------------===//
+// NamedFullLikeOp
+//===----------------------------------------------------------------------===//
+
+template <typename Op>
+static ::mlir::LogicalResult namedFullLikeOpVerify(Op op) {
+  RankedTensorType output = op.getResult().getType();
+  ArrayRef<int64_t> inputShape = op.getInput().getType().getShape();
+  ArrayRef<int64_t> outputShape = output.getShape();
+
+  if (inputShape != outputShape) {
+    return op.emitOpError() << "output tensor shape must be (" << inputShape
+                            << "), but got (" << outputShape << ")";
+  }
+
+  // TODO(#4610): We should remove this check once we create a verifier for
+  // output layout trait
+  TTNNLayoutAttr layoutAttr = mlir::cast<TTNNLayoutAttr>(output.getEncoding());
+
+  if (op.getLayout() != layoutAttr.getLayout()) {
+    return op.emitOpError()
+           << "output tensor layout " << stringifyLayout(layoutAttr.getLayout())
+           << " must match layout attribute "
+           << stringifyLayout(*op.getLayout());
+  }
+
+  return success();
+}
+
+::mlir::LogicalResult mlir::tt::ttnn::ZerosLikeOp::verify() {
+  return namedFullLikeOpVerify(*this);
+}
+
+::mlir::LogicalResult mlir::tt::ttnn::OnesLikeOp::verify() {
+  return namedFullLikeOpVerify(*this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/constant.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/empty.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/creation/full_like.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full_with.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/pad.cpp

--- a/runtime/lib/ttnn/operations/creation/full_like.cpp
+++ b/runtime/lib/ttnn/operations/creation/full_like.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/creation/full_like.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+static void runFullLikeOp(const ::tt::target::ttnn::NamedFullLikeOp *op,
+                          ProgramContext &context, auto &&ttnnOp) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+
+  std::optional<::ttnn::DataType> dtype;
+  std::optional<::ttnn::Layout> layout;
+  OptionalMeshDeviceRef targetDevice = std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
+  if (op->dtype()) {
+    dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
+  }
+
+  if (op->layout()) {
+    layout = ::tt::runtime::ttnn::utils::toTTNNLayout(*(op->layout()));
+  }
+
+  if (op->device()) {
+    targetDevice = std::ref(context.getMeshDevice());
+  }
+
+  ::ttnn::Tensor out = ttnnOp(input, dtype, layout, targetDevice, memoryConfig);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+void run(const ::tt::target::ttnn::NamedFullLikeOp *op,
+         ProgramContext &context) {
+  switch (op->type()) {
+  case ::tt::target::ttnn::NamedFullLikeOpType::Zeros: {
+    return runFullLikeOp(op, context, ::ttnn::zeros_like);
+  }
+  case ::tt::target::ttnn::NamedFullLikeOpType::Ones: {
+    return runFullLikeOp(op, context, ::ttnn::ones_like);
+  }
+  }
+}
+} // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/full_like.h
+++ b/runtime/lib/ttnn/operations/creation/full_like.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CREATION_FULL_LIKE_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CREATION_FULL_LIKE_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+
+void run(const ::tt::target::ttnn::NamedFullLikeOp *op,
+         ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::creation
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -20,6 +20,7 @@
 #include "operations/creation/constant.h"
 #include "operations/creation/empty.h"
 #include "operations/creation/full.h"
+#include "operations/creation/full_like.h"
 #include "operations/creation/full_with.h"
 #include "operations/data_movement/concat.h"
 #include "operations/data_movement/pad.h"
@@ -176,6 +177,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::NamedFullOp: {
     return operations::creation::run(op->type_as_NamedFullOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::NamedFullLikeOp: {
+    return operations::creation::run(op->type_as_NamedFullLikeOp(),
+                                     getContext());
   }
   case ::tt::target::ttnn::OpType::FullOp: {
     return operations::creation::run(op->type_as_FullOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -981,6 +981,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_NamedFullOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::NamedFullLikeOp: {
+    tensorRef = opContext.type_as_NamedFullLikeOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::FullOp: {
     tensorRef = opContext.type_as_FullOp()->out();
     break;
@@ -1433,6 +1437,10 @@ getOpInputRefs(OpContext opContextHandle,
     break;
   }
   case ::tt::target::ttnn::OpType::NamedFullOp: {
+    break;
+  }
+  case ::tt::target::ttnn::OpType::NamedFullLikeOp: {
+    tensorRefs = {opContext.type_as_NamedFullLikeOp()->input()};
     break;
   }
   case ::tt::target::ttnn::OpType::FuncCallOp: {

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2899,3 +2899,32 @@ def test_rms_norm(
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
     )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (32, 128),
+        (2, 4, 64),
+        (3, 7),
+    ],
+)
+@pytest.mark.parametrize("type", ["zeros", "ones"])
+def test_full_like(shape: Shape, type: str, request):
+    def full_like(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        if type == "zeros":
+            return builder.zeros_like(in0, unit_attrs=unit_attrs)
+        elif type == "ones":
+            return builder.ones_like(in0, unit_attrs=unit_attrs)
+        else:
+            raise ValueError(f"Unsupported type: {type}")
+
+    compile_ttir_to_flatbuffer(
+        full_like,
+        [shape],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )

--- a/test/ttmlir/Dialect/TTIR/creation/ones_like/ones_like_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/creation/ones_like/ones_like_tests_negative.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt %s 2>&1 | FileCheck %s
+module {
+  func.func @forward(%arg0: tensor<1x4x100x100xbf16>) -> tensor<1x3x100x100xbf16> {
+    %0 = ttir.empty() : tensor<1x3x100x100xbf16>
+    // CHECK: error: 'ttir.ones_like' op requires the same type for all operands and results
+    %1 = "ttir.ones_like"(%arg0, %0) : (tensor<1x4x100x100xbf16>, tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16>
+    return %1 : tensor<1x3x100x100xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/creation/zeros_like/zeros_like_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/creation/zeros_like/zeros_like_tests_negative.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt %s 2>&1 | FileCheck %s
+module {
+  func.func @forward(%arg0: tensor<1x4x100x100xbf16>) -> tensor<1x3x100x100xbf16> {
+    %0 = ttir.empty() : tensor<1x3x100x100xbf16>
+    // CHECK: error: 'ttir.zeros_like' op requires the same type for all operands and results
+    %1 = "ttir.zeros_like"(%arg0, %0) : (tensor<1x4x100x100xbf16>, tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16>
+    return %1 : tensor<1x3x100x100xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_negative.mlir
@@ -10,7 +10,7 @@ module {
   }
 }
 
-// CHECK: error: 'ttnn.multiply' op Output tensor layout data type bf16 must match output data type attribute f32
+// CHECK: error: 'ttnn.multiply' op output tensor layout data type bf16 must match output data type attribute f32
 
 // -----
 #dram = #ttnn.buffer_type<dram>
@@ -24,4 +24,4 @@ module {
   }
 }
 
-// CHECK: error: 'ttnn.multiply' op Output data type attribute is not defined for op that has output layout attribute.
+// CHECK: error: 'ttnn.multiply' op output data type attribute is not defined for op that has output layout attribute.

--- a/test/ttmlir/Dialect/TTNN/creation/ones_like/ones_like_tests.mlir
+++ b/test/ttmlir/Dialect/TTNN/creation/ones_like/ones_like_tests.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  func.func @forward(%arg0: tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16> {
+    %0 = ttir.empty() : tensor<1x3x100x100xbf16>
+    // CHECK: "ttnn.ones_like"
+    %1 = "ttir.ones_like"(%arg0, %0) : (tensor<1x3x100x100xbf16>, tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16>
+    return %1 : tensor<1x3x100x100xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/creation/ones_like/ones_like_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/creation/ones_like/ones_like_tests_negative.mlir
@@ -1,0 +1,52 @@
+// RUN: not ttmlir-opt --ttcore-register-device --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for ones_like operation
+
+// Verify that the parsing fails if input and output shapes do not match.
+module {
+  func.func @ones_like_shape_mismatch(%arg0: tensor<64x64xbf16>) -> tensor<64x128xbf16> {
+    // CHECK: error: 'ttnn.ones_like' op output tensor shape must be (64, 64), but got (64, 128)
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttnn.ones_like"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output data types do not match.
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @ones_like_data_type_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.ones_like' op output tensor layout data type f32 must match output data type attribute bf16
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.ones_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output tensor layout do not match.
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @ones_like_layout_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.ones_like' op output tensor layout tile must match layout attribute row_major
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.ones_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output tensor memory config do not match.
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @ones_like_memory_config_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.ones_like' op Output tensor buffer type dram must match memory config buffer type l1
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.ones_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/creation/zeros_like/zeros_like_tests.mlir
+++ b/test/ttmlir/Dialect/TTNN/creation/zeros_like/zeros_like_tests.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  func.func @forward(%arg0: tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16> {
+    %0 = ttir.empty() : tensor<1x3x100x100xbf16>
+    // CHECK: "ttnn.zeros_like"
+    %1 = "ttir.zeros_like"(%arg0, %0) : (tensor<1x3x100x100xbf16>, tensor<1x3x100x100xbf16>) -> tensor<1x3x100x100xbf16>
+    return %1 : tensor<1x3x100x100xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/creation/zeros_like/zeros_like_tests.negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/creation/zeros_like/zeros_like_tests.negative.mlir
@@ -1,0 +1,52 @@
+// RUN: not ttmlir-opt --ttcore-register-device --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for zeros_like operation
+
+// Verify that the parsing fails if input and output shapes do not match.
+module {
+  func.func @zeros_like_shape_mismatch(%arg0: tensor<64x64xbf16>) -> tensor<64x128xbf16> {
+    // CHECK: error: 'ttnn.zeros_like' op output tensor shape must be (64, 64), but got (64, 128)
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttnn.zeros_like"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output data types do not match.
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @zeros_like_data_type_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.zeros_like' op output tensor layout data type f32 must match output data type attribute bf16
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.zeros_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output tensor layout do not match.
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @zeros_like_layout_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.zeros_like' op output tensor layout tile must match layout attribute row_major
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.zeros_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// -----
+// Verify that parsing fails in case if input and output tensor memory config do not match.
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @zeros_like_memory_config_mismatch(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    // CHECK: error: 'ttnn.zeros_like' op Output tensor buffer type dram must match memory config buffer type l1
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.zeros_like"(%arg0, %0) <{ output_dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#l1, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
+    return %1 : tensor<64x128xf32, #ttnn_layout>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/ones_like.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones_like.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+func.func @transpose(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.ones_like"(%arg0, %0): (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  return %1 : tensor<64x128xbf16>
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros_like.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros_like.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+func.func @transpose(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.zeros_like"(%arg0, %0): (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  return %1 : tensor<64x128xbf16>
+}

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -2251,6 +2251,8 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # Tensor creation
     ttir.ZerosOp: zeros_golden,
     ttir.OnesOp: ones_golden,
+    ttir.ZerosLikeOp: torch.zeros_like,
+    ttir.OnesLikeOp: torch.ones_like,
     ttir.ArangeOp: arange_golden,
     # Quantization operations
     ttir.QuantizeOp: quantize_golden,

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -4933,3 +4933,25 @@ class TTIRBuilder(Builder):
             organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
             unit_attrs=unit_attrs,
         )
+
+    def zeros_like(self, in0: Operand, unit_attrs: Optional[List[str]] = None):
+        return self._op_proxy(
+            ttir.ZerosLikeOp,
+            [in0],
+            organize_ttir_args=lambda i, o, _: (
+                i[0],
+                o,
+            ),
+            unit_attrs=unit_attrs,
+        )
+
+    def ones_like(self, in0: Operand, unit_attrs: Optional[List[str]] = None):
+        return self._op_proxy(
+            ttir.OnesLikeOp,
+            [in0],
+            organize_ttir_args=lambda i, o, _: (
+                i[0],
+                o,
+            ),
+            unit_attrs=unit_attrs,
+        )


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/4348

### Problem description
TT-MLIR lacks support for Zero/Ones like ops.

### What's changed
Implemented Zeros/Ones like op in the TTIR and TTNN compiler part of the stack. Also implemented runtime support and added tests.

### Checklist
- [x] New/Existing tests provide coverage for changes
