### PR TITLE
#4636: Add support for empty mesh in AnalyzeMesh pass and add explicit issues for unsupported ops in multi device path.

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
@@ -17,6 +17,9 @@ inline const llvm::SmallVector<llvm::SmallVector<int64_t, 2>, 7>
         {{1, 1}, {1, 2}, {1, 4}, {1, 8}, {2, 4}, {1, 32}, {8, 4}}};
 
 // Check if the meshMap is valid.
+// todo: https://github.com/tenstorrent/tt-mlir/issues/4668
+// Currently we only support a few mesh shapes. We need to extend this to
+// support more mesh shapes (like 1x3, 2x5 etc).
 inline mlir::LogicalResult
 checkValidMesh(llvm::SmallVector<int64_t> meshShape) {
   return mlir::success(

--- a/lib/Dialect/StableHLO/Transforms/AnalyzeMesh.cpp
+++ b/lib/Dialect/StableHLO/Transforms/AnalyzeMesh.cpp
@@ -254,12 +254,23 @@ public:
         return;
       }
 
-      // If mesh is 1D, we will bump it up to 2D mesh with dim0 as 1.
       llvm::SmallVector<int64_t> originalMeshShape =
           shardy_utils::getMeshShapeFromMeshAttr(
               parsedMeshOps[0].getMeshAttr());
+
+      if (originalMeshShape.size() > 2) {
+        rootModule.emitError("Currently, only 1D and 2D meshes are supported");
+        signalPassFailure();
+        return;
+      }
+
+      // If the mesh is not 2D (or if the mesh is empty), we need to update the
+      // mesh to either insert a 1x1 mesh (if the mesh is empty), or bump up a
+      // 1D mesh to 1xn.
       llvm::SmallVector<int64_t> newMeshShape = originalMeshShape;
-      if (newMeshShape.size() == 1) {
+      if (newMeshShape.size() == 0) {
+        newMeshShape = {1, 1};
+      } else if (newMeshShape.size() == 1) {
         newMeshShape = {1, newMeshShape[0]};
       }
 
@@ -277,7 +288,7 @@ public:
         // Get the old mesh axis name. We will make the new dim0 "1" axis name
         // from the old mesh axis name. This is to ensure that we don't have
         // duplicate axis names in the mesh.
-        std::string existingAxisName;
+        std::string existingAxisName = "default";
         for (auto meshAxisAttr : parsedMeshOps[0].getMeshAttr().getAxes()) {
           existingAxisName = meshAxisAttr.getName().str();
         }

--- a/lib/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCLPatterns.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCLPatterns.cpp
@@ -380,12 +380,44 @@ public:
   }
 };
 
+// AllSliceOp
+class ShardyToStableHLOAllSliceOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::AllSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(mlir::sdy::AllSliceOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    srcOp.emitError()
+        << "ShardyToStableHLO lowering for AllSliceOp is not implemented yet: "
+           "https://github.com/tenstorrent/tt-mlir/issues/3368.";
+    return failure();
+  }
+};
+
+// CollectivePermuteOp
+class ShardyToStableHLOCollectivePermuteOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::CollectivePermuteOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(mlir::sdy::CollectivePermuteOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    srcOp.emitError() << "ShardyToStableHLO lowering for CollectivePermuteOp "
+                         "is not implemented yet: "
+                         "https://github.com/tenstorrent/tt-mlir/issues/3370.";
+    return failure();
+  }
+};
+
 void populateShardyCCLToStableHLOCCLPatterns(MLIRContext *ctx,
                                              RewritePatternSet &patterns) {
   patterns.add<ShardyToStableHLOAllGatherOpRewritePattern>(ctx);
   patterns.add<ShardyToStableHLOAllReduceOpRewritePattern>(ctx);
   patterns.add<ShardyToStableHLOReduceScatterOpRewritePattern>(ctx);
   patterns.add<ShardyToStableHLOAllToAllOpRewritePattern>(ctx);
+  patterns.add<ShardyToStableHLOAllSliceOpRewritePattern>(ctx);
+  patterns.add<ShardyToStableHLOCollectivePermuteOpRewritePattern>(ctx);
 }
 
 } // namespace mlir::tt::stablehlo

--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -161,6 +161,20 @@ static FailureOr<mlir::OperationState> createNewOperationState(
 
             return mlir::success();
           })
+          .Case<mlir::stablehlo::CompareOp>([&](auto compareOp) {
+            compareOp->emitError(
+                "Compare operation is not supported in stablehlo-pipeline for "
+                "meshes not 1x1: "
+                "https://github.com/tenstorrent/tt-mlir/issues/3497.");
+            return mlir::failure();
+          })
+          .Case<mlir::stablehlo::ScatterOp>([&](auto scatterOp) {
+            scatterOp->emitError(
+                "Scatter operation is not supported in stablehlo-pipeline for "
+                "meshes not 1x1: "
+                "https://github.com/tenstorrent/tt-mlir/issues/3496.");
+            return mlir::failure();
+          })
           .Default([](mlir::Operation *op) { return mlir::success(); });
 
   if (failed(updatedAttributeResult)) {

--- a/test/ttmlir/Dialect/StableHLO/analyze_mesh/shardy.mlir
+++ b/test/ttmlir/Dialect/StableHLO/analyze_mesh/shardy.mlir
@@ -1,13 +1,25 @@
 // REQUIRES: stablehlo
-// RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s
+// RUN: ttmlir-opt -split-input-file --stablehlo-pipeline -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 
-module @jit_reshape attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
-  sdy.mesh @mesh = <["x"=1, "batch"=8]>
+module {
+  // CHECK: sdy.mesh @mesh = <["batch_updated"=1, "batch"=8]>
+  sdy.mesh @mesh = <["batch"=8]>
   func.func public @main(%arg0: tensor<1024x2x32x32xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}) -> (tensor<2048x1024xf32> {jax.result_info = ""}) {
     %0 = stablehlo.reshape %arg0 : (tensor<1024x2x32x32xf32>) -> tensor<2048x1024xf32>
     return %0 : tensor<2048x1024xf32>
   }
 }
 
-// CHECK: sdy.mesh @mesh = <["x"=1, "batch"=8]>
+// -----
+module {
+  // CHECK: sdy.mesh @empty_mesh = <["default_updated"=1, "default"=1]>
+  sdy.mesh @empty_mesh = <[]>
+  func.func public @main(%arg0: tensor<784x128xf32> {sdy.sharding = #sdy.sharding<@empty_mesh, [{}, {}]>}, %arg1: tensor<128xf32> {sdy.sharding = #sdy.sharding<@empty_mesh, [{}]>}, %arg2: tensor<128x784xf32> {sdy.sharding = #sdy.sharding<@empty_mesh, [{}, {}]>}) -> tensor<128x128xf32> {
+    %0 = stablehlo.dot_general %arg2, %arg0, contracting_dims = [1] x [0] : (tensor<128x784xf32>, tensor<784x128xf32>) -> tensor<128x128xf32>
+    %1 = stablehlo.reshape %arg1 : (tensor<128xf32>) -> tensor<1x128xf32>
+    %2 = stablehlo.broadcast_in_dim %1, dims = [0, 1] : (tensor<1x128xf32>) -> tensor<128x128xf32>
+    %3 = stablehlo.add %0, %2 : tensor<128x128xf32>
+    return %3 : tensor<128x128xf32>
+  }
+}


### PR DESCRIPTION
https://github.com/tenstorrent/tt-mlir/issues/4636

This translates any empty mesh into 1x1 mesh. 