### PR TITLE
Enable multi-device tensor and mesh_shard op in D2M runtime

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -155,3 +155,15 @@ table MLIR {
   name: string;
   source: string;
 }
+
+enum MeshShardDirection: uint32 {
+  FullToShardShape,
+  ShardToFullShape,
+}
+
+enum MeshShardType: uint32 {
+  Identity,
+  Replicate,
+  Maximal,
+  Devices,
+}

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -64,6 +64,15 @@ table CpuCommand {
 table FinishCommand {
 }
 
+table MeshShardCommand {
+  src: BufferRef;
+  dst: BufferRef;
+  shard_type: MeshShardType;
+  shard_direction: MeshShardDirection;
+  shard_shape: [int64];
+  shard_dims: [int64];
+}
+
 union CommandType {
   HostAllocCommand,
   ReturnCommand,
@@ -78,6 +87,7 @@ union CommandType {
   MemrefCopyCommand,
   CpuCommand,
   FinishCommand,
+  MeshShardCommand,
 }
 
 table Command {

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -23,8 +23,8 @@ table MeshShardOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
-  shard_direction: tt.target.ttnn.MeshShardDirection;
-  shard_type: tt.target.ttnn.MeshShardType;
+  shard_direction: tt.target.MeshShardDirection;
+  shard_type: tt.target.MeshShardType;
   shard_shape: [int64];
   shard_dims: [int64];
 }

--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -14,18 +14,6 @@ enum StorageType: ushort {
     Device,
 }
 
-enum MeshShardDirection: uint32 {
-  FullToShardShape,
-  ShardToFullShape,
-}
-
-enum MeshShardType: uint32 {
-  Identity,
-  Replicate,
-  Maximal,
-  Devices,
-}
-
 enum ShardOrientation: uint32 {
   RowMajor,
   ColMajor,

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -802,25 +802,23 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
   llvm::ArrayRef<int64_t> shardShape = op.getShardShape();
   llvm::ArrayRef<int64_t> shardDims = op.getShardDims();
 
-  ::tt::target::ttnn::MeshShardDirection meshShardDirection;
+  ::tt::target::MeshShardDirection meshShardDirection;
   if (shardDirection == mlir::tt::ttcore::MeshShardDirection::FullToShard) {
-    meshShardDirection =
-        ::tt::target::ttnn::MeshShardDirection::FullToShardShape;
+    meshShardDirection = ::tt::target::MeshShardDirection::FullToShardShape;
   } else if (shardDirection ==
              mlir::tt::ttcore::MeshShardDirection::ShardToFull) {
-    meshShardDirection =
-        ::tt::target::ttnn::MeshShardDirection::ShardToFullShape;
+    meshShardDirection = ::tt::target::MeshShardDirection::ShardToFullShape;
   } else {
     llvm_unreachable("unhandled mesh_shard direction");
   }
 
-  ::tt::target::ttnn::MeshShardType meshShardType;
+  ::tt::target::MeshShardType meshShardType;
   if (shardType == mlir::tt::ttcore::MeshShardType::Replicate) {
-    meshShardType = ::tt::target::ttnn::MeshShardType::Replicate;
+    meshShardType = ::tt::target::MeshShardType::Replicate;
   } else if (shardType == mlir::tt::ttcore::MeshShardType::Devices) {
-    meshShardType = ::tt::target::ttnn::MeshShardType::Devices;
+    meshShardType = ::tt::target::MeshShardType::Devices;
   } else if (shardType == mlir::tt::ttcore::MeshShardType::Identity) {
-    meshShardType = ::tt::target::ttnn::MeshShardType::Identity;
+    meshShardType = ::tt::target::MeshShardType::Identity;
   } else {
     llvm_unreachable("unhandled mesh_shard type");
   }

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -7,6 +7,7 @@
 
 #define FMT_HEADER_ONLY
 #include "tt-metalium/circular_buffer.hpp"
+#include "tt-metalium/distributed_host_buffer.hpp"
 #include "tt-metalium/event.hpp"
 #include "tt-metalium/hal.hpp"
 #include "tt-metalium/host_api.hpp"
@@ -24,31 +25,43 @@
 
 namespace tt::runtime::ttmetal {
 
+using HostBuffer = std::shared_ptr<::tt::tt_metal::HostBuffer>;
+using DistributedHostBuffer =
+    std::shared_ptr<::tt::tt_metal::DistributedHostBuffer>;
 using MeshBuffer = std::shared_ptr<::tt::tt_metal::distributed::MeshBuffer>;
-using MetalTensor = std::variant<TensorDesc, MeshBuffer>;
+using MetalTensor =
+    std::variant<TensorDesc, HostBuffer, DistributedHostBuffer, MeshBuffer>;
 
 Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);
-
-inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
-  LOG_ASSERT(utils::isSupportedDataType(desc.dataType),
-             "Creating owned tensor with unsupported data type: " +
-                 std::string(target::EnumNameDataType(desc.dataType)) +
-                 "is not implemented for the TTMetal runtime");
-  std::shared_ptr<void> owned = utils::malloc_shared(desc.sizeBytes());
-  std::memcpy(owned.get(), data, desc.sizeBytes());
-  return ttmetal::createBorrowedHostTensor(owned, desc);
-}
-
-inline Tensor createOwnedHostTensor(std::shared_ptr<void> data,
-                                    const TensorDesc &desc) {
-  return ttmetal::createOwnedHostTensor(data.get(), desc);
-}
 
 inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
   return ttmetal::createBorrowedHostTensor(utils::unsafe_borrow_shared(data),
                                            desc);
 }
+
+std::shared_ptr<::tt::tt_metal::HostBuffer>
+createMetalHostBuffer(const void *data, const std::vector<std::uint32_t> &shape,
+                      const ::tt::target::DataType dataType);
+
+Tensor createOwnedHostTensor(const void *data,
+                             const std::vector<std::uint32_t> &shape,
+                             const std::vector<std::uint32_t> &stride,
+                             std::uint32_t itemsize,
+                             ::tt::target::DataType dataType);
+
+Tensor createMultiDeviceHostTensor(
+    const std::vector<Tensor> &tensorShards,
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
+
+Tensor createMultiDeviceHostTensor(
+    const std::vector<const void *> &data,
+    const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType,
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
 
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);
@@ -62,6 +75,8 @@ std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
+HostBuffer getHostBuffer(::tt::runtime::Tensor tensor);
+DistributedHostBuffer getDistributedHostBuffer(::tt::runtime::Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -206,7 +206,7 @@ Tensor createOwnedHostTensor(const void *data,
       },
       [&]() -> RetType {
         return ::tt::runtime::ttmetal::createOwnedHostTensor(
-            data, TensorDesc(shape, stride, itemsize, dataType));
+            data, shape, stride, itemsize, dataType);
       });
 }
 
@@ -228,7 +228,8 @@ Tensor createMultiDeviceHostTensor(
             data, shape, stride, itemsize, dataType, strategy, meshShape);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+        return ::tt::runtime::ttmetal::createMultiDeviceHostTensor(
+            data, shape, stride, itemsize, dataType, strategy, meshShape);
       });
 }
 
@@ -245,7 +246,8 @@ Tensor createMultiDeviceHostTensor(
             tensorShards, strategy, meshShape);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+        return ::tt::runtime::ttmetal::createMultiDeviceHostTensor(
+            tensorShards, strategy, meshShape);
       });
 }
 

--- a/runtime/lib/ttmetal/CMakeLists.txt
+++ b/runtime/lib/ttmetal/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(TTRuntimeTTMetal
   STATIC
   runtime.cpp
   executor.cpp
+  meshshard_utils.cpp
 )
 # We have to set the C++ standard to 20 because tt-metal requires it
 set_property(TARGET TTRuntimeTTMetal PROPERTY CXX_STANDARD 20)

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -4,6 +4,7 @@
 
 #include "executor.h"
 #include "executor_utils.h"
+#include "meshshard_utils.h"
 
 #include "tools/profiler/op_profiler.hpp"
 #include "tracy/Tracy.hpp"
@@ -21,6 +22,7 @@
 #include "ttmlir/Target/TTMetal/Target.h"
 #include "ttmlir/Target/TTMetal/types_generated.h"
 #include "ttmlir/Version.h"
+#include "types_generated.h"
 
 #include <cstdint>
 #include <string>
@@ -62,6 +64,7 @@ private:
   void execute(const target::metal::MemrefCopyCommand *command);
   void execute(const target::metal::CpuCommand *command);
   void execute(const target::metal::FinishCommand *command);
+  void execute(const target::metal::MeshShardCommand *command);
 
   std::uint64_t getUniqueProgramRuntimeId() { return nextProgramRuntimeId++; }
 
@@ -103,9 +106,19 @@ MCQExecutor::MCQExecutor(
                          hostBuffers.try_emplace(ref->global_id(), input);
                      LOG_ASSERT(inserted);
                    },
-                   [&](const MeshBuffer &mesh_buffer) {
+                   [&](const HostBuffer &hostBuffer) {
                      auto [_, inserted] =
-                         meshBuffers.try_emplace(ref->global_id(), mesh_buffer);
+                         hostBuffers.try_emplace(ref->global_id(), input);
+                     LOG_ASSERT(inserted);
+                   },
+                   [&](const DistributedHostBuffer &distributedHostBuffer) {
+                     auto [_, inserted] =
+                         hostBuffers.try_emplace(ref->global_id(), input);
+                     LOG_ASSERT(inserted);
+                   },
+                   [&](const MeshBuffer &meshBuffer) {
+                     auto [_, inserted] =
+                         meshBuffers.try_emplace(ref->global_id(), meshBuffer);
                      LOG_ASSERT(inserted);
                    },
                },
@@ -191,6 +204,10 @@ void MCQExecutor::execute(const target::metal::Command *command) {
     execute(command->type_as_FinishCommand());
     break;
   }
+  case target::metal::CommandType::MeshShardCommand: {
+    execute(command->type_as_MeshShardCommand());
+    break;
+  }
   case target::metal::CommandType::NONE: {
     LOG_FATAL("Unsupported CommandType::NONE");
     break;
@@ -212,17 +229,36 @@ void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
   if (!data) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");
   }
-
   if (command->data() != nullptr) {
     assert(command->data()->size() == size);
     std::memcpy(data.get(), command->data()->data(), size);
   }
 
-  std::shared_ptr<MetalTensor> tensor = std::make_shared<MetalTensor>(desc);
-  auto [_, inserted] = hostBuffers.try_emplace(
-      command->dst()->global_id(), std::static_pointer_cast<void>(tensor), data,
-      DeviceRuntime::TTMetal);
-  LOG_ASSERT(inserted);
+  auto meshShape = meshDevice->shape();
+  if (meshShape.mesh_size() == 1) {
+    auto [_, inserted] = hostBuffers.try_emplace(
+        command->dst()->global_id(),
+        std::static_pointer_cast<void>(std::make_shared<MetalTensor>(desc)),
+        data, DeviceRuntime::TTMetal);
+    LOG_ASSERT(inserted);
+  } else {
+    auto distributedHostBufferPtr =
+        std::make_shared<tt_metal::DistributedHostBuffer>(
+            tt_metal::DistributedHostBuffer::create(meshDevice->shape()));
+    for (const auto &coord :
+         tt_metal::distributed::MeshCoordinateRange(meshShape)) {
+      const auto hostBuffer =
+          createMetalHostBuffer(data.get(), shape, bufferDesc->data_type());
+      distributedHostBufferPtr->emplace_shard(
+          coord, [&buffer = *hostBuffer]() { return buffer; });
+    }
+    auto [_, inserted] = hostBuffers.try_emplace(
+        command->dst()->global_id(),
+        std::static_pointer_cast<void>(
+            std::make_shared<MetalTensor>(distributedHostBufferPtr)),
+        nullptr, DeviceRuntime::TTMetal);
+    LOG_ASSERT(inserted);
+  }
 }
 
 void MCQExecutor::execute(const target::metal::ReturnCommand *command) {
@@ -336,20 +372,20 @@ void MCQExecutor::execute(
     const target::metal::EnqueueWriteBufferCommand *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
 
-  void *src = hostBuffers.at(command->src()->global_id()).data.get();
-  LOG_ASSERT(src);
+  auto input = hostBuffers.at(command->src()->global_id());
   auto meshBuffer = meshBuffers.at(command->dst()->global_id());
-  mcq->enqueue_write_mesh_buffer(meshBuffer, src, blockingCQ);
+  tt::runtime::ttmetal::writeHostTensorToMeshBuffer(mcq, input, meshBuffer,
+                                                    blockingCQ);
 }
 
 void MCQExecutor::execute(
     const target::metal::EnqueueReadBufferCommand *command) {
   ZoneScopedN("EnqueueReadBufferCommand");
 
-  void *dst = hostBuffers.at(command->dst()->global_id()).data.get();
-  LOG_ASSERT(dst);
   auto meshBuffer = meshBuffers.at(command->src()->global_id());
-  mcq->enqueue_read_mesh_buffer(dst, meshBuffer, true);
+  auto output = hostBuffers.at(command->dst()->global_id());
+  tt::runtime::ttmetal::readHostTensorFromMeshBuffer(mcq, meshBuffer, output,
+                                                     blockingCQ);
 }
 
 void MCQExecutor::execute(const target::metal::CreateBufferCommand *command) {
@@ -430,6 +466,63 @@ void MCQExecutor::execute(const target::metal::CpuCommand *command) {
 void MCQExecutor::execute(const target::metal::FinishCommand *) {
   ZoneScopedN("FinishCommand");
   distributed::Finish(*mcq);
+}
+
+void MCQExecutor::execute(const target::metal::MeshShardCommand *command) {
+  ZoneScopedN("MeshShardCommand");
+
+  LOG_ASSERT(command->src()->desc()->buffer_detail_type() ==
+                 tt::target::metal::BufferDetail::SystemBuffer,
+             "MeshShardCommand requries system memory as input");
+  LOG_ASSERT(command->dst()->desc()->buffer_detail_type() ==
+                 tt::target::metal::BufferDetail::SystemBuffer,
+             "MeshShardCommand requries system memory as output");
+  const auto dstDataType = command->dst()->desc()->data_type();
+  const auto *fbTensorShape = command->src()->desc()->shape();
+  const std::vector<size_t> tensorShape(fbTensorShape->begin(),
+                                        fbTensorShape->end());
+  const auto *fbShardDims = command->shard_dims();
+  const std::vector<int64_t> meshShardDims(fbShardDims->begin(),
+                                           fbShardDims->end());
+  const auto meshShardType = command->shard_type();
+
+  auto srcBufferIter = hostBuffers.find(command->src()->global_id());
+  LOG_ASSERT(srcBufferIter != hostBuffers.end(),
+             "Input host buffer not found.");
+  const Tensor input = srcBufferIter->second;
+
+  auto putHostTensor = [&](const Tensor &output) -> void {
+    LOG_ASSERT(hostBuffers.find(command->dst()->global_id()) ==
+                   hostBuffers.end(),
+               "Output host buffer already exists.");
+    auto [_, inserted] =
+        hostBuffers.try_emplace(command->dst()->global_id(), output);
+    LOG_ASSERT(inserted);
+  };
+
+  if (meshShardType == target::MeshShardType::Identity) {
+    // Identity: copy from src tensor to dst tensor
+    putHostTensor(input);
+    return;
+  }
+
+  if (command->shard_direction() ==
+      target::MeshShardDirection::FullToShardShape) {
+    auto distributedHostBufferPtr = meshshard_utils::tensorFullToShard(
+        input, meshDevice->shape(), dstDataType, tensorShape, meshShardType,
+        meshShardDims);
+    putHostTensor(
+        Tensor(std::static_pointer_cast<void>(
+                   std::make_shared<MetalTensor>(distributedHostBufferPtr)),
+               nullptr, DeviceRuntime::TTMetal));
+  } else {
+    auto hostBufferPtr = meshshard_utils::tensorShardToFull(
+        input, meshDevice->shape(), dstDataType, tensorShape, meshShardType,
+        meshShardDims);
+    putHostTensor(Tensor(std::static_pointer_cast<void>(
+                             std::make_shared<MetalTensor>(hostBufferPtr)),
+                         nullptr, DeviceRuntime::TTMetal));
+  }
 }
 
 std::vector<Tensor>

--- a/runtime/lib/ttmetal/meshshard_utils.cpp
+++ b/runtime/lib/ttmetal/meshshard_utils.cpp
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define FMT_HEADER_ONLY
+#include "meshshard_utils.h"
+
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttmetal/ttmetal.h"
+#include "tt/runtime/types.h"
+
+#include <tt_stl/overloaded.hpp>
+#include <tt_stl/small_vector.hpp>
+
+namespace tt::runtime::ttmetal::meshshard_utils {
+
+namespace target = ::tt::target;
+namespace tt_metal = ::tt::tt_metal;
+namespace distributed = ::tt::tt_metal::distributed;
+namespace xtensor = ::ttnn::experimental::xtensor;
+
+// Copy from increment_indices() in ttnn/tensor/xtensor/partition.cpp.
+static bool incrementIndices(const ttsl::SmallVector<int> &limits,
+                             ttsl::SmallVector<int> &indices) {
+  for (int i = static_cast<int>(indices.size()) - 1; i >= 0; --i) {
+    if (++indices[i] < limits[i]) {
+      return true;
+    }
+    indices[i] = 0;
+  }
+  return false;
+}
+
+// Mainly from TensorToMesh in ttnn/tensor/xtensor/partition.cpp and adjust for
+// direct use of HostBuffer and DistributedHostBuffer.
+template <typename T>
+tt_metal::DistributedHostBuffer
+shard(const tt_metal::HostBuffer &hostBuffer,
+      const std::vector<size_t> &tensorShape,
+      const tt_metal::distributed::MeshShape &meshShape,
+      const std::vector<int64_t> &meshShardDims) {
+
+  ttsl::SmallVector<size_t> shardDims;
+  ttsl::SmallVector<int> numChunksPerDim;
+  ttsl::SmallVector<int> tensorDims;
+  ttsl::SmallVector<size_t> replicateDims;
+  size_t shardedMeshSize = 1;
+  for (size_t dimIdx = 0; dimIdx < meshShardDims.size(); ++dimIdx) {
+    if (meshShardDims[dimIdx] >= 0) {
+      shardDims.push_back(dimIdx);
+      tensorDims.push_back(meshShardDims[dimIdx]);
+      numChunksPerDim.push_back(meshShape[dimIdx]);
+      shardedMeshSize *= meshShape[dimIdx];
+    } else {
+      replicateDims.push_back(dimIdx);
+    }
+  }
+
+  if (shardDims.empty()) {
+    // replicate should not be handled here.
+    LOG_FATAL("Replicate shard type should not be handled here.");
+  }
+
+  // devices: use xtensor to chunk the data into shards.
+  ttsl::Span<const T> span = hostBuffer.view_as<const T>();
+  size_t tensorVolume =
+      std::accumulate(tensorShape.cbegin(), tensorShape.cend(), uint64_t{1},
+                      std::multiplies<uint64_t>());
+  LOG_ASSERT(span.size() == tensorVolume,
+             "Current buffer size is different from shape volume");
+
+  auto inputXtensor = xtensor::adapt(
+      span, std::vector<size_t>(tensorShape.cbegin(), tensorShape.cend()));
+
+  auto chunks = xtensor::chunk_ndim(inputXtensor, numChunksPerDim, tensorDims);
+
+  LOG_ASSERT(chunks.size() >= 1, "No chunks were produced");
+  LOG_ASSERT(meshShape.dims() == 1 || chunks.size() == shardedMeshSize,
+             "Nd sharding requires the number of chunks to match the mesh "
+             "dimension size.");
+
+  using StridedViewRef =
+      std::reference_wrapper<xtensor::StridedView<decltype(inputXtensor)>>;
+  tt_metal::distributed::MeshContainer<std::optional<StridedViewRef>>
+      shardedXtensorViews(meshShape, std::nullopt);
+
+  // Distribute chunks to appropriate mesh coordinates.
+  size_t chunk_idx = 0;
+  ttsl::SmallVector<int> shardIndices(shardDims.size(), 0);
+  do {
+    ttsl::SmallVector<uint32_t> meshCoords(meshShape.dims(), 0);
+    for (size_t i = 0; i < shardDims.size(); ++i) {
+      meshCoords[shardDims[i]] = shardIndices[i];
+    }
+    tt_metal::distributed::MeshCoordinate coord(ttsl::make_span(meshCoords));
+    if (chunk_idx < chunks.size()) {
+      shardedXtensorViews.at(coord) = chunks[chunk_idx];
+    }
+    chunk_idx++;
+  } while (incrementIndices(numChunksPerDim, shardIndices));
+
+  // Handle replicated dims: treat shards placed at the beginning of each
+  // replication axes as "replication sources" and copy its value to all other
+  // shards along the axes.
+  if (!replicateDims.empty()) {
+    ttsl::SmallVector<int> replicateSizes;
+    for (size_t replicateDim : replicateDims) {
+      replicateSizes.push_back(meshShape[replicateDim]);
+    }
+    for (const auto &[coord, xtensorView] : shardedXtensorViews) {
+      const bool replication_source = std::all_of(
+          replicateDims.begin(), replicateDims.end(),
+          [&](size_t replicateDim) { return coord[replicateDim] == 0; });
+      if (xtensorView.has_value() && replication_source) {
+        ttsl::SmallVector<int> replicateIndices(replicateDims.size(), 0);
+        do {
+          ttsl::SmallVector<uint32_t> meshCoords(coord.coords().begin(),
+                                                 coord.coords().end());
+          for (size_t i = 0; i < replicateDims.size(); ++i) {
+            meshCoords[replicateDims[i]] = replicateIndices[i];
+          }
+          shardedXtensorViews.at(tt_metal::distributed::MeshCoordinate(
+              ttsl::make_span(meshCoords))) = *xtensorView;
+        } while (incrementIndices(replicateSizes, replicateIndices));
+      }
+    }
+  }
+
+  auto distributedHostBuffer =
+      tt_metal::DistributedHostBuffer::create(meshShape);
+  using XTensorViewKey = decltype(&shardedXtensorViews.values().front()->get());
+  std::unordered_map<XTensorViewKey, tt::tt_metal::HostBuffer>
+      convertedHostBuffers;
+  for (const auto &[coord, xtensorView] : shardedXtensorViews) {
+    if (xtensorView.has_value()) {
+      distributedHostBuffer.emplace_shard(coord, [&convertedHostBuffers,
+                                                  &xtensorView]() {
+        auto it = convertedHostBuffers.find(&xtensorView->get());
+        if (it != convertedHostBuffers.end()) {
+          return it->second;
+        }
+        std::vector<std::remove_const_t<T>> data_vec(xtensorView->get().begin(),
+                                                     xtensorView->get().end());
+        auto hostBuffer = tt_metal::HostBuffer(std::move(data_vec));
+        convertedHostBuffers.emplace(&xtensorView->get(), hostBuffer);
+        return hostBuffer;
+      });
+    }
+  }
+
+  return distributedHostBuffer;
+}
+
+static tt_metal::DistributedHostBuffer
+shardHostBuffer(const tt_metal::HostBuffer &hostBuffer,
+                const tt_metal::distributed::MeshShape &meshShape,
+                const target::DataType dataType,
+                const std::vector<size_t> &tensorShape,
+                const target::MeshShardType meshShardType,
+                const std::vector<int64_t> &meshShardDims) {
+
+  // replicate - use the host buffer for all shards in distributed buffer.
+  if (meshShardType == target::MeshShardType::Replicate) {
+    LOG_ASSERT(meshShardDims.size() == 1 && meshShardDims[0] == -1,
+               "Replicate shard type should have a single dimension set to -1");
+    auto distributedBuffer = tt_metal::DistributedHostBuffer::create(meshShape);
+    for (const auto &coord :
+         tt_metal::distributed::MeshCoordinateRange(meshShape)) {
+      distributedBuffer.emplace_shard(
+          coord, [&buffer = hostBuffer]() { return buffer; });
+    }
+    return distributedBuffer;
+  }
+
+  auto shard_impl = [&]<typename T>() -> tt_metal::DistributedHostBuffer {
+    return shard<T>(hostBuffer, tensorShape, meshShape, meshShardDims);
+  };
+
+  switch (dataType) {
+  case target::DataType::BFP_BFloat4:
+  case target::DataType::BFP_BFloat8:
+  case target::DataType::Float32:
+    return shard_impl.template operator()<float>();
+  case target::DataType::BFloat16:
+    return shard_impl.template operator()<bfloat16>();
+  case target::DataType::Int32:
+    return shard_impl.template operator()<int32_t>();
+  case target::DataType::UInt8:
+    return shard_impl.template operator()<uint8_t>();
+  case target::DataType::UInt16:
+    return shard_impl.template operator()<uint16_t>();
+  case target::DataType::UInt32:
+    return shard_impl.template operator()<uint32_t>();
+  default:
+    LOG_FATAL("Unsupported data type");
+  }
+}
+
+// Mainly from MeshToTensor::compose() in ttnn/tensor/xtensor/partition.cpp and
+// adjust for direct use of HostBuffer and DistributedHostBuffer.
+template <typename T>
+std::vector<T>
+concat(const tt_metal::DistributedHostBuffer &distributedHostBuffer,
+       const tt_metal::distributed::MeshShape &meshShape,
+       const std::vector<int32_t> &meshShardDims,
+       const std::vector<size_t> &tensorShape) {
+
+  // Convert shards into a linear buffer of xtensor views.
+  std::vector<xtensor::AdaptedView<const T>> xtensorViews;
+  xtensorViews.reserve(meshShape.mesh_size());
+  distributedHostBuffer.apply(
+      [&xtensorViews, &tensorShape](const tt::tt_metal::HostBuffer &shard) {
+        xtensorViews.push_back(
+            xtensor::adapt(shard.view_as<const T>(), tensorShape));
+      });
+
+  ttsl::SmallVector<int> numChunks;
+  if (meshShardDims.size() == 1) {
+    numChunks.push_back(xtensorViews.size());
+  } else {
+    LOG_ASSERT(xtensorViews.size() == meshShape.mesh_size(),
+               "Nd composition requires the number of tensors to match the "
+               "mesh shape");
+    for (size_t i = 0; i < meshShape.dims(); ++i) {
+      numChunks.push_back(meshShape[i]);
+    }
+  };
+
+  auto xtensorAdapter = xtensor::concat_ndim(
+      xtensorViews, numChunks,
+      ttsl::SmallVector<int>(meshShardDims.cbegin(), meshShardDims.cend()));
+
+  return std::move(xtensorAdapter).data();
+}
+
+static tt_metal::HostBuffer concatDistributedHostBuffers(
+    const tt_metal::DistributedHostBuffer &distributedHostBuffer,
+    const tt_metal::distributed::MeshShape &meshShape,
+    const target::DataType dataType, const std::vector<size_t> &tensorShape,
+    const target::MeshShardType meshShardType,
+    const std::vector<int64_t> meshShardDims) {
+
+  // replicate - pick up the first host buffer as they are identical.
+  if (meshShardType == target::MeshShardType::Replicate) {
+    std::vector<const tt_metal::HostBuffer *> hostBuffers;
+    distributedHostBuffer.apply(
+        [&hostBuffers](const tt_metal::HostBuffer &hostBuffer) -> void {
+          return hostBuffers.push_back(&hostBuffer);
+        });
+    return *hostBuffers[0];
+  }
+
+  std::vector<int32_t> shardDims(meshShardDims.size());
+  std::transform(meshShardDims.begin(), meshShardDims.end(), shardDims.begin(),
+                 [](int64_t val) { return static_cast<int32_t>(val); });
+
+  auto concat_impl = [&]<typename T>() -> tt_metal::HostBuffer {
+    auto data =
+        concat<T>(distributedHostBuffer, meshShape, shardDims, tensorShape);
+    return tt_metal::HostBuffer(std::move(data));
+  };
+
+  switch (dataType) {
+  case target::DataType::BFP_BFloat4:
+  case target::DataType::BFP_BFloat8:
+  case target::DataType::Float32:
+    return concat_impl.template operator()<float>();
+  case target::DataType::BFloat16:
+    return concat_impl.template operator()<bfloat16>();
+  case target::DataType::Int32:
+    return concat_impl.template operator()<int32_t>();
+  case target::DataType::UInt8:
+    return concat_impl.template operator()<uint8_t>();
+  case target::DataType::UInt16:
+    return concat_impl.template operator()<uint16_t>();
+  case target::DataType::UInt32:
+    return concat_impl.template operator()<uint32_t>();
+  default:
+    LOG_FATAL("Unsupported data type");
+  }
+}
+
+std::shared_ptr<tt_metal::DistributedHostBuffer> tensorFullToShard(
+    const Tensor &input, const tt_metal::distributed::MeshShape &meshShape,
+    const target::DataType dataType, const std::vector<size_t> &tensorShape,
+    const target::MeshShardType meshShardType,
+    const std::vector<int64_t> &meshShardDims) {
+
+  return std::visit(
+      utils::overloaded{
+          [&](const TensorDesc &tensorDesc)
+              -> std::shared_ptr<tt_metal::DistributedHostBuffer> {
+            void *dst = input.data.get();
+            LOG_ASSERT(dst, "Tensor data is null");
+            auto hostBuffer = tt::runtime::ttmetal::createMetalHostBuffer(
+                dst, tensorDesc.shape, tensorDesc.dataType);
+            return std::make_shared<tt_metal::DistributedHostBuffer>(
+                meshshard_utils::shardHostBuffer(*hostBuffer, meshShape,
+                                                 dataType, tensorShape,
+                                                 meshShardType, meshShardDims));
+          },
+          [&](const HostBuffer &hostBuffer) {
+            return std::make_shared<tt_metal::DistributedHostBuffer>(
+                meshshard_utils::shardHostBuffer(*hostBuffer, meshShape,
+                                                 dataType, tensorShape,
+                                                 meshShardType, meshShardDims));
+          },
+          [&](const DistributedHostBuffer &distributedHostBuffer) {
+            LOG_FATAL("tensorFullToShard from DistributedHostBuffer not "
+                      "supported.");
+            return std::make_shared<tt_metal::DistributedHostBuffer>(
+                tt_metal::DistributedHostBuffer::create(meshShape));
+          },
+          [&](const MeshBuffer &meshBuffer) {
+            LOG_FATAL("tensorFullToShard from MeshBuffer not supported.");
+            return std::make_shared<tt_metal::DistributedHostBuffer>(
+                tt_metal::DistributedHostBuffer::create(meshShape));
+          },
+      },
+      input.as<MetalTensor>(DeviceRuntime::TTMetal));
+}
+
+std::shared_ptr<tt_metal::HostBuffer> tensorShardToFull(
+    const Tensor &input, const tt_metal::distributed::MeshShape &meshShape,
+    const target::DataType dataType, const std::vector<size_t> &tensorShape,
+    const target::MeshShardType meshShardType,
+    const std::vector<int64_t> &meshShardDims) {
+
+  return std::visit(
+      utils::overloaded{
+          [&](const TensorDesc &tensorDesc)
+              -> std::shared_ptr<tt_metal::HostBuffer> {
+            LOG_FATAL("tensorShardToFull from TensorDesc not supported.");
+            return std::make_shared<tt_metal::HostBuffer>();
+          },
+          [&](const HostBuffer &hostBuffer) {
+            LOG_FATAL("tensorShardToFull from HostBuffer not supported.");
+            return std::make_shared<tt_metal::HostBuffer>();
+          },
+          [&](const DistributedHostBuffer &distributedHostBuffer) {
+            return std::make_shared<tt_metal::HostBuffer>(
+                meshshard_utils::concatDistributedHostBuffers(
+                    *distributedHostBuffer, meshShape, dataType, tensorShape,
+                    meshShardType, meshShardDims));
+          },
+          [&](const MeshBuffer &meshBuffer) {
+            LOG_FATAL("tensorShardToFull from MeshBuffer not supported.");
+            return std::make_shared<tt_metal::HostBuffer>();
+          },
+      },
+      input.as<MetalTensor>(DeviceRuntime::TTMetal));
+}
+
+} // namespace tt::runtime::ttmetal::meshshard_utils

--- a/runtime/lib/ttmetal/meshshard_utils.h
+++ b/runtime/lib/ttmetal/meshshard_utils.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTMETAL_MESHSCHARD_UTILS_H
+#define RUNTIME_LIB_TTMETAL_MESHSCHARD_UTILS_H
+
+#include "ttmlir/Target/TTMetal/Target.h"
+#include "ttnn/tensor/xtensor/partition.hpp"
+
+#include "tt/runtime/detail/ttmetal/ttmetal.h"
+
+namespace tt::runtime::ttmetal::meshshard_utils {
+
+std::shared_ptr<tt_metal::DistributedHostBuffer> tensorFullToShard(
+    const Tensor &input, const tt_metal::distributed::MeshShape &meshShape,
+    const target::DataType dataType, const std::vector<size_t> &tensorShape,
+    const target::MeshShardType meshShardType,
+    const std::vector<int64_t> &meshShardDims);
+
+std::shared_ptr<tt_metal::HostBuffer> tensorShardToFull(
+    const Tensor &input, const tt_metal::distributed::MeshShape &meshShape,
+    const target::DataType dataType, const std::vector<size_t> &tensorShape,
+    const target::MeshShardType meshShardType,
+    const std::vector<int64_t> &meshShardDims);
+
+} // namespace tt::runtime::ttmetal::meshshard_utils
+
+#endif // RUNTIME_LIB_TTMETAL_MESHSCHARD_UTILS_H

--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -18,13 +18,12 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
   ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
-  const ::tt::target::ttnn::MeshShardDirection shardDirection =
-      op->shard_direction();
-  const ::tt::target::ttnn::MeshShardType shardType = op->shard_type();
+  const ::tt::target::MeshShardDirection shardDirection = op->shard_direction();
+  const ::tt::target::MeshShardType shardType = op->shard_type();
   const auto *fbShardDims = op->shard_dims();
   std::vector<int64_t> shardDims(fbShardDims->begin(), fbShardDims->end());
 
-  if (shardType == ::tt::target::ttnn::MeshShardType::Identity) {
+  if (shardType == ::tt::target::MeshShardType::Identity) {
     // Forward tensor in runtime for identity shard type assuming that the input
     // tensor is pre-sharded by frontend and output tensor is expected to be
     // pre-sharded by frontend. Thus, no sharding is required, but need to makes
@@ -38,7 +37,7 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
                  "replicate and devices operations.");
   }
 
-  if (shardType == ::tt::target::ttnn::MeshShardType::Identity) {
+  if (shardType == ::tt::target::MeshShardType::Identity) {
     // Forward tensor in runtime for identity shard type assuming that the input
     // tensor is pre-sharded by frontend and output tensor is expected to be
     // pre-sharded by frontend.
@@ -48,13 +47,12 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
 
   auto fullMeshShape = meshDevice.shape();
   ::ttnn::Tensor out;
-  if (shardDirection ==
-      ::tt::target::ttnn::MeshShardDirection::FullToShardShape) {
+  if (shardDirection == ::tt::target::MeshShardDirection::FullToShardShape) {
     // Nd Sharding
     MeshMapperConfig meshMapperConfig;
     meshMapperConfig.placements.resize(fullMeshShape.dims(),
                                        MeshMapperConfig::Replicate{});
-    if (shardType == ::tt::target::ttnn::MeshShardType::Devices) {
+    if (shardType == ::tt::target::MeshShardType::Devices) {
       std::transform(shardDims.cbegin(), shardDims.cend(),
                      meshMapperConfig.placements.begin(),
                      [](const int dim) -> MeshMapperConfig::Placement {
@@ -70,7 +68,7 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   } else {
     // Nd (partial) Concat
     MeshComposerConfig meshComposerConfig;
-    if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
+    if (shardType == ::tt::target::MeshShardType::Replicate) {
       meshComposerConfig.dims.push_back(static_cast<int>(1));
       meshComposerConfig.mesh_shape_override = ::ttnn::MeshShape({1});
     } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4640)

### Problem description
Current D2M runtime needs to support two things for multi-device computation.
1. Enable multi-device tensor in D2M runtime
2. Enable mesh_shard op in D2M runtime

### What's changed
This PR includes the support of multi-device tensor and mesh_shard operation support in D2M runtime.
This PR is the first one and following PR (#4641) will cover lowering of mesh_shard op in D2M pipeline. This feature depends on some ongoing changes in PR, so needed to be split into two PRs.

### Checklist
- Tests will be added once the D2M lowering of MeshShard op is enabled in following ticket https://github.com/tenstorrent/tt-mlir/issues/4641.