### PR TITLE
[D2M] DMA Region Merging

### DIFF
--- a/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
@@ -84,7 +84,7 @@ public:
           op, [&] { newGeneric.getRegion(regionIndex++).takeBody(region); });
     }
 
-    unsigned computeRegionIndex = op.getNumRegions() - 1;
+    unsigned computeRegionIndex = newGeneric.getNumRegions() - 1;
     unsigned lastInputRegionIndex = inputOperandsLength - 1;
 
     // Output DMA regions that contain a lone ttir.await are special, in that

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -116,8 +116,8 @@ void createTTIRToTTMetalMiddleendPipeline(
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(ttir::createTTIRGenericLinearizeMemref());
   pm.addPass(ttir::createTTIRGenericGenerateDatamovement());
-  pm.addPass(ttir::createTTIRGenericLowerDMAs());
   pm.addPass(ttir::createTTIRGenericHWThreadSelection());
+  pm.addPass(ttir::createTTIRGenericLowerDMAs());
   pm.addPass(ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm, options);
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());

--- a/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
@@ -1,4 +1,5 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-generic-hw-thread-selection %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-generic-hw-thread-selection -o %t %s
+// RUN: FileCheck %s --input-file=%t
 
 #dram = #ttcore.memory_space<dram>
 #l1_ = #ttcore.memory_space<l1>
@@ -9,6 +10,7 @@
 #parallel = #ttcore.iterator_type<parallel>
 #reduction = #ttcore.iterator_type<reduction>
 
+// CHECK: func.func @add
 func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_>, %arg1: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
@@ -19,6 +21,7 @@ func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<163
     ttir.yield %cb1 : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>)
   }, {
   // CHECK-NOT: ^datamovement2
+  // CHECK: ^compute
   // CHECK: ttir.yield [[CB2:%.*]] : {{.*}}
   // CHECK-NEXT: ttir.await [[CB2]] : {{.*}}
   ^datamovement2(%cb0: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>):
@@ -39,6 +42,7 @@ func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<163
   return %alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_>
 }
 
+// CHECK: func.func @matmul_single_core
 func.func @matmul_single_core(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1_>, %arg1: memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
@@ -49,6 +53,7 @@ func.func @matmul_single_core(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #t
     ttir.yield %cb1 : (memref<4x2x!ttcore.tile<32x32, f32>, #l1_>)
   }, {
   // CHECK-NOT: ^datamovement2
+  // CHECK: ^compute
   // CHECK: ttir.yield [[CB2:%.*]] : {{.*}}
   // CHECK-NEXT: ttir.await [[CB2]] : {{.*}}
   ^datamovement2(%cb0: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!ttcore.tile<32x32, f32>, #l1_>):
@@ -62,15 +67,14 @@ func.func @matmul_single_core(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #t
   return %alloc : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>
 }
 
+// CHECK: func.func @tilize
 func.func @tilize(%arg0: memref<2x4x128x192xf32, #ttcore.shard<768x4>, #l1_>) -> memref<2x4x4x6x!ttcore.tile<32x32, f32>, #ttcore.shard<24576x4096>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!ttcore.tile<32x32, f32>, #ttcore.shard<24576x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!ttcore.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<128x192xf32, #l1_>)
   }, {
-  // CHECK-NOT: ^datamovement1
-  // CHECK: ttir.yield [[CB1:%.*]] : {{.*}}
-  // CHECK-NEXT: ttir.await [[CB1]] : {{.*}}
+  // CHECK-NOT: ^datamovement2
   ^datamovement1(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!ttcore.tile<32x32, f32>, #l1_>):
     ttir.await %cb1 : (memref<4x6x!ttcore.tile<32x32, f32>, #l1_>)
   }, {
@@ -80,4 +84,50 @@ func.func @tilize(%arg0: memref<2x4x128x192xf32, #ttcore.shard<768x4>, #l1_>) ->
     ttir.yield %cb1 : (memref<4x6x!ttcore.tile<32x32, f32>, #l1_>)
   }) : (memref<2x4x128x192xf32, #ttcore.shard<768x4>, #l1_>, memref<2x4x4x6x!ttcore.tile<32x32, f32>, #ttcore.shard<24576x4096>, #l1_>) -> ()
   return %alloc : memref<2x4x4x6x!ttcore.tile<32x32, f32>, #ttcore.shard<24576x4096>, #l1_>
+}
+
+#l1 = #ttcore.memory_space<l1>
+// CHECK: func.func @mergeNonTrivialDatamovementThreads
+func.func @mergeNonTrivialDatamovementThreads(%arg0: memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) {
+  %alloc = memref.alloc() {address = 296352 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_0 = memref.alloc() {address = 361888 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream = "ttir.stream_layout"(%alloc, %alloc_0) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+  %alloc_1 = memref.alloc() {address = 427424 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_2 = memref.alloc() {address = 492960 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream_3 = "ttir.stream_layout"(%alloc_1, %alloc_2) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+  %alloc_4 = memref.alloc() {address = 558496 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_5 = memref.alloc() {address = 624032 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream_6 = "ttir.stream_layout"(%alloc_4, %alloc_5) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+  ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>]}
+      ins(%stream, %stream_3 : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>)
+      outs(%stream_6 : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>)  {
+  ^datamovement0(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    %tx = ttir.dma %stream<#map>, %cb0 : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }, {
+  ^datamovement1(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    %tx = ttir.dma %stream_3<#map>, %cb1 : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }, {
+  // CHECK: ^datamovement0
+  // CHECK: ttir.dma [[STREAM0:%.*]]<#map>, [[CB0:%.*]]
+  // CHECK: ttir.yield [[CB0:%.*]] : {{.*}}
+  // CHECK: ^datamovement1
+  // CHECK: ttir.dma [[STREAM1:%.*]]<#map>, [[CB1:%.*]]
+  // CHECK: ttir.yield [[CB1:%.*]] : {{.*}}
+  // CHECK-NEXT: ttir.await [[CB2:%.*]] : {{.*}}
+  // CHECK-NOT: ^datamovement2
+  // CHECK: ^compute
+  ^datamovement2(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    ttir.await %cb2 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+    %tx = ttir.dma %cb2, %stream_6<#map> : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+  }, {
+  ^compute0(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    ttir.await %cb0, %cb1 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+    ttir.yield %cb2 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }
+  return
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
@@ -131,3 +131,79 @@ func.func @mergeNonTrivialDatamovementThreads(%arg0: memref<1x1x4x4x!ttcore.tile
   }
   return
 }
+
+
+// CHECK: func.func @mergeManyNonTrivialDatamovementThreads
+func.func @mergeManyNonTrivialDatamovementThreads(%arg0: memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) {
+  %alloc = memref.alloc() {address = 296352 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_0 = memref.alloc() {address = 361888 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream = "ttir.stream_layout"(%alloc, %alloc_0) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+  %alloc_1 = memref.alloc() {address = 427424 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_2 = memref.alloc() {address = 492960 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream_3 = "ttir.stream_layout"(%alloc_1, %alloc_2) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+  %alloc_4 = memref.alloc() {address = 558496 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_5 = memref.alloc() {address = 624032 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream_6 = "ttir.stream_layout"(%alloc_4, %alloc_5) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+
+  %alloc_8 = memref.alloc() {address = 296352 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %alloc_9 = memref.alloc() {address = 361888 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>
+  %stream_9 = "ttir.stream_layout"(%alloc, %alloc_0) : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>, #l1>) -> memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+
+  ttir.generic {block_factors = [1, 1],
+        grid = #ttcore.grid<1x1>,
+        indexing_maps = [#map, #map, #map, #map],
+        iterator_types = [#parallel, #parallel],
+        threads = [
+            #ttir.thread<datamovement>,
+            #ttir.thread<datamovement>,
+            #ttir.thread<datamovement>,
+            #ttir.thread<datamovement>,
+            #ttir.thread<compute>]}
+      ins(%stream, %stream_3, %stream_9 :
+        memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>,
+        memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>,
+        memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>
+        )
+      outs(%stream_6 : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>)  {
+  // CHECK: ^datamovement0
+  // CHECK: ttir.dma [[STREAM0:%.*]]<#map>, [[CB0:%.*]]
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.yield [[CB0:%.*]] : {{.*}}
+  // CHECK-NEXT: ttir.dma [[STREAM2:%.*]]<#map>, [[CB2:%.*]]
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.yield [[CB2:%.*]] : {{.*}}
+  ^datamovement0(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb3: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    %tx = ttir.dma %stream<#map>, %cb0 : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }, {
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.dma [[STREAM1:%.*]]<#map>, [[CB1:%.*]]
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.yield [[CB1:%.*]] : {{.*}}
+  // CHECK-NEXT: ttir.await [[CB3:%.*]] : {{.*}}
+  // CHECK-NEXT: ttir.dma [[CB3:%.*]], [[STREAM3:%.*]]<#map>
+  // CHECK-NEXT: ttir.dma_wait
+  ^datamovement1(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb3: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    %tx = ttir.dma %stream_3<#map>, %cb1 : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }, {
+  ^datamovement2(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb3: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    %tx = ttir.dma %stream_9<#map>, %cb2 : (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb2 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }, {
+  // CHECK-NOT: ^datamovement2
+  // CHECK: ^compute
+  ^datamovement3(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb3: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    ttir.await %cb3 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+    %tx = ttir.dma %cb3, %stream_6<#map> : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+  }, {
+  ^compute0(%cb0: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb1: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb2: memref<4x4x!ttcore.tile<32x32, f32>, #l1>, %cb3: memref<4x4x!ttcore.tile<32x32, f32>, #l1>):
+    ttir.await %cb0, %cb1, %cb2 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+    ttir.yield %cb3 : (memref<4x4x!ttcore.tile<32x32, f32>, #l1>)
+  }
+  return
+}


### PR DESCRIPTION
### Ticket
See https://github.com/tenstorrent/tt-mlir/issues/4621

### Problem description
In order to have fully streaming binary ops, we must merge >2 DMA regions onto 2 physical DMA regions we can implement on a BRISC/NCRISC pair.

### What's changed
- GenericHWThreadSelection has swapped positions in pipeline with GenericLowerDMAs
  - DMA threads are merged _before_ lowering
- GenericHWThreadSelection merges all DMA regions according to following scheme
  - First, input DMA regions are round-robin merged into DMA regions 0 and 1 to balance load
  - Second, output DMA regions are always merged to ^datamovement1, to ensure they have access to NOC1
    - **rationale**: Most streaming DMA writes will be to DRAM, where using NOC1 is very important to avoid congestion. Even if this results in two output threads sharing NOC1, that is still generally preferable than using NOC0 for DRAM writes.
  - For correctness, output DMA threads are always merged _after_ all input DMA blocks within each DMA region
  - **special case for local ttir.await**: merged into _compute region_ to avoid blocking dma threads unnecessarily (same behavior as before). 
    - If ^datamovement1 is not used for input DMA, the local ttir.await is left in ^datamovement1
  - If a compute region is **NOT** present in original op:
    - DMA Merging is still performed, but all excess DMA threads are merged to datamovement regions
    - A new compute region is NOT created

### Checklist
- [ ] New/Existing tests provide coverage for changes
