### PR TITLE
TTNN Generic Op Flatbuffer schema

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -146,6 +146,11 @@ enum MathFidelity : uint8 {
   HiFi4 = 4,
 }
 
+enum UnpackToDestMode : uint8 {
+  Fp32,
+  Default,
+}
+
 table DynamicLib {
   dylib_id: uint32;
   raw_file: [uint8];

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -8,24 +8,9 @@ enum NocIndex : ushort {
   Noc1,
 }
 
-enum NocMode : uint8 {
-  DM_DEDICATED_NOC,
-  DM_DYNAMIC_NOC,
-}
-
 enum EthType : ushort {
   Sender,
   Receiver,
-}
-
-enum UnpackToDestMode : uint8 {
-  Fp32,
-  Default,
-}
-
-enum DataMovementType : uint8 {
-  RISCV_0,
-  RISCV_1,
 }
 
 table NocConfig {

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -8,14 +8,24 @@ enum NocIndex : ushort {
   Noc1,
 }
 
+enum NocMode : uint8 {
+  DM_DEDICATED_NOC,
+  DM_DYNAMIC_NOC,
+}
+
 enum EthType : ushort {
   Sender,
   Receiver,
 }
 
 enum UnpackToDestMode : uint8 {
-    Fp32,
-    Default,
+  Fp32,
+  Default,
+}
+
+enum DataMovementType : uint8 {
+  RISCV_0,
+  RISCV_1,
 }
 
 table NocConfig {

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TTNN_OPERATIONS_FBS_GEN_SOURCES
   operations/deallocate.fbs
   operations/eltwise.fbs
   operations/embedding.fbs
+  operations/generic_op.fbs
   operations/kv_cache.fbs
   operations/layout.fbs
   operations/load_cached.fbs

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -23,6 +23,11 @@ enum CoreType : uint8{
   ETH,
 }
 
+enum SourceType : uint8 {
+  FILE_PATH,
+  SOURCE_CODE,
+}
+
 table KernelCBFormat {
   buffer_index: uint32;
   dtype: DataType;
@@ -98,6 +103,7 @@ table KernelCoreRTArgs {
 
 table KernelDescriptor {
   kernel_source: string;
+  source_type: SourceType = SOURCE_CODE;
   kernel_config: KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
   ct_args: KernelCoreArgs;

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -81,8 +81,12 @@ union KernelArgType {
   KernelArgSemaphore,
 }
 
+table KernelArg {
+  arg : KernelArgType;
+}
+
 table KernelCoreArgs {
-  args: [KernelArgType];
+  args: [KernelArg];
 }
 
 table KernelCoreRTArgs {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -1,0 +1,60 @@
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
+
+namespace tt.target.ttnn;
+
+table KernelCBFormat {
+  buffer_index: uint32;
+  dtype: DataType;
+  page_size: uint32;
+}
+
+table KernelCBDescriptor {
+  total_size: uint32;
+  core_range: tt.target.ttnn.CoreRangeSet;
+  kernel_cb_formats: [KernelCBFormat];
+}
+
+table ComputeKernelConfig {
+  /*
+  math_fidelity : MathFidelity = HiFi4;
+  fp32_dest_acc_en : bool = false;
+  dst_full_sync_en : bool = false;
+  unpack_to_dest_modes: [UnpackToDestMode];
+  bfp8_pack_precise : bool = false;
+  math_approx_mode : bool = false;
+  */
+}
+
+table ReaderKernelConfig{}
+table WriterKernelConfig{}
+
+union KernelConfig {
+  ComputeKernelConfig,
+  ReaderKernelConfig,
+  WriterKernelConfig
+}
+
+table CoreRTArgs {
+  args: [uint32];
+}
+
+table KernelDescriptor {
+  kernel_source : string;
+  kernel_config : KernelConfig;
+  core_ranges: tt.target.ttnn.CoreRangeSet;
+  ct_args: [uint32];
+  rt_args: [CoreRTArgs];
+  common_rt_args: [uint32];
+}
+
+table ProgramDescriptor {
+  kernels: [KernelDescriptor];
+  cbs: [KernelCBDescriptor];
+}
+
+table GenericOp {
+  inputs: [tt.target.ttnn.TensorRef];
+  program_desc: ProgramDescriptor;
+  out: tt.target.ttnn.TensorRef;
+}

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -18,6 +18,11 @@ enum DataMovementType : uint8 {
   RISCV_1,
 }
 
+enum CoreType : uint8{
+  WORKER,
+  ETH,
+}
+
 table KernelCBFormat {
   buffer_index: uint32;
   dtype: DataType;
@@ -31,17 +36,17 @@ table KernelCBDescriptor {
 }
 
 table ComputeKernelConfig {
-  math_fidelity : MathFidelity = HiFi4;
-  fp32_dest_acc_en : bool = false;
-  dst_full_sync_en : bool = false;
+  math_fidelity: MathFidelity = HiFi4;
+  fp32_dest_acc_en: bool = false;
+  dst_full_sync_en: bool = false;
   unpack_to_dest_modes: [UnpackToDestMode];
-  bfp8_pack_precise : bool = false;
-  math_approx_mode : bool = false;
+  bfp8_pack_precise: bool = false;
+  math_approx_mode: bool = false;
 }
 
 table DataMovementKernelConfig {
-  processor : DataMovementType = RISCV_0;
-  noc : Noc = Noc0;
+  processor: DataMovementType = RISCV_0;
+  noc: Noc = Noc0;
   noc_mode: NocMode = DM_DEDICATED_NOC;
 }
 
@@ -57,19 +62,19 @@ union KernelConfig {
 
 
 table KernelArgCBPort {
-  idx : uint32;
+  idx: uint32;
 }
 
 table KernelArgBufferAddress {
-  addr : uint32;
+  addr: uint32;
 }
 
 table KernelArgBufferAddressOfTensor {
-  tensor_idx : uint32;
+  tensor_idx: uint32;
 }
 
 table KernelArgSemaphore {
-  semaphore_id : uint32;
+  semaphore_id: uint32;
 }
 
 union KernelArgType {
@@ -80,7 +85,7 @@ union KernelArgType {
 }
 
 table KernelArg {
-  arg : KernelArgType;
+  arg: KernelArgType;
 }
 
 table KernelCoreArgs {
@@ -92,16 +97,23 @@ table KernelCoreRTArgs {
 }
 
 table KernelDescriptor {
-  kernel_source : string;
-  kernel_config : KernelConfig;
+  kernel_source: string;
+  kernel_config: KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
   ct_args: KernelCoreArgs;
   rt_args: [KernelCoreRTArgs];
   common_rt_args: KernelCoreArgs;
 }
 
+table SemaphoreDescriptor {
+  core_type: CoreType;
+  core_ranges: tt.target.ttnn.CoreRangeSet;
+  initial_value: uint32;
+}
+
 table ProgramDescriptor {
   kernels: [KernelDescriptor];
+  semaphores: [SemaphoreDescriptor];
   cbs: [KernelCBDescriptor];
 }
 

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -66,16 +66,16 @@ union KernelConfig {
 }
 
 
-table KernelArgCBPort {
-  idx: uint32;
+table KernelArgCBBufferIndex {
+  buffer_index: uint32;
 }
 
 table KernelArgBufferAddress {
-  addr: uint32;
+  address: uint32;
 }
 
 table KernelArgBufferAddressOfTensor {
-  tensor_idx: uint32;
+  tensor_index: uint32;
 }
 
 table KernelArgSemaphore {
@@ -83,7 +83,7 @@ table KernelArgSemaphore {
 }
 
 union KernelArgType {
-  KernelArgCBPort,
+  KernelArgCBBufferIndex,
   KernelArgBufferAddress,
   KernelArgBufferAddressOfTensor,
   KernelArgSemaphore,

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -1,5 +1,6 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
+include "ttmlir/Target/TTMetal/program.fbs";
 
 namespace tt.target.ttnn;
 
@@ -16,14 +17,18 @@ table KernelCBDescriptor {
 }
 
 table ComputeKernelConfig {
-  /*
   math_fidelity : MathFidelity = HiFi4;
   fp32_dest_acc_en : bool = false;
   dst_full_sync_en : bool = false;
-  unpack_to_dest_modes: [UnpackToDestMode];
+  unpack_to_dest_modes: [tt.target.metal.UnpackToDestMode];
   bfp8_pack_precise : bool = false;
   math_approx_mode : bool = false;
-  */
+}
+
+table DataMovementKernelConfig {
+  processor : tt.target.metal.DataMovementType = RISCV_0;
+  noc : tt.target.metal.NocIndex = Noc0;
+  noc_mode: tt.target.metal.NocMode = DM_DEDICATED_NOC;
 }
 
 table ReaderKernelConfig{}
@@ -31,21 +36,33 @@ table WriterKernelConfig{}
 
 union KernelConfig {
   ComputeKernelConfig,
+  DataMovementKernelConfig,
   ReaderKernelConfig,
   WriterKernelConfig
 }
 
-table CoreRTArgs {
-  args: [uint32];
+table KernelArgBufferAddressOfTensor {
+  tensor_idx : uint32;
+}
+
+union KernelArgType {
+  tt.target.metal.KernelArgCBPort,
+  tt.target.metal.KernelArgBufferAddress,
+  KernelArgBufferAddressOfTensor,
+  tt.target.metal.KernelArgSemaphore,
+}
+
+table KernelCoreArgs {
+  args: [KernelArgType];
 }
 
 table KernelDescriptor {
-  kernel_source : string;
+  kernel_source : tt.target.metal.KernelSource;
   kernel_config : KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
-  ct_args: [uint32];
-  rt_args: [CoreRTArgs];
-  common_rt_args: [uint32];
+  ct_args: KernelCoreArgs;
+  rt_args: [KernelCoreArgs];
+  common_rt_args: KernelCoreArgs;
 }
 
 table ProgramDescriptor {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -37,7 +37,7 @@ table KernelCBFormat {
 table KernelCBDescriptor {
   total_size: uint32;
   core_range: tt.target.ttnn.CoreRangeSet;
-  kernel_cb_formats: [KernelCBFormat];
+  formats: [KernelCBFormat];
 }
 
 table ComputeKernelConfig {
@@ -102,9 +102,9 @@ table KernelCoreRTArgs {
 }
 
 table KernelDescriptor {
-  kernel_source: string;
+  source: string;
   source_type: SourceType = SOURCE_CODE;
-  kernel_config: KernelConfig;
+  config: KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
   ct_args: KernelCoreArgs;
   rt_args: [KernelCoreRTArgs];
@@ -124,7 +124,6 @@ table ProgramDescriptor {
 }
 
 table GenericOp {
-  inputs: [tt.target.ttnn.TensorRef];
-  program_desc: ProgramDescriptor;
-  out: tt.target.ttnn.TensorRef;
+  io_tensors: [tt.target.ttnn.TensorRef];
+  program: ProgramDescriptor;
 }

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -85,12 +85,16 @@ table KernelCoreArgs {
   args: [KernelArgType];
 }
 
+table KernelCoreRTArgs {
+  args: [KernelCoreArgs];
+}
+
 table KernelDescriptor {
   kernel_source : string;
   kernel_config : KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
   ct_args: KernelCoreArgs;
-  rt_args: [KernelCoreArgs];
+  rt_args: [KernelCoreRTArgs];
   common_rt_args: KernelCoreArgs;
 }
 

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -69,9 +69,7 @@ table KernelArgBufferAddressOfTensor {
 }
 
 table KernelArgSemaphore {
-  // core_type : CoreType
-  core_ranges : tt.target.ttnn.CoreRangeSet;
-  initial_value : uint32 = 0;
+  semaphore_id : uint32;
 }
 
 union KernelArgType {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -78,15 +78,15 @@ table KernelArgBufferAddressOfTensor {
   tensor_index: uint32;
 }
 
-table KernelArgSemaphore {
-  semaphore_id: uint32;
+table KernelArgSemaphoreAt {
+  semaphore_index: uint32;
 }
 
 union KernelArgType {
   KernelArgCBBufferIndex,
   KernelArgBufferAddress,
   KernelArgBufferAddressOfTensor,
-  KernelArgSemaphore,
+  KernelArgSemaphoreAt,
 }
 
 table KernelArg {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -1,8 +1,22 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
-include "ttmlir/Target/TTMetal/program.fbs";
 
 namespace tt.target.ttnn;
+
+enum Noc : uint8 {
+  Noc0,
+  Noc1,
+}
+
+enum NocMode : uint8 {
+  DM_DEDICATED_NOC,
+  DM_DYNAMIC_NOC,
+}
+
+enum DataMovementType : uint8 {
+  RISCV_0,
+  RISCV_1,
+}
 
 table KernelCBFormat {
   buffer_index: uint32;
@@ -20,15 +34,15 @@ table ComputeKernelConfig {
   math_fidelity : MathFidelity = HiFi4;
   fp32_dest_acc_en : bool = false;
   dst_full_sync_en : bool = false;
-  unpack_to_dest_modes: [tt.target.metal.UnpackToDestMode];
+  unpack_to_dest_modes: [UnpackToDestMode];
   bfp8_pack_precise : bool = false;
   math_approx_mode : bool = false;
 }
 
 table DataMovementKernelConfig {
-  processor : tt.target.metal.DataMovementType = RISCV_0;
-  noc : tt.target.metal.NocIndex = Noc0;
-  noc_mode: tt.target.metal.NocMode = DM_DEDICATED_NOC;
+  processor : DataMovementType = RISCV_0;
+  noc : Noc = Noc0;
+  noc_mode: NocMode = DM_DEDICATED_NOC;
 }
 
 table ReaderKernelConfig{}
@@ -41,15 +55,30 @@ union KernelConfig {
   WriterKernelConfig
 }
 
+
+table KernelArgCBPort {
+  idx : uint32;
+}
+
+table KernelArgBufferAddress {
+  addr : uint32;
+}
+
 table KernelArgBufferAddressOfTensor {
   tensor_idx : uint32;
 }
 
+table KernelArgSemaphore {
+  // core_type : CoreType
+  core_ranges : tt.target.ttnn.CoreRangeSet;
+  initial_value : uint32 = 0;
+}
+
 union KernelArgType {
-  tt.target.metal.KernelArgCBPort,
-  tt.target.metal.KernelArgBufferAddress,
+  KernelArgCBPort,
+  KernelArgBufferAddress,
   KernelArgBufferAddressOfTensor,
-  tt.target.metal.KernelArgSemaphore,
+  KernelArgSemaphore,
 }
 
 table KernelCoreArgs {
@@ -57,7 +86,7 @@ table KernelCoreArgs {
 }
 
 table KernelDescriptor {
-  kernel_source : tt.target.metal.KernelSource;
+  kernel_source : string;
   kernel_config : KernelConfig;
   core_ranges: tt.target.ttnn.CoreRangeSet;
   ct_args: KernelCoreArgs;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -10,6 +10,7 @@ include "ttmlir/Target/TTNN/operations/data_movement.fbs";
 include "ttmlir/Target/TTNN/operations/deallocate.fbs";
 include "ttmlir/Target/TTNN/operations/eltwise.fbs";
 include "ttmlir/Target/TTNN/operations/embedding.fbs";
+include "ttmlir/Target/TTNN/operations/generic_op.fbs";
 include "ttmlir/Target/TTNN/operations/kv_cache.fbs";
 include "ttmlir/Target/TTNN/operations/layout.fbs";
 include "ttmlir/Target/TTNN/operations/load_cached.fbs";
@@ -56,6 +57,7 @@ union OpType {
   FromDeviceOp,
   FullOp,
   FuncCallOp,
+  GenericOp,
   GetDeviceOp,
   LinearOp,
   LoadCachedOp,

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -98,18 +98,18 @@ static target::MathFidelity toFlatbuffer(ttmetal::MathFidelity mathFidelity) {
   assert(false && "Unsupported MathFidelity");
 }
 
-static std::vector<target::metal::UnpackToDestMode>
+static std::vector<target::UnpackToDestMode>
 toFlatbuffer(llvm::ArrayRef<ttmetal::UnpackToDestMode> unpackToDestModes) {
-  std::vector<target::metal::UnpackToDestMode> result;
+  std::vector<target::UnpackToDestMode> result;
   result.reserve(unpackToDestModes.size());
 
   for (auto mode : unpackToDestModes) {
     switch (mode) {
     case ttmetal::UnpackToDestMode::Fp32:
-      result.push_back(target::metal::UnpackToDestMode::Fp32);
+      result.push_back(target::UnpackToDestMode::Fp32);
       break;
     case ttmetal::UnpackToDestMode::Default:
-      result.push_back(target::metal::UnpackToDestMode::Default);
+      result.push_back(target::UnpackToDestMode::Default);
       break;
     }
   }

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -521,12 +521,12 @@ createKernelConfig(
     for (auto mode : *fbComputeConfig->unpack_to_dest_mode()) {
       LOG_ASSERT(modeIdx < NUM_CIRCULAR_BUFFERS);
       switch (mode) {
-      case tt::target::metal::UnpackToDestMode::Fp32: {
+      case tt::target::UnpackToDestMode::Fp32: {
         computeConfig.unpack_to_dest_mode[modeIdx] =
             UnpackToDestMode::UnpackToDestFp32;
         break;
       }
-      case tt::target::metal::UnpackToDestMode::Default: {
+      case tt::target::UnpackToDestMode::Default: {
         computeConfig.unpack_to_dest_mode[modeIdx] = UnpackToDestMode::Default;
         break;
       }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1175,6 +1175,11 @@ getOpOutputRef(OpContext opContextHandle,
                     opContext.type_type())]);
     return std::nullopt;
   }
+  case ::tt::target::ttnn::OpType::GenericOp: {
+    LOG_WARNING("GenericOp runtime to be implemented.");
+    tensorRef = opContext.type_as_GenericOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::NONE: {
     LOG_FATAL("Invalid op type");
     break;
@@ -1466,6 +1471,13 @@ getOpInputRefs(OpContext opContextHandle,
   }
   case ::tt::target::ttnn::OpType::ConcatenateHeadsOp: {
     tensorRefs = {opContext.type_as_ConcatenateHeadsOp()->in()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::GenericOp: {
+    LOG_WARNING("GenericOp runtime to be implemented.");
+    for (const auto *input : *opContext.type_as_GenericOp()->inputs()) {
+      tensorRefs.push_back(input);
+    }
     break;
   }
   case ::tt::target::ttnn::OpType::NONE: {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1176,7 +1176,7 @@ getOpOutputRef(OpContext opContextHandle,
     return std::nullopt;
   }
   case ::tt::target::ttnn::OpType::GenericOp: {
-    LOG_WARNING("GenericOp runtime to be implemented.");
+    LOG_FATAL("GenericOp runtime to be implemented.");
     auto size = opContext.type_as_GenericOp()->io_tensors()->size();
     tensorRef = opContext.type_as_GenericOp()->io_tensors()->Get(size - 1);
     break;
@@ -1475,7 +1475,7 @@ getOpInputRefs(OpContext opContextHandle,
     break;
   }
   case ::tt::target::ttnn::OpType::GenericOp: {
-    LOG_WARNING("GenericOp runtime to be implemented.");
+    LOG_FATAL("GenericOp runtime to be implemented.");
     for (const auto *input : *opContext.type_as_GenericOp()->io_tensors()) {
       tensorRefs.push_back(input);
     }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1177,7 +1177,8 @@ getOpOutputRef(OpContext opContextHandle,
   }
   case ::tt::target::ttnn::OpType::GenericOp: {
     LOG_WARNING("GenericOp runtime to be implemented.");
-    tensorRef = opContext.type_as_GenericOp()->out();
+    auto size = opContext.type_as_GenericOp()->io_tensors()->size();
+    tensorRef = opContext.type_as_GenericOp()->io_tensors()->Get(size - 1);
     break;
   }
   case ::tt::target::ttnn::OpType::NONE: {
@@ -1475,7 +1476,7 @@ getOpInputRefs(OpContext opContextHandle,
   }
   case ::tt::target::ttnn::OpType::GenericOp: {
     LOG_WARNING("GenericOp runtime to be implemented.");
-    for (const auto *input : *opContext.type_as_GenericOp()->inputs()) {
+    for (const auto *input : *opContext.type_as_GenericOp()->io_tensors()) {
       tensorRefs.push_back(input);
     }
     break;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4519)

### Problem description
Definition of TTNN GenericOp Flatbuffer schema. Schema should align generic_op dialect definition and reflect ttnn proper and what's defined in `tt-metallium/program_descriptors`.

### What's changed
- new flatbuffer schema `TTNN/operations/generic_op.fbs`
- move `UnpackToDestMode` enum to `Common/types.fbs` and propagate changes through metal runtime
- `LOG_WARNING` in `ttnn/runtime.cpp` indicating generic_op runtime is not implemented yet

Follow up [issue/task](https://github.com/tenstorrent/tt-mlir/issues/4634) will be to implement the runtime for generic_op

### Checklist
- [ ] New/Existing tests provide coverage for changes
