### PR TITLE
Generate null CircularBufferConfig for Sharded DRAM buffers

### DIFF
--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -350,7 +350,11 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
       // only generate CircularBufferConfig for L1 memspace
       flatbuffers::Offset<target::metal::CircularBufferConfig>
           circularBufferConfig =
-              memrefTypeToCircularBufferConfigFlatbuffer(cache, memref, device);
+              isMemrefDeviceL1Memspace(memref)
+                  ? memrefTypeToCircularBufferConfigFlatbuffer(cache, memref,
+                                                               device)
+                  : 0;
+
       bufferDetail = target::metal::CreateMetalBuffer(
                          *cache.fbb, bufferType,
                          target::metal::BufferConfig::ShardedBufferConfig,


### PR DESCRIPTION
### Problem description
Eliminates crash stemming from flatbuffer including bogus CircularBufferConfig for sharded DRAM buffers

### Checklist
- [ ] New/Existing tests provide coverage for changes
