### PR TITLE
Skip CreateInputGenerators for const eval funcs

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -186,10 +186,13 @@ public:
         rewriter.modifyOpInPlace(funcOp, [&]() { funcOp.setSymName("_main"); });
       }
 
-      if (!funcOp->getUses().empty()) {
-        mlir::WalkResult::skip();
+      if (!funcOp->getUses().empty() ||
+          ttmlir::utils::isConstEvalFunc(funcOp)) {
+        return mlir::WalkResult::skip();
       }
+
       forwardFuncOps.push_back(funcOp);
+      return mlir::WalkResult::advance();
     });
 
     // Iterate over all func ops and add input tensor generator functions.

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -3,7 +3,7 @@
 
 module {
 	// CHECK-LABEL: @add_const_eval_0
-	// CHECK: @add(
+	// CHECK-LABEL: @add(
 
 	// CHECK-LABEL: @create_inputs_for_add
 	// CHECK: "ttnn.ones"

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -2,21 +2,21 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
-	// CHECK-LABEL: @add_const_eval_0
-	// CHECK-LABEL: @add(
+  // CHECK-LABEL: @add_const_eval_0
+  // CHECK-LABEL: @add(
 
-	// CHECK-LABEL: @create_inputs_for_add
-	// CHECK: "ttnn.ones"
-	// CHECK-NEXT: %[[ARG0:.*]] = "ttnn.to_device"
-	// CHECK: "ttnn.ones"
-	// CHECK-NEXT: %[[ARG1:.*]] = "ttnn.to_device"
-	// CHECK: %[[RES:.*]] = ttcore.tuple %[[ARG0]], %[[ARG1]]
+  // CHECK-LABEL: @create_inputs_for_add
+  // CHECK: "ttnn.ones"
+  // CHECK-NEXT: %[[ARG0:.*]] = "ttnn.to_device"
+  // CHECK: "ttnn.ones"
+  // CHECK-NEXT: %[[ARG1:.*]] = "ttnn.to_device"
+  // CHECK: %[[RES:.*]] = ttcore.tuple %[[ARG0]], %[[ARG1]]
 
   func.func @add(%arg0 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<input> }) -> tensor<32x32xbf16> {
-		%0 = ttir.empty() : tensor<32x32xbf16>
-		%1 = "ttir.add"(%arg0, %arg0, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-		%2 = ttir.empty() : tensor<32x32xbf16>
-		%3 = "ttir.subtract"(%arg1, %1, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-		return %3 : tensor<32x32xbf16>
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.add"(%arg0, %arg0, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %2 = ttir.empty() : tensor<32x32xbf16>
+    %3 = "ttir.subtract"(%arg1, %1, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %3 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -1,31 +1,22 @@
-// RUN: ttmlir-opt --ttnn-create-input-gens -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline=%system_desc_path% --ttcore-unwrap-device-module --ttnn-tuplify-tensors --ttnn-create-input-gens -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-#dram = #ttnn.buffer_type<dram>
-#system_desc = #ttnn.buffer_type<system_memory>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-module attributes {ttcore.system_desc = #system_desc} {
-  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
-  // CHECK: func.func @add(%arg0: tuple<[[TENSOR_A:.*>]], [[TENSOR_B:.*]]>) -> tuple<[[TENSOR_OUT:.*]]> {
-  func.func @add(%arg0: tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tuple<tensor<64x128xf32, #ttnn_layout>> {
-    %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tensor<64x128xf32, #ttnn_layout>
-    %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tensor<64x128xf32, #ttnn_layout>
-    %2 = "ttnn.add"(%0, %1) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
-    "ttnn.deallocate"(%1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
-    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
-    %3 = ttcore.tuple %2 : tuple<tensor<64x128xf32, #ttnn_layout>>
-    return %3 : tuple<tensor<64x128xf32, #ttnn_layout>>
-  }
-// Confirm that the generator func is generated, and that the tensor attrs match:
-//
-// CHECK: func.func @create_inputs_for_add() -> tuple<[[TENSOR_A]], [[TENSOR_B]]> {
-// CHECK: {{.*}} -> [[TENSOR_A]]
-// CHECK: {{.*}} -> [[TENSOR_B]]
-// CHECK: return %{{[0-9]+}} : tuple<[[TENSOR_A]], [[TENSOR_B]]>
+module {
+	// CHECK-LABEL: @add_const_eval_0
+  // CHECK: @add(
 
-// Confirm that the main func is generated, and that the tensor attrs match:
-//
-// CHECK: func.func @main() -> i32 {
-// CHECK: %[[ARG:[0-9]+]] = call @create_inputs_for_add() : () -> tuple<[[TENSOR_A]], [[TENSOR_B]]>
-// CHECK: %{{[0-9]+}} = call @add(%[[ARG]]) : (tuple<[[TENSOR_A]], [[TENSOR_B]]>) -> tuple<[[TENSOR_OUT]]>
+	// CHECK-LABEL: @create_inputs_for_add
+	// CHECK: "ttnn.ones"
+	// CHECK-NEXT: %[[ARG0:.*]] = "ttnn.to_device"
+	// CHECK: "ttnn.ones"
+	// CHECK-NEXT: %[[ARG1:.*]] = "ttnn.to_device"
+	// CHECK: %[[RES:.*]] = ttcore.tuple %[[ARG0]], %[[ARG1]]
+
+  func.func @add(%arg0 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<input> }) -> tensor<32x32xbf16> {
+		%0 = ttir.empty() : tensor<32x32xbf16>
+		%1 = "ttir.add"(%arg0, %arg0, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+		%2 = ttir.empty() : tensor<32x32xbf16>
+		%3 = "ttir.subtract"(%arg1, %1, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %3 : tensor<32x32xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -3,7 +3,7 @@
 
 module {
 	// CHECK-LABEL: @add_const_eval_0
-  // CHECK: @add(
+	// CHECK: @add(
 
 	// CHECK-LABEL: @create_inputs_for_add
 	// CHECK: "ttnn.ones"
@@ -17,6 +17,6 @@ module {
 		%1 = "ttir.add"(%arg0, %arg0, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
 		%2 = ttir.empty() : tensor<32x32xbf16>
 		%3 = "ttir.subtract"(%arg1, %1, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-    return %3 : tensor<32x32xbf16>
+		return %3 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline=%system_desc_path% --ttcore-unwrap-device-module --ttnn-tuplify-tensors --ttnn-create-input-gens -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttcore-unwrap-device-module --ttnn-tuplify-tensors --ttnn-create-input-gens -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 module {


### PR DESCRIPTION
Currently we are adding input generators for all top level functions including const-eval functions. After we run generators and lower to cpp we get below:

```cpp
::std::vector<::ttnn::Tensor> create_inputs_for_forward_const_eval_0() {
  ....
}

int32_t main() {
  ::std::vector<::ttnn::Tensor> v1 =
create_inputs_for_forward_const_eval_0();
  ::std::vector<::ttnn::Tensor> v2 = forward_const_eval_0(v1);
  ....
```

We have unnecessary definition and call to generator from `main` for each const-eval function. This PR skips processing of const eval functions for input generators.