### PR TITLE
[L1InterleavedFallbackAnalysis] Fix YOLO_v8 L1 memory exhaustion by preventing model output upgrade to L1

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -80,6 +80,9 @@ private:
   // Check if operation has exactly one user that is immediate next in schedule.
   bool hasImmediateConsumer(Operation *op) const;
 
+  // Check if operation produces model output (i.e. its user is a return op).
+  bool producesModelOutput(Operation *op) const;
+
   // Try to upgrade an operation to L1 interleaved layout by testing available
   // L1 configurations and selecting the first one that passes validation.
   void tryUpgradeToL1Interleaved(Operation *op);

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/addx10.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/addx10.mlir
@@ -17,6 +17,7 @@ module @L1InterleavedAddx10 attributes {} {
                     %arg10: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttir.name = "param10"} loc("SimpleAddModel":0:0)) -> (tensor<32x4096xbf16> {ttir.name = "SimpleAddModel.output"}) {
 
     // CHECK-DAG: #[[L1_LAYOUT:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
+    // CHECK-DAG: #[[DRAM_LAYOUT:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 
     // Add operations should be upgraded to L1 interleaved when beneficial
     %0 = ttir.empty() : tensor<32x4096xbf16>
@@ -53,8 +54,8 @@ module @L1InterleavedAddx10 attributes {} {
     %17 = "ttir.add"(%15, %arg9, %16) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
 
     %18 = ttir.empty() : tensor<32x4096xbf16>
-    // Final add - output may stay in DRAM since it's the return value
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<32x4096xbf16, #[[L1_LAYOUT]]>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<32x4096xbf16, #[[DRAM_LAYOUT]]>
     %19 = "ttir.add"(%17, %arg10, %18) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
     return %19 : tensor<32x4096xbf16>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/fork_join.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/fork_join.mlir
@@ -33,6 +33,10 @@ module @L1InterleavedTestForkJoin attributes {} {
     %12 = ttir.empty() : tensor<64x128xbf16>
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L1]]>
     %13 = "ttir.add"(%9, %11, %12) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
-    return %13 : tensor<64x128xbf16>
+    %14 = ttir.empty() : tensor<64x128xbf16>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: %{{.*}} = "ttnn.abs"{{.*}} -> tensor<{{.*}}, #[[DRAM]]>
+    %15 = "ttir.abs"(%13, %14) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %15 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/fork_join_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/fork_join_sharded.mlir
@@ -34,7 +34,12 @@ module @L1InterleavedTestForkJoin attributes {} {
     // sharded inputs fit with the result in L1 -> L1
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L1]]>
     %13 = "ttir.add"(%9, %11, %12) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
-    return %13 : tensor<64x128xbf16>
+    %14 = ttir.empty() : tensor<64x128xbf16>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: %{{.*}} = "ttnn.abs"{{.*}} -> tensor<{{.*}}, #[[DRAM]]>
+    %15 = "ttir.abs"(%13, %14) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+
+    return %15 : tensor<64x128xbf16>
   }
 }
 #loc = loc("op")

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/minimal.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/minimal.mlir
@@ -6,6 +6,7 @@
 module @L1InterleavedTestMinimal attributes {} {
   func.func @forward(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>, %arg2: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
     // CHECK-DAG: #[[L1_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+    // CHECK-DAG: #[[DRAM_LAYOUT:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 
     %0 = ttir.empty() : tensor<32x32xbf16>
     // CHECK: %{{.*}} = "ttnn.multiply"{{.*}} -> tensor<32x32xbf16, #[[L1_LAYOUT]]>
@@ -16,7 +17,8 @@ module @L1InterleavedTestMinimal attributes {} {
     %3 = "ttir.add"(%1, %arg2, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
 
     %4 = ttir.empty() : tensor<32x32xbf16>
-    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<32x32xbf16, #[[L1_LAYOUT]]>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<32x32xbf16, #[[DRAM_LAYOUT]]>
     %5 = "ttir.relu"(%3, %4) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
 
     return %5 : tensor<32x32xbf16>

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/row_major_workaround.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/row_major_workaround.mlir
@@ -6,22 +6,26 @@
 module @L1AddMaxPool2D attributes {} {
   func.func @forward(%arg0: tensor<1x64x32x32xbf16>, %arg1: tensor<1x64x32x32xbf16>) -> tensor<1x32x16x32xbf16> {
     // CHECK-DAG: #[[L1_LAYOUT1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
-    // CHECK-DAG: #[[L1_LAYOUT2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
     // CHECK-DAG: #[[DRAM_LAYOUT1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
     // CHECK-DAG: #[[DRAM_LAYOUT2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
     // CHECK-DAG: #[[DRAM_LAYOUT3:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
     // CHECK-DAG: #[[DRAM_LAYOUT4:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+    // CHECK-DAG: #[[DRAM_LAYOUT5:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 
     %0 = ttir.empty() : tensor<1x64x32x32xbf16>
     // Add operation - should be eligible for L1 upgrade
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x64x32x32xbf16, #[[L1_LAYOUT2]]>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x64x32x32xbf16, #[[L1_LAYOUT1]]>
     %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<1x64x32x32xbf16>, tensor<1x64x32x32xbf16>, tensor<1x64x32x32xbf16>) -> tensor<1x64x32x32xbf16>
 
     %2 = ttir.empty() : tensor<1x32x16x32xbf16>
     // MaxPool2D operation - ignored for L1 upgrade because of row-major workaround
-    // CHECK: %{{.*}} = "ttnn.max_pool2d"{{.*}} -> tensor<1x1x512x32xbf16, #[[DRAM_LAYOUT4]]>
+    // CHECK: %{{.*}} = "ttnn.max_pool2d"{{.*}} -> tensor<1x1x512x32xbf16, #[[DRAM_LAYOUT5]]>
     %3 = "ttir.max_pool2d"(%1, %2) <{kernel = array<i32: 2, 2>, stride = array<i32: 2, 2>, padding = array<i32: 0, 0>, dilation = array<i32: 1, 1>, ceil_mode = false}> : (tensor<1x64x32x32xbf16>, tensor<1x32x16x32xbf16>) -> tensor<1x32x16x32xbf16>
 
-    return %3 : tensor<1x32x16x32xbf16>
+    %4 = ttir.empty() : tensor<1x32x16x32xbf16>
+    // Not the real model output here, as an additional reshape is the consumer of this op, so might be in L1.
+    %5 = "ttir.relu"(%3, %4) : (tensor<1x32x16x32xbf16>, tensor<1x32x16x32xbf16>) -> tensor<1x32x16x32xbf16>
+
+    return %5 : tensor<1x32x16x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/runtime_support_typecast_slice.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/runtime_support_typecast_slice.mlir
@@ -88,6 +88,7 @@ module @L1InterleavedRuntimeSupportTypecastSlice attributes {} {
     %31 = "ttir.add"(%29, %7, %30) : (tensor<1x32x8400xf32>, tensor<1x32x8400xf32>, tensor<1x32x8400xf32>) -> tensor<1x32x8400xf32>
 
     %32 = ttir.empty() : tensor<1x16x8400xf32>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM anyway.
     // CHECK: %{{.*}} = "ttnn.slice_static"{{.*}} -> tensor<1x16x8400xf32, #[[DRAM_LAYOUT3]]>
     %33 = "ttir.slice_static"(%31, %32) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [1 : i32, 16 : i32, 8400 : i32], step = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<1x32x8400xf32>, tensor<1x16x8400xf32>) -> tensor<1x16x8400xf32>
 

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
@@ -20,13 +20,16 @@ module @L1InterleavedTestConv2D attributes {} {
   }
 }
 
+// CHECK-DAG: #[[DRAM_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[DRAM_2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 // CHECK-DAG: #[[L1_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
 // CHECK-DAG: #[[L1_2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
-// CHECK-DAG: #[[L1_3:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
 
-// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_3]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_3]]>
 // CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L1_1]]>
-// CHECK: return{{.*}} : tensor<{{.*}}, #[[L1_1]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_1]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
+
+// As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[DRAM_2]]>
+// CHECK: return{{.*}} : tensor<{{.*}}, #[[DRAM_2]]>

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/storage_fail_operand.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/storage_fail_operand.mlir
@@ -16,6 +16,11 @@ module @L1InterleavedTestLargeTensorInput attributes {} {
     %2 = ttir.empty() : tensor<5120x5120xbf16>
     %3 = "ttir.add"(%1, %arg1, %2) : (tensor<5120x5120xbf16>, tensor<5120x5120xbf16>, tensor<5120x5120xbf16>) -> tensor<5120x5120xbf16>
 
-    return %3 : tensor<5120x5120xbf16>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: "ttnn.add"{{.*}} -> tensor<5120x5120xbf16, #[[DRAM_LAYOUT]]>
+    %4 = ttir.empty() : tensor<5120x5120xbf16>
+    %5 = "ttir.add"(%3, %arg1, %4) : (tensor<5120x5120xbf16>, tensor<5120x5120xbf16>, tensor<5120x5120xbf16>) -> tensor<5120x5120xbf16>
+
+    return %5 : tensor<5120x5120xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/storage_fail_result.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/storage_fail_result.mlir
@@ -15,6 +15,11 @@ module @L1InterleavedTestLargeTensorOutput attributes {} {
     %2 = ttir.empty() : tensor<8192x8192xbf16>
     %3 = "ttir.add"(%1, %arg1, %2) : (tensor<8192x8192xbf16>, tensor<8192x8192xbf16>, tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16>
 
-    return %3 : tensor<8192x8192xbf16>
+    // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
+    // CHECK: "ttnn.add"{{.*}} -> tensor<8192x8192xbf16, #[[DRAM_LAYOUT]]>
+    %4 = ttir.empty() : tensor<8192x8192xbf16>
+    %5 = "ttir.add"(%3, %arg1, %4) : (tensor<8192x8192xbf16>, tensor<8192x8192xbf16>, tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16>
+
+    return %5 : tensor<8192x8192xbf16>
   }
 }


### PR DESCRIPTION
### Problem: 
YOLO v8 was failing with L1 OOM when run from ForgeFE frontend, specifically breaking in runtime on the second loop iteration (which is technically the first real iteration - the first loop is used by the frontend for validity checking). The failure occurred on a large convolution operation that technically fits in L1 memory. Interestingly, the same model succeeded when run with ttrt, even with multiple loops. 
The issue was L1 memory leakage - final result tensors were never deallocated between iterations, and L1InterleavedFallbackAnalysis was upgrading model output operations to L1, providing no benefit while consuming memory that wasn't reclaimed.

### Discovery
Issue surfaced when `tensor-l1-usage-cap=1.0` was used, allowing full L1 utilization and making the memory leakage critical.

### Solution
Added check to skip upgrading operations that produce model outputs (operations consumed by return statements) to L1 interleaved layout. 
This prevents L1 memory leakage and ensures each loop iteration has the same amount of L1 memory available.

### Checklist
- [x] Adjusted existing tests to this change, without changing their original purpose.
