### PR TITLE
Add constraints API for Prod and ArgMax

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -850,7 +850,9 @@ def TTNN_MinOp : TTNN_ReductionOp<"min"> {
   }];
 }
 
-def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
+def TTNN_ArgMaxOp : TTNN_Op<"argmax",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
   let summary = "Argmax reduction op.";
   let description = [{
     Determine the indices of the maximum values along a specified dimension of a tensor or over all elements in a tensor.
@@ -899,7 +901,7 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
 }
 
 def TTNN_ProdOp : TTNN_Op<"prod",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
   let summary = "Product reduction op.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -898,7 +898,9 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
   let results = (outs AnyRankedTensor:$result);
 }
 
-def TTNN_ProdOp : TTNN_Op<"prod"> {
+def TTNN_ProdOp : TTNN_Op<"prod",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      > {
   let summary = "Product reduction op.";
   let description = [{
     This op computes the product of all elements of the tensor (full product)

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -54,6 +54,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/operations/pool/generic/generic_pools.hpp"
 #include "ttnn/operations/pool/upsample/upsample.hpp"
 #include "ttnn/operations/rand/rand.hpp"
+#include "ttnn/operations/reduction/argmax/argmax.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -55,6 +55,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/operations/pool/upsample/upsample.hpp"
 #include "ttnn/operations/rand/rand.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -321,6 +321,25 @@ template <>
 struct OpModel<MinOp> : ReductionOpModel<MinOp> {};
 
 //===----------------------------------------------------------------------===//
+// ArgMaxOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<ArgMaxOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
+                   bool keepDim, bool multicore, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             std::optional<int32_t> dim,
+                                             bool keepDim, bool multicore,
+                                             TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // ProdOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -321,6 +321,23 @@ template <>
 struct OpModel<MinOp> : ReductionOpModel<MinOp> {};
 
 //===----------------------------------------------------------------------===//
+// ProdOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<ProdOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
+                   bool keepDim, TTNNLayoutAttr outputLayout);
+
+  /*static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t>
+     inputShape, TTNNLayoutAttr inputLayout, std::optional<int64_t> dim, bool
+     keepDim, TTNNLayoutAttr outputLayout);*/
+};
+
+//===----------------------------------------------------------------------===//
 // Named Full Ops
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -350,10 +350,6 @@ struct OpModel<ProdOp> {
                    llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
-
-  /*static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t>
-     inputShape, TTNNLayoutAttr inputLayout, std::optional<int64_t> dim, bool
-     keepDim, TTNNLayoutAttr outputLayout);*/
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -312,10 +312,26 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, shape, dtype,
       layout, memoryConfig, opConfig.outputLayout);
 }
-} // namespace detail
 
-// Forward declaration for function used by ops that don't support getOpRuntime
-static llvm::Expected<size_t> issueErrorForGetOpRuntime(mlir::Operation *op);
+// query_op_runtime has to execute the op to measure the runtime (and not just
+// invoke the op in NO_DISPATCH mode as query_op_constraint does). Therefore,
+// any op that writes to memory, such as EmptyOp,ArangeOp, ZerosOp, OnesOp,
+// etc., triggers a runtime error (`Writes are not supported during trace
+// capture.`). As a consequence, we disable the runtime measurement for these
+// ops. Alternatively, we could avoid defining the getOpRuntime API for such
+// ops, but that would prevent us from the ultimate goal of supporting
+// getOpRuntime and getOpConstraint for "all" ttnn ops. This is
+// tracked/described here:
+// https://github.com/tenstorrent/tt-mlir/issues/4199#issuecomment-3140045496
+static llvm::Expected<size_t> issueErrorForGetOpRuntime(mlir::Operation *op) {
+  auto opName = op->getName().getStringRef();
+  return llvm::make_error<llvm::StringError>(
+      "opRuntime is not supported for " + opName.str() +
+          " since it requires memory IO.",
+      llvm::inconvertibleErrorCode());
+}
+
+} // namespace detail
 
 //===----------------------------------------------------------------------===//
 // ReluOp - TTNN Op Model Interface
@@ -1829,14 +1845,9 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
-  std::optional<int32_t> dim;
-  if (getDim()) {
-    dim = getDim();
-  }
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], dim, getKeepDim(), getUseMulticore(),
+      inputShape, inputs[0], getDim(), getKeepDim(), getUseMulticore(),
       opConfig.outputLayout);
 }
 
@@ -1847,14 +1858,9 @@ ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  std::optional<int32_t> dim;
-  if (getDim()) {
-    dim = getDim();
-  }
-
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpRuntime, *this, inputShape, inputs[0],
-      dim, getKeepDim(), getUseMulticore(), opConfig.outputLayout);
+      getDim(), getKeepDim(), getUseMulticore(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1875,20 +1881,15 @@ ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
-  std::optional<int64_t> dim;
-  if (getDimArg()) {
-    dim = getDimArg();
-  }
-
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ProdOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], dim, getKeepDim(), opConfig.outputLayout);
+      inputShape, inputs[0], getDimArg(), getKeepDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 ProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(getOperation());
+  return detail::issueErrorForGetOpRuntime(getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2326,8 +2327,7 @@ PrepareConv2dWeightsOp::getOpConstraints(
 llvm::Expected<size_t>
 PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+  return detail::issueErrorForGetOpRuntime(getOperation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -1809,6 +1809,51 @@ SortOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// ProdOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  std::optional<int64_t> dim;
+  if (getDimArg()) {
+    dim = getDimArg();
+  }
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<ProdOp>::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], dim, getKeepDim(), opConfig.outputLayout);
+}
+
+/*llvm::Expected<size_t>
+ProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  std::optional<int64_t> dim;
+  if (getDimArg()) {
+    dim = getDimArg();
+  }
+
+  return opRuntimeCache().getOrCompute(op_model::OpModel<ProdOp>::getOpRuntime,
+                                       *this, inputShape, inputs[0], dim,
+                                       getKeepDim(), opConfig.outputLayout);
+}*/
+
+//===----------------------------------------------------------------------===//
 // LinearOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2433,6 +2433,67 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// ArgMaxOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim, bool keepDim,
+    bool multicore, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Create query closure
+  auto argMaxOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
+        multicore, detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     argMaxOpQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                TTNNLayoutAttr inputLayout,
+                                std::optional<int32_t> dim, bool keepDim,
+                                bool multicore, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  // Create query closure
+  auto argMaxOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
+        multicore, detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+  };
+
+  return operation::getOpRuntime(argMaxOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // ProdOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
@@ -2463,33 +2524,6 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
 }
-
-/*llvm::Expected<size_t> OpModel<ProdOp>::getOpRuntime(
-  llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-  std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
-#ifdef TTMLIR_ENABLE_OPMODEL
-::tt::tt_metal::distributed::MeshDevice *device =
-    SingletonDeviceContext::getInstance().getDevice();
-
-auto inputSpecExp =
-    detail::convertToTensorSpec(device, inputShape, inputLayout);
-if (!inputSpecExp) {
-  return inputSpecExp.takeError();
-}
-::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-
-// Create query closure
-auto prodOpQuery = [=]() {
-  return ::ttnn::graph::query_op_runtime(
-      ::ttnn::prod, device, inputSpec, dim, keepDim,
-      detail::getNullableMemoryConfig(outputLayout));
-};
-
-return operation::getOpRuntime(prodOpQuery);
-#else
-return llvm::createStringError("Not Implemented");
-#endif // TTMLIR_ENABLE_OPMODEL
-}*/
 
 //===----------------------------------------------------------------------===//
 // LinearOp

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -442,6 +442,44 @@ INSTANTIATE_TEST_SUITE_P(MaxTests, OpModelMaxParam, reductionParams);
 
 INSTANTIATE_TEST_SUITE_P(MinTests, OpModelMinParam, reductionParams);
 
+TEST_F(OpModelTest, Prod) {
+  const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300,
+                                                  workerCoresN300};
+  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+  const TTNNLayoutAttr layoutDRAM = CreateTiledLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1Interleaved = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr layoutL1WSharded = CreateTiledLayout(
+      tensorShape, BufferType::L1, TensorMemoryLayout::WidthSharded);
+
+  auto legalExp = Device::getDeviceConstraints(workerGrid);
+  EXPECT_TRUE(static_cast<bool>(legalExp));
+
+  auto constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false, layoutDRAM);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  OpConstraints &opCstr = constraintsExp.get();
+  EXPECT_EQ(opCstr.cbL1PeakSize, 12288);
+  EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+  EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+
+  constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAM, 0, false,
+      layoutL1Interleaved);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  opCstr = constraintsExp.get();
+  EXPECT_EQ(opCstr.cbL1PeakSize, 12288);
+  EXPECT_EQ(opCstr.tensorL1PeakSize, 8192);
+  EXPECT_EQ(opCstr.outputL1BufferSize, 2048);
+
+  constraintsExp = op_model::OpModel<ProdOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutL1Interleaved, 0, false,
+      layoutL1WSharded);
+  EXPECT_FALSE(static_cast<bool>(constraintsExp));
+  llvm::consumeError(constraintsExp.takeError());
+}
+
 TEST_F(OpModelTest, SoftmaxInterleaved) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -442,6 +442,68 @@ INSTANTIATE_TEST_SUITE_P(MaxTests, OpModelMaxParam, reductionParams);
 
 INSTANTIATE_TEST_SUITE_P(MinTests, OpModelMinParam, reductionParams);
 
+TEST_F(OpModelTest, ArgMax) {
+  const llvm::SmallVector<int64_t> tensorShape = {64, 64};
+  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+
+  // ArgMax requires ROW_MAJOR layout for both input and output
+  // Note: L1 + ROW_MAJOR doesn't work (see tt-mlir issue #2976), so we use DRAM
+  const TTNNLayoutAttr layoutDRAMRowMajor = CreateRowMajorLayout(
+      tensorShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto legalExp = Device::getDeviceConstraints(workerGrid);
+  EXPECT_TRUE(static_cast<bool>(legalExp));
+
+  // Test case 1: no keepDim
+  auto constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAMRowMajor, 1, false, false,
+      layoutDRAMRowMajor);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  OpConstraints &opCstr = constraintsExp.get();
+  EXPECT_EQ(opCstr.cbL1PeakSize, 384);
+  EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+  EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+
+  auto runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
+      tensorShape, layoutDRAMRowMajor, 1, false, false, layoutDRAMRowMajor);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
+
+  // Test case 2: with keepDim
+  constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape, layoutDRAMRowMajor, 1, true, false,
+      layoutDRAMRowMajor);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  opCstr = constraintsExp.get();
+  EXPECT_EQ(opCstr.cbL1PeakSize, 160);
+  EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+  EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+
+  runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
+      tensorShape, layoutDRAMRowMajor, 1, true, false, layoutDRAMRowMajor);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
+
+  // Test case 3: Different tensor shape, no keepDim
+  const llvm::SmallVector<int64_t> tensorShape2 = {32, 128};
+  const TTNNLayoutAttr layoutDRAMRowMajor2 = CreateRowMajorLayout(
+      tensorShape2, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  constraintsExp = OpModel<ArgMaxOp>::getOpConstraints(
+      CreateWorkerGrid(), tensorShape2, layoutDRAMRowMajor2, 1, false, false,
+      layoutDRAMRowMajor2);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  opCstr = constraintsExp.get();
+  EXPECT_EQ(opCstr.cbL1PeakSize, 384);
+  EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+  EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+
+  runtimeExp = OpModel<ArgMaxOp>::getOpRuntime(
+      tensorShape2, layoutDRAMRowMajor2, 1, false, false, layoutDRAMRowMajor2);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
+}
+
 TEST_F(OpModelTest, Prod) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300,
                                                   workerCoresN300};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1121,6 +1121,31 @@ TEST_F(OpModelBase, SumOpInterface) {
   op_model::SingletonDeviceContext::resetInstance();
 }
 
+TEST_F(OpModelBase, ProdOpInterface) {
+  // create ProdOp
+  llvm::SmallVector<int64_t> tensorShapeA = {64, 64};
+
+  auto input = createEmptyTensor(tensorShapeA);
+  auto output = createEmptyTensor(tensorShapeA);
+
+  auto prod = builder.create<ProdOp>(builder.getUnknownLoc(), output.getType(),
+                                     input, builder.getI64IntegerAttr(0),
+                                     builder.getBoolAttr(false), nullptr);
+
+  // test prod Op interface
+  auto constraintsExp = getOpConstraints(prod.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto &[cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 12288);
+    EXPECT_EQ(peakSize, 8192);
+    EXPECT_EQ(outputSize, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+}
+
 TEST_F(OpModelBase, ReshapeOpInterface) {
   // create ReshapeOp
   llvm::SmallVector<int64_t> tensorShapeA = {64, 1024};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1121,6 +1121,48 @@ TEST_F(OpModelBase, SumOpInterface) {
   op_model::SingletonDeviceContext::resetInstance();
 }
 
+TEST_F(OpModelBase, ArgMaxOpInterface) {
+  // create ArgMaxOp
+  llvm::SmallVector<int64_t> tensorShapeA = {64, 64};
+
+  // ArgMaxOp requires ROW_MAJOR layout for inputs and outputs
+  auto inputLayout = CreateRowMajorLayout(tensorShapeA, BufferType::DRAM,
+                                          TensorMemoryLayout::Interleaved);
+  auto outputLayout = CreateRowMajorLayout(tensorShapeA, BufferType::DRAM,
+                                           TensorMemoryLayout::Interleaved);
+
+  auto input =
+      createEmptyTensor(tensorShapeA, builder.getBF16Type(), inputLayout);
+  auto outputType =
+      createRankedTensorType(tensorShapeA, builder.getBF16Type(), outputLayout);
+
+  auto argMax = builder.create<ArgMaxOp>(builder.getUnknownLoc(), outputType,
+                                         input, builder.getI32IntegerAttr(1),
+                                         false, false, nullptr);
+
+  // getOutputLayout() hardcodes tiled L1 layout, so we cannot use it
+  OpModel backend = dyn_cast<OpModel>(argMax.getOperation());
+  auto constraintsExp =
+      backend.getOpConstraints(getInputLayouts(argMax), OpConfig(outputLayout));
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto &[cbSize, peakSize, outputSize, outputLayoutReadBack] = l1;
+    EXPECT_EQ(cbSize, 384);
+    EXPECT_EQ(peakSize, 0);
+    EXPECT_EQ(outputSize, 0);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(argMax.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, ProdOpInterface) {
   // create ProdOp
   llvm::SmallVector<int64_t> tensorShapeA = {64, 64};


### PR DESCRIPTION
### Ticket
#4198 

Added constraints for `ProdOp` and `ArgMaxOp`.

`getOpRuntime` for `ProdOp` is not supported because `"Writes are not supported during trace capture."`
