### PR TITLE
Mark ND builder test fails for matmul after metal uplift

### DIFF
--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -283,8 +283,8 @@ def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     [
         # [(8192, 784), (784, 16384)],
         [(1024, 32), (32, 512)],
-        [(1024, 16), (16, 512)],
-        [(1024, 8), (8, 512)],
+        pytest.param([(1024, 16), (16, 512)], marks=pytest.mark.fails_golden),
+        pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.fails_golden),
         [(256, 128), (128, 124)],
         [(256, 128), (128, 132)],
         pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.fails_golden),


### PR DESCRIPTION
### Ticket
None

### Problem description
Missed xfailing tests that were ND during last metal uplift PR #4609
Fails are showing up in unrelated CI runs for [[explorer uplift]](https://github.com/tenstorrent/tt-mlir/actions/runs/17317075464), [[D2M changes]](https://github.com/tenstorrent/tt-mlir/actions/runs/17307913600)

### What's changed
xfailed ND golden mismatches in builder tests
Failures are expected to be investigated as part of #4712 

### Checklist
- [x] New/Existing tests provide coverage for changes
- For ND validation, [[CI passes 5 times]](https://github.com/tenstorrent/tt-mlir/actions/runs/17321486198) after xfailing these tests