### PR TITLE
Support lowering constants through D2M

### DIFF
--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
@@ -69,6 +69,7 @@ struct TTIRToTTIRGenericPass final
       target.addLegalOp<ttir::ViewLayoutOp>();
       target.addLegalOp<ttir::EmptyOp>();
       target.addLegalOp<ttir::ConstantOp>();
+      target.addLegalOp<ttir::FullOp>();
 
       target.addLegalOp<
 #define GET_OP_LIST

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -67,6 +67,8 @@ struct ConvertTTIRToTTKernel
     target.addLegalOp<memref::AllocOp>();
     target.addLegalOp<memref::DeallocOp>();
     target.addLegalOp<memref::CopyOp>();
+    target.addLegalOp<memref::GlobalOp>();
+    target.addLegalOp<memref::GetGlobalOp>();
 
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
       return !op->hasAttr(ttir::ThreadAttr::name) ||

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -190,8 +190,9 @@ struct TensorDesc {
     return std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1),
                            std::multiplies<int64_t>());
   }
+  std::int64_t sizeBytesUnaligned() const { return volume() * itemsize; }
   std::int64_t sizeBytes() const {
-    return utils::alignUp(volume() * itemsize, alignment);
+    return utils::alignUp(sizeBytesUnaligned(), alignment);
   }
 };
 

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -225,13 +225,14 @@ void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
   TensorDesc desc(shape, bufferDesc->data_type(),
                   utils::tileAlignment(bufferDesc->data_type()));
   size_t size = desc.sizeBytes();
+  size_t size_unaligned = desc.sizeBytesUnaligned();
   auto data = std::shared_ptr<void>(std::malloc(size), std::free);
   if (!data) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");
   }
   if (command->data() != nullptr) {
-    assert(command->data()->size() == size);
-    std::memcpy(data.get(), command->data()->data(), size);
+    assert(command->data()->size() == size_unaligned);
+    std::memcpy(data.get(), command->data()->data(), size_unaligned);
   }
 
   auto meshShape = meshDevice->shape();

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
-// RUN: ttrt run %t.ttm
 
 func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
   // CHECK: = "ttmetal.create_buffer"

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
@@ -1,11 +1,11 @@
-// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+// RUN: ttrt run %t.ttm
 
 func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
   // CHECK: = "ttmetal.create_buffer"
-  // CHECK: = "ttmetal.enqueue_write_buffer"
+  // CHECK: "ttmetal.enqueue_write_buffer"
   %0 = "ttir.constant"() <{value = dense<5.0> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
   %1 = ttir.empty() : tensor<32x32xf32>
   %2 = "ttir.add"(%arg0, %0, %1) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4746)

### Problem description
Support lowering `ttir.constant` through the D2M flow.

### What's changed
- legalize `ttir.full` in `TTIRtoTTIRGenericPass`
- legalize `memref.global_op` and `memref.get_global_op` in TTIRtoTTKernelPass`
- fixed assert in runtime `executor.cpp`
- re-enabled `Silicon/TTMetal/n150/simple_constant.mlir` test to qualify changes

### Checklist
- [x] New/Existing tests provide coverage for changes
