### PR TITLE
[D2M] Fix single bank DRAM sharded host interop

### DIFF
--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -364,9 +364,6 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     bool isSharded = mlir::isa<ttcore::ShardLayoutAttr>(memref.getLayout());
 
     if (isSharded) {
-
-      llvm::dbgs() << "SHARDED memref: " << memref << " \n";
-
       flatbuffers::Offset<target::metal::ShardedBufferConfig>
           shardedBufferConfig = memrefTypeToShardedBufferConfigFlatbuffer(
               cache, memref, device, elementShape);
@@ -385,7 +382,6 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                          shardedBufferConfig.Union(), circularBufferConfig)
                          .Union();
     } else {
-      llvm::dbgs() << "INTERLEAVED memref: " << memref << " \n";
       // must be interleaved if not sharded
       flatbuffers::Offset<target::metal::InterleavedBufferConfig>
           interleavedBufferConfig =

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -169,18 +169,30 @@ createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
 
   // NOTE: for DRAM, the coreRangeSet is a core range set from (0,0) to
   // (num_banks=12,1)
-  constexpr int32_t numBanks = 12;
+  // constexpr int32_t numBanks = 12;
   std::vector<target::Dim2dRange> coreRangeSet = {
-      target::Dim2dRange(target::Dim2d(0, 0), target::Dim2d(numBanks, 1))};
+      target::Dim2dRange(target::Dim2d(0, 0), target::Dim2d(1, 1))};
+
+  auto shardLayout = mlir::cast<ttcore::ShardLayoutAttr>(memref.getLayout());
+  auto memrefShardShape = shardLayout.getShardShape(memref);
 
   uint64_t pageSize = device.getMemrefSizeBytes(memref);
-  uint64_t shardSize = pageSize;
-  uint64_t size = pageSize * numBanks;
+  // uint64_t shardSize = pageSize;
+  uint64_t size = pageSize;
 
   // shard shape is (num_elems, 1)
-  target::Dim2d shardShape(shardSize, 1);
-  target::Dim2d pageShape(pageSize, 1);
-  target::Dim2d tensorShapeInPages(numBanks, 1);
+  target::Dim2d shardShape(memrefShardShape[0], memrefShardShape[1]);
+  target::Dim2d pageShape(memrefShardShape[0], memrefShardShape[1]);
+  target::Dim2d tensorShapeInPages(1, 1);
+
+  llvm::dbgs() << "  page size:    " << pageSize << " \n";
+  llvm::dbgs() << "  overall size: " << size << " \n";
+  llvm::dbgs() << "  shard shape:  " << shardShape.x() << "x" << shardShape.y()
+               << " \n";
+  llvm::dbgs() << "  page shape:   " << pageShape.x() << "x" << pageShape.y()
+               << " \n";
+  llvm::dbgs() << "  tensor shape: " << tensorShapeInPages.x() << "x"
+               << tensorShapeInPages.y() << " \n";
 
   auto shardSpec = target::metal::CreateShardSpecDirect(
       *cache.fbb, &coreRangeSet, &shardShape);
@@ -343,6 +355,9 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     bool isSharded = mlir::isa<ttcore::ShardLayoutAttr>(memref.getLayout());
 
     if (isSharded) {
+
+      llvm::dbgs() << "SHARDED memref: " << memref << " \n";
+
       flatbuffers::Offset<target::metal::ShardedBufferConfig>
           shardedBufferConfig = memrefTypeToShardedBufferConfigFlatbuffer(
               cache, memref, device, elementShape);
@@ -361,6 +376,7 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                          shardedBufferConfig.Union(), circularBufferConfig)
                          .Union();
     } else {
+      llvm::dbgs() << "INTERLEAVED memref: " << memref << " \n";
       // must be interleaved if not sharded
       flatbuffers::Offset<target::metal::InterleavedBufferConfig>
           interleavedBufferConfig =

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -167,39 +167,48 @@ createShardedBufferConfigForDRAMMemref(FlatbufferObjectCache &cache,
                                        MemRefType memref,
                                        ttcore::DeviceAttr device) {
 
-  // NOTE: for DRAM, the coreRangeSet is a core range set from (0,0) to
-  // (num_banks=12,1)
-  // constexpr int32_t numBanks = 12;
-  std::vector<target::Dim2dRange> coreRangeSet = {
-      target::Dim2dRange(target::Dim2d(0, 0), target::Dim2d(1, 1))};
+  // The code below configures the sharded buffer AS-IF it was a Nx1 sharded
+  // DRAM tensor large enough to hold all the shards distributed across all DRAM
+  // banks. However the shapes and size here are **dummy values**, such that
+  // the buffer spec occupies that exact size of the underlying D2M DRAM buffer.
+  // However the shapes in the spec DO NOT actually correspond to the D2M tensor
+  // or shard shape.
+  //
+  // This kludge is due to D2M DRAM shard->bank mapping being _cyclic_, which
+  // cannot be represented by the ShardedBufferConfig. Host<->Device transfers
+  // will have to be properly fixed using BufferDistributionSpec to describe how
+  // sharded D2M DRAM buffers are actually laid out.
+  //
+  // NOTE: For the special case of a single shard mapped to a single DRAM bank,
+  // the shapes and size here are incidentally correct. So host
+  // enqueue_write_buffer and enqeue_read_buffer commands will work correctly.
 
   auto shardLayout = mlir::cast<ttcore::ShardLayoutAttr>(memref.getLayout());
-  auto memrefShardShape = shardLayout.getShardShape(memref);
+  auto memrefGridShape = shardLayout.getGridShape(memref);
+  uint64_t actualShardSize = device.getMemrefSizeBytes(memref);
+  uint64_t gridVolume = ttmlir::utils::volume(memrefGridShape);
 
-  uint64_t pageSize = device.getMemrefSizeBytes(memref);
-  // uint64_t shardSize = pageSize;
-  uint64_t size = pageSize;
+  // determine how many DRAM banks are actually used by D2M
+  constexpr uint64_t numDRAMBanks = 12;
+  uint64_t numDRAMBanksUsed = std::min(numDRAMBanks, gridVolume);
+  std::vector<target::Dim2dRange> coreRangeSet = {target::Dim2dRange(
+      target::Dim2d(0, 0), target::Dim2d(numDRAMBanksUsed, 1))};
 
-  // shard shape is (num_elems, 1)
-  target::Dim2d shardShape(memrefShardShape[0], memrefShardShape[1]);
-  target::Dim2d pageShape(memrefShardShape[0], memrefShardShape[1]);
-  target::Dim2d tensorShapeInPages(1, 1);
+  uint64_t actualShardsPerBank = std::ceil(float(gridVolume) / numDRAMBanks);
 
-  llvm::dbgs() << "  page size:    " << pageSize << " \n";
-  llvm::dbgs() << "  overall size: " << size << " \n";
-  llvm::dbgs() << "  shard shape:  " << shardShape.x() << "x" << shardShape.y()
-               << " \n";
-  llvm::dbgs() << "  page shape:   " << pageShape.x() << "x" << pageShape.y()
-               << " \n";
-  llvm::dbgs() << "  tensor shape: " << tensorShapeInPages.x() << "x"
-               << tensorShapeInPages.y() << " \n";
+  // compute dummy shapes that occupy same space as actual D2M memref
+  target::Dim2d dummyShardShape(actualShardsPerBank, actualShardSize);
+  target::Dim2d dummyPageShape(actualShardsPerBank, actualShardSize);
+  uint64_t dummyShardSize = dummyShardShape.x() * dummyShardShape.y();
+  target::Dim2d dummyTensorShapeInPages(numDRAMBanksUsed, 1);
+  uint64_t dummyTensorSize = numDRAMBanksUsed * dummyShardSize;
 
   auto shardSpec = target::metal::CreateShardSpecDirect(
-      *cache.fbb, &coreRangeSet, &shardShape);
+      *cache.fbb, &coreRangeSet, &dummyShardShape);
   auto shardSpecBuffer = target::metal::CreateShardSpecBuffer(
-      *cache.fbb, shardSpec, &pageShape, &tensorShapeInPages);
-  return target::metal::CreateShardedBufferConfig(*cache.fbb, size, pageSize,
-                                                  shardSpecBuffer);
+      *cache.fbb, shardSpec, &dummyPageShape, &dummyTensorShapeInPages);
+  return target::metal::CreateShardedBufferConfig(
+      *cache.fbb, dummyTensorSize, dummyShardSize, shardSpecBuffer);
 }
 
 static flatbuffers::Offset<target::metal::ShardedBufferConfig>


### PR DESCRIPTION
### Problem description
It is convenient to be able to be able to read/write row-major tensors to a single bank in device DRAM. This avoids D2M runtime's lack of support for row-major interleaved tensors while still allowing device side tilization/untilization. 

However the ability to do this was broken recently (it is not clear when), _and likely only worked accidentally for certain cases_. This PR adds more robust support for host<->device transfers using single-bank, single-shard tensors till more complete support is ready. 

### What's changed
- Instead of configuring all DRAM buffers to be 12x1 sharded, DRAM buffers now use only the DRAM banks they actually use in D2M
  - This fixes single-shard host<->device transfers
- The ShardedBufferConfig shapes now has the _same total size as actual buffer_, but use dummy shard and page shapes to support grids that overflow/wrap 12x1 DRAM banks

Note: _**host<->device transfers for multi-shard configs are still broken**. D2M DRAM sharding scheme is not supportable via ShardedBufferConfig due to a lack of support for wrapping grid dims.

### Checklist
- [ ] New/Existing tests provide coverage for changes
