### PR TITLE
Double persistent_intermediate_buffer size for reduce_scatter_minimal_async

### DIFF
--- a/test/python/golden/test_ttir_llama_1x2_tp.py
+++ b/test/python/golden/test_ttir_llama_1x2_tp.py
@@ -14,6 +14,7 @@ from builder.base.builder_utils import compile_ttir_to_flatbuffer
 
 pytestmark = [pytest.mark.n300, pytest.mark.frontend("ttir")]
 
+
 # utility functions to increase readability
 def get_input_tensors_from_builder(args: List, builder: TTIRBuilder):
     input_tensors = []
@@ -163,7 +164,6 @@ def golden_part2(
 
 
 # llama attention part 1 with 1x2
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -372,7 +372,6 @@ def test_llama_attention_1x2_tp_part1(
 
 
 # llama attention part 2 with 1x2
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/test/python/golden/test_ttir_llama_1x2_tp.py
+++ b/test/python/golden/test_ttir_llama_1x2_tp.py
@@ -14,7 +14,6 @@ from builder.base.builder_utils import compile_ttir_to_flatbuffer
 
 pytestmark = [pytest.mark.n300, pytest.mark.frontend("ttir")]
 
-
 # utility functions to increase readability
 def get_input_tensors_from_builder(args: List, builder: TTIRBuilder):
     input_tensors = []

--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -283,8 +283,8 @@ def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     [
         # [(8192, 784), (784, 16384)],
         [(1024, 32), (32, 512)],
-        pytest.param([(1024, 16), (16, 512)], marks=pytest.mark.fails_golden),
-        pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.fails_golden),
+        [(1024, 16), (16, 512)],
+        [(1024, 8), (8, 512)],
         [(256, 128), (128, 124)],
         [(256, 128), (128, 132)],
         [(1024, 8), (8, 512)],

--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -72,9 +72,9 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     [
         pytest.param((1, 1, 256, 512), marks=pytest.mark.run_error),
         pytest.param((1, 1, 2, 4), marks=pytest.mark.run_error),
-        pytest.param((1, 1, 64, 128), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 64, 256), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 128, 256), marks=pytest.mark.fails_golden),
+        (1, 1, 64, 128),
+        (1, 1, 64, 256),
+        (1, 1, 128, 256),
         pytest.param((1, 1, 256, 256), marks=pytest.mark.run_error),
         pytest.param((1, 1, 128, 512), marks=pytest.mark.run_error),
     ],
@@ -114,13 +114,13 @@ def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
 @pytest.mark.parametrize(
     "shape",
     [
-        pytest.param((1, 1, 512, 512), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 256, 1024), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 256, 1024), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 256, 512), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 254, 1024), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 256, 1024), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 128, 1024), marks=pytest.mark.fails_golden),
+        (1, 1, 512, 512),
+        (1, 1, 256, 1024),
+        (1, 1, 256, 1024),
+        (1, 1, 256, 512),
+        (1, 1, 254, 1024),
+        (1, 1, 256, 1024),
+        (1, 1, 128, 1024),
         (1, 1, 256, 1008),
         pytest.param((1, 1, 256, 1040), marks=pytest.mark.run_error),
         pytest.param((1, 1, 128, 256), marks=pytest.mark.run_error),
@@ -128,8 +128,8 @@ def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
         (1, 1, 128, 64),
         pytest.param((1, 1, 64, 64), marks=pytest.mark.run_error),
         pytest.param((1, 1, 64, 128), marks=pytest.mark.run_error),
-        pytest.param((1, 1, 2, 16), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 128, 512), marks=pytest.mark.fails_golden),
+        (1, 1, 2, 16),
+        (1, 1, 128, 512),
         (1, 1, 64, 512),
         pytest.param((1, 1, 32, 512), marks=pytest.mark.run_error),
     ],
@@ -224,13 +224,13 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
         [(1024, 16), (16, 512)],
         [(1024, 8), (8, 512)],
         [(1024, 8), (8, 512)],
-        pytest.param([(256, 128), (128, 128)], marks=pytest.mark.fails_golden),
+        [(256, 128), (128, 128)],
         [(256, 128), (128, 124)],
         [(256, 128), (128, 120)],
-        pytest.param([(254, 128), (128, 128)], marks=pytest.mark.fails_golden),
-        pytest.param([(252, 128), (128, 128)], marks=pytest.mark.fails_golden),
-        pytest.param([(258, 128), (128, 128)], marks=pytest.mark.fails_golden),
-        pytest.param([(260, 128), (128, 128)], marks=pytest.mark.fails_golden),
+        [(254, 128), (128, 128)],
+        [(252, 128), (128, 128)],
+        [(258, 128), (128, 128)],
+        [(260, 128), (128, 128)],
         [(256, 128), (128, 132)],
         [(256, 128), (128, 136)],
         pytest.param([(256, 32), (32, 64)], marks=pytest.mark.run_error),
@@ -287,7 +287,7 @@ def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
         pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.fails_golden),
         [(256, 128), (128, 124)],
         [(256, 128), (128, 132)],
-        pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.fails_golden),
+        [(1024, 8), (8, 512)],
         pytest.param([(512, 32), (32, 128)], marks=pytest.mark.run_error),
         pytest.param([(256, 128), (128, 128)], marks=pytest.mark.run_error),
         [(256, 128), (128, 120)],
@@ -715,9 +715,7 @@ def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], r
     "shapes",
     [
         [(1024, 32), (32, 512), (1024, 512)],
-        pytest.param(
-            [(256, 128), (128, 128), (256, 128)], marks=pytest.mark.fails_golden
-        ),
+        [(256, 128), (128, 128), (256, 128)],
     ],
 )
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
@@ -770,7 +768,7 @@ def test_matmul_and_binary_op(
     "shapes",
     [
         [(1024, 32), (32, 512)],
-        pytest.param([(256, 128), (128, 128)], marks=pytest.mark.fails_golden),
+        [(256, 128), (128, 128)],
     ],
 )
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])

--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -72,9 +72,9 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     [
         pytest.param((1, 1, 256, 512), marks=pytest.mark.run_error),
         pytest.param((1, 1, 2, 4), marks=pytest.mark.run_error),
-        (1, 1, 64, 128),
-        (1, 1, 64, 256),
-        (1, 1, 128, 256),
+        pytest.param((1, 1, 64, 128), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 64, 256), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 128, 256), marks=pytest.mark.run_error),
         pytest.param((1, 1, 256, 256), marks=pytest.mark.run_error),
         pytest.param((1, 1, 128, 512), marks=pytest.mark.run_error),
     ],

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -78,8 +78,8 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         (1, 1, 128, 508),
         (1, 1, 126, 508),
         (1, 1, 130, 508),
-        pytest.param((1, 1, 32, 2), marks=pytest.mark.fails_golden),
-        pytest.param((1, 1, 1, 2), marks=pytest.mark.fails_golden),
+        (1, 1, 32, 2),
+        (1, 1, 1, 2),
         (1, 1, 128, 516),
         (1, 1, 128, 516),
         (1, 1, 126, 516),
@@ -219,7 +219,6 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -432,7 +431,6 @@ def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], r
     )
 
 
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -486,7 +484,6 @@ def test_matmul_and_binary_op(
     )
 
 
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -538,7 +535,6 @@ def test_matmul_and_unary_op(shapes: List[Shape], mesh_shape: Tuple[int, int], r
     )
 
 
-@pytest.mark.skip(reason="failed with new CCL op - skip temporarily")
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -89,7 +89,7 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         (1, 1, 32, 8),
     ],
 )
-@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
+@pytest.mark.parametrize("mesh_shape", [(1, 2)])
 def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_reduce(in0: Operand, builder: TTIRBuilder):
         sharded = builder.mesh_shard(

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from builder.base.builder import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_utils import compile_ttir_to_flatbuffer
+from test_utils import Marks, shape_str
 
 pytestmark = [pytest.mark.n300, pytest.mark.frontend("ttir")]
 
@@ -78,8 +79,8 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         (1, 1, 128, 508),
         (1, 1, 126, 508),
         (1, 1, 130, 508),
-        (1, 1, 32, 2),
-        (1, 1, 1, 2),
+        pytest.param((1, 1, 32, 2), marks=pytest.mark.fails_golden),
+        pytest.param((1, 1, 1, 2), marks=pytest.mark.fails_golden),
         (1, 1, 128, 516),
         (1, 1, 128, 516),
         (1, 1, 126, 516),
@@ -88,7 +89,7 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         (1, 1, 32, 8),
     ],
 )
-@pytest.mark.parametrize("mesh_shape", [(1, 2)])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=shape_str)
 def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_reduce(in0: Operand, builder: TTIRBuilder):
         sharded = builder.mesh_shard(


### PR DESCRIPTION
### Ticket
closes #4712

### Problem description
`reduce_scatter_minimal_async` with a linear topology requires a `persistent_intermediate_buffer` that is twice the input tensor size.

### What's changed
Increased the persistent_intermediate_buffer size by 2×.
Fixes the low-PCC issue observed with new CCL op.

### Checklist
- [ ] New/Existing tests provide coverage for changes
