### PR TITLE
Exclude `to_layout` ops in `perf` reports

### DIFF
--- a/runtime/include/tt/runtime/perf.h
+++ b/runtime/include/tt/runtime/perf.h
@@ -12,7 +12,8 @@ namespace tt::runtime::perf {
 enum class TracyLogTag {
   MLIR_OP_LOCATION,
   MLIR_CONST_EVAL_OP,
-  MLIR_PROGRAM_METADATA
+  MLIR_PROGRAM_METADATA,
+  MLIR_INPUT_LAYOUT_CONVERSION_OP
 };
 
 inline std::string toString(TracyLogTag tracyLogTag) {
@@ -23,6 +24,8 @@ inline std::string toString(TracyLogTag tracyLogTag) {
     return "MLIR_CONST_EVAL_OP";
   case TracyLogTag::MLIR_PROGRAM_METADATA:
     return "MLIR_PROGRAM_METADATA";
+  case TracyLogTag::MLIR_INPUT_LAYOUT_CONVERSION_OP:
+    return "MLIR_INPUT_LAYOUT_CONVERSION_OP";
   }
 }
 
@@ -55,6 +58,7 @@ struct Env {
 
   void tracyLogOpLocation(const std::string &locInfo) const;
   void tracyLogConstEvalProgram(bool constEvalOp) const;
+  void tracyLogInputLayoutConversion(bool inputLayoutConversionOp) const;
   void tracyLogProgramMetadata(const std::string &metaData) const;
   void setProgramMetadata(const std::string &programMetadata);
 

--- a/runtime/lib/common/perf.cpp
+++ b/runtime/lib/common/perf.cpp
@@ -42,6 +42,15 @@ void Env::tracyLogProgramMetadata(const std::string &metaData) const {
 #endif
 }
 
+void Env::tracyLogInputLayoutConversion(bool inputLayoutConversionOp) const {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  std::string message =
+      perf::toString(perf::TracyLogTag::MLIR_INPUT_LAYOUT_CONVERSION_OP) + ";" +
+      std::string(inputLayoutConversionOp ? "true" : "false");
+  TracyMessage(message.c_str(), message.size());
+#endif
+}
+
 void Env::setProgramMetadata(const std::string &programMetadata) {
   tracyProgramMetadata = programMetadata;
 }

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -497,6 +497,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def_static("get", &tt::runtime::perf::Env::get, nb::rv_policy::reference)
       .def("set_program_metadata", &tt::runtime::perf::Env::setProgramMetadata)
       .def("tracy_log_op_location", &tt::runtime::perf::Env::tracyLogOpLocation)
+      .def("tracy_log_input_layout_conversion",
+           &tt::runtime::perf::Env::tracyLogInputLayoutConversion)
       .def("tracy_log_const_eval_program",
            &tt::runtime::perf::Env::tracyLogConstEvalProgram)
       .def("tracy_log_program_metadata",

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -529,6 +529,7 @@ class Run:
                         fbb, program_index, input_index
                     )
                     perf_env.tracy_log_op_location(f"loc(arg_{input_index})")
+                    perf_env.tracy_log_input_layout_conversion(True)
                     inputs_converted.append(
                         ttrt.runtime.to_layout(
                             inputs[input_index], device, input_layout, True
@@ -821,6 +822,7 @@ class Run:
                                         perf_env.tracy_log_op_location(
                                             f"loc(arg_{input_idx})"
                                         )
+                                        perf_env.tracy_log_input_layout_conversion(True)
                                         result_tensor = ttrt.runtime.to_layout(
                                             tensor_to_dirty,
                                             device,


### PR DESCRIPTION
### Ticket
Closes #4558 

### Problem description
At runtime, `to_layout` ops are prepended to input operands to ensure they are in the correct format. We don't wish to include those in perf reports, and wish to be able to track them

### What's changed
`to_layout` ops inserted at runtime are now tagged and optionally excluded from the csv depending on what is passed into `--filter`