### PR TITLE
Uplift third_party/tt-metal to 1c6f2b7a835ff8a9ca20d024cbf7e8cba4c53a69 2025-09-03

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -180,7 +180,7 @@ public:
 
 namespace {
 template <typename SourceOp>
-class EltwiseUnaryWithAccuracyModeOpConversionPattern
+class EltwiseUnaryWithOutputAndApproxModeOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
 
 public:
@@ -198,7 +198,7 @@ public:
         emitter.emit(srcOp.getInput()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
         /*output=*/emitter.emit(std::nullopt),
-        /*accuracy=*/emitter.emit(true),
+        /*approx=*/emitter.emit(false),
     };
 
     emitter.replaceOp(*this, args);
@@ -2557,45 +2557,46 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Eltwise unary ops
   //
-  patterns.add<
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::AbsOp>,
-      EltwiseUnaryCompositeOpConversionPattern<mlir::tt::ttnn::CbrtOp>,
-      ClampOpConversionPattern<::mlir::tt::ttnn::ClampScalarOp>,
-      ClampOpConversionPattern<mlir::tt::ttnn::ClampTensorOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::FloorOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::IsFiniteOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::LogicalNotOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::BitwiseNotOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::NegOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::ReluOp>,
-      ElementwiseUnaryWithFloatParameterOpConversionPattern<
-          mlir::tt::ttnn::LeakyReluOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::GeluOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SqrtOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::RsqrtOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SignOp>,
-      EltwiseUnaryWithVectorAndFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::SigmoidOp>,
-      EltwiseUnaryCompositeWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::Log1pOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::ReciprocalOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::ExpOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::ErfOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::ErfcOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::CeilOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SinOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::CosOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::Expm1Op>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::TanOp>,
-      EltwiseUnaryWithAccuracyModeOpConversionPattern<mlir::tt::ttnn::TanhOp>,
-      EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::AtanOp>,
-      EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
-          mlir::tt::ttnn::LogOp>>(typeConverter, ctx);
+  patterns
+      .add<EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::AbsOp>,
+           EltwiseUnaryCompositeOpConversionPattern<mlir::tt::ttnn::CbrtOp>,
+           ClampOpConversionPattern<::mlir::tt::ttnn::ClampScalarOp>,
+           ClampOpConversionPattern<mlir::tt::ttnn::ClampTensorOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::FloorOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::IsFiniteOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::LogicalNotOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::BitwiseNotOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::NegOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::ReluOp>,
+           ElementwiseUnaryWithFloatParameterOpConversionPattern<
+               mlir::tt::ttnn::LeakyReluOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::GeluOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SqrtOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::RsqrtOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SignOp>,
+           EltwiseUnaryWithVectorAndFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::SigmoidOp>,
+           EltwiseUnaryCompositeWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::Log1pOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::ReciprocalOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::ExpOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::ErfOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::ErfcOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::CeilOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SinOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::CosOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::Expm1Op>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::TanOp>,
+           EltwiseUnaryWithOutputAndApproxModeOpConversionPattern<
+               mlir::tt::ttnn::TanhOp>,
+           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::AtanOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::LogOp>>(typeConverter, ctx);
 
   // Eltwise binary ops
   //

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -46,7 +46,7 @@ static void runEltwiseUnaryTanhOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out =
-      ttnnOp(in, outputMemoryConfig, std::nullopt, /* accuracy= */ true);
+      ttnnOp(in, outputMemoryConfig, std::nullopt, /* approx= */ false);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -261,6 +261,47 @@ const std::initializer_list<
                                BufferType::L1},
             detail::ExpectedResult{false})};
 
+const std::initializer_list<
+    std::tuple<detail::TestTensor, detail::TestTensor, detail::ExpectedResult>>
+    tanhParams = {
+        std::make_tuple(detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 28672, 0, 0}),
+        std::make_tuple(detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 28672, 2048, 2048}),
+        std::make_tuple(detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 28672, 0, 0}),
+        std::make_tuple(detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 28672, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::ExpectedResult{true, 143360, 14 * 32 * 32 * 2,
+                                   14 * 32 * 32 * 2}),
+        std::make_tuple(
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::ExpectedResult{false}),
+        std::make_tuple(
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::HeightSharded,
+                               BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               TensorMemoryLayout::Interleaved,
+                               BufferType::L1},
+            detail::ExpectedResult{false})};
+
 INSTANTIATE_TEST_SUITE_P(ReluTests, OpModelReluParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
@@ -280,7 +321,7 @@ INSTANTIATE_TEST_SUITE_P(ExpTests, OpModelExpParam,
                          ::testing::ValuesIn(unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(TanhTests, OpModelTanhParam,
-                         ::testing::ValuesIn(unaryEltwiseParams));
+                         ::testing::ValuesIn(tanhParams));
 
 INSTANTIATE_TEST_SUITE_P(LogTests, OpModelLogParam,
                          ::testing::ValuesIn(unaryEltwiseParams));

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -194,6 +194,7 @@ TEST_P(UnaryOpModelTest, TestOpInterfaceNullOutput) {
 
 const ExpectedResult expected{true, 8192, 2048, 2048};
 const ExpectedResult cbrtExpected{true, 12288, 6144, 2048};
+const ExpectedResult tanhExpected{true, 28672, 2048, 2048};
 
 //===---------------------------------------------------------===
 const auto createRelu = [](OpBuilder &b, Location loc, Type type,
@@ -296,7 +297,7 @@ const std::vector<UnaryOpTestParams> unaryOpTestParams = {
     {"Sin", createSin, expected},
     {"Cos", createCos, expected},
     {"Exp", createExp, expected},
-    {"Tanh", createTanh, expected},
+    {"Tanh", createTanh, tanhExpected},
     {"Log", createLog, expected},
     {"Abs", createAbs, expected},
     {"Ceil", createCeil, expected},

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "652c0dc44aefab4a17cd717bd4be0791b4b8475d")
+set(TT_METAL_VERSION "1c6f2b7a835ff8a9ca20d024cbf7e8cba4c53a69")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 1c6f2b7a835ff8a9ca20d024cbf7e8cba4c53a69

- Replace accurate mode and update op model expected cbsize after tanh updated in metal commit e818062