### PR TITLE
Mention `TTMLIR_TOOLCHAIN_DIR` instead of hardcoding a path

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -79,8 +79,8 @@ This section explains how to manually build the environment so you can use tt-ml
 
 ```bash
 export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/
-sudo mkdir -p /opt/ttmlir-toolchain
-sudo chown -R $USER /opt/ttmlir-toolchain
+sudo mkdir -p "${TTMLIR_TOOLCHAIN_DIR}"
+sudo chown -R "${USER}" "${TTMLIR_TOOLCHAIN_DIR}"
 ```
 
 3. Please ensure that you do not already have an environment (venv) activated before running the following commands:


### PR DESCRIPTION
### What's changed

If one wants to use a different path, copy-pasting the current instructions is daunting because they need to change the path in 3 different places, consistently. Referring to the variable defined at the beginning of the instructions makes this process much smoother instead (they need to change the path only in one place).

### Checklist
- [ ] New/Existing tests provide coverage for changes
