### PR TITLE
#4799: Fix bug when updating slice op attribute dictionary

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -65,39 +65,46 @@ static FailureOr<mlir::OperationState> createNewOperationState(
             return mlir::success();
           })
           .Case<mlir::stablehlo::SliceOp>([&](auto sliceOp) {
+            // 1. Get the sharding for each operand dimension.
+            llvm::ArrayRef<mlir::sdy::DimensionShardingAttr>
+                operandDimShardings =
+                    shardy_utils::getOperandShardingAttr(
+                        sliceOp.getOperation()->getOpOperand(0), globalMeshOp)
+                        .getDimShardings();
+
+            // 2. Copy the current start_indices and limit_indices attributes.
             llvm::SmallVector<int64_t> startIndices(sliceOp.getStartIndices());
             llvm::SmallVector<int64_t> limitIndices(sliceOp.getLimitIndices());
 
-            // Iterate through start and limit indices and update them based on
-            // the sharding annotation for that dimension.
-            for (uint32_t i = 0; i < tensorShardings.size(); i++) {
-              llvm::ArrayRef<mlir::sdy::DimensionShardingAttr> dimShardings =
-                  tensorShardings[i].getDimShardings();
+            // 3. Iterate through start and limit indices and update them based
+            // on the sharding annotation for that dimension.
+            for (auto [i, dimShardings] :
+                 llvm::enumerate(operandDimShardings)) {
+              llvm::ArrayRef<mlir::sdy::DimensionShardingAttr> shardings =
+                  dimShardings;
 
-              for (const auto [index, dimShardingAttr] :
-                   llvm::enumerate(dimShardings)) {
-                FailureOr<int64_t> updatedStartDim =
-                    shardy_utils::calculateUpdatedDim(globalMeshOp.getMesh(),
-                                                      dimShardingAttr,
-                                                      startIndices[index]);
-                FailureOr<int64_t> updatedLimitDim =
-                    shardy_utils::calculateUpdatedDim(globalMeshOp.getMesh(),
-                                                      dimShardingAttr,
-                                                      limitIndices[index]);
-
-                if (failed(updatedStartDim) || failed(updatedLimitDim)) {
-                  sliceOp->emitError(
-                      "Could not apply propagated tensor shardings "
-                      "to attribute dictionary for slice op");
-                  return mlir::failure();
-                }
-
-                startIndices[index] = *updatedStartDim;
-                limitIndices[index] = *updatedLimitDim;
+              if (shardings.size() > 1) {
+                sliceOp->emitError(
+                    "Slice operation has multiple shardings on a single tensor "
+                    "dimension. This is not supported.");
+                return mlir::failure();
               }
+
+              FailureOr<int64_t> updatedLimitDim =
+                  shardy_utils::calculateUpdatedDim(
+                      globalMeshOp.getMesh(), shardings[0], limitIndices[i]);
+
+              if (failed(updatedLimitDim)) {
+                sliceOp->emitError(
+                    "Could not apply propagated tensor shardings "
+                    "to attribute dictionary for slice op");
+                return mlir::failure();
+              }
+
+              limitIndices[i] = *updatedLimitDim;
             }
 
-            // Update start and limit indices in op named attributes.
+            // 4. Update start and limit indices in op named attributes.
             llvm::StringRef startIndicesAttrName = "start_indices";
             llvm::StringRef limitIndicesAttrName = "limit_indices";
 

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
@@ -43,3 +43,12 @@ func.func @non_batch_dim_slice(%arg0: tensor<4x40x256xf32> {sdy.sharding = #sdy.
 // CHECK: stablehlo.slice %arg2 [0:4, 0:16, 0:256] : (tensor<4x20x256xf32>) -> tensor<4x16x256xf32>
 // CHECK: stablehlo.slice %arg3 [0:4, 0:24, 0:256] : (tensor<4x30x256xf32>) -> tensor<4x24x256xf32>
 // CHECK: sdy.return %3 : tensor<4x40x256xf32>
+
+func.func @main(%arg0: tensor<4x128x16384xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"batch"}]>}) -> (tensor<4x128x8192xbf16>) {
+  %1 = stablehlo.slice %arg0 [0:4, 0:128, 1:16384:2] : (tensor<4x128x16384xbf16>) -> tensor<4x128x8192xbf16>
+  return %1 : tensor<4x128x8192xbf16>
+}
+
+// CHECK: sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {}, {"batch"}]>] out_shardings=[<@mesh, [{}, {}, {"batch"}]>]
+// CHECK: stablehlo.slice %arg1 [0:4, 0:128, 1:8192:2] : (tensor<4x128x8192xbf16>) -> tensor<4x128x4096xbf16>
+// CHECK: sdy.return %1 : tensor<4x128x4096xbf16>


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/4799

In shardy partitioner, we incorrectly use the output tensor shardings when updating the slice op attribute dictionary. We need to use the input sharding of this op, as well as update only the limit indices. 