### PR TITLE
Add permission needed for tt-forge's perf benchmark workflow

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -39,6 +39,7 @@ permissions:
   contents: read
   packages: write
   checks: write
+  id-token: write
 
 jobs:
   trigger:


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge/issues/344)

### Problem description
Even though tt-mlir doesn't have the new performance benchmark regression check, the workflow call will fail without the added permission.

### What's changed
Added the needed permission.

### Checklist
- [ ] New/Existing tests provide coverage for changes
