### PR TITLE
[L1InterleavedFallbackAnalysis] Improve perf by skipping L1 upgrades for matmul, linear and specific conv2d 

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -111,6 +111,9 @@ bool producesL1Layout(Operation *op);
 
 // Check if operation's first result uses tiled tensor layout.
 bool producesTiledTensorLayout(Operation *op);
+
+// Check if conv2D uses matmul (1x1 kernel, stride=1, padding=0, groups=1)
+bool isConv2DConvertibleToMatMul(Operation *op);
 } // namespace mlir::tt::ttnn::utils
 
 #endif // TTMLIR_DIALECT_TTNN_UTILS_UTILS_H

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -37,11 +37,16 @@ void L1InterleavedFallbackAnalysis::analysisImplementation() {
     if (isa<ttnn::SliceStaticOp, ttnn::TypecastOp>(op)) {
       return;
     }
-    // Skip output of Conv2D that uses matmul under the hood, inefficient in L1.
+    // Skip Matmul and Linear input, inefficient for L1 interleaved.
+    if (isa<ttnn::MatmulOp, ttnn::LinearOp>(op)) {
+      return;
+    }
+    // Skip output of Conv2D that uses matmul under the hood, inefficient for L1
+    // interleaved.
     if (utils::isConv2DConvertibleToMatMul(op)) {
       TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                    "L1InterleavedFallbackAnalysis: Skipping {} - Conv2D "
-                   "uses matmul, inefficient in L1.",
+                   "uses matmul, inefficient for L1 interleaved.",
                    op->getName());
       return;
     }
@@ -53,13 +58,17 @@ void L1InterleavedFallbackAnalysis::analysisImplementation() {
       if (isa<ttnn::SliceStaticOp, ttnn::TypecastOp>(user)) {
         return;
       }
-      // Skip input of Conv2D that uses matmul under the hood, inefficient in
-      // L1.
+      // Skip Matmul and Linear input, inefficient for L1 interleaved.
+      if (isa<ttnn::MatmulOp, ttnn::LinearOp>(user)) {
+        return;
+      }
+      // Skip input of Conv2D that uses matmul under the hood, inefficient for
+      // L1 interleaved.
       if (utils::isConv2DConvertibleToMatMul(user)) {
         TTMLIR_TRACE(
             ttmlir::LogComponent::Optimizer,
             "L1InterleavedFallbackAnalysis: Skipping {} - Consumer Conv2D "
-            "uses matmul, inefficient in L1.",
+            "uses matmul, inefficient for L1 interleaved.",
             op->getName());
         return;
       }

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -12,9 +12,9 @@
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Casting.h"
 
-#include "llvm/ADT/ArrayRef.h"
 #include <optional>
 
 namespace mlir::tt::ttnn::utils {
@@ -309,8 +309,6 @@ bool producesTiledTensorLayout(Operation *op) {
   return ttnnLayout && ttnnLayout->isTiled();
 }
 
-/// Check if a Conv2D operation would be converted to MatMul
-/// (1x1 kernel, stride=1, padding=0, groups=1)
 bool isConv2DConvertibleToMatMul(Operation *op) {
   auto conv2dOp = dyn_cast<ttnn::Conv2dOp>(op);
   if (!conv2dOp) {

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
@@ -22,13 +22,21 @@ module @L1InterleavedTestConv2D attributes {} {
 
 // CHECK-DAG: #[[DRAM_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 // CHECK-DAG: #[[DRAM_2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[DRAM_3:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[DRAM_4:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[DRAM_5:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[DRAM_6:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+
 // CHECK-DAG: #[[L1_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
-// CHECK-DAG: #[[L1_2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
 
 // CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L1_1]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_1]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L1_2]]>
+
+// Consumer is conv2d which uses matmul, stays in DRAM.
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_4]]>
+// Conv2d which uses matmul, stays in DRAM.
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_6]]>
+// Conv2d which uses matmul, stays in DRAM.
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_6]]>
 
 // As output is the return value, not beneficial to move to L1, will always stay in DRAM.
 // CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[DRAM_2]]>


### PR DESCRIPTION
This PR improves the L1 interleaved fallback analysis by explicitly skipping the upgrades for inputs and output tensors of `ttnn::matmul` and `ttnn::linear` ops, as well as `ttnn::conv2d` ops that are convertible to the other two at lower levels (i.e., 1x1 kernel, stride=1, padding=0, groups=1). 
These operations are inefficient with L1 interleaved layout inputs/outputs and should not be upgraded by the analysis.

### What's changed
- Performance Impact:
  - Enabling L1IFA now provides visible performance improvements for models like YOLO_v8/v9/v10, where previously L1IFA had no effect or caused slight regression.
  - For other ops that previously benefitted from L1IFA, performance is either unchanged or further improved.

- No API changes.

### Checklist
- [x] New/Existing tests provide coverage for changes