### PR TITLE
D2M: Support writing TTNNGeneric to Flatbuffer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -704,7 +704,7 @@ def TTNN_KernelSemaphoreAttr: TTNN_Attr<"KernelSemaphore", "kernel_semaphore"> {
   }];
 
   let parameters = (ins "KernelCoreType":$core_type,
-                        TTNN_CoreRangeAttr:$core_range,
+                        TTNN_CoreRangeSetAttr:$core_ranges,
                         "uint32_t":$initial_value);
   let assemblyFormat = "`<` struct(params) `>`";
 
@@ -732,9 +732,9 @@ def TTNN_KernelCBAttr: TTNN_Attr<"KernelCB", "kernel_cb"> {
   }];
 
   let parameters = (ins "uint32_t":$total_size,
-                        TTNN_CoreRangeAttr:$core_range,
+                        TTNN_CoreRangeSetAttr:$core_ranges,
                         ArrayRefParameter<"KernelCBFormatAttr">:$formats);
-  let assemblyFormat = "`<` struct($total_size, $core_range) `,` `formats` `=` `[` $formats `]` `>`";
+  let assemblyFormat = "`<` struct($total_size, $core_ranges) `,` `formats` `=` `[` $formats `]` `>`";
 
   let genVerifyDecl = 1;
 }
@@ -776,7 +776,7 @@ def TTNN_ComputeKernelAttr: TTNN_Attr<"ComputeKernel", "compute_kernel", [TTNN_K
   }];
 
   let parameters = (ins "SymbolRefAttr":$symbol_ref,
-                        TTNN_CoreRangeAttr:$core_range,
+                        TTNN_CoreRangeSetAttr:$core_ranges,
                         "ComputeKernelMathFidelity":$math_fidelity,
                         "bool":$fp32_dest_acc_en,
                         "bool":$dst_full_sync_en,
@@ -786,7 +786,7 @@ def TTNN_ComputeKernelAttr: TTNN_Attr<"ComputeKernel", "compute_kernel", [TTNN_K
                         OptionalArrayRefParameter<"mlir::Attribute">:$common_rt_args,
                         OptionalArrayRefParameter<"mlir::Attribute">:$ct_args
                         );
-  let assemblyFormat = "`<` struct($symbol_ref, $core_range, $math_fidelity, $fp32_dest_acc_en, $dst_full_sync_en)  `,` `unpack_to_dest_modes` `=` `[` $unpack_to_dest_modes `]` `,` struct($bfp8_pack_precise, $math_approx_mode) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
+  let assemblyFormat = "`<` struct($symbol_ref, $core_ranges, $math_fidelity, $fp32_dest_acc_en, $dst_full_sync_en)  `,` `unpack_to_dest_modes` `=` `[` $unpack_to_dest_modes `]` `,` struct($bfp8_pack_precise, $math_approx_mode) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
 
   let genVerifyDecl = 1;
 }
@@ -798,10 +798,10 @@ def TTNN_ReadKernelAttr: TTNN_Attr<"ReadKernel", "read_kernel", [TTNN_KernelInte
   }];
 
   let parameters = (ins "SymbolRefAttr":$symbol_ref,
-                        TTNN_CoreRangeAttr:$core_range,
+                        TTNN_CoreRangeSetAttr:$core_ranges,
                         OptionalArrayRefParameter<"mlir::Attribute">:$common_rt_args,
                         OptionalArrayRefParameter<"mlir::Attribute">:$ct_args);
-  let assemblyFormat = "`<` struct($symbol_ref, $core_range) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
+  let assemblyFormat = "`<` struct($symbol_ref, $core_ranges) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
 
   let genVerifyDecl = 1;
 }
@@ -813,10 +813,10 @@ def TTNN_WriteKernelAttr: TTNN_Attr<"WriteKernel", "write_kernel", [TTNN_KernelI
   }];
 
   let parameters = (ins "SymbolRefAttr":$symbol_ref,
-                        TTNN_CoreRangeAttr:$core_range,
+                        TTNN_CoreRangeSetAttr:$core_ranges,
                         OptionalArrayRefParameter<"mlir::Attribute">:$common_rt_args,
                         OptionalArrayRefParameter<"mlir::Attribute">:$ct_args);
-  let assemblyFormat = "`<` struct($symbol_ref, $core_range) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
+  let assemblyFormat = "`<` struct($symbol_ref, $core_ranges) `,` `ct_args` `=` `[` (`]`) : ($ct_args^ `]`)?  `,` `common_rt_args` `=` `[` (`]`) : ($common_rt_args^ `]`)? `>`";
 
   let genVerifyDecl = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNKernelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNKernelInterface.td
@@ -20,7 +20,7 @@ def TTNN_KernelInterface: AttrInterface<"KernelInterface"> {
     >,
     InterfaceMethod<
       "Get the core range for this kernel",
-      "mlir::Attribute", "getCoreRange", (ins)
+      "mlir::Attribute", "getCoreRanges", (ins)
     >,
     InterfaceMethod<
       "Get common runtime arguments",

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -934,6 +934,64 @@ ttnnLayoutAttrToFlatbuffer(FlatbufferObjectCache &cache,
                    layoutAttr.getGrid(), deviceAttr.getWorkerGrid()));
 }
 
+inline ::tt::target::ttnn::CoreType
+toFlatbuffer(FlatbufferObjectCache &cache, ttnn::KernelCoreType coreType) {
+  ::tt::target::ttnn::CoreType fbCoreType;
+
+  switch (coreType) {
+  case ttnn::KernelCoreType::Eth:
+    fbCoreType = ::tt::target::ttnn::CoreType::ETH;
+    break;
+  case ttnn::KernelCoreType::Worker:
+    fbCoreType = ::tt::target::ttnn::CoreType::WORKER;
+    break;
+  }
+
+  return fbCoreType;
+}
+
+inline std::vector<::tt::target::UnpackToDestMode> toFlatbuffer(
+    FlatbufferObjectCache &cache,
+    ::llvm::ArrayRef<ttnn::ComputeKernelUnpackToDestMode> unpackToDestModes) {
+  std::vector<::tt::target::UnpackToDestMode> fbUnpackToDestModes;
+
+  for (auto mode : unpackToDestModes) {
+    switch (mode) {
+    case ttnn::ComputeKernelUnpackToDestMode::Fp32:
+      fbUnpackToDestModes.push_back(::tt::target::UnpackToDestMode::Fp32);
+      break;
+    case ttnn::ComputeKernelUnpackToDestMode::Default:
+      fbUnpackToDestModes.push_back(::tt::target::UnpackToDestMode::Default);
+      break;
+    }
+  }
+
+  return fbUnpackToDestModes;
+}
+
+inline ::tt::target::MathFidelity
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttnn::ComputeKernelMathFidelity mathFidelity) {
+
+  ::tt::target::MathFidelity fbMathFidelity;
+
+  switch (mathFidelity) {
+  case ttnn::ComputeKernelMathFidelity::LoFi:
+    fbMathFidelity = ::tt::target::MathFidelity::LoFi;
+    break;
+  case ttnn::ComputeKernelMathFidelity::HiFi2:
+    fbMathFidelity = ::tt::target::MathFidelity::HiFi2;
+    break;
+  case ttnn::ComputeKernelMathFidelity::HiFi3:
+    fbMathFidelity = ::tt::target::MathFidelity::HiFi3;
+    break;
+  case ttnn::ComputeKernelMathFidelity::HiFi4:
+    fbMathFidelity = ::tt::target::MathFidelity::HiFi4;
+    break;
+  }
+  return fbMathFidelity;
+}
+
 } // namespace mlir::tt
 
 #endif

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -988,7 +988,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 
 ::llvm::LogicalResult KernelCBAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    uint32_t totalSize, CoreRangeAttr coreRange,
+    uint32_t totalSize, CoreRangeSetAttr coreRanges,
     llvm::ArrayRef<mlir::tt::ttnn::KernelCBFormatAttr> formats) {
   return ::llvm::success();
 }
@@ -1001,7 +1001,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 
 ::llvm::LogicalResult KernelSemaphoreAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    KernelCoreType coreType, ::mlir::tt::ttnn::CoreRangeAttr coreRange,
+    KernelCoreType coreType, ::mlir::tt::ttnn::CoreRangeSetAttr coreRanges,
     uint32_t initialValue) {
   return ::llvm::success();
 }
@@ -1036,7 +1036,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 
 ::llvm::LogicalResult ComputeKernelAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    SymbolRefAttr symbolRef, ::mlir::tt::ttnn::CoreRangeAttr coreRange,
+    SymbolRefAttr symbolRef, ::mlir::tt::ttnn::CoreRangeSetAttr coreRanges,
     ComputeKernelMathFidelity mathFidelity, bool fp32DestAccEn,
     bool dstFullSyncEn,
     ::llvm::ArrayRef<ComputeKernelUnpackToDestMode> unpackToDestModes,
@@ -1053,7 +1053,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 
 ::llvm::LogicalResult ReadKernelAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    mlir::SymbolRefAttr symbolRef, CoreRangeAttr coreRange,
+    mlir::SymbolRefAttr symbolRef, CoreRangeSetAttr coreRanges,
     ::llvm::ArrayRef<mlir::Attribute> commonRtArgs,
     ::llvm::ArrayRef<mlir::Attribute> ctArgs) {
   if (failed(verifyCommonRuntimeArgs(emitError, commonRtArgs)) ||
@@ -1066,7 +1066,7 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 
 ::llvm::LogicalResult WriteKernelAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    mlir::SymbolRefAttr symbolRef, CoreRangeAttr coreRange,
+    mlir::SymbolRefAttr symbolRef, CoreRangeSetAttr coreRanges,
     ::llvm::ArrayRef<mlir::Attribute> commonRtArgs,
     ::llvm::ArrayRef<mlir::Attribute> ctArgs) {
   if (failed(verifyCommonRuntimeArgs(emitError, commonRtArgs)) ||

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -21,10 +21,12 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Common/types_generated.h"
 #include "ttmlir/Target/LLVM/LLVMToDynamicLib.h"
+#include "ttmlir/Target/TTKernel/TTKernelToCpp.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/TTNN/binary_generated.h"
 #include "ttmlir/Target/TTNN/operations/conv_generated.h"
 #include "ttmlir/Target/TTNN/operations/creation_generated.h"
+#include "ttmlir/Target/TTNN/operations/generic_op_generated.h"
 #include "ttmlir/Target/TTNN/operations/pool_generated.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttmlir/Target/TTNN/utils.h"
@@ -1965,6 +1967,195 @@ createOp(FlatbufferObjectCache &cache, ConcatenateHeadsOp op) {
                                                       memoryConfig);
 }
 
+std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>>
+createKernelArgs(FlatbufferObjectCache &cache,
+                 llvm::ArrayRef<mlir::Attribute> argsAttrs) {
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>> args;
+
+  for (auto argAttr : argsAttrs) {
+    ::tt::target::ttnn::KernelArgType arg_type =
+        ::tt::target::ttnn::KernelArgType::NONE;
+    ::flatbuffers::Offset<void> arg = 0;
+
+    if (auto kernelArgCBBufferIndexAttr =
+            llvm::dyn_cast<KernelArgCBBufferIndexAttr>(argAttr);
+        kernelArgCBBufferIndexAttr) {
+      arg_type = ::tt::target::ttnn::KernelArgType::KernelArgCBBufferIndex;
+      arg = ::tt::target::ttnn::CreateKernelArgCBBufferIndex(
+                *cache.fbb, kernelArgCBBufferIndexAttr.getBufferIndex())
+                .Union();
+    } else if (auto kernelArgAddressOfTensorAttr =
+                   llvm::dyn_cast<KernelArgAddressOfTensorAttr>(argAttr);
+               kernelArgAddressOfTensorAttr) {
+      arg_type =
+          ::tt::target::ttnn::KernelArgType::KernelArgBufferAddressOfTensor;
+      arg = ::tt::target::ttnn::CreateKernelArgBufferAddressOfTensor(
+                *cache.fbb, kernelArgAddressOfTensorAttr.getTensorIndex())
+                .Union();
+    } else if (auto kernelArgSemaphoreAtAttr =
+                   llvm::dyn_cast<KernelArgSemaphoreAtAttr>(argAttr);
+               kernelArgSemaphoreAtAttr) {
+      arg_type = ::tt::target::ttnn::KernelArgType::KernelArgSemaphoreAt;
+      arg = ::tt::target::ttnn::CreateKernelArgSemaphoreAt(
+                *cache.fbb, kernelArgSemaphoreAtAttr.getSemaphoreIndex())
+                .Union();
+    }
+
+    args.push_back(
+        ::tt::target::ttnn::CreateKernelArg(*cache.fbb, arg_type, arg));
+  }
+
+  return args;
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::GenericOp>
+createOp(FlatbufferObjectCache &cache, GenericOp op) {
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ios;
+  for (auto operand : op.getInputsAndOutputs()) {
+    ios.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(operand)));
+  }
+
+  ::mlir::tt::ttnn::ProgramAttr programAttr = op.getProgramAttr();
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelDescriptor>>
+      kernels;
+
+  ModuleOp module = dyn_cast<ModuleOp>(op->getParentOp()->getParentOp());
+
+  for (auto kernelAttr : programAttr.getKernels()) {
+    auto kernelInterface = llvm::cast<KernelInterface>(kernelAttr);
+    StringRef kernelSymbol = kernelInterface.getSymbolRef().getRootReference();
+
+    std::string source;
+    llvm::raw_string_ostream stream(source);
+    LogicalResult result =
+        ttkernel::translateTopLevelKernelToCpp(module, stream, kernelSymbol);
+    assert(result.succeeded());
+    assert(source.size() > 0 && "empty kernel source");
+
+    ::tt::target::ttnn::KernelConfig configType =
+        ::tt::target::ttnn::KernelConfig::NONE;
+    ::flatbuffers::Offset<void> config = 0;
+
+    if (auto readKernelAttr = llvm::dyn_cast<ReadKernelAttr>(kernelAttr);
+        readKernelAttr) {
+      configType = ::tt::target::ttnn::KernelConfig::ReaderKernelConfig;
+      config = ::tt::target::ttnn::CreateReaderKernelConfig(*cache.fbb).Union();
+    } else if (auto computeKernelAttr =
+                   llvm::dyn_cast<ComputeKernelAttr>(kernelAttr);
+               computeKernelAttr) {
+      ::tt::target::MathFidelity mathFidelity;
+
+      switch (computeKernelAttr.getMathFidelity()) {
+      case ComputeKernelMathFidelity::LoFi:
+        mathFidelity = ::tt::target::MathFidelity::LoFi;
+        break;
+      case ComputeKernelMathFidelity::HiFi2:
+        mathFidelity = ::tt::target::MathFidelity::HiFi2;
+        break;
+      case ComputeKernelMathFidelity::HiFi3:
+        mathFidelity = ::tt::target::MathFidelity::HiFi3;
+        break;
+      case ComputeKernelMathFidelity::HiFi4:
+        mathFidelity = ::tt::target::MathFidelity::HiFi4;
+        break;
+      }
+
+      std::vector<::tt::target::UnpackToDestMode> unpackToDestModes;
+
+      for (auto mode : computeKernelAttr.getUnpackToDestModes()) {
+        switch (mode) {
+        case ComputeKernelUnpackToDestMode::Fp32:
+          unpackToDestModes.push_back(::tt::target::UnpackToDestMode::Fp32);
+          break;
+        case ComputeKernelUnpackToDestMode::Default:
+          unpackToDestModes.push_back(::tt::target::UnpackToDestMode::Default);
+          break;
+        }
+      }
+
+      configType = ::tt::target::ttnn::KernelConfig::ComputeKernelConfig;
+      config =
+          ::tt::target::ttnn::CreateComputeKernelConfigDirect(
+              *cache.fbb, mathFidelity, computeKernelAttr.getFp32DestAccEn(),
+              computeKernelAttr.getDstFullSyncEn(), &unpackToDestModes,
+              computeKernelAttr.getBfp8PackPrecise(),
+              computeKernelAttr.getMathApproxMode())
+              .Union();
+    } else if (auto writeKernelAttr =
+                   llvm::dyn_cast<WriteKernelAttr>(kernelAttr);
+               writeKernelAttr) {
+      configType = ::tt::target::ttnn::KernelConfig::WriterKernelConfig;
+      config = ::tt::target::ttnn::CreateWriterKernelConfig(*cache.fbb).Union();
+    }
+
+    std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>> ct_args =
+        createKernelArgs(cache, kernelInterface.getCtArgs());
+    std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>>
+        common_rt_args =
+            createKernelArgs(cache, kernelInterface.getCommonRtArgs());
+
+    kernels.push_back(::tt::target::ttnn::CreateKernelDescriptorDirect(
+        *cache.fbb, source.data(), ::tt::target::ttnn::SourceType::SOURCE_CODE,
+        configType, config,
+        toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
+                                kernelInterface.getCoreRanges())),
+        ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb, &ct_args),
+        nullptr,
+        ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb,
+                                                       &common_rt_args)));
+  }
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::SemaphoreDescriptor>>
+      semaphores;
+
+  for (auto semaphoresAttr : programAttr.getSemaphores()) {
+    ::tt::target::ttnn::CoreType coreType;
+
+    switch (semaphoresAttr.getCoreType()) {
+    case KernelCoreType::Eth:
+      coreType = ::tt::target::ttnn::CoreType::ETH;
+      break;
+    case KernelCoreType::Worker:
+      coreType = ::tt::target::ttnn::CoreType::WORKER;
+      break;
+    }
+
+    semaphores.push_back(::tt::target::ttnn::CreateSemaphoreDescriptor(
+        *cache.fbb, coreType,
+        toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
+                                semaphoresAttr.getCoreRanges())),
+        semaphoresAttr.getInitialValue()));
+  }
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelCBDescriptor>>
+      cbs;
+
+  for (auto kernelCbAttr : programAttr.getCbs()) {
+    std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelCBFormat>>
+        formats;
+
+    for (auto formatAttr : kernelCbAttr.getFormats()) {
+      formats.push_back(::tt::target::ttnn::CreateKernelCBFormat(
+          *cache.fbb, formatAttr.getBufferIndex(),
+          toFlatbuffer(cache, formatAttr.getDtype()),
+          formatAttr.getPageSize()));
+    }
+
+    cbs.push_back(::tt::target::ttnn::CreateKernelCBDescriptorDirect(
+        *cache.fbb, kernelCbAttr.getTotalSize(),
+        toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
+                                kernelCbAttr.getCoreRanges())),
+        &formats));
+  }
+
+  auto program = ::tt::target::ttnn::CreateProgramDescriptorDirect(
+      *cache.fbb, &kernels, &semaphores, &cbs);
+
+  return ::tt::target::ttnn::CreateGenericOpDirect(*cache.fbb, &ios, program);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::Operation>
 emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                   const llvm::StringMap<uint32_t> &programIndexMap,
@@ -2482,6 +2673,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
     return createOperation(cache, createOp(cache, concatenateHeadsOp),
                            debugString, locInfo);
   }
+  if (auto genericOp = dyn_cast<GenericOp>(op); genericOp) {
+    return createOperation(cache, createOp(cache, genericOp), debugString,
+                           locInfo);
+  }
 
   llvm_unreachable("unhandled op in emitTTNNOperation");
 }
@@ -2560,7 +2755,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   // pass.
   populateProgramIdxMap([](func::FuncOp func) {
     return ttmlir::utils::isConstEvalFunc(func) ||
-           ttnn::utils::isTTNNTraceFunc(func);
+           ttnn::utils::isTTNNTraceFunc(func) ||
+           func->hasAttr(ttkernel::ThreadTypeAttr::name);
   });
   // Add const-eval funcs after normal funcs.
   populateProgramIdxMap(
@@ -2596,7 +2792,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   generatePrograms(
       [](func::FuncOp func) {
         return ttmlir::utils::isConstEvalFunc(func) ||
-               ttnn::utils::isTTNNTraceFunc(func);
+               ttnn::utils::isTTNNTraceFunc(func) ||
+               func->hasAttr(ttkernel::ThreadTypeAttr::name);
       },
       /*isPrivate=*/false);
   // Then process const-eval funcs in 2nd pass.

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2103,7 +2103,8 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
         toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
                                 kernelInterface.getCoreRanges())),
         ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb, &ct_args),
-        nullptr,
+        nullptr, // TODO: Support non-common runtime arguments, see
+                 // https://github.com/tenstorrent/tt-mlir/issues/4827
         ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb,
                                                        &common_rt_args)));
   }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2038,13 +2038,8 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
         ::tt::target::ttnn::KernelConfig::NONE;
     ::flatbuffers::Offset<void> config = 0;
 
-    if (auto readKernelAttr = llvm::dyn_cast<ReadKernelAttr>(kernelAttr);
-        readKernelAttr) {
-      configType = ::tt::target::ttnn::KernelConfig::ReaderKernelConfig;
-      config = ::tt::target::ttnn::CreateReaderKernelConfig(*cache.fbb).Union();
-    } else if (auto computeKernelAttr =
-                   llvm::dyn_cast<ComputeKernelAttr>(kernelAttr);
-               computeKernelAttr) {
+    if (auto computeKernelAttr = llvm::dyn_cast<ComputeKernelAttr>(kernelAttr);
+        computeKernelAttr) {
       ::tt::target::MathFidelity mathFidelity;
 
       switch (computeKernelAttr.getMathFidelity()) {
@@ -2083,11 +2078,17 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
               computeKernelAttr.getBfp8PackPrecise(),
               computeKernelAttr.getMathApproxMode())
               .Union();
+    } else if (auto readKernelAttr = llvm::dyn_cast<ReadKernelAttr>(kernelAttr);
+               readKernelAttr) {
+      configType = ::tt::target::ttnn::KernelConfig::ReaderKernelConfig;
+      config = ::tt::target::ttnn::CreateReaderKernelConfig(*cache.fbb).Union();
     } else if (auto writeKernelAttr =
                    llvm::dyn_cast<WriteKernelAttr>(kernelAttr);
                writeKernelAttr) {
       configType = ::tt::target::ttnn::KernelConfig::WriterKernelConfig;
       config = ::tt::target::ttnn::CreateWriterKernelConfig(*cache.fbb).Union();
+    } else {
+      llvm_unreachable("Unsupported kernel attribute");
     }
 
     std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>> ct_args =

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2103,8 +2103,7 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
         toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
                                 kernelInterface.getCoreRanges())),
         ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb, &ct_args),
-        nullptr, // TODO: Support non-common runtime arguments, see
-                 // https://github.com/tenstorrent/tt-mlir/issues/4827
+        nullptr, // TODO (#4827): Support non-common runtime arguments
         ::tt::target::ttnn::CreateKernelCoreArgsDirect(*cache.fbb,
                                                        &common_rt_args)));
   }


### PR DESCRIPTION
### Ticket
#4520 

### Problem description
Extend `translateTTNNToFlatbuffer` to support writing TTNNGeneric operation to Flatbuffer.

### What's changed
- Added `createOp` function for `GenericOp` op;
- Change `TTNN_CoreRangeAttr:$core_range` to `TTNN_CoreRangeSetAttr:$core_ranges`;
- Distinguish kernel `func.func`'s by the presence of `ttkernel.thread` attribute;
- Used `ttkernel::translateTopLevelKernelToCpp` to translate kernels to C++;
- Tested with `ttmlir-translate --ttnn-to-flatbuffer` and `ttrt read` the resulting Flatbuffers file for IR included in [D2M/TTNN Integration](https://docs.google.com/document/d/1SyJyK7yYPvMDzm0eBe89vrjhA5ZkIFc2_Lw2gOIarhY/edit?usp=sharing).