### PR TITLE
Lower sdy.all_slice to a StableHLO all_to_all followed by a slice  wh…

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
@@ -144,6 +144,9 @@ private:
   mlir::sdy::TensorShardingAttr sdySharding;
 };
 
+// Return true if every dimension has no axes -> replicated.
+bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh);
+
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 
 } // namespace mlir::tt::shardy_utils

--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -639,6 +639,15 @@ ShardyMeshSharding::generate(sdy::MeshAttr meshAttr,
                             shardStatus,    meshAttr,  sdySharding};
 }
 
+bool isFullyReplicatedTensor(mlir::sdy::TensorShardingAttr tsh) {
+  for (auto dim : tsh.getDimShardings()) {
+    if (!dim.getAxes().empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 
 } // namespace mlir::tt::shardy_utils

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/all_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/all_slice.mlir
@@ -1,0 +1,72 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline --split-input-file  -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module {
+  sdy.mesh @mesh = <["model"=1, "batch"=2]>
+  func.func @all_slice_replicated_input(%arg0: tensor<32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}]>}) -> tensor<32xbf16> {
+    %0 = sdy.all_slice [{"batch"}] %arg0 out_sharding=<@mesh, [{"batch"}]> : tensor<32xbf16>
+    return %0 : tensor<32xbf16>
+  }
+}
+
+// CHECK: sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}]>] out_shardings=[<@mesh, [{"batch"}]>] manual_axes={"model", "batch"}
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<2x16xbf16>
+// CHECK: stablehlo.all_to_all
+// CHECK-SAME: (tensor<2x16xbf16>) -> tensor<2x16xbf16>
+// CHECK: stablehlo.slice
+// CHECK-SAME: [0:1, 0:16] : (tensor<2x16xbf16>) -> tensor<1x16xbf16>
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<16xbf16>
+// CHECK: sdy.return
+
+// -----
+
+module {
+  sdy.mesh @mesh = <["model"=2, "batch"=4]>
+  func.func @all_slice_2d_replicated_input(%arg0: tensor<4x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<4x32xbf16> {
+    %0 = sdy.all_slice [{"batch"}, {"model"}] %arg0 out_sharding=<@mesh, [{"batch"}, {"model"}]> : tensor<4x32xbf16>
+    return %0 : tensor<4x32xbf16>
+  }
+}
+
+// CHECK: sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {}]>] out_shardings=[<@mesh, [{"batch"}, {"model"}]>] manual_axes={"model", "batch"}
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<4x1x32xbf16>
+// CHECK: stablehlo.all_to_all
+// CHECK-SAME: (tensor<4x1x32xbf16>) -> tensor<4x1x32xbf16>
+// CHECK: stablehlo.slice
+// CHECK-SAME: [0:1, 0:1, 0:32] : (tensor<4x1x32xbf16>) -> tensor<1x1x32xbf16>
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<1x32xbf16>
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<1x2x16xbf16>
+// CHECK: stablehlo.all_to_all
+// CHECK-SAME: (tensor<1x2x16xbf16>) -> tensor<1x2x16xbf16>
+// CHECK: stablehlo.slice
+// CHECK-SAME: [0:1, 0:1, 0:16] : (tensor<1x2x16xbf16>) -> tensor<1x1x16xbf16>
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<1x16xbf16>
+// CHECK: sdy.return
+
+// -----
+
+module {
+  sdy.mesh @mesh = <["model"=2, "batch"=4]>
+  func.func @all_slice_2d_partial_sharded_input(%arg0: tensor<4x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) -> tensor<4x32xbf16> {
+    %0 = sdy.all_slice [{}, {"model"}] %arg0 out_sharding=<@mesh, [{"batch"}, {"model"}]> : tensor<4x32xbf16>
+    return %0 : tensor<4x32xbf16>
+  }
+}
+
+// CHECK: sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{"batch"}, {}]>] out_shardings=[<@mesh, [{"batch"}, {"model"}]>] manual_axes={"model", "batch"} (%arg1: tensor<1x32xbf16>)
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<1x2x16xbf16>
+// CHECK: stablehlo.all_to_all
+// CHECK-SAME: (tensor<1x2x16xbf16>) -> tensor<1x2x16xbf16>
+// CHECK: stablehlo.slice
+// CHECK-SAME: [0:1, 0:1, 0:16] : (tensor<1x2x16xbf16>) -> tensor<1x1x16xbf16>
+// CHECK: stablehlo.reshape
+// CHECK-SAME: -> tensor<1x16xbf16>
+// CHECK: sdy.return

--- a/test/ttmlir/Silicon/StableHLO/llmbox/sdy_all_slice.mlir
+++ b/test/ttmlir/Silicon/StableHLO/llmbox/sdy_all_slice.mlir
@@ -1,0 +1,11 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=1,8 automatic-arg-analysis" --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,8" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module {
+  sdy.mesh @mesh = <["model"=1, "batch"=8]>
+  func.func @all_slice_replicated_input(%arg0: tensor<1x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<1x32xbf16> {
+    %0 = sdy.all_slice [{}, {"batch"}] %arg0 out_sharding=<@mesh, [{}, {"batch"}]> : tensor<1x32xbf16>
+    return %0 : tensor<1x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n300/sdy_all_slice.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n300/sdy_all_slice.mlir
@@ -1,0 +1,11 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=1,2 automatic-arg-analysis" --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,2" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module {
+  sdy.mesh @mesh = <["model"=1, "batch"=2]>
+  func.func @all_slice_replicated_input(%arg0: tensor<1x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<1x32xbf16> {
+    %0 = sdy.all_slice [{}, {"batch"}] %arg0 out_sharding=<@mesh, [{}, {"batch"}]> : tensor<1x32xbf16>
+    return %0 : tensor<1x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/tg/sdy_all_slice.mlir
+++ b/test/ttmlir/Silicon/StableHLO/tg/sdy_all_slice.mlir
@@ -1,0 +1,11 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=1,32 automatic-arg-analysis" --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,32" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module {
+  sdy.mesh @mesh = <["model"=1, "batch"=32]>
+  func.func @all_slice_replicated_input(%arg0: tensor<1x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<1x32xbf16> {
+    %0 = sdy.all_slice [{}, {"batch"}] %arg0 out_sharding=<@mesh, [{}, {"batch"}]> : tensor<1x32xbf16>
+    return %0 : tensor<1x32xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3368) 

### Problem description
We don't yet support all_slice op in sdy.

### What's changed
require replicated input; emit notifyMatchFailure otherwise.
Support 1D/2D meshes; build replica_groups from the mesh.
Reshape [..., N, ...] → [..., parts, chunk, ...], run all_to_all on the inserted parts dim, take a static slice (index 0), and reshape back (so the result size is chunk = N / parts).
Reject multiple mesh axes mapped to a single tensor dimension.
Non-replicated inputs: add a dynamic-slice fallback when ReplicaId/PartitionId become available in TTIR/TTNN.

### Checklist
- [ ] New/Existing tests provide coverage for changes
