### PR TITLE
[CI] Extend timeout

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -173,7 +173,7 @@ jobs:
 
   run-tests:
 
-    timeout-minutes: 45
+    timeout-minutes: 70
     needs:
       - build-image
       - build-ttmlir


### PR DESCRIPTION
### Ticket

### Problem description
Some workflows fail due to timeout especially during peak hours when network lags due to the traffic and adds significant time to the jobs.

### What's changed
Quick fix is to set timeout to 70 minutes which will not make huge difference.
Safe timeout is considered to be 2 times normal test duration and should be triggered only in case of hangs/machine failures/etc.

### Checklist
- [ ] New/Existing tests provide coverage for changes
