### PR TITLE
GenericOp silicon test

### DIFF
--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -130,5 +130,22 @@ toUnpackToDestMode(const tt::target::UnpackToDestMode &unpackToDestMode) {
   }
 }
 
+inline std::vector<UnpackToDestMode>
+toUnpackToDestModes(const ::flatbuffers::Vector<tt::target::UnpackToDestMode>
+                        *unpackToDestModesFB) {
+  std::vector<UnpackToDestMode> unpackToDestModes(NUM_CIRCULAR_BUFFERS,
+                                                  UnpackToDestMode::Default);
+  if (unpackToDestModesFB == nullptr) {
+    return unpackToDestModes;
+  }
+  uint32_t modeIdx = 0;
+  for (auto mode : *unpackToDestModesFB) {
+    LOG_ASSERT(modeIdx < NUM_CIRCULAR_BUFFERS);
+    unpackToDestModes[modeIdx] = toUnpackToDestMode(mode);
+    ++modeIdx;
+  }
+  return unpackToDestModes;
+}
+
 } // namespace tt::runtime::common
 #endif // TT_RUNTIME_DETAIL_COMMON_COMMON_H

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -515,24 +515,8 @@ createKernelConfig(
     computeConfig.math_approx_mode = fbComputeConfig->math_approx_mode();
 
     // Metal asserts that unpack_to_dest_mode.size() == NUM_CIRCULAR_BUFFERS.
-    computeConfig.unpack_to_dest_mode.resize(NUM_CIRCULAR_BUFFERS,
-                                             UnpackToDestMode::Default);
-    uint32_t modeIdx = 0;
-    for (auto mode : *fbComputeConfig->unpack_to_dest_mode()) {
-      LOG_ASSERT(modeIdx < NUM_CIRCULAR_BUFFERS);
-      switch (mode) {
-      case tt::target::UnpackToDestMode::Fp32: {
-        computeConfig.unpack_to_dest_mode[modeIdx] =
-            UnpackToDestMode::UnpackToDestFp32;
-        break;
-      }
-      case tt::target::UnpackToDestMode::Default: {
-        computeConfig.unpack_to_dest_mode[modeIdx] = UnpackToDestMode::Default;
-        break;
-      }
-      }
-      ++modeIdx;
-    }
+    computeConfig.unpack_to_dest_mode =
+        common::toUnpackToDestModes(fbComputeConfig->unpack_to_dest_mode());
 
     return computeConfig;
   }

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -98,13 +98,8 @@ createKernelConfigDescriptor(
   switch (kernelDesc.config_type()) {
   case ::tt::target::ttnn::KernelConfig::ComputeKernelConfig: {
     const auto *computeConfig = kernelDesc.config_as_ComputeKernelConfig();
-    std::vector<UnpackToDestMode> unpackToDestModes(
-        computeConfig->unpack_to_dest_modes()->size());
-    for (unsigned int i = 0; i < computeConfig->unpack_to_dest_modes()->size();
-         i++) {
-      unpackToDestModes[i] = common::toUnpackToDestMode(
-          computeConfig->unpack_to_dest_modes()->Get(i));
-    }
+    std::vector<UnpackToDestMode> unpackToDestModes =
+        common::toUnpackToDestModes(computeConfig->unpack_to_dest_modes());
     return ::tt::tt_metal::ComputeConfigDescriptor{
         .math_fidelity = tt::runtime::ttnn::utils::toTTNNMathFidelity(
             computeConfig->math_fidelity()),
@@ -180,21 +175,27 @@ createKernelDescriptor(const ::tt::target::ttnn::KernelDescriptor &kernelDesc,
   CoreRangeSet coreRanges =
       tt::runtime::ttnn::utils::toTTNNCoreRangeSet(*kernelDesc.core_ranges());
   ::tt::tt_metal::KernelDescriptor::CommonRuntimeArgs commonRuntimeArgs =
-      createKernelArgs(*kernelDesc.common_rt_args());
+      createKernelArgs(*kernelDesc.common_rt_args(), ioTensors);
   ::tt::tt_metal::KernelDescriptor::CompileTimeArgs compileTimeArgs =
       createKernelArgs(*kernelDesc.ct_args());
 
-  auto sizeX = kernelDesc.rt_args()->size();
-  auto sizeY = kernelDesc.rt_args()->Get(0)->args()->size();
-  ::tt::tt_metal::KernelDescriptor::RuntimeArgs runtimeArgs(
-      sizeX,
-      std::vector<::tt::tt_metal::KernelDescriptor::CoreRuntimeArgs>(sizeY));
-  for (unsigned int i = 0; i < sizeX; i++) {
-    for (unsigned int j = 0; j < sizeY; j++) {
-      ::tt::tt_metal::KernelDescriptor::CoreRuntimeArgs coreRuntimeArgs =
-          createKernelArgs(*kernelDesc.rt_args()->Get(i)->args()->Get(j),
-                           ioTensors);
-      runtimeArgs[i][j] = coreRuntimeArgs;
+  ::tt::tt_metal::KernelDescriptor::RuntimeArgs runtimeArgs;
+  if (kernelDesc.rt_args()) {
+    auto sizeX = kernelDesc.rt_args()->size();
+    auto sizeY = kernelDesc.rt_args()->Get(0)->args()->size();
+    runtimeArgs.resize(
+        sizeX,
+        std::vector<::tt::tt_metal::KernelDescriptor::CoreRuntimeArgs>(sizeY));
+    // ::tt::tt_metal::KernelDescriptor::RuntimeArgs runtimeArgs(
+    // sizeX,
+    // std::vector<::tt::tt_metal::KernelDescriptor::CoreRuntimeArgs>(sizeY));
+    for (unsigned int i = 0; i < sizeX; i++) {
+      for (unsigned int j = 0; j < sizeY; j++) {
+        ::tt::tt_metal::KernelDescriptor::CoreRuntimeArgs coreRuntimeArgs =
+            createKernelArgs(*kernelDesc.rt_args()->Get(i)->args()->Get(j),
+                             ioTensors);
+        runtimeArgs[i][j] = coreRuntimeArgs;
+      }
     }
   }
   ::tt::tt_metal::KernelDescriptor kernelDescriptor = {
@@ -225,20 +226,24 @@ void run(const ::tt::target::ttnn::GenericOp *op, ProgramContext &context) {
   // ProgramDescriptor is initialized with pre-allocated SmallVector capacity
   const auto *programDesc = op->program();
   tt::tt_metal::ProgramDescriptor programDescriptor;
+  LOG_DEBUG("creating kernel descs");
   for (const tt::target::ttnn::KernelDescriptor *kernelDesc :
        *programDesc->kernels()) {
     programDescriptor.kernels.push_back(
         createKernelDescriptor(*kernelDesc, ioTensors));
   }
+  LOG_DEBUG("creating cb descs");
   for (const tt::target::ttnn::KernelCBDescriptor *cbDesc :
        *programDesc->cbs()) {
     programDescriptor.cbs.push_back(createCBDescriptor(*cbDesc));
   }
+  LOG_DEBUG("creating semaphore descs");
   for (const tt::target::ttnn::SemaphoreDescriptor *semaphoreDesc :
        *programDesc->semaphores()) {
     programDescriptor.semaphores.push_back(
         createSemaphoreDescriptor(*semaphoreDesc));
   }
+  LOG_DEBUG("running generic op");
   ::ttnn::Tensor outputTensor =
       ::ttnn::generic_op(ioTensors, programDescriptor);
   tensorPool.insertTTNNTensorAndValidate(op->io_tensors()->Get(size - 1),

--- a/test/ttmlir/Silicon/TTNN/n150/generic_op/generic_op.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/generic_op/generic_op.mlir
@@ -1,0 +1,176 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+// Use single core
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>, <physical>>>
+
+// In- and out- CB descriptors
+#in_cb_format = #ttnn.kernel_cb_format<
+  buffer_index = 0,
+  dtype = f32,
+  page_size = 4096>
+
+#in_cb = #ttnn.kernel_cb<
+  total_size = 4096,
+  core_ranges = #core_ranges,
+  formats = [#in_cb_format]>
+
+#out_cb_format = #ttnn.kernel_cb_format<
+  buffer_index = 1,
+  dtype = f32,
+  page_size = 4096>
+
+#out_cb = #ttnn.kernel_cb<
+  total_size = 4096,
+  core_ranges = #core_ranges,
+  formats = [#out_cb_format]>
+
+// CB descriptor reference by position in #cbs
+#in_cb_arg = #ttnn.kernel_arg_cb_buffer_index<0>
+// Tensor address by position in IO tensors
+#in_addr_arg = #ttnn.kernel_arg_address_of_tensor<0>
+
+#out_cb_arg = #ttnn.kernel_arg_cb_buffer_index<1>
+#out_addr_arg = #ttnn.kernel_arg_address_of_tensor<1>
+
+#read_kernel = #ttnn.read_kernel<
+  symbol_ref = @read_kernel,
+  core_ranges = #core_ranges,
+  ct_args = [#in_cb_arg],
+  // Pass tensor address and CB as runtime arguments
+  common_rt_args = [#in_addr_arg]>
+
+#compute_kernel = #ttnn.compute_kernel<
+  symbol_ref = @compute_kernel,
+  core_ranges = #core_ranges,
+  math_fidelity = hifi4,
+  fp32_dest_acc_en = false,
+  dst_full_sync_en = false,
+  unpack_to_dest_modes = [default],
+  bfp8_pack_precise = false,
+  math_approx_mode = false,
+  ct_args = [
+      #in_cb_arg,
+      #out_cb_arg
+  ],
+  common_rt_args = []>
+
+#write_kernel = #ttnn.write_kernel<
+  symbol_ref = @write_kernel,
+  core_ranges = #core_ranges,
+  ct_args = [#out_cb_arg],
+  common_rt_args = [#out_addr_arg]>
+
+#program = #ttnn.program<
+  kernels = [#read_kernel, #compute_kernel, #write_kernel],
+  cbs = [#in_cb, #out_cb],
+  semaphores = []>
+
+// Layout for single tile in DRAM
+#dram_layout = #ttnn.ttnn_layout<
+  (d0, d1) -> (d0, d1),
+  <1x1>,
+  memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>
+  >
+
+// Layout for single tile in L1
+#l1_layout = #ttnn.ttnn_layout<
+  (d0, d1) -> (d0, d1),
+  <1x1, (d0, d1) -> (0, d0, d1)>,
+  memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>
+  >
+
+// CHECK: module attributes {ttcore.system_desc = #system_desc}
+// CHECK: ttcore.device @default_device
+module {
+  func.func @test(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #dram_layout> {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // Move single tile from DRAM to L1
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #l1_memory_config}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+    // Allocate single tile in L1 for result
+    %2 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #l1_memory_config, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #l1_layout>
+
+    "ttnn.generic"(%1, %2) <{program = #program}> : (tensor<32x32xf32, #l1_layout>, tensor<32x32xf32, #l1_layout>) -> ()
+
+    // Move single tile from L1 to DRAM
+    %3 = "ttnn.to_memory_config"(%2) <{memory_config = #dram_memory_config}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
+
+    return %3 : tensor<32x32xf32, #dram_layout>
+  }
+  func.func private @read_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %1 = "emitc.constant"() <{value = 4096 : i32}> : () -> i32
+
+    %zero = "emitc.constant"() <{value = 0 : i32}> : () -> i32
+    %2 = emitc.call_opaque "get_common_arg_val"(%zero) {template_args = [#emitc.opaque<"uint32_t">]} : (i32) -> i32
+    %3 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
+    %4 = emitc.literal "my_x[noc_index]" : !emitc.size_t
+    %5 = emitc.literal "my_y[noc_index]" : !emitc.size_t
+
+    // Move single tile from address in L1 to CB
+    emitc.call_opaque "cb_reserve_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    %6 = emitc.call_opaque "get_write_ptr"(%3) : (!emitc.opaque<"::tt::CB">) -> i32
+    %7 = emitc.call_opaque "get_noc_addr"(%4, %5, %2) : (!emitc.size_t, !emitc.size_t, i32) -> i64
+    emitc.call_opaque "noc_async_read"(%7, %6, %1) : (i64, i32, i32) -> ()
+    emitc.call_opaque "noc_async_read_barrier"() : () -> ()
+    emitc.call_opaque "cb_push_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    return
+  }
+  func.func private @compute_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %1 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
+
+    %2 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
+    %3 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
+
+    // Move single tile from CB to register
+    emitc.call_opaque "cb_reserve_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.call_opaque "init_sfpu"(%2, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+    emitc.call_opaque "tile_regs_acquire"() : () -> ()
+    emitc.call_opaque "copy_tile_init"(%2) : (!emitc.opaque<"::tt::CB">) -> ()
+    emitc.call_opaque "copy_tile"(%2, %1, %1) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+
+    // Compute abs
+    emitc.call_opaque "abs_tile_init"() : () -> ()
+    emitc.call_opaque "abs_tile"(%1) : (!emitc.size_t) -> ()
+
+    // Move single tile from register to CB
+    emitc.call_opaque "tile_regs_commit"() : () -> ()
+    emitc.call_opaque "tile_regs_wait"() : () -> ()
+    emitc.call_opaque "pack_tile"(%1, %3, %1) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
+    emitc.call_opaque "tile_regs_release"() : () -> ()
+    emitc.call_opaque "cb_push_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    return
+  }
+  func.func private @write_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+    %1 = "emitc.constant"() <{value = 4096 : i32}> : () -> i32
+
+    %zero = "emitc.constant"() <{value = 0 : i32}> : () -> i32
+    %2 = emitc.call_opaque "get_common_arg_val"(%zero) {template_args = [#emitc.opaque<"uint32_t">]} : (i32) -> i32
+    %3 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
+    %4 = emitc.literal "my_x[noc_index]" : !emitc.size_t
+    %5 = emitc.literal "my_y[noc_index]" : !emitc.size_t
+
+    // Move single tile from CB to address in L1
+    emitc.call_opaque "cb_wait_front"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    %6 = emitc.call_opaque "get_read_ptr"(%3) : (!emitc.opaque<"::tt::CB">) -> i32
+    %7 = emitc.call_opaque "get_noc_addr"(%4, %5, %2) : (!emitc.size_t, !emitc.size_t, i32) -> i64
+    emitc.call_opaque "noc_async_write"(%6, %7, %1) : (i32, i64, i32) -> ()
+    emitc.call_opaque "noc_async_write_barrier"() : () -> ()
+    emitc.call_opaque "cb_pop_front"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    return
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4805)
This is not a true E2E test case. We are still missing the entire D2M/TTNN integration part in order to mark a ttir op and have to lower to a generic.

### Problem description
Silicon test validating these PRs:

### What's changed
- commonized conversion of `UnpackToDestMode` for metal and ttnn runtime
- added a `generic_op.mlir` test

ToDo: 
- wait for generic translation to flatbuffer PR 
- check that test runs in CI

### Checklist
- [ ] New/Existing tests provide coverage for changes
