### PR TITLE
Remove hardcoded persistent buffer allocation code

### DIFF
--- a/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
+++ b/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
@@ -44,8 +44,13 @@ void run(const ::tt::target::ttnn::ReduceScatterOp *op,
 
   ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
 
+  // NOTE: The caller is currently responsible for creating/passing semaphores.
+  // TODO(hkwon): Remove semaphore creation here once
+  // reduce_scatter_minimal_async manages semaphores internally. Tracking:
+  // https://github.com/tenstorrent/tt-metal/issues/26952
   std::vector<::ttnn::GlobalSemaphore> semaphores;
-  // reduce_scatter_minimal_async requires 3 semaphores.
+  // reduce_scatter_minimal_async currently requires 3 semaphores.
+  // See: https://github.com/tenstorrent/tt-metal/issues/25212 for details.
   for (int i = 0; i < 3; i++) {
     semaphores.push_back(::ttnn::global_semaphore::create_global_semaphore(
         &meshDevice,

--- a/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
+++ b/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
@@ -59,9 +59,11 @@ void run(const ::tt::target::ttnn::ReduceScatterOp *op,
         0, tt::tt_metal::BufferType::L1));
   }
   ::ttnn::Tensor out = ::ttnn::experimental::reduce_scatter_minimal_async(
-      input, std::nullopt, scatterDimension, semaphores, std::nullopt, numLinks,
-      outputMemoryConfig.value(), std::nullopt, ::ttnn::ccl::Topology::Linear,
-      std::nullopt, clusterAxis);
+      input, /*persistent_output_buffers=*/std::nullopt, scatterDimension,
+      semaphores, /*barrier_semaphore=*/std::nullopt, numLinks,
+      outputMemoryConfig.value(), /*intermediate_memory_config=*/std::nullopt,
+      ::ttnn::ccl::Topology::Linear, /*subdevice_id=*/std::nullopt,
+      clusterAxis);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::ccl


### PR DESCRIPTION
### Ticket
partially resolve #4758

### Problem description
The argument `persistent_output_buffers` on `reduce_scatter_minimal_async`Op updated as `std::optional`.
We don't need to allocate intermediate/output persistent buffers.

### What's changed
Remove code blocks related to allocating persistent buffer for reduce_scatter_minimal_async from runtime.
Add descriptive comments about semaphores.

### Checklist
- [ ] New/Existing tests provide coverage for changes
