### PR TITLE
Adding builder uint8 golden suppport

### DIFF
--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -296,7 +296,8 @@ void populatePassesModule(nb::module_ &m) {
       .value("Float32", ::tt::target::DataType::Float32)
       .value("Float16", ::tt::target::DataType::Float16)
       .value("BFloat16", ::tt::target::DataType::BFloat16)
-      .value("Int32", ::tt::target::DataType::Int32);
+      .value("Int32", ::tt::target::DataType::Int32)
+      .value("UInt8", ::tt::target::DataType::UInt8);
 
   m.def("lookup_dtype", [](std::string enumName) {
     // Function to return the enum value based on the name.

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2170,10 +2170,6 @@ def test_hoisted_where(shapes, request, target: str):
     "dtype", [torch.float32, torch.int32, torch.uint8], ids=["f32", "i32", "ui8"]
 )
 def test_reshape(shapes, dtype: torch.dtype, request):
-    if dtype == torch.uint8:
-        pytest.skip(
-            "ttrt cannot support uint8 input: https://github.com/tenstorrent/tt-mlir/issues/4813"
-        )
     input_shape, output_shape = shapes
 
     def reshape_wrapper(in0: Operand, builder: TTIRBuilder):

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -159,11 +159,11 @@ class Builder:
                 return DataType.Float16
             case torch.bfloat16:
                 return DataType.BFloat16
-            case torch.float32:
-                return DataType.Float32
+            case torch.uint8:
+                return DataType.UInt8
             case torch.int32 | torch.qint32:
                 return DataType.Int32
-            case None:
+            case torch.float32 | None:
                 return DataType.Float32
 
     def _get_type(self, input: Operand) -> RankedTensorType:


### PR DESCRIPTION
### Ticket
Closes [#4813](https://github.com/tenstorrent/tt-mlir/issues/4813) 

### Problem description
Builder stores torch golden tensors constructed with uint8 dtype as `GoldenTensor` with float32 dtype.

### What's changed
Added uint8 support to `Passes.cpp` `GoldenTensor` construction.
Added uint8 support to builder dtype conversion. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
