### PR TITLE
Update template args for `reduce_init` and `reduce_tile`

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -440,7 +440,8 @@ def TTKernel_ReduceInitOp : TTKernel_InitOp<"reduce_init"> {
                          TTKernel_CB:$scaling_cb,
                          TTKernel_CB:$out_cb,
                          TTKernel_ReduceTypeAttr:$reduce_type,
-                         TTKernel_ReduceDimAttr:$reduce_dim);
+                         TTKernel_ReduceDimAttr:$reduce_dim,
+                         UnitAttr:$full_fp32);
 
     let assemblyFormat = [{
       `(` $in_cb `,` $scaling_cb `,` $out_cb `,` $reduce_type `,` $reduce_dim `)` attr-dict `:` functional-type(operands, results)
@@ -468,7 +469,8 @@ def TTKernel_ReduceTileOp : TTKernel_FPUOp<"reduce_tile", [TTKernel_BinaryOpTrai
                          IndexLike:$scaling_tile_index,
                          IndexLike:$dst_index,
                          TTKernel_ReduceTypeAttr:$reduce_type,
-                         TTKernel_ReduceDimAttr:$reduce_dim);
+                         TTKernel_ReduceDimAttr:$reduce_dim,
+                         UnitAttr:$full_fp32);
 
     let assemblyFormat = [{
       `(` $in_cb `,` $scaling_cb `,` $in_tile_index `,` $scaling_tile_index `,` $dst_index `,` $reduce_type `,` $reduce_dim `)` attr-dict `:` functional-type(operands, results)

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -262,18 +262,18 @@ public:
     return name;
   }
 
-  template <typename ReduceKindOp>
-  std::pair<StringRef, StringRef> getReduceTypeAndDim(ReduceKindOp op) const {
+  std::pair<StringRef, StringRef>
+  reduceTypeAndDimToString(ttkernel::ReduceTypeAttr reduceTypeAttr,
+                           ttkernel::ReduceDimAttr reduceDimAttr) const {
     StringRef reduceType =
-        op.getReduceTypeAttr().getValue() == ttkernel::ReduceType::Max
+        reduceTypeAttr.getValue() == ttkernel::ReduceType::Max
             ? "PoolType::MAX"
             : "PoolType::SUM";
-    StringRef reduceDim =
-        op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::Col
-            ? "ReduceDim::REDUCE_COL"
-        : op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::Row
-            ? "ReduceDim::REDUCE_ROW"
-            : "ReduceDim::REDUCE_SCALAR";
+    StringRef reduceDim = reduceDimAttr.getValue() == ttkernel::ReduceDim::Col
+                              ? "ReduceDim::REDUCE_COL"
+                          : reduceDimAttr.getValue() == ttkernel::ReduceDim::Row
+                              ? "ReduceDim::REDUCE_ROW"
+                              : "ReduceDim::REDUCE_SCALAR";
     return {reduceType, reduceDim};
   }
 
@@ -293,23 +293,16 @@ public:
   ArrayAttr getTemplateArgs(Builder &builder, SourceOp op) const {
     if constexpr (std::is_same_v<SourceOp, ttkernel::ReduceInitOp> ||
                   std::is_same_v<SourceOp, ttkernel::ReduceTileOp>) {
-      SmallVector<Attribute, 4> template_args;
+      SmallVector<Attribute, 3> template_args;
       StringRef reduceType, reduceDim;
-      if (mlir::isa<ttkernel::ReduceInitOp>(op)) {
-        auto reduceInitOp = mlir::cast<ttkernel::ReduceInitOp>(op);
-        template_args.push_back(emitc::OpaqueAttr::get(
-            op.getContext(), "true")); // "at_start" template argument
-        std::tie(reduceType, reduceDim) =
-            getReduceTypeAndDim<ttkernel::ReduceInitOp>(reduceInitOp);
-      } else {
-        auto reduceOp = mlir::cast<ttkernel::ReduceTileOp>(op);
-        std::tie(reduceType, reduceDim) =
-            getReduceTypeAndDim<ttkernel::ReduceTileOp>(reduceOp);
-      }
+      std::tie(reduceType, reduceDim) = reduceTypeAndDimToString(
+          op.getReduceTypeAttr(), op.getReduceDimAttr());
       template_args.push_back(
           emitc::OpaqueAttr::get(op.getContext(), reduceType));
       template_args.push_back(
           emitc::OpaqueAttr::get(op.getContext(), reduceDim));
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(), op.getFullFp32() ? "true" : "false"));
       return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::UnaryBcastInitOp> ||
                          std::is_same_v<SourceOp, ttkernel::UnaryBcastTileOp>) {

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -427,7 +427,7 @@ module {
       %scaling_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(2)"
       %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
-      // CHECK: emitc.call_opaque "reduce_init"(%[[IN_CB]], %[[SCALING_CB]], %[[OUT_CB]]) {{.+}}SUM{{.+}}REDUCE_SCALAR
+      // CHECK: emitc.call_opaque "reduce_init"(%[[IN_CB]], %[[SCALING_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"PoolType::SUM">, #emitc.opaque<"ReduceDim::REDUCE_SCALAR">, #emitc.opaque<"false">]}
       "ttkernel.reduce_init"(%in_cb, %scaling_cb, %out_cb) <{reduce_dim = #ttkernel.reduce_dim<reduce_dim_scalar>, reduce_type = #ttkernel.reduce_type<reduce_sum>}> : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
       return
     }
@@ -444,7 +444,7 @@ module {
       %scaling_tile_index = arith.constant 2 : i32
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : i32
-      // CHECK: emitc.call_opaque "reduce_tile"(%[[IN_CB]], %[[SCALING_CB]],  %[[IN_TILE_INDEX]], %[[SCALING_TILE_INDEX]], %[[DST_INDEX]]) {{.+}}MAX{{.+}}REDUCE_ROW
+      // CHECK: emitc.call_opaque "reduce_tile"(%[[IN_CB]], %[[SCALING_CB]],  %[[IN_TILE_INDEX]], %[[SCALING_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"PoolType::MAX">, #emitc.opaque<"ReduceDim::REDUCE_ROW">, #emitc.opaque<"false">]}
       "ttkernel.reduce_tile"(%in_cb, %scaling_cb, %in_tile_index, %scaling_tile_index, %dst_index) <{
         reduce_dim = #ttkernel.reduce_dim<reduce_dim_row>, reduce_type = #ttkernel.reduce_type<reduce_max>
         }> : (!cb0_tiles, !cb1_tiles, i32, i32, i32) -> ()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The following things were changed:
1.) `reduce_init` had the wrong order for template args and had the arg
  names wrong as well.
2.) `full_fp32` arg was not being set in either of the ops.

### What's changed
Correct the template arguments order and also add support to set `full_fp32`. Would enable full use of the lower level `llk` intrinsics.

### Checklist
- [ ] New/Existing tests provide coverage for changes
