### PR TITLE
Add `unary_bcast_init` and `unary_bcast_tile` ops

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -392,6 +392,44 @@ def TTKernel_MulTilesOp : TTKernel_FPUOp<"mul_tiles", [TTKernel_BinaryOpTrait]> 
     }];
 }
 
+def TTKernel_UnaryBcastInitOp : TTKernel_InitOp<"unary_bcast_init"> {
+    let summary = "Init function";
+    let description = [{
+      Must be run before bcast_tile.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         TTKernel_CB:$out_cb,
+                         TTKernel_BcastTypeAttr:$bcast_type
+                        );
+
+    let assemblyFormat = [{
+      `(` $in_cb `,` $out_cb `,` $bcast_type `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_UnaryBcastTileOp : TTKernel_FPUOp<"unary_bcast", [TTKernel_UnaryOpTrait]> {
+    let summary = "Broadcast operation";
+    let description = [{
+      Performs a broadcast operation *B = broadcast(A)* using bcast_dim for
+      dimension expansion on a tile in the CB at a given index and writes the
+      result to the DST register at index *dst_tile_index*. The supported
+      broadcast dimensions are `row`, `col`, `scalar` (both row and column). The
+      DST register buffer must be in acquired state via *tile_regs_acquire*
+      call. This call is blocking and is only available on the compute engine.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         IndexLike:$in_tile_index,
+                         IndexLike:$dst_tile_index,
+                         TTKernel_BcastTypeAttr:$bcast_type
+    );
+
+    let assemblyFormat = [{
+      `(` $in_cb `,` $in_tile_index `,` $dst_tile_index `,` $bcast_type `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 def TTKernel_ReduceInitOp : TTKernel_InitOp<"reduce_init"> {
     let summary = "Init function";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -105,6 +105,22 @@ def TTKernel_ReduceType : I32EnumAttr<"ReduceType", "TTKernel Reduce Types",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
+def TTKernel_BcastTypeNone : I32EnumAttrCase<"None", 0, "bcast_type_none">;
+def TTKernel_BcastTypeCol : I32EnumAttrCase<"Col", 1, "bcast_type_col">;
+def TTKernel_BcastTypeRow : I32EnumAttrCase<"Row", 2, "bcast_type_row">;
+def TTKernel_BcastTypeScalar : I32EnumAttrCase<"Scalar", 3, "bcast_type_scalar">;
+
+def TTKernel_BcastType : I32EnumAttr<"BcastType", "TTKernel broadcast types",
+                         [
+                           TTKernel_BcastTypeNone,
+                           TTKernel_BcastTypeCol,
+                           TTKernel_BcastTypeRow,
+                           TTKernel_BcastTypeScalar
+                         ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
 def TTKernel_ReduceDimRow : I32EnumAttrCase<"Row", 0, "reduce_dim_row">;
 def TTKernel_ReduceDimCol : I32EnumAttrCase<"Col", 1, "reduce_dim_col">;
 def TTKernel_ReduceDimScalar : I32EnumAttrCase<"Scalar", 2, "reduce_dim_scalar">;

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -56,6 +56,10 @@ def TTKernel_ThreadTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ThreadType, "t
 
 def TTKernel_ThreadTypeArrayAttr : TypedArrayAttrBase<TTKernel_ThreadTypeAttr, "">;
 
+def TTKernel_BcastTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_BcastType, "bcast_type"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
 def TTKernel_ReduceTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceType, "reduce_type"> {
   let assemblyFormat = "`<` $value `>`";
 }

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -58,6 +58,8 @@ public:
                                         /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/matmul.h",
                                         /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/bcast.h",
+                                        /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/tilize.h",
                                         /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/untilize.h",

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -213,6 +213,42 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @unary_bcast_init
+    func.func @unary_bcast_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_row>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_col>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_scalar>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_none>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+      // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::NONE">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @unary_bcast
+    func.func @unary_bcast() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %in_tile_index = arith.constant 1 : index
+      %dst_index = arith.constant 3 : index
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
+      // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_row>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_col>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_scalar>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_none>}> : (!cb0_tiles, index, index) -> ()
+      // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]}
+      // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]}
+      // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]}
+      // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::NONE">]}
+      return
+    }
+
     // CHECK-LABEL: func @sub_tiles_init
     func.func @sub_tiles_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`unary_bcast_init` and `unary_bcast` ops are missing from `tt-mlir`.

### What's changed
Add broadcast a single tile from a CB. The tile is read from the CB and the broadcast result is stored in the provided DST register index. Broadcast along `rows` or `columns` or along both is supported.

### Checklist
- [ ] New/Existing tests provide coverage for changes
