### PR TITLE
Allow creation of empty borrowed tensors

### DIFF
--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -195,6 +195,12 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
                          const std::vector<std::uint32_t> &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType) {
+  LOG_ASSERT(
+      data != nullptr ||
+          (shape.size() == 0 ||
+           std::accumulate(shape.begin(), shape.end(), 1,
+                           std::multiplies<std::uint32_t>()) == 0),
+      "Cannot create borrowed tensor with null data unless the volume is 0.");
   LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(dataType),
              "Cannot create borrowed tensor with unsupported data type");
   ::ttnn::Shape ttnnShape(shape);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
vLLM internally makes some empty tensors during initialization. Our runtime asserts that the buffers we wish to create tensors for are non null. TTNN can create a borrowed tensor with null data if the volume is zero. 

### What's changed
- Removed the assertion that causes this to fail and let ttnn make the tensor.
### Checklist
- [ ] New/Existing tests provide coverage for changes
