### PR TITLE
D2M: Use explicit DST output index in binary SFPU ops

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -531,15 +531,15 @@ def TTKernel_AddBinaryTilesOp : TTKernel_SFPUOp<"add_binary_tile", [TTKernel_Bin
     let summary = "Addition operation between two tiles";
     let description = [{
       Performs element-wise computation of addition operation
-      DST[dst0_index] <- DST[dst0_index] + DST[dst1_index]
+      DST[odst_index] <- DST[dst0_index] + DST[dst1_index]
       on DST register operands. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call.
     }];
 
-    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index);
+    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index, IndexLike:$odst_index);
 
     let assemblyFormat = [{
-      `(` $dst0_index `,` $dst1_index `)` attr-dict `:` functional-type(operands, results)
+      `(` $dst0_index `,` $dst1_index `,` $odst_index `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -560,15 +560,15 @@ def TTKernel_MulBinaryTilesOp : TTKernel_SFPUOp<"mul_binary_tile", [TTKernel_Bin
     let summary = "Multiplication operation between two tiles";
     let description = [{
       Performs element-wise computation of multiplication operation
-      DST[dst0_index] <- DST[dst0_index] * DST[dst1_index]
+      DST[odst_index] <- DST[dst0_index] * DST[dst1_index]
       on DST register operands. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call.
     }];
 
-    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index);
+    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index, IndexLike:$odst_index);
 
     let assemblyFormat = [{
-      `(` $dst0_index `,` $dst1_index `)` attr-dict `:` functional-type(operands, results)
+      `(` $dst0_index `,` $dst1_index `,` $odst_index `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -589,15 +589,15 @@ def TTKernel_SubBinaryTilesOp : TTKernel_SFPUOp<"sub_binary_tile", [TTKernel_Bin
     let summary = "Subtraction operation between two tiles";
     let description = [{
       Performs element-wise computation of subtraction operation
-      DST[dst0_index] <- DST[dst0_index] - DST[dst1_index]
+      DST[odst_index] <- DST[dst0_index] - DST[dst1_index]
       on DST register operands. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call.
     }];
 
-    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index);
+    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index, IndexLike:$odst_index);
 
     let assemblyFormat = [{
-      `(` $dst0_index `,` $dst1_index `)` attr-dict `:` functional-type(operands, results)
+      `(` $dst0_index `,` $dst1_index `,` $odst_index `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -618,15 +618,15 @@ def TTKernel_DivBinaryTilesOp : TTKernel_SFPUOp<"div_binary_tile", [TTKernel_Bin
     let summary = "Divide operation between two tiles";
     let description = [{
       Performs element-wise computation of division operation
-      DST[dst0_index] <- DST[dst0_index] / DST[dst1_index]
+      DST[odst_index] <- DST[dst0_index] / DST[dst1_index]
       on DST register operands. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call.
     }];
 
-    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index);
+    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index, IndexLike:$odst_index);
 
     let assemblyFormat = [{
-      `(` $dst0_index `,` $dst1_index `)` attr-dict `:` functional-type(operands, results)
+      `(` $dst0_index `,` $dst1_index `,` $odst_index `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -677,15 +677,15 @@ def TTKernel_PowBinaryTilesOp : TTKernel_SFPUOp<"power_binary_tile", [TTKernel_B
     let summary = "Power operation between two tiles";
     let description = [{
       Performs element-wise computation of power operation
-      DST[dst0_index] <- DST[dst0_index] ^ DST[dst1_index]
+      DST[odst_index] <- DST[dst0_index] ^ DST[dst1_index]
       on DST register operands. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call.
     }];
 
-    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index);
+    let arguments = (ins IndexLike:$dst0_index, IndexLike:$dst1_index, IndexLike:$odst_index);
 
     let assemblyFormat = [{
-      `(` $dst0_index `,` $dst1_index `)` attr-dict `:` functional-type(operands, results)
+      `(` $dst0_index `,` $dst1_index `,` $odst_index `)` attr-dict `:` functional-type(operands, results)
     }];
 }
 

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -307,31 +307,33 @@ struct OpMap {};
 
 // clang-format off
 using ComputeOpMap = OpMap<
-  // Elementwise FPU
-  std::pair<ttir::TileAddOp,        std::pair<ttkernel::AddTilesInitOp,            ttkernel::AddTilesOp>>,
-  std::pair<ttir::TileMatmulOp,     std::pair<ttkernel::MatmulInitOp,              ttkernel::MatmulTilesOp>>,
-  std::pair<ttir::TileMatmulBlockOp, std::pair<ttkernel::MatmulBlockInitOp,        ttkernel::ExperimentalMatmulBlockOp>>,
-  std::pair<ttir::TileMulOp,        std::pair<ttkernel::MulTilesInitOp,            ttkernel::MulTilesOp>>,
-  std::pair<ttir::TileSubOp,        std::pair<ttkernel::SubTilesInitOp,            ttkernel::SubTilesOp>>,
+  // Elementwise FPU.
+  std::pair<ttir::TileAddOp,         std::pair<ttkernel::AddTilesInitOp,            ttkernel::AddTilesOp>>,
+  std::pair<ttir::TileMatmulOp,      std::pair<ttkernel::MatmulInitOp,              ttkernel::MatmulTilesOp>>,
+  std::pair<ttir::TileMatmulBlockOp, std::pair<ttkernel::MatmulBlockInitOp,         ttkernel::ExperimentalMatmulBlockOp>>,
+  std::pair<ttir::TileMulOp,         std::pair<ttkernel::MulTilesInitOp,            ttkernel::MulTilesOp>>,
+  std::pair<ttir::TileSubOp,         std::pair<ttkernel::SubTilesInitOp,            ttkernel::SubTilesOp>>,
 
-  // Elementwise SFPU
-  std::pair<ttir::TileAbsOp,        std::pair<ttkernel::AbsTileInitOp,             ttkernel::AbsTileOp>>,
-  std::pair<ttir::TileCeilOp,       std::pair<ttkernel::RoundingTileInitOp,        ttkernel::CeilTileOp>>,
-  std::pair<ttir::TileCosOp,        std::pair<ttkernel::CosTileInitOp,             ttkernel::CosTileOp>>,
-  std::pair<ttir::TileDivOp,        std::pair<ttkernel::DivBinaryTilesInitOp,      ttkernel::DivBinaryTilesOp>>,
-  std::pair<ttir::TileExpOp,        std::pair<ttkernel::ExpTileInitOp,             ttkernel::ExpTileOp>>,
-  std::pair<ttir::TileFloorOp,      std::pair<ttkernel::RoundingTileInitOp,        ttkernel::FloorTileOp>>,
-  std::pair<ttir::TileLogOp,        std::pair<ttkernel::LogTileInitOp,             ttkernel::LogTileOp>>,
-  std::pair<ttir::TileLogicalNotOp, std::pair<ttkernel::LogicalNotUnaryTileInitOp, ttkernel::LogicalNotUnaryTileOp>>,
-  std::pair<ttir::TileMaximumOp,    std::pair<ttkernel::MaxTilesInitOp,            ttkernel::MaxTilesOp>>,
-  std::pair<ttir::TileNegativeOp,   std::pair<ttkernel::NegativeTileInitOp,        ttkernel::NegativeTileOp>>,
-  std::pair<ttir::TilePowOp,        std::pair<ttkernel::PowBinaryTilesInitOp,      ttkernel::PowBinaryTilesOp>>,
-  std::pair<ttir::TileRecipOp,      std::pair<ttkernel::RecipTileInitOp,           ttkernel::RecipTileOp>>,
-  std::pair<ttir::TileRsqrtOp,      std::pair<ttkernel::RsqrtTileInitOp,           ttkernel::RsqrtTileOp>>,
-  std::pair<ttir::TileSqrtOp,       std::pair<ttkernel::SqrtTileInitOp,            ttkernel::SqrtTileOp>>,
-  std::pair<ttir::TileSigmoidOp,    std::pair<ttkernel::SigmoidTileInitOp,         ttkernel::SigmoidTileOp>>,
-  std::pair<ttir::TileSinOp,        std::pair<ttkernel::SinTileInitOp,             ttkernel::SinTileOp>>,
-  std::pair<ttir::TileTanOp,        std::pair<ttkernel::TanTileInitOp,             ttkernel::TanTileOp>>
+  // Elementwise SFPU Unary.
+  std::pair<ttir::TileAbsOp,         std::pair<ttkernel::AbsTileInitOp,             ttkernel::AbsTileOp>>,
+  std::pair<ttir::TileCeilOp,        std::pair<ttkernel::RoundingTileInitOp,        ttkernel::CeilTileOp>>,
+  std::pair<ttir::TileCosOp,         std::pair<ttkernel::CosTileInitOp,             ttkernel::CosTileOp>>,
+  std::pair<ttir::TileExpOp,         std::pair<ttkernel::ExpTileInitOp,             ttkernel::ExpTileOp>>,
+  std::pair<ttir::TileFloorOp,       std::pair<ttkernel::RoundingTileInitOp,        ttkernel::FloorTileOp>>,
+  std::pair<ttir::TileLogOp,         std::pair<ttkernel::LogTileInitOp,             ttkernel::LogTileOp>>,
+  std::pair<ttir::TileLogicalNotOp,  std::pair<ttkernel::LogicalNotUnaryTileInitOp, ttkernel::LogicalNotUnaryTileOp>>,
+  std::pair<ttir::TileNegativeOp,    std::pair<ttkernel::NegativeTileInitOp,        ttkernel::NegativeTileOp>>,
+  std::pair<ttir::TileRecipOp,       std::pair<ttkernel::RecipTileInitOp,           ttkernel::RecipTileOp>>,
+  std::pair<ttir::TileRsqrtOp,       std::pair<ttkernel::RsqrtTileInitOp,           ttkernel::RsqrtTileOp>>,
+  std::pair<ttir::TileSqrtOp,        std::pair<ttkernel::SqrtTileInitOp,            ttkernel::SqrtTileOp>>,
+  std::pair<ttir::TileSigmoidOp,     std::pair<ttkernel::SigmoidTileInitOp,         ttkernel::SigmoidTileOp>>,
+  std::pair<ttir::TileSinOp,         std::pair<ttkernel::SinTileInitOp,             ttkernel::SinTileOp>>,
+  std::pair<ttir::TileTanOp,         std::pair<ttkernel::TanTileInitOp,             ttkernel::TanTileOp>>,
+
+  // Elementwise SFPU Binary.
+  std::pair<ttir::TileDivOp,         std::pair<ttkernel::DivBinaryTilesInitOp,      ttkernel::DivBinaryTilesOp>>,
+  std::pair<ttir::TileMaximumOp,     std::pair<ttkernel::MaxTilesInitOp,            ttkernel::MaxTilesOp>>,
+  std::pair<ttir::TilePowOp,         std::pair<ttkernel::PowBinaryTilesInitOp,      ttkernel::PowBinaryTilesOp>>
 >;
 // clang-format on
 
@@ -556,8 +558,12 @@ public:
       }
     } else if constexpr (arity == 1) {
       rewriter.create<SFPUOp>(op->getLoc(), adaptor.getInput());
-    } else {
+    } else if constexpr (std::is_same_v<SFPUOp, ttkernel::MaxTilesOp>) {
       rewriter.create<SFPUOp>(op->getLoc(), adaptor.getLhs(), adaptor.getRhs());
+    } else {
+      const auto dstIdx = getDstIdxFromResult(op.getResult());
+      rewriter.create<SFPUOp>(op->getLoc(), adaptor.getLhs(), adaptor.getRhs(),
+                              dstIdx);
     }
 
     rewriter.eraseOp(op);
@@ -1295,24 +1301,26 @@ void populateTTIRToTTKernelPatterns(
                ttkernel::TTIRFPUOpsRewriter<ttir::TileMulOp>,
                ttkernel::TTIRFPUOpsRewriter<ttir::TileSubOp>,
 
-               // Elementwise SFPU.
+               // Elementwise SFPU Unary.
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileAbsOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileCeilOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileCosOp>,
-               ttkernel::TTIRSFPUOpsRewriter<ttir::TileDivOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileExpOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileFloorOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileLogOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileLogicalNotOp>,
-               ttkernel::TTIRSFPUOpsRewriter<ttir::TileMaximumOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileNegativeOp>,
-               ttkernel::TTIRSFPUOpsRewriter<ttir::TilePowOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileRecipOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileRsqrtOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileSqrtOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileSigmoidOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileSinOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileTanOp>,
+
+               // Elementwise SFPU Binary.
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TileDivOp>,
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TileMaximumOp>,
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TilePowOp>,
 
                ttkernel::TTIRTilizeUntilizeRewriter,
                ttkernel::TTIRTileTransposeRewriter,

--- a/test/ttmlir/Conversion/TTIRToTTKernel/single_tile_ops.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/single_tile_ops.mlir
@@ -86,7 +86,7 @@ module {
     // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
     // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
     // CHECK: ttkernel.max_tile_init
-    // CHECK: ttkernel.max_tile
+    // CHECK: ttkernel.max_tile(%{{.+}}, %{{.+}})
     %2 = "ttir.tile_maximum"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -106,7 +106,7 @@ module {
     // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
     // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
     // CHECK: ttkernel.div_binary_tile_init
-    // CHECK: ttkernel.div_binary_tile
+    // CHECK: ttkernel.div_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
     %2 = "ttir.tile_div"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -142,7 +142,7 @@ module {
     // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
     // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
     // CHECK: ttkernel.power_binary_tile_init
-    // CHECK: ttkernel.power_binary_tile
+    // CHECK: ttkernel.power_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
     %2 = "ttir.tile_pow"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -464,10 +464,12 @@ module {
     func.func @test_add_binary_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
       // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
-      // CHECK: emitc.call_opaque "add_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[DST0_INDEX]])
-      "ttkernel.add_binary_tile"(%c0, %c1) : (index, index) -> ()
+      // CHECK: %[[ODST_INDEX:.*]] = "emitc.constant"
+      // CHECK: emitc.call_opaque "add_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[ODST_INDEX]])
+      "ttkernel.add_binary_tile"(%c0, %c1, %c2) : (index, index, index) -> ()
       return
     }
 
@@ -482,10 +484,12 @@ module {
     func.func @test_mul_binary_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
       // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
-      // CHECK: emitc.call_opaque "mul_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[DST0_INDEX]])
-      "ttkernel.mul_binary_tile"(%c0, %c1) : (index, index) -> ()
+      // CHECK: %[[ODST_INDEX:.*]] = "emitc.constant"
+      // CHECK: emitc.call_opaque "mul_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[ODST_INDEX]])
+      "ttkernel.mul_binary_tile"(%c0, %c1, %c2) : (index, index, index) -> ()
       return
     }
 
@@ -500,10 +504,12 @@ module {
     func.func @test_sub_binary_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
       // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
-      // CHECK: emitc.call_opaque "sub_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[DST0_INDEX]])
-      "ttkernel.sub_binary_tile"(%c0, %c1) : (index, index) -> ()
+      // CHECK: %[[ODST_INDEX:.*]] = "emitc.constant"
+      // CHECK: emitc.call_opaque "sub_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[ODST_INDEX]])
+      "ttkernel.sub_binary_tile"(%c0, %c1, %c2) : (index, index, index) -> ()
       return
     }
 
@@ -538,8 +544,10 @@ module {
       %dst0_index = arith.constant 1 : i32
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
       %dst1_index = arith.constant 2 : i32
-      // CHECK: emitc.call_opaque "div_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[DST0_INDEX]])
-      "ttkernel.div_binary_tile"(%dst0_index, %dst1_index) : (i32, i32) -> ()
+      // CHECK: %[[ODST_INDEX:.*]] = "emitc.constant"
+      %odst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "div_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[ODST_INDEX]])
+      "ttkernel.div_binary_tile"(%dst0_index, %dst1_index, %odst_index) : (i32, i32, i32) -> ()
       return
     }
 
@@ -572,8 +580,10 @@ module {
       %dst0_index = arith.constant 1 : i32
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
       %dst1_index = arith.constant 2 : i32
-      // CHECK: emitc.call_opaque "power_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[DST0_INDEX]])
-      "ttkernel.power_binary_tile"(%dst0_index, %dst1_index) : (i32, i32) -> ()
+      // CHECK: %[[ODST_INDEX:.*]] = "emitc.constant"
+      %odst_index = arith.constant 3 : i32
+      // CHECK: emitc.call_opaque "power_binary_tile"(%[[DST0_INDEX]], %[[DST1_INDEX]], %[[ODST_INDEX]])
+      "ttkernel.power_binary_tile"(%dst0_index, %dst1_index, %odst_index) : (i32, i32, i32) -> ()
       return
     }
 

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -30,8 +30,8 @@ func.func @test_add_binary_tile_init() -> () {
 // CHECK-LABEL: func.func @test_add_binary_tile
 func.func @test_add_binary_tile() -> () {
   %c0 = arith.constant 0 : index
-  ttkernel.add_binary_tile(%c0, %c0) : (index, index) -> ()
-  // CHECK: ttkernel.add_binary_tile(%{{.*}}, %{{.*}}) : (index, index) -> ()
+  ttkernel.add_binary_tile(%c0, %c0, %c0) : (index, index, index) -> ()
+  // CHECK: ttkernel.add_binary_tile(%{{.*}}, %{{.*}}, %{{.*}}) : (index, index, index) -> ()
   return
 }
 
@@ -45,8 +45,8 @@ func.func @test_mul_binary_tile_init() -> () {
 // CHECK-LABEL: func.func @test_mul_binary_tile
 func.func @test_mul_binary_tile() -> () {
   %c0 = arith.constant 0 : index
-  ttkernel.mul_binary_tile(%c0, %c0) : (index, index) -> ()
-  // CHECK: ttkernel.mul_binary_tile(%{{.*}}, %{{.*}}) : (index, index) -> ()
+  ttkernel.mul_binary_tile(%c0, %c0, %c0) : (index, index, index) -> ()
+  // CHECK: ttkernel.mul_binary_tile(%{{.*}}, %{{.*}}, %{{.*}}) : (index, index, index) -> ()
   return
 }
 
@@ -60,8 +60,8 @@ func.func @test_sub_binary_tile_init() -> () {
 // CHECK-LABEL: func.func @test_sub_binary_tile
 func.func @test_sub_binary_tile() -> () {
   %c0 = arith.constant 0 : index
-  ttkernel.sub_binary_tile(%c0, %c0) : (index, index) -> ()
-  // CHECK: ttkernel.sub_binary_tile(%{{.*}}, %{{.*}}) : (index, index) -> ()
+  ttkernel.sub_binary_tile(%c0, %c0, %c0) : (index, index, index) -> ()
+  // CHECK: ttkernel.sub_binary_tile(%{{.*}}, %{{.*}}, %{{.*}}) : (index, index, index) -> ()
   return
 }
 


### PR DESCRIPTION
### Ticket
Closes #4754

### Problem description
Metal commit https://github.com/tenstorrent/tt-metal/commit/e855cb2d976aba4298c8cab7989fff41663f7b35 modified some (but not all) SFPU binary op APIs to add a 3rd argument to specify the output DST tile index. This PR removes the WA added during our uplift and addresses the issue.

### What's changed
Support the 3rd argument in the modified SFPU compute kernel APIs.

### Checklist
- [x] New/Existing tests provide coverage for changes
