### PR TITLE
Update ttnn-precompiled.hpp in templates of tt-alchemist after trace impl

### DIFF
--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -6,6 +6,7 @@
 #define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 
 #include "tt-metalium/bfloat16.hpp"
+#include "ttnn/common/queue_id.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -36,6 +37,7 @@
 #include "ttnn/operations/reduction/argmax/argmax.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
+#include "ttnn/operations/trace.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
@@ -60,7 +62,8 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15;
+  static constexpr std::size_t l1SmallSize = 1 << 15;     // 32 kB
+  static constexpr std::size_t traceRegionSize = 1 << 20; // 1 MB
 
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.
@@ -70,7 +73,7 @@ public:
     }
 
     static std::shared_ptr<ttnn::MeshDevice> ownedInstance =
-        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
+        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize, traceRegionSize);
     hasOwnedDevice = true;
     return ownedInstance.get();
   }

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -6,6 +6,7 @@
 #define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 
 #include "tt-metalium/bfloat16.hpp"
+#include "ttnn/common/queue_id.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -36,6 +37,7 @@
 #include "ttnn/operations/reduction/argmax/argmax.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
+#include "ttnn/operations/trace.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
@@ -60,7 +62,8 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15;
+  static constexpr std::size_t l1SmallSize = 1 << 15;     // 32 kB
+  static constexpr std::size_t traceRegionSize = 1 << 20; // 1 MB
 
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.
@@ -70,7 +73,7 @@ public:
     }
 
     static std::shared_ptr<ttnn::MeshDevice> ownedInstance =
-        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
+        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize, traceRegionSize);
     hasOwnedDevice = true;
     return ownedInstance.get();
   }


### PR DESCRIPTION
### Ticket
Ad-hoc fix

### What's changed
Trace was implemented for emitc recently, this PR includes necessary trace-related headers in `ttnn-precompiled.hpp` templates of tt-alchemist.

### Checklist
- [ ] New/Existing tests provide coverage for changes
