### PR TITLE
Fix EmitC trace output assignment

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2830,6 +2830,12 @@ public:
           loc, TypeRange{}, srcOp.getExecuteCallee(), nullptr, nullptr,
           loadGlobalVariable(rewriter, loc, traceId));
 
+      // Load the result to the return variable.
+      assert(returnVariable.size() == 1 && "expected one return variable");
+      rewriter.create<emitc::AssignOp>(
+          loc, returnVariable[0],
+          loadGlobalVariable(rewriter, loc, traceOutputVariable[0]));
+
       rewriter.create<emitc::YieldOp>(loc);
     }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Execute path of `capture_or_execute_trace` didn't assign the output tensor to the return variable.

### Checklist
- [ ] New/Existing tests provide coverage for changes
