### PR TITLE
Narrow down unittest linked libs

### DIFF
--- a/test/unittests/OpModel/TTNN/Conversion/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Conversion/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(TestConversion
     gtest_main
     TTNNOpModelLib
     MLIRTTCoreDialect
-    MLIRTTIRDialect
     MLIRTTNNDialect
     MLIRTTTransforms
 )

--- a/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(TestOpModelLib
     gtest_main
     TTNNOpModelLib
     MLIRTTCoreDialect
-    MLIRTTIRDialect
     MLIRTTNNDialect
     MLIRTTTransforms
 )

--- a/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(TestOpModelInterface
     gtest_main
     TTNNOpModelLib
     MLIRTTCoreDialect
-    MLIRTTIRDialect
     MLIRTTNNDialect
     MLIRTTTransforms
 )

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -10,7 +10,7 @@ add_mlir_unittest(OptimizerTests
 
 target_link_libraries(OptimizerTests
     PRIVATE
-    MLIRTTCoreDialect
+    MLIRTTNNDialect
+    MLIRTTTransforms
     MLIRTTNNAnalysis
-    MLIRTTNNPipelines
 )

--- a/test/unittests/TTNNToEmitC/CMakeLists.txt
+++ b/test/unittests/TTNNToEmitC/CMakeLists.txt
@@ -4,5 +4,5 @@ add_mlir_unittest(TTNNToEmitCTests
 
 target_link_libraries(TTNNToEmitCTests
     PRIVATE
-    MLIRTTNNPipelines
+    MLIRIR
 )

--- a/test/unittests/TestScheduler/CMakeLists.txt
+++ b/test/unittests/TestScheduler/CMakeLists.txt
@@ -4,8 +4,7 @@ add_mlir_unittest(SchedulerTests
 
 target_link_libraries(SchedulerTests
     PRIVATE
-    MLIRTTCoreDialect
-    MLIRTTIRDialect
-    MLIRTTNNPipelines
+    MLIRTTNNDialect
+    MLIRTTTransforms
     MLIRScheduler
 )

--- a/test/unittests/Validation/CMakeLists.txt
+++ b/test/unittests/Validation/CMakeLists.txt
@@ -5,10 +5,6 @@ add_mlir_unittest(ValidationTests
 
 target_link_libraries(ValidationTests
     PRIVATE
-    MLIRTTCoreDialect
-    MLIRTTNNDialect
     MLIRTTNNValidation
-    TTMLIRTTNNUtils
-    TTNNOpModelLib
     MLIRTTTransforms
 )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some unit test targets require much broader libraries compared to what's actually needed. This results in an unnecessary executable size in the debug build mode (and more often than not, a broken build; fix for that in the following PR).

### Checklist
- [ ] New/Existing tests provide coverage for changes
