### PR TITLE
Fix library dependencies

### DIFF
--- a/lib/Dialect/StableHLO/Utils/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Utils/CMakeLists.txt
@@ -4,4 +4,10 @@ add_mlir_dialect_library(TTMLIRSTABLEHLOUtils
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/StableHLO
+
+  LINK_LIBS
+  PUBLIC
+  SdyDialect
+  PRIVATE
+  SdyCommonFileUtils
 )

--- a/lib/Dialect/TTIR/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Pipelines/CMakeLists.txt
@@ -17,10 +17,21 @@ set(TTMLIR_PIPELINES_LIBS
   MLIRTTTransforms
   MLIRPass
   MLIRTransforms
+  TTMLIRTTIRToLinalg
+  MLIRTosaToLinalg
+  MLIRTosaToTensor
+  MLIRTosaToArith
+  TTMLIRTransforms
+  MLIRSCFToGPU
+  MLIRGPUToNVVMTransforms
+  MLIRNVVMToLLVM
+  TTMLIRTTIRToTTIRDecomposition
 )
 
 if(TTMLIR_ENABLE_STABLEHLO)
   list(APPEND TTMLIR_PIPELINES_LIBS
+    TTMLIRStableHLOToTTIR
+    TTMLIRSTABLEHLOUtils
     StablehloLinalgTransforms
     StablehloPasses
   )
@@ -33,6 +44,7 @@ add_mlir_dialect_library(MLIRTTIRPipelines
   ${PROJECT_SOURCE_DIR}/include/ttmlir
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/ArithToLLVM
 
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PRIVATE
   ${TTMLIR_PIPELINES_LIBS}
 )

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -37,8 +37,14 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         MLIRTTNNPassesIncGen
         MLIRTTCoreOpsIncGen
 
-        LINK_LIBS PUBLIC
+        LINK_LIBS
+        PUBLIC
         MLIRTTNNDialect
         MLIRTTNNAnalysis
         MLIRTTCoreDialect
+        PRIVATE
+        TTMLIRTTIRToTTNN
+        MLIRTTNNValidation
+        TTMLIRTTNNToEmitC
+        TTMLIRTTNNToEmitPy
         )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Library dependencies were broken in multiple places. One example that exposes it is an `OptimizerTests` target in debug build mode. TBH, it's a miracle that we managed to get this far without catching it, but the two main reasons are:
- in release build `-ffunction-sections -Wl,--gc-sections` is used, so unused functions don't need to be resolved
- tools like `ttmlir-opt` and `ttmlir-translate` link all MLIR libraries

### Checklist
- [ ] New/Existing tests provide coverage for changes
