### PR TITLE
[L1IFA] Fix to skip empty config vector in relevant condition check

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -122,6 +122,7 @@ L1InterleavedFallbackAnalysis::getL1InterleavedLayoutConfigs(
     Operation *op) const {
   const auto it = analysisInput.legalL1InterleavedConfigs.find(op);
   assert(it != analysisInput.legalL1InterleavedConfigs.end());
+  assert(!it->second.empty());
   return it->second;
 }
 

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -318,7 +318,9 @@ public:
               l1InterleavedConfigs.push_back(config);
             }
           }
-          l1InterleavedLegalConfigs[op] = std::move(l1InterleavedConfigs);
+          if (!l1InterleavedConfigs.empty()) {
+            l1InterleavedLegalConfigs[op] = std::move(l1InterleavedConfigs);
+          }
         }
       });
     });


### PR DESCRIPTION
### Problem description
When logging reasons for updates in L1IFA, some failing cases were unclear in the YOLO_v4 model.
Specifically, some `ttnn::toLayout` ops were added to `l1InterleavedLegalConfigs` but had no valid L1 Interleaved legal layout, so their map elements were empty.
This led to confusing update failures that were hard to locate.

### What's changed
The fix checks ahead and skips adding ops to the map if there are no configs for them.
An assertion is added when fetching configs to catch these cases early.

### Checklist
- No changes in behavior, just better code organization.
- No new/existing tests required, as this is a preventive change to make future errors easier to detect.
