### PR TITLE
[builder] pass test_base to build_ttir_module

### DIFF
--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -387,6 +387,7 @@ def compile_ttir_to_flatbuffer(
         fn,
         inputs_shapes,
         inputs_types,
+        base=test_base,
         mesh_name=mesh_name,
         mesh_dict=mesh_dict,
         module_dump=module_dump,


### PR DESCRIPTION
### Ticket


### Problem description
The `ttir builder` does not produce TTIR dump for all test cases.

### What's changed
Pass  `test_base` to `build_ttir_module`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
