### PR TITLE
D2M: replace affine loop coalescing w/ affine licm

### DIFF
--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -110,7 +110,7 @@ void createTTIRToTTMetalMiddleendPipeline(
       ttir::createTTIRInsertDstRegisterAccess(insertDstRegisterAccessOptions));
 
   OpPassManager &funcPm = pm.nest<func::FuncOp>();
-  funcPm.addPass(affine::createLoopCoalescingPass());
+  funcPm.addPass(affine::createAffineLoopInvariantCodeMotionPass());
 
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());


### PR DESCRIPTION
### Ticket
#4903 

### Problem description
This should've been affine LICM to begin with. It looked like the loop was removed, it was actually just fused :(

### What's changed
Replace affine loop coalescing pass w/ affine LICM pass. 

### Checklist
- [X] New/Existing tests provide coverage for changes
