### PR TITLE
Revert "[builder] pass test_base to build_ttir_module"

### DIFF
--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -387,7 +387,6 @@ def compile_ttir_to_flatbuffer(
         fn,
         inputs_shapes,
         inputs_types,
-        base=test_base,
         mesh_name=mesh_name,
         mesh_dict=mesh_dict,
         module_dump=module_dump,


### PR DESCRIPTION
Reverts tenstorrent/tt-mlir#4922

Reverts a duplicate modification introduced alongside tenstorrent/tt-mlir#4927.  
 - The 'base' argument assignment for build_ttir_module was accidentally duplicated on different lines.  