### PR TITLE
D2M/TTNN Integration: Convert TTNN to TTIR pass 

### DIFF
--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -21,6 +21,7 @@
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
 #include "ttmlir/Conversion/TTNNToEmitPy/TTNNToEmitPy.h"
+#include "ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h"
 #include "ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -205,5 +205,10 @@ def ConvertTTIRToLinalg: Pass<"convert-ttir-to-linalg", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::linalg::LinalgDialect", "mlir::tosa::TosaDialect"];
 }
 
+def ConvertTTNNToTTIR : Pass<"convert-ttnn-to-ttir", "::mlir::ModuleOp"> {
+let summary = "Convert TTNN dialect to TTIR dialect.";
+  let constructor = "createConvertTTNNToTTIRPass()";
+  let dependentDialects = ["mlir::tt::ttnn::TTNNDialect", "mlir::tt::ttir::TTIRDialect"];
+}
 
 #endif // TTMLIR_CONVERSION_PASSES

--- a/include/ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h
+++ b/include/ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTNNTOTTIR_TTNNTOTTIR_H
+#define TTMLIR_CONVERSION_TTNNTOTTIR_TTNNTOTTIR_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+namespace ttir {
+
+#define GEN_PASS_DECL_CONVERTTTNNTOTTIR
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace ttir
+
+void populateTTNNToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter);
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTNNToTTIRPass();
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTNNTOTTIR_TTNNTOTTIR_H

--- a/include/ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h
+++ b/include/ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h
@@ -10,12 +10,12 @@
 
 namespace mlir::tt {
 
-namespace ttir {
+namespace ttnn {
 
 #define GEN_PASS_DECL_CONVERTTTNNTOTTIR
 #include "ttmlir/Conversion/Passes.h.inc"
 
-} // namespace ttir
+} // namespace ttnn
 
 void populateTTNNToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
                                 TypeConverter &typeConverter);

--- a/include/ttmlir/Dialect/TTNN/Types/Types.h
+++ b/include/ttmlir/Dialect/TTNN/Types/Types.h
@@ -13,6 +13,8 @@ inline constexpr uint32_t TILE_HEIGHT = 32;
 inline constexpr uint32_t TILE_WIDTH = 32;
 inline constexpr std::array<uint32_t, 2> VALID_CQ_IDS = {0, 1};
 inline constexpr llvm::StringLiteral g_TTNNTraceAttrName = "ttnn.trace";
+inline constexpr llvm::StringLiteral g_TTNNHoistGenericViaD2MAttrName =
+    "ttnn.hoist_generic_via_d2m";
 inline constexpr llvm::StringLiteral g_TTNNCaptureTracePrefix =
     "run_and_capture_";
 inline constexpr llvm::StringLiteral g_TTNNExecuteTracePrefix = "execute_";

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -92,6 +92,7 @@ createShardSpecIfNeeded(TensorMemoryLayoutAttr tensorMemoryLayout,
                         mlir::tt::ttcore::GridAttr deviceGrid);
 
 bool isTTNNTraceFunc(func::FuncOp funcOp);
+bool isTTNNHoistGenericViaD2MOp(mlir::Operation *op);
 
 // Returns all TTNN dialect registered operations.
 std::set<mlir::StringRef> getAllTTNNDialectOps(MLIRContext *context);

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(TTIRToTTMetal)
 add_subdirectory(TTKernelToEmitC)
 add_subdirectory(TTIRToTTKernel)
 add_subdirectory(SFPIToEmitC)
+add_subdirectory(TTNNToTTIR)
 
 if (TTMLIR_ENABLE_STABLEHLO)
 add_subdirectory(StableHLOToTTIR)

--- a/lib/Conversion/TTNNToTTIR/CMakeLists.txt
+++ b/lib/Conversion/TTNNToTTIR/CMakeLists.txt
@@ -1,6 +1,3 @@
-include_directories(${TTMLIR_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 add_mlir_conversion_library(TTMLIRTTNNToTTIR
   TTNNToTTIRPass.cpp
   TTNNToTTIRPatterns.cpp

--- a/lib/Conversion/TTNNToTTIR/CMakeLists.txt
+++ b/lib/Conversion/TTNNToTTIR/CMakeLists.txt
@@ -1,0 +1,20 @@
+include_directories(${TTMLIR_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+add_mlir_conversion_library(TTMLIRTTNNToTTIR
+  TTNNToTTIRPass.cpp
+  TTNNToTTIRPatterns.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTNNToTTIR
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Dialect/TTNN
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  TTMLIRTTNNUtils
+  TTMLIRTTIRUtils
+)

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPass.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPass.cpp
@@ -22,17 +22,14 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-using namespace mlir;
-using namespace mlir::tt;
-
-namespace mlir::tt::ttir {
+namespace mlir::tt::ttnn {
 
 #define GEN_PASS_DEF_CONVERTTTNNTOTTIR
 #include "ttmlir/Conversion/Passes.h.inc"
 
 namespace {
 struct ConvertTTNNToTTIRPass
-    : public ttir::impl::ConvertTTNNToTTIRBase<ConvertTTNNToTTIRPass> {
+    : public ttnn::impl::ConvertTTNNToTTIRBase<ConvertTTNNToTTIRPass> {
 
   ConvertTTNNToTTIRPass() = default;
 
@@ -42,7 +39,6 @@ struct ConvertTTNNToTTIRPass
     // Common legal/illegal ops/dialects for both partial and full conversion.
     target.addLegalDialect<ttir::TTIRDialect>();
     target.addLegalDialect<ttcore::TTCoreDialect>();
-    target.addLegalOp<mlir::tt::ttir::EmptyOp>();
     target.addLegalOp<mlir::ModuleOp>();
 
     TypeConverter typeConverter;
@@ -77,12 +73,12 @@ struct ConvertTTNNToTTIRPass
   }
 };
 } // namespace
-} // namespace mlir::tt::ttir
+} // namespace mlir::tt::ttnn
 
 namespace mlir::tt {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTNNToTTIRPass() {
-  return std::make_unique<ttir::ConvertTTNNToTTIRPass>();
+  return std::make_unique<ttnn::ConvertTTNNToTTIRPass>();
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPass.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPass.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/Quant/IR/Quant.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_CONVERTTTNNTOTTIR
+#include "ttmlir/Conversion/Passes.h.inc"
+
+namespace {
+struct ConvertTTNNToTTIRPass
+    : public ttir::impl::ConvertTTNNToTTIRBase<ConvertTTNNToTTIRPass> {
+
+  ConvertTTNNToTTIRPass() = default;
+
+  void runOnOperation() final {
+    mlir::ConversionTarget target(getContext());
+
+    // Common legal/illegal ops/dialects for both partial and full conversion.
+    target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalDialect<ttcore::TTCoreDialect>();
+    target.addLegalOp<mlir::tt::ttir::EmptyOp>();
+    target.addLegalOp<mlir::ModuleOp>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+
+    RewritePatternSet patterns(&getContext());
+
+    ::mlir::tt::populateTTNNToTTIRPatterns(&getContext(), patterns,
+                                           typeConverter);
+
+    // Function type conversions.
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+             typeConverter.isLegal(&op.getBody());
+    });
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::ReturnOp>(
+        [&](func::ReturnOp op) { return typeConverter.isLegal(op); });
+    populateCallOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::CallOp>(
+        [&](func::CallOp op) { return typeConverter.isLegal(op); });
+
+    // For partial conversion, we can leave TTNN dialect as neither
+    // explicitly legal so the patterns run, nor explicitly illegal so
+    // leftover ops won't throw an error.
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+} // namespace mlir::tt::ttir
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTNNToTTIRPass() {
+  return std::make_unique<ttir::ConvertTTNNToTTIRPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -24,137 +24,109 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-using namespace mlir;
-using namespace mlir::tt;
-
 namespace {
-template <typename SrcOp, typename DestOp,
-          typename Adaptor = typename SrcOp::Adaptor>
-class TTNNToTTIROpDefaultConversionPattern : public OpConversionPattern<SrcOp> {
+template <typename SrcOp, typename DestOp>
+class TTNNToTTIRElementwiseConversionPattern
+    : public mlir::OpConversionPattern<SrcOp> {
 
-  using OpConversionPattern<SrcOp>::OpConversionPattern;
+  using mlir::OpConversionPattern<SrcOp>::OpConversionPattern;
+  using Adaptor = typename SrcOp::Adaptor;
 
 public:
-  LogicalResult
+  mlir::LogicalResult
   matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (ttnn::utils::isTTNNHoistGenericViaD2MOp(srcOp)) {
-      auto outputType = mlir::cast<RankedTensorType>(
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    if (mlir::tt::ttnn::utils::isTTNNHoistGenericViaD2MOp(srcOp)) {
+      auto outputType = mlir::cast<mlir::RankedTensorType>(
           this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-      ttir::utils::replaceOpWithNewDPSOp<DestOp>(rewriter, srcOp, outputType,
-                                                 adaptor.getOperands());
+      mlir::tt::ttir::utils::replaceOpWithNewDPSOp<DestOp>(
+          rewriter, srcOp, outputType, adaptor.getOperands());
     }
-    return success();
+    return mlir::success();
   }
 };
 } // namespace
 
 static void
-addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
-                                         RewritePatternSet &patterns,
-                                         TypeConverter &typeConverter) {
+addElementwiseUnaryOpsConversionPatterns(mlir::MLIRContext *ctx,
+                                         mlir::RewritePatternSet &patterns,
+                                         mlir::TypeConverter &typeConverter) {
 
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::AbsOp,
-                                                    mlir::tt::ttir::AbsOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CbrtOp,
-                                                    mlir::tt::ttir::CbrtOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::TypecastOp, mlir::tt::ttir::TypecastOp>>(typeConverter,
-                                                               ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CeilOp,
-                                                    mlir::tt::ttir::CeilOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CosOp,
-                                                    mlir::tt::ttir::CosOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::ExpOp,
-                                                    mlir::tt::ttir::ExpOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::FloorOp,
-                                                    mlir::tt::ttir::FloorOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::IsFiniteOp, mlir::tt::ttir::IsFiniteOp>>(typeConverter,
-                                                               ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::NegOp,
-                                                    mlir::tt::ttir::NegOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::RsqrtOp,
-                                                    mlir::tt::ttir::RsqrtOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SinOp,
-                                                    mlir::tt::ttir::SinOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SqrtOp,
-                                                    mlir::tt::ttir::SqrtOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Log1pOp,
-                                                    mlir::tt::ttir::Log1pOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Expm1Op,
-                                                    mlir::tt::ttir::Expm1Op>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SignOp,
-                                                    mlir::tt::ttir::SignOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SigmoidOp,
-                                                    mlir::tt::ttir::SigmoidOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::TanOp,
-                                                    mlir::tt::ttir::TanOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::TanhOp,
-                                                    mlir::tt::ttir::TanhOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::LogOp,
-                                                    mlir::tt::ttir::LogOp>>(
-      typeConverter, ctx);
+  patterns
+      .add<TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::AbsOp,
+                                                  mlir::tt::ttir::AbsOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::CbrtOp,
+                                                  mlir::tt::ttir::CbrtOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::TypecastOp,
+                                                  mlir::tt::ttir::TypecastOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::CeilOp,
+                                                  mlir::tt::ttir::CeilOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::CosOp,
+                                                  mlir::tt::ttir::CosOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::ExpOp,
+                                                  mlir::tt::ttir::ExpOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::FloorOp,
+                                                  mlir::tt::ttir::FloorOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::IsFiniteOp,
+                                                  mlir::tt::ttir::IsFiniteOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::NegOp,
+                                                  mlir::tt::ttir::NegOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::RsqrtOp,
+                                                  mlir::tt::ttir::RsqrtOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::SinOp,
+                                                  mlir::tt::ttir::SinOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::SqrtOp,
+                                                  mlir::tt::ttir::SqrtOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::Log1pOp,
+                                                  mlir::tt::ttir::Log1pOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::Expm1Op,
+                                                  mlir::tt::ttir::Expm1Op>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::SignOp,
+                                                  mlir::tt::ttir::SignOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::SigmoidOp,
+                                                  mlir::tt::ttir::SigmoidOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::TanOp,
+                                                  mlir::tt::ttir::TanOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::TanhOp,
+                                                  mlir::tt::ttir::TanhOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::LogOp,
+                                                  mlir::tt::ttir::LogOp>>(
+          typeConverter, ctx);
 }
 
 static void
-addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter &typeConverter) {
+addElementwiseBinaryOpsConversionPatterns(mlir::MLIRContext *ctx,
+                                          mlir::RewritePatternSet &patterns,
+                                          mlir::TypeConverter &typeConverter) {
 
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::AddOp,
-                                                    mlir::tt::ttir::AddOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::DivideOp,
-                                                    mlir::tt::ttir::DivOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::MaxOp,
-                                                    mlir::tt::ttir::MaximumOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::MinOp,
-                                                    mlir::tt::ttir::MinimumOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::MultiplyOp, mlir::tt::ttir::MultiplyOp>>(typeConverter,
-                                                               ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::SubtractOp, mlir::tt::ttir::SubtractOp>>(typeConverter,
-                                                               ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::RemainderOp, mlir::tt::ttir::RemainderOp>>(typeConverter,
-                                                                 ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::WhereOp,
-                                                    mlir::tt::ttir::WhereOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::PowOp,
-                                                    mlir::tt::ttir::PowOp>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Atan2Op,
-                                                    mlir::tt::ttir::Atan2Op>>(
-      typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::LogicalRightShiftOp,
-      mlir::tt::ttir::LogicalRightShiftOp>>(typeConverter, ctx);
-  patterns.add<TTNNToTTIROpDefaultConversionPattern<
-      mlir::tt::ttnn::LogicalLeftShiftOp, mlir::tt::ttir::LogicalLeftShiftOp>>(
-      typeConverter, ctx);
+  patterns
+      .add<TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::AddOp,
+                                                  mlir::tt::ttir::AddOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::DivideOp,
+                                                  mlir::tt::ttir::DivOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::MaxOp,
+                                                  mlir::tt::ttir::MaximumOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::MinOp,
+                                                  mlir::tt::ttir::MinimumOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::MultiplyOp,
+                                                  mlir::tt::ttir::MultiplyOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::SubtractOp,
+                                                  mlir::tt::ttir::SubtractOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::RemainderOp,
+                                                  mlir::tt::ttir::RemainderOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::WhereOp,
+                                                  mlir::tt::ttir::WhereOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::PowOp,
+                                                  mlir::tt::ttir::PowOp>,
+           TTNNToTTIRElementwiseConversionPattern<mlir::tt::ttnn::Atan2Op,
+                                                  mlir::tt::ttir::Atan2Op>,
+           TTNNToTTIRElementwiseConversionPattern<
+               mlir::tt::ttnn::LogicalRightShiftOp,
+               mlir::tt::ttir::LogicalRightShiftOp>,
+           TTNNToTTIRElementwiseConversionPattern<
+               mlir::tt::ttnn::LogicalLeftShiftOp,
+               mlir::tt::ttir::LogicalLeftShiftOp>>(typeConverter, ctx);
 }
 
 namespace mlir::tt {

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTNNToTTIR/TTNNToTTIR.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/Utils/Mesh.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace {
+template <typename SrcOp, typename DestOp,
+          typename Adaptor = typename SrcOp::Adaptor>
+class TTNNToTTIROpDefaultConversionPattern : public OpConversionPattern<SrcOp> {
+
+  using OpConversionPattern<SrcOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (ttnn::utils::isTTNNHoistGenericViaD2MOp(srcOp)) {
+      auto outputType = mlir::cast<RankedTensorType>(
+          this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+      ttir::utils::replaceOpWithNewDPSOp<DestOp>(rewriter, srcOp, outputType,
+                                                 adaptor.getOperands());
+    }
+    return success();
+  }
+};
+} // namespace
+
+static void
+addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
+
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::AbsOp,
+                                                    mlir::tt::ttir::AbsOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CbrtOp,
+                                                    mlir::tt::ttir::CbrtOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::TypecastOp, mlir::tt::ttir::TypecastOp>>(typeConverter,
+                                                               ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CeilOp,
+                                                    mlir::tt::ttir::CeilOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::CosOp,
+                                                    mlir::tt::ttir::CosOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::ExpOp,
+                                                    mlir::tt::ttir::ExpOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::FloorOp,
+                                                    mlir::tt::ttir::FloorOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::IsFiniteOp, mlir::tt::ttir::IsFiniteOp>>(typeConverter,
+                                                               ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::NegOp,
+                                                    mlir::tt::ttir::NegOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::RsqrtOp,
+                                                    mlir::tt::ttir::RsqrtOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SinOp,
+                                                    mlir::tt::ttir::SinOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SqrtOp,
+                                                    mlir::tt::ttir::SqrtOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Log1pOp,
+                                                    mlir::tt::ttir::Log1pOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Expm1Op,
+                                                    mlir::tt::ttir::Expm1Op>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SignOp,
+                                                    mlir::tt::ttir::SignOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::SigmoidOp,
+                                                    mlir::tt::ttir::SigmoidOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::TanOp,
+                                                    mlir::tt::ttir::TanOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::TanhOp,
+                                                    mlir::tt::ttir::TanhOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::LogOp,
+                                                    mlir::tt::ttir::LogOp>>(
+      typeConverter, ctx);
+}
+
+static void
+addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
+
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::AddOp,
+                                                    mlir::tt::ttir::AddOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::DivideOp,
+                                                    mlir::tt::ttir::DivOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::MaxOp,
+                                                    mlir::tt::ttir::MaximumOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::MinOp,
+                                                    mlir::tt::ttir::MinimumOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::MultiplyOp, mlir::tt::ttir::MultiplyOp>>(typeConverter,
+                                                               ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::SubtractOp, mlir::tt::ttir::SubtractOp>>(typeConverter,
+                                                               ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::RemainderOp, mlir::tt::ttir::RemainderOp>>(typeConverter,
+                                                                 ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::WhereOp,
+                                                    mlir::tt::ttir::WhereOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::PowOp,
+                                                    mlir::tt::ttir::PowOp>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<mlir::tt::ttnn::Atan2Op,
+                                                    mlir::tt::ttir::Atan2Op>>(
+      typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::LogicalRightShiftOp,
+      mlir::tt::ttir::LogicalRightShiftOp>>(typeConverter, ctx);
+  patterns.add<TTNNToTTIROpDefaultConversionPattern<
+      mlir::tt::ttnn::LogicalLeftShiftOp, mlir::tt::ttir::LogicalLeftShiftOp>>(
+      typeConverter, ctx);
+}
+
+namespace mlir::tt {
+
+void populateTTNNToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter) {
+  addElementwiseUnaryOpsConversionPatterns(ctx, patterns, typeConverter);
+  addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
+}
+
+} // namespace mlir::tt

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -10,10 +10,10 @@
 
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "llvm/Support/Casting.h"
 
-#include <mlir/IR/Operation.h>
 #include <optional>
 
 namespace mlir::tt::ttnn::utils {

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/Value.h"
 #include "llvm/Support/Casting.h"
 
+#include <mlir/IR/Operation.h>
 #include <optional>
 
 namespace mlir::tt::ttnn::utils {
@@ -252,6 +253,10 @@ std::optional<ShardSpecAttr> createShardSpecIfNeeded(
 
 bool isTTNNTraceFunc(func::FuncOp funcOp) {
   return funcOp->hasAttr(g_TTNNTraceAttrName);
+}
+
+bool isTTNNHoistGenericViaD2MOp(mlir::Operation *op) {
+  return op->hasAttr(g_TTNNHoistGenericViaD2MAttrName);
 }
 
 std::set<mlir::StringRef> getAllTTNNDialectOps(MLIRContext *context) {

--- a/test/ttmlir/Conversion/TTNNToTTIR/binary_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/binary_op.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>, <physical>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test(%arg0: tensor<32x32xf32, #dram_layout>, %arg1: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+        %2 = "ttnn.to_memory_config"(%arg1) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.add"(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %3 = "ttnn.add"(%1, %2) {ttnn.hoist_generic_via_d2m, dtype = #ttcore.supportedDataTypes<f32>} : (tensor<32x32xf32, #l1_layout>, tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        %4 = "ttnn.to_memory_config"(%3) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
+
+        return %4 : tensor<32x32xf32, #dram_layout>
+    }
+}

--- a/test/ttmlir/Conversion/TTNNToTTIR/skip_binary_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/skip_binary_op.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>, <physical>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test(%arg0: tensor<32x32xf32, #dram_layout>, %arg1: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+        %2 = "ttnn.to_memory_config"(%arg1) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
+        // CHECK-NOT: %{{[0-9]+}} = "ttir.add"(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %3 = "ttnn.add"(%1, %2) {dtype = #ttcore.supportedDataTypes<f32>} : (tensor<32x32xf32, #l1_layout>, tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        %4 = "ttnn.to_memory_config"(%3) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
+
+        return %4 : tensor<32x32xf32, #dram_layout>
+    }
+}

--- a/test/ttmlir/Conversion/TTNNToTTIR/skip_unary_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/skip_unary_op.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>, <physical>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
+        // CHECK-NOT: %{{[0-9]+}} = "ttir.abs"(%{{[0-9]+}}, %{{[0-9]+}}) : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %2 = "ttnn.abs"(%1) : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
+
+        return %3 : tensor<32x32xf32, #dram_layout>
+    }
+}

--- a/test/ttmlir/Conversion/TTNNToTTIR/unary_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/unary_op.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>, <physical>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32x32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.abs"(%{{[0-9]+}}, %{{[0-9]+}}) : (tensor<32x32xf32, #ttnn_layout1>, tensor<32x32xf32, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout1>
+        %2 = "ttnn.abs"(%1) {ttnn.hoist_generic_via_d2m} : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #dram_layout>
+
+        return %3 : tensor<32x32xf32, #dram_layout>
+    }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4763)

### Problem description
Convert TTNN operations targged with `ttnn.hoist_generic_via_d2m` attribute to TTIR. Limit support to unary and binary element-wise operations. See [design doc](https://docs.google.com/document/d/1SyJyK7yYPvMDzm0eBe89vrjhA5ZkIFc2_Lw2gOIarhY/edit?tab=t.0).

### What's changed
- Add ConvertTTNNToTTIR pass;
- Add MLIR test for unary and binary op.