### PR TITLE
[L1InterleavedFallbackAnalysis] Improve perf by skipping L1 upgrades for reshape ops that can be optimized in runtime

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -124,7 +125,7 @@ private:
   // row-major input
   //
   // Called by handleReshapeOps() if conditions 3&4 are met.
-  bool checkReshapeSkip(Operation *reshapeOperation) const;
+  bool checkReshapeSkip(ReshapeOp reshapeOp) const;
 
   // Try to upgrade an operation to L1 interleaved layout by testing available
   // L1 configurations and selecting the first one that passes validation.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -88,8 +88,9 @@ private:
   // (1x1 kernel, stride=1, padding=0, dilation=1)
   bool isConv2DConvertibleToMatMul(Operation *op);
 
-  // Check if a reshape operation should be skipped based on TTNN optimization
+  // Check if a reshape operation should be skipped based on tt-metal TTNN optimization
   // rules. Returns true if the operation should be skipped, false otherwise.
+  // reference: ttnn::operations::data_movement::ReshapeViewOperation::invoke
   // Parameters:
   // - reshapeOp: The reshape operation to analyze
   // - contextOp: The operation context for logging (producer op for user

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -90,13 +90,21 @@ private:
 
   // Check if a reshape operation should be skipped based on tt-metal TTNN
   // optimization rules. Returns true if the operation should be skipped, false
-  // otherwise. reference:
+  // otherwise.
+  //
+  // This check is performed in two contexts:
+  // 1. When checking the reshape operation itself - upgrading its output tensor
+  //    would change buffer type, potentially breaking tt-metal's view
+  //    optimization
+  // 2. Before that, alongside checking reshape's predecessor, producer of its
+  //    input tensor - upgrading the producer would change the
+  //    buffer type of reshape's input tensor, again potentially breaking
+  //    tt-metal's view optimization.
+  //
+  // reference:
   // ttnn::operations::data_movement::ReshapeViewOperation::invoke
-  // Parameters:
-  // - reshapeOp: The reshape operation to analyze
-  // - isUserOp: true if this is a user reshape check, false for direct reshape
   // TODO(bmalesevic,#5086): replace to dynamic check when tt-metal fixed
-  bool checkReshapeSkip(Operation *reshapeOperation, bool isUserOp) const;
+  bool checkReshapeSkip(Operation *reshapeOperation) const;
 
   // Try to upgrade an operation to L1 interleaved layout by testing available
   // L1 configurations and selecting the first one that passes validation.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -91,13 +91,12 @@ private:
   // Check if a reshape operation should be skipped based on tt-metal TTNN
   // optimization rules. Returns true if the operation should be skipped, false
   // otherwise. reference:
-  // ttnn::operations::data_movement::ReshapeViewOperation::invoke Parameters:
+  // ttnn::operations::data_movement::ReshapeViewOperation::invoke
+  // Parameters:
   // - reshapeOp: The reshape operation to analyze
-  // - contextOp: The operation context for logging (producer op for user
-  // reshapes)
   // - isUserOp: true if this is a user reshape check, false for direct reshape
-  bool checkReshapeSkip(Operation *reshapeOperation, Operation *contextOp,
-                        bool isUserOp) const;
+  // TODO(bmalesevic,#5086): replace to dynamic check when tt-metal fixed
+  bool checkReshapeSkip(Operation *reshapeOperation, bool isUserOp) const;
 
   // Try to upgrade an operation to L1 interleaved layout by testing available
   // L1 configurations and selecting the first one that passes validation.

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -88,6 +88,16 @@ private:
   // (1x1 kernel, stride=1, padding=0, dilation=1)
   bool isConv2DConvertibleToMatMul(Operation *op);
 
+  // Check if a reshape operation should be skipped based on TTNN optimization
+  // rules. Returns true if the operation should be skipped, false otherwise.
+  // Parameters:
+  // - reshapeOp: The reshape operation to analyze
+  // - contextOp: The operation context for logging (producer op for user
+  // reshapes)
+  // - isUserOp: true if this is a user reshape check, false for direct reshape
+  bool checkReshapeSkip(Operation *reshapeOperation, Operation *contextOp,
+                        bool isUserOp) const;
+
   // Try to upgrade an operation to L1 interleaved layout by testing available
   // L1 configurations and selecting the first one that passes validation.
   void tryUpgradeToL1Interleaved(Operation *op);

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.h
@@ -88,10 +88,10 @@ private:
   // (1x1 kernel, stride=1, padding=0, dilation=1)
   bool isConv2DConvertibleToMatMul(Operation *op);
 
-  // Check if a reshape operation should be skipped based on tt-metal TTNN optimization
-  // rules. Returns true if the operation should be skipped, false otherwise.
-  // reference: ttnn::operations::data_movement::ReshapeViewOperation::invoke
-  // Parameters:
+  // Check if a reshape operation should be skipped based on tt-metal TTNN
+  // optimization rules. Returns true if the operation should be skipped, false
+  // otherwise. reference:
+  // ttnn::operations::data_movement::ReshapeViewOperation::invoke Parameters:
   // - reshapeOp: The reshape operation to analyze
   // - contextOp: The operation context for logging (producer op for user
   // reshapes)

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -109,6 +109,9 @@ bool producesL1Layout(Operation *op);
 // Check if operation's first result uses tiled tensor layout.
 bool producesTiledTensorLayout(Operation *op);
 
+// Check if operation's first operand uses DRAM buffer layout.
+bool hasFirstOperandInDRAM(Operation *op);
+
 mlir::RankedTensorType getTraceIdType(MLIRContext *ctx);
 } // namespace mlir::tt::ttnn::utils
 

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -227,40 +227,6 @@ bool L1InterleavedFallbackAnalysis::checkReshapeSkip(
     return true;
   }
 
-  // Check if padded shapes would be identical (TTNN early return case)
-  auto computePaddedDim = [](int64_t dim) -> int64_t {
-    return ((dim + 31) / 32) * 32; // Round up to next tile boundary
-  };
-
-  bool paddedShapesWouldBeIdentical = true;
-  if (inputShape.size() >= 2 && outputShape.size() >= 2) {
-    // Check if last 2 dimensions would have same padding
-    int64_t inputPaddedH = computePaddedDim(inputShape[inputShape.size() - 2]);
-    int64_t inputPaddedW = computePaddedDim(inputShape[inputShape.size() - 1]);
-    int64_t outputPaddedH =
-        computePaddedDim(outputShape[outputShape.size() - 2]);
-    int64_t outputPaddedW =
-        computePaddedDim(outputShape[outputShape.size() - 1]);
-
-    paddedShapesWouldBeIdentical =
-        (inputPaddedH == outputPaddedH) && (inputPaddedW == outputPaddedW);
-  }
-
-  if (paddedShapesWouldBeIdentical) {
-    if (isUserOp) {
-      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
-                   "L1InterleavedFallbackAnalysis: Skipping {} - user reshape "
-                   "padded no-op.",
-                   contextOp->getName());
-    } else {
-      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
-                   "L1InterleavedFallbackAnalysis: Skipping {} - reshape "
-                   "padded no-op.",
-                   contextOp->getName());
-    }
-    return true;
-  }
-
   // Check if this reshape can be optimized to a view (TTNN-style check)
   bool canBeView = false;
   if (inputShape.size() >= 1 && outputShape.size() >= 1) {
@@ -276,15 +242,42 @@ bool L1InterleavedFallbackAnalysis::checkReshapeSkip(
 
     // TTNN view conditions adapted for MLIR:
     // 1. Last dimension must be the same
-    // 2. Either second-to-last dimension is the same OR no tile padding
+    // 2. Either second-to-last dimension is the same OR no tile padding OR
+    // row-major input
+    // 3. Sharded/Interleaved must match for output and input
+    // 4. L1/DRAM must match for output and input
     const int64_t tileHeight = 32; // tt::constants::TILE_HEIGHT
     const int64_t tileWidth = 32;  // tt::constants::TILE_WIDTH
 
+    bool inputTensorSharded = false;
+    if (auto ttnnLayout =
+            mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding())) {
+      inputTensorSharded = ttnnLayout.hasShardedL1TensorMemoryLayout();
+    }
+    bool outputTensorSharded = false;
+    if (auto ttnnLayout =
+            mlir::dyn_cast<TTNNLayoutAttr>(outputType.getEncoding())) {
+      outputTensorSharded = ttnnLayout.hasShardedL1TensorMemoryLayout();
+    }
+    bool inputTensorTiled = false;
+    if (auto ttnnLayout =
+            mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding())) {
+      inputTensorTiled = ttnnLayout.isTiled();
+    }
+
     canBeView =
+        // 1. Sharded/Interleaved must match for output and input for metal
+        // optimization (always false for tensor checked for upgrade since in
+        // DRAM -> never sharded) so there is no point to keep the tensor in
+        // DRAM if the other is L1 sharded.
+        // 2. Since sharding is the only way any of these can already be in L1,
+        // and the other must be in DRAM to be considered for upgrade,
+        // checking sharding covers the input.isL1() == output.isL1() as well.
+        (inputTensorSharded == outputTensorSharded) &&
         (inputLastDim == outputLastDim) &&
-        ((inputSecondLastDim == outputSecondLastDim) || // Second last dim same
+        (!inputTensorTiled || (inputSecondLastDim == outputSecondLastDim) ||
          (outputSecondLastDim % tileHeight == 0 &&
-          inputSecondLastDim % tileWidth == 0)); // No tile padding
+          inputSecondLastDim % tileWidth == 0));
   }
 
   if (canBeView) {

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -280,8 +280,7 @@ bool L1InterleavedFallbackAnalysis::checkReshapeSkip(
         // 2. Since sharding is the only way any of these can already be in
         // L1, and the other must be in DRAM to be considered for upgrade,
         // checking sharding covers the input.isL1() == output.isL1() as well.
-        !otherTensorSharded &&
-        (inputLastDim == outputLastDim) &&
+        !otherTensorSharded && (inputLastDim == outputLastDim) &&
         (!inputTensorTiled || (inputSecondLastDim == outputSecondLastDim) ||
          (outputSecondLastDim % tileHeight == 0 &&
           inputSecondLastDim % tileWidth == 0));

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 #include "llvm/Support/Casting.h"
 
 #include <optional>
@@ -327,12 +328,9 @@ bool hasFirstOperandInDRAM(Operation *op) {
   auto firstOperand = op->getOperand(0);
   auto tensorType =
       mlir::dyn_cast<mlir::RankedTensorType>(firstOperand.getType());
-  if (!tensorType) {
-    return false;
-  }
 
   if (auto ttnnLayout =
-          mlir::dyn_cast<TTNNLayoutAttr>(tensorType.getEncoding())) {
+          mlir::dyn_cast_if_present<TTNNLayoutAttr>(tensorType.getEncoding())) {
     return ttnnLayout.hasDRAMBufferType();
   }
 

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -319,6 +319,26 @@ bool producesTiledTensorLayout(Operation *op) {
   return ttnnLayout && ttnnLayout->isTiled();
 }
 
+bool hasFirstOperandInDRAM(Operation *op) {
+  if (op->getNumOperands() == 0) {
+    return false;
+  }
+
+  auto firstOperand = op->getOperand(0);
+  auto tensorType =
+      mlir::dyn_cast<mlir::RankedTensorType>(firstOperand.getType());
+  if (!tensorType) {
+    return false;
+  }
+
+  if (auto ttnnLayout =
+          mlir::dyn_cast<TTNNLayoutAttr>(tensorType.getEncoding())) {
+    return ttnnLayout.hasDRAMBufferType();
+  }
+
+  return false;
+}
+
 mlir::RankedTensorType getTraceIdType(MLIRContext *ctx) {
   return ::mlir::RankedTensorType::get(
       /*shape=*/{},

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/simple_conv2d.mlir
@@ -27,12 +27,11 @@ module @L1InterleavedTestConv2D attributes {} {
 // CHECK-DAG: #[[DRAM_5:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 // CHECK-DAG: #[[DRAM_6:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
 
-// CHECK-DAG: #[[L1_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
-
-// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L1_1]]>
+// Reshape skipped to be optimized out in metal lowering, stays in DRAM.
+// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[DRAM_3]]>
 
 // Consumer is conv2d which uses matmul, stays in DRAM.
-// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_4]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_3]]>
 // Conv2d which uses matmul, stays in DRAM.
 // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[DRAM_6]]>
 // Conv2d which uses matmul, stays in DRAM.


### PR DESCRIPTION
This PR enhances the L1 interleaved fallback analysis by skipping reshape operation inputs/outputs that can be optimized to zero-cost view operations at runtime. The analysis now implements TTNN's reshape-to-view optimization logic to predict when reshapes would be converted to views if they stayed in DRAM, avoiding unnecessary L1 memory allocation for operations that didn't benefit from it or even caused perf degradation.

The new `checkReshapeSkip` function evaluates reshape operations using the same criteria as TTNN's runtime optimization:
- First checks if input and output tensors have identical shapes (no-op detection)
- For non-trivial reshapes, validates view optimization conditions:
  - Last dimension preservation for memory layout compatibility  
  - Memory layout consistency (sharded/interleaved matching)
  - Memory buffer consistency (DRAM/L1)
  - At least one of: tile alignment (32x32), second-to-last dimension preservation, or row-major input

This prevents the analysis from upgrading reshape operations to L1 when they will be optimized away at the tt-metal runtime level.

### What's changed
- Performance Impact: 
  - Prevents performance degradation from unnecessary reshapes being kept as regular ops in runtime
  - Reduces unnecessary L1 memory pressure by skipping reshape operations that become zero-cost views
  - With future changes, might show to enable more beneficial operations to utilize available L1 memory for actual performance gains
- No API changes
### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Test perf for all models with newest changes, on Forge-FE (when python3.11 upgraded on CI)
