### PR TITLE
[L1InterleavedFallbackAnalysis] Fixed error for toLayoutOp checking input tensor layout validity

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -355,7 +355,7 @@ L1InterleavedFallbackAnalysis::checkUpgradeToL1Interleaved(
   assert(nextConsumerOp && "Operation must have a consumer");
   // If next consumer has TTNN layout output encoding, verify both operations
   // can coexist in L1.
-  if (utils::producesTTNNLayoutEncoding(nextConsumerOp)) {
+  if (utils::producesTTNNLayoutEncoding(nextConsumerOp) && !isa<ttnn::ToLayoutOp>(nextConsumerOp)) {
     const OpConfig &nextConsumerOpConfig =
         analysisInput.currentConfigs.at(nextConsumerOp);
 

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedFallbackAnalysis.cpp
@@ -355,7 +355,8 @@ L1InterleavedFallbackAnalysis::checkUpgradeToL1Interleaved(
   assert(nextConsumerOp && "Operation must have a consumer");
   // If next consumer has TTNN layout output encoding, verify both operations
   // can coexist in L1.
-  if (utils::producesTTNNLayoutEncoding(nextConsumerOp) && !isa<ttnn::ToLayoutOp>(nextConsumerOp)) {
+  if (utils::producesTTNNLayoutEncoding(nextConsumerOp) &&
+      !isa<ttnn::ToLayoutOp>(nextConsumerOp)) {
     const OpConfig &nextConsumerOpConfig =
         analysisInput.currentConfigs.at(nextConsumerOp);
 


### PR DESCRIPTION
### Problem description
During recursive validation in L1 interleaved fallback analysis, `toLayoutOp` operations were causing failures because they have no valid configurations set in the OpModel system. Since `toLayoutOp` is inherently layout-agnostic and designed to handle any input layout, OpModel validation is unnecessary and inappropriate for these operations.

### What's changed
Added logic in `checkUpgradeToL1Interleaved` to skip OpModel validation for `toLayoutOp`. These operations are designed to handle layout transitions and don't impose constraints on their input layouts, making OpModel validation both unnecessary and problematic, so we upgrade the tensor based on producer's OpModel validation only.

### Checklist
- [ ] New/Existing tests provide coverage for changes
