### PR TITLE
Fix bug in concatenating 1d tensor

### DIFF
--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -69,7 +69,11 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
     // Nd (partial) Concat
     MeshComposerConfig meshComposerConfig;
     if (shardType == ::tt::target::MeshShardType::Replicate) {
-      meshComposerConfig.dims.push_back(static_cast<int>(1));
+      // All buffers in devices are replicated across devices. Thus, we pick up
+      // the data from the first device by providing {1} mesh shape. By setting
+      // 0 in the dim, we allow all dimensional tensors staring from single
+      // dimensional tensor.
+      meshComposerConfig.dims.push_back(static_cast<int>(0));
       meshComposerConfig.mesh_shape_override = ::ttnn::MeshShape({1});
     } else {
       // meshComposerConfig.dims must be unique, and thus, we need to find


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4992

### Problem description
When concatenating replicated ttnn tensors, current code assume at least two dimensional tensor. 

### What's changed
Relax such 2d requirement and allow 1d tensor concatenation.

