### PR TITLE
D2M/TTNN Integration - `ttnn_metal_layout_cast` op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -402,8 +402,8 @@ def TTIR_TTNNMetalLayoutCastOp : TTIR_Op<"ttnn_metal_layout_cast",
     ```
   }];
 
-  let arguments = (ins AnyRankedTensor:$input);
-  let results   = (outs AnyRankedTensor:$result);
+  let arguments = (ins AnyRankedTensorOrMemRef:$input);
+  let results   = (outs AnyRankedTensorOrMemRef:$result);
 
   let assemblyFormat = [{
     $input attr-dict `:` type($input) `->` type($result)

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -387,18 +387,30 @@ def TTIR_TTNNMetalLayoutCastOp : TTIR_Op<"ttnn_metal_layout_cast",
   ]> {
   let summary = "Cast TTNN layout-encoded tensor to/from TTCore metal layout-encoded tensor";
   let description = [{
-    This op reinterprets a tensor's layout encoding from `#ttnn.ttnn_layout<...>`
+    Purely representational op that reinterprets a tensor's layout encoding from `#ttnn.ttnn_layout<...>`
     to/from `#ttcore.metal_layout<...>` without modifying the underlying data.
 
     Pre-bufferization, the input and output must be a RankedTensorType where one holds a
     `ttnn::TTNNLayoutAttr` and the other, a `ttcore::MetalLayoutAttr`. Post bufferization,
     the tensor encoded with a `ttcore::MetalLayoutAttr` is bufferized to a memref.
 
-    Example:
+    Examples:
     ```
-    %cast = ttir.ttnn_metal_layout_cast %arg0
-            : tensor<32x32xf32, #ttnn.ttnn_layout<...>>
-           -> tensor<32x32xf32, #ttcore.metal_layout<...>>
+    %cast_to_metal = ttir.ttnn_metal_layout_cast %arg0
+                      : tensor<32x32xf32, #ttnn.ttnn_layout<...>>
+                    -> tensor<32x32xf32, #ttcore.metal_layout<...>>
+
+    %cast_to_metal_bufferized = ttir.ttnn_metal_layout_cast %arg0
+                            : tensor<32x32xf32, #ttnn.ttnn_layout<...>>
+                          -> memref<32x32xf32, ...>
+
+    %cast_to_ttnn = ttir.ttnn_metal_layout_cast %arg0
+                    : tensor<32x32xf32, #ttcore.metal_layout<...>>
+                  -> tensor<32x32xf32, #ttnn.ttnn_layout<...>>
+
+    %cast_to_ttnn_bufferized = ttir.ttnn_metal_layout_cast %arg0
+                            : memref<32x32xf32, ...>
+                          -> tensor<32x32xf32, #ttnn.ttnn_layout<...>>
     ```
   }];
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -374,7 +374,7 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
     let hasFolder = 1;
 }
 
-def TTIR_TTNNToMetalLayoutCastOp : TTIR_Op<"ttnn_to_metal_layout_cast",
+def TTIR_TTNNMetalLayoutCastOp : TTIR_Op<"ttnn_metal_layout_cast",
   [ Pure
   , TTIROpInterface
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
@@ -385,17 +385,18 @@ def TTIR_TTNNToMetalLayoutCastOp : TTIR_Op<"ttnn_to_metal_layout_cast",
                                                        , "getBufferType"
                                                        ]>
   ]> {
-  let summary = "Cast TTNN layout-encoded tensor to TTCore metal layout-encoded tensor";
+  let summary = "Cast TTNN layout-encoded tensor to/from TTCore metal layout-encoded tensor";
   let description = [{
     This op reinterprets a tensor's layout encoding from `#ttnn.ttnn_layout<...>`
-    to `#ttcore.metal_layout<...>` without modifying the underlying data.
+    to/from `#ttcore.metal_layout<...>` without modifying the underlying data.
 
-    The input must be a RankedTensorType whose encoding is `ttnn::TTNNLayoutAttr`.
-    The result must be a RankedTensorType whose encoding is `ttcore::MetalLayoutAttr`.
+    Pre-bufferization, the input and output must be a RankedTensorType where one holds a
+    `ttnn::TTNNLayoutAttr` and the other, a `ttcore::MetalLayoutAttr`. Post bufferization,
+    the tensor encoded with a `ttcore::MetalLayoutAttr` is bufferized to a memref.
 
     Example:
     ```
-    %cast = ttir.ttnn_to_metal_layout_cast %arg0
+    %cast = ttir.ttnn_metal_layout_cast %arg0
             : tensor<32x32xf32, #ttnn.ttnn_layout<...>>
            -> tensor<32x32xf32, #ttcore.metal_layout<...>>
     ```

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -374,6 +374,43 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
     let hasFolder = 1;
 }
 
+def TTIR_TTNNToMetalLayoutCastOp : TTIR_Op<"ttnn_to_metal_layout_cast",
+  [ Pure
+  , TTIROpInterface
+  , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
+  ]> {
+  let summary = "Cast TTNN layout-encoded tensor to TTCore metal layout-encoded tensor";
+  let description = [{
+    This op reinterprets a tensor's layout encoding from `#ttnn.ttnn_layout<...>`
+    to `#ttcore.metal_layout<...>` without modifying the underlying data.
+
+    The input must be a RankedTensorType whose encoding is `ttnn::TTNNLayoutAttr`.
+    The result must be a RankedTensorType whose encoding is `ttcore::MetalLayoutAttr`.
+
+    Example:
+    ```
+    %cast = ttir.ttnn_to_metal_layout_cast %arg0
+            : tensor<32x32xf32, #ttnn.ttnn_layout<...>>
+           -> tensor<32x32xf32, #ttcore.metal_layout<...>>
+    ```
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input);
+  let results   = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // TTIR top level ops
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -102,10 +102,9 @@ struct TTIRToTTMetalPipelineOptions
                      "(>=1). Default is 2."),
       llvm::cl::init(2)};
   // Option to lower through D2m to TTNN GenericOp.
-  Option<bool> lowerToTTNNGeneric{
-      *this, "lower-to-ttnn-generic",
-      llvm::cl::desc("Lower through D2m to TTNN GenericOp"),
-      llvm::cl::init(false)};
+  Option<bool> ttnnMode{*this, "ttnn-mode",
+                        llvm::cl::desc("D2M/TTNN integration mode."),
+                        llvm::cl::init(false)};
 };
 
 void createTTIRBufferizationPipeline(

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -101,9 +101,15 @@ struct TTIRToTTMetalPipelineOptions
       llvm::cl::desc("Number of backing buffers to allocate per stream storage "
                      "(>=1). Default is 2."),
       llvm::cl::init(2)};
+  // Option to lower through D2m to TTNN GenericOp.
+  Option<bool> lowerToTTNNGeneric{
+      *this, "lower-to-ttnn-generic",
+      llvm::cl::desc("Lower through D2m to TTNN GenericOp"),
+      llvm::cl::init(false)};
 };
 
-void createTTIRBufferizationPipeline(OpPassManager &pm);
+void createTTIRBufferizationPipeline(
+    OpPassManager &pm, const TTIRToTTMetalPipelineOptions &options);
 
 void createTTIRToTTMetalBackendPipeline(
     OpPassManager &pm, const TTIRToTTMetalPipelineOptions &options);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3178,10 +3178,6 @@ mlir::LogicalResult mlir::tt::ttir::TTNNMetalLayoutCastOp::verify() {
   auto inputType = mlir::dyn_cast<mlir::ShapedType>(getInput().getType());
   auto outputType = mlir::dyn_cast<mlir::ShapedType>(getResult().getType());
 
-  if (!inputType || !outputType) {
-    return emitOpError("Input/output must be shaped types (tensor or memref)");
-  }
-
   const bool inputIsMemref = mlir::isa<mlir::MemRefType>(inputType);
   const bool outputIsMemref = mlir::isa<mlir::MemRefType>(outputType);
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3165,19 +3165,19 @@ mlir::OpFoldResult mlir::tt::ttir::ViewLayoutOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
-// TTNNToMetalLayoutCastOp
+// TTNNMetalLayoutCastOp
 //===----------------------------------------------------------------------===//
 
-mlir::LogicalResult mlir::tt::ttir::TTNNToMetalLayoutCastOp::verify() {
+mlir::LogicalResult mlir::tt::ttir::TTNNMetalLayoutCastOp::verify() {
   return success();
 }
 
-void mlir::tt::ttir::TTNNToMetalLayoutCastOp::getAsmResultNames(
+void mlir::tt::ttir::TTNNMetalLayoutCastOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), "cast");
 }
 
-mlir::LogicalResult mlir::tt::ttir::TTNNToMetalLayoutCastOp::bufferize(
+mlir::LogicalResult mlir::tt::ttir::TTNNMetalLayoutCastOp::bufferize(
     mlir::RewriterBase &rewriter,
     const mlir::bufferization::BufferizationOptions &options,
     mlir::bufferization::BufferizationState &state) {
@@ -3185,7 +3185,7 @@ mlir::LogicalResult mlir::tt::ttir::TTNNToMetalLayoutCastOp::bufferize(
   //   return failure();
   // }
 
-  // TT_assertv(getNumResults() == 1, "TTNNToMetalLayoutCastOp should have
+  // TT_assertv(getNumResults() == 1, "TTNNMetalLayoutCastOp should have
   // exactly one result");
 
   if (!mlir::isa<::mlir::RankedTensorType>(getResult().getType()) ||
@@ -3225,27 +3225,27 @@ mlir::LogicalResult mlir::tt::ttir::TTNNToMetalLayoutCastOp::bufferize(
 }
 
 mlir::bufferization::AliasingValueList
-mlir::tt::ttir::TTNNToMetalLayoutCastOp::getAliasingValues(
+mlir::tt::ttir::TTNNMetalLayoutCastOp::getAliasingValues(
     mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
   bufferization::AliasingValueList result;
   return result;
 }
 
 mlir::FailureOr<mlir::BaseMemRefType>
-mlir::tt::ttir::TTNNToMetalLayoutCastOp::getBufferType(
+mlir::tt::ttir::TTNNMetalLayoutCastOp::getBufferType(
     mlir::Value value, const mlir::bufferization::BufferizationOptions &,
     const mlir::bufferization::BufferizationState &,
     ::llvm::SmallVector<mlir::Value> &) {
   return mlir::tt::ttir::getBufferType(value.getType(), /*isView=*/false);
 }
 
-bool mlir::tt::ttir::TTNNToMetalLayoutCastOp::bufferizesToMemoryRead(
+bool mlir::tt::ttir::TTNNMetalLayoutCastOp::bufferizesToMemoryRead(
     mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
   // no-op
   return false;
 }
 
-bool mlir::tt::ttir::TTNNToMetalLayoutCastOp::bufferizesToMemoryWrite(
+bool mlir::tt::ttir::TTNNMetalLayoutCastOp::bufferizesToMemoryWrite(
     mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
   // no-op
   return false;

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -466,6 +466,7 @@ mlir::LogicalResult mlir::tt::ttir::EmptyOp::bufferize(
     return success();
   }
 
+  // Don't bufferize if tensor has a ttnn_layout; lowering to ttnn generic.
   if (options.allowUnknownOps &&
       mlir::isa<ttnn::TTNNLayoutAttr>(getResult().getType().getEncoding())) {
     return success();

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<Pass> createCanonicalizerPassWithOptions(
 void createTTIRBufferizationPipeline(
     OpPassManager &pm, const TTIRToTTMetalPipelineOptions &options) {
   bufferization::OneShotBufferizePassOptions bufferizePassOptions;
-  if (options.lowerToTTNNGeneric) {
+  if (options.ttnnMode) {
     bufferizePassOptions.allowUnknownOps = true;
     bufferizePassOptions.bufferizeFunctionBoundaries = false;
   } else {

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -100,7 +100,6 @@ void createTTIRToTTMetalMiddleendPipeline(
   ttir::TTIRAllocateOptions allocateOptions;
   { allocateOptions.numStreamBuffers = options.numStreamBuffers; }
   pm.addPass(ttir::createTTIRAllocate(allocateOptions));
-  pm.addPass(ttir::createTTIRAllocate());
   pm.addPass(createCanonicalizerPassWithOptions(options));
   ttir::TTIRGenericApplyInterchangeOptions applyInterchangeOptions;
   {

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -1,7 +1,8 @@
+// RUN: ttmlir-opt --ttir-bufferization-pipeline="lower-to-ttnn-generic=true" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
 
 #l1 = #ttnn.buffer_type<l1>
-
-#ttnn_layout = #ttnn.ttnn_layout<
+#ttnn_l1_layout = #ttnn.ttnn_layout<
   (d0, d1) -> (d0, d1),
   <1x1, (d0, d1) -> (0, d0, d1)>,
   memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>
@@ -14,10 +15,29 @@
   >
 
 module {
-  func.func @test_no_bufferization(%arg0 : tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout> {
-    %0 = ttir.empty() : tensor<32x32xf32, #ttnn_layout>
-    %1 = ttir.ttnn_metal_layout_cast %0 : tensor<32x32xf32, #ttnn_layout> -> tensor<32x32xf32, #metal_layout>
-    %2 = ttir.ttnn_metal_layout_cast %1 : tensor<32x32xf32, #metal_layout> -> tensor<32x32xf32, #ttnn_layout>
-    return %2 : tensor<32x32xf32, #ttnn_layout>
+  // CHECK-NOT: %arg0: memref
+  func.func @test_bufferization(%arg0: tensor<32x32xf32, #ttnn_l1_layout>) -> tensor<32x32xf32, #ttnn_l1_layout> {
+    // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> memref<32x32xf32, {{.*}}>
+    %2 = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<32x32xf32, #metal_layout>
+
+    // CHECK-NOT: memref.alloc()
+    %3 =  ttir.empty() : tensor<32x32xf32, #ttnn_l1_layout>
+
+    // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %{{[0-9]+}} : tensor<32x32xf32, #ttnn_layout> -> memref<32x32xf32, {{.*}}>
+    %4 = ttir.ttnn_metal_layout_cast %3 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<32x32xf32, #metal_layout>
+
+    // CHECK: ins(%[[CAST0]] : memref<32x32xf32, {{.*}}>)
+    // CHECK: outs(%[[CAST1]] : memref<32x32xf32, {{.*}}>)
+    ttir.generic {grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], block_factors = [], threads = [#ttir.thread<compute>]}
+        ins(%2 : tensor<32x32xf32, #metal_layout>)
+        outs(%4 : tensor<32x32xf32, #metal_layout>) {
+      ^compute0(%arg_in: tensor<32x32xf32>, %arg_out: tensor<32x32xf32>):
+        ttir.yield %arg_in : (tensor<32x32xf32>)
+    } : tensor<32x32xf32, #metal_layout>
+
+    // CHECK: ttir.ttnn_metal_layout_cast %[[CAST1]] : memref<32x32xf32, {{.*}}> -> tensor<32x32xf32, #ttnn_layout>
+    %5 = ttir.ttnn_metal_layout_cast %4 : tensor<32x32xf32, #metal_layout> -> tensor<32x32xf32, #ttnn_l1_layout>
+
+    return %5 : tensor<32x32xf32, #ttnn_l1_layout>
   }
 }

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -1,0 +1,23 @@
+
+#l1 = #ttnn.buffer_type<l1>
+
+#ttnn_layout = #ttnn.ttnn_layout<
+  (d0, d1) -> (d0, d1),
+  <1x1, (d0, d1) -> (0, d0, d1)>,
+  memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>
+  >
+
+#metal_layout = #ttcore.metal_layout<
+  logical_shape = 32x32,
+  dim_alignments = 32x32,
+  collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1
+  >
+
+module {
+  func.func @test_no_bufferization(%arg0 : tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout> {
+    %0 = ttir.empty() : tensor<32x32xf32, #ttnn_layout>
+    %1 = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> tensor<32x32xf32, #metal_layout>
+    %2 = ttir.ttnn_metal_layout_cast %1 : tensor<32x32xf32, #metal_layout> -> tensor<32x32xf32, #ttnn_layout>
+    return %2 : tensor<32x32xf32, #ttnn_layout>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -16,7 +16,7 @@
 module {
   func.func @test_no_bufferization(%arg0 : tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout> {
     %0 = ttir.empty() : tensor<32x32xf32, #ttnn_layout>
-    %1 = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> tensor<32x32xf32, #metal_layout>
+    %1 = ttir.ttnn_metal_layout_cast %0 : tensor<32x32xf32, #ttnn_layout> -> tensor<32x32xf32, #metal_layout>
     %2 = ttir.ttnn_metal_layout_cast %1 : tensor<32x32xf32, #metal_layout> -> tensor<32x32xf32, #ttnn_layout>
     return %2 : tensor<32x32xf32, #ttnn_layout>
   }

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -16,26 +16,26 @@
 module {
   // CHECK-NOT: %arg0: memref
   func.func @test_bufferization(%arg0: tensor<32x32xf32, #ttnn_l1_layout>) -> tensor<32x32xf32, #ttnn_l1_layout> {
-    // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> memref<32x32xf32, {{.*}}>
-    %2 = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<32x32xf32, #metal_layout>
+    // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> memref<
+    %2 = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout>
 
     // CHECK-NOT: memref.alloc()
     %3 =  ttir.empty() : tensor<32x32xf32, #ttnn_l1_layout>
 
-    // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %{{[0-9]+}} : tensor<32x32xf32, #ttnn_layout> -> memref<32x32xf32, {{.*}}>
-    %4 = ttir.ttnn_metal_layout_cast %3 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<32x32xf32, #metal_layout>
+    // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %{{[0-9]+}} : tensor<32x32xf32, #ttnn_layout> -> memref
+    %4 = ttir.ttnn_metal_layout_cast %3 : tensor<32x32xf32, #ttnn_l1_layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout>
 
-    // CHECK: ins(%[[CAST0]] : memref<32x32xf32, {{.*}}>)
-    // CHECK: outs(%[[CAST1]] : memref<32x32xf32, {{.*}}>)
+    // CHECK: ins(%[[CAST0]] : memref<{{.*}}>)
+    // CHECK: outs(%[[CAST1]] : memref<{{.*}}>)
     ttir.generic {grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], block_factors = [], threads = [#ttir.thread<compute>]}
-        ins(%2 : tensor<32x32xf32, #metal_layout>)
-        outs(%4 : tensor<32x32xf32, #metal_layout>) {
-      ^compute0(%arg_in: tensor<32x32xf32>, %arg_out: tensor<32x32xf32>):
-        ttir.yield %arg_in : (tensor<32x32xf32>)
-    } : tensor<32x32xf32, #metal_layout>
+        ins(%2 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout>)
+        outs(%4 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout>) {
+      ^compute0(%arg_in: tensor<1x1x1x1x!ttcore.tile<32x32, f32>>, %arg_out: tensor<1x1x1x1x!ttcore.tile<32x32, f32>>):
+        ttir.yield %arg_in : (tensor<1x1x1x1x!ttcore.tile<32x32, f32>>)
+    } : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout>
 
-    // CHECK: ttir.ttnn_metal_layout_cast %[[CAST1]] : memref<32x32xf32, {{.*}}> -> tensor<32x32xf32, #ttnn_layout>
-    %5 = ttir.ttnn_metal_layout_cast %4 : tensor<32x32xf32, #metal_layout> -> tensor<32x32xf32, #ttnn_l1_layout>
+    // CHECK: ttir.ttnn_metal_layout_cast %[[CAST1]] : memref{{.*}}> -> tensor<32x32xf32, #ttnn_layout>
+    %5 = ttir.ttnn_metal_layout_cast %4 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #metal_layout> -> tensor<32x32xf32, #ttnn_l1_layout>
 
     return %5 : tensor<32x32xf32, #ttnn_l1_layout>
   }

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -7,11 +7,10 @@
   <1x1, (d0, d1) -> (0, d0, d1)>,
   memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>
   >
-
 #metal_layout = #ttcore.metal_layout<
   logical_shape = 32x32,
   dim_alignments = 32x32,
-  collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1
+  collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1
   >
 
 module {

--- a/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/ttnn_metal_layout_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-bufferization-pipeline="lower-to-ttnn-generic=true" -o %t.mlir %s
+// RUN: ttmlir-opt --ttir-bufferization-pipeline="ttnn-mode=true" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 
 #l1 = #ttnn.buffer_type<l1>


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4976)

### Problem description
Purely representational op that marks the conversion between ttnn and metal layouts.

### What's changed
- added `ttnn_metal_layout_cast_op`
- added `ttnn-mode` flag in `TTIRToTTMetalPipelineOptions`, where when true in one-shot-bufferize pass:
    - no longer bufferize function parameters
    - allow for unbufferized tensors (in this case, only `ttir.empty` with a ttnn layout attached)
- implemented `bufferize` 
- implemented basic `verifier`
    - follow up issue to amend: https://github.com/tenstorrent/tt-mlir/issues/4977
- added mlir test case

### Checklist
- [x] New/Existing tests provide coverage for changes
