### PR TITLE
Fix doc link to constraints/runtime APIs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -43,6 +43,7 @@
   - [Coding Guidelines](./coding-guidelines.md)
   - [TTNN Dialect Guidelines](./ttnn-dialect-guidelines.md)
 - [Adding an op](./adding-an-op.md)
+  - [Adding constraints/runtime APIs](./ttnn-op-constraints.md)
 - [Decomposing an op in TTIR](./decomposing-an-op-in-ttir.md)
 - [Docs & Doxygen](./docs.md)
 - [Specifications](./specs/specs.md)


### PR DESCRIPTION
The recently added doc for adding constraints/runtime APIs wasn't added to `SUMMARY.md`, so it wasn't properly built, which resulted in a broken link.