### PR TITLE
Add `ttnn.load_tensor` and `ttnn.dump_tensor`

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1559,6 +1559,9 @@ public:
   mlir::Attribute
   emit(::mlir::TypedValue<::mlir::tt::ttnn::DeviceType> device) {
     if (!device) {
+      if constexpr (std::is_pointer_v<TargetTy>) {
+        return rewriter.getType<emitc::OpaqueAttr>("nullptr");
+      }
       return emit(std::nullopt);
     }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2409,4 +2409,36 @@ def TTNN_RotaryEmbeddingLlamaOp : TTNN_Op<"rotary_embedding_llama", [TTNN_Memory
     let hasVerifier = 1;
 }
 
+def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
+  let summary = "Saves a tensor to disk in the TT-NN binary format";
+  let description = [{
+    Saves a tensor to disk in the TT-NN binary format. Files must use the `.tensorbin` extension.
+
+    Inputs:
+      TODO (azecevic)
+  }];
+
+  let arguments = (ins StrAttr:$file_path,
+                       AnyRankedTensor:$input);
+}
+
+def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
+  let summary = "Loads a tensor from disk";
+  let description = [{
+    Loads a tensor from disk, optionally placing it directly on a device.
+
+    Inputs:
+      TODO (azecevic)
+    Outputs:
+      TODO (azecevic)
+  }];
+
+  let arguments = (ins StrAttr:$file_path,
+                       Optional<TTNN_Device>:$device);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2410,9 +2410,9 @@ def TTNN_RotaryEmbeddingLlamaOp : TTNN_Op<"rotary_embedding_llama", [TTNN_Memory
 }
 
 def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
-  let summary = "Saves a tensor to disk in the TT-NN binary format";
+  let summary = "Saves a tensor to disk in the TTNN binary format";
   let description = [{
-    Saves a tensor to disk in the TT-NN binary format. Files must use the `.tensorbin` extension.
+    Saves a tensor to disk in the TTNN binary format. Files must use the `.tensorbin` extension.
 
     Inputs:
       - `file_path` StrAttr: Path of the file where tensor should be dumped. Must end with `.tensorbin` extension.
@@ -2432,9 +2432,9 @@ def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
 
     Inputs:
       - `file_path` StrAttr: Path of the file of the serialized tensor. Must end with `.tensorbin` extension.
-      - `device` Optional<TTNN_Device>: Device where tensor should be desirialized. It has to be provided iff the serialized tensor is a deivce tensor.
+      - `device` Optional<TTNN_Device>: Device where tensor should be deserialized. It has to be provided iff the serialized tensor is a device tensor.
     Outputs:
-      - `result` AnyRankedTensor: Desirialized tensor from the `file_path`.
+      - `result` AnyRankedTensor: Deserialized tensor from the `file_path`.
   }];
 
   let arguments = (ins StrAttr:$file_path,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2420,6 +2420,8 @@ def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
 
   let arguments = (ins StrAttr:$file_path,
                        AnyRankedTensor:$input);
+
+  let hasVerifier = 1;
 }
 
 def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2415,7 +2415,8 @@ def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
     Saves a tensor to disk in the TT-NN binary format. Files must use the `.tensorbin` extension.
 
     Inputs:
-      TODO (azecevic)
+      - `file_path` StrAttr: Path of the file where tensor should be dumped. Must end with `.tensorbin` extension.
+      - `input` AnyRankedTensor: Tensor to serialize.
   }];
 
   let arguments = (ins StrAttr:$file_path,
@@ -2430,9 +2431,10 @@ def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
     Loads a tensor from disk, optionally placing it directly on a device.
 
     Inputs:
-      TODO (azecevic)
+      - `file_path` StrAttr: Path of the file of the serialized tensor. Must end with `.tensorbin` extension.
+      - `device` Optional<TTNN_Device>: Device where tensor should be desirialized. It has to be provided iff the serialized tensor is a deivce tensor.
     Outputs:
-      TODO (azecevic)
+      - `result` AnyRankedTensor: Desirialized tensor from the `file_path`.
   }];
 
   let arguments = (ins StrAttr:$file_path,

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TTNN_OPERATIONS_FBS_GEN_SOURCES
   operations/pool.fbs
   operations/rand.fbs
   operations/reduction.fbs
+  operations/tensor_serialization.fbs
   operations/trace.fbs
   operations/transformer.fbs
 )

--- a/include/ttmlir/Target/TTNN/operations/tensor_serialization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/tensor_serialization.fbs
@@ -1,0 +1,15 @@
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
+
+namespace tt.target.ttnn;
+
+table DumpTensorOp {
+  file_path: string;
+  input: tt.target.ttnn.TensorRef;
+}
+
+table LoadTensorOp {
+  file_path: string;
+  device: tt.target.DeviceRef;
+  output: tt.target.ttnn.TensorRef;
+}

--- a/include/ttmlir/Target/TTNN/operations/tensor_serialization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/tensor_serialization.fbs
@@ -5,11 +5,11 @@ namespace tt.target.ttnn;
 
 table DumpTensorOp {
   file_path: string;
-  input: tt.target.ttnn.TensorRef;
+  in: tt.target.ttnn.TensorRef;
 }
 
 table LoadTensorOp {
   file_path: string;
   device: tt.target.DeviceRef;
-  output: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -23,6 +23,7 @@ include "ttmlir/Target/TTNN/operations/normalization.fbs";
 include "ttmlir/Target/TTNN/operations/pool.fbs";
 include "ttmlir/Target/TTNN/operations/rand.fbs";
 include "ttmlir/Target/TTNN/operations/reduction.fbs";
+include "ttmlir/Target/TTNN/operations/tensor_serialization.fbs";
 include "ttmlir/Target/TTNN/operations/trace.fbs";
 include "ttmlir/Target/TTNN/operations/transformer.fbs";
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -95,7 +95,9 @@ union OpType {
   TypecastOp,
   UpdateCacheOp,
   UpsampleOp,
-  WriteTensorOp
+  WriteTensorOp,
+  DumpTensorOp,
+  LoadTensorOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2982,6 +2982,15 @@ public:
 namespace {
 class DumpTensorOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::DumpTensorOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return mlir::tt::ttnn::DumpTensorOp::getOperationName().str();
+  }
+
+  std::string getPrefixSwapPattern() const override {
+    return "::tt::tt_metal::dump_tensor_flatbuffer";
+  }
+
 public:
   using TTNNToEmitCBaseOpConversionPattern<
       mlir::tt::ttnn::DumpTensorOp>::TTNNToEmitCBaseOpConversionPattern;
@@ -2994,8 +3003,8 @@ public:
         srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getFilePath()),
+        emitter.emit(srcOp.getInput()),
     };
 
     emitter.replaceOp(*this, args);
@@ -3007,6 +3016,15 @@ public:
 namespace {
 class LoadTensorOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::LoadTensorOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return mlir::tt::ttnn::LoadTensorOp::getOperationName().str();
+  }
+
+  std::string getPrefixSwapPattern() const override {
+    return "::tt::tt_metal::load_tensor_flatbuffer";
+  }
+
 public:
   using TTNNToEmitCBaseOpConversionPattern<
       mlir::tt::ttnn::LoadTensorOp>::TTNNToEmitCBaseOpConversionPattern;
@@ -3208,10 +3226,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Tensor serialization ops
   //
-  patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::LoadTensorOp>>(
-      typeConverter, ctx);
-  patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::DumpTensorOp>>(
-      typeConverter, ctx);
+  patterns.add<DumpTensorOpConversionPattern>(typeConverter, ctx);
+  patterns.add<LoadTensorOpConversionPattern>(typeConverter, ctx);
 
   // Trace ops
   //

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2979,6 +2979,56 @@ public:
 };
 } // namespace
 
+namespace {
+class DumpTensorOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::DumpTensorOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::DumpTensorOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::DumpTensorOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::DumpTensorOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getFilePath()),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class LoadTensorOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::LoadTensorOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::LoadTensorOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LoadTensorOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::LoadTensorOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getFilePath()),
+        emitter.emit(srcOp.getDevice()),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
+} // namespace
+
 namespace mlir::tt {
 
 // ANCHOR: op_rewriter_pattern_set_emitc
@@ -3154,6 +3204,13 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::UpdateCacheOp>>(
       typeConverter, ctx);
   patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::FillCacheOp>>(
+      typeConverter, ctx);
+
+  // Tensor serialization ops
+  //
+  patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::LoadTensorOp>>(
+      typeConverter, ctx);
+  patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::DumpTensorOp>>(
       typeConverter, ctx);
 
   // Trace ops

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -875,8 +875,8 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // Tensor serialization ops
   //
   // clang-format off
-  patterns.add<DefaultOpConversionPattern<mlir::tt::ttnn::LoadTensorOp>,
-               DefaultOpConversionPattern<mlir::tt::ttnn::DumpTensorOp>>(typeConverter, ctx);
+  patterns.add<DumpTensorOpConversionPattern,
+               LoadTensorOpConversionPattern>(typeConverter, ctx);
   // clang-format on
 
   // Module op

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3478,4 +3478,26 @@ mlir::LogicalResult RotaryEmbeddingLlamaOp::verify() {
   return mlir::success();
 }
 
+//===----------------------------------------------------------------------===//
+    // LoadTensorOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult LoadTensorOp::verify() {
+  auto resultLayout =
+      mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
+  auto device = getDevice();
+
+  if (device && !resultLayout.isDeviceBufferType()) {
+    return emitOpError(
+        "device operand must be null for system memory buffer type");
+  }
+
+  if (!device && resultLayout.isDeviceBufferType()) {
+    return emitOpError(
+        "device operand must be specified for device memory buffer type");
+  }
+
+  return mlir::success();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3479,10 +3479,28 @@ mlir::LogicalResult RotaryEmbeddingLlamaOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-    // LoadTensorOp
+// DumpTensorOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult DumpTensorOp::verify() {
+  if (!getFilePath().ends_with(".tensorbin")) {
+    return emitOpError() << "file " << getFilePath()
+                         << " must end with .tensorbin extension";
+  }
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
+// LoadTensorOp
 //===----------------------------------------------------------------------===//
 
 ::mlir::LogicalResult LoadTensorOp::verify() {
+  if (!getFilePath().ends_with(".tensorbin")) {
+    return emitOpError() << "file " << getFilePath()
+                         << " must end with .tensorbin extension";
+  }
+
   auto resultLayout =
       mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
   auto device = getDevice();

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3364,4 +3364,41 @@ CaptureOrExecuteTraceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return issueErrorForGetOpRuntime(
       getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
 }
+
+//===----------------------------------------------------------------------===//
+// DumpTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+DumpTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+DumpTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// LoadTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+LoadTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+LoadTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
 } // namespace mlir::tt::ttnn

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -51,6 +51,7 @@
 #include "ttnn/operations/trace.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
+#include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -64,6 +64,8 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/argmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/prod.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_serialization/dump_tensor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_serialization/load_tensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/trace/begin_trace_capture.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/trace/capture_or_execute_trace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/trace/end_trace_capture.cpp

--- a/runtime/lib/ttnn/operations/tensor_serialization/dump_tensor.cpp
+++ b/runtime/lib/ttnn/operations/tensor_serialization/dump_tensor.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/tensor_serialization/dump_tensor.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::tensor_serialization {
+
+void run(const ::tt::target::ttnn::DumpTensorOp *op, ProgramContext &context) {
+  ::ttnn::Tensor input =
+      context.getTensorPool().getTTNNTensorAndValidate(op->in());
+  std::string filePath = op->file_path()->str();
+
+  ::tt::tt_metal::dump_tensor_flatbuffer(filePath, input);
+}
+
+} // namespace tt::runtime::ttnn::operations::tensor_serialization

--- a/runtime/lib/ttnn/operations/tensor_serialization/dump_tensor.h
+++ b/runtime/lib/ttnn/operations/tensor_serialization/dump_tensor.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_DUMP_TENSOR_H
+#define TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_DUMP_TENSOR_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/Target.h"
+
+namespace tt::runtime::ttnn::operations::tensor_serialization {
+
+void run(const ::tt::target::ttnn::DumpTensorOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::tensor_serialization
+
+#endif // TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_DUMP_TENSOR_H

--- a/runtime/lib/ttnn/operations/tensor_serialization/load_tensor.cpp
+++ b/runtime/lib/ttnn/operations/tensor_serialization/load_tensor.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/tensor_serialization/load_tensor.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::tensor_serialization {
+
+void run(const ::tt::target::ttnn::LoadTensorOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  std::string filePath = op->file_path()->str();
+  ::ttnn::MeshDevice *device =
+      op->device() ? context.getMeshDevicePtr().get() : nullptr;
+
+  ::ttnn::Tensor out = ::tt::tt_metal::load_tensor_flatbuffer(filePath, device);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+} // namespace tt::runtime::ttnn::operations::tensor_serialization

--- a/runtime/lib/ttnn/operations/tensor_serialization/load_tensor.h
+++ b/runtime/lib/ttnn/operations/tensor_serialization/load_tensor.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_LOAD_TENSOR_H
+#define TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_LOAD_TENSOR_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/Target.h"
+
+namespace tt::runtime::ttnn::operations::tensor_serialization {
+
+void run(const ::tt::target::ttnn::LoadTensorOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::tensor_serialization
+
+#endif // TT_RUNTIME_TTNN_OPERATIONS_TENSOR_SERIALIZATION_LOAD_TENSOR_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -61,6 +61,8 @@
 #include "operations/reduction/argmax.h"
 #include "operations/reduction/prod.h"
 #include "operations/reduction/reduction.h"
+#include "operations/tensor_serialization/dump_tensor.h"
+#include "operations/tensor_serialization/load_tensor.h"
 #include "operations/trace/begin_trace_capture.h"
 #include "operations/trace/capture_or_execute_trace.h"
 #include "operations/trace/end_trace_capture.h"
@@ -347,6 +349,14 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::BatchNormOp: {
     return operations::batch_norm::run(op->type_as_BatchNormOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::DumpTensorOp: {
+    return operations::tensor_serialization::run(op->type_as_DumpTensorOp(),
+                                                 getContext());
+  }
+  case ::tt::target::ttnn::OpType::LoadTensorOp: {
+    return operations::tensor_serialization::run(op->type_as_LoadTensorOp(),
+                                                 getContext());
   }
   case ::tt::target::ttnn::OpType::BeginTraceCaptureOp: {
     return operations::trace::run(op->type_as_BeginTraceCaptureOp(),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1186,6 +1186,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_RotaryEmbeddingLlamaOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::LoadTensorOp: {
+    tensorRef = opContext.type_as_LoadTensorOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::SortOp:
   case ::tt::target::ttnn::OpType::LoadCachedOp:
   case ::tt::target::ttnn::OpType::GetDeviceOp:
@@ -1194,7 +1198,8 @@ getOpOutputRef(OpContext opContextHandle,
   case ::tt::target::ttnn::OpType::WriteTensorOp:
   case ::tt::target::ttnn::OpType::EndTraceCaptureOp:
   case ::tt::target::ttnn::OpType::ExecuteTraceOp:
-  case ::tt::target::ttnn::OpType::CaptureOrExecuteTraceOp: {
+  case ::tt::target::ttnn::OpType::CaptureOrExecuteTraceOp:
+  case ::tt::target::ttnn::OpType::DumpTensorOp: {
     LOG_WARNING("getting output tensor is not supported for ",
                 ::tt::target::ttnn::EnumNamesOpType()[static_cast<size_t>(
                     opContext.type_type())]);
@@ -1509,6 +1514,13 @@ getOpInputRefs(OpContext opContextHandle,
                   opContext.type_as_RotaryEmbeddingLlamaOp()->cos_cache(),
                   opContext.type_as_RotaryEmbeddingLlamaOp()->sin_cache(),
                   opContext.type_as_RotaryEmbeddingLlamaOp()->trans_mat()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::DumpTensorOp: {
+    tensorRefs = {opContext.type_as_DumpTensorOp()->in()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::LoadTensorOp: {
     break;
   }
   case ::tt::target::ttnn::OpType::NONE: {

--- a/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
+// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_host = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #system_memory>>
+#ttnn_layout_device = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+module {
+  // Test dump and load operations with tensor on device.
+  func.func @dump_load_device_tensor(%arg0: tensor<32x32xf32, #ttnn_layout_device>) -> tensor<32x32xf32, #ttnn_layout_device> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    "ttnn.dump_tensor"(%arg0) <{file_path = "device_tensor.tensorbin"}> : (tensor<32x32xf32, #ttnn_layout_device>) -> ()
+    %loaded = "ttnn.load_tensor"(%device) <{file_path = "device_tensor.tensorbin"}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_device>
+    return %loaded : tensor<32x32xf32, #ttnn_layout_device>
+  }
+
+  // Test dump and load operations with tensor in system memory.
+  func.func @dump_load_system_tensor(%arg0: tensor<32x32xf32, #ttnn_layout_host>) -> tensor<32x32xf32, #ttnn_layout_host> {
+    "ttnn.dump_tensor"(%arg0) <{file_path = "system_tensor.tensorbin"}> : (tensor<32x32xf32, #ttnn_layout_host>) -> ()
+    %loaded = "ttnn.load_tensor"() <{file_path = "system_tensor.tensorbin"}> : () -> tensor<32x32xf32, #ttnn_layout_host>
+    return %loaded : tensor<32x32xf32, #ttnn_layout_host>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/tensor_serialization/dump_load.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/tensor_serialization/dump_load.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_host = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #system_memory>>
+#ttnn_layout_device = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+// This is a sanity check test that calls to `ttnn.dump_tensor` and `ttnn.load_tensor` are executed successfully.
+// Verification of semantics is done in @runtime/test/ttnn/gtest/test_tensor_serialization.cpp.
+module {
+  // Test dump and load operations with tensor on device.
+  func.func @dump_load_device_tensor(%arg0: tensor<32x32xf32, #ttnn_layout_device>) -> tensor<32x32xf32, #ttnn_layout_device> {
+    %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    "ttnn.dump_tensor"(%arg0) <{file_path = "device_tensor.tensorbin"}> : (tensor<32x32xf32, #ttnn_layout_device>) -> ()
+    %loaded = "ttnn.load_tensor"(%device) <{file_path = "device_tensor.tensorbin"}> : (!ttnn.device) -> tensor<32x32xf32, #ttnn_layout_device>
+    return %loaded : tensor<32x32xf32, #ttnn_layout_device>
+  }
+
+  // Test dump and load operations with tensor in system memory.
+  func.func @dump_load_system_tensor(%arg0: tensor<32x32xf32, #ttnn_layout_host>) -> tensor<32x32xf32, #ttnn_layout_host> {
+    "ttnn.dump_tensor"(%arg0) <{file_path = "system_tensor.tensorbin"}> : (tensor<32x32xf32, #ttnn_layout_host>) -> ()
+    %loaded = "ttnn.load_tensor"() <{file_path = "system_tensor.tensorbin"}> : () -> tensor<32x32xf32, #ttnn_layout_host>
+    return %loaded : tensor<32x32xf32, #ttnn_layout_host>
+  }
+}

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -38,6 +38,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/trace.hpp"
+#include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -38,6 +38,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/trace.hpp"
+#include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -44,6 +44,7 @@
 #include "ttnn/device.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp"
+#include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4965

### Problem description
https://github.com/tenstorrent/tt-mlir/pull/4909 has added a runtime support for these operations, but we need to model it on the TTNN dialect level. We have a use case for `load_tensor` in codegen paths.

### What's changed
Added support for these ops on the dialect level. In the runtime, I've added an implementation for ops execution that's unrelated to https://github.com/tenstorrent/tt-mlir/pull/4909, since these are pretty much direct calls to the `tt-metal` APIs.

### Checklist
- [x] New/Existing tests provide coverage for changes
