### PR TITLE
Add a ttnn-requirements.txt deps file for python TTNN lib

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -5,6 +5,6 @@
 
 # Calculate hash from the following files. This hash is used to tag the docker images.
 # Any change in these files will result in a new docker image build
-DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/patches/shardy.patch env/patches/llvm.patch env/patches/shardy_mpmd_pybinds.patch test/python/requirements.txt"
+DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/ttnn-requirements.txt env/patches/shardy.patch env/patches/llvm.patch env/patches/shardy_mpmd_pybinds.patch test/python/requirements.txt"
 DOCKERFILE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES | sha256sum | cut -d ' ' -f 1)
 echo dt-$DOCKERFILE_HASH

--- a/env/init_venv.sh
+++ b/env/init_venv.sh
@@ -28,4 +28,5 @@ fi
 python -m pip install --upgrade pip
 # Requirements for third party projects are installed during their build in `CMakeLists.txt`
 pip install -r $ENV_DIR/build-requirements.txt
+pip install -r $ENV_DIR/ttnn-requirements.txt
 pip install -r $ENV_DIR/../test/python/requirements.txt

--- a/env/ttnn-requirements.txt
+++ b/env/ttnn-requirements.txt
@@ -1,0 +1,6 @@
+# Packages needed to run TT-NN Python lib (i.e. `import ttnn`)
+
+graphviz
+loguru
+pandas
+seaborn


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/4987

### Problem description
Python codegen'd models would fail due to couple missing python libs, needed by TTNN pylib.

### What's changed
Added a `ttnn-requirements.txt` to venv. All missing packages (4) were added here.

To add these packages to the current env, one can run:
```
cmake --build env/build --verbose -- python-venv
```
> [!NOTE]  
> This was failing for me due to ownership issues, as I was using the ird mlir docker that comes with prebuilt toolchain. To change owner from `root` to your own alias, you can run `sudo chown -R $USER /opt/ttmlir-toolchain`.

@tenstorrent/forge-developers-mlir-devops I've added this new file to docker hash file list. This is a small change to the python env and shouldn't affect anyone's workflow today as they wouldn't be using these packages yet. Is there any follow-up that needs to happen on my side?

### Checklist
- [ ] New/Existing tests provide coverage for changes
