### PR TITLE
Reinstate sentinel exceptions in builder

### DIFF
--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -337,18 +337,18 @@ def pytest_runtest_call(item: pytest.Item):
     Runtime report data includes:
     - failure_stage: Categorizes where in the compilation pipeline the test failed
       - "success": Test passed completely
-      - "compile": Failed during TTIR compilation (`TTIRCompileException`)
-      - "runtime": Failed during execution (`TTIRRuntimeException`)
-      - "golden": Failed golden result verification (`TTIRGoldenException`)
+      - "compile": Failed during TTBuilder compilation (`TTBuilderCompileException`)
+      - "runtime": Failed during execution (`TTBuilderRuntimeException`)
+      - "golden": Failed golden result verification (`TTBuilderGoldenException`)
     The "runtime" and "golden" are currently unused, but are needed for
     downstream schemas to support future features once pytest itself
     orchestrates the running of the generated flatbuffers
     """
 
-    TTIR_EXCEPTIONS = {
-        "TTIRCompileException": "compile",
-        "TTIRRuntimeException": "runtime",
-        "TTIRGoldenException": "golden",
+    TTBUILDER_EXCEPTIONS = {
+        "TTBuilderCompileException": "compile",
+        "TTBuilderRuntimeException": "runtime",
+        "TTBuilderGoldenException": "golden",
     }
 
     failure_stage = "success"  # Default to success.
@@ -359,7 +359,12 @@ def pytest_runtest_call(item: pytest.Item):
     except Exception as exc:
         exc_type = type(exc)
         exc_name = exc_type.__name__
-        failure_stage = TTIR_EXCEPTIONS.get(exc_name, "unknown")
+        try:
+            failure_stage = TTBUILDER_EXCEPTIONS[exc_name]
+        except KeyError as e:
+            pytest.fail(
+                f"Unknown failure detected! Please address this or correctly throw a `TTBuilder*` exception instead if this is a compilation issue, runtime error, or golden mismatch. Exception: {e}:{type(e)}"
+            )
     finally:
         _safe_add_property(item, "failure_stage", failure_stage)
 


### PR DESCRIPTION
There are a group of exception classes in builder utils to mark certain failure stages of tests that are needed for proper test reports. These have been reinstated to reraise any compilation errors that occur as these exceptions, so the test reported can pick up on them

### Problem description
A previous change removed these exceptions, breaking failure stage reporting

### What's changed
Exceptions have been re-added