### PR TITLE
[skip ci] Remove all mentions of separate ttrt build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@
 - **Environment**: `source env/activate` (activate virtual environment first)
 - **Configure**: `cmake -G Ninja -B build -DCMAKE_CXX_COMPILER_LAUNCHER=ccache`
 - **Build**: `cmake --build build`
-- **Build ttrt**: `cmake --build build --target ttrt`
 - **Lint**: `pre-commit run --all-files` (includes clang-format, black, copyright checks)
 - **Compiler tests**: `cmake --build build --target check-ttmlir`
 - **Single MLIR test**: `llvm-lit test/ttmlir/path/to/test.mlir`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,7 @@ targets tt-metal.
   command before running any other commands.
 - `cmake -G Ninja -B build -DCMAKE_CXX_COMPILER_LAUNCHER=ccache`: Configures the
   project using CMake.
-- `cmake --build build`: Builds the project using CMake.
-- `cmake --build build --target ttrt`: Builds ttrt tool and installs it into venv
-  using CMake.
+- `cmake --build build`: Builds and installs the project into venv using CMake.
 - `ttrt query --save-artifacts`: Runs ttrt to query and save a system descriptor
   to location `ttrt-artifacts/system_desc.ttsys`.  Required before running
   python tests.

--- a/docs/src/builder/stablehlo-builder.md
+++ b/docs/src/builder/stablehlo-builder.md
@@ -305,10 +305,10 @@ builder.set_graph_input_output([input_0], [output_0], override=True)
 
 ### Running flatbuffer with golden data in ttrt
 
-Running flatbuffers in `ttrt` requires additional building and setting up the environment. Run these commands before creating MLIR modules or flatbuffers so the system description in the flatbuffers match your device.
+Running flatbuffers in `ttrt` requires building and setting up the environment. Run these commands before creating MLIR modules or flatbuffers so the system description in the flatbuffers match your device.
 
 ```bash
-cmake --build build -- ttrt
+cmake --build build
 ttrt query --save-artifacts
 export SYSTEM_DESC_PATH=/path/to/system_desc.ttsys
 ```

--- a/docs/src/builder/ttir-builder.md
+++ b/docs/src/builder/ttir-builder.md
@@ -616,10 +616,10 @@ builder.set_graph_input_output([input_0], [output_0], override=True)
 
 ### Running flatbuffer with golden data in ttrt
 
-Running flatbuffers in `ttrt` requires additional building and setting up the environment. Run these commands before creating MLIR modules or flatbuffers so the system description in the flatbuffers match your device.
+Running flatbuffers in `ttrt` requires building and setting up the environment. Run these commands before creating MLIR modules or flatbuffers so the system description in the flatbuffers match your device.
 
 ```bash
-cmake --build build -- ttrt
+cmake --build build
 ttrt query --save-artifacts
 export SYSTEM_DESC_PATH=/path/to/system_desc.ttsys
 ```

--- a/runtime/test/ttnn/python/conftest.py
+++ b/runtime/test/ttnn/python/conftest.py
@@ -5,7 +5,7 @@ try:
     import ttrt
 except (ImportError, ModuleNotFoundError):
     raise ImportError(
-        "Error: runtime python tests require ttrt to built and installed. Please run `cmake --build build -- ttrt`"
+        "Error: runtime python tests require ttrt to built and installed. Please run `cmake --build build`"
     )
 import ttrt.runtime
 from ttrt.common.api import API

--- a/tools/ttrt/README.md
+++ b/tools/ttrt/README.md
@@ -5,7 +5,7 @@ This tool is intended to be a swiss army knife for working with flatbuffers gene
 ## Building
 ```bash
 source env/activate
-cmake --build build -- ttrt
+cmake --build build
 ttrt --help
 ```
 


### PR DESCRIPTION
### Problem description
Bots are still doing `cmake --build build -- ttrt`.

### What's changed
Remove all mentions of this build target.