### PR TITLE
D2M: use SFPU for add/sub/mul

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -85,10 +85,10 @@ class TTIR_GenericRegionDatamovementOp<string mnemonic, list<Trait> traits = []>
 // TTIR Generic Region Math Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-def TTIR_TileAddOp : TTIR_GenericRegionComputeOp<"tile_add"> {
+def TTIR_TileAddOp : TTIR_GenericRegionComputeBinaryDstOp<"tile_add"> {
     let summary = "TTIR Tile Add Op";
     let description = [{
-        The `tile_add` operation adds two tiles element-wise.
+        The `tile_add` operation adds two tiles element-wise on the SFPU.
     }];
 
     let arguments = (ins TTCore_Tile:$lhs,
@@ -96,10 +96,10 @@ def TTIR_TileAddOp : TTIR_GenericRegionComputeOp<"tile_add"> {
     let results = (outs TTCore_Tile:$result);
 }
 
-def TTIR_TileSubOp : TTIR_GenericRegionComputeOp<"tile_sub"> {
+def TTIR_TileSubOp : TTIR_GenericRegionComputeBinaryDstOp<"tile_sub"> {
     let summary = "TTIR Tile Sub Op";
     let description = [{
-        The `tile_sub` operation subtracts two tiles element-wise.
+        The `tile_sub` operation subtracts two tiles element-wise on the SFPU.
     }];
 
     let arguments = (ins TTCore_Tile:$lhs,
@@ -107,10 +107,10 @@ def TTIR_TileSubOp : TTIR_GenericRegionComputeOp<"tile_sub"> {
     let results = (outs TTCore_Tile:$result);
 }
 
-def TTIR_TileMulOp : TTIR_GenericRegionComputeOp<"tile_mul"> {
+def TTIR_TileMulOp : TTIR_GenericRegionComputeBinaryDstOp<"tile_mul"> {
     let summary = "TTIR Tile Mul Op";
     let description = [{
-        The `tile_mul` operation multiplies two tiles element-wise.
+        The `tile_mul` operation multiplies two tiles element-wise on the SFPU.
     }];
 
     let arguments = (ins TTCore_Tile:$lhs,
@@ -287,17 +287,6 @@ def TTIR_TileLogicalNotOp : TTIR_GenericRegionComputeUnaryDstOp<"tile_logical_no
     }];
 
     let arguments = (ins TTCore_Tile:$input);
-    let results = (outs TTCore_Tile:$result);
-}
-
-def TTIR_TileSubBinaryOp : TTIR_GenericRegionComputeBinaryDstOp<"tile_sub_binary"> {
-    let summary = "TTIR Tile Subtract Binary Op";
-    let description = [{
-        The `tile_sub_binary` operation uses the SFPU to subtract two tiles element-wise.
-    }];
-
-    let arguments = (ins TTCore_Tile:$lhs,
-                         TTCore_Tile:$rhs);
     let results = (outs TTCore_Tile:$result);
 }
 

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -22,7 +22,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 
-#include <algorithm>
 #include <array>
 
 namespace mlir::tt {
@@ -321,7 +320,7 @@ private:
 
               if constexpr (isComparisonOp) {
                 // For comparison ops, first subtract then compare with zero
-                mlir::Value subResult = bbBuilder.create<ttir::TileSubBinaryOp>(
+                mlir::Value subResult = bbBuilder.create<ttir::TileSubOp>(
                     loc, /*resultTypes=*/bbArgs.take_back(numOutputs),
                     /*operands=*/bbArgs.take_front(numInputs));
                 yield = bbBuilder.create<TileOp>(

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -15,12 +15,11 @@
 #include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include <type_traits>
 
+#include <type_traits>
 #include <utility>
 
 namespace mlir::tt::ttkernel {
@@ -142,7 +141,8 @@ static Value getCB(ConversionPatternRewriter &rewriter, Value cb) {
   llvm_unreachable("Expected load or subview op");
 }
 
-static Value getDstIdxFromResult(Value ttirOpResult) {
+static Value getDstIdxFromResult(Value ttirOpResult,
+                                 PatternRewriter &rewriter) {
   memref::StoreOp storeOp;
   for (Operation *op : ttirOpResult.getUsers()) {
     auto maybeStore = mlir::dyn_cast<memref::StoreOp>(op);
@@ -155,7 +155,29 @@ static Value getDstIdxFromResult(Value ttirOpResult) {
   assert(storeOp && "Expected store op.");
   assert(storeOp.getIndices().size() == 1 &&
          "Expected single index in store op");
-  return storeOp.getIndices().front();
+
+  Value dstIndex = storeOp.getIndices().front();
+
+  // The DST index could be defined by an operation that comes after the current
+  // operation (e.g. loop variables), we need to move the index to before the
+  // current operation to ensure proper SSA ordering.
+  if (Operation *idxDefOp = dstIndex.getDefiningOp()) {
+    // If defined in the same block, check ordering.
+    Block *currentBlock = rewriter.getInsertionBlock();
+    if (currentBlock == idxDefOp->getBlock()) {
+      auto insertionPoint = rewriter.getInsertionPoint();
+
+      // Move if the definition comes after the insertion point.
+      for (auto it = insertionPoint; it != currentBlock->end(); it++) {
+        if (&(*it) == idxDefOp) {
+          rewriter.moveOpBefore(idxDefOp, ttirOpResult.getDefiningOp());
+          break;
+        }
+      }
+    }
+  }
+
+  return dstIndex;
 }
 
 // This is a workaround special case for getting an in/out CB. This whole
@@ -310,12 +332,9 @@ struct OpMap {};
 
 // clang-format off
 using ComputeOpMap = OpMap<
-  // Elementwise FPU.
-  std::pair<ttir::TileAddOp,         std::pair<ttkernel::AddTilesInitOp,            ttkernel::AddTilesOp>>,
+  // FPU.
   std::pair<ttir::TileMatmulOp,      std::pair<ttkernel::MatmulInitOp,              ttkernel::MatmulTilesOp>>,
   std::pair<ttir::TileMatmulBlockOp, std::pair<ttkernel::MatmulBlockInitOp,         ttkernel::ExperimentalMatmulBlockOp>>,
-  std::pair<ttir::TileMulOp,         std::pair<ttkernel::MulTilesInitOp,            ttkernel::MulTilesOp>>,
-  std::pair<ttir::TileSubOp,         std::pair<ttkernel::SubTilesInitOp,            ttkernel::SubTilesOp>>,
 
   // Elementwise SFPU Unary.
   std::pair<ttir::TileAbsOp,         std::pair<ttkernel::AbsTileInitOp,             ttkernel::AbsTileOp>>,
@@ -341,10 +360,12 @@ using ComputeOpMap = OpMap<
   std::pair<ttir::TileLezOp,         std::pair<ttkernel::LezTileInitOp,             ttkernel::LezTileOp>>,
 
   // Elementwise SFPU Binary.
-  std::pair<ttir::TileSubBinaryOp,   std::pair<ttkernel::SubBinaryTilesInitOp,      ttkernel::SubBinaryTilesOp>>,
+  std::pair<ttir::TileAddOp,         std::pair<ttkernel::AddBinaryTilesInitOp,      ttkernel::AddBinaryTilesOp>>,
   std::pair<ttir::TileDivOp,         std::pair<ttkernel::DivBinaryTilesInitOp,      ttkernel::DivBinaryTilesOp>>,
   std::pair<ttir::TileMaximumOp,     std::pair<ttkernel::MaxTilesInitOp,            ttkernel::MaxTilesOp>>,
-  std::pair<ttir::TilePowOp,         std::pair<ttkernel::PowBinaryTilesInitOp,      ttkernel::PowBinaryTilesOp>>
+  std::pair<ttir::TileMulOp,         std::pair<ttkernel::MulBinaryTilesInitOp,      ttkernel::MulBinaryTilesOp>>,
+  std::pair<ttir::TilePowOp,         std::pair<ttkernel::PowBinaryTilesInitOp,      ttkernel::PowBinaryTilesOp>>,
+  std::pair<ttir::TileSubOp,         std::pair<ttkernel::SubBinaryTilesInitOp,      ttkernel::SubBinaryTilesOp>>
 >;
 // clang-format on
 
@@ -480,14 +501,6 @@ public:
       tryEraseDeadCBReinterpret(op.getA());
       tryEraseDeadCBReinterpret(op.getB());
       tryEraseDeadCBReinterpret(op.getOutput());
-
-    } else if constexpr (arity == 2) {
-      auto dstIdx = getDstIdxFromResult(op.getResult());
-      rewriter.create<InitOp>(op->getLoc(), getCB(rewriter, op.getLhs()),
-                              getCB(rewriter, op.getRhs()));
-      rewriter.create<FPUOp>(op->getLoc(), getCB(rewriter, op.getLhs()),
-                             getCB(rewriter, op.getRhs()), adaptor.getLhs(),
-                             adaptor.getRhs(), dstIdx);
     } else {
       return llvm::failure();
     }
@@ -524,12 +537,7 @@ public:
     auto inCB = getInCB(rewriter, op);
     auto outCB = getOutCB(rewriter, op);
     setInsertionPointAfterOperands(rewriter, {inCB, outCB});
-    // Don't init_sfpu for tile sub binary op because it's only used in
-    // conjuction with a comparison op that calls init_sfpu and we only need one
-    // per compute kernel.
-    if constexpr (!std::is_same_v<ConcreteOp, ttir::TileSubBinaryOp>) {
-      rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), inCB, outCB);
-    }
+    rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), inCB, outCB);
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
     rewriter.create<InitOp>(op->getLoc());
@@ -614,7 +622,7 @@ public:
     } else if constexpr (std::is_same_v<SFPUOp, ttkernel::MaxTilesOp>) {
       rewriter.create<SFPUOp>(op->getLoc(), adaptor.getLhs(), adaptor.getRhs());
     } else {
-      const auto dstIdx = getDstIdxFromResult(op.getResult());
+      const auto dstIdx = getDstIdxFromResult(op.getResult(), rewriter);
       rewriter.create<SFPUOp>(op->getLoc(), adaptor.getLhs(), adaptor.getRhs(),
                               dstIdx);
     }
@@ -717,7 +725,7 @@ public:
     Value tileIndex = adaptor.getInput();
 
     // Get the destination index where the result will be stored.
-    Value dstIdx = getDstIdxFromResult(op.getResult());
+    Value dstIdx = getDstIdxFromResult(op.getResult(), rewriter);
 
     rewriter.create<ttkernel::TransposeTileOp>(op->getLoc(), inCB, tileIndex,
                                                dstIdx);
@@ -1373,12 +1381,9 @@ void populateTTIRToTTKernelPatterns(
   // clang-format off
   patterns.add<ttkernel::TTIRKernelFunctionArgsRewriter,
 
-               // Elementwise FPU.
-               ttkernel::TTIRFPUOpsRewriter<ttir::TileAddOp>,
+               // FPU.
                ttkernel::TTIRFPUOpsRewriter<ttir::TileMatmulOp>,
                ttkernel::TTIRFPUOpsRewriter<ttir::TileMatmulBlockOp>,
-               ttkernel::TTIRFPUOpsRewriter<ttir::TileMulOp>,
-               ttkernel::TTIRFPUOpsRewriter<ttir::TileSubOp>,
 
                // Elementwise SFPU Unary.
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileAbsOp>,
@@ -1404,10 +1409,12 @@ void populateTTIRToTTKernelPatterns(
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileLezOp>,
 
                // Elementwise SFPU Binary.
-               ttkernel::TTIRSFPUOpsRewriter<ttir::TileSubBinaryOp>,
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TileAddOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileDivOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TileMaximumOp>,
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TileMulOp>,
                ttkernel::TTIRSFPUOpsRewriter<ttir::TilePowOp>,
+               ttkernel::TTIRSFPUOpsRewriter<ttir::TileSubOp>,
 
                ttkernel::TTIRTilizeUntilizeRewriter,
                ttkernel::TTIRTileTransposeRewriter,

--- a/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
@@ -14,7 +14,7 @@ module {
     // named elementwise op, binary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_add
+    // CHECK: "ttir.tile_add"(%{{.*}}, %{{.*}})
     %0 = "ttir.add"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, unary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
@@ -24,7 +24,7 @@ module {
     // named elementwise op, binary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_mul
+    // CHECK: "ttir.tile_mul"(%{{.*}}, %{{.*}})
     %2 = "ttir.multiply"(%0, %1, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, unary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
@@ -44,7 +44,7 @@ module {
     // named elementwise op, binary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     %6 = "ttir.subtract"(%4, %5, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, unary:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
@@ -109,37 +109,37 @@ module {
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_eqz
     %19 = "ttir.eq"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_nez
     %20 = "ttir.ne"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_ltz
     %21 = "ttir.lt"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_lez
     %22 = "ttir.le"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_gtz
     %23 = "ttir.gt"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, binary comparison:
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel]
     // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
-    // CHECK: ttir.tile_sub_binary
+    // CHECK: "ttir.tile_sub"(%{{.*}}, %{{.*}})
     // CHECK: ttir.tile_gez
     %24 = "ttir.ge"(%lhs, %rhs, %out) : (!ttype, !ttype, !ttype) -> !ttype
     // named elementwise op, unary:

--- a/test/ttmlir/Conversion/TTIRToTTKernel/get_dst_idx.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/get_dst_idx.mlir
@@ -1,0 +1,139 @@
+// RUN: ttmlir-opt --ttcore-register-device --convert-ttir-to-ttkernel %s | FileCheck %s
+
+#l1_ = #ttcore.memory_space<l1>
+#dst_ = #ttcore.memory_space<dst>
+
+module {
+  // CHECK-LABEL: func.func @test_get_dst_idx_2x2
+  func.func @test_get_dst_idx_2x2(%arg0: memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    ttir.await %arg0, %arg1 : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>)
+    %collapse_shape = memref.collapse_shape %arg0 [[0, 1]] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_> into memref<4x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_0 = memref.collapse_shape %arg1 [[0, 1]] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_> into memref<4x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_1 = memref.collapse_shape %arg2 [[0, 1]] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_> into memref<4x!ttcore.tile<32x32, f32>, #l1_>
+    %dst = ttir.acquire_dst() : memref<2x2x2x!ttcore.tile<32x32, f32>, #dst_>
+    %collapse_shape_2 = memref.collapse_shape %dst [[0, 1, 2]] : memref<2x2x2x!ttcore.tile<32x32, f32>, #dst_> into memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = arith.muli %arg3, %c2 overflow<nsw> : index
+      scf.for %arg4 = %c0 to %c2 step %c1 {
+        %1 = arith.addi %0, %arg4 : index
+        %2 = memref.load %collapse_shape[%1] : memref<4x!ttcore.tile<32x32, f32>, #l1_>
+        memref.store %2, %collapse_shape_2[%1] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+        %3 = memref.load %collapse_shape_0[%1] : memref<4x!ttcore.tile<32x32, f32>, #l1_>
+        %4 = arith.addi %1, %c4 : index
+        memref.store %3, %collapse_shape_2[%4] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      }
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = arith.muli %arg3, %c2 overflow<nsw> : index
+      scf.for %arg4 = %c0 to %c2 step %c1 {
+        %1 = arith.addi %0, %arg4 : index
+        %2 = memref.load %collapse_shape_2[%1] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+        %3 = arith.addi %1, %c4 : index
+        %4 = memref.load %collapse_shape_2[%3] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+        // CHECK: ttkernel.div_binary_tile_init
+        // CHECK-NEXT: %[[DST_IDX:.*]] = arith{{.*}} : index
+        // CHECK-NEXT: ttkernel.div_binary_tile(%{{.*}}, %{{.*}}, %[[DST_IDX]])
+        %5 = "ttir.tile_div"(%2, %4) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        %6 = arith.addi %1, %c8 : index
+        memref.store %5, %collapse_shape_2[%6] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      }
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = arith.muli %arg3, %c2 overflow<nsw> : index
+      scf.for %arg4 = %c0 to %c2 step %c1 {
+        %1 = arith.addi %0, %arg4 : index
+        %2 = arith.addi %1, %c8 : index
+        %3 = memref.load %collapse_shape_2[%2] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+        memref.store %3, %collapse_shape_1[%1] : memref<4x!ttcore.tile<32x32, f32>, #l1_>
+      }
+    }
+    ttir.yield %arg2 : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>)
+    ttir.await %arg2 : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>)
+    return
+  }
+
+  // CHECK-LABEL: func.func @test_get_dst_idx_2x1
+  func.func @test_get_dst_idx_2x1(%arg0: memref<2x1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<2x1x!ttcore.tile<32x32, f32>, #l1_>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    ttir.await %arg0, %arg1 : (memref<2x1x!ttcore.tile<32x32, f32>, #l1_>, memref<2x1x!ttcore.tile<32x32, f32>, #l1_>)
+    %collapse_shape = memref.collapse_shape %arg0 [[0, 1]] : memref<2x1x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_0 = memref.collapse_shape %arg1 [[0, 1]] : memref<2x1x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_1 = memref.collapse_shape %arg2 [[0, 1]] : memref<2x1x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %dst = ttir.acquire_dst() : memref<4x2x1x!ttcore.tile<32x32, f32>, #dst_>
+    %collapse_shape_2 = memref.collapse_shape %dst [[0, 1, 2]] : memref<4x2x1x!ttcore.tile<32x32, f32>, #dst_> into memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = memref.load %collapse_shape[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+      memref.store %0, %collapse_shape_2[%arg3] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      %1 = memref.load %collapse_shape_0[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = arith.addi %arg3, %c2 : index
+      memref.store %1, %collapse_shape_2[%2] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = memref.load %collapse_shape_2[%arg3] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      %1 = arith.addi %arg3, %c2 : index
+      %2 = memref.load %collapse_shape_2[%1] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      // CHECK: ttkernel.div_binary_tile_init
+      // CHECK-NEXT: %[[DST_IDX:.*]] = arith{{.*}} : index
+      // CHECK-NEXT: ttkernel.div_binary_tile(%{{.*}}, %{{.*}}, %[[DST_IDX]])
+      %3 = "ttir.tile_div"(%0, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+      %4 = arith.addi %arg3, %c4 : index
+      memref.store %3, %collapse_shape_2[%4] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = arith.addi %arg3, %c4 : index
+      %1 = memref.load %collapse_shape_2[%0] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      memref.store %1, %collapse_shape_1[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    }
+    ttir.yield %arg2 : (memref<2x1x!ttcore.tile<32x32, f32>, #l1_>)
+    ttir.await %arg2 : (memref<2x1x!ttcore.tile<32x32, f32>, #l1_>)
+    return
+  }
+
+  // CHECK-LABEL: func.func @test_get_dst_idx_1x2
+  func.func @test_get_dst_idx_1x2(%arg0: memref<1x2x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x2x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x2x!ttcore.tile<32x32, f32>, #l1_>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    ttir.await %arg0, %arg1 : (memref<1x2x!ttcore.tile<32x32, f32>, #l1_>, memref<1x2x!ttcore.tile<32x32, f32>, #l1_>)
+    %collapse_shape = memref.collapse_shape %arg0 [[0, 1]] : memref<1x2x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_0 = memref.collapse_shape %arg1 [[0, 1]] : memref<1x2x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %collapse_shape_1 = memref.collapse_shape %arg2 [[0, 1]] : memref<1x2x!ttcore.tile<32x32, f32>, #l1_> into memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    %dst = ttir.acquire_dst() : memref<4x1x2x!ttcore.tile<32x32, f32>, #dst_>
+    %collapse_shape_2 = memref.collapse_shape %dst [[0, 1, 2]] : memref<4x1x2x!ttcore.tile<32x32, f32>, #dst_> into memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = memref.load %collapse_shape[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+      memref.store %0, %collapse_shape_2[%arg3] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      %1 = memref.load %collapse_shape_0[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = arith.addi %arg3, %c2 : index
+      memref.store %1, %collapse_shape_2[%2] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = memref.load %collapse_shape_2[%arg3] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      %1 = arith.addi %arg3, %c2 : index
+      %2 = memref.load %collapse_shape_2[%1] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      // CHECK: ttkernel.div_binary_tile_init
+      // CHECK-NEXT: %[[DST_IDX:.*]] = arith{{.*}} : index
+      // CHECK-NEXT: ttkernel.div_binary_tile(%{{.*}}, %{{.*}}, %[[DST_IDX]])
+      %3 = "ttir.tile_div"(%0, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+      %4 = arith.addi %arg3, %c4 : index
+      memref.store %3, %collapse_shape_2[%4] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+    }
+    scf.for %arg3 = %c0 to %c2 step %c1 {
+      %0 = arith.addi %arg3, %c4 : index
+      %1 = memref.load %collapse_shape_2[%0] : memref<8x!ttcore.tile<32x32, f32>, #dst_>
+      memref.store %1, %collapse_shape_1[%arg3] : memref<2x!ttcore.tile<32x32, f32>, #l1_>
+    }
+    ttir.yield %arg2 : (memref<1x2x!ttcore.tile<32x32, f32>, #l1_>)
+    ttir.await %arg2 : (memref<1x2x!ttcore.tile<32x32, f32>, #l1_>)
+    return
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTKernel/single_tile_ops.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/single_tile_ops.mlir
@@ -30,9 +30,9 @@ module {
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     // CHECK-NOT: ttir.tile_add
-    // CHECK: ttkernel.binary_op_init_common
-    // CHECK: ttkernel.add_tiles_init
-    // CHECK: ttkernel.add_tiles
+    // CHECK: ttkernel.init_sfpu
+    // CHECK: ttkernel.add_binary_tile_init
+    // CHECK: ttkernel.add_binary_tile
     %2 = "ttir.tile_add"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -45,9 +45,9 @@ module {
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     // CHECK-NOT: ttir.tile_sub
-    // CHECK: ttkernel.binary_op_init_common
-    // CHECK: ttkernel.sub_tiles_init
-    // CHECK: ttkernel.sub_tiles
+    // CHECK: ttkernel.init_sfpu
+    // CHECK: ttkernel.sub_binary_tile_init
+    // CHECK: ttkernel.sub_binary_tile
     %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -60,9 +60,9 @@ module {
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     // CHECK-NOT: ttir.tile_mul
-    // CHECK: ttkernel.binary_op_init_common
-    // CHECK: ttkernel.mul_tiles_init
-    // CHECK: ttkernel.mul_tiles
+    // CHECK: ttkernel.init_sfpu
+    // CHECK: ttkernel.mul_binary_tile_init
+    // CHECK: ttkernel.mul_binary_tile
     %2 = "ttir.tile_mul"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -446,14 +446,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_eqz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.eqz_tile_init
     // CHECK: ttkernel.eqz_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_eqz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -465,14 +465,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_nez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.nez_tile_init
     // CHECK: ttkernel.nez_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_nez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -484,14 +484,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_gtz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.gtz_tile_init
     // CHECK: ttkernel.gtz_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_gtz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -503,14 +503,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_gez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.gez_tile_init
     // CHECK: ttkernel.gez_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_gez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -522,14 +522,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_ltz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.ltz_tile_init
     // CHECK: ttkernel.ltz_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_ltz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -541,14 +541,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_lez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.lez_tile_init
     // CHECK: ttkernel.lez_tile
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     %3 = "ttir.tile_lez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
@@ -564,14 +564,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_eqz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.eqz_tile_init
     // CHECK: ttkernel.eqz_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_eqz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
@@ -583,14 +583,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_nez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.nez_tile_init
     // CHECK: ttkernel.nez_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_nez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
@@ -602,14 +602,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_gtz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.gtz_tile_init
     // CHECK: ttkernel.gtz_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_gtz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
@@ -621,14 +621,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_gez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.gez_tile_init
     // CHECK: ttkernel.gez_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_gez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
@@ -640,14 +640,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_ltz
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.ltz_tile_init
     // CHECK: ttkernel.ltz_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_ltz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
@@ -659,14 +659,14 @@ module {
     %c0 = arith.constant 0 : index
     %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
     %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: ttir.tile_sub_binary
+    // CHECK-NOT: ttir.tile_sub
     // CHECK-NOT: ttir.tile_lez
     // CHECK: ttkernel.init_sfpu
     // CHECK: ttkernel.sub_binary_tile_init
     // CHECK: ttkernel.sub_binary_tile
     // CHECK: ttkernel.lez_tile_init
     // CHECK: ttkernel.lez_tile_int32
-    %2 = "ttir.tile_sub_binary"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+    %2 = "ttir.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     %3 = "ttir.tile_lez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
     // CHECK: ttkernel.pack_tile
     affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>

--- a/test/ttmlir/Dialect/TTIR/Transforms/insert_dst_register_access_intermediate_results_thru_dst_in_place_intermediate.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/insert_dst_register_access_intermediate_results_thru_dst_in_place_intermediate.mlir
@@ -48,8 +48,8 @@ module {
           %subview_16 = memref.subview %cb2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #ttcore.memory_space<l1>>
           linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_15 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #ttcore.memory_space<l1>>) outs(%subview_16 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #ttcore.memory_space<l1>>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %in_17: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
-            %0 = "ttir.tile_sub_binary"(%in, %in_17) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-            // CHECK: %[[SUB_RESULT:.*]] = "ttir.tile_sub_binary"(%[[DST0_VAL:.*]], %[[DST1_VAL:.*]]) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %0 = "ttir.tile_sub"(%in, %in_17) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            // CHECK: %[[SUB_RESULT:.*]] = "ttir.tile_sub"(%[[DST0_VAL:.*]], %[[DST1_VAL:.*]]) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             // CHECK: affine.store %[[SUB_RESULT]], %[[DST:.*]][2, 0, 0] : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
             // CHECK: %[[DST_SUB:.*]] = affine.load %[[DST]][2, 0, 0] : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
             %1 = "ttir.tile_eqz"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_eltwise.mlir
@@ -3,27 +3,27 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>
-  // CHECK: emitc.call_opaque "binary_op_init_common"
-  // CHECK: emitc.call_opaque "mul_tiles_init"
-  // CHECK-NEXT: emitc.call_opaque "mul_tiles"
+  // CHECK: emitc.call_opaque "init_sfpu"
+  // CHECK: emitc.call_opaque "mul_binary_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "mul_binary_tile"
   %1 = "ttir.multiply"(%arg0, %arg1, %0) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
 
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>
-  // CHECK: emitc.call_opaque "binary_op_init_common"
-  // CHECK: emitc.call_opaque "add_tiles_init"
-  // CHECK-NEXT: emitc.call_opaque "add_tiles"
+  // CHECK: emitc.call_opaque "init_sfpu"
+  // CHECK: emitc.call_opaque "add_binary_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "add_binary_tile"
   %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
 
 func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>
-  // CHECK: emitc.call_opaque "binary_op_init_common"
-  // CHECK: emitc.call_opaque "sub_tiles_init"
-  // CHECK-NEXT: emitc.call_opaque "sub_tiles"
+  // CHECK: emitc.call_opaque "init_sfpu"
+  // CHECK: emitc.call_opaque "sub_binary_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "sub_binary_tile"
   %1 = "ttir.subtract"(%arg0, %arg1, %0) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
The FPU add/sub/mul ops are reading from the CBs and writing to the DST, makes it difficult/costly to fuse them even with other eltwise ops, blocking our op fusion & bcast work.

### What's changed
Switch to the SFPU variants, the FPU ones are still present in the TTKernel dialect, but are orphans now.
Fix an existing bug that leads to incorrect SSA ordering when the DST index is loop-dependent.

### Known issue
The comparison ops are decomposed into sub+cmpz, and will have two `init_sfpu` inserted. This is localized in the D2M comparison ops and is benign atm. The duplicates will be removed by the soon-to-land init hoisting work.

### Checklist
- [x] New/Existing tests provide coverage for changes
