### PR TITLE
Fix static library linking ordering

### DIFF
--- a/runtime/lib/ttnn/utils/CMakeLists.txt
+++ b/runtime/lib/ttnn/utils/CMakeLists.txt
@@ -17,5 +17,5 @@ target_include_directories(TTRuntimeTTNNUtils PUBLIC
 )
 target_include_directories(TTRuntimeTTNNUtils SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 add_dependencies(TTRuntimeTTNNUtils TTNN_LIBRARY tt-metal FBS_GENERATION)
-target_link_libraries(TTRuntimeTTNNUtils PUBLIC TTNN_LIBRARY)
+target_link_libraries(TTRuntimeTTNNUtils PUBLIC TTNN_LIBRARY PRIVATE TTRuntimeTypes)
 target_link_libraries(TTRuntimeTTNNUtils PUBLIC coverage_config)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5035

### Problem description
```
tt-mlir> FAILED: [code=1] runtime/lib/libTTMLIRRuntime.so
tt-mlir> : && /nix/store/qkkpr4fjkbsdfhxs5ms8b53phzhpp38i-clang-wrapper-19.1.7/bin/clang++ -fPIC -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG  -Wl,-z,defs -Wl,-z,nodelete   -Xlinker --dependency-file=runtime/lib/CMakeFiles/TTMLIRRuntime.dir/link.d -shared -Wl,-soname,libTTMLIRRuntime.so -o runtime/lib/libTTMLIRRuntime.so runtime/lib/CMakeFiles/TTMLIRRuntime.dir/runtime.cpp.o -L/nix/store/kjn3fxxw3slqk9v3825fp63y7fa4m7di-tt-mlir-0.4.0.dev20250920/lib   -L/nix/store/kjn3fxxw3slqk9v3825fp63y7fa4m7di-tt-mlir-0.4.0.dev20250920/lib64 -Wl,-rpath,"\$ORIGIN"  runtime/lib/libTTBinary.a  runtime/lib/common/libTTRuntimeTypes.a  runtime/lib/common/libTTRuntimeUtils.a  runtime/lib/common/libTTRuntimeSysDesc.a  runtime/lib/ttnn/libTTRuntimeTTNN.a  runtime/lib/ttmetal/libTTRuntimeTTMetal.a  runtime/lib/common/libTTRuntimeContext.a  runtime/lib/common/libTTRuntimeDebug.a  runtime/lib/common/libTTRuntimePerf.a  runtime/lib/common/libTTRuntimeWorkarounds.a  runtime/lib/common/libTTRuntimeDylibs.a  /build/source/third_party/tt-metal/src/tt-metal/build/lib/libtt_metal.so  /build/source/third_party/tt-metal/src/tt-metal/build/lib/libdevice.so  /build/source/third_party/tt-metal/src/tt-metal/build/lib/libtt_stl.so  -lflatbuffers  runtime/lib/ttnn/operations/libTTRuntimeTTNNOps.a  /build/source/third_party/tt-metal/src/tt-metal/build/lib/libtracy.so  runtime/lib/ttnn/types/libTTRuntimeTTNNTypes.a  runtime/lib/ttnn/utils/libTTRuntimeTTNNUtils.a  /build/source/third_party/tt-metal/src/tt-metal/build/lib/_ttnncpp.so && :
tt-mlir> /nix/store/rbiv5lk989aiz4px6ynlbhgmv80683w1-binutils-2.44/bin/ld: runtime/lib/ttnn/libTTRuntimeTTNN.a(runtime.cpp.o): in function `tt::runtime::Device::Device(std::shared_ptr<void>, std::shared_ptr<tt::runtime::TraceCache>, tt::runtime::DeviceRuntime)':
tt-mlir> runtime.cpp:(.text._ZN2tt7runtime6DeviceC2ESt10shared_ptrIvES2_INS0_10TraceCacheEENS0_13DeviceRuntimeE[_ZN2tt7runtime6DeviceC2ESt10shared_ptrIvES2_INS0_10TraceCacheEENS0_13DeviceRuntimeE]+0x100): undefined reference to `tt::runtime::Device::nextDeviceGlobalId()'
tt-mlir> /nix/store/rbiv5lk989aiz4px6ynlbhgmv80683w1-binutils-2.44/bin/ld: runtime/lib/ttnn/libTTRuntimeTTNN.a(runtime.cpp.o): in function `std::__detail::_Hash_node<std::pair<unsigned int const, tt::runtime::Tensor>, false>* std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, tt::runtime::Tensor>, false> > >::_M_allocate_node<std::piecewise_construct_t const&, std::tuple<unsigned int&&>, std::tuple<> >(std::piecewise_construct_t const&, std::tuple<unsigned int&&>&&, std::tuple<>&&)':
tt-mlir> runtime.cpp:(.text._ZNSt8__detail16_Hashtable_allocISaINS_10_Hash_nodeISt4pairIKjN2tt7runtime6TensorEELb0EEEEE16_M_allocate_nodeIJRKSt21piecewise_construct_tSt5tupleIJOjEESF_IJEEEEEPS8_DpOT_[_ZNSt8__detail16_Hashtable_allocISaINS_10_Hash_nodeISt4pairIKjN2tt7runtime6TensorEELb0EEEEE16_M_allocate_nodeIJRKSt21piecewise_construct_tSt5tupleIJOjEESF_IJEEEEEPS8_DpOT_]+0x58): undefined reference to `tt::runtime::Tensor::nextTensorGlobalId()'
tt-mlir> /nix/store/rbiv5lk989aiz4px6ynlbhgmv80683w1-binutils-2.44/bin/ld: runtime/lib/ttmetal/libTTRuntimeTTMetal.a(runtime.cpp.o): in function `tt::runtime::Tensor::Tensor(std::shared_ptr<void>, std::shared_ptr<void>, tt::runtime::DeviceRuntime, std::optional<std::shared_ptr<void> >)':
tt-mlir> runtime.cpp:(.text._ZN2tt7runtime6TensorC2ESt10shared_ptrIvES3_NS0_13DeviceRuntimeESt8optionalIS3_E[_ZN2tt7runtime6TensorC2ESt10shared_ptrIvES3_NS0_13DeviceRuntimeESt8optionalIS3_E]+0x198): undefined reference to `tt::runtime::Tensor::nextTensorGlobalId()'
tt-mlir> clang++: error: linker command failed with exit code 1 (use -v to see invocation)
tt-mlir> ninja: build stopped: subcommand failed.
```
We can see that `TTRuntimeTTNN` fails linking phase. `TTRuntimeTTNN` links `TTRuntimeTTNNUtils`, which in turn uses `TTRuntimeTypes` but never links it.