### PR TITLE
Fix Gather to Embedding Op transformation

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -681,7 +681,7 @@ struct GatherToEmbeddingConversionPattern
           rewriter, inputPermuted.getType().getShape(), op);
     }
     auto startIndices = startIndicesTransformed;
-    if (startIndices.getType().getShape().size() >= 3) {
+    if (startIndices.getType().getShape().size() != 2) {
       startIndices =
           reshapeStartIndices(rewriter,
                               ttmlir::utils::appendLocationSuffix(
@@ -825,14 +825,14 @@ private:
   }
 
   // Helper that reshapes start indices to reduce number of dims, as Embedding
-  // Op input can be 1D or 2D.
+  // Op input needs to be 2D.
   static ttir::ReshapeOp reshapeStartIndices(
       ConversionPatternRewriter &rewriter, Location loc,
       ::mlir::TypedValue<::mlir::RankedTensorType> startIndices) {
     auto startIndicesShape = startIndices.getType().getShape();
-    llvm::SmallVector<int64_t, 1> newStartIndicesShape{
-        std::accumulate(startIndicesShape.begin(), startIndicesShape.end(),
-                        int64_t{1}, std::multiplies<>())};
+    llvm::SmallVector<int64_t, 2> newStartIndicesShape{
+        1, std::accumulate(startIndicesShape.begin(), startIndicesShape.end(),
+                           int64_t{1}, std::multiplies<>())};
     return createReshapeOp(rewriter, loc, startIndices, newStartIndicesShape);
   }
 

--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
@@ -21,8 +21,7 @@ module attributes {} {
 
   func.func @gather_1(%operand: tensor<448x384xbf16>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x384xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: : (tensor<2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<2x384xbf16, {{.+}}>
-    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: : (tensor<1x2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<1x2x384xbf16, {{.+}}>
     %0 = ttir.empty() : tensor<1x2x384xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         offset_dims = array<i64: 2>,
@@ -74,7 +73,7 @@ module attributes {} {
 
   func.func @gather_4(%operand: tensor<2048x1x200xf32>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x1x200xf32> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<2x200xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<1x2x200xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<1x2x1x200xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -114,7 +113,7 @@ module attributes {} {
   // Examples 6 to 9 test different rank combinations for input, start indices and output.
   func.func @gather_6(%operand: tensor<1xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1xui32, {{.+}}>, tensor<1x1xbf16, {{.+}}>) -> tensor<1x1xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<1x1xbf16, {{.+}}>) -> tensor<1x1x1xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<1xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -132,7 +131,7 @@ module attributes {} {
 
   func.func @gather_7(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1xui32, {{.+}}>, tensor<6x1xbf16, {{.+}}>) -> tensor<1x1xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<6x1xbf16, {{.+}}>) -> tensor<1x1x1xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<1xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -210,7 +209,7 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<4xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<4x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x4xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<1x4x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<2x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -231,7 +230,7 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<9xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<9x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x9xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<1x9x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<3x1x3x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -252,7 +251,7 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<2x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<1x2x4xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<2x1x1x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/4966

### Problem description
`ttnn.embedding` expects 2D tensor for input

### What's changed
`startIndices` get reshaped to be `{1,N}` instead of `{N}` in `reshapeStartIndices` method.
 
### Checklist
- [ ] New/Existing tests provide coverage for changes
