### PR TITLE
Change default tensorL1UsageCap to 100% and Pass pipeline option cap to Validation pass

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -211,7 +211,7 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, OptionNames::tensorL1UsageCap,
       llvm::cl::desc("Override tensor L1 usage cap in L1 Interleaved Fallback "
                      "Analysis and Memory Layout Analysis. [0.0-1.0]"),
-      llvm::cl::init(0.8f)};
+      llvm::cl::init(1.0f)};
 
   // Option to enable/disable the workaround pass.
   //

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -31,7 +31,7 @@ struct TTNNOptimizerOptions {
   bool memReconfigEnabled = false;
   int64_t maxLegalLayouts = 64;
   bool rowMajorEnabled = false;
-  float tensorL1UsageCap = 0.8f; // Default to 80% of maximum free space in L1.
+  float tensorL1UsageCap = 1.0f; // Default to 100% of maximum free space in L1.
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> devicePtr = nullptr;
 };
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -224,6 +224,12 @@ def TTNNOperationValidationAndFallback: Pass<"ttnn-operation-validation-and-fall
     fallback strategies by transforming input operand layouts and data types
     to find working configurations.
   }];
+  let options = [
+    Option<"tensorL1UsageCap",
+           "tensor-l1-usage-cap",
+           "float", /*default=*/"1.0",
+           "Limit L1 memory usage to this fraction of available space (0.0-1.0)">
+  ];
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -38,7 +38,7 @@ struct ValidationResult {
 // Returns: ValidationResult if valid, error otherwise.
 llvm::Expected<ValidationResult>
 validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                  const OpConfig &config);
+                  const OpConfig &config, float tensorL1UsageCap);
 
 // Test multiple attributes with all layouts.
 // op: Operation to validate.
@@ -48,11 +48,10 @@ validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
 // referenceConfigs: Reference configurations to search for matches. If empty,
 //                   only validation is performed without matching to reference.
 // Returns: Vector of ValidationResults, one per op config tested.
-llvm::Expected<std::vector<ValidationResult>>
-validateWithMultipleAttributes(Operation *op,
-                               llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                               llvm::ArrayRef<OpConfig> opConfigs,
-                               llvm::ArrayRef<OpConfig> referenceConfigs);
+llvm::Expected<std::vector<ValidationResult>> validateWithMultipleAttributes(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    llvm::ArrayRef<OpConfig> opConfigs,
+    llvm::ArrayRef<OpConfig> referenceConfigs, float tensorL1UsageCap);
 
 // Core constraint validation using OpModel interface.
 // op: The operation to validate.
@@ -61,7 +60,7 @@ validateWithMultipleAttributes(Operation *op,
 // Returns: Expected output layout if valid, error otherwise.
 llvm::Expected<TTNNLayoutAttr>
 validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config);
+                    const OpConfig &config, float tensorL1UsageCap);
 
 } // namespace op_constraint_validation
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -99,7 +99,10 @@ void createTTNNPipelineAnalysisPasses(
     pm.addPass(mlir::tt::ttnn::createTTNNOptimizer(optimizerOptions));
     pm.addPass(mlir::createCanonicalizerPass());
 #ifdef TTMLIR_ENABLE_OPMODEL
-    pm.addPass(mlir::tt::ttnn::createTTNNOperationValidationAndFallback());
+    ttnn::TTNNOperationValidationAndFallbackOptions validationOptions{
+        options.tensorL1UsageCap};
+    pm.addPass(mlir::tt::ttnn::createTTNNOperationValidationAndFallback(
+        validationOptions));
     pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeightsAndBias());
 #endif
   }

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -186,7 +186,7 @@ protected:
       ::llvm::cl::desc(
           "Override tensor L1 usage cap in L1 Interleaved Fallback Analysis "
           "and Memory Layout Analysis. [0.0-1.0]"),
-      ::llvm::cl::init(0.8f)};
+      ::llvm::cl::init(1.0f)};
 
   // Calculate the usable L1 cache size with capacity scaling.
   // For analysis purposes, usableL1CacheSize is scaled by a cap value between

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -138,8 +138,9 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   uint64_t usableL1CacheSize = chipDesc.getUsableL1Size();
 
   // TODO(rpavlovicTT): pass tensorL1UsageCap as parameter. Use the one from
-  // PipelineOptions added in fe415d34d95a777f38e7864a84a618bd946b35ca.
-  constexpr float tensorL1UsageCap = 0.8;
+  // PipelineOptions added in fe415d34d95a777f38e7864a84a618bd946b35ca. Update
+  // accordingly to it.
+  constexpr float tensorL1UsageCap = 1.0f;
 
   // Calculate total L1 usage from all input layouts.
   uint64_t totalInputL1Usage = 0;

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -92,9 +92,10 @@ TEST_F(OpConstraintValidationTest, ValidateOperationRealAddOp) {
   auto addOp = createMockAddOp();
   auto layouts = ttnn::utils::extractInputLayouts(addOp);
   OpConfig config = createTestConfig();
+  float tensorL1UsageCap = 1.0f;
 
-  auto result =
-      op_constraint_validation::validateOperation(addOp, layouts, config);
+  auto result = op_constraint_validation::validateOperation(
+      addOp, layouts, config, tensorL1UsageCap);
 
   // This should either succeed or fail gracefully (not crash)
   // The exact result depends on OpModel implementation
@@ -114,10 +115,11 @@ TEST_F(OpConstraintValidationTest, ValidateWithMultipleAttributesRealAddOp) {
 
   // Create 10 empty attributes
   std::vector<OpConfig> configs(10);
+  float tensorL1UsageCap = 1.0f;
 
   // Test with null reference configs (should succeed if validation passes)
   auto results = op_constraint_validation::validateWithMultipleAttributes(
-      addOp, layouts, configs, /*referenceConfigs=*/{});
+      addOp, layouts, configs, /*referenceConfigs=*/{}, tensorL1UsageCap);
 
   if (results) {
     EXPECT_EQ(results->size(), 10);


### PR DESCRIPTION
This PR updates the default percentage of L1 memory considered usable in the Optimizer and related passes. Previously, the default was set to 80%; it is now increased to 100% (i.e., full L1 capacity). Specifically, both analyses in the Optimizer (L1IFA and MLA) now use the updated option value.

Additionally, the newer post-Optimizer validation pass now receives this usage cap as a pipeline option, rather than relying on a hardcoded value. This ensures that the validation logic aligns with the cap used in earlier passes. When the cap was set to 0.8, the validation pass would revert changes that utilized more memory, which significantly degraded performance for the Resnet model in particular. With the cap set to 1.0, such degradation is avoided, and performance improves.

While an intermediate cap value might be considered in the future if "L1 out of memory" runtime error or other issues arise, there is currently no observed need for extra safety.

### Checklist
- [ ] New/Existing tests provide coverage for changes
