### PR TITLE
feat: add support for stablehlo.compare operation in automatic shardy…

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -192,13 +192,6 @@ static FailureOr<mlir::OperationState> createNewOperationState(
 
             return mlir::success();
           })
-          .Case<mlir::stablehlo::CompareOp>([&](auto compareOp) {
-            compareOp->emitError(
-                "Compare operation is not supported in stablehlo-pipeline for "
-                "meshes not 1x1: "
-                "https://github.com/tenstorrent/tt-mlir/issues/3497.");
-            return mlir::failure();
-          })
           .Case<mlir::stablehlo::ScatterOp>([&](auto scatterOp) {
             scatterOp->emitError(
                 "Scatter operation is not supported in stablehlo-pipeline for "

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/compare.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/compare.mlir
@@ -1,0 +1,27 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+sdy.mesh @mesh = <["model"=1, "batch"=2]>
+
+func.func @compare_with_shard_on_operands(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}) -> tensor<4x56x56x96xi1> {
+  %0 = stablehlo.compare  EQ, %arg0, %arg1 : (tensor<4x56x56x96xbf16>, tensor<4x56x56x96xbf16>) -> tensor<4x56x56x96xi1>
+  return %0 : tensor<4x56x56x96xi1>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{"batch"}, {}, {}, {}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>]
+// CHECK: %1 = stablehlo.compare  EQ, %arg2, %arg3 : (tensor<2x56x56x96xbf16>, tensor<2x56x56x96xbf16>) -> tensor<2x56x56x96xi1>
+// CHECK: sdy.return %1 : tensor<2x56x56x96xi1>
+
+func.func @compare_with_different_comparison_directions(%arg0: tensor<4x56x56x96xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<4x56x56x96xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}) -> (tensor<4x56x56x96xi1>, tensor<4x56x56x96xi1>, tensor<4x56x56x96xi1>) {
+  %0 = stablehlo.compare  LT, %arg0, %arg1 : (tensor<4x56x56x96xf32>, tensor<4x56x56x96xf32>) -> tensor<4x56x56x96xi1>
+  %1 = stablehlo.compare  GT, %arg0, %arg1 : (tensor<4x56x56x96xf32>, tensor<4x56x56x96xf32>) -> tensor<4x56x56x96xi1>
+  %2 = stablehlo.compare  NE, %arg0, %arg1 : (tensor<4x56x56x96xf32>, tensor<4x56x56x96xf32>) -> tensor<4x56x56x96xi1>
+  return %0, %1, %2 : tensor<4x56x56x96xi1>, tensor<4x56x56x96xi1>, tensor<4x56x56x96xi1>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{"batch"}, {}, {}, {}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{"batch"}, {}, {}, {}]>]
+// CHECK: %1 = stablehlo.compare  LT, %arg2, %arg3 : (tensor<2x56x56x96xf32>, tensor<2x56x56x96xf32>) -> tensor<2x56x56x96xi1>
+// CHECK: %2 = stablehlo.compare  GT, %arg2, %arg3 : (tensor<2x56x56x96xf32>, tensor<2x56x56x96xf32>) -> tensor<2x56x56x96xi1>
+// CHECK: %3 = stablehlo.compare  NE, %arg2, %arg3 : (tensor<2x56x56x96xf32>, tensor<2x56x56x96xf32>) -> tensor<2x56x56x96xi1>
+// CHECK: sdy.return %1, %2, %3 : tensor<2x56x56x96xi1>, tensor<2x56x56x96xi1>, tensor<2x56x56x96xi1>


### PR DESCRIPTION

### Ticket
Resolves #3497

### Problem description
Support compare operation in automic shardy pass

### What's changed
Remove error case for CompareOp in createNewOperationState function, allowing it to use default attribute handling since comparison_direction doesn't need updates based on tensor sharding.


### Checklist
- [x] New/Existing tests provide coverage for changes
