### PR TITLE
[D2M] Interleaved DRAM layout support

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
@@ -52,6 +52,22 @@ def TTCore_DeviceLayoutInterface : AttrInterface<"DeviceLayoutInterface"> {
         return std::accumulate(shardShape.begin(), shardShape.end(), 1LL, std::multiplies<int64_t>());
       }]
     >,
+    InterfaceMethod<
+      "Return true if the layout is a view on top of a physical layout",
+      "bool", "isView", (ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return false;
+      }]
+    >,
+    InterfaceMethod<
+      "Return true if the layout is physical rather than a view",
+      "bool", "isPhysical", (ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return !isView();
+      }]
+    >,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
@@ -196,6 +196,18 @@ def TTCore_ArgumentType : I32EnumAttr<"ArgumentType", "Argument Type",
   let symbolToStringFnName = "ArgumentTypeEnumToString";
 }
 
+def TTCore_TensorMemoryLayout_Interleaved : I32EnumAttrCase<"Interleaved", 0, "interleaved">;
+def TTCore_TensorMemoryLayout_Sharded     : I32EnumAttrCase<"Sharded",     1, "sharded">;
+
+def TTCore_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TTCore Tensor Memory Layout",
+                           [
+                            TTCore_TensorMemoryLayout_Interleaved,
+                            TTCore_TensorMemoryLayout_Sharded,
+                           ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttcore";
+}
+
 def TTCore_ShardStatus_Presharded: I32EnumAttrCase<"Presharded", 0, "presharded">;
 def TTCore_ShardStatus_Unsharded: I32EnumAttrCase<"Unsharded", 1, "unsharded">;
 

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -250,6 +250,8 @@ def TTCore_ViewLayoutAttr : TTCore_Attr<"ViewLayout", "view", [TTCore_DeviceLayo
   let extraClassDeclaration = [{
       // Compose two view layouts f(g(x)) where f=this and g=other.
       ViewLayoutAttr compose(ViewLayoutAttr g) const;
+
+      bool isView() { return true; }
   }];
 }
 
@@ -273,6 +275,29 @@ def TTCore_ShardLayoutAttr : TTCore_Attr<"ShardLayout", "shard", [TTCore_DeviceL
     static ShardLayoutAttr get(::mlir::MLIRContext *context, ArrayRef<int64_t> shape, uint64_t elementSize, uint32_t buffers);
     static ShardLayoutAttr get(ArrayRef<int64_t> shape, Type elementType, uint32_t buffers);
     static ShardLayoutAttr get(MemRefType memrefType, uint32_t buffers);
+
+    bool isView() { return false; }
+
+    AffineMap getAffineMap() const;
+  }];
+}
+
+def TTCore_InterleavedLayoutAttr : TTCore_Attr<"InterleavedLayout", "interleaved", [TTCore_DeviceLayoutInterface, MemRefLayoutAttrInterface]> {
+  let summary = "Interleaved layout attribute in TT dialect";
+  let description = [{
+    Describes overall layout of an interleaved memref buffer.
+    - Stride: Stride of each dim in bytes.
+  }];
+  let parameters = (ins ArrayRefParameter<"int64_t">:$stride);
+
+  let assemblyFormat = "`<` custom<DimensionList>($stride) `>`";
+
+  let extraClassDeclaration = [{
+    static InterleavedLayoutAttr get(::mlir::MLIRContext *context, ArrayRef<int64_t> shape, uint64_t elementSize);
+    static InterleavedLayoutAttr get(ArrayRef<int64_t> shape, Type elementType);
+    static InterleavedLayoutAttr get(MemRefType memrefType);
+
+    bool isView() { return false; }
 
     AffineMap getAffineMap() const;
   }];
@@ -373,30 +398,36 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
     // Memory space for the tensor.
     DefaultValuedParameter<"MemorySpace", "MemorySpace::System">:$memory_space,
 
+    DefaultValuedParameter<"TensorMemoryLayout", "TensorMemoryLayout::Sharded">:$memory_layout,
+
     // Optional index remapping (e.g., view remap or virtual→physical grid mapping).
     // Defaults to empty, which is treated as identity.
     DefaultValuedParameter<"AffineMap", "$_builder.getEmptyAffineMap()">:$indexAffineMap
   );
 
-  let assemblyFormat = "`<` `logical_shape` `=` custom<DimensionList>($logical_shape) `,` `dim_alignments` `=` custom<DimensionList>($dim_alignments) `,` `collapsed_intervals` `=` $collapsed_intervals `,` $oob_val (`,` $memory_space^)? (`,` `index_map` `=` custom<IdentityAffineMap>($indexAffineMap)^)? `>`";
+  let assemblyFormat = "`<` `logical_shape` `=` custom<DimensionList>($logical_shape) `,` `dim_alignments` `=` custom<DimensionList>($dim_alignments) `,` `collapsed_intervals` `=` $collapsed_intervals `,` $oob_val (`,` $memory_space^)? (`,` $memory_layout^)? (`,` `index_map` `=` custom<IdentityAffineMap>($indexAffineMap)^)? `>`";
 
   let extraClassDeclaration = [{
     static MetalLayoutAttr get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
-                                     OOBVal oobVal, MemorySpace memorySpace);
+                                     OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout);
 
     static MetalLayoutAttr get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout,
                                      DenseIntElementsAttr collapseIntervals);
-
     static MetalLayoutAttr get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
-                                     DenseIntElementsAttr collapseIntervals, ArrayRef<int64_t> dimAlignments);
+                                     TensorMemoryLayout memoryLayout,
+                                     DenseIntElementsAttr collapseIntervals,
+                                     ArrayRef<int64_t> dimAlignments
+                                     );
 
     // Convenience getter: same as the 5-arg variant but attaches an explicit
     // index_map to the resulting attribute.
@@ -404,7 +435,9 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
-                                     mlir::AffineMap indexAffineMap);
+                                     TensorMemoryLayout memoryLayout,
+                                     mlir::AffineMap indexAffineMap
+                                     );
 
     // Derive the physical tensor shape from logical shape and grid.
     llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> tileShape) const;
@@ -431,6 +464,8 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
     // Returns the explicit index_map if present; otherwise returns an
     // identity map of the provided rank.
     mlir::AffineMap getIndexAffineMapOrIdentity(unsigned rank) const;
+
+    bool isView() { return false; }
   }];
 }
 

--- a/lib/CAPI/TTCoreAttrs.cpp
+++ b/lib/CAPI/TTCoreAttrs.cpp
@@ -135,9 +135,9 @@ MlirAttribute ttmlirTTMetalLayoutAttrGet(MlirContext ctx, intptr_t logicalRank,
   llvm::ArrayRef<int64_t> logicalShapeRef(logicalShape, logicalRank);
   llvm::ArrayRef<int64_t> gridShapeRef(gridShape, gridRank);
 
-  return wrap(MetalLayoutAttr::get(unwrap(ctx), logicalShapeRef, gridShapeRef,
-                                   static_cast<OOBVal>(oobVal),
-                                   static_cast<MemorySpace>(memorySpace)));
+  return wrap(MetalLayoutAttr::get(
+      unwrap(ctx), logicalShapeRef, gridShapeRef, static_cast<OOBVal>(oobVal),
+      static_cast<MemorySpace>(memorySpace), TensorMemoryLayout::Sharded));
 }
 
 MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -161,7 +161,11 @@ public:
     assert(op.getMemref().getType().getMemorySpace() &&
            "No memref memory space found, failing.");
     auto memrefType = op.getMemref().getType();
-    assert(mlir::isa<ttcore::ShardLayoutAttr>(memrefType.getLayout()));
+
+    auto layout = mlir::dyn_cast_if_present<ttcore::DeviceLayoutInterface>(
+        memrefType.getLayout());
+    assert(layout && layout.isPhysical() && "expected physical device layout");
+
     rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(op, memrefType,
                                                          address);
 

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -99,7 +99,8 @@ createDefaultLayout(mlir::MLIRContext *ctx,
 
   return mlir::tt::ttcore::MetalLayoutAttr::get(
       ctx, logicalShape, squareGridShape, mlir::tt::ttcore::OOBVal::Undef,
-      mlir::tt::ttcore::MemorySpace::System);
+      mlir::tt::ttcore::MemorySpace::System,
+      mlir::tt::ttcore::TensorMemoryLayout::Sharded);
 }
 } // namespace
 

--- a/lib/Dialect/D2M/IR/D2MOpsInterfaces.cpp
+++ b/lib/Dialect/D2M/IR/D2MOpsInterfaces.cpp
@@ -35,9 +35,11 @@ mlir::tt::d2m::applyViews(mlir::Operation *op) {
   Value input = viewOp.getInput();
   auto inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
 
-  assert(
-      mlir::isa<ttcore::ShardLayoutAttr>(inputMemref.getLayout()) &&
-      "Expected ShardLayoutAttr, only one level of view nesting is supported");
+  auto devLayout = mlir::dyn_cast_or_null<ttcore::DeviceLayoutInterface>(
+      inputMemref.getLayout());
+  assert(devLayout && devLayout.isPhysical() &&
+         "Expected physical layout attr; only one level of "
+         "view nesting is supported");
 
   return std::make_pair(inputMemref, map);
 }

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -142,8 +142,7 @@ public:
       auto enc = ttcore::MetalLayoutAttr::get(
           ctx, baseLayout.getLogicalShape(), baseLayout.getDimAlignments(),
           baseLayout.getCollapsedIntervals(), baseLayout.getOobVal(),
-          baseLayout.getMemorySpace(), map);
-
+          baseLayout.getMemorySpace(), baseLayout.getMemoryLayout(), map);
       auto resultTy =
           RankedTensorType::get(toTy.getShape(), toTy.getElementType(), enc);
       return rewriter
@@ -273,7 +272,8 @@ class D2MSplitCompoundLayoutRewriter : public OpRewritePattern<ToLayoutOp> {
           ctx, referenceLayout.getLogicalShape(),
           referenceLayout.getDimAlignments(),
           referenceLayout.getCollapsedIntervals(), referenceLayout.getOobVal(),
-          memSpace, referenceLayout.getIndexAffineMap());
+          memSpace, referenceLayout.getMemoryLayout(),
+          referenceLayout.getIndexAffineMap());
 
       // Compute the device shape using the referenceType's grid shape.
       ArrayRef<int64_t> tileShape;
@@ -312,7 +312,7 @@ class D2MSplitCompoundLayoutRewriter : public OpRewritePattern<ToLayoutOp> {
       auto layout = ttcore::MetalLayoutAttr::get(
           ctx, baseLayout.getLogicalShape(), baseLayout.getDimAlignments(),
           baseLayout.getCollapsedIntervals(), baseLayout.getOobVal(), memSpace,
-          baseLayout.getIndexAffineMap());
+          baseLayout.getMemoryLayout(), baseLayout.getIndexAffineMap());
 
       ArrayRef<int64_t> tileShape;
       if (mlir::isa<ttcore::TileType>(elementType)) {

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -555,22 +555,34 @@ ShardLayoutAttr ShardLayoutAttr::get(mlir::MemRefType memrefType,
 }
 
 mlir::AffineMap ShardLayoutAttr::getAffineMap() const {
-  auto *context = getContext();
-  int64_t rank = getStride().size();
-  SmallVector<mlir::AffineExpr> mapExprs(rank + 1);
+  return ttmlir::utils::generateAffineMapFromShardStrides(getStride(),
+                                                          getContext());
+}
 
-  for (int64_t i = 0; i < rank; i++) {
-    mapExprs[i] = getAffineDimExpr(i, context);
+InterleavedLayoutAttr InterleavedLayoutAttr::get(mlir::MLIRContext *context,
+                                                 ArrayRef<int64_t> shape,
+                                                 uint64_t elementSize) {
+  return get(context, ttmlir::utils::calculateStrides(
+                          shape, static_cast<int64_t>(elementSize)));
+}
+
+InterleavedLayoutAttr InterleavedLayoutAttr::get(ArrayRef<int64_t> shape,
+                                                 Type elementType) {
+  return get(elementType.getContext(), shape, getElementSizeBytes(elementType));
+}
+
+InterleavedLayoutAttr InterleavedLayoutAttr::get(mlir::MemRefType memrefType) {
+  ArrayRef<int64_t> shape = memrefType.getShape();
+  if (auto layout =
+          mlir::dyn_cast<DeviceLayoutInterface>(memrefType.getLayout())) {
+    shape = layout.getShardShape(memrefType);
   }
+  return get(shape, memrefType.getElementType());
+}
 
-  mapExprs[rank] = getAffineConstantExpr(0, context);
-  for (int64_t i = rank - 1; i >= 0; i--) {
-    mlir::AffineExpr shardDim = getAffineDimExpr(rank + i, context);
-    mlir::AffineExpr stride = getAffineConstantExpr(getStride()[i], context);
-    mapExprs[rank] = shardDim * stride + mapExprs[rank];
-  }
-
-  return mlir::AffineMap::get(getStride().size() * 2, 0, mapExprs, context);
+mlir::AffineMap InterleavedLayoutAttr::getAffineMap() const {
+  return ttmlir::utils::generateAffineMapFromShardStrides(getStride(),
+                                                          getContext());
 }
 
 ViewLayoutAttr ViewLayoutAttr::compose(ViewLayoutAttr g) const {
@@ -965,7 +977,8 @@ MetalLayoutAttr::computeAlignments(ArrayRef<int64_t> logicalShape,
 MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
-                                     OOBVal oobVal, MemorySpace memorySpace) {
+                                     OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout) {
   // Create collapse intervals.
   int64_t numDimsToCollapse = logicalShape.size() - deviceGridShape.size() + 1;
   llvm::SmallVector<int64_t> flattenedIntervals;
@@ -993,7 +1006,7 @@ MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
       computeAlignments(logicalShape, deviceGridShape, flattenedIntervals);
 
   return get(context, logicalShape, dimAlignmentsVec, collapsedIntervals,
-             oobVal, memorySpace, mlir::AffineMap::get(context));
+             oobVal, memorySpace, memoryLayout, mlir::AffineMap::get(context));
 }
 
 // Getter with explicit collapsedIntervals, we calculate the alignments.
@@ -1001,6 +1014,7 @@ MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout,
                                      DenseIntElementsAttr collapsedIntervals) {
   llvm::SmallVector<int64_t> normalizedIntervals =
       normalizeAndFlattenIntervals(collapsedIntervals, logicalShape.size());
@@ -1008,7 +1022,7 @@ MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
       computeAlignments(logicalShape, deviceGridShape, normalizedIntervals);
 
   return get(context, logicalShape, dimAlignmentsVec, collapsedIntervals,
-             oobVal, memorySpace, mlir::AffineMap::get(context));
+             oobVal, memorySpace, memoryLayout, mlir::AffineMap::get(context));
 }
 
 // Getter with explicit collapsedIntervals and dimAlignments.
@@ -1016,10 +1030,11 @@ MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout,
                                      DenseIntElementsAttr collapsedIntervals,
                                      ArrayRef<int64_t> dimAlignments) {
   return get(context, logicalShape, dimAlignments, collapsedIntervals, oobVal,
-             memorySpace, mlir::AffineMap::get(context));
+             memorySpace, memoryLayout, mlir::AffineMap::get(context));
 }
 
 mlir::MemRefType
@@ -1043,14 +1058,15 @@ MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      ArrayRef<int64_t> deviceGridShape,
                                      OOBVal oobVal, MemorySpace memorySpace,
+                                     TensorMemoryLayout memoryLayout,
                                      mlir::AffineMap indexAffineMap) {
   // Reuse the existing path that computes intervals/alignments, then attach
   // map.
-  MetalLayoutAttr base =
-      get(context, logicalShape, deviceGridShape, oobVal, memorySpace);
+  MetalLayoutAttr base = get(context, logicalShape, deviceGridShape, oobVal,
+                             memorySpace, memoryLayout);
   return get(context, base.getLogicalShape(), base.getDimAlignments(),
              base.getCollapsedIntervals(), base.getOobVal(),
-             base.getMemorySpace(), indexAffineMap);
+             base.getMemorySpace(), base.getMemoryLayout(), indexAffineMap);
 }
 
 // Get effective stride (use provided or calculate from shape)
@@ -1331,35 +1347,67 @@ DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
 mlir::AffineMap DeviceAttr::getMemoryMap(MemRefType memrefType, size_t pageSize,
                                          std::optional<AffineMap> view,
                                          size_t baseOffset) const {
-  assert(mlir::isa<ShardLayoutAttr>(memrefType.getLayout()) &&
-         "only memref with ShardLayout are supported by this function");
   MemorySpace memorySpace =
       mlir::cast<MemorySpaceAttr>(memrefType.getMemorySpace()).getValue();
   AffineMap affineMap = memrefType.getLayout().getAffineMap();
   if (view) {
     affineMap = affineMap.compose(*view);
   }
-  switch (memorySpace) {
-  case MemorySpace::DeviceL1: {
-    SmallVector<int64_t> symbols = {static_cast<int64_t>(baseOffset)};
-    return ttmlir::utils::replaceAffineMapSymbols(getL1Map(), symbols)
-        .compose(affineMap);
-  }
-  case MemorySpace::DeviceDRAM: {
-    // The DRAM page size is 1<->1 mapped to underlying memref shard size;
-    // pageSize argument is ignored.
-    pageSize = getMemrefSizeBytes(memrefType);
-    assert(pageSize > 0 && "expected positive page size");
+
+  if (mlir::isa<ShardLayoutAttr>(memrefType.getLayout())) {
+
+    switch (memorySpace) {
+    case MemorySpace::DeviceL1: {
+      SmallVector<int64_t> symbols = {static_cast<int64_t>(baseOffset)};
+      return ttmlir::utils::replaceAffineMapSymbols(getL1Map(), symbols)
+          .compose(affineMap);
+    }
+    case MemorySpace::DeviceDRAM: {
+      // The DRAM page size is 1<->1 mapped to underlying memref shard size;
+      // pageSize argument is ignored.
+      pageSize = getMemrefSizeBytes(memrefType);
+      assert(pageSize > 0 && "expected positive page size");
+      SmallVector<int64_t> symbols(memrefType.getShape());
+      symbols.push_back(static_cast<int64_t>(pageSize));
+      symbols.push_back(static_cast<int64_t>(baseOffset));
+      symbols.push_back(getElementSizeBytes(memrefType.getElementType()));
+      return ttmlir::utils::replaceAffineMapSymbols(getDramMap(), symbols)
+          .compose(affineMap);
+    }
+    default: {
+      llvm_unreachable("Unsupported memory space");
+    }
+    }
+  } else if (mlir::isa<ttcore::InterleavedLayoutAttr>(memrefType.getLayout())) {
+
+    assert(memorySpace == MemorySpace::DeviceDRAM &&
+           "interleavedLayoutAttr only supported for deviceDRAM memory space");
+
+    auto interleavedLayout =
+        mlir::cast<ttcore::InterleavedLayoutAttr>(memrefType.getLayout());
+
+    // interleaved layout is either single tile or stride of outermost dim
+    int64_t elementSizeBytes = getElementSizeBytes(memrefType.getElementType());
+    pageSize = mlir::isa<ttcore::TileType>(memrefType.getElementType())
+                   ? elementSizeBytes
+                   : interleavedLayout.getStride().front();
+
+    // interleaved layout for DRAM is constrained to have unit grid dims,
+    // similar to TTNNLayoutAttr convention
+    assert(ttmlir::utils::volume(interleavedLayout.getGridShape(memrefType)) ==
+               1 &&
+           "All dims in grid shape for DRAM interleaved memref must be 1 (i.e. "
+           "1x1x...x1) ");
+
     SmallVector<int64_t> symbols(memrefType.getShape());
     symbols.push_back(static_cast<int64_t>(pageSize));
     symbols.push_back(static_cast<int64_t>(baseOffset));
-    symbols.push_back(getElementSizeBytes(memrefType.getElementType()));
+    symbols.push_back(elementSizeBytes);
+
     return ttmlir::utils::replaceAffineMapSymbols(getDramMap(), symbols)
         .compose(affineMap);
-  }
-  default: {
-    llvm_unreachable("Unsupported memory space");
-  }
+  } else {
+    assert(false && "Unsupported layout type on memref");
   }
 }
 
@@ -1412,8 +1460,26 @@ size_t DeviceAttr::getMemrefSizeBytes(MemRefType memrefType, size_t pageSize,
     }
   }
 
-  // Assume that memref size footprint is equal to shard size
-  return getShardSizeInBytes(memrefType, alignSize, includeBuffers);
+  int64_t numBuffers = 1;
+  ArrayRef<int64_t> shardShape;
+  auto layout = memrefType.getLayout();
+  if (auto devLayout = mlir::dyn_cast<DeviceLayoutInterface>(layout)) {
+    shardShape = devLayout.getShardShape(memrefType);
+    // if the layout is sharded, numBuffers is programmable
+    if (auto shardLayout = mlir::dyn_cast<ShardLayoutAttr>(devLayout)) {
+      numBuffers = (includeBuffers) ? shardLayout.getBuffers() : 1;
+    }
+  } else {
+    // local memrefs have no layout attribute
+    numBuffers = 1;
+    shardShape = memrefType.getShape();
+  }
+
+  auto elementSizeBytes = getElementSizeBytes(memrefType.getElementType());
+  return ttmlir::utils::alignUp(
+      static_cast<size_t>(ttmlir::utils::volume(
+          shardShape, static_cast<int64_t>(elementSizeBytes * numBuffers))),
+      alignSize);
 }
 
 size_t DeviceAttr::getMemrefCBPageSizeBytes(MemRefType memrefType) const {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -90,7 +90,15 @@ MemRefType getBufferType(Type type, bool isView,
     layoutAttr = ttcore::ViewLayoutAttr::get(ctx, map);
   } else {
     SmallVector<int64_t> shardStride = layout.getShardStride(tensorType);
-    layoutAttr = ttcore::ShardLayoutAttr::get(ctx, shardStride, /*buffered=*/1);
+    if (layout.getMemoryLayout() == ttcore::TensorMemoryLayout::Sharded) {
+      layoutAttr =
+          ttcore::ShardLayoutAttr::get(ctx, shardStride, /*buffered=*/1);
+    } else if (layout.getMemoryLayout() ==
+               ttcore::TensorMemoryLayout::Interleaved) {
+      layoutAttr = ttcore::InterleavedLayoutAttr::get(ctx, shardStride);
+    } else {
+      llvm_unreachable("Unsupported memory layout");
+    }
   }
 
   return MemRefType::get(

--- a/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
@@ -11,7 +11,7 @@
 #layout1 = #ttcore.metal_layout<logical_shape = 128x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1>
 #layout2 = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1>
 #layout3 = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1>
-#layout4 = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1, index_map = (d0, d1, d2, d3) -> (d1, d0, d2, d3)>
+#layout4 = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1, sharded, index_map = (d0, d1, d2, d3) -> (d1, d0, d2, d3)>
 
 func.func @matmul() -> tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout2> {
   %arg0 = d2m.empty() : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout>
@@ -58,4 +58,11 @@ func.func @constant() -> tensor<32x32xf32> {
   // CHECK: = memref.get_global @__constant_32x32xf32 : memref<32x32xf32>
   %c = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
   return %c : tensor<32x32xf32>
+}
+
+#layout5 = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>, undef, l1, interleaved>
+func.func @interleaved_tensor_memory_layout() -> tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout5> {
+  // CHECK: memref.alloc() : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.interleaved<16384x4096>, #l1>
+  %1 = ttir.empty() : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout5>
+  return %1 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout5>
 }

--- a/test/ttmlir/Dialect/D2M/bufferization/view_map.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/view_map.mlir
@@ -8,7 +8,7 @@
   logical_shape = 64x128,
   dim_alignments = 32x32,
   collapsed_intervals = dense<[[0, -1]]> : tensor<1x2xi64>,
-  undef, l1,
+  undef, l1, sharded,
   index_map = (d0, d1, d2, d3) -> (d1, d0, d2, d3)
 >
 

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -481,6 +481,7 @@ class Builder:
         memorySpace=None,  # Will default to ttcore.MemorySpace.DeviceL1 in the utility
         grid: Optional[Tuple[int, int]] = None,
         index_map: Optional[AffineMap] = None,
+        memory_layout=None,  # Will default to ttcore.TensorMemoryLayout.Sharded in the utility
     ):
         """Create a metal tensor layout using the shared implementation."""
         from builder.base.builder_utils import get_metal_tensor_layout
@@ -491,7 +492,16 @@ class Builder:
             oobVal = ttcore.OOBVal.Undef
         if memorySpace is None:
             memorySpace = ttcore.MemorySpace.DeviceL1
+        if memory_layout is None:
+            memory_layout = ttcore.TensorMemoryLayout.Sharded
 
         return get_metal_tensor_layout(
-            self._ctx, logical_shape, tiled, oobVal, memorySpace, grid, index_map
+            self._ctx,
+            logical_shape,
+            tiled,
+            oobVal,
+            memorySpace,
+            grid,
+            index_map,
+            memory_layout,
         )

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -69,6 +69,9 @@ def get_metal_tensor_layout(
     memorySpace=ttcore.MemorySpace.DeviceL1,
     grid: Optional[Tuple[int, int]] = None,
     index_map: Optional[AffineMap] = None,
+    memory_layout: Optional[
+        ttcore.TensorMemoryLayout
+    ] = ttcore.TensorMemoryLayout.Sharded
 ) -> RankedTensorType:
     """
     Create a metal tensor layout.
@@ -110,11 +113,11 @@ def get_metal_tensor_layout(
     # Create layout with original logical shape.
     if index_map is None:
         layout = ttcore.ir.MetalLayoutAttr.get(
-            ctx, logical_shape, worker_grid, oobVal, memorySpace
+            ctx, logical_shape, worker_grid, oobVal, memorySpace, memory_layout
         )
     else:
         layout = ttcore.ir.MetalLayoutAttr.get(
-            ctx, logical_shape, worker_grid, oobVal, memorySpace, index_map
+            ctx, logical_shape, worker_grid, oobVal, memorySpace, memory_layout, index_map
         )
 
     shard_shape = []

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -71,7 +71,7 @@ def get_metal_tensor_layout(
     index_map: Optional[AffineMap] = None,
     memory_layout: Optional[
         ttcore.TensorMemoryLayout
-    ] = ttcore.TensorMemoryLayout.Sharded
+    ] = ttcore.TensorMemoryLayout.Sharded,
 ) -> RankedTensorType:
     """
     Create a metal tensor layout.
@@ -117,7 +117,13 @@ def get_metal_tensor_layout(
         )
     else:
         layout = ttcore.ir.MetalLayoutAttr.get(
-            ctx, logical_shape, worker_grid, oobVal, memorySpace, memory_layout, index_map
+            ctx,
+            logical_shape,
+            worker_grid,
+            oobVal,
+            memorySpace,
+            memory_layout,
+            index_map,
         )
 
     shard_shape = []


### PR DESCRIPTION
### Problem description
D2M x TTNN integration requires support for interleaved DRAM layouts (the only DRAM layout supported).

### What's changed
- A new layout attribute called `InterleavedLayoutAttr` conforming to `DeviceLayoutInterface` can be used as the layout attribute on a memref. 
  - This behaves similarly to `ShardLayoutAttr`, but results in an interleaved-compatible affine map being generated by `DeviceAttr::getMemoryMap`
  
- Introduces a new interface in TTCoreAttrInterfaces called `BufferedDeviceLayoutInterface` that only InterleavedLayoutAttr and ShardLayoutAttr conform to
  - Sole function in API is `getBuffers()` for now
  
- `MetalLayoutAttr` has a new enum parameter `TensorMemoryLayout` that closely matches the existing layout categorization used by TTNNLayoutAttr
  - Layout can be either interleaved, width_sharded, height_sharded, or block_sharded
  - Defaults to block sharded
  - Allows casting tensors with TTNNLayoutAttr to MetalLayoutAttr without losing this layout information
  
- A new pair of functions `isPhysical`/`isView` have been added to the DeviceLayoutInterface API
  - Previously the presence of `ShardLayoutAttr` was enough to determine if the memref was to a physical device tensor
  - Allows differentiating between memrefs that are physical versus views

### Checklist
- [X] New/Existing tests provide coverage for changes
