### PR TITLE
Remove DeviceLayoutInterface from HostLayoutAttr

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -263,7 +263,7 @@ def TTCore_ShardLayoutAttr : TTCore_Attr<"ShardLayout", "shard", [TTCore_DeviceL
   }];
 }
 
-def TTCore_HostLayoutAttr : TTCore_Attr<"HostLayout", "host_layout", [TTCore_DeviceLayoutInterface, MemRefLayoutAttrInterface]> {
+def TTCore_HostLayoutAttr : TTCore_Attr<"HostLayout", "host_layout", [MemRefLayoutAttrInterface]> {
   let summary = "Host-side memref layout attribute with padding support.";
   let description = [{
     Describes a host-side memref layout with a logical shape where each


### PR DESCRIPTION
We discovered that this interface shouldn't be applied to host layouts.
