### PR TITLE
Bump pytorch version for ttrt and change explorer cmd path

### DIFF
--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,4 +1,4 @@
 lit
 pytest
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.5.0
+torch==2.7.0

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -228,6 +228,7 @@ class ModelRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            cwd=os.environ.get("TT_MLIR_HOME", os.getcwd()),
         )
 
         for line in process.stdout:

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -1,1 +1,1 @@
-torch==2.5.0 --index-url https://download.pytorch.org/whl/cpu
+torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
### Ticket
None

### Problem description
ttrt and tt-xla depend on different versions of pytorch.
Updating pytorch version in ttrt to the newer version tt-xla uses.

### What's changed
- Bump pytorch version from 2.5 to 2.7
- Update tt-explorer to run commands (ttrt, translate, opt) from mlir home dir for consistency

### Checklist
- [ ] New/Existing tests provide coverage for changes
