### PR TITLE
General SDPA op bringup

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5385,7 +5385,7 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
         value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
 
     Keyword args:
-        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x max_seq_len x max_seq_len]. Head broadcasting is implied.
+        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
         is_causal (bool): Defaults to `true`.
         scale (float, optional): Defaults to `None`.
         memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5344,9 +5344,9 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
         The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
 
         Args:
-            query (AnyRankedTensor): the input tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            key (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
-            value (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
+            query (AnyRankedTensor): the query tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
+            key (AnyRankedTensor): the key tensor [b x nkv x   s x dh].
+            value (AnyRankedTensor): the value tensor [b x nkv x   s x dh].
             is_causal (bool, optional): whether the attention is is causal. Defaults to `true`.
             attention_mask (AnyRankedTensor, optional): the attention mask [b x 1 x nh x s].
             cur_pos_tensor (AnyRankedTensor): [b] tensor of integers of length b.
@@ -5380,9 +5380,9 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
     The implementation is FlashAttention-2."
 
     Args:
-        query (ttnn.Tensor): the input tensor.          [b x nh x s x dh]
-        key (ttnn.Tensor): the input tensor.            [b x nkv x max_seq_len x dh]
-        value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
+        query (ttnn.Tensor): the query tensor.          [b x nh x s x dh]
+        key (ttnn.Tensor): the key tensor.            [b x nkv x max_seq_len x dh]
+        value (ttnn.Tensor): the value tensor.          [b x nkv x max_seq_len x dh]
 
     Keyword args:
         attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5376,7 +5376,23 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
 def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attention"> {
   let summary = "Scaled dot product attention operation.";
   let description = [{
-    The scaled_dot_product_attention operation applies scaled dot product attention to the input tensor.
+    Scaled dot product attention.
+    The implementation is FlashAttention-2."
+
+    Args:
+        query (ttnn.Tensor): the input tensor.          [b x nh x s x dh]
+        key (ttnn.Tensor): the input tensor.            [b x nkv x max_seq_len x dh]
+        value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
+
+    Keyword args:
+        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
+        is_causal (bool): Defaults to `true`.
+        scale (float, optional): Defaults to `None`.
+        memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+
+
+    Returns:
+        ttnn.Tensor: the output tensor [b x nh x s x dh].
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5373,5 +5373,23 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
     let hasVerifier = 1;
 }
 
+def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attention"> {
+  let summary = "Scaled dot product attention operation.";
+  let description = [{
+    The scaled_dot_product_attention operation applies scaled dot product attention to the input tensor.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$query,
+                       AnyRankedTensor:$key,
+                       AnyRankedTensor:$value,
+                       Optional<AnyRankedTensor>:$attention_mask,
+                       AnyRankedTensor:$output,
+                       DefaultValuedAttr<BoolAttr, "true">:$is_causal,
+                       OptionalAttr<F32Attr>:$scale);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 0;
+}
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5347,7 +5347,7 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
             query (AnyRankedTensor): the query tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
             key (AnyRankedTensor): the key tensor [b x nkv x   s x dh].
             value (AnyRankedTensor): the value tensor [b x nkv x   s x dh].
-            is_causal (bool, optional): whether the attention is is causal. Defaults to `true`.
+            is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
             attention_mask (AnyRankedTensor, optional): the attention mask [b x 1 x nh x s].
             cur_pos_tensor (AnyRankedTensor): [b] tensor of integers of length b.
             attention_sink (AnyRankedTensor, optional): the attention sink [nh, 32] (must be a single tile wide).
@@ -5380,16 +5380,13 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
     The implementation is FlashAttention-2."
 
     Args:
-        query (ttnn.Tensor): the query tensor.          [b x nh x s x dh]
-        key (ttnn.Tensor): the key tensor.            [b x nkv x max_seq_len x dh]
-        value (ttnn.Tensor): the value tensor.          [b x nkv x max_seq_len x dh]
-
-    Keyword args:
-        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
-        is_causal (bool): Defaults to `true`.
+        query (AnyRankedTensor): the query tensor.          [b x nh x s x dh]
+        key (AnyRankedTensor): the key tensor.              [b x nkv x max_seq_len x dh]
+        value (AnyRankedTensor): the value tensor.          [b x nkv x max_seq_len x dh]
+        attention_mask (AnyRankedTensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
+        output (AnyRankedTensor): the output DPS operand [b x nh x s x dh].
+        is_causal (bool): Whether the attention is causal. Defaults to `true`.
         scale (float, optional): Defaults to `None`.
-        memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-
 
     Returns:
         ttnn.Tensor: the output tensor [b x nh x s x dh].

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5405,7 +5405,7 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
 
   let results = (outs AnyRankedTensor:$result);
 
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5389,7 +5389,7 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
         scale (float, optional): Defaults to `None`.
 
     Returns:
-        ttnn.Tensor: the output tensor [batch x num_heads x seq_len x head_size].
+        AnyRankedTensor: the output tensor [batch x num_heads x seq_len x head_size].
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5344,18 +5344,18 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
         The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
 
         Args:
-            query (AnyRankedTensor): the query tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            key (AnyRankedTensor): the key tensor [b x nkv x   s x dh].
-            value (AnyRankedTensor): the value tensor [b x nkv x   s x dh].
+            query (AnyRankedTensor): the query tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
+            key (AnyRankedTensor): the key tensor [batch x num_kv_heads x seq_len x head_size].
+            value (AnyRankedTensor): the value tensor [batch x num_kv_heads x seq_len x head_size].
             is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): the attention mask [b x 1 x nh x s].
-            cur_pos_tensor (AnyRankedTensor): [b] tensor of integers of length b.
-            attention_sink (AnyRankedTensor, optional): the attention sink [nh, 32] (must be a single tile wide).
-            output (AnyRankedTensor): the output DPS operand [1 x b x nh x dh].
+            attention_mask (AnyRankedTensor, optional): the attention mask [batch x 1 x num_heads x seq_len].
+            cur_pos_tensor (AnyRankedTensor): [batch] tensor of integers of length batch.
+            attention_sink (AnyRankedTensor, optional): the attention sink [num_heads, 32] (must be a single tile wide).
+            output (AnyRankedTensor): the output DPS operand [1 x batch x num_heads x head_size].
             scale (float, optional): Defaults to `None`.
 
         Returns:
-            AnyRankedTensor: the output tensor [1 x b x nh x dh].
+            AnyRankedTensor: the output tensor [1 x batch x num_heads x head_size].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,
@@ -5380,16 +5380,16 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
     The implementation is FlashAttention-2."
 
     Args:
-        query (AnyRankedTensor): the query tensor.          [b x nh x s x dh]
-        key (AnyRankedTensor): the key tensor.              [b x nkv x max_seq_len x dh]
-        value (AnyRankedTensor): the value tensor.          [b x nkv x max_seq_len x dh]
-        attention_mask (AnyRankedTensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
-        output (AnyRankedTensor): the output DPS operand [b x nh x s x dh].
+        query (AnyRankedTensor): the query tensor.          [batch x num_heads x query_seq_len x head_size]
+        key (AnyRankedTensor): the key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
+        value (AnyRankedTensor): the value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
+        attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
+        output (AnyRankedTensor): the output DPS operand [batch x num_heads x query_seq_len x head_size].
         is_causal (bool): Whether the attention is causal. Defaults to `true`.
         scale (float, optional): Defaults to `None`.
 
     Returns:
-        ttnn.Tensor: the output tensor [b x nh x s x dh].
+        ttnn.Tensor: the output tensor [batch x num_heads x seq_len x head_size].
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5344,18 +5344,18 @@ def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_at
         The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
 
         Args:
-            query (AnyRankedTensor): the query tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            key (AnyRankedTensor): the key tensor [batch x num_kv_heads x seq_len x head_size].
-            value (AnyRankedTensor): the value tensor [batch x num_kv_heads x seq_len x head_size].
+            query (AnyRankedTensor): The query tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
+            key (AnyRankedTensor): The key tensor [batch x num_kv_heads x seq_len x head_size].
+            value (AnyRankedTensor): The value tensor [batch x num_kv_heads x seq_len x head_size].
             is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): the attention mask [batch x 1 x num_heads x seq_len].
-            cur_pos_tensor (AnyRankedTensor): [batch] tensor of integers of length batch.
-            attention_sink (AnyRankedTensor, optional): the attention sink [num_heads, 32] (must be a single tile wide).
-            output (AnyRankedTensor): the output DPS operand [1 x batch x num_heads x head_size].
+            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x num_heads x seq_len].
+            cur_pos_tensor (AnyRankedTensor): [batch] Tensor of integers of length batch.
+            attention_sink (AnyRankedTensor, optional): The attention sink [num_heads, 32] (must be a single tile wide).
+            output (AnyRankedTensor): The output DPS operand [1 x batch x num_heads x head_size].
             scale (float, optional): Defaults to `None`.
 
         Returns:
-            AnyRankedTensor: the output tensor [1 x batch x num_heads x head_size].
+            AnyRankedTensor: The output tensor [1 x batch x num_heads x head_size].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,
@@ -5380,16 +5380,16 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
     The implementation is FlashAttention-2."
 
     Args:
-        query (AnyRankedTensor): the query tensor.          [batch x num_heads x query_seq_len x head_size]
-        key (AnyRankedTensor): the key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
-        value (AnyRankedTensor): the value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
+        query (AnyRankedTensor): The query tensor.          [batch x num_heads x query_seq_len x head_size]
+        key (AnyRankedTensor): The key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
+        value (AnyRankedTensor): The value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
         attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
-        output (AnyRankedTensor): the output DPS operand [batch x num_heads x query_seq_len x head_size].
-        is_causal (bool): Whether the attention is causal. Defaults to `true`.
+        output (AnyRankedTensor): The output DPS operand [batch x num_heads x query_seq_len x head_size].
+        is_causal (bool): Whether The attention is causal. Defaults to `true`.
         scale (float, optional): Defaults to `None`.
 
     Returns:
-        AnyRankedTensor: the output tensor [batch x num_heads x seq_len x head_size].
+        AnyRankedTensor: The output tensor [batch x num_heads x seq_len x head_size].
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5385,7 +5385,7 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
         value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
 
     Keyword args:
-        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
+        attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x max_seq_len x max_seq_len]. Head broadcasting is implied.
         is_causal (bool): Defaults to `true`.
         scale (float, optional): Defaults to `None`.
         memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2518,7 +2518,23 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
 def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [TTNN_MemoryConfigOpInterface]> {
     let summary = "Scaled dot product attention operation.";
     let description = [{
-      Applies scaled dot product attention to the input tensor.
+      Scaled dot product attention.
+      The implementation is FlashAttention-2."
+
+      Args:
+          query (ttnn.Tensor): the input tensor.          [b x nh x s x dh]
+          key (ttnn.Tensor): the input tensor.            [b x nkv x s x dh]
+          value (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+
+      Keyword args:
+          attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
+          is_causal (bool): Defaults to `true`.
+          scale (float, optional): Defaults to `None`.
+          memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+
+
+      Returns:
+          ttnn.Tensor: the output tensor [b x nh x s x dh].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2523,8 +2523,8 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
 
       Args:
           query (ttnn.Tensor): the input tensor.          [b x nh x s x dh]
-          key (ttnn.Tensor): the input tensor.            [b x nkv x s x dh]
-          value (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+          key (ttnn.Tensor): the input tensor.            [b x nkv x max_seq_len x dh]
+          value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
 
       Keyword args:
           attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2515,4 +2515,23 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
     let hasVerifier = 1;
 }
 
+def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [TTNN_MemoryConfigOpInterface]> {
+    let summary = "Scaled dot product attention operation.";
+    let description = [{
+      Applies scaled dot product attention to the input tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$query,
+                         AnyRankedTensor:$key,
+                         AnyRankedTensor:$value,
+                         Optional<AnyRankedTensor>:$attention_mask,
+                         DefaultValuedAttr<BoolAttr, "true">:$is_causal,
+                         OptionalAttr<F32Attr>:$scale,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 0;
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2547,7 +2547,7 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
 
     let results = (outs AnyRankedTensor:$result);
 
-    let hasVerifier = 0;
+    let hasVerifier = 1;
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2527,7 +2527,7 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
           value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
 
       Keyword args:
-          attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x s]. Head broadcasting is implied.
+          attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
           is_causal (bool): Defaults to `true`.
           scale (float, optional): Defaults to `None`.
           memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2522,17 +2522,17 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       The implementation is FlashAttention-2."
 
       Args:
-          query (AnyRankedTensor): the query tensor.          [b x nh x s x dh]
-          key (AnyRankedTensor): the key tensor.              [b x nkv x max_seq_len x dh]
-          value (AnyRankedTensor): the value tensor.          [b x nkv x max_seq_len x dh]
-          attention_mask (AnyRankedTensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
+          query (AnyRankedTensor): the query tensor.          [batch x num_heads x query_seq_len x head_size]
+          key (AnyRankedTensor): the key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
+          value (AnyRankedTensor): the value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
+          attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
           is_causal (bool): Whether the attention is causal. Defaults to `true`.
           scale (float, optional): Defaults to `None`.
           memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
 
 
       Returns:
-          AnyRankedTensor: the output tensor [b x nh x s x dh].
+          AnyRankedTensor: the output tensor [batch x num_heads x query_seq_len x head_size].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2489,7 +2489,7 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
             input_tensor_q (AnyRankedTensor): the input tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
             input_tensor_k (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
             input_tensor_v (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
-            is_causal (bool, optional): whether the attention is is causal. Defaults to `true`.
+            is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
             attention_mask (AnyRankedTensor, optional): the attention mask [b x 1 x s x s].
             cur_pos_tensor (AnyRankedTensor): [b] tensor of integers of length b.
             attention_sink (AnyRankedTensor, optional): the attention sink [nh, 32] (must be a single tile wide).
@@ -2522,19 +2522,17 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       The implementation is FlashAttention-2."
 
       Args:
-          query (ttnn.Tensor): the input tensor.          [b x nh x s x dh]
-          key (ttnn.Tensor): the input tensor.            [b x nkv x max_seq_len x dh]
-          value (ttnn.Tensor): the input tensor.          [b x nkv x max_seq_len x dh]
-
-      Keyword args:
-          attn_mask (ttnn.Tensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
-          is_causal (bool): Defaults to `true`.
+          query (AnyRankedTensor): the query tensor.          [b x nh x s x dh]
+          key (AnyRankedTensor): the key tensor.              [b x nkv x max_seq_len x dh]
+          value (AnyRankedTensor): the value tensor.          [b x nkv x max_seq_len x dh]
+          attention_mask (AnyRankedTensor, optional): Defaults to `None`. [b x 1 x s x max_seq_len]. Head broadcasting is implied.
+          is_causal (bool): Whether the attention is causal. Defaults to `true`.
           scale (float, optional): Defaults to `None`.
-          memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+          memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
 
 
       Returns:
-          ttnn.Tensor: the output tensor [b x nh x s x dh].
+          AnyRankedTensor: the output tensor [b x nh x s x dh].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2486,18 +2486,18 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
         The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
 
         Args:
-            input_tensor_q (AnyRankedTensor): the input tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            input_tensor_k (AnyRankedTensor): the input tensor [batch x num_kv_heads x   seq_len x head_size].
-            input_tensor_v (AnyRankedTensor): the input tensor [b x num_kv_heads x   seq_len x head_size].
+            input_tensor_q (AnyRankedTensor): The input tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
+            input_tensor_k (AnyRankedTensor): The input tensor [batch x num_kv_heads x   seq_len x head_size].
+            input_tensor_v (AnyRankedTensor): The input tensor [b x num_kv_heads x   seq_len x head_size].
             is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): the attention mask [batch x 1 x query_seq_len x kv_seq_len].
-            cur_pos_tensor (AnyRankedTensor): [batch] tensor of integers of length batch.
-            attention_sink (AnyRankedTensor, optional): the attention sink [num_heads, 32] (must be a single tile wide).
+            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x query_seq_len x kv_seq_len].
+            cur_pos_tensor (AnyRankedTensor): [batch] Tensor of integers of length batch.
+            attention_sink (AnyRankedTensor, optional): The attention sink [num_heads, 32] (must be a single tile wide).
             scale (float, optional): Defaults to `None`.
             memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
 
         Returns:
-            AnyRankedTensor: the output tensor [1 x b x pnh x dh].
+            AnyRankedTensor: The output tensor [1 x b x pnh x dh].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,
@@ -2522,9 +2522,9 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       The implementation is FlashAttention-2."
 
       Args:
-          query (AnyRankedTensor): the query tensor.          [batch x num_heads x query_seq_len x head_size]
-          key (AnyRankedTensor): the key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
-          value (AnyRankedTensor): the value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
+          query (AnyRankedTensor): The query tensor.          [batch x num_heads x query_seq_len x head_size]
+          key (AnyRankedTensor): The key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
+          value (AnyRankedTensor): The value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
           attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
           is_causal (bool): Whether the attention is causal. Defaults to `true`.
           scale (float, optional): Defaults to `None`.
@@ -2532,7 +2532,7 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
 
 
       Returns:
-          AnyRankedTensor: the output tensor [batch x num_heads x query_seq_len x head_size].
+          AnyRankedTensor: The output tensor [batch x num_heads x query_seq_len x head_size].
     }];
 
     let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2486,13 +2486,13 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
         The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
 
         Args:
-            input_tensor_q (AnyRankedTensor): the input tensor [1 x b x nh x dh]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            input_tensor_k (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
-            input_tensor_v (AnyRankedTensor): the input tensor [b x nkv x   s x dh].
+            input_tensor_q (AnyRankedTensor): the input tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
+            input_tensor_k (AnyRankedTensor): the input tensor [batch x num_kv_heads x   seq_len x head_size].
+            input_tensor_v (AnyRankedTensor): the input tensor [b x num_kv_heads x   seq_len x head_size].
             is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): the attention mask [b x 1 x s x s].
-            cur_pos_tensor (AnyRankedTensor): [b] tensor of integers of length b.
-            attention_sink (AnyRankedTensor, optional): the attention sink [nh, 32] (must be a single tile wide).
+            attention_mask (AnyRankedTensor, optional): the attention mask [batch x 1 x query_seq_len x kv_seq_len].
+            cur_pos_tensor (AnyRankedTensor): [batch] tensor of integers of length batch.
+            attention_sink (AnyRankedTensor, optional): the attention sink [num_heads, 32] (must be a single tile wide).
             scale (float, optional): Defaults to `None`.
             memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
 

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -80,6 +80,7 @@ inline Tensor extract_output_tensor(
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
+#include "ttnn/operations/transformer/sdpa/sdpa.hpp"
 #include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -675,6 +675,29 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
                std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
 };
 
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+template <>
+struct OpModel<ScaledDotProductAttentionOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
+      TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
+      TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
+      TTNNLayoutAttr valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
+      std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+               llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+               llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+               std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+               std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
+               std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+};
+
 //===-----------------------------------------------------------------------===//
 // RotaryEmbeddingLlamaOp
 // ===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -46,3 +46,14 @@ table ScaledDotProductAttentionDecodeOp {
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
 }
+
+table ScaledDotProductAttentionOp {
+  query: tt.target.ttnn.TensorRef;
+  key: tt.target.ttnn.TensorRef;
+  value: tt.target.ttnn.TensorRef;
+  is_causal: bool;
+  attention_mask: tt.target.ttnn.TensorRef;
+  scale: float = null;
+  out: tt.target.ttnn.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -86,6 +86,7 @@ union OpType {
   RepeatOp,
   RMSNormOp,
   ReshapeOp,
+  ScaledDotProductAttentionOp,
   ScaledDotProductAttentionDecodeOp,
   SliceOp,
   SoftmaxOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3286,7 +3286,8 @@ public:
             srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
     if (!frontendAttributes) {
       return rewriter.notifyMatchFailure(
-          srcOp, "FillCache op must have mhlo.frontend_attributes attribute.");
+          srcOp, "ScaledDotProductAttention op must have "
+                 "mhlo.frontend_attributes attribute.");
     }
 
     auto isCausalSringAttr =

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3333,21 +3333,14 @@ public:
     ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
+    Value attentionMask = nullptr;
     if (adaptor.getOperands().size() == 4) {
-      Value attentionMask = adaptor.getOperands()[3];
-      rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
-          srcOp,
-          cast<RankedTensorType>(
-              getTypeConverter()->convertType(srcOp.getResult(0).getType())),
-          query, key, value, attentionMask, outputTensor, isCausalAttr,
-          scaleAttr);
-    } else {
-      rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
-          srcOp,
-          cast<RankedTensorType>(
-              getTypeConverter()->convertType(srcOp.getResult(0).getType())),
-          query, key, value, nullptr, outputTensor, isCausalAttr, scaleAttr);
+      attentionMask = adaptor.getOperands()[3];
     }
+
+    rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
+        srcOp, outputType, query, key, value, attentionMask, outputTensor,
+        isCausalAttr, scaleAttr);
 
     return success();
   }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3266,6 +3266,93 @@ public:
 };
 } // namespace
 
+namespace {
+class StableHLOToTTIRScaledDotProductAttentionOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
+    if (funcName != "tt.scaled_dot_product_attention") {
+      return failure();
+    }
+
+    mlir::DictionaryAttr frontendAttributes =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (!frontendAttributes) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "FillCache op must have mhlo.frontend_attributes attribute.");
+    }
+
+    auto isCausalSringAttr =
+        frontendAttributes.getAs<mlir::StringAttr>("is_causal");
+    bool isCausal = true;
+    if (isCausalSringAttr) {
+      if (isCausalSringAttr.getValue().lower() == "true") {
+        isCausal = true;
+      } else if (isCausalSringAttr.getValue().lower() == "false") {
+        isCausal = false;
+      } else {
+        return rewriter.notifyMatchFailure(
+            srcOp, "is_causal attribute must be true or false. Recived \"" +
+                       isCausalSringAttr.getValue() + "\".");
+      }
+    }
+
+    BoolAttr isCausalAttr = rewriter.getBoolAttr(isCausal);
+
+    auto scaleStringAttr = frontendAttributes.getAs<mlir::StringAttr>("scale");
+    std::optional<float> scale = std::nullopt;
+    if (scaleStringAttr) {
+      float _scale;
+      if (!llvm::to_float(scaleStringAttr.getValue(), _scale)) {
+        return rewriter.notifyMatchFailure(
+            srcOp,
+            "scale attribute string must be convertible to float. Recived \"" +
+                scaleStringAttr.getValue() + "\".");
+      }
+      scale = _scale;
+    }
+
+    FloatAttr scaleAttr =
+        scale ? rewriter.getF32FloatAttr(scale.value()) : nullptr;
+
+    Value query = adaptor.getOperands()[0];
+    Value key = adaptor.getOperands()[1];
+    Value value = adaptor.getOperands()[2];
+
+    RankedTensorType outputType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult(0).getType()));
+
+    ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+
+    if (adaptor.getOperands().size() == 4) {
+      Value attentionMask = adaptor.getOperands()[3];
+      rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
+          srcOp,
+          cast<RankedTensorType>(
+              getTypeConverter()->convertType(srcOp.getResult(0).getType())),
+          query, key, value, attentionMask, outputTensor, isCausalAttr,
+          scaleAttr);
+    } else {
+      rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
+          srcOp,
+          cast<RankedTensorType>(
+              getTypeConverter()->convertType(srcOp.getResult(0).getType())),
+          query, key, value, nullptr, outputTensor, isCausalAttr, scaleAttr);
+    }
+
+    return success();
+  }
+};
+} // namespace
+
 static void
 addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
                                          RewritePatternSet &patterns,
@@ -3571,7 +3658,8 @@ static void addScaledDotProductAttentionDecodeOpConversionPattern(
     MLIRContext *ctx, RewritePatternSet &patterns,
     TypeConverter &typeConverter) {
   patterns
-      .add<StableHLOToTTIRScaledDotProductAttentionDecodeOpConversionPattern>(
+      .add<StableHLOToTTIRScaledDotProductAttentionDecodeOpConversionPattern,
+           StableHLOToTTIRScaledDotProductAttentionOpConversionPattern>(
           typeConverter, ctx);
 }
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2495,7 +2495,7 @@ public:
 
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::ScaledDotProductAttentionOp>
         emitter(srcOp, adaptor, rewriter);
-
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getQuery()),
         emitter.emit(srcOp.getKey()),
@@ -2505,6 +2505,7 @@ public:
         emitter.emit(srcOp.getScale()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
+    // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
     emitter.replaceOp(*this, args);
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2468,6 +2468,51 @@ public:
 };
 } // namespace
 
+// ScaledDotProductAttentionOp conversion pattern
+//
+namespace {
+class ScaledDotProductAttentionOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::ScaledDotProductAttentionOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.scaled_dot_product_attention";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::transformer::scaled_dot_product_attention";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::ScaledDotProductAttentionOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ScaledDotProductAttentionOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::ScaledDotProductAttentionOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getQuery()),
+        emitter.emit(srcOp.getKey()),
+        emitter.emit(srcOp.getValue()),
+        emitter.emit(srcOp.getAttentionMask()),
+        emitter.emit(srcOp.getIsCausal()),
+        emitter.emit(srcOp.getScale()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // RMSNormOp conversion pattern
 //
 namespace {
@@ -3397,6 +3442,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<NLPConcatHeadsDecodeOpConversionPattern>(typeConverter, ctx);
   patterns.add<ScaledDotProductAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);
+  patterns.add<ScaledDotProductAttentionOpConversionPattern>(typeConverter,
+                                                             ctx);
 }
 // ANCHOR_END: op_rewriter_pattern_set_emitc
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -4662,7 +4662,7 @@ mlir::tt::ttir::ScaledDotProductAttentionDecodeOp::verify() {
   int64_t maxSeqLen = keyType.getShape()[2];
 
   // NOTE: The q_chunk_size is 32 by default in ttnn. This is configurable via
-  // the program config. However, this is not modelled in the ttnn dialect.
+  // the program config. However, this is not modeled in the ttnn dialect.
   if (seqLen % 32 != 0) {
     return emitOpError(
         "Sequence length must be divisible by q_chunk_size (32)");

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -4626,4 +4626,99 @@ mlir::tt::ttir::ScaledDotProductAttentionDecodeOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::ScaledDotProductAttentionOp::verify() {
+
+  RankedTensorType queryType = getQuery().getType();
+  RankedTensorType keyType = getKey().getType();
+  RankedTensorType valueType = getValue().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  if (queryType != resultType) {
+    return emitOpError("Query and result must have the same type");
+  }
+
+  if (keyType != valueType) {
+    return emitOpError("Key and value must have the same type");
+  }
+  if (queryType.getShape().size() != 4) {
+    return emitOpError("Query must be a 4D tensor");
+  }
+  if (keyType.getShape().size() != 4) {
+    return emitOpError("Key/Value must be a 4D tensor");
+  }
+  if (resultType.getShape().size() != 4) {
+    return emitOpError("Output must be a 4D tensor");
+  }
+
+  int64_t batchSize = queryType.getShape()[0];
+  int64_t nQueryHeads = queryType.getShape()[1];
+  int64_t nKVHeads = keyType.getShape()[1];
+  int64_t headSize = queryType.getShape()[3];
+  int64_t seqLen = queryType.getShape()[2];
+  int64_t maxSeqLen = keyType.getShape()[2];
+
+  // NOTE: The q_chunk_size is 32 by default in ttnn. This is configurable via
+  // the program config. However, this is not modelled in the ttnn dialect.
+  if (seqLen % 32 != 0) {
+    return emitOpError(
+        "Sequence length must be divisible by q_chunk_size (32)");
+  }
+
+  if (keyType.getShape()[0] != batchSize) {
+    return emitOpError("Key/Value batch size must match query batch size");
+  }
+
+  if (keyType.getShape()[3] != headSize) {
+    return emitOpError("Key/Value head size must match query head size");
+  }
+
+  if (nQueryHeads % nKVHeads != 0) {
+    return emitOpError(
+        "Query num heads must be divisible by key/value num heads");
+  }
+
+  if (getAttentionMask()) {
+    if (getIsCausal()) {
+      return emitOpError(
+          "Attention mask is not allowed when is_causal is true");
+    }
+    RankedTensorType attentionMaskType = getAttentionMask().getType();
+    if (attentionMaskType.getShape().size() != 4) {
+      return emitOpError("Attention mask must be a 4D tensor");
+    }
+    if (attentionMaskType.getShape()[0] != batchSize) {
+      return emitOpError(
+          "Attention mask batch size must match query batch size");
+    }
+    if (attentionMaskType.getShape()[1] != 1) {
+      return emitOpError("Attention mask dim 1 must be 1");
+    }
+    if (attentionMaskType.getShape()[2] != seqLen) {
+      return emitOpError(
+          "Attention mask at dim 2 must match query sequence length");
+    }
+    if (attentionMaskType.getShape()[3] != maxSeqLen) {
+      return emitOpError("Attention mask at dim 3 must match key/value "
+                         "sequence length (max sequence length)");
+    }
+  } else {
+    if (!getIsCausal()) {
+      return emitOpError("Attention mask is required when is_causal is false");
+    }
+  }
+
+  if (getIsCausal()) {
+    if (seqLen != maxSeqLen) {
+      return emitOpError("Sequence length must match key/value sequence length "
+                         "when is_causal is true");
+    }
+  }
+
+  return success();
+}
+
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3716,4 +3716,99 @@ mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::ScaledDotProductAttentionOp::verify() {
+
+  RankedTensorType queryType = getQuery().getType();
+  RankedTensorType keyType = getKey().getType();
+  RankedTensorType valueType = getValue().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  if (queryType != resultType) {
+    return emitOpError("Query and result must have the same type");
+  }
+
+  if (keyType != valueType) {
+    return emitOpError("Key and value must have the same type");
+  }
+  if (queryType.getShape().size() != 4) {
+    return emitOpError("Query must be a 4D tensor");
+  }
+  if (keyType.getShape().size() != 4) {
+    return emitOpError("Key/Value must be a 4D tensor");
+  }
+  if (resultType.getShape().size() != 4) {
+    return emitOpError("Output must be a 4D tensor");
+  }
+
+  int64_t batchSize = queryType.getShape()[0];
+  int64_t nQueryHeads = queryType.getShape()[1];
+  int64_t nKVHeads = keyType.getShape()[1];
+  int64_t headSize = queryType.getShape()[3];
+  int64_t seqLen = queryType.getShape()[2];
+  int64_t maxSeqLen = keyType.getShape()[2];
+
+  // NOTE: The q_chunk_size is 32 by default in ttnn. This is configurable via
+  // the program config. However, this is not modelled in the ttnn dialect.
+  if (seqLen % 32 != 0) {
+    return emitOpError(
+        "Sequence length must be divisible by q_chunk_size (32)");
+  }
+
+  if (keyType.getShape()[0] != batchSize) {
+    return emitOpError("Key/Value batch size must match query batch size");
+  }
+
+  if (keyType.getShape()[3] != headSize) {
+    return emitOpError("Key/Value head size must match query head size");
+  }
+
+  if (nQueryHeads % nKVHeads != 0) {
+    return emitOpError(
+        "Query num heads must be divisible by key/value num heads");
+  }
+
+  if (getAttentionMask()) {
+    if (getIsCausal()) {
+      return emitOpError(
+          "Attention mask is not allowed when is_causal is true");
+    }
+    RankedTensorType attentionMaskType = getAttentionMask().getType();
+    if (attentionMaskType.getShape().size() != 4) {
+      return emitOpError("Attention mask must be a 4D tensor");
+    }
+    if (attentionMaskType.getShape()[0] != batchSize) {
+      return emitOpError(
+          "Attention mask batch size must match query batch size");
+    }
+    if (attentionMaskType.getShape()[1] != 1) {
+      return emitOpError("Attention mask dim 1 must be 1");
+    }
+    if (attentionMaskType.getShape()[2] != seqLen) {
+      return emitOpError(
+          "Attention mask at dim 2 must match query sequence length");
+    }
+    if (attentionMaskType.getShape()[3] != maxSeqLen) {
+      return emitOpError("Attention mask at dim 3 must match key/value "
+                         "sequence length (max sequence length)");
+    }
+  } else {
+    if (!getIsCausal()) {
+      return emitOpError("Attention mask is required when is_causal is false");
+    }
+  }
+
+  if (getIsCausal()) {
+    if (seqLen != maxSeqLen) {
+      return emitOpError("Sequence length must match key/value sequence length "
+                         "when is_causal is true");
+    }
+  }
+
+  return success();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1907,7 +1907,7 @@ llvm::Expected<op_model::OpConstraints>
 ScaledDotProductAttentionOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "ttnn::scaled_dot_product_attention_decode can have 3 or 5 operands "
+         "ttnn::scaled_dot_product_attention can have 3 or 4 operands "
          "input tensors");
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
@@ -1938,11 +1938,7 @@ ScaledDotProductAttentionOp::getOpConstraints(
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "ttnn::scaled_dot_product_attention_decode can have 3 or 4 "
-         "input tensors");
-
-  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "ttnn::scaled_dot_product_attention_decode can have 3 or 4 "
+         "ttnn::scaled_dot_product_attention can have 3 or 4 "
          "input tensors");
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1907,8 +1907,8 @@ llvm::Expected<op_model::OpConstraints>
 ScaledDotProductAttentionOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "ttnn::scaled_dot_product_attention can have 3 or 4 operands "
-         "input tensors");
+         "ttnn::scaled_dot_product_attention can have 3 or 4 operands input "
+         "tensors");
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -1938,8 +1938,7 @@ ScaledDotProductAttentionOp::getOpConstraints(
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
-         "ttnn::scaled_dot_product_attention can have 3 or 4 "
-         "input tensors");
+         "ttnn::scaled_dot_product_attention can have 3 or 4 input tensors");
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2350,6 +2350,34 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
+// ScaledDotProductAttentionOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints>
+OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> queryShape,
+    TTNNLayoutAttr queryLayout, llvm::ArrayRef<int64_t> keyShape,
+    TTNNLayoutAttr keyLayout, llvm::ArrayRef<int64_t> valueShape,
+    TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
+    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+
+  return OpConstraints{};
+}
+
+llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
+    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+
+  return llvm::createStringError("Not Implemented");
+}
+
 //===-----------------------------------------------------------------------===//
 // RotaryEmbeddingLlamaOp
 // ===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2446,10 +2446,7 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
 
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
-  // The current position information is required for this op. It can either be
-  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
-  // std::optional so we must pass an empty vector.
-  constexpr std::vector<uint32_t> curPosEmpty = {};
+
   auto scaledDotProductAttentionOpQuery = [=]() {
     return ::ttnn::graph::query_op_runtime(
         ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2363,8 +2363,50 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
     std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
     std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
 
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  std::optional<float> scaleFloat =
+      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+
+  auto scaledDotProductAttentionOpQuery = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
+        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*program_config=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt);
+  };
+
+  return operation::getOpConstraints(queryLayout.getContext(), deviceGrid,
+                                     scaledDotProductAttentionOpQuery);
+#else
   return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
 }
 
 llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
@@ -2375,7 +2417,52 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> attentionMaskLayout, bool isCausal,
     std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
 
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  std::optional<float> scaleFloat =
+      scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  // The current position information is required for this op. It can either be
+  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
+  // std::optional so we must pass an empty vector.
+  constexpr std::vector<uint32_t> curPosEmpty = {};
+  auto scaledDotProductAttentionOpQuery = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
+        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*program_config=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt);
+  };
+
+  return operation::getOpRuntime(scaledDotProductAttentionOpQuery);
+#else
   return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
 }
 
 //===-----------------------------------------------------------------------===//

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1930,6 +1930,7 @@ createOp(FlatbufferObjectCache &cache, ScaledDotProductAttentionDecodeOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ScaledDotProductAttentionOp>
 createOp(FlatbufferObjectCache &cache, ScaledDotProductAttentionOp op) {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
   auto query = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getQuery()));
   auto key = cache.at<::tt::target::ttnn::TensorRef>(
@@ -1951,6 +1952,7 @@ createOp(FlatbufferObjectCache &cache, ScaledDotProductAttentionOp op) {
                  ? std::make_optional(op.getScale().value().convertToFloat())
                  : std::nullopt);
 
+  // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
   return ::tt::target::ttnn::CreateScaledDotProductAttentionOp(
       *cache.fbb, query, key, value, isCausal, attentionMask, scale, out,
       memoryConfig);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -51,6 +51,7 @@
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/trace.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
+#include "ttnn/operations/transformer/sdpa/sdpa.hpp"
 #include "ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/serialization.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/rotary_embedding_llama.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/nlp_concat_heads.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/nlp_concat_heads_decode.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/transformer/scaled_dot_product_attention.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/transformer/scaled_dot_product_attention_decode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
 )

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
@@ -31,10 +31,6 @@ static void runScaledDotProductAttentionOp(
 
   std::optional<float> scale = op->scale();
 
-  // The current position information is required for this op. It can either be
-  // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
-  // std::optional so we must pass an empty vector.
-  constexpr std::vector<uint32_t> curPosEmpty = {};
   ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention(
       query, key, value, attentionMask, isCausal, scale, outputMemoryConfig,
       std::nullopt, std::nullopt);

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
@@ -33,7 +33,8 @@ static void runScaledDotProductAttentionOp(
 
   ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention(
       query, key, value, attentionMask, isCausal, scale, outputMemoryConfig,
-      std::nullopt, std::nullopt);
+      /*program_config=*/std::nullopt,
+      /*compute_kernel_config=*/std::nullopt);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.h
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_SCALED_DOT_PRODUCT_ATTENTION_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_SCALED_DOT_PRODUCT_ATTENTION_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::transformer {
+void run(const ::tt::target::ttnn::ScaledDotProductAttentionOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::transformer
+
+#endif

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
@@ -45,7 +45,9 @@ static void runScaledDotProductAttentionDecodeOp(
   const std::vector<uint32_t> curPosEmpty = {};
   ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention_decode(
       query, key, value, isCausal, attentionMask, curPosEmpty, curPosTensor,
-      attentionSink, scale, outputMemoryConfig, std::nullopt, std::nullopt);
+      attentionSink, scale, outputMemoryConfig,
+      /*program_config=*/std::nullopt,
+      /*compute_kernel_config=*/std::nullopt);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -71,6 +71,7 @@
 #include "operations/transformer/nlp_concat_heads.h"
 #include "operations/transformer/nlp_concat_heads_decode.h"
 #include "operations/transformer/rotary_embedding_llama.h"
+#include "operations/transformer/scaled_dot_product_attention.h"
 #include "operations/transformer/scaled_dot_product_attention_decode.h"
 #include "tt/runtime/debug.h"
 #include "tt/runtime/detail/ttnn/types/types.h"
@@ -393,6 +394,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::ScaledDotProductAttentionDecodeOp: {
     return operations::transformer::run(
         op->type_as_ScaledDotProductAttentionDecodeOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::ScaledDotProductAttentionOp: {
+    return operations::transformer::run(
+        op->type_as_ScaledDotProductAttentionOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::NONE: {
     LOG_FATAL("Unsupported operation type: ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1198,6 +1198,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_ScaledDotProductAttentionDecodeOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::ScaledDotProductAttentionOp: {
+    tensorRef = opContext.type_as_ScaledDotProductAttentionOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::NLPConcatHeadsDecodeOp: {
     tensorRef = opContext.type_as_NLPConcatHeadsDecodeOp()->out();
     break;
@@ -1538,6 +1542,14 @@ getOpInputRefs(OpContext opContextHandle,
         opContext.type_as_ScaledDotProductAttentionDecodeOp()->cur_pos_tensor(),
         opContext.type_as_ScaledDotProductAttentionDecodeOp()
             ->attention_sink()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ScaledDotProductAttentionOp: {
+    tensorRefs = {
+        opContext.type_as_ScaledDotProductAttentionOp()->query(),
+        opContext.type_as_ScaledDotProductAttentionOp()->key(),
+        opContext.type_as_ScaledDotProductAttentionOp()->value(),
+        opContext.type_as_ScaledDotProductAttentionOp()->attention_mask()};
     break;
   }
   case ::tt::target::ttnn::OpType::RotaryEmbeddingLlamaOp: {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/transformer/scaled_dot_product_attention.mlir
@@ -1,0 +1,17 @@
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module @sdpa attributes {} {
+  func.func public @sdpa_with_attn_mask(%query: tensor<1x12x32x64xbf16>, %key: tensor<1x12x32x64xbf16>, %value: tensor<1x12x32x64xbf16>, %mask: tensor<1x1x32x32xbf16>) -> tensor<1x12x32x64xbf16> {
+    // CHECK: "ttir.scaled_dot_product_attention"
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%query, %key, %value, %mask) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "False"}} : (tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1x1x32x32xbf16>) -> tensor<1x12x32x64xbf16>
+    return %0 : tensor<1x12x32x64xbf16>
+  }
+
+  func.func public @sdpa_causal(%query: tensor<1x12x32x64xbf16>, %key: tensor<1x12x32x64xbf16>, %value: tensor<1x12x32x64xbf16>) -> tensor<1x12x32x64xbf16> {
+    // CHECK: "ttir.scaled_dot_product_attention"
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%query, %key, %value) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "True"}} : (tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>) -> tensor<1x12x32x64xbf16>
+    return %0 : tensor<1x12x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/transformer/scaled_dot_product_attention_decode.mlir
@@ -1,0 +1,17 @@
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module @sdpa attributes {} {
+  func.func public @sdpa_with_attn_mask(%query: tensor<1x1x12x64xbf16>, %key: tensor<1x12x32x64xbf16>, %value: tensor<1x12x32x64xbf16>, %cur_pos: tensor<1xi32>, %attn_mask: tensor<1x1x12x32xbf16>) -> tensor<1x1x12x64xbf16> {
+    // CHECK: "ttir.scaled_dot_product_attention_decode"
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention_decode(%query, %key, %value, %cur_pos, %attn_mask) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "True", has_attention_sink = "False", is_causal = "False"}} : (tensor<1x1x12x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1xi32>, tensor<1x1x12x32xbf16>) -> tensor<1x1x12x64xbf16>
+    return %0 : tensor<1x1x12x64xbf16>
+  }
+
+  func.func public @sdpa_causal(%query: tensor<1x1x12x64xbf16>, %key: tensor<1x12x32x64xbf16>, %value: tensor<1x12x32x64xbf16>, %cur_pos: tensor<1xi32>) -> tensor<1x1x12x64xbf16> {
+    // CHECK: "ttir.scaled_dot_product_attention_decode"
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention_decode(%query, %key, %value, %cur_pos) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "False", has_attention_sink = "False", is_causal = "True"}} : (tensor<1x1x12x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1x12x32x64xbf16>, tensor<1xi32>) -> tensor<1x1x12x64xbf16>
+    return %0 : tensor<1x1x12x64xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+module {
+    func.func @qkv_causal_sdpa(%query: tensor<8x12x32x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>) -> tensor<8x12x32x32xbf16> {
+        %output = ttir.empty() : tensor<8x12x32x32xbf16>
+        // CHECK: "ttnn.scaled_dot_product_attention"
+        %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %output) <{is_causal = true, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x12x32x32xbf16>) -> tensor<8x12x32x32xbf16>
+        return %1 : tensor<8x12x32x32xbf16>
+    }
+
+    func.func @qkv_attn_mask_sdpa(%query: tensor<8x12x32x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %attn_mask: tensor<8x1x32x32xbf16>) -> tensor<8x12x32x32xbf16> {
+        %output = ttir.empty() : tensor<8x12x32x32xbf16>
+        // CHECK: "ttnn.scaled_dot_product_attention"
+        %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %attn_mask, %output) <{is_causal = false, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x32x32xbf16>, tensor<8x12x32x32xbf16>) -> tensor<8x12x32x32xbf16>
+        return %1 : tensor<8x12x32x32xbf16>
+    }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+    func.func @qkv_causal_sdpa(%query: tensor<8x12x32x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>) -> tensor<8x12x32x32xbf16> {
+        %output = ttir.empty() : tensor<8x12x32x32xbf16>
+        // CHECK: "ttnn.scaled_dot_product_attention"
+        %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %output) <{is_causal = true, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x12x32x32xbf16>) -> tensor<8x12x32x32xbf16>
+        return %1 : tensor<8x12x32x32xbf16>
+    }
+
+    func.func @qkv_attn_mask_sdpa(%query: tensor<8x12x32x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %attn_mask: tensor<8x1x32x32xbf16>) -> tensor<8x12x32x32xbf16> {
+        %output = ttir.empty() : tensor<8x12x32x32xbf16>
+        // CHECK: "ttnn.scaled_dot_product_attention"
+        %1 = "ttir.scaled_dot_product_attention"(%query, %key, %value, %attn_mask, %output) <{is_causal = false, scale = 1.0 : f32 }> : (tensor<8x12x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x32x32xbf16>, tensor<8x12x32x32xbf16>) -> tensor<8x12x32x32xbf16>
+        return %1 : tensor<8x12x32x32xbf16>
+    }
+}

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -109,28 +109,6 @@ public:
         builder.getUnknownLoc(), rankedTensorType, nullptr,
         ShapeAttr::get(&context, tensorShape), nullptr, nullptr, nullptr);
   }
-
-  // template <typename ElementaryDtype>
-  // mlir::Value createFullTensor(llvm::ArrayRef<int64_t> tensorShape,
-  //                              mlir::Type elementType = nullptr,
-  //                              TTNNLayoutAttr layout = nullptr,
-  //                              ElementaryDtype fillValue = 0.0) {
-  //   if (!elementType) {
-  //     elementType = builder.getBF16Type();
-  //   }
-  //   mlir::Attribute fillValueAttr;
-  //   if constexpr (std::is_integral_v<ElementaryDtype>) {
-  //     fillValueAttr = builder.getI32IntegerAttr(fillValue);
-  //   } else {
-  //     fillValueAttr = builder.getF32FloatAttr(fillValue);
-  //   }
-  //   RankedTensorType rankedTensorType =
-  //       createRankedTensorType(tensorShape, elementType, layout);
-  //   return builder.create<FullOp>(builder.getUnknownLoc(), rankedTensorType,
-  //                                 nullptr,
-  //                                 ShapeAttr::get(&context, tensorShape),
-  //                                 fillValueAttr, nullptr, nullptr, nullptr);
-  // }
 };
 struct ExpectedResult {
   bool expectedLegal = false;
@@ -1745,6 +1723,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
 
     EXPECT_LE(cbSize, 483328);
     EXPECT_LE(totalPeakSize, 483328);
+    EXPECT_LE(l1PeakSize, 2048);
+    EXPECT_EQ(outputSize, 2048);
 
     ASSERT_TRUE(outputLayout);
     EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
@@ -1822,6 +1802,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
 
     EXPECT_LE(cbSize, 483328);
     EXPECT_LE(totalPeakSize, 483328);
+    EXPECT_LE(l1PeakSize, 2048);
+    EXPECT_EQ(outputSize, 2048);
 
     ASSERT_TRUE(outputLayout);
     EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1724,7 +1724,7 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
     EXPECT_LE(cbSize, 483328);
     EXPECT_LE(totalPeakSize, 483328);
     EXPECT_LE(l1PeakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
+    EXPECT_EQ(outputSize, 0);
 
     ASSERT_TRUE(outputLayout);
     EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
@@ -1803,7 +1803,7 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
     EXPECT_LE(cbSize, 483328);
     EXPECT_LE(totalPeakSize, 483328);
     EXPECT_LE(l1PeakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
+    EXPECT_EQ(outputSize, 0);
 
     ASSERT_TRUE(outputLayout);
     EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -110,27 +110,27 @@ public:
         ShapeAttr::get(&context, tensorShape), nullptr, nullptr, nullptr);
   }
 
-  template <typename ElementaryDtype>
-  mlir::Value createFullTensor(llvm::ArrayRef<int64_t> tensorShape,
-                               mlir::Type elementType = nullptr,
-                               TTNNLayoutAttr layout = nullptr,
-                               ElementaryDtype fillValue = 0.0) {
-    if (!elementType) {
-      elementType = builder.getBF16Type();
-    }
-    mlir::Attribute fillValueAttr;
-    if constexpr (std::is_integral_v<ElementaryDtype>) {
-      fillValueAttr = builder.getI32IntegerAttr(fillValue);
-    } else {
-      fillValueAttr = builder.getF32FloatAttr(fillValue);
-    }
-    RankedTensorType rankedTensorType =
-        createRankedTensorType(tensorShape, elementType, layout);
-    return builder.create<FullOp>(builder.getUnknownLoc(), rankedTensorType,
-                                  nullptr,
-                                  ShapeAttr::get(&context, tensorShape),
-                                  fillValueAttr, nullptr, nullptr, nullptr);
-  }
+  // template <typename ElementaryDtype>
+  // mlir::Value createFullTensor(llvm::ArrayRef<int64_t> tensorShape,
+  //                              mlir::Type elementType = nullptr,
+  //                              TTNNLayoutAttr layout = nullptr,
+  //                              ElementaryDtype fillValue = 0.0) {
+  //   if (!elementType) {
+  //     elementType = builder.getBF16Type();
+  //   }
+  //   mlir::Attribute fillValueAttr;
+  //   if constexpr (std::is_integral_v<ElementaryDtype>) {
+  //     fillValueAttr = builder.getI32IntegerAttr(fillValue);
+  //   } else {
+  //     fillValueAttr = builder.getF32FloatAttr(fillValue);
+  //   }
+  //   RankedTensorType rankedTensorType =
+  //       createRankedTensorType(tensorShape, elementType, layout);
+  //   return builder.create<FullOp>(builder.getUnknownLoc(), rankedTensorType,
+  //                                 nullptr,
+  //                                 ShapeAttr::get(&context, tensorShape),
+  //                                 fillValueAttr, nullptr, nullptr, nullptr);
+  // }
 };
 struct ExpectedResult {
   bool expectedLegal = false;
@@ -1762,6 +1762,82 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
     FAIL()
         << "Runtime test failed for ScaledDotProductAttentionDecodeOp; Error="
         << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
+  int64_t batch_size = 1;
+  int64_t num_heads = 1;
+  int64_t seq_len = 32;
+  int64_t kv_len = 128;
+  int64_t head_size = 32;
+
+  llvm::SmallVector<int64_t> queryShape{batch_size, num_heads, seq_len,
+                                        head_size};
+  llvm::SmallVector<int64_t> keyValueShape{batch_size, num_heads, kv_len,
+                                           head_size};
+
+  llvm::SmallVector<int64_t> curPosShape{batch_size};
+  // Provide an attention mask to satisfy optional-arg handling in the
+  // interface. Use broadcastable mask shape [B, 1, nH, T].
+  llvm::SmallVector<int64_t> maskShape{batch_size, 1, seq_len, kv_len};
+
+  auto tiledElemType = ttcore::TileType::get(builder.getBF16Type());
+
+  auto gridAttr = ttcore::GridAttr::get(&context);
+  auto tensorMemoryLayoutAttr =
+      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
+
+  auto queryLayout =
+      TTNNLayoutAttr::get(&context, queryShape, tiledElemType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+  auto keyValueLayout =
+      TTNNLayoutAttr::get(&context, keyValueShape, tiledElemType,
+                          BufferType::DRAM, gridAttr, tensorMemoryLayoutAttr);
+  auto maskLayout =
+      TTNNLayoutAttr::get(&context, maskShape, tiledElemType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+
+  auto query = createEmptyTensor(queryShape, tiledElemType, queryLayout);
+  auto key = createEmptyTensor(keyValueShape, tiledElemType, keyValueLayout);
+  auto value = createEmptyTensor(keyValueShape, tiledElemType, keyValueLayout);
+  auto attentionMask = createEmptyTensor(maskShape, tiledElemType, maskLayout);
+
+  auto outputType =
+      createRankedTensorType(queryShape, tiledElemType, queryLayout);
+
+  auto sdpAttention = builder.create<ScaledDotProductAttentionOp>(
+      builder.getUnknownLoc(), outputType, query, key, value,
+      /*attention_mask=*/attentionMask,
+      /*is_causal=*/false,
+      /*scale=*/nullptr,
+      /*memory_config=*/nullptr);
+
+  OpModel backend = dyn_cast<OpModel>(sdpAttention.getOperation());
+  auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
+                                                 OpConfig(queryLayout));
+  if (constraintsExp) {
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
+        constraintsExp.get();
+
+    EXPECT_LE(cbSize, 483328);
+    EXPECT_LE(totalPeakSize, 483328);
+
+    ASSERT_TRUE(outputLayout);
+    EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
+    EXPECT_TRUE(outputLayout.hasInterleavedDRAMTensorMemoryLayout());
+  } else {
+    FAIL() << "Missing L1 constraints for ScaledDotProductAttentionOp; "
+              "Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = getOpRuntime(sdpAttention.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << "Runtime test failed for ScaledDotProductAttentionOp; Error="
+           << llvm::toString(runtimeExp.takeError());
   }
 }
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -39,6 +39,7 @@
 #include "operations/reduction/prod/prod.hpp"
 #include "operations/trace.hpp"
 #include "operations/transformer/concatenate_heads/concatenate_heads.hpp"
+#include "operations/transformer/sdpa/sdpa.hpp"
 #include "operations/transformer/sdpa_decode/sdpa_decode.hpp"
 #include "tt-metalium/bfloat16.hpp"
 #include "ttnn/common/queue_id.hpp"


### PR DESCRIPTION
### Ticket
[#4265](https://github.com/tenstorrent/tt-mlir/issues/4265)

### Problem description
- We do not model `ttnn.transformer.scaled_dot_product_attention`
- We need this op to perform attention during prefill

### What's changed
- Bringup `scaled_dot_product_attention` through runtime, ttnn, ttir, and solo
- Add ttnn -> emitc conversion for op
- Add tests
- Also added sdpa decode shlo -> ttir tests

### Checklist
- [X] New/Existing tests provide coverage for changes
