### PR TITLE
Fix build after SDPA decode changes

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2260,7 +2260,7 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
   // The current position information is required for this op. It can either be
   // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
   // std::optional so we must pass an empty vector.
-  constexpr std::vector<uint32_t> curPosEmpty = {};
+  const std::vector<uint32_t> curPosEmpty = {};
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::transformer::scaled_dot_product_attention_decode, device,
@@ -2332,7 +2332,7 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
   // The current position information is required for this op. It can either be
   // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
   // std::optional so we must pass an empty vector.
-  constexpr std::vector<uint32_t> curPosEmpty = {};
+  const std::vector<uint32_t> curPosEmpty = {};
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
     return ::ttnn::graph::query_op_runtime(
         ::ttnn::transformer::scaled_dot_product_attention_decode, device,

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
@@ -42,7 +42,7 @@ static void runScaledDotProductAttentionDecodeOp(
   // The current position information is required for this op. It can either be
   // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
   // std::optional so we must pass an empty vector.
-  constexpr std::vector<uint32_t> curPosEmpty = {};
+  const std::vector<uint32_t> curPosEmpty = {};
   ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention_decode(
       query, key, value, isCausal, attentionMask, curPosEmpty, curPosTensor,
       attentionSink, scale, outputMemoryConfig, std::nullopt, std::nullopt);


### PR DESCRIPTION
### Ticket
No ticket; tt-xla uplift is failing https://github.com/tenstorrent/tt-xla/pull/1478

### Problem description
Opmodel changes introduced in https://github.com/tenstorrent/tt-mlir/pull/5018 are failing to build(both on tt-xla uplift CI, and on tt-mlir locally for me).
I'm not sure how this wasn't caught in CI...

### What's changed
Demoted contexpr to const on empty vectors.

### Checklist
- [ ] New/Existing tests provide coverage for changes
