### PR TITLE
Fix macOS nanobind build failure (#3526)

### DIFF
--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -57,3 +57,13 @@ if (TTMLIR_ENABLE_RUNTIME)
   target_sources(_ttmlir_runtime PRIVATE $<TARGET_OBJECTS:_mlir_runtime_utils>)
   set_property(TARGET _mlir_runtime_utils PROPERTY CXX_STANDARD 20)
 endif()
+
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options("nanobind-static" PRIVATE
+      -Wno-cast-qual
+      -Wno-zero-length-array
+      -Wno-nested-anon-types
+      -Wno-c++98-compat-extra-semi
+      -Wno-covered-switch-default
+  )
+endif()


### PR DESCRIPTION
On macOS nanobind fails with some warnings that we treat as errors. This patch works around the issue by disabling those warnings on the nanobind target.
