### PR TITLE
Custom load/store kernel dir

### DIFF
--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -99,6 +99,8 @@ table KernelConfig {
   args: KernelArgs;
   type: KernelConfigType;
   debug_info: string;
+  symbol: string;
+  loc: string;
 }
 
 table ProgramDesc {

--- a/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
@@ -87,8 +87,11 @@ public:
             threadType, builder.getAttr<SymbolRefAttr>(symbolName));
         auto threadAttrWithoutSym =
             builder.getAttr<ThreadAttr>(threadType, nullptr);
+        Location loc = region.getNumArguments() > 0
+                           ? region.getArgument(0).getLoc()
+                           : generic.getLoc();
         auto func = builder.create<func::FuncOp>(
-            generic.getLoc(), symbolName,
+            loc, symbolName,
             FunctionType::get(builder.getContext(), region.getArgumentTypes(),
                               {}));
         func.setPrivate();

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -587,11 +587,18 @@ kernelConfigToFlatbuffer(FlatbufferObjectCache &cache,
   }
   }
 
+  std::string locStr;
+  if (auto nameLoc =
+          mlir::dyn_cast<NameLoc>(LocationAttr(kernelEntry->getLoc()))) {
+    locStr = nameLoc.getName().getValue();
+  }
+
   return target::metal::CreateKernelConfigDirect(
       *cache.fbb, target::metal::Kernel::KernelSource,
       target::metal::CreateKernelSourceDirect(*cache.fbb, source.c_str())
           .Union(),
-      &coreRangeSet, args, configType, configUnion, kernelSymbol.data());
+      &coreRangeSet, args, configType, configUnion, kernelSymbol.data(),
+      kernelSymbol.data(), locStr.empty() ? nullptr : locStr.c_str());
 }
 
 static flatbuffers::Offset<::flatbuffers::Vector<uint8_t>>

--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -19,7 +19,7 @@ struct Env {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   static const Env &
 #else
-  constexpr static Env
+  static Env
 #endif
   get(bool dumpKernelsToDisk = false, bool loadKernelsFromDisk = false,
       bool useLocForKernelName = false, std::string kernelSourceDir = {},

--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -22,25 +22,31 @@ struct Env {
   constexpr static Env
 #endif
   get(bool dumpKernelsToDisk = false, bool loadKernelsFromDisk = false,
+      bool useLocForKernelName = false, std::string kernelSourceDir = {},
       bool deviceAddressValidation = false, bool blockingCQ = false)
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
       ;
 #else
   {
-    return Env(false, false, false, false);
+    return Env(false, false, false, {}, false, false);
   }
 #endif
 
   bool dumpKernelsToDisk;
   bool loadKernelsFromDisk;
+  bool useLocForKernelName;
+  std::string kernelSourceDir;
   bool deviceAddressValidation;
   bool blockingCQ;
 
 private:
-  constexpr Env(bool dumpKernelsToDisk, bool loadKernelsFromDisk,
-                bool deviceAddressValidation, bool blockingCQ)
+  Env(bool dumpKernelsToDisk, bool loadKernelsFromDisk,
+      bool useLocForKernelName, std::string kernelSourceDir,
+      bool deviceAddressValidation, bool blockingCQ)
       : dumpKernelsToDisk(dumpKernelsToDisk),
         loadKernelsFromDisk(loadKernelsFromDisk),
+        useLocForKernelName(useLocForKernelName),
+        kernelSourceDir(kernelSourceDir),
         deviceAddressValidation(deviceAddressValidation),
         blockingCQ(blockingCQ) {}
 };
@@ -51,6 +57,10 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << "dumpKernelsToDisk: " << env.dumpKernelsToDisk << "\n"
      << "\t"
      << "loadKernelsFromDisk: " << env.loadKernelsFromDisk << "\n"
+     << "\t"
+     << "useLocForKernelName: " << env.useLocForKernelName << "\n"
+     << "\t"
+     << "kernelSourceDir: " << env.kernelSourceDir << "\n"
      << "\t"
      << "deviceAddressValidation: " << env.deviceAddressValidation << "\n"
      << "\t"

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -13,9 +13,10 @@
 namespace tt::runtime::debug {
 
 const Env &Env::get(bool dumpKernelsToDisk, bool loadKernelsFromDisk,
+                    bool useLocForKernelName, std::string kernelSourceDir,
                     bool deviceAddressValidation, bool blockingCQ) {
-  static Env config(dumpKernelsToDisk, loadKernelsFromDisk,
-                    deviceAddressValidation, blockingCQ);
+  static Env config(dumpKernelsToDisk, loadKernelsFromDisk, useLocForKernelName,
+                    kernelSourceDir, deviceAddressValidation, blockingCQ);
   return config;
 }
 

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -312,7 +312,8 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
         createKernelConfig(kernelConfig, command->buffers(), meshBuffers,
                            command->cbs(), deviceAddressValidator,
                            createSemaphore),
-        currentProgramName, debugInfo, kernelConfig->debug_info()->c_str());
+        currentProgramName, debugInfo, kernelConfig->debug_info()->c_str(),
+        kernelConfig->loc() ? kernelConfig->loc()->c_str() : nullptr);
 
     std::vector<uint32_t> rtArgsVec = processRuntimeArgs(
         kernelConfig->args()->rt_args(), command->buffers(), meshBuffers,

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -11,6 +11,7 @@
 
 #include "ttmlir/Target/TTMetal/Target.h"
 
+#include <filesystem>
 #include <functional>
 #include <variant>
 
@@ -298,14 +299,15 @@ inline std::string createKernelFilePath(
     const char *kernelLoc, const CoreRangeSet &coreRangeSet,
     const std::variant<tt_metal::DataMovementConfig, tt_metal::ComputeConfig,
                        tt_metal::EthernetConfig> &kernelConfig,
-    std::string prefix = {}, const char *extention = ".cpp") {
+    std::filesystem::path prefix = {}, const char *extention = ".cpp") {
   if (prefix.empty()) {
-    prefix = "/tmp/ttmlir_";
+    prefix = "/tmp";
   }
-  std::string path(prefix);
+  std::filesystem::path path(prefix);
   if (debug::Env::get().useLocForKernelName && kernelLoc) {
-    path += kernelLoc;
+    path /= kernelLoc;
   } else {
+    prefix /= "ttmlir_";
     path += currentProgramName;
     path += "_";
     path += kernelDebugInfo;

--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -149,6 +149,13 @@ class Run:
             help="pickup the kernels from disk (/tmp) instead of the flatbuffer, must have previously run with --dump-kernels-to-disk",
         )
         Run.register_arg(
+            name="--use-loc-for-kernel-name",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="Use the location information to derive the kernel's filename when dumping to disk",
+        )
+        Run.register_arg(
             name="--disable-device-address-validation",
             type=bool,
             default=False,

--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -156,6 +156,13 @@ class Run:
             help="Use the location information to derive the kernel's filename when dumping to disk",
         )
         Run.register_arg(
+            name="--kernel-source-dir",
+            type=str,
+            default="",
+            choices=None,
+            help="test dir to save kernels to",
+        )
+        Run.register_arg(
             name="--disable-device-address-validation",
             type=bool,
             default=False,

--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -566,6 +566,8 @@ class Run:
             debug_env = ttrt.runtime.DebugEnv.get(
                 self["--dump-kernels-to-disk"],
                 self["--load-kernels-from-disk"],
+                self["--use-loc-for-kernel-name"],
+                self["--kernel-source-dir"],
                 not self["--disable-device-address-validation"],
                 self["--blocking-cq"],
             )


### PR DESCRIPTION
You can now specify somewhere to dump kernels to other than /tmp.

```bash
ttrt run --kernel-source-dir /my/path ...
```

You can also now use the location name (if it exists) as the kernel name.  This makes it possible to tag a particular kernel function with a location name and have the dumped artifact match exactly.