### PR TITLE
TTKernel to EmitC ArithFloorDivRewriter

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -674,6 +674,34 @@ public:
 } // namespace
 
 namespace {
+// Arith FloorDivSIOp doesn't have an emitc lowering, probably because of the
+// spec which says:
+//   Signed integer division. Rounds towards negative infinity, i.e. 5 / -2 = -3
+//
+// However we know our index type will map to size_t which is unsigned, making a
+// negative denominator impossible, so as long as we assert that this floordiv
+// is working on values of `index` type it's safe to map this op to regular
+// divi.
+class ArithFloorDivRewriter : public OpConversionPattern<arith::FloorDivSIOp> {
+public:
+  using OpConversionPattern<arith::FloorDivSIOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::FloorDivSIOp op, arith::FloorDivSIOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    if (!mlir::isa<IndexType>(op.getResult().getType())) {
+      return failure();
+    }
+
+    rewriter.replaceOpWithNewOp<arith::DivSIOp>(op, op.getResult().getType(),
+                                                op.getOperands());
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertTTKernelToEmitCPass
     : public ttkernel::impl::ConvertTTKernelToEmitCBase<
           ConvertTTKernelToEmitCPass> {
@@ -918,6 +946,8 @@ public:
         TTKernelTensorAccessorOpsRewriter<
             ttkernel::TensorAccessorIsLocalShardOp>>(typeConverter,
                                                      funcOp.getContext());
+
+    patterns.add<ArithFloorDivRewriter>(typeConverter, funcOp.getContext());
 
     return applyFullConversion(funcOp, target, std::move(patterns));
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/floor_div.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/floor_div.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Arith FloorDivSIOp doesn't have an emitc lowering, probably because of the spec
+// which says:
+//   Signed integer division. Rounds towards negative infinity, i.e. 5 / -2 = -3
+//
+// However we know our index type will map to size_t which is unsigned, making a
+// negative denominator impossible, so as long as we assert that this floordiv
+// is working on values of `index` type it's safe to map this op to regular
+// divi.
+
+// CHECK-LABEL: func @floor_div
+func.func @floor_div() -> index attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+  %1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+  %2 = arith.index_cast %0 : i32 to index
+  %3 = arith.index_cast %1 : i32 to index
+  // CHECK: emitc.div
+  %4 = arith.floordivsi %2, %3 : index
+  return %4 : index
+}

--- a/test/ttmlir/Conversion/TTKernelToEmitC/negative_floor_div.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/negative_floor_div.mlir
@@ -1,0 +1,19 @@
+// RUN: not ttmlir-opt --convert-ttkernel-to-emitc %s 2>&1 | FileCheck %s
+
+// Arith FloorDivSIOp doesn't have an emitc lowering, probably because of the spec
+// which says:
+//   Signed integer division. Rounds towards negative infinity, i.e. 5 / -2 = -3
+//
+// However we know our index type will map to size_t which is unsigned, making a
+// negative denominator impossible, so as long as we assert that this floordiv
+// is working on values of `index` type it's safe to map this op to regular
+// divi.
+
+// CHECK: error: failed to legalize operation 'arith.floordivsi'
+
+func.func @negative_floor_div() -> i32 attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+  %0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> i32
+  %1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> i32
+  %2 = arith.floordivsi %0, %1 : i32
+  return %2 : i32
+}


### PR DESCRIPTION
Arith FloorDivSIOp doesn't have an emitc lowering, probably because of the spec which says:

>  Signed integer division. Rounds towards negative infinity, i.e. 5 / -2 = -3

However we know our index type will map to size_t which is unsigned, making a negative denominator impossible, so as long as we assert that this floordiv is working on values of `index` type it's safe to map this op to regular divi.

Prerequisite for DSL 2 work.