### PR TITLE
TTIRBuilder - NonDPS style update - dot_general, permute

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -348,7 +348,7 @@ def get_dimension_size(
     "shapes,batch_dims_lhs,contract_dims_lhs,batch_dims_rhs,contract_dims_rhs",
     [
         (
-            [(4, 10, 3, 5, 7), (4, 10, 5, 7, 3), (4, 10, 3, 7, 10, 7, 3)],
+            [(4, 10, 3, 5, 7), (4, 10, 5, 7, 3)],
             [0],
             [3],
             [0],
@@ -367,14 +367,12 @@ def test_dot_general(
     def dot_general(
         in0: Operand,
         in1: Operand,
-        out0: Operand,
         builder: TTIRBuilder,
         unit_attrs: Optional[List[str]] = None,
     ):
         return builder.dot_general(
             in0,
             in1,
-            out0,
             batch_dims_lhs,
             contract_dims_lhs,
             batch_dims_rhs,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1657,30 +1657,27 @@ def test_reduce_or(shape: Shape, dim_args: List[int], request):
 
 def permute(
     in0: Operand,
-    in1: Operand,
     builder: TTIRBuilder,
     permutation: List[int],
     unit_attrs: Optional[List[str]] = None,
 ):
     return builder.permute(
         in0,
-        in1,
         permutation=permutation,
         unit_attrs=unit_attrs,
     )
 
 
-@pytest.mark.parametrize("shapes", [[(2, 3, 4), (3, 4, 2)]])
+@pytest.mark.parametrize("shapes", [[(2, 3, 4)]])
 @pytest.mark.parametrize("permutation", [[1, 2, 0]])
 def test_permute(shapes: List[Shape], permutation: List[int], request):
     # Create a wrapper function that captures permutation
     def permute_wrapper(
         in0: Operand,
-        in1: Operand,
         builder: TTIRBuilder,
         unit_attrs: Optional[List[str]] = None,
     ):
-        return permute(in0, in1, builder, permutation, unit_attrs)
+        return permute(in0, builder, permutation, unit_attrs)
 
     # Set the name for better test identification
     permute_wrapper.__name__ = "permute"

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -824,7 +824,6 @@ def linear_golden(
 def dot_general_golden(
     lhs: BuilderGoldenTensor,
     rhs: BuilderGoldenTensor,
-    out: BuilderGoldenTensor,
     batch_dims_lhs,
     contract_dims_lhs,
     batch_dims_rhs,
@@ -839,8 +838,6 @@ def dot_general_golden(
         Left-hand side tensor
     rhs : BuilderGoldenTensor
         Right-hand side tensor
-    out : BuilderGoldenTensor
-        Output tensor shape reference
     batch_dims_lhs : List[int]
         Batch dimensions for left tensor
     contract_dims_lhs : List[int]
@@ -857,9 +854,22 @@ def dot_general_golden(
     """
     non_batch_dims_lhs = [d for d in range(lhs.dim()) if d not in batch_dims_lhs]
     non_batch_dims_rhs = [d for d in range(rhs.dim()) if d not in batch_dims_rhs]
+
+    # Compute output shape
+    lhs_shape = list(lhs.shape)
+    rhs_shape = list(rhs.shape)
+    batch_shape = [lhs_shape[d] for d in batch_dims_lhs]
+    non_contract_lhs = [d for d in non_batch_dims_lhs if d not in contract_dims_lhs]
+    non_contract_rhs = [d for d in non_batch_dims_rhs if d not in contract_dims_rhs]
+    out_shape = (
+        batch_shape
+        + [lhs_shape[d] for d in non_contract_lhs]
+        + [rhs_shape[d] for d in non_contract_rhs]
+    )
+
     transposed_lhs = torch.permute(lhs, (batch_dims_lhs + non_batch_dims_lhs))
     transposed_rhs = torch.permute(rhs, (batch_dims_rhs + non_batch_dims_rhs))
-    result = out.zeros_like_builder(out.shape)
+    result = lhs.zeros_like_builder(out_shape)
 
     dim_ranges = []
     for i in range(len(batch_dims_lhs)):

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -210,7 +210,6 @@ class TTIRBuilder(Builder):
         self,
         in0: Operand,
         in1: Operand,
-        out0: Operand,
         batch_dims_lhs: List[int],
         contract_dims_lhs: List[int],
         batch_dims_rhs: List[int],
@@ -252,7 +251,7 @@ class TTIRBuilder(Builder):
         """
         return self._op_proxy(
             ttir.DotGeneralOp,
-            [in0, in1, out0],
+            [in0, in1],
             ttir_kwargs={
                 "batch_dims_lhs": batch_dims_lhs,
                 "contract_dims_lhs": contract_dims_lhs,

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -3467,7 +3467,6 @@ class TTIRBuilder(Builder):
     def permute(
         self,
         in0: Operand,
-        in1: Operand,
         permutation: List[int],
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -3494,10 +3493,9 @@ class TTIRBuilder(Builder):
         """
         return self._op_proxy(
             ttir.PermuteOp,
-            [in0, in1],
+            [in0],
             ttir_kwargs={"permutation": DenseI64ArrayAttr.get(permutation)},
             organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
-            organize_ttir_args=lambda i, o, _: (self._get_type(i[1]), i[0], i[1]),
             unit_attrs=unit_attrs,
         )
 


### PR DESCRIPTION
### Ticket
#5099

### Problem description
TTIRBuilder ops currently use mixed argument styles - some DPS, some non-DPS.

### What's changed
Update dot_general, permute as non-DPS style.

### Checklist
- [x] New/Existing tests provide coverage for changes
