### PR TITLE
Fix `tt-alchemist` solution linking error

### DIFF
--- a/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
+++ b/tools/tt-alchemist/templates/cpp/local/CMakeLists.txt
@@ -108,6 +108,7 @@ set(LINK_DIRS
 set(LINK_LIBS
     tt_metal
     device
+    tt_stl
     ${METAL_LIB_DIR}/_ttnncpp.so
 )
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5122

### Problem description
When trying to call:
```
tt-alchemist generate-cpp test/ttmlir/EmitC/TTNN/eltwise_binary/add.mlir --local -o add_cpp
cd add_cpp
./run
```
I'm getting a linking error:
```
[3/3] Linking CXX executable ttnn-local
FAILED: [code=1] ttnn-local 
: && /usr/bin/clang++ -O3 -DNDEBUG  CMakeFiles/ttnn-local.dir/ttnn-local.cpp.o -o ttnn-local -L/localdev/azecevic/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib -Wl,-rpath,/localdev/azecevic/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib  -ltt_metal  -ldevice  /localdev/azecevic/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib/_ttnncpp.so && :
/usr/bin/ld: CMakeFiles/ttnn-local.dir/ttnn-local.cpp.o: undefined reference to symbol '_ZN4ttsl6detail4llvm15SmallVectorBaseIjE8grow_podEPvmm'
/usr/bin/ld: /localdev/azecevic/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib/libtt_stl.so: error adding symbols: DSO missing from command line
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
The reason was that `CMakeLists.txt` for the solution didn't link `tt_stl` library.

### What's changed
Added `tt_stl` to the list of linked libraries.

### Checklist
- [ ] New/Existing tests provide coverage for changes
