### PR TITLE
Introduce FloatTypeInterface to ttcore.tile type

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -601,7 +601,7 @@ class TTCore_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def TTCore_Tile : TTCore_Type<"Tile", "tile", [MemRefElementTypeInterface]> {
+def TTCore_Tile : TTCore_Type<"Tile", "tile", [MemRefElementTypeInterface, FloatTypeInterface]> {
     let summary = "TT tile";
     let description = "Tile type in TT dialect";
     let parameters = (ins ArrayRefParameter<"int64_t">:$shape, "DataType":$dataType);
@@ -618,6 +618,9 @@ def TTCore_Tile : TTCore_Type<"Tile", "tile", [MemRefElementTypeInterface]> {
       // Returns the scalar element type of the tile, if compressed it returns
       // the corresponding uncompressed element type, i.e. bfp_bf8 -> bf16
       Type getElementType() const;
+      const ::llvm::fltSemantics &getFloatSemantics() {
+        llvm_unreachable("TTCore_Tile::getFloatSemantics unimplemented #5124");
+      }
     }];
 
     let genVerifyDecl = 1;

--- a/test/ttmlir/Dialect/TTCore/tile_float_type_interface.mlir
+++ b/test/ttmlir/Dialect/TTCore/tile_float_type_interface.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// This test verifies you can use tile types w/ the arith dialect
+// which requires its types to conform to the FloatTypeInterface
+
+// CHECK-NOT: error: 'arith.negf' op operand #0 must be floating-point-like
+
+func.func @float_interface(%arg0: !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32> {
+  %1 = arith.negf %arg0 : !ttcore.tile<32x32, f32>
+  return %1 : !ttcore.tile<32x32, f32>
+}
+
+func.func @float_interface_element_type(%arg0: tensor<2x4x!ttcore.tile<32x32, f32>>) -> tensor<2x4x!ttcore.tile<32x32, f32>> {
+  %1 = arith.negf %arg0 : tensor<2x4x!ttcore.tile<32x32, f32>>
+  return %1 : tensor<2x4x!ttcore.tile<32x32, f32>>
+}


### PR DESCRIPTION
The float type interface is introduced in order to support using the ttcore tile type in arith and math dialects, however, we don't currently need any upstream passes that reference this interface method hence we will leave it unimplemented for now.

Filed an issue for it's proper implementation if need be:
- #5124