### PR TITLE
Fix `ld` linker errors

### DIFF
--- a/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
@@ -15,6 +15,11 @@ add_mlir_library(MLIRTTNNInterfaces
   MLIRTTNNWorkaroundInterfaceIncGen
   MLIRTTNNKernelInterfaceIncGen
 
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   MLIRIR
+
+  PRIVATE
+  MLIRTTCoreDialect
+  TTNNOpModelLib
 )

--- a/lib/Dialect/TTNN/Utils/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Utils/CMakeLists.txt
@@ -9,4 +9,8 @@ add_mlir_dialect_library(TTMLIRTTNNUtils
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/TTNN
+
+  LINK_LIBS
+  PRIVATE
+  MLIRTTCoreDialect
 )

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -20,7 +20,7 @@ if (TTMLIR_ENABLE_OPMODEL)
     # Link to tt-metal libs and include directories
     target_include_directories(${LIB_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
     set(TTNN_LIBS TTMETAL_LIBRARY DEVICE_LIBRARY TTNN_LIBRARY TT_STL_LIBRARY TRACY_LIBRARY)
-    target_link_libraries(${LIB_NAME} PUBLIC ${TTNN_LIBS})
+    target_link_libraries(${LIB_NAME} PUBLIC ${TTNN_LIBS} PRIVATE TTMLIRTTNNUtils)
     target_compile_definitions(${LIB_NAME} PUBLIC TTMLIR_ENABLE_OPMODEL)
 else()
     # link stubs implementation when op model library is disabled

--- a/test/unittests/TestScheduler/CMakeLists.txt
+++ b/test/unittests/TestScheduler/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_unittest(SchedulerTests
 
 target_link_libraries(SchedulerTests
     PRIVATE
-    MLIRTTNNDialect
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,MLIRTTNNDialect>
     MLIRTTTransforms
     MLIRScheduler
 )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5063

### Problem description
Error log in the linked issue. The usual pattern is linking order of 'top' level targets, where the crux is unspecified linking targets on the lower level.
