### PR TITLE
Add flag to enable GlobalAveragePoolPattern in fusing pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -189,6 +189,10 @@ def TTIRFusing: Pass<"ttir-fusing", "::mlir::ModuleOp">
              "ttnn-enable-conv2d-with-multiply-pattern",
              "bool", /*default=*/"false",
              "Controls if we should enable the Conv2dWithMultiply pattern">,
+      Option<"globalPoolFusingEnabled",
+              "ttnn-enable-global-avg-pool-pattern",
+              "bool", /*default=*/"false",
+              "Controls if we should enable the GlobalAveragePoolingPattern fusing pattern">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -249,6 +249,12 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc("Enable Conv2dWithMultiply pattern in the fusing pass."),
       llvm::cl::init(false)};
 
+  Option<bool> enableFusingGlobalPoolPattern{
+      *this, "enable-fusing-global-avg-pool-pattern",
+      llvm::cl::desc(
+          "Enable GlobalAveragePoolingPattern pattern in the fusing pass."),
+      llvm::cl::init(false)};
+
   Option<ttcore::TTArgumentTypeMap, ttcore::ArgumentTypeMapParser>
       argumentTypeMap{
           *this, ttcore::OptionNames::argumentTypes,

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -2067,6 +2067,7 @@ public:
       if (conv2dWithMultiplyEnabled) {
         patterns.add<Conv2dWithMultiply>(&getContext());
         patterns.add<ConvolutionWithMultiply>(&getContext());
+        patterns.add<BatchNormDecomposition>(&getContext());
       }
       patterns.add<CacheFillUpdatePattern>(&getContext());
       patterns.add<ConcatenateHeadsUpdatePattern>(&getContext());
@@ -2074,11 +2075,10 @@ public:
       patterns.add<PadPoolingFusionPattern>(&getContext());
       patterns.add<AveragePoolingWithPoolingDenominatorFusionPattern>(
           &getContext());
-      patterns.add<GlobalAveragePoolingPattern>(&getContext());
-
-      if (conv2dWithMultiplyEnabled) {
-        patterns.add<BatchNormDecomposition>(&getContext());
+      if (globalPoolFusingEnabled) {
+        patterns.add<GlobalAveragePoolingPattern>(&getContext());
       }
+
       patterns.add<GeluFusionPattern>(&getContext());
 
       GreedyRewriteConfig config;

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -41,7 +41,8 @@ void createTTNNPipelineTTIRPasses(
       mlir::tt::ttcore::createTTPopulateArgumentTypes(options.argumentTypeMap));
   pm.addPass(mlir::createCanonicalizerPass());
   ttir::TTIRFusingOptions fusingOptions{
-      options.enableFusingConv2dWithMultiplyPattern};
+      options.enableFusingConv2dWithMultiplyPattern,
+      options.enableFusingGlobalPoolPattern};
   if (options.enableFusing) {
     pm.addPass(mlir::tt::ttir::createTTIRFusing(fusingOptions));
   }

--- a/test/ttmlir/Dialect/TTIR/fusing/global_avg_pool_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/global_avg_pool_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --canonicalize --ttir-fusing -o %t %s
+// RUN: ttmlir-opt --canonicalize --ttir-fusing="ttnn-enable-global-avg-pool-pattern=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 func.func @global_avg_pool(%input: tensor<1x32x112x112xbf16>) -> tensor<1x32x1x1xbf16> {


### PR DESCRIPTION
### Problem description
`GlobalAveragePool` fusing can cause OOM in some cases, we need a way to disable it.
### What's changed
Added a flag to enable `GlobalAveragePoolPattern` in the fusing pass which is off by default.

### Checklist
- [ ] New/Existing tests provide coverage for changes
