### PR TITLE
Fix MemLayout access in TensorSpec conversions

### DIFF
--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -252,7 +252,8 @@ getShardSpec(const TTNNLayoutAttr &layout) {
     return std::nullopt;
   }
 
-  if (!isShardedMemoryLayout(layout.getMemLayout().getValue())) {
+  if (!isShardedMemoryLayout(
+          layout.getMemLayoutOpt().value_or(TensorMemoryLayout::Interleaved))) {
     return std::nullopt;
   }
 
@@ -362,7 +363,8 @@ getTensorMemoryLayout(const TensorMemoryLayoutAttr memLayoutAttr) {
 }
 
 ::tt::tt_metal::MemoryConfig getMemoryConfig(const TTNNLayoutAttr &layout) {
-  auto tensorMemoryLayout = getTensorMemoryLayout(layout.getMemLayout());
+  auto tensorMemoryLayout = getTensorMemoryLayout(
+      layout.getMemLayoutOpt().value_or(TensorMemoryLayout::Interleaved));
   auto bufferType = getBufferType(layout);
 
   auto shardSpec = getShardSpec(layout);


### PR DESCRIPTION
When tensor is in sys mem, we don't set TensorMemoryLayoutAttr but rather leave it NULL. This leads to segfault in conversion when trying to generate Tensor spec.


