### PR TITLE
[runtime] `hasLayout` API

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -205,6 +205,8 @@ std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
                                Layout layout,
                                std::optional<bool> retain = std::nullopt);
 
+bool hasLayout(Tensor tensor, Layout layout);
+
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -181,6 +181,8 @@ std::vector<Tensor> toHost(Tensor tensor, bool untilize = false,
 Tensor toLayout(Tensor tensor, Device device, Layout layout,
                 std::optional<bool> retain = std::nullopt);
 
+bool hasLayout(Tensor tensor, Layout layout);
+
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -621,6 +621,19 @@ Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
       });
 }
 
+/// Returns whether the provided tensor has the specified layout.
+bool hasLayout(Tensor tensor, Layout layout) {
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::hasLayout(tensor, layout);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+      });
+}
+
 void memcpy(void *dst, Tensor src,
             std::optional<::tt::target::DataType> dstDataType) {
   using RetType = void;

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -788,6 +788,16 @@ std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
   return result;
 }
 
+bool hasLayout(::tt::runtime::Tensor tensor, Layout layout) {
+  const std::shared_ptr<LayoutDesc> tensorLayoutDesc =
+      LayoutDesc::fromTensor(tensor);
+
+  const LayoutDesc &desiredLayoutDesc =
+      layout.as<LayoutDesc>(DeviceRuntime::TTNN);
+
+  return *tensorLayoutDesc == desiredLayoutDesc;
+}
+
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex) {
   const ::tt::target::ttnn::TTNNBinary &fbb =


### PR DESCRIPTION
Introducing function `bool hasLayout(Tensor t, Layout l)` to the runtime API. This function returns whether the provided tensor has the specified layout.

This is needed since the `toLayout()` function has a side-effect (dirtying of the tensor) regardless of whether or not the tensor is already in the correct (desired) layout - which affects the tensor cache for consteval. So, in FEs we would like to be able to know if the `toLayout()` is needed before we execute it - e.g. in scenarios where one tensor is used with multiple programs with different layouts.

Issue tenstorrent/tt-xla#953