### PR TITLE
[D2M/TTNN Integration] Enable Translation of DRAM Interleaved Tensor Layouts

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -94,10 +94,13 @@ protected:
         mlir::cast<ttcore::TileType>(ttnnLayout.getElementType()).getHeight() ==
             ttcore::TileType::getDefaultShape()[0] &&
         "Only default tile shape is supported");
-    assert(ttnnLayout.hasL1BufferType() &&
-           ttnnLayout.getMemLayout().getValue() ==
-               ttnn::TensorMemoryLayout::BlockSharded &&
-           "Only block sharded L1 tensor memory layout is supported");
+    bool isBlockSharded = ttnnLayout.hasL1BufferType() &&
+                          ttnnLayout.getMemLayout().getValue() ==
+                              ttnn::TensorMemoryLayout::BlockSharded;
+    bool isInterleaved = ttnnLayout.hasInterleavedDRAMTensorMemoryLayout();
+    assert((isBlockSharded || isInterleaved) &&
+           "Only block sharded L1 or interleaved DRAM tensor memory layouts "
+           "are supported");
   }
 
   RankedTensorType
@@ -114,7 +117,7 @@ protected:
             ? ttcore::MemorySpace::DeviceDRAM
             : ttcore::MemorySpace::DeviceL1;
 
-    Type elementType = ttnnLayout.getElementType();
+    // Hardcode collapse intervals to [[0, -1)] to match ttnn.
     auto i64Ty = IntegerType::get(rewriter.getContext(), 64);
     auto intervalTy = RankedTensorType::get({1, 2}, i64Ty);
     DenseIntElementsAttr collapsedIntervals =
@@ -126,14 +129,19 @@ protected:
             ? ttcore::TensorMemoryLayout::Interleaved
             : ttcore::TensorMemoryLayout::Sharded;
 
+    // For tiled tensors the tile dims need to be 32 aligned.
+    llvm::SmallVector<int64_t> dimAlignments(tensorType.getShape().size(), 1);
+    dimAlignments[dimAlignments.size() - 1] = 32;
+    dimAlignments[dimAlignments.size() - 2] = 32;
+
     // The index map in TTNNLayoutAttr is for collapsing an N-D tensor on to
     // the grid. It has no relevance to the index map in MetalLayoutAttr.
-    // Hardcode collapse intervals to [[0, -1]].
     // MetalLayoutAttr takes the grid shape of the device, not the grid on which
     // the tensor is sharded.
     auto metalLayout = ttcore::MetalLayoutAttr::get(
         rewriter.getContext(), tensorType.getShape(), targetSquareGridShape,
-        ttcore::OOBVal::Undef, memSpace, memLayout, collapsedIntervals);
+        ttcore::OOBVal::Undef, memSpace, memLayout, collapsedIntervals,
+        dimAlignments);
 
     llvm::SmallVector<int64_t> unshardedShape =
         metalLayout.getPhysicalShape(ttcore::TileType::getDefaultShape());
@@ -141,6 +149,7 @@ protected:
     llvm::SmallVector<int64_t> shardedShape = metalLayout.getDeviceShape(
         ttnnLayout.getGrid().getShape(), ttcore::TileType::getDefaultShape());
 
+    Type elementType = ttnnLayout.getElementType();
     return mlir::RankedTensorType::get(shardedShape, elementType, metalLayout);
   }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5020

### Problem description
TTNN DRAM interleaved tensors need to be translated to Metal DRAM interleaved tensors. Support for metal DRAM interleaved tensors was added in https://github.com/tenstorrent/tt-mlir/pull/5082

### What's changed
- Enabled DRAM interleaved translation
  - Removed gating assertion
  - Fixed dim alignment inference
- Add IR tests to verify correct layout translation 
- Closes #5020 

### Checklist
- [X] New/Existing tests provide coverage for changes
