### PR TITLE
Add fusing pattern for relu6

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -7,7 +7,6 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include <llvm/Support/raw_ostream.h>
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNFUSING

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -29,9 +29,12 @@ public:
     Value activationInput = activationOp.getInput();
 
     auto activation = getActivationOpType(rewriter);
+
+    // For conv2d that will be converted to matmul, we cannot fuse relu6 as
+    // tt-metal doesn't support relu6 fusion for matmul.
+    // TODO(mvasiljevic): remove this once tt-metal supports relu6 fusion for
+    // matmul (https://github.com/tenstorrent/tt-metal/issues/29886)
     if (isMatmul(srcOp) && activation == ttnn::UnaryOpType::Relu6) {
-      // For conv2d that will be converted to matmul, we cannot fuse relu6 as
-      // tt-metal doesn't support relu6 fusion for matmul.
       return failure();
     }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -128,23 +128,19 @@ private:
     // Check stride is 1.
     llvm::ArrayRef<int32_t> strideAttr = srcOp.getStride();
     if (strideAttr.size() != 2 || strideAttr[0] != 1 || strideAttr[1] != 1) {
-      llvm::outs() << "Stride is not 1\n";
       return false;
     }
 
     // Check padding is 0.
     llvm::ArrayRef<int32_t> paddingAttr = srcOp.getPadding();
     if (llvm::any_of(paddingAttr, [](int32_t v) { return v != 0; })) {
-      llvm::outs() << "Padding is not 0\n";
       return false;
     }
 
     // only groups = 1 is supported for now
     if (srcOp.getGroups() != 1) {
-      llvm::outs() << "Groups is not 1\n";
       return false;
     }
-    llvm::outs() << "Conv2d can be converted to matmul\n";
     return true;
   }
 };

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <llvm/Support/raw_ostream.h>
 #ifdef TTMLIR_ENABLE_OPMODEL
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -349,14 +349,11 @@ getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout) {
 
 ::tt::tt_metal::TensorMemoryLayout
 getTensorMemoryLayout(const TensorMemoryLayoutAttr memLayoutAttr) {
-  llvm::outs() << "Getting tensor memory layout for attr: " << memLayoutAttr
-               << "\n";
   auto tensorMemoryLayout = memLayoutAttr.getValue();
   return getTensorMemoryLayout(tensorMemoryLayout);
 }
 
 ::tt::tt_metal::MemoryConfig getMemoryConfig(const TTNNLayoutAttr &layout) {
-  llvm::outs() << "Getting memory config for layout: " << layout << "\n";
   auto tensorMemoryLayout = getTensorMemoryLayout(
       layout.getMemLayoutOpt().value_or(TensorMemoryLayout::Interleaved));
   auto bufferType = getBufferType(layout);

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <llvm/Support/raw_ostream.h>
 #ifdef TTMLIR_ENABLE_OPMODEL
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 
@@ -348,11 +349,14 @@ getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout) {
 
 ::tt::tt_metal::TensorMemoryLayout
 getTensorMemoryLayout(const TensorMemoryLayoutAttr memLayoutAttr) {
+  llvm::outs() << "Getting tensor memory layout for attr: " << memLayoutAttr
+               << "\n";
   auto tensorMemoryLayout = memLayoutAttr.getValue();
   return getTensorMemoryLayout(tensorMemoryLayout);
 }
 
 ::tt::tt_metal::MemoryConfig getMemoryConfig(const TTNNLayoutAttr &layout) {
+  llvm::outs() << "Getting memory config for layout: " << layout << "\n";
   auto tensorMemoryLayout = getTensorMemoryLayout(
       layout.getMemLayoutOpt().value_or(TensorMemoryLayout::Interleaved));
   auto bufferType = getBufferType(layout);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4,7 +4,6 @@
 
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Utils.h"
-#include <llvm/Support/Error.h>
 
 #ifdef TTMLIR_ENABLE_OPMODEL
 
@@ -505,7 +504,7 @@ createMetalHostTensor(llvm::ArrayRef<int64_t> shape,
   for (size_t i = 0; i < shape.size(); i++) {
     volume *= shape[i];
   }
-  dataType = ttcore::DataType::BFloat16; // Temporary override
+
   auto metalDataType = conversion::getDataType(dataType);
   auto hostBuffer = createHostBuffer(volume, metalDataType);
   auto metalShape = conversion::getShape(shape);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -505,8 +505,6 @@ createMetalHostTensor(llvm::ArrayRef<int64_t> shape,
   for (size_t i = 0; i < shape.size(); i++) {
     volume *= shape[i];
   }
-  llvm::outs() << "Creating tensor with datatype: "
-               << static_cast<int>(dataType) << "\n";
   dataType = ttcore::DataType::BFloat16; // Temporary override
   auto metalDataType = conversion::getDataType(dataType);
   auto hostBuffer = createHostBuffer(volume, metalDataType);
@@ -552,12 +550,6 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  llvm::outs() << "Input shape: ";
-  for (auto dim : inputShape) {
-    llvm::outs() << dim << " ";
-  }
-  llvm::outs() << "\n";
-  llvm::outs() << "Input layout: " << inputLayout << "\n";
   auto inputSpecExp =
       detail::convertToTensorSpec(device, inputShape, inputLayout);
   if (!inputSpecExp) {
@@ -640,8 +632,6 @@ getPrepareConv2dBiasOpOutputTensorSpec(
   }
 
   // TODO(rpavlovicTT):: Move this to tt-metal side #4043
-  llvm::outs() << "and data type: "
-               << static_cast<int>(biasLayout.getDataType()) << "\n";
   if (biasLayout.getDataType() != ttcore::DataType::Float32 &&
       biasLayout.getDataType() != ttcore::DataType::BFloat16) {
     return llvm::createStringError(

--- a/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
@@ -1,18 +1,18 @@
+// RUN: ttmlir-opt --canonicalize --ttir-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
 module @SyncTensorsGraph.2210 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
-    func.func @main(%arg0: tensor<32x3x3x3xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "weight"} loc("xla__device_data"), %arg1: tensor<8x3x224x224xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "input"} loc("xla__device_data"), %arg2: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_scale"}, %arg3: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_offset"}, %arg4: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_mean"}, %arg5: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_variance"}) -> (tensor<8x32x112x112xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    func.func @main(%arg0: tensor<32x3x3x3xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "weight"} loc("xla__device_data"), %arg1: tensor<8x3x224x224xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "input"} loc("xla__device_data")) -> (tensor<8x32x112x112xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
         %0 = "ttir.constant"() <{value = dense<6.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
         %1 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
-        
         %2 = ttir.empty() : tensor<8x32x112x112xbf16> 
         %3 = "ttir.convolution"(%arg1, %arg0, %2) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2x3, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 1, 1>, padding = array<i64: 1, 1, 1, 1>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 2, 2>}> : (tensor<8x3x224x224xbf16>, tensor<32x3x3x3xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
-        
         %4 = ttir.empty() : tensor<8x32x112x112xbf16>
-        %5 = "ttir.batch_norm"(%3, %arg2, %arg3, %arg4, %arg5, %4) <{dimension = 1 : i32, epsilon = 9.99999974E-6 : f32, training = false}> : (tensor<8x32x112x112xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
-        
-        %6 = ttir.empty() : tensor<8x32x112x112xbf16> 
-        %7 = "ttir.maximum"(%5, %1, %6) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
-        %8 = ttir.empty() : tensor<8x32x112x112xbf16> 
-        %9 = "ttir.minimum"(%7, %0, %8) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
-        return %9 : tensor<8x32x112x112xbf16> 
+        %5 = "ttir.relu"(%3, %4) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
+        %6 = ttir.empty() : tensor<8x32x112x112xbf16>
+        // CHECK: "ttir.relu6"
+        // CHECK-NOT: "ttir.relu"
+        %7 = "ttir.minimum"(%5, %0, %6) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
+        return %7 : tensor<8x32x112x112xbf16> 
     }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
@@ -3,16 +3,15 @@
 
 module @SyncTensorsGraph.2210 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
     func.func @main(%arg0: tensor<32x3x3x3xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "weight"} loc("xla__device_data"), %arg1: tensor<8x3x224x224xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "input"} loc("xla__device_data")) -> (tensor<8x32x112x112xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
-        %0 = "ttir.constant"() <{value = dense<6.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
-        %1 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
-        %2 = ttir.empty() : tensor<8x32x112x112xbf16> 
-        %3 = "ttir.convolution"(%arg1, %arg0, %2) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2x3, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 1, 1>, padding = array<i64: 1, 1, 1, 1>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 2, 2>}> : (tensor<8x3x224x224xbf16>, tensor<32x3x3x3xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
-        %4 = ttir.empty() : tensor<8x32x112x112xbf16>
-        %5 = "ttir.relu"(%3, %4) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
-        %6 = ttir.empty() : tensor<8x32x112x112xbf16>
+        %0 = "ttir.constant"() <{value = dense<6.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16>
+        %1 = ttir.empty() : tensor<8x32x112x112xbf16>
+        %2 = "ttir.convolution"(%arg1, %arg0, %1) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2x3, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 1, 1>, padding = array<i64: 1, 1, 1, 1>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 2, 2>}> : (tensor<8x3x224x224xbf16>, tensor<32x3x3x3xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
+        %3 = ttir.empty() : tensor<8x32x112x112xbf16>
+        %4 = "ttir.relu"(%2, %3) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
+        %5 = ttir.empty() : tensor<8x32x112x112xbf16>
         // CHECK: "ttir.relu6"
         // CHECK-NOT: "ttir.relu"
-        %7 = "ttir.minimum"(%5, %0, %6) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
-        return %7 : tensor<8x32x112x112xbf16> 
+        %6 = "ttir.minimum"(%4, %0, %5) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
+        return %6 : tensor<8x32x112x112xbf16>
     }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/relu6_fusing.mlir
@@ -1,0 +1,18 @@
+module @SyncTensorsGraph.2210 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+    func.func @main(%arg0: tensor<32x3x3x3xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "weight"} loc("xla__device_data"), %arg1: tensor<8x3x224x224xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "input"} loc("xla__device_data"), %arg2: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_scale"}, %arg3: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_offset"}, %arg4: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_mean"}, %arg5: tensor<32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "bn_variance"}) -> (tensor<8x32x112x112xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+        %0 = "ttir.constant"() <{value = dense<6.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
+        %1 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<8x32x112x112xbf16>}> : () -> tensor<8x32x112x112xbf16> 
+        
+        %2 = ttir.empty() : tensor<8x32x112x112xbf16> 
+        %3 = "ttir.convolution"(%arg1, %arg0, %2) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2x3, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 1, 1>, padding = array<i64: 1, 1, 1, 1>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 2, 2>}> : (tensor<8x3x224x224xbf16>, tensor<32x3x3x3xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
+        
+        %4 = ttir.empty() : tensor<8x32x112x112xbf16>
+        %5 = "ttir.batch_norm"(%3, %arg2, %arg3, %arg4, %arg5, %4) <{dimension = 1 : i32, epsilon = 9.99999974E-6 : f32, training = false}> : (tensor<8x32x112x112xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<32xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16>
+        
+        %6 = ttir.empty() : tensor<8x32x112x112xbf16> 
+        %7 = "ttir.maximum"(%5, %1, %6) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
+        %8 = ttir.empty() : tensor<8x32x112x112xbf16> 
+        %9 = "ttir.minimum"(%7, %0, %8) : (tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>, tensor<8x32x112x112xbf16>) -> tensor<8x32x112x112xbf16> 
+        return %9 : tensor<8x32x112x112xbf16> 
+    }
+}

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
@@ -52,6 +52,28 @@ module {
     return %3 : tensor<1x30x30x64xbf16>
   }
 
+  // Test that we cannot fuse Conv2d and relu6 if Conv2d will be converted to matmul.
+  // CHECK-LABEL: func.func @conv2d_to_matmul_with_relu6
+  func.func @conv2d_to_matmul_with_relu6(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x1x1xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
+    %0 = ttir.empty() : tensor<1x32x32x64xbf16>
+    // CHECK: %{{.*}} = "ttnn.conv2d"
+    // CHECK-NOT: activation ={{.*}}relu6
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x1x1xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+
+    // CHECK: %[[RELU6:.*]] = "ttnn.relu6"
+    %2 = ttir.empty() : tensor<1x32x32x64xbf16>
+    %3 = "ttir.relu6"(%1, %2) : (tensor<1x32x32x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+
+    // CHECK: return %[[RELU6]]
+    return %3 : tensor<1x32x32x64xbf16>
+  }
+
   // Test that we cannot fuse Conv2d and ReLU because Conv2d has multiple uses.
   // CHECK-LABEL: func.func @conv2d_with_multiple_uses
   func.func @conv2d_with_multiple_uses(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4631)

### Problem description
Mobilenet through torch-xla uses `minimum(relu(x), 6.0)` instead of a `relu6` op.

### What's changed
- Added `Relu6FusionPattern` that matches `minimum(relu(x), 6)` and converts to `relu6`
- Updated `TTNNConv2dWithActivation` to skip convs converted to matmul, as `relu6` is not supported for matmul in metal

### Checklist
- [x] New/Existing tests provide coverage for changes
