### PR TITLE
remove legacy ttrt build flag from ci yaml

### DIFF
--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -77,7 +77,7 @@ runs:
       shell: bash
       run: |
         source env/activate
-        cmake --build ${{ inputs.build-output-dir }} -- ttrt
+        cmake --build ${{ inputs.build-output-dir }}
         cmake --build ${{ inputs.build-output-dir }} -- compile-ttmlir-tests
 
     - name: Build tt-alchemist

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -94,7 +94,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build.build_type }} -- ttrt
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build.build_type }}
 
     - name: Upload Test Report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What's changed
Removed legacy ttrt build flag from CI yamls

