### PR TITLE
Update the stream_layout op's verifier

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -105,6 +105,18 @@ ArrayRef<int64_t> getTensorTileShape(RankedTensorType tensorType);
 
 ArrayRef<int64_t> getTensorTileShapeOrEmpty(RankedTensorType tensorType);
 
+// Retrieve the layout from the shaped type (ie. getEncoding for tensors and
+// getLayout for memrefs).
+inline DeviceLayoutInterface getDeviceLayout(ShapedType shapedType) {
+  if (auto tensor = mlir::dyn_cast_if_present<RankedTensorType>(shapedType)) {
+    return mlir::dyn_cast_if_present<DeviceLayoutInterface>(
+        tensor.getEncoding());
+  } else if (auto memref = mlir::dyn_cast_if_present<MemRefType>(shapedType)) {
+    return mlir::dyn_cast_if_present<DeviceLayoutInterface>(memref.getLayout());
+  }
+  return nullptr;
+}
+
 } // namespace mlir::tt::ttcore
 
 #endif // TTMLIR_DIALECT_TTCORE_IR_UTILS_H

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -111,9 +111,12 @@ inline DeviceLayoutInterface getDeviceLayout(ShapedType shapedType) {
   if (auto tensor = mlir::dyn_cast_if_present<RankedTensorType>(shapedType)) {
     return mlir::dyn_cast_if_present<DeviceLayoutInterface>(
         tensor.getEncoding());
-  } else if (auto memref = mlir::dyn_cast_if_present<MemRefType>(shapedType)) {
+  }
+
+  if (auto memref = mlir::dyn_cast_if_present<MemRefType>(shapedType)) {
     return mlir::dyn_cast_if_present<DeviceLayoutInterface>(memref.getLayout());
   }
+
   return nullptr;
 }
 

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -210,103 +210,59 @@ struct ToLayoutFoldRedundantPattern : public OpRewritePattern<ToLayoutOp> {
 };
 
 static ::mlir::LogicalResult
-verifyLayoutOp(mlir::Operation *op, mlir::Type inputTensorOrMemrefTy,
-               mlir::Type outputTensorOrMemrefTy, bool allowFormatChange,
-               bool allowMemorySpaceChange, bool checkMemrefRank = false,
-               bool checkMemrefGridShardForm = false,
-               bool checkMemrefShardShape = false) {
-  if (mlir::RankedTensorType inputTy =
-          mlir::dyn_cast<mlir::RankedTensorType>(inputTensorOrMemrefTy)) {
-    mlir::RankedTensorType outputTy =
-        mlir::dyn_cast<mlir::RankedTensorType>(outputTensorOrMemrefTy);
-    if (!outputTy) {
-      return op->emitOpError("Input and output types must be the same");
-    }
-
-    auto inputLayout =
-        mlir::dyn_cast_if_present<mlir::tt::ttcore::MetalLayoutAttr>(
-            inputTy.getEncoding());
-    auto outputLayout =
-        mlir::dyn_cast_if_present<mlir::tt::ttcore::MetalLayoutAttr>(
-            outputTy.getEncoding());
-
-    if (!inputLayout || !outputLayout) {
-      // If the input/output tensor does not have a layout, we can early exit.
-      return mlir::success();
-    }
-
-    const bool isFormatChange =
-        inputTy.getElementType() != outputTy.getElementType();
-    if (isFormatChange && !allowFormatChange) {
-      return op->emitOpError(
-          "Input and output tensor element types must be the same");
-    }
-
-    const bool isMemorySpaceChange =
-        inputLayout.getMemorySpace() != outputLayout.getMemorySpace();
-    if (!allowMemorySpaceChange && isMemorySpaceChange) {
-      return op->emitOpError(
-          "Input and output layout memory spaces must be the same");
-    }
+verifyLayoutOp(mlir::Operation *op, const char *aName, const char *bName,
+               mlir::Type aType, mlir::Type bType, bool checkSameElementType,
+               bool checkSameMemorySpace = false, bool checkSameRank = false,
+               bool checkSameGridShape = false,
+               bool checkSameShardShape = false) {
+  mlir::ShapedType a = mlir::cast<mlir::ShapedType>(aType);
+  mlir::ShapedType b = mlir::cast<mlir::ShapedType>(bType);
+  ttcore::DeviceLayoutInterface aLayout = ttcore::getDeviceLayout(a);
+  ttcore::DeviceLayoutInterface bLayout = ttcore::getDeviceLayout(b);
+  if (!aLayout || !bLayout) {
+    // If no layout present, we can early exit.
     return mlir::success();
   }
 
-  if (mlir::MemRefType inputTy =
-          mlir::dyn_cast<mlir::MemRefType>(inputTensorOrMemrefTy)) {
-    mlir::MemRefType outputTy =
-        mlir::dyn_cast<mlir::MemRefType>(outputTensorOrMemrefTy);
-    if (!outputTy) {
-      return op->emitOpError("Input and output types must be the same");
-    }
-
-    const bool isFormatChange =
-        inputTy.getElementType() != outputTy.getElementType();
-    if (!allowFormatChange && isFormatChange) {
-      return op->emitOpError(
-          "Input and output layout element types must be the same");
-    }
-
-    const bool isMemorySpaceChange =
-        inputTy.getMemorySpace() != outputTy.getMemorySpace();
-    if (!allowMemorySpaceChange && isMemorySpaceChange) {
-      return op->emitOpError(
-          "Input and output memref memory spaces must be the same");
-    }
-
-    const bool sameRank = inputTy.getRank() == outputTy.getRank();
-    if (checkMemrefRank && !sameRank) {
-      return op->emitOpError("Input and output memref ranks must be the same");
-    }
-
-    auto inputDeviceLayout =
-        mlir::dyn_cast<mlir::tt::ttcore::DeviceLayoutInterface>(
-            inputTy.getLayout());
-    if (checkMemrefGridShardForm && !inputDeviceLayout) {
-      return op->emitOpError(
-          "input memref must have device layout, i.e. have even rank, grid "
-          "shape followed by shard shape of equal rank, e.g. GxGxSxS");
-    }
-
-    auto outputDeviceLayout =
-        mlir::dyn_cast<mlir::tt::ttcore::DeviceLayoutInterface>(
-            outputTy.getLayout());
-    if (checkMemrefGridShardForm && !outputDeviceLayout) {
-      return op->emitOpError(
-          "output memref must have device layout, i.e. have even rank, grid "
-          "shape followed by shard shape of equal rank, e.g. GxGxSxS");
-    }
-
-    return mlir::success();
+  if (checkSameElementType && (a.getElementType() != b.getElementType())) {
+    return op->emitOpError()
+           << aName << " and " << bName << "'s element types must be the same";
   }
 
-  return op->emitOpError("Unsupported input type for view");
+  if (checkSameMemorySpace && mlir::isa<MemRefType>(a)) {
+    if (mlir::cast<MemRefType>(a).getMemorySpace() !=
+        mlir::cast<MemRefType>(b).getMemorySpace()) {
+      return op->emitOpError() << aName << " and " << bName
+                               << "'s memref memory spaces must be the same";
+    }
+  }
+
+  if (checkSameRank && a.getRank() != b.getRank()) {
+    return op->emitOpError()
+           << aName << " and " << bName << "'s ranks must be the same";
+  }
+
+  if (checkSameGridShape &&
+      (aLayout.getGridShape(a) != bLayout.getGridShape(b))) {
+    return op->emitOpError()
+           << aName << " and " << bName << "'s grid shape must be the same";
+  }
+
+  if (checkSameShardShape &&
+      (aLayout.getShardShape(a) != bLayout.getShardShape(b))) {
+    return op->emitOpError()
+           << aName << " and " << bName << "'s shard shape must be the same";
+  }
+
+  return mlir::success();
 }
 
 // ToLayoutOp verification
 ::mlir::LogicalResult ToLayoutOp::verify() {
-  return verifyLayoutOp(*this, getInput().getType(), getOutput().getType(),
-                        /*allowFormatChange*/ true,
-                        /*allowMemorySpaceChange*/ true);
+  return verifyLayoutOp(*this, "input", "output", getInput().getType(),
+                        getOutput().getType(),
+                        /*checkSameElementType*/ false,
+                        /*checkSameMemorySpace*/ false);
 }
 
 // ToLayoutOp utility methods
@@ -641,35 +597,37 @@ void d2m::StreamLayoutOp::getCanonicalizationPatterns(
 }
 
 mlir::LogicalResult StreamLayoutOp::verify() {
-  auto inputStorageVerification =
-      verifyLayoutOp(*this, getInput().getType(), getStorage().getType(),
-                     /*allowFormatChange*/ false,
-                     /*allowMemorySpaceChange*/ true,
-                     /*checkMemrefRank*/ true,
-                     /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefShardShape*/ false);
+  auto inputStorageVerification = verifyLayoutOp(
+      *this, "input", "storage", getInput().getType(), getStorage().getType(),
+      /*checkSameElementType*/ true,
+      /*checkSameMemorySpace*/ false,
+      /*checkSameRank*/ true,
+      /*checkSameGridShape*/ false,
+      /*checkSameShardShape*/ false);
   if (failed(inputStorageVerification)) {
     return inputStorageVerification;
   }
 
-  auto storageResultVerification =
-      verifyLayoutOp(*this, getStorage().getType(), getResult().getType(),
-                     /*allowFormatChange*/ false,
-                     /*allowMemorySpaceChange*/ true,
-                     /*checkMemrefRank*/ true,
-                     /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefShardShape*/ true);
+  auto storageResultVerification = verifyLayoutOp(
+      *this, "storage", "result", getStorage().getType(), getResult().getType(),
+      /*checkSameElementType*/ true,
+      /*checkSameMemorySpace*/ false,
+      /*checkSameRank*/ true,
+      /*checkSameGridShape*/ false,
+      /*checkSameShardShape*/ true);
   if (failed(storageResultVerification)) {
     return storageResultVerification;
   }
 
-  MemRefType inputMemrefType = mlir::dyn_cast<MemRefType>(getInput().getType());
-  MemRefType resultMemrefType =
-      mlir::dyn_cast<MemRefType>(getResult().getType());
-  if (inputMemrefType && resultMemrefType &&
-      (inputMemrefType.getMemorySpace() != resultMemrefType.getMemorySpace())) {
-    return this->emitOpError(
-        "Input and result memref memory spaces must be the same");
+  auto inputResultVerification = verifyLayoutOp(
+      *this, "input", "result", getInput().getType(), getResult().getType(),
+      /*checkSameElementType*/ true,
+      /*checkSameMemorySpace*/ true,
+      /*checkSameRank*/ true,
+      /*checkSameGridShape*/ false,
+      /*checkSameShardShape*/ false);
+  if (failed(inputResultVerification)) {
+    return inputResultVerification;
   }
 
   return success();

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -160,6 +160,8 @@ struct OperandContext {
   // possible spilling (e.g. because of an intra-core data movement
   // pattern.)
   bool requiresStream = false;
+  // Index of this operand for the associated generic op.
+  size_t operandIndex = 0;
 
   // Fields used to link this Value to a `Planner` decision variable.
 
@@ -392,6 +394,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
          operandIndex < genericOp.getNumOperands(); ++operandIndex) {
       OperandContext &operandCtx = result.emplace_back();
 
+      operandCtx.operandIndex = operandIndex;
+
       operandCtx.isOutput = (operandIndex >= outputsStart);
 
       // A core participating in a reduction dim necessarily requires
@@ -619,7 +623,10 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                     // In principle, buffer shape/size could depend on whether
                     // the stream is out of L1 or DRAM... but not right now.
                     operandCtx.bufferType = selectStreamBuffer(
-                        rewriter, memrefCtx.type, numStreamBuffers);
+                        rewriter,
+                        mlir::cast<MemRefType>(
+                            user.getOperand(operandCtx.operandIndex).getType()),
+                        numStreamBuffers);
                   }
                   const AllocSizeT bufferSize =
                       getStreamBufferSizeBytes(operandCtx.bufferType, device);


### PR DESCRIPTION
The stream layout previously didn't have a stringent enough verifier, which is now able to validate that shard shapes between the storage and the result type are equal.

There was one bit of fallout that was detected by an existing test `test/ttmlir/Dialect/D2M/allocate/generic_form_streams_matmul.mlir`. The subtest `matmul_multi_core_transpose` uses a view_layout op to transpose the input on the fly.  The allocator needed a small update to the stream_layout's storage memref type which must come from the post view's shape.  This is accomplished by reading the generic's operand type.
