### PR TITLE
Implement TTNN to TTIR for reduction ops

### DIFF
--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -6,7 +6,6 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/IR/Builders.h"
@@ -20,9 +19,7 @@
 namespace {
 
 template <typename SrcOp, typename DestOp>
-class TTNNToTTIRElementwiseConversionPattern
-    : public mlir::OpConversionPattern<SrcOp> {
-
+class TTNNToTTIROpConversionPattern : public mlir::OpConversionPattern<SrcOp> {
   using mlir::OpConversionPattern<SrcOp>::OpConversionPattern;
   using Adaptor = typename SrcOp::Adaptor;
 
@@ -35,6 +32,123 @@ public:
 
     mlir::tt::ttir::utils::replaceOpWithNewDPSOp<DestOp>(
         rewriter, srcOp, outputType, adaptor.getOperands());
+
+    return mlir::success();
+  }
+};
+
+template <typename SrcOp, typename DestOp>
+class TTNNToTTIRElementwiseConversionPattern
+    : public TTNNToTTIROpConversionPattern<SrcOp, DestOp> {
+public:
+  using TTNNToTTIROpConversionPattern<SrcOp,
+                                      DestOp>::TTNNToTTIROpConversionPattern;
+  // Reuse base; this exists simply for clarity and potential future extensions
+};
+
+template <typename SrcOp, typename DestOp>
+class TTNNToTTIRReductionConversionPattern
+    : public TTNNToTTIROpConversionPattern<SrcOp, DestOp> {
+public:
+  using TTNNToTTIROpConversionPattern<SrcOp,
+                                      DestOp>::TTNNToTTIROpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(SrcOp srcOp, typename SrcOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    // Handle attribute differences between TTNN and TTIR
+    auto dimArgAttr =
+        srcOp.getDimArg()
+            ? rewriter.getI32ArrayAttr(llvm::to_vector(llvm::map_range(
+                  srcOp.getDimArg().value(),
+                  [](mlir::Attribute attr) {
+                    return static_cast<int32_t>(
+                        mlir::cast<mlir::IntegerAttr>(attr).getInt());
+                  })))
+            : nullptr;
+
+    // Use the utility function to handle DPS pattern with converted attributes
+    mlir::tt::ttir::utils::replaceOpWithNewDPSOp<DestOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), srcOp.getKeepDim(),
+        dimArgAttr);
+
+    return mlir::success();
+  }
+};
+
+class TTNNArgMaxToTTIRArgMaxConversionPattern
+    : public mlir::OpConversionPattern<mlir::tt::ttnn::ArgMaxOp> {
+public:
+  using mlir::OpConversionPattern<
+      mlir::tt::ttnn::ArgMaxOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ArgMaxOp srcOp,
+                  mlir::tt::ttnn::ArgMaxOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    // ArgMax: TTNN has dim (I32Attr), TTIR has dim_arg (I32ArrayAttr)
+    auto keepDimAttr = rewriter.getBoolAttr(srcOp.getKeepDim());
+    auto dimArgAttr =
+        srcOp.getDim()
+            ? rewriter.getI32ArrayAttr({static_cast<int32_t>(*srcOp.getDim())})
+            : nullptr;
+
+    mlir::tt::ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ArgMaxOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), keepDimAttr,
+        dimArgAttr);
+
+    return mlir::success();
+  }
+};
+
+class TTNNProdToTTIRProdConversionPattern
+    : public mlir::OpConversionPattern<mlir::tt::ttnn::ProdOp> {
+public:
+  using mlir::OpConversionPattern<mlir::tt::ttnn::ProdOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ProdOp srcOp,
+                  mlir::tt::ttnn::ProdOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    auto keepDimAttr = rewriter.getBoolAttr(srcOp.getKeepDim());
+    // Prod uses I64Attr for TTNN dimArg, convert to I32ArrayAttr for TTIR
+    auto dimArgAttr = srcOp.getDimArg()
+                          ? rewriter.getI32ArrayAttr(
+                                {static_cast<int32_t>(*srcOp.getDimArg())})
+                          : nullptr;
+
+    mlir::tt::ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ProdOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), keepDimAttr,
+        dimArgAttr);
+
+    return mlir::success();
+  }
+};
+
+class TTNNMorehCumSumToTTIRCumSumConversionPattern
+    : public mlir::OpConversionPattern<mlir::tt::ttnn::MorehCumSumOp> {
+public:
+  using mlir::OpConversionPattern<
+      mlir::tt::ttnn::MorehCumSumOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::MorehCumSumOp srcOp,
+                  mlir::tt::ttnn::MorehCumSumOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    mlir::tt::ttir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::CumSumOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), srcOp.getDim());
 
     return mlir::success();
   }
@@ -148,12 +262,32 @@ addElementwiseBinaryOpsConversionPatterns(mlir::MLIRContext *ctx,
                mlir::tt::ttir::LogicalLeftShiftOp>>(typeConverter, ctx);
 }
 
+static void
+addReductionOpsConversionPatterns(mlir::MLIRContext *ctx,
+                                  mlir::RewritePatternSet &patterns,
+                                  mlir::TypeConverter &typeConverter) {
+
+  patterns.add<TTNNToTTIRReductionConversionPattern<mlir::tt::ttnn::SumOp,
+                                                    mlir::tt::ttir::SumOp>,
+               TTNNToTTIRReductionConversionPattern<mlir::tt::ttnn::MeanOp,
+                                                    mlir::tt::ttir::MeanOp>,
+               TTNNToTTIRReductionConversionPattern<mlir::tt::ttnn::MaxOp,
+                                                    mlir::tt::ttir::MaxOp>,
+               TTNNToTTIRReductionConversionPattern<mlir::tt::ttnn::MinOp,
+                                                    mlir::tt::ttir::MinOp>,
+               TTNNArgMaxToTTIRArgMaxConversionPattern,
+               TTNNProdToTTIRProdConversionPattern,
+               TTNNMorehCumSumToTTIRCumSumConversionPattern>(typeConverter,
+                                                             ctx);
+}
+
 namespace mlir::tt {
 
 void populateTTNNToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
                                 TypeConverter &typeConverter) {
   addElementwiseUnaryOpsConversionPatterns(ctx, patterns, typeConverter);
   addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
+  addReductionOpsConversionPatterns(ctx, patterns, typeConverter);
   patterns.add<TTNNMatmulToTTIRMatmulConversionPattern>(typeConverter, ctx);
 }
 

--- a/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/reduction_op.mlir
@@ -1,0 +1,82 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test_sum(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.sum"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: "ttnn.sum"
+        %2 = "ttnn.sum"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+
+    func.func @test_mean(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.mean"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: "ttnn.mean"
+        %2 = "ttnn.mean"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+
+    func.func @test_max(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.max"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: "ttnn.max"
+        %2 = "ttnn.max"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+
+    func.func @test_min(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.min"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: "ttnn.min"
+        %2 = "ttnn.min"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+
+    func.func @test_prod(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK: %{{[0-9]+}} = "ttir.prod"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: "ttnn.prod"
+        %2 = "ttnn.prod"(%1) {ttnn.hoist_generic_via_d2m, dim_arg = 1, keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+
+}

--- a/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
+++ b/test/ttmlir/Conversion/TTNNToTTIR/skip_reduction_op.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --convert-ttnn-to-ttir -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#core_range = #ttnn.core_range<(0,0), (0,0)>
+#core_ranges = #ttnn.core_range_set<[#core_range]>
+
+#dram_memory_config = #ttnn.memory_config<#dram, <interleaved>>
+#l1_memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#core_range]>, <32x32>, <row_major>>>
+
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+
+module {
+    func.func @test_sum_no_tag(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32xf32, #dram_layout> {
+        %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (0,0)>]>, <32x32>, <row_major>>>}> : (tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout>
+
+        // CHECK-NOT: %{{[0-9]+}} = ttir.empty() : tensor<32xf32, #ttnn_layout1>
+        // CHECK-NOT: %{{[0-9]+}} = "ttir.sum"(%{{[0-9]+}}, %{{[0-9]+}}) <{dim_arg = array<i32: 1>, keep_dim = false}> : (tensor<32x32xf32, #ttnn_layout1>, tensor<32xf32, #ttnn_layout1>) -> tensor<32xf32, #ttnn_layout1>
+        %2 = "ttnn.sum"(%1) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32, #l1_layout>) -> tensor<32xf32, #l1_layout>
+
+        %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32xf32, #l1_layout>) -> tensor<32xf32, #dram_layout>
+
+        return %3 : tensor<32xf32, #dram_layout>
+    }
+}


### PR DESCRIPTION
### Ticket
#5159

### Problem description
Implement TTNN to TTIR conversion for reduction ops:

| ttnn Op | TTNN Dialect | TTIR Dialect|
|-----------|------|------|
| **Sum** | `TTNN_SumOp` | `TTIR_SumOp` |
| **Mean** | `TTNN_MeanOp` | `TTIR_MeanOp` |
| **Max** | `TTNN_MaxOp` | `TTIR_MaxOp` |
| **Min** | `TTNN_MinOp` | `TTIR_MinOp` |
| **ArgMax** | `TTNN_ArgMaxOp` | `TTIR_ArgMaxOp` |
| **Prod** | `TTNN_ProdOp` | `TTIR_ProdOp` |
| **MorehCumSum** | `TTNN_MorehCumSumOp` | `TTIR_CumSumOp` |

### What's changed
To minimize almost-identical code, a common conversion base class provides support for both the elementwise and most reduction ops. Reductions that have different attributes (`argmax`, `prod`, `cumsum`) have individual conversion classes.

### Checklist
- [ X ] New/Existing tests provide coverage for changes
