### PR TITLE
Supporting ttir.gather case from AlexNet model

### DIFF
--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
@@ -330,7 +330,7 @@ module attributes {} {
     return %1 : tensor<1x2x3xf32>
   }
 
-  // a1
+  // In examples 17 to 23 there are dims that are in start index map that don't have slice size 1
   func.func @gather_17(%operand : tensor<2x3x2xbf16>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2x2xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<2x2x2x2xbf16>
@@ -347,7 +347,6 @@ module attributes {} {
     return %1 : tensor<2x2x2x2xbf16>
   }
 
-  // a2
   func.func @gather_18(%operand : tensor<2x3x2xbf16>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x1x3x2xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<2x2x1x3x2xbf16>
@@ -364,7 +363,6 @@ module attributes {} {
     return %1 : tensor<2x2x1x3x2xbf16>
   }
 
-  // a3
   func.func @gather_19(%operand : tensor<5x2x3xbf16>, %start_indices: tensor<2x1xi32>) -> (tensor<2x2x2x3xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<2x2x2x3xbf16>
@@ -381,7 +379,6 @@ module attributes {} {
     return %1 : tensor<2x2x2x3xbf16>
   }
 
-  // a4
   func.func @gather_20(%operand : tensor<2x5x2xbf16>, %start_indices: tensor<2x3xi32>) -> (tensor<2x2x2x3x2xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<2x2x2x3x2xbf16>
@@ -398,7 +395,6 @@ module attributes {} {
     return %1 : tensor<2x2x2x3x2xbf16>
   }
 
-  // a5
   func.func @gather_21(%operand : tensor<2x3x4x6xbf16>, %start_indices: tensor<5x4xi32>) -> (tensor<5x2x3x4x3xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<5x2x3x4x3xbf16>
@@ -415,7 +411,6 @@ module attributes {} {
     return %1 : tensor<5x2x3x4x3xbf16>
   }
 
-  // a6
   func.func @gather_22(%operand : tensor<2x6xbf16>, %start_indices: tensor<5x2xi32>) -> (tensor<5x2x3xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<5x2x3xbf16>
@@ -432,7 +427,6 @@ module attributes {} {
     return %1 : tensor<5x2x3xbf16>
   }
 
-  // a7
   func.func @gather_23(%operand : tensor<2x3x6x2xbf16>, %start_indices: tensor<3x2x3xi32>) -> (tensor<2x2x3x3x4x2xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     %0 = ttir.empty() : tensor<2x2x3x3x4x2xbf16>

--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
@@ -21,7 +21,7 @@ module attributes {} {
 
   func.func @gather_1(%operand: tensor<448x384xbf16>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x384xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: : (tensor<1x2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<1x2x384xbf16, {{.+}}>
+    // CHECK-SAME: : (tensor<2x1xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<2x1x384xbf16, {{.+}}>
     %0 = ttir.empty() : tensor<1x2x384xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         offset_dims = array<i64: 2>,
@@ -73,7 +73,7 @@ module attributes {} {
 
   func.func @gather_4(%operand: tensor<2048x1x200xf32>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x1x200xf32> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<1x2x200xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2x1xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<2x1x200xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<1x2x1x200xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -110,26 +110,8 @@ module attributes {} {
     return %1 : tensor<2x512xf32>
   }
 
-  // Examples 6 to 9 test different rank combinations for input, start indices and output.
-  func.func @gather_6(%operand: tensor<1xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
-    // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<1x1xbf16, {{.+}}>) -> tensor<1x1x1xbf16, {{.+}}>
-    // CHECK: "ttnn.reshape"
-    %0 = ttir.empty() : tensor<1xbf16>
-    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
-        collapsed_slice_dims = array<i64: 0>,
-        index_vector_dim = 0 : si64,
-        indices_are_sorted = false,
-        offset_dims = array<i64>,
-        operand_batching_dims = array<i64>,
-        slice_sizes = array<i64: 1>,
-        start_index_map = array<i64: 0>,
-        start_indices_batching_dims = array<i64>
-      }> : (tensor<1xbf16>, tensor<1xi32>, tensor<1xbf16>) -> tensor<1xbf16>
-    return %1 : tensor<1xbf16>
-  }
-
-  func.func @gather_7(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
+  // Examples 6 to 8 test different rank combinations for input, start indices and output.
+  func.func @gather_6(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<6x1xbf16, {{.+}}>) -> tensor<1x1x1xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
@@ -147,7 +129,7 @@ module attributes {} {
     return %1 : tensor<1xbf16>
   }
 
-  func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
+  func.func @gather_7(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
@@ -165,7 +147,7 @@ module attributes {} {
     return %1 : tensor<3x4xbf16>
   }
 
-  func.func @gather_9(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
+  func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
     %0 = ttir.empty() : tensor<3x1x4xbf16>
@@ -182,8 +164,8 @@ module attributes {} {
     return %1 : tensor<3x1x4xbf16>
   }
 
-  // In examples 10 to 15 more than one dim is being indexed
-  func.func @gather_10(%operand: tensor<3x2x3xf32>, %start_indices: tensor<1x2xi32>) -> (tensor<1x3xf32> {jax.result_info = "result"}) {
+  // In examples 9 to 14 more than one dim is being indexed
+  func.func @gather_9(%operand: tensor<3x2x3xf32>, %start_indices: tensor<1x2xi32>) -> (tensor<1x3xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.constant"
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
@@ -204,12 +186,12 @@ module attributes {} {
     return %1 : tensor<1x3xf32>
   }
 
-  func.func @gather_11(%operand: tensor<7x8x2xf32>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_10(%operand: tensor<7x8x2xf32>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.constant"
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x4xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<1x4x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<4x1xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<4x1x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<2x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -225,12 +207,12 @@ module attributes {} {
     return %1 : tensor<2x2x2xf32>
   }
 
-  func.func @gather_12(%operand: tensor<18x17x2xf32>, %start_indices: tensor<3x1x3x2xi32>) -> (tensor<3x1x3x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_11(%operand: tensor<18x17x2xf32>, %start_indices: tensor<3x1x3x2xi32>) -> (tensor<3x1x3x2xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.constant"
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x9xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<1x9x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<9x1xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<9x1x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<3x1x3x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -246,12 +228,12 @@ module attributes {} {
     return %1 : tensor<3x1x3x2xf32>
   }
 
-  func.func @gather_13(%operand: tensor<4x5x2x2xf32>, %start_indices: tensor<2x1x1x2xi32>) -> (tensor<2x1x1x2x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_12(%operand: tensor<4x5x2x2xf32>, %start_indices: tensor<2x1x1x2xi32>) -> (tensor<2x1x1x2x2xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.constant"
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<1x2x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2x1xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<2x1x4xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %0 = ttir.empty() : tensor<2x1x1x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
@@ -267,10 +249,7 @@ module attributes {} {
     return %1 : tensor<2x1x1x2x2xf32>
   }
 
-  func.func @gather_14(%operand: tensor<1x7x2xbf16>, %start_indices: tensor<1x2xi32>) -> (tensor<1x2xbf16> {jax.result_info = "result"}) {
-    // CHECK: "ttnn.constant"
-    // CHECK: "ttnn.typecast"
-    // CHECK: "ttnn.matmul"
+  func.func @gather_13(%operand: tensor<1x7x2xbf16>, %start_indices: tensor<1x2xi32>) -> (tensor<1x2xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<7x2xbf16, {{.+}}>) -> tensor<1x1x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
@@ -288,7 +267,7 @@ module attributes {} {
     return %1 : tensor<1x2xbf16>
   }
 
-  func.func @gather_15(%operand: tensor<3x2x3x4xf32>, %start_indices: tensor<1x3xi32>) -> (tensor<1x4xf32> {jax.result_info = "result"}) {
+  func.func @gather_14(%operand: tensor<3x2x3x4xf32>, %start_indices: tensor<1x3xi32>) -> (tensor<1x4xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.constant"
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
@@ -309,8 +288,8 @@ module attributes {} {
     return %1 : tensor<1x4xf32>
   }
 
-  // In examples 16 and 17 permute ops are needed
-  func.func @gather_16(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
+  // In examples 15 and 16 permute ops are needed
+  func.func @gather_15(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.permute"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
@@ -331,7 +310,7 @@ module attributes {} {
     return %1 : tensor<1x2x3x4xf32>
   }
 
-  func.func @gather_17(%operand: tensor<1x2x5x7xf32>, %start_indices: tensor<3x2xi32>) -> (tensor<1x2x3xf32> {jax.result_info = "result"}) {
+  func.func @gather_16(%operand: tensor<1x2x5x7xf32>, %start_indices: tensor<3x2xi32>) -> (tensor<1x2x3xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.permute"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
@@ -349,5 +328,124 @@ module attributes {} {
         start_indices_batching_dims = array<i64>
       }> : (tensor<1x2x5x7xf32>, tensor<3x2xi32>, tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
     return %1 : tensor<1x2x3xf32>
+  }
+
+  // a1
+  func.func @gather_17(%operand : tensor<2x3x2xbf16>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2x2xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<2x2x2x2xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64: 1>,
+        index_vector_dim = 0 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 0,2>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,1,2>,
+        start_index_map = array<i64: 0,1>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x3x2xbf16>, tensor<2x2x2xi32>, tensor<2x2x2x2xbf16>) -> tensor<2x2x2x2xbf16>
+    return %1 : tensor<2x2x2x2xbf16>
+  }
+
+  // a2
+  func.func @gather_18(%operand : tensor<2x3x2xbf16>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x1x3x2xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<2x2x1x3x2xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 1 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 2,3,4>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 1,3,2>,
+        start_index_map = array<i64: 0,2>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x3x2xbf16>, tensor<2x2x2xi32>, tensor<2x2x1x3x2xbf16>) -> tensor<2x2x1x3x2xbf16>
+    return %1 : tensor<2x2x1x3x2xbf16>
+  }
+
+  // a3
+  func.func @gather_19(%operand : tensor<5x2x3xbf16>, %start_indices: tensor<2x1xi32>) -> (tensor<2x2x2x3xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<2x2x2x3xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 1 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 1,2,3>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,2,3>,
+        start_index_map = array<i64: 0>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<5x2x3xbf16>, tensor<2x1xi32>, tensor<2x2x2x3xbf16>) -> tensor<2x2x2x3xbf16>
+    return %1 : tensor<2x2x2x3xbf16>
+  }
+
+  // a4
+  func.func @gather_20(%operand : tensor<2x5x2xbf16>, %start_indices: tensor<2x3xi32>) -> (tensor<2x2x2x3x2xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<2x2x2x3x2xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 2 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 0,1,4>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,2,2>,
+        start_index_map = array<i64: 1>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x5x2xbf16>, tensor<2x3xi32>, tensor<2x2x2x3x2xbf16>) -> tensor<2x2x2x3x2xbf16>
+    return %1 : tensor<2x2x2x3x2xbf16>
+  }
+
+  // a5
+  func.func @gather_21(%operand : tensor<2x3x4x6xbf16>, %start_indices: tensor<5x4xi32>) -> (tensor<5x2x3x4x3xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<5x2x3x4x3xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 1 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 1,2,3,4>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,3,4,3>,
+        start_index_map = array<i64: 0,1,2,3>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x3x4x6xbf16>, tensor<5x4xi32>, tensor<5x2x3x4x3xbf16>) -> tensor<5x2x3x4x3xbf16>
+    return %1 : tensor<5x2x3x4x3xbf16>
+  }
+
+  // a6
+  func.func @gather_22(%operand : tensor<2x6xbf16>, %start_indices: tensor<5x2xi32>) -> (tensor<5x2x3xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<5x2x3xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 1 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 1,2>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,3>,
+        start_index_map = array<i64: 0,1>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x6xbf16>, tensor<5x2xi32>, tensor<5x2x3xbf16>) -> tensor<5x2x3xbf16>
+    return %1 : tensor<5x2x3xbf16>
+  }
+
+  // a7
+  func.func @gather_23(%operand : tensor<2x3x6x2xbf16>, %start_indices: tensor<3x2x3xi32>) -> (tensor<2x2x3x3x4x2xbf16> {jax.result_info = "result"}) {
+    // CHECK: "ttnn.embedding"
+    %0 = ttir.empty() : tensor<2x2x3x3x4x2xbf16>
+    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
+        collapsed_slice_dims = array<i64>,
+        index_vector_dim = 0 : si64,
+        indices_are_sorted = false,
+        offset_dims = array<i64: 0,3,4,5>,
+        operand_batching_dims = array<i64>,
+        slice_sizes = array<i64: 2,3,4,2>,
+        start_index_map = array<i64: 0,2,3>,
+        start_indices_batching_dims = array<i64>
+      }> : (tensor<2x3x6x2xbf16>, tensor<3x2x3xi32>, tensor<2x2x3x3x4x2xbf16>) -> tensor<2x2x3x3x4x2xbf16>
+    return %1 : tensor<2x2x3x3x4x2xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/embedding/gather_to_embedding.mlir
@@ -96,23 +96,8 @@ module attributes {} {
     return %1 : tensor<2x512xf32>
   }
 
-  // Examples 6 to 9 test different rank combinations for input, start indices and output.
-  func.func @gather_6(%operand: tensor<1xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
-    %0 = ttir.empty() : tensor<1xbf16>
-    %1 = "ttir.gather"(%operand, %start_indices, %0) <{
-        collapsed_slice_dims = array<i64: 0>,
-        index_vector_dim = 0 : si64,
-        indices_are_sorted = false,
-        offset_dims = array<i64>,
-        operand_batching_dims = array<i64>,
-        slice_sizes = array<i64: 1>,
-        start_index_map = array<i64: 0>,
-        start_indices_batching_dims = array<i64>
-      }> : (tensor<1xbf16>, tensor<1xi32>, tensor<1xbf16>) -> tensor<1xbf16>
-    return %1 : tensor<1xbf16>
-  }
-
-  func.func @gather_7(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
+  // Examples 6 to 8 test different rank combinations for input, start indices and output.
+  func.func @gather_6(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0>,
@@ -127,7 +112,7 @@ module attributes {} {
     return %1 : tensor<1xbf16>
   }
 
-  func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
+  func.func @gather_7(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
     %0 = ttir.empty() : tensor<3x4xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0>,
@@ -142,7 +127,7 @@ module attributes {} {
     return %1 : tensor<3x4xbf16>
   }
 
-  func.func @gather_9(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
+  func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
     %0 = ttir.empty() : tensor<3x1x4xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0>,
@@ -157,8 +142,8 @@ module attributes {} {
     return %1 : tensor<3x1x4xbf16>
   }
 
-  // In examples 10 to 15 more than one dim is being indexed
-  func.func @gather_10(%operand: tensor<3x2x3xf32>, %start_indices: tensor<1x2xi32>) -> (tensor<1x3xf32> {jax.result_info = "result"}) {
+  // In examples 9 to 14 more than one dim is being indexed
+  func.func @gather_9(%operand: tensor<3x2x3xf32>, %start_indices: tensor<1x2xi32>) -> (tensor<1x3xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1x3xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0, 1>,
@@ -173,7 +158,7 @@ module attributes {} {
     return %1 : tensor<1x3xf32>
   }
 
-  func.func @gather_11(%operand: tensor<7x8x2xf32>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_10(%operand: tensor<7x8x2xf32>, %start_indices: tensor<2x2x2xi32>) -> (tensor<2x2x2xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<2x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0, 1>,
@@ -188,7 +173,7 @@ module attributes {} {
     return %1 : tensor<2x2x2xf32>
   }
 
-  func.func @gather_12(%operand: tensor<18x17x2xf32>, %start_indices: tensor<3x1x3x2xi32>) -> (tensor<3x1x3x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_11(%operand: tensor<18x17x2xf32>, %start_indices: tensor<3x1x3x2xi32>) -> (tensor<3x1x3x2xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<3x1x3x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0, 1>,
@@ -203,7 +188,7 @@ module attributes {} {
     return %1 : tensor<3x1x3x2xf32>
   }
 
-  func.func @gather_13(%operand: tensor<4x5x2x2xf32>, %start_indices: tensor<2x1x1x2xi32>) -> (tensor<2x1x1x2x2xf32> {jax.result_info = "result"}) {
+  func.func @gather_12(%operand: tensor<4x5x2x2xf32>, %start_indices: tensor<2x1x1x2xi32>) -> (tensor<2x1x1x2x2xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<2x1x1x2x2xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
       collapsed_slice_dims = array<i64: 0, 1>,
@@ -218,7 +203,7 @@ module attributes {} {
     return %1 : tensor<2x1x1x2x2xf32>
   }
 
-  func.func @gather_14(%operand: tensor<1x7x2xbf16>, %start_indices: tensor<1x2xi32>) -> (tensor<1x2xbf16> {jax.result_info = "result"}) {
+  func.func @gather_13(%operand: tensor<1x7x2xbf16>, %start_indices: tensor<1x2xi32>) -> (tensor<1x2xbf16> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1x2xbf16>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0, 1>,
@@ -233,7 +218,7 @@ module attributes {} {
     return %1 : tensor<1x2xbf16>
   }
 
-  func.func @gather_15(%operand: tensor<3x2x3x4xf32>, %start_indices: tensor<1x3xi32>) -> (tensor<1x4xf32> {jax.result_info = "result"}) {
+  func.func @gather_14(%operand: tensor<3x2x3x4xf32>, %start_indices: tensor<1x3xi32>) -> (tensor<1x4xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1x4xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 0, 1, 2>,
@@ -248,8 +233,8 @@ module attributes {} {
     return %1 : tensor<1x4xf32>
   }
 
-  // In examples 16 and 17 permute ops are needed
-  func.func @gather_16(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
+  // In examples 15 and 16 permute ops are needed
+  func.func @gather_15(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1x2x3x4xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 3>,
@@ -264,7 +249,7 @@ module attributes {} {
     return %1 : tensor<1x2x3x4xf32>
   }
 
-  func.func @gather_17(%operand: tensor<1x2x5x7xf32>, %start_indices: tensor<3x2xi32>) -> (tensor<1x2x3xf32> {jax.result_info = "result"}) {
+  func.func @gather_16(%operand: tensor<1x2x5x7xf32>, %start_indices: tensor<3x2xi32>) -> (tensor<1x2x3xf32> {jax.result_info = "result"}) {
     %0 = ttir.empty() : tensor<1x2x3xf32>
     %1 = "ttir.gather"(%operand, %start_indices, %0) <{
         collapsed_slice_dims = array<i64: 2, 3>,


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/4795

### Problem description
This example has two _ that are not supported:
1. There are dims that are in start_index_map for which slice_size is full dim size, which means they aren't actually being indexed, they are taken whole
2. There is a dim in start_index_map for which slice_size is larger than 1, but not full, which means multiple 'rows' are selected with one index

### What's changed
Changed TTIR to TTIR decomposition to now supports cases where:
- for all but one dim in start_index_map, slice_size is full dim size, and the slice_size for the remaining dim can be anything less than full size. For dims that aren't in start_index_map, slice_size has to be full dim size.

The two _ are supported:
 1. When there are dims from start_index_map that are taken whole, they are removed from start_index_map. Start_indices are sliced (with `static slice op`) to leave only one index which applies to the actually indexed dimension. This is also taken into account when output of `embedding op` is permuted and reshaped, because only the 'real' indexed dim is moved to the front of the operand before `embedding op`.
 2. When there is a sliced indexed dim (dim in start_index_map for which slice_size is larger than 1 and less than full dim size), start_indices are expanded to include the implied indices as well. This is done by broadcasting start_indices from Nx1 to Nxslice_size, and adding a constant Nxslice_size tensor that has [0, 1, 2, ..., sliceSize-1] for every row. This is done after reshaping start_indices to make sure they are Nx1 shape.

### Checklist
- [ ] New/Existing tests provide coverage for changes
