### PR TITLE
Run ttrt tests with saving and restoring existing ttrt artifacts

### DIFF
--- a/tools/ttrt/test/conftest.py
+++ b/tools/ttrt/test/conftest.py
@@ -6,16 +6,24 @@ import os
 import pytest
 
 from util import *
+import shutil
 
 
 @pytest.fixture(scope="session", autouse=True)
 def session_setup():
+    # save previous ttrt-artifacts directory
+    if os.path.exists("ttrt-artifacts"):
+        try:
+            os.rename("ttrt-artifacts", "save-artifacts")
+        except Exception as e:
+            print(f"An error occurred while renaming the directory: {e}")
+
     directory_name = "ttrt-results"
     if not os.path.exists(directory_name):
         try:
             os.mkdir(directory_name)
         except Exception as e:
-            print(f"An error occurred while creating the directory: {e}")
+            print(f"An error occurred while saving artifacts: {e}")
 
     yield
 
@@ -24,3 +32,11 @@ def pytest_runtest_teardown(item, nextitem):
     assert (
         check_results(f"ttrt-results/{item.name}.json") == 0
     ), f"one of more tests failed in={item.name}"
+
+    # Remove ttrt-artifacts directory and all of its content and restore previous one
+    if os.path.exists("ttrt-artifacts") and os.path.exists("save-artifacts"):
+        try:
+            shutil.rmtree("ttrt-artifacts")
+            os.rename("save-artifacts", "ttrt-artifacts")
+        except Exception as e:
+            print(f"An error occurred while restoring artifacts: {e}")


### PR DESCRIPTION
### Ticket

### Problem description
When running ttrt tests along with other tests it garbles tart-artifacts and make other tests fail.

### What's changed
Save existing ttrt-artifacts before test and restore after tests are finished.

### Checklist
- [ ] New/Existing tests provide coverage for changes
