### PR TITLE
Fix typecast op dst access

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
+++ b/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTIRTOTTMETAL_TTIRTOTTMETAL_H
+#define TTMLIR_CONVERSION_TTIRTOTTMETAL_TTIRTOTTMETAL_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.h"
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DECL_CONVERTTTIRTOTTMETAL
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttir
+
+namespace mlir::tt {
+
+void populateTTIRToTTMetalPatterns(
+    MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
+    ttmetal::MathFidelity mathFidelity = ttmetal::MathFidelity::HiFi4);
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass(
+    const ttir::ConvertTTIRToTTMetalOptions &options);
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTIRTOTTMETAL_TTIRTOTTMETAL_H

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -287,7 +287,23 @@ public:
   LogicalResult
   matchAndRewrite(memref::StoreOp op, memref::StoreOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto load = mlir::dyn_cast<memref::LoadOp>(op.getValue().getDefiningOp());
+    // Look for the load operation, potentially through an unrealized conversion
+    // cast
+    Operation *definingOp = op.getValue().getDefiningOp();
+    auto load = mlir::dyn_cast<memref::LoadOp>(definingOp);
+
+    // If not a direct load, check if it's an unrealized cast wrapping a load
+    if (!load && definingOp) {
+      if (auto unrealizedCast =
+              mlir::dyn_cast<UnrealizedConversionCastOp>(definingOp)) {
+        // Look through the unrealized cast to find the actual load
+        if (unrealizedCast.getNumOperands() == 1) {
+          load = mlir::dyn_cast_or_null<memref::LoadOp>(
+              unrealizedCast.getOperand(0).getDefiningOp());
+        }
+      }
+    }
+
     bool storeToDst = ttcore::getMemorySpace(op.getMemRef()) ==
                       ttcore::MemorySpace::RegisterDst;
 
@@ -295,6 +311,10 @@ public:
       // If we are coming from a load, then we are a copy tile. Pattern:
       //    %0 = memref.load %arg0, %c0 : memref<1x!tt.tile, l1>
       //    tt.store %0, %arg1, %c0 : memref<1x!tt.tile, dst>
+      // OR with unrealized cast:
+      //    %0 = memref.load %arg0, %c0 : memref<1x!tt.tile, l1>
+      //    %1 = unrealized_conversion_cast %0 : type1 -> type2
+      //    tt.store %1, %arg1, %c0 : memref<1x!tt.tile, dst>
       return lowerCopyTile(load, op, adaptor, rewriter);
     }
 
@@ -743,13 +763,15 @@ public:
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
-    if (mlir::isa<d2m::TileTypecastOp>(op)) {
+    if (auto typecastOp = mlir::dyn_cast<d2m::TileTypecastOp>(op)) {
       rewriter.create<ttkernel::TypecastTileInitOp>(op->getLoc());
 
       auto inDtype =
-          mlir::cast<ttcore::TileType>(operands[0].getType()).getDataType();
-      auto outDtype = mlir::cast<ttcore::TileType>(op->getResult(0).getType())
-                          .getDataType();
+          mlir::cast<ttcore::TileType>(typecastOp.getInput().getType())
+              .getDataType();
+      auto outDtype =
+          mlir::cast<ttcore::TileType>(typecastOp.getResult().getType())
+              .getDataType();
       rewriter.create<ttkernel::TypecastTileOp>(
           op->getLoc(), i32(rewriter, op->getLoc(), 0), inDtype, outDtype);
     } else {

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
@@ -105,4 +105,9 @@ createConvertD2MToTTMetalPass(const d2m::ConvertD2MToTTMetalOptions &options) {
   return std::make_unique<ConvertD2MToTTMetal>(options);
 }
 
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass(
+    const ttir::ConvertTTIRToTTMetalOptions &options) {
+  return std::make_unique<ConvertTTIRToTTMetal>(options);
+}
+
 } // namespace mlir::tt

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
@@ -105,9 +105,4 @@ createConvertD2MToTTMetalPass(const d2m::ConvertD2MToTTMetalOptions &options) {
   return std::make_unique<ConvertD2MToTTMetal>(options);
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass(
-    const ttir::ConvertTTIRToTTMetalOptions &options) {
-  return std::make_unique<ConvertTTIRToTTMetal>(options);
-}
-
 } // namespace mlir::tt

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
@@ -448,14 +449,37 @@ public:
               AffineMap dstAccessMap, ValueRange dstAccessIndices) {
             auto dstLoad = rewriter.create<affine::AffineLoadOp>(
                 loc, dst, dstAccessMap, dstAccessIndices);
+            Value valueToStore = dstLoad.getResult();
+
+            // Insert unrealized conversion cast if destination CB type differs
+            // from dst type
+            auto cbType = mlir::cast<MemRefType>(cb.getType());
+            if (valueToStore.getType() != cbType.getElementType()) {
+              valueToStore = rewriter
+                                 .create<UnrealizedConversionCastOp>(
+                                     loc, cbType.getElementType(), valueToStore)
+                                 .getResult(0);
+            }
+
             rewriter.create<affine::AffineStoreOp>(
-                loc, dstLoad.getResult(), cb, l1AccessMap, l1AccessIndices);
+                loc, valueToStore, cb, l1AccessMap, l1AccessIndices);
           },
           // Replacement of the original store with one from dst.
           [&](PatternRewriter &rewriter, affine::AffineStoreOp op,
               AffineMap dstAccessMap, ValueRange dstAccessIndices) {
+            Value valueToStore = op.getValue();
+            // Insert unrealized conversion cast if value type differs from dst
+            // type
+            auto dstType = mlir::cast<MemRefType>(dst.getType());
+            if (valueToStore.getType() != dstType.getElementType()) {
+              valueToStore =
+                  rewriter
+                      .create<UnrealizedConversionCastOp>(
+                          op.getLoc(), dstType.getElementType(), valueToStore)
+                      .getResult(0);
+            }
             rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
-                op, op.getValue(), dst, dstAccessMap, dstAccessIndices);
+                op, valueToStore, dst, dstAccessMap, dstAccessIndices);
           });
     }
   }
@@ -612,8 +636,18 @@ public:
 
       rewriter.setInsertionPointAfter(op);
 
+      // Insert unrealized conversion cast if compute result type differs from
+      // dst type
+      Value valueToStore = op->getResult(0);
+      if (valueToStore.getType() != dstType.getElementType()) {
+        valueToStore = rewriter
+                           .create<UnrealizedConversionCastOp>(
+                               loc, dstType.getElementType(), valueToStore)
+                           .getResult(0);
+      }
+
       auto storeOp = rewriter.create<affine::AffineStoreOp>(
-          loc, op->getResult(0), dst, storeMap, storeIndices);
+          loc, valueToStore, dst, storeMap, storeIndices);
 
       auto loadedResult = rewriter.create<affine::AffineLoadOp>(
           loc, dst, storeMap, storeIndices);


### PR DESCRIPTION
### Ticket
#4351

### Problem description
Dst acquired using original type, typecast result stored back to dst causes type mismatch. The same issue would show during storing back to L1.

### What's changed
`InsertDstRegisterAccess`: Utilized `builtin.unrealized_conversion_cast` to bypass the mismatch. An unrealized conversion cast is inserted after the main typecast operation before storing back to dst, and another cast is inserted before storing back to L1.
`D2MToTTKernel`: Modified load/store copy pattern to see through unrealized casts. Fixed minor bug in the TypecastRewriter that was using the converted input/output types (IndexType) instead of the original ones (TileType).

