### PR TITLE
TTNN builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ test/lit.site.cfg.py
 
 # Builder Test Default Artifact Paths
 /ttir-builder-artifacts/
+/ttnn-builder-artifacts/
 /stablehlo-builder-artifacts/
 
 # TTNN and TTMetal flatbuffers

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -98,28 +98,24 @@ void populateTTNNModule(nb::module_ &m) {
   tt_attribute_class<tt::ttnn::TTNNLayoutAttr>(m, "TTNNLayoutAttr")
       .def_static(
           "get",
-          [](MlirContext ctx, MlirAffineMap linear, MlirAttribute grid,
-             MlirType memref, std::optional<unsigned> memLayout = std::nullopt,
-             std::optional<tt::ttcore::TensorMeshAttr> tensorMesh =
-                 std::nullopt) {
+          [](MlirContext ctx, std::vector<std::int64_t> shape, MlirType type,
+             uint32_t bufferType, MlirAttribute gridAttr,
+             std::optional<unsigned> memLayout = std::nullopt) {
             tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr;
             if (memLayout.has_value()) {
               memLayoutAttr = tt::ttnn::TensorMemoryLayoutAttr::get(
                   unwrap(ctx),
                   static_cast<tt::ttnn::TensorMemoryLayout>(memLayout.value()));
             }
-            tt::ttcore::TensorMeshAttr tensorMeshAttr;
-            if (tensorMesh.has_value()) {
-              tensorMeshAttr = tensorMesh.value();
-            }
             return wrap(tt::ttnn::TTNNLayoutAttr::get(
-                unwrap(ctx), mlir::cast<AffineMap>(unwrap(linear)),
-                mlir::cast<tt::ttcore::GridAttr>(unwrap(grid)),
-                mlir::cast<MemRefType>(unwrap(memref)), memLayoutAttr,
-                tensorMeshAttr));
+                unwrap(ctx), shape, mlir::cast<Type>(unwrap(type)),
+                static_cast<tt::ttnn::BufferType>(bufferType),
+                mlir::cast<tt::ttcore::GridAttr>(unwrap(gridAttr)),
+                memLayoutAttr));
           },
-          nb::arg("ctx"), nb::arg("linear"), nb::arg("grid"), nb::arg("memref"),
-          nb::arg("memLayout") = nb::none(), nb::arg("tensorMesh") = nb::none())
+          nb::arg("ctx"), nb::arg("shape"), nb::arg("grid"),
+          nb::arg("memrefType"), nb::arg("memLayout") = nb::none(),
+          nb::arg("tensorMesh") = nb::none())
       .def_prop_ro(
           "linear",
           [](tt::ttnn::TTNNLayoutAttr self) { return wrap(self.getLinear()); })

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -66,6 +66,11 @@ void populateUtilModule(nb::module_ &m) {
   m.def("is_dps", [](MlirOperation op) {
     return mlir::isa<DestinationStyleOpInterface>(unwrap(op));
   });
+
+  m.def("element_type_to_data_type", [](MlirType type) {
+    return static_cast<uint32_t>(
+        tt::ttcore::elementTypeToDataType(unwrap(type)));
+  });
 }
 
 } // namespace mlir::ttmlir::python

--- a/test/python/golden/test_ttnn_ops.py
+++ b/test/python/golden/test_ttnn_ops.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import Callable
+
+from builder.base.builder import Operand, Shape
+from builder.ttnn.ttnn_builder import TTNNBuilder
+from builder.base.builder_utils import compile_ttnn_to_flatbuffer
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttnn")
+
+
+def multiply(
+    in0: Operand,
+    in1: Operand,
+    builder: TTNNBuilder,
+):
+    builder.set_graph_level_check(True)
+    return builder.multiply(in0, in1)
+
+
+@pytest.mark.parametrize("shape", [(32, 32)], ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize(
+    "test_fn",
+    [
+        multiply,
+    ],
+)
+def test_binary_ops(
+    test_fn: Callable,
+    shape: Shape,
+    dtype: torch.dtype,
+    request,
+):
+    compile_ttnn_to_flatbuffer(
+        test_fn,
+        [shape, shape],
+        [dtype, dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )

--- a/tools/builder/CMakeLists.txt
+++ b/tools/builder/CMakeLists.txt
@@ -20,6 +20,10 @@ declare_mlir_python_sources(BuilderSources
     # d2m subpackage files
     d2m/__init__.py
     d2m/d2m_builder.py
+
+    # ttnn subpackage files
+    ttnn/__init__.py
+    ttnn/ttnn_builder.py
 )
 
 add_mlir_python_modules(BuilderPythonModules

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -10,7 +10,7 @@ from typing import Callable, List, Optional, Tuple, Union, Literal, Dict
 from collections import OrderedDict
 
 from ttmlir.ir import *
-from ttmlir.dialects import func, ttcore
+from ttmlir.dialects import func, ttcore, ttnn
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
@@ -29,6 +29,7 @@ from ttmlir.passes import (
 from builder.base.builder import *
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
+from builder.ttnn.ttnn_builder import TTNNBuilder
 from builder.d2m.d2m_builder import D2MBuilder
 
 # ----- Exception Classes -----
@@ -664,6 +665,181 @@ def compile_ttir_to_flatbuffer(
         )
     except Exception as e:
         raise TTBuilderCompileException(e)
+
+
+def build_ttnn_module(
+    fn: Callable,
+    inputs_shapes: List[Shape],
+    inputs_types: List[torch.dtype],
+):
+    """
+    Builds mlir module containing TTNN ops defined by `fn`.
+
+    Parameters
+    ----------
+    fn : Callable
+        Python function to be converted to MLIR
+
+    inputs_shapes : *List[Shape]*
+        Shapes of the respective ranked tensor inputs of the test function.
+
+    inputs_types: *Optional[List[Union[torch.dtype, TypeInfo]]]*
+        Data types of the input tensors
+
+    Returns
+    -------
+    Module
+        MLIR module containing MLIR op graph defined by `fn`
+    """
+
+    if len(inputs_shapes) != len(inputs_types):
+        raise ValueError(
+            f"inputs_shapes and inputs_types must have the same length: "
+            f"{len(inputs_shapes)} != {len(inputs_types)}"
+        )
+
+    ctx = Context()
+
+    # Grab the location of the test function in python for later debugging
+    try:
+        fname = inspect.getfile(fn)
+        line_no = inspect.getsourcelines(fn)[1]
+        loc = Location.file(fname, line_no, 0, ctx)
+    except (OSError, TypeError):
+        loc = Location.unknown(ctx)
+
+    with ctx, loc:
+        ttnn_builder = TTNNBuilder(ctx, loc)
+
+        # Converts input dtype such as torch.float32 to f32
+        # or torch.bfloat16 to bf16.
+        element_types = [
+            ttnn_builder._get_type_from_torch_dtype(dtype) for dtype in inputs_types
+        ]
+        input_shapes_and_types = list(zip(inputs_shapes, element_types))
+
+        # TTNN ops operate on RankedTensorType but require encoding attribute
+        # so we call create_ttnn_tensor to create the correct type.
+        fn_input_types = [
+            ttnn_builder.create_ttnn_tensor(shape, elem_type)
+            for (shape, elem_type) in input_shapes_and_types
+        ]
+
+        # Wrap everything in a mlir module.
+        module = Module.create()
+        with InsertionPoint(module.body):
+            # Wrap everything in a mlir function.
+            @func.func(*fn_input_types, name=fn.__name__)
+            def decorated_func(*inputs):
+                input_goldens: Dict[Operand, BuilderGoldenTensor] = {}
+                for _, (operand, dtype) in enumerate(zip(inputs, inputs_types)):
+                    input_goldens[operand] = ttnn_builder._generate_golden_tensor(
+                        operand, dtype
+                    )
+
+                ttnn_builder._set_goldens(input_goldens)
+                ttnn_builder._set_input_ordering(inputs)
+
+                result = fn(*inputs, ttnn_builder)
+                output_ops = result if hasattr(result, "__iter__") else (result,)
+                output_goldens: Dict[Operand, BuilderGoldenTensor] = {}
+                for op in output_ops:
+                    output_goldens[op] = ttnn_builder._get_golden_tensor(op)
+                ttnn_builder._set_goldens(output_goldens)
+                ttnn_builder._set_output_ordering(output_ops)
+                return result
+
+        print(f"`{fn.__name__}` sucessfully transformed into a MLIR module.")
+
+        return module, ttnn_builder
+
+
+def compile_ttnn_to_flatbuffer(
+    fn: Callable,
+    inputs_shapes: List[Shape],
+    inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
+    system_desc_path: str = "ttrt-artifacts/system_desc.ttsys",
+    test_base: str = "test",
+    output_root: str = ".",
+    mesh_dict: OrderedDict[str, int] = OrderedDict([("x", 1), ("y", 1)]),
+    pipeline_options: List[str] = [],
+) -> str:
+    """
+    Compiles a TTNN function to flatbuffer format.
+
+    This helper function generates a TTNN mlir module runs the compilation
+    pipeline using ttir-to-ttnn-backend-pipeline and finally generates a flatbuffer.
+
+    Parameters
+    ----------
+    fn : Callable
+        The TTNN function to compile
+
+    inputs_shapes : *List[Shape]*
+        Shapes of the respective ranked tensor inputs of the test function
+
+    inputs_types : *Optional[List[Union[torch.dtype, TypeInfo]]]*, optional
+        The dtypes to use for the inputs to `fn`
+
+    system_desc_path : str, optional
+        Path to the system descriptor file
+
+    test_base : str, optional
+        The string to be used as the test_base name for dumped files
+
+    output_root : str, optional
+        The path to dump all generated files under
+
+    target : *Literal["ttnn", "ttmetal", "ttnn-standalone"]*, optional
+        The target backend to use. Default is "ttnn"
+
+    mesh_name : str, optional
+        Name of the mesh to be used in the module
+
+    mesh_dict : *OrderedDict[str, int]*, optional
+        Dictionary that defines the mesh shape
+
+    pipeline_options: *List[str]*
+        Additional pipeline options to pass to the pipeline
+
+    Returns
+    -------
+    str
+        The path to the generated TTNN MLIR file.
+
+    Raises
+    ------
+    ValueError
+        If inputs_shapes and inputs_types have different lengths
+    TTBuilderCompileException
+        If compilation fails at any stage
+    """
+
+    if inputs_types is not None:
+        if len(inputs_shapes) != len(inputs_types):
+            raise ValueError("inputs_shapes and inputs_types must have the same length")
+
+    # Create module containing TTNN ops
+    try:
+        module, builder = build_ttnn_module(
+            fn,
+            inputs_shapes,
+            inputs_types,
+        )
+    except Exception as e:
+        raise TTBuilderCompileException(e)
+
+    return compile_ttir_module_to_flatbuffer(
+        module,
+        builder,
+        system_desc_path=system_desc_path,
+        test_base=test_base,
+        output_root=output_root,
+        target="ttnn",
+        builder_dir="ttnn-builder-artifacts",
+        mesh_dict=mesh_dict,
+        pipeline_options=pipeline_options,
+    )
 
 
 def compile_d2m_to_flatbuffer(

--- a/tools/builder/ttnn/__init__.py
+++ b/tools/builder/ttnn/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .ttnn_builder import TTNNBuilder

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import List, Callable, Any
+import torch
+
+from ttmlir.ir import *
+from ttmlir import util
+from ttmlir.dialects import ttnn, ttcore
+
+from builder.base.builder import *
+
+
+class TTNNBuilder(Builder):
+    # ----- Methods -----
+
+    def __init__(self, ctx: Context, location: Location):
+        super().__init__(ctx, location)
+
+    # ----- Private Methods ----
+
+    def _op_proxy(
+        self,
+        op_golden_function: Callable,
+        op_ttnn_function: Callable,
+        inputs: List[Operand],
+        output_type: RankedTensorType,
+        ttnn_kwargs: dict = {},
+    ) -> Any:
+        with self._ctx, self._loc:
+            if len(inputs) == 0:
+                golden_output = op_golden_function()
+            else:
+                golden_output = op_golden_function(
+                    *self._organize_eltwise_golden(inputs)
+                )
+
+            id = self._get_next_global_id()
+            loc = self._get_loc_of_extra_file_callee(id=id)
+
+            op = op_ttnn_function(
+                output_type,
+                *inputs,
+                loc=loc,
+                **ttnn_kwargs,
+            )
+
+            if not self._disable_golden_check:
+                self._set_golden_tensor(op, golden_output)
+
+            return op
+
+    def _eltwise_proxy(
+        self,
+        op_golden_function: Callable,
+        op_ttnn_function: Callable,
+        inputs: List[Operand],
+        ttnn_kwargs: dict = {},
+    ) -> OpView:
+        # Eltwise operations require dtype attribute to be set
+        # so we extract it from the input operand
+        ttnn_kwargs = {
+            "dtype": self._get_data_type_attribute(inputs[0]),
+        }
+        output_type = self.create_ttnn_tensor(
+            shape=inputs[0].type.shape,
+            element_type=inputs[0].type.element_type,
+        )
+        return self._op_proxy(
+            op_golden_function,
+            op_ttnn_function,
+            inputs,
+            output_type,
+            ttnn_kwargs=ttnn_kwargs,
+        )
+
+    def _get_data_type_attribute(self, operand: Operand) -> ttcore.ir.DataTypeAttr:
+        with self._ctx, self._loc:
+            dtype = ttnn.ir.TTNNLayoutAttr.maybe_downcast(
+                operand.type.encoding
+            ).data_type_as_int
+            return ttcore.ir.DataTypeAttr.get(self._ctx, dtype)
+
+    # ----- Public Helper Methods ----
+
+    def create_ttnn_tensor(self, shape: Shape, element_type: Type) -> RankedTensorType:
+        """
+        TTNN tensors require that encoding information is present.
+        This method creates a TTNN tensor with encoding information.
+        For simplicity we will always create DRAM/Interlaved tiled tensor.
+        """
+        with self._ctx, self._loc:
+            data_type = util.element_type_to_data_type(element_type)
+            tile_element_type = ttcore.ir.TileType.get(self._ctx, 32, 32, data_type)
+            buffer_type = ttnn.BufferType.DRAM
+            grid_attr = ttcore.ir.GridAttr.get(self._ctx, [1, 1])
+            ttnn_layout_attr = ttnn.ir.TTNNLayoutAttr.get(
+                self._ctx,
+                shape,
+                tile_element_type,
+                buffer_type,
+                grid_attr,
+                ttnn.TensorMemoryLayout.Interleaved,
+            )
+            return RankedTensorType.get(shape, element_type, ttnn_layout_attr)
+
+    # ----- Public TTNN Op Generators ----
+
+    def multiply(self, in0: Operand, in1: Operand) -> OpView:
+        """
+        Creates ``ttnn.multiply``.
+        """
+        return self._eltwise_proxy(
+            torch.multiply,
+            ttnn.MultiplyOp,
+            [in0, in1],
+        )


### PR DESCRIPTION
This adds minimal changes for ttnn builder. With new LLM ops we are adding in TTNN this builder is needed asap in order to test fusing. I've only added minimal changes for this builder, in order to run eltwise binary op, so I omitted stuff like `dump_module`, `print_ir` and other options which are not used.

Biggest difference between ttnn_builder and ttir_builder is how we create tensors where ttnn tensors require encoding attribute and ttir tensors don't. 