### PR TITLE
Fix tt-milr wheel build in CI

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -34,7 +34,6 @@ jobs:
           docker-images: true
           swap-storage: true
 
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -23,8 +23,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Maximize space
-        uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Ticket
/

### Problem description
Tt-mlir wheel build has started to fail because of lack of disk space on the runner (ubuntu-latest).

### What's changed
Change the method for cleaning up the unused files on the runner.
The available space on the runner has increased and the tt-mlir wheel build is now passing.

### Checklist
- [ ] New/Existing tests provide coverage for changes
