### PR TITLE
D2M/TTNN Integration - alias buffer in ttnn.generic op

### DIFF
--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -426,6 +426,17 @@ def D2MGenericApplyInterchange : Pass<"d2m-generic-apply-interchange", "::mlir::
   ];
 }
 
+defvar D2MStreamingOptions = [
+  Option<"numStreamBuffers",
+         "num-stream-buffers",
+         "unsigned", /*default=*/"2",
+         "Number of backing buffers to allocate per stream storage (>=1) Default is 2.">,
+  Option<"allowOutputSpilling",
+         "allow-output-spilling",
+         "bool", /*default=*/"false",
+         "Make generic outputs eligible for spilling to DRAM.">,
+];
+
 def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
   let summary = "Create streams required by generic ops.";
   let description = [{
@@ -479,16 +490,7 @@ def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
   }];
   let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect", "::mlir::memref::MemRefDialect"];
 
-  let options = [
-    Option<"numStreamBuffers",
-           "num-stream-buffers",
-           "unsigned", /*default=*/"2",
-           "Number of backing buffers to allocate per stream storage (>=1) Default is 2.">,
-    Option<"allowOutputSpilling",
-           "allow-output-spilling",
-           "bool", /*default=*/"false",
-           "Make generic outputs eligible for spilling to DRAM.">,
-    ];
+  let options = D2MStreamingOptions;
 }
 
 def D2MInsertStreams: Pass<"d2m-insert-streams", "::mlir::ModuleOp"> {
@@ -500,12 +502,7 @@ def D2MInsertStreams: Pass<"d2m-insert-streams", "::mlir::ModuleOp"> {
     Example:
   }];
   let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect", "::mlir::memref::MemRefDialect"];
-  let options = [
-    Option<"numStreamBuffers",
-           "num-stream-buffers",
-           "unsigned", /*default=*/"2",
-           "Number of backing buffers to allocate per stream storage (>=1) Default is 2.">,
-  ];
+  let options = D2MStreamingOptions;
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -728,6 +728,15 @@ def TTNN_KernelCBFormatAttr: TTNN_Attr<"KernelCBFormat", "kernel_cb_format"> {
   let genVerifyDecl = 1;
 }
 
+def TTNN_KernelCBGlobalBufferAddressOfTensorAttr : TTNN_Attr<"KernelCBGlobalBufferAddressOfTensor", "kernel_cb_global_buffer_address_of_tensor"> {
+  let summary = "Global buffer address of tensor argument";
+  let description = [{
+    TTNN Generic CB Descriptor argument for address aliased global buffer.
+  }];
+  let parameters = (ins "size_t":$tensor_index);
+  let assemblyFormat = "`<` $tensor_index `>`";
+}
+
 def TTNN_KernelCBAttr: TTNN_Attr<"KernelCB", "kernel_cb"> {
   let summary = "Kernel CB descriptor";
   let description = [{
@@ -736,8 +745,10 @@ def TTNN_KernelCBAttr: TTNN_Attr<"KernelCB", "kernel_cb"> {
 
   let parameters = (ins "uint32_t":$total_size,
                         TTNN_CoreRangeSetAttr:$core_ranges,
-                        ArrayRefParameter<"KernelCBFormatAttr">:$formats);
-  let assemblyFormat = "`<` struct($total_size, $core_ranges) `,` `formats` `=` `[` $formats `]` `>`";
+                        ArrayRefParameter<"KernelCBFormatAttr">:$formats,
+                        OptionalParameter<"KernelCBGlobalBufferAddressOfTensorAttr">:$buffer);
+
+  let assemblyFormat = "`<` struct($total_size, $core_ranges) `,` `formats` `=` `[` $formats `]` (`,` `buffer` `=` qualified($buffer)^)? `>`";
 
   let genVerifyDecl = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -733,8 +733,8 @@ def TTNN_KernelCBGlobalBufferAddressOfTensorAttr : TTNN_Attr<"KernelCBGlobalBuff
   let description = [{
     TTNN Generic CB Descriptor argument for address aliased global buffer.
   }];
-  let parameters = (ins "size_t":$tensor_index);
-  let assemblyFormat = "`<` $tensor_index `>`";
+  let parameters = (ins "size_t":$tensor_operand_index);
+  let assemblyFormat = "`<` $tensor_operand_index `>`";
 }
 
 def TTNN_KernelCBAttr: TTNN_Attr<"KernelCB", "kernel_cb"> {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -35,7 +35,7 @@ table KernelCBFormat {
 }
 
 table KernelGlobalCBIndexOfTensor {
-  tensor_index: uint32;
+  tensor_operand_index: uint32;
 }
 
 table KernelCBDescriptor {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -35,7 +35,7 @@ table KernelCBFormat {
 }
 
 table KernelGlobalCBIndexOfTensor {
-  buffer_index: uint32;
+  tensor_index: uint32;
 }
 
 table KernelCBDescriptor {

--- a/include/ttmlir/Target/TTNN/operations/generic_op.fbs
+++ b/include/ttmlir/Target/TTNN/operations/generic_op.fbs
@@ -34,10 +34,15 @@ table KernelCBFormat {
   page_size: uint32;
 }
 
+table KernelGlobalCBIndexOfTensor {
+  buffer_index: uint32;
+}
+
 table KernelCBDescriptor {
   total_size: uint32;
   core_range: tt.target.ttnn.CoreRangeSet;
   formats: [KernelCBFormat];
+  buffer: KernelGlobalCBIndexOfTensor;
 }
 
 table ComputeKernelConfig {

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -149,7 +149,7 @@ public:
         ios[i] = castOp.getOperand();
         cbs[i] = operand;
       } else {
-        llvm_unreachable("Expected stream_layout op for the input.");
+        llvm_unreachable("Expected stream_layout or cast op as operand.");
       }
       cbPorts[i] = cbPort++;
     }
@@ -160,8 +160,6 @@ public:
     }
 
     // Create CBDescriptor.
-    // TODO (vtangTT) #5031: support setting buffer ptr in CBDescriptor for
-    // aliasing.
     ttnn::KernelCBAttr cbDescriptor;
     for (auto [i, cb] : llvm::enumerate(cbs)) {
       auto cb_memref = dyn_cast<MemRefType>(cb.getType());

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -142,6 +142,12 @@ public:
               "Expected TTNNMetalLayoutCastOp producing stream input.");
         }
         cbs[i] = streamLayoutOp.getStorage();
+      } else if (auto castOp =
+                     mlir::dyn_cast_if_present<ttir::TTNNMetalLayoutCastOp>(
+                         operand.getDefiningOp());
+                 castOp) {
+        ios[i] = castOp.getOperand();
+        cbs[i] = operand;
       } else {
         llvm_unreachable("Expected stream_layout op for the input.");
       }
@@ -156,9 +162,9 @@ public:
     // Create CBDescriptor.
     // TODO (vtangTT) #5031: support setting buffer ptr in CBDescriptor for
     // aliasing.
+    ttnn::KernelCBAttr cbDescriptor;
     for (auto [i, cb] : llvm::enumerate(cbs)) {
       auto cb_memref = dyn_cast<MemRefType>(cb.getType());
-
       TT_assertv(mlir::isa<ttcore::TileType>(cb_memref.getElementType()),
                  "Only TileType supported.");
       ttcore::DataType dtype =
@@ -168,8 +174,20 @@ public:
 
       ttnn::KernelCBFormatAttr cbFormat =
           ttnn::KernelCBFormatAttr::get(ctx, i, dtype, pageSize);
-      ttnn::KernelCBAttr cbDescriptor = ttnn::KernelCBAttr::get(
-          ctx, numPages * pageSize, coreRangeSet, {cbFormat});
+
+      ttnn::KernelCBGlobalBufferAddressOfTensorAttr globalCBIndexOfTensor;
+      if (auto castOp = mlir::dyn_cast_if_present<ttir::TTNNMetalLayoutCastOp>(
+              cb.getDefiningOp())) {
+        // Not streamed, thus buffer is aliased.
+        TT_assertv(ttcore::getMemorySpace(cb_memref) ==
+                       ttcore::MemorySpace::DeviceL1,
+                   "Can only alias L1 buffers.");
+        globalCBIndexOfTensor =
+            ttnn::KernelCBGlobalBufferAddressOfTensorAttr::get(ctx, i);
+      }
+      cbDescriptor =
+          ttnn::KernelCBAttr::get(ctx, numPages * pageSize, coreRangeSet,
+                                  {cbFormat}, globalCBIndexOfTensor);
       cbDescriptors[i] = cbDescriptor;
     }
 

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -176,7 +176,7 @@ public:
       ttnn::KernelCBGlobalBufferAddressOfTensorAttr globalCBIndexOfTensor;
       if (auto castOp = mlir::dyn_cast_if_present<ttir::TTNNMetalLayoutCastOp>(
               cb.getDefiningOp())) {
-        // Not streamed, thus buffer is aliased.
+        // Input is not streamed, thus buffer must be aliased.
         TT_assertv(ttcore::getMemorySpace(cb_memref) ==
                        ttcore::MemorySpace::DeviceL1,
                    "Can only alias L1 buffers.");

--- a/lib/Dialect/D2M/Transforms/InsertStreams.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertStreams.cpp
@@ -20,12 +20,16 @@ namespace mlir::tt::d2m {
 namespace {
 class D2MInsertStreamsRewriter final : public OpRewritePattern<d2m::GenericOp> {
 public:
-  D2MInsertStreamsRewriter(MLIRContext *context, unsigned numStreamBuffers)
+  D2MInsertStreamsRewriter(MLIRContext *context, unsigned numStreamBuffers,
+                           bool allowOutputSpilling)
       : OpRewritePattern<d2m::GenericOp>(context),
-        numStreamBuffers(numStreamBuffers) {}
+        numStreamBuffers(numStreamBuffers),
+        allowOutputSpilling(allowOutputSpilling) {}
 
   LogicalResult matchAndRewrite(d2m::GenericOp op,
                                 PatternRewriter &rewriter) const final {
+    TT_assertv(!allowOutputSpilling, "Output spilling is not allowed");
+
     // For DMA-only form, stream insertion will break semantics.
     if (op.isDMAOnlyForm()) {
       return failure();
@@ -33,13 +37,15 @@ public:
 
     bool modified = false;
     for (OpOperand &operand : op->getOpOperands()) {
-      // If input is not already a stream, insert one.
-      if (mlir::isa_and_nonnull<d2m::StreamLayoutOp>(
-              operand.get().getDefiningOp())) {
-        continue;
-      }
-      auto memref = mlir::cast<MemRefType>(operand.get().getType());
-      if (ttcore::getMemorySpace(memref) == ttcore::MemorySpace::DeviceL1) {
+      bool isOutput = !op.isDpsInput(&operand);
+      bool alreadyStreamed = mlir::isa_and_nonnull<d2m::StreamLayoutOp>(
+          operand.get().getDefiningOp());
+      bool isL1Memspace =
+          ttcore::getMemorySpace(mlir::cast<MemRefType>(
+              operand.get().getType())) == ttcore::MemorySpace::DeviceL1;
+
+      if ((isOutput && !allowOutputSpilling) || alreadyStreamed ||
+          isL1Memspace) {
         continue;
       }
       insertStream(rewriter, operand, op);
@@ -61,7 +67,8 @@ public:
         ttcore::ShardLayoutAttr::get(memref, /*buffers=*/numStreamBuffers);
     auto storageMemref =
         MemRefType::get(memref.getShape(), memref.getElementType(), storageAttr,
-                        memref.getMemorySpace());
+                        rewriter.getAttr<ttcore::MemorySpaceAttr>(
+                            ttcore::MemorySpace::DeviceL1));
     auto storage = rewriter.create<memref::AllocOp>(op.getLoc(), storageMemref);
     auto streamLayout = rewriter.create<d2m::StreamLayoutOp>(
         op.getLoc(), streamMemref, operand.get(), storage);
@@ -71,6 +78,7 @@ public:
 
 private:
   unsigned numStreamBuffers;
+  bool allowOutputSpilling;
 };
 } // namespace
 
@@ -82,7 +90,8 @@ public:
 
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns.add<D2MInsertStreamsRewriter>(&getContext(), numStreamBuffers);
+    patterns.add<D2MInsertStreamsRewriter>(&getContext(), numStreamBuffers,
+                                           allowOutputSpilling);
     if (failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Dialect/D2M/Transforms/InsertStreams.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertStreams.cpp
@@ -38,6 +38,10 @@ public:
               operand.get().getDefiningOp())) {
         continue;
       }
+      auto memref = mlir::cast<MemRefType>(operand.get().getType());
+      if (ttcore::getMemorySpace(memref) == ttcore::MemorySpace::DeviceL1) {
+        continue;
+      }
       insertStream(rewriter, operand, op);
       modified = true;
     }

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -1022,7 +1022,8 @@ DeviceComputeKernelConfigAttr::withDstFullSyncEn(bool value) const {
 ::llvm::LogicalResult KernelCBAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     uint32_t totalSize, CoreRangeSetAttr coreRanges,
-    llvm::ArrayRef<mlir::tt::ttnn::KernelCBFormatAttr> formats) {
+    llvm::ArrayRef<mlir::tt::ttnn::KernelCBFormatAttr> formats,
+    mlir::tt::ttnn::KernelCBGlobalBufferAddressOfTensorAttr buffer) {
   return ::llvm::success();
 }
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2108,7 +2108,7 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
         buffer;
     if (kernelCbAttr.getBuffer()) {
       buffer = ::tt::target::ttnn::CreateKernelGlobalCBIndexOfTensor(
-          *cache.fbb, kernelCbAttr.getBuffer().getTensorIndex());
+          *cache.fbb, kernelCbAttr.getBuffer().getTensorOperandIndex());
     }
 
     cbs.push_back(::tt::target::ttnn::CreateKernelCBDescriptorDirect(

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2104,12 +2104,18 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
           toFlatbuffer(cache, formatAttr.getDtype()),
           formatAttr.getPageSize()));
     }
+    ::flatbuffers::Offset<::tt::target::ttnn::KernelGlobalCBIndexOfTensor>
+        buffer;
+    if (kernelCbAttr.getBuffer()) {
+      buffer = ::tt::target::ttnn::CreateKernelGlobalCBIndexOfTensor(
+          *cache.fbb, kernelCbAttr.getBuffer().getTensorIndex());
+    }
 
     cbs.push_back(::tt::target::ttnn::CreateKernelCBDescriptorDirect(
         *cache.fbb, kernelCbAttr.getTotalSize(),
         toFlatbuffer(cache, llvm::cast<ttnn::CoreRangeSetAttr>(
                                 kernelCbAttr.getCoreRanges())),
-        &formats));
+        &formats, buffer));
   }
 
   auto program = ::tt::target::ttnn::CreateProgramDescriptorDirect(

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -41,7 +41,7 @@ createCBDescriptor(const ::tt::target::ttnn::KernelCBDescriptor &cbDesc,
   // Right now, metal assumes only one CBFormatDescriptor per KernelDescriptor
   tt::tt_metal::Buffer *buffer = nullptr;
   if (cbDesc.buffer()) {
-    uint32_t tensorIdx = cbDesc.buffer()->buffer_index();
+    uint32_t tensorIdx = cbDesc.buffer()->tensor_index();
     LOG_DEBUG("cbdescriptor getting buffer of tensor: ", tensorIdx);
     buffer = ioTensors[tensorIdx].buffer();
   }

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -36,15 +36,23 @@ static ::tt::tt_metal::SemaphoreDescriptor createSemaphoreDescriptor(
 }
 
 static ::tt::tt_metal::CBDescriptor
-createCBDescriptor(const ::tt::target::ttnn::KernelCBDescriptor &cbDesc) {
+createCBDescriptor(const ::tt::target::ttnn::KernelCBDescriptor &cbDesc,
+                   const std::vector<::ttnn::Tensor> &ioTensors) {
   // Right now, metal assumes only one CBFormatDescriptor per KernelDescriptor
+  tt::tt_metal::Buffer *buffer = nullptr;
+  if (cbDesc.buffer()) {
+    uint32_t tensorIdx = cbDesc.buffer()->buffer_index();
+    LOG_DEBUG("cbdescriptor getting buffer of tensor: ", tensorIdx);
+    buffer = ioTensors[tensorIdx].buffer();
+  }
   tt::tt_metal::CBDescriptor cbDescriptor = {
       .total_size = cbDesc.total_size(),
       .core_ranges =
           tt::runtime::ttnn::utils::toTTNNCoreRangeSet(*cbDesc.core_range()),
       .format_descriptors = {createCBFormatDescriptor(
           *cbDesc.formats()->Get(0))},
-      .remote_format_descriptors = {}};
+      .remote_format_descriptors = {},
+      .buffer = buffer};
   return cbDescriptor;
 }
 
@@ -227,7 +235,7 @@ void run(const ::tt::target::ttnn::GenericOp *op, ProgramContext &context) {
   }
   for (const tt::target::ttnn::KernelCBDescriptor *cbDesc :
        *programDesc->cbs()) {
-    programDescriptor.cbs.push_back(createCBDescriptor(*cbDesc));
+    programDescriptor.cbs.push_back(createCBDescriptor(*cbDesc, ioTensors));
   }
   for (const tt::target::ttnn::SemaphoreDescriptor *semaphoreDesc :
        *programDesc->semaphores()) {

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -41,8 +41,7 @@ createCBDescriptor(const ::tt::target::ttnn::KernelCBDescriptor &cbDesc,
   // Right now, metal assumes only one CBFormatDescriptor per KernelDescriptor
   tt::tt_metal::Buffer *buffer = nullptr;
   if (cbDesc.buffer()) {
-    uint32_t tensorIdx = cbDesc.buffer()->tensor_index();
-    LOG_DEBUG("cbdescriptor getting buffer of tensor: ", tensorIdx);
+    uint32_t tensorIdx = cbDesc.buffer()->tensor_operand_index();
     buffer = ioTensors[tensorIdx].buffer();
   }
   tt::tt_metal::CBDescriptor cbDescriptor = {

--- a/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
@@ -68,6 +68,13 @@ module {
         ins(%stream_input : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #ttcore.memory_space<l1>>)
         outs(%stream_output : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #ttcore.memory_space<l1>>)
 
+    // CHECK: "ttnn.generic"(%[[T1]], %[[T2]])
+    // CHECK-SAME: buffer = #ttnn.kernel_cb_global_buffer_address_of_tensor<0>>
+    // CHECK-SAME: buffer = #ttnn.kernel_cb_global_buffer_address_of_tensor<1>>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @read_kernel>, #d2m.thread<datamovement, @write_kernel>, #d2m.thread<compute, @compute_kernel0>]}
+        ins(%metal_input_l1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #ttcore.memory_space<l1>>)
+        outs(%metal_output_l1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #ttcore.memory_space<l1>>)
+
     // CHECK-NOT: ttir.ttnn_metal_layout_cast
     %output_l1 = ttir.ttnn_metal_layout_cast %metal_output_l1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #ttcore.memory_space<l1>> -> tensor<32x32xf32, #l1_layout>
 
@@ -75,64 +82,12 @@ module {
     return %output_dram : tensor<32x32xf32, #dram_layout>
   }
   func.func private @read_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-    %c1_i32 = arith.constant 1 : i32
-    %c4096_i32 = arith.constant 4096 : i32
-
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttkernel.get_common_arg_val(%c0_i32) : (i32) -> i32
-    %1 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>
-    %2 = ttkernel.my_x() : () -> index
-    %3 = ttkernel.my_y() : () -> index
-
-    // Move single tile from address in L1 to CB
-    ttkernel.cb_reserve_back(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
-    %4 = ttkernel.get_write_ptr(%1) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>) -> i32
-    %5 = ttkernel.get_noc_addr(%2, %3, %0) : (index, index, i32) -> !ttkernel.noc_addr
-    ttkernel.noc_async_read(%5, %4, %c4096_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
-    ttkernel.noc_async_read_barrier() : () -> ()
-    ttkernel.cb_push_back(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
   func.func private @compute_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-    %c1_i32 = arith.constant 1 : i32
-    %c0 = arith.constant 0 : index
-    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
-    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
-    ttkernel.cb_reserve_back(%1, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
-    ttkernel.cb_wait_front(%0, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
-    %2 = ttkernel.cb_reinterpret_shape(%0) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
-    %3 = ttkernel.cb_reinterpret_shape(%1) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
-    ttkernel.init_sfpu(%2, %3) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> ()
-    ttkernel.tile_regs_acquire() : () -> ()
-    ttkernel.copy_tile_init(%2) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> ()
-    ttkernel.copy_tile(%2, %c0, %c0) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, index, index) -> ()
-    ttkernel.abs_tile_init() : () -> ()
-    ttkernel.abs_tile(%c0) : (index) -> ()
-    ttkernel.tile_regs_commit() : () -> ()
-    ttkernel.tile_regs_wait() : () -> ()
-    ttkernel.pack_tile(%c0, %3, %c0, true) : (index, !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, index) -> ()
-    ttkernel.tile_regs_release() : () -> ()
-    ttkernel.cb_push_back(%1, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
-    ttkernel.cb_pop_front(%0, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
   func.func private @write_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-    %c1_i32 = arith.constant 1 : i32
-    %c4096_i32 = arith.constant 4096 : i32
-
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttkernel.get_common_arg_val(%c0_i32) : (i32) -> i32
-    %1 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>
-    %2 = ttkernel.my_x() : () -> index
-    %3 = ttkernel.my_y() : () -> index
-
-    // Move single tile from CB to address in L1
-    ttkernel.cb_wait_front(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
-    %4 = ttkernel.get_read_ptr(%1) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>) -> i32
-    %5 = ttkernel.get_noc_addr(%2, %3, %0) : (index, index, i32) -> !ttkernel.noc_addr
-    ttkernel.noc_async_write(%4, %5, %c4096_i32) : (i32, !ttkernel.noc_addr, i32) -> ()
-    ttkernel.noc_async_write_barrier() : () -> ()
-    ttkernel.cb_pop_front(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
 }

--- a/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
+++ b/test/ttmlir/Conversion/D2MToTTNN/sanity.mlir
@@ -82,12 +82,64 @@ module {
     return %output_dram : tensor<32x32xf32, #dram_layout>
   }
   func.func private @read_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    %c1_i32 = arith.constant 1 : i32
+    %c4096_i32 = arith.constant 4096 : i32
+
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttkernel.get_common_arg_val(%c0_i32) : (i32) -> i32
+    %1 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>
+    %2 = ttkernel.my_x() : () -> index
+    %3 = ttkernel.my_y() : () -> index
+
+    // Move single tile from address in L1 to CB
+    ttkernel.cb_reserve_back(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
+    %4 = ttkernel.get_write_ptr(%1) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>) -> i32
+    %5 = ttkernel.get_noc_addr(%2, %3, %0) : (index, index, i32) -> !ttkernel.noc_addr
+    ttkernel.noc_async_read(%5, %4, %c4096_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
+    ttkernel.noc_async_read_barrier() : () -> ()
+    ttkernel.cb_push_back(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
   func.func private @compute_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    %c1_i32 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
+    %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
+    ttkernel.cb_reserve_back(%1, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
+    ttkernel.cb_wait_front(%0, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
+    %2 = ttkernel.cb_reinterpret_shape(%0) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
+    %3 = ttkernel.cb_reinterpret_shape(%1) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>
+    ttkernel.init_sfpu(%2, %3) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> ()
+    ttkernel.tile_regs_acquire() : () -> ()
+    ttkernel.copy_tile_init(%2) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>) -> ()
+    ttkernel.copy_tile(%2, %c0, %c0) : (!ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, index, index) -> ()
+    ttkernel.abs_tile_init() : () -> ()
+    ttkernel.abs_tile(%c0) : (index) -> ()
+    ttkernel.tile_regs_commit() : () -> ()
+    ttkernel.tile_regs_wait() : () -> ()
+    ttkernel.pack_tile(%c0, %3, %c0, true) : (index, !ttkernel.cb<memref<1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, index) -> ()
+    ttkernel.tile_regs_release() : () -> ()
+    ttkernel.cb_push_back(%1, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
+    ttkernel.cb_pop_front(%0, %c1_i32) : (!ttkernel.cb<memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
   func.func private @write_kernel() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< rt_args = [<arg_type = buffer_address, operand_index = 1>] ct_args = [<arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    %c1_i32 = arith.constant 1 : i32
+    %c4096_i32 = arith.constant 4096 : i32
+
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttkernel.get_common_arg_val(%c0_i32) : (i32) -> i32
+    %1 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>
+    %2 = ttkernel.my_x() : () -> index
+    %3 = ttkernel.my_y() : () -> index
+
+    // Move single tile from CB to address in L1
+    ttkernel.cb_wait_front(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
+    %4 = ttkernel.get_read_ptr(%1) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>) -> i32
+    %5 = ttkernel.get_noc_addr(%2, %3, %0) : (index, index, i32) -> !ttkernel.noc_addr
+    ttkernel.noc_async_write(%4, %5, %c4096_i32) : (i32, !ttkernel.noc_addr, i32) -> ()
+    ttkernel.noc_async_write_barrier() : () -> ()
+    ttkernel.cb_pop_front(%1, %c1_i32) : (!ttkernel.cb<memref<32x32xf32, #ttcore.memory_space<l1>>>, i32) -> ()
     return
   }
 }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_cast.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_cast.mlir
@@ -2,31 +2,54 @@
 // RUN: FileCheck %s --input-file=%t
 
 #l1 = #ttnn.buffer_type<l1>
+#dram = #ttnn.buffer_type<dram>
+
 #l1_1 = #ttcore.memory_space<l1>
+#dram_1 = #ttcore.memory_space<dram>
+
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #ttcore.iterator_type<parallel>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+#l1_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, <block_sharded>>
+#dram_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
 module {
-  // CHECK-LABEL: func @test_allocate_cast
-  func.func @test_allocate_cast(%arg0: tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout> {
+  // CHECK-LABEL: func @test_cast_no_stream
+  func.func @test_cast_no_stream(%arg0: tensor<32x32xf32, #l1_layout>) -> tensor<32x32xf32, #l1_layout> {
     // CHECK: %[[CAST:.*]] = ttir.ttnn_metal_layout_cast {{.*}}
     // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast
-    // CHECK: %[[ALLOC:.*]] = memref.alloc()
-    // CHECK: %[[STREAM:.*]] = "d2m.stream_layout"(%[[CAST]], %[[ALLOC]])
-    // CHECK: %[[ALLOC0:.*]] = memref.alloc()
-    // CHECK: %[[STREAM0:.*]] = "d2m.stream_layout"(%[[CAST0]], %[[ALLOC0]])
-    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #ttnn_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>
-    %0 = d2m.empty() : tensor<32x32xf32, #ttnn_layout>
-    %cast_0 = ttir.ttnn_metal_layout_cast %0 : tensor<32x32xf32, #ttnn_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>
+    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #l1_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>
+    %0 = d2m.empty() : tensor<32x32xf32, #l1_layout>
+    %cast_0 = ttir.ttnn_metal_layout_cast %0 : tensor<32x32xf32, #l1_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>
 
-    // CHECK: ins(%[[STREAM]] : {{.*}})
-    // CHECK: outs(%[[STREAM0]] : {{.*}})
+    // CHECK: ins(%[[CAST]] : {{.*}})
+    // CHECK: outs(%[[CAST0]] : {{.*}})
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<compute>]}
       ins(%cast : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>)
       outs(%cast_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>)  {
     ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_1>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_1>):
     }
-    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1> -> tensor<32x32xf32, #ttnn_layout>
-    return %cast_1 : tensor<32x32xf32, #ttnn_layout>
+    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1> -> tensor<32x32xf32, #l1_layout>
+    return %cast_1 : tensor<32x32xf32, #l1_layout>
+  }
+
+  // CHECK-LABEL: func @test_cast_dram_input_stream
+  func.func @test_cast_dram_input_stream(%arg0: tensor<32x32xf32, #dram_layout>) -> tensor<32x32xf32, #l1_layout> {
+    // CHECK: %[[CAST:.*]] = ttir.ttnn_metal_layout_cast {{.*}}
+    // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast
+    // CHECK: %[[ALLOC:.*]] = memref.alloc()
+    // CHECK: %[[STREAM:.*]] = "d2m.stream_layout"(%[[CAST]], %[[ALLOC]])
+    %cast = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x32xf32, #dram_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #dram_1>
+    %0 = d2m.empty() : tensor<32x32xf32, #l1_layout>
+    %cast_0 = ttir.ttnn_metal_layout_cast %0 : tensor<32x32xf32, #l1_layout> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>
+
+    // CHECK: ins(%[[STREAM]] : {{.*}})
+    // CHECK: outs(%[[CAST0]] : {{.*}})
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<compute>]}
+      ins(%cast : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #dram_1>)
+      outs(%cast_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1>)  {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #dram_1>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_1>):
+    }
+    %cast_1 = ttir.ttnn_metal_layout_cast %cast_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_1> -> tensor<32x32xf32, #l1_layout>
+    return %cast_1 : tensor<32x32xf32, #l1_layout>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5031

### Problem description
Right now for `ttnn-mode` we are always streaming both inputs and outputs since we can't alias buffers in the ttnn.generic op.

### What's changed
- wire the buffer pointer from `D2MToTTNN` pass to flatbuffer and mlir runtime the same way we pass tensor buffer address: as an index that will choose the correct tensor from `io_tensors`
    - add `TTNN_KernelCBGlobalBufferAddressOfTensorAttr` to `TTNN_KernelCBAttr` as an optional
    - add `KernelGlobalCBIndexOfTensor` to `generic_op.fbs`
    - relevant changes to flatbuffer conversion and mlir runtime
- change `InsertStreams` pass to only insert streams for inputs that need to be streamed from DRAM.
    - never stream output, but wired up `allowOutputSpilling` for the future when we could spill to DRAM.
- modified existing lit tests
### Checklist
- [x] New/Existing tests provide coverage for changes -> e2e jit tests will now never be streamed, qualifying this change.
