### PR TITLE
Adding shardy annotation infrastructure to StableHLOBuilder

### DIFF
--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from builder.base.builder import Operand, Shape, TypeInfo
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 from builder.base.builder_utils import compile_stablehlo_to_flatbuffer
-from test_utils import Marks, shape_str
+from test_utils import Marks, shape_str, sharding_str
 
 pytestmark = [pytest.mark.frontend("shlo"), pytest.mark.n300]
 
@@ -36,10 +36,9 @@ def sharding_constraint(
             ),
         ],
     )
-    sharding_attr = builder.create_sharding_attr_from_tuples(
-        "mesh", [("x", True), ("y", False)]
-    )
-    return builder.add(in0, in1, unit_attrs=unit_attrs, sharding_attr=sharding_attr)
+
+    builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
+    return builder.add(in0, in1, unit_attrs=unit_attrs)
 
 
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
@@ -60,6 +59,52 @@ def test_sharding_constraint(
 ):
     compile_stablehlo_to_flatbuffer(
         test_fn,
+        [shape, shape],
+        [dtype, dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        mesh_name="mesh",
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+    )
+
+
+@pytest.mark.parametrize("shape", [(2, 4, 8, 16)], ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("mesh_shape", [(1, 2)], ids=["1x2"])
+@pytest.mark.parametrize(
+    "sharding",
+    [
+        [("x", True), ("y", False), ("", False), ("", False)],
+        [("x", True), ("", False), ("y", False), ("", False)],
+        [("x", True), ("", False), ("", False), ("y", False)],
+        [("", False), ("x", True), ("", False), ("", False)],
+        [("", False), ("x", True), ("", False), ("y", False)],
+        [("", False), ("", False), ("x", True), ("y", False)],
+    ],
+    ids=sharding_str,
+)
+def test_sharding_annotation(
+    shape: Shape,
+    dtype: torch.dtype,
+    mesh_shape: Tuple[int, int],
+    sharding: List[Tuple[str, bool]],
+    request,
+):
+    def sharding_annotation(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        sharding_attr = builder.create_sharding_attr_from_tuples("mesh", sharding)
+        return builder.add(in0, in1, unit_attrs=unit_attrs, sharding_attr=sharding_attr)
+
+    test_bundle = sharding_annotation_wrap_factory()
+
+    compile_stablehlo_to_flatbuffer(
+        test_bundle.test_fn,
         [shape, shape],
         [dtype, dtype],
         test_base=request.node.name,

--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -101,10 +101,8 @@ def test_sharding_annotation(
         sharding_attr = builder.create_sharding_attr_from_tuples("mesh", sharding)
         return builder.add(in0, in1, unit_attrs=unit_attrs, sharding_attr=sharding_attr)
 
-    test_bundle = sharding_annotation_wrap_factory()
-
     compile_stablehlo_to_flatbuffer(
-        test_bundle.test_fn,
+        sharding_annotation,
         [shape, shape],
         [dtype, dtype],
         test_base=request.node.name,

--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -36,9 +36,10 @@ def sharding_constraint(
             ),
         ],
     )
-
-    builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    sharding_attr = builder.create_sharding_attr_from_tuples(
+        "mesh", [("x", True), ("y", False)]
+    )
+    return builder.add(in0, in1, unit_attrs=unit_attrs, sharding_attr=sharding_attr)
 
 
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)

--- a/test/python/golden/test_utils.py
+++ b/test/python/golden/test_utils.py
@@ -68,6 +68,23 @@ def shape_str(shape):
     return "x".join(map(str, shape))
 
 
+def sharding_str(sharding):
+    """
+    Converts shape tuple to string.
+
+    Parameters
+    ----------
+    sharding : *List[Tuple[str, bool]]*
+        Sharding annotation config to convert to string
+
+    Returns
+    -------
+    str
+        String representation of the sharding config (e.g., '32x32' for shape (32, 32))
+    """
+    return "".join(map(str, sharding))
+
+
 def make_shard_shape(
     tensor_rank: int,
     shard_dims: Sequence[int],

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -119,7 +119,6 @@ class StableHLOBuilder(Builder):
         loc: Optional[Union[str, Location]] = None,
         skip_golden: bool = False,
     ) -> Any:
-
         if not golden_kwargs:
             golden_kwargs = stablehlo_kwargs
 


### PR DESCRIPTION
### Ticket
Closes [#4806](https://github.com/tenstorrent/tt-mlir/issues/4806)

### Problem description
Generating tests with parameterized shardy annotations is useful for optimization testing, no infrastructure exists to efficiently do so.

### What's changed
Added `sharding_attr` argument to `_op_proxy` and StableHLOBuilder op generators (similar to `unit_attrs`) to optionally annotate operations with a `tensor_sharding_per_value_attr`.
Wrote `create_sharding_attr_from_tuples()` to simplify attribute building.
Added parameterized test `test_sharding_annotation`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
