### PR TITLE
Restrict D2M matmul builder test inputs and other improvements

### DIFF
--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -6,13 +6,35 @@ import pytest
 import torch
 from typing import List
 
-from ttmlir.ir import *
+from test_utils import shape_str
 
 from builder.base.builder import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_utils import compile_ttir_to_flatbuffer
 
 pytestmark = pytest.mark.frontend("ttir")
+
+
+# Matmul runs on the FPU and so needs special care around accuracy checks.
+# 1. F32 inputs are truncated into TF32, losing 13 mantissa bits. When positive
+#    and negative values with very close abs values are added together, some
+#    arithmetic operations will have over 5 orders of magnitude of differences
+#    in their operands. TF32 dosn't have this much "dynamic range".
+# 2. When the CPU doesn't have native F16/BF16 support, torch will use
+#    software-emulated arithmetic operations to generate the matmul golden
+#    output, which is too slow.
+# Solution: constraint the input range to within (0.001, 0.999) to avoid large
+# differences of magnitudes in the calculation.
+def create_matmul_constrained_inputs(lhs_shape, rhs_shape):
+    def matmul_constrained_inputs(
+        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    ):
+        in_lhs = torch.rand(lhs_shape, dtype=torch.float32) * 0.999 + 0.001
+        in_rhs = torch.rand(rhs_shape, dtype=torch.float32) * 0.999 + 0.001
+        builder.set_goldens(inputs={in0: in_lhs, in1: in_rhs})
+        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
+
+    return matmul_constrained_inputs
 
 
 @pytest.mark.fails_golden
@@ -38,21 +60,13 @@ def test_matmul_single_core_8otpc(
         n * tile_size,
     )
 
-    def matmul(
-        in0: Operand,
-        in1: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
-    ):
-        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
-
     options = [
         f"override-device-shape=1,1",
         f"num-stream-buffers=1",
     ]
 
     compile_ttir_to_flatbuffer(
-        matmul,
+        create_matmul_constrained_inputs(lhs, rhs),
         [lhs, rhs],
         target=target,
         custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
@@ -86,20 +100,12 @@ def test_matmul_multi_core_8otpc(
         n * tile_size,
     )
 
-    def matmul(
-        in0: Operand,
-        in1: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
-    ):
-        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
-
     options = [
         f"num-stream-buffers=1",
     ]
 
     compile_ttir_to_flatbuffer(
-        matmul,
+        create_matmul_constrained_inputs(lhs, rhs),
         [lhs, rhs],
         target=target,
         custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
@@ -122,6 +128,7 @@ def test_matmul_multi_core_8otpc(
         (1024, 2048, 2048),
         (2048, 2048, 2048),
     ],
+    ids=shape_str,
 )
 @pytest.mark.parametrize("use_tile_matmul", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -141,21 +148,13 @@ def test_matmul_ttnn_shapes_single_buffered(
         shape[2],
     )
 
-    def matmul(
-        in0: Operand,
-        in1: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
-    ):
-        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
-
     options = [
         f"matmul-interchange=2,0,1",
         f"num-stream-buffers=1",
         f"use-tile-matmul={use_tile_matmul}",
     ]
     compile_ttir_to_flatbuffer(
-        matmul,
+        create_matmul_constrained_inputs(lhs, rhs),
         [lhs, rhs],
         target=target,
         custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
@@ -177,6 +176,7 @@ def test_matmul_ttnn_shapes_single_buffered(
         (1024, 1024, 1024),
         (1024, 1024, 2048),
     ],
+    ids=shape_str,
 )
 @pytest.mark.parametrize("use_tile_matmul", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -196,20 +196,12 @@ def test_matmul_ttnn_shapes_double_buffered(
         shape[2],
     )
 
-    def matmul(
-        in0: Operand,
-        in1: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
-    ):
-        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
-
     options = [
         f"matmul-interchange=2,0,1",
         f"use-tile-matmul={use_tile_matmul}",
     ]
     compile_ttir_to_flatbuffer(
-        matmul,
+        create_matmul_constrained_inputs(lhs, rhs),
         [lhs, rhs],
         target=target,
         custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -18,6 +18,7 @@ from ttmlir.ir import DenseI32ArrayAttr
 from test_utils import (
     Marks,
     shape_str,
+    shapes_list_str,
     make_shard_shape,
     shard_wrap_factory,
 )
@@ -224,7 +225,7 @@ def gelu(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = N
     return builder.gelu(in0, unit_attrs=unit_attrs)
 
 
-@pytest.mark.parametrize("shape", [(64, 128)])
+@pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)
 @pytest.mark.parametrize("max_arg,min_arg", [(3.0, 2.0)])
 def test_clamp_scalar(shape: Shape, max_arg: float, min_arg: float, request):
     def clamp_scalar(
@@ -243,7 +244,9 @@ def test_clamp_scalar(shape: Shape, max_arg: float, min_arg: float, request):
     )
 
 
-@pytest.mark.parametrize("shapes", [[(32, 64), (32, 64), (32, 64)]])
+@pytest.mark.parametrize(
+    "shapes", [[(32, 64), (32, 64), (32, 64)]], ids=shapes_list_str
+)
 def test_clamp_tensor(shapes: List[Shape], request):
     def clamp_tensor(
         in0: Operand,
@@ -628,7 +631,9 @@ def minimum(
     return builder.minimum(in0, in1, unit_attrs=unit_attrs)
 
 
-@pytest.mark.parametrize("shapes", [[(10, 64, 32), (32, 128), (128,)]])
+@pytest.mark.parametrize(
+    "shapes", [[(10, 64, 32), (32, 128), (128,)]], ids=shapes_list_str
+)
 def test_linear(shapes: List[Shape], request):
     def linear(
         in0: Operand,
@@ -762,7 +767,7 @@ def squeeze(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] 
 
 
 @pytest.mark.fails_golden
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dim_arg", [0])
 @pytest.mark.parametrize("keep_dim", [False])
 def test_prod(shape: Shape, dim_arg: int, keep_dim: bool, request):
@@ -812,7 +817,7 @@ def concat(
     return builder.concat([in0, in1, in2], dim=dim, unit_attrs=unit_attrs)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 32)])
+@pytest.mark.parametrize("shape", [(1, 1, 32)], ids=shape_str)
 @pytest.mark.parametrize("broadcast_dimensions", [[1, 16, 1]])
 def test_broadcast(shape: Shape, broadcast_dimensions: List[int], request):
     # Create a wrapper function that captures broadcast_dimensions
@@ -835,7 +840,7 @@ def test_broadcast(shape: Shape, broadcast_dimensions: List[int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 128, 128, 1)])
+@pytest.mark.parametrize("shape", [(1, 128, 128, 1)], ids=shape_str)
 @pytest.mark.parametrize("dim", [0])
 def test_squeeze(shape: Shape, dim: int, request):
     def squeeze(
@@ -852,7 +857,7 @@ def test_squeeze(shape: Shape, dim: int, request):
     )
 
 
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dim", [0])
 def test_unsqueeze(shape: Shape, dim: int, request):
     def unsqueeze(
@@ -869,7 +874,7 @@ def test_unsqueeze(shape: Shape, dim: int, request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 32, 32), (2, 16, 16), (1, 1, 64)])
+@pytest.mark.parametrize("shape", [(1, 32, 32), (2, 16, 16), (1, 1, 64)], ids=shape_str)
 @pytest.mark.parametrize("dims", [[32, 1, 1], [1, 2, 2], [2, 3, 4], [1, 1, 1]])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.int32], ids=["f32", "i32"])
 def test_repeat(shape: Shape, dims: List[int], dtype, request):
@@ -896,6 +901,7 @@ def test_repeat(shape: Shape, dims: List[int], dtype, request):
             (1, 8, 1, 12, 64),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("dim", [0])
 @pytest.mark.parametrize("repeats", [1])
@@ -928,6 +934,7 @@ def test_repeat_interleave(shapes: List[Shape], repeats: int, dim: int, request)
             (16, 128),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("dim", [0])
 def test_concat(shapes: List[Shape], dim: int, request):
@@ -962,6 +969,7 @@ def test_concat(shapes: List[Shape], dim: int, request):
             (1, 1, 1, 64),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize(
     "input_dtypes",
@@ -1030,6 +1038,7 @@ def test_conv2d(
             (1, 1, 1, 64),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("stride", [[2, 1]])
 @pytest.mark.parametrize("dilation", [[2, 1]])
@@ -1079,6 +1088,7 @@ def test_conv2d_consteval(
             (1, 1, 1, 64),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("stride", [[2, 1]])
 @pytest.mark.parametrize("dilation", [[2, 1]])
@@ -1136,6 +1146,7 @@ def test_hoisted_conv2d(
             (1, 1, 1, 256),
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("dtypes", [[torch.float32] * 3])
 @pytest.mark.parametrize(
@@ -1226,7 +1237,7 @@ def test_max_pool2d(
     "kernel,stride,dilation,padding,ceil_mode",
     [([2, 2], [2, 2], [1, 1], [0, 0, 0, 0], False)],
 )
-@pytest.mark.parametrize("shape", [(1, 128, 128, 32)])
+@pytest.mark.parametrize("shape", [(1, 128, 128, 32)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32])
 @pytest.mark.parametrize("target", ["ttnn"])
 @pytest.mark.run_error  # Issue #5133.
@@ -1285,7 +1296,7 @@ def test_hoisted_max_pool2d(
         ),  # This test will produce a different output if count_include_pad is True for spatial dims (31, 31)
     ],
 )
-@pytest.mark.parametrize("shape", [(1, 31, 31, 32)])
+@pytest.mark.parametrize("shape", [(1, 31, 31, 32)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_avg_pool2d(
     shape: Shape,
@@ -1335,6 +1346,7 @@ def test_avg_pool2d(
             (64,),  # variance
         ]
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("dtypes", [[torch.float32] * 5])
 @pytest.mark.parametrize("dimension", [1])  # channel dimension
@@ -1381,7 +1393,7 @@ def test_batch_norm(
 
 
 @pytest.mark.fails_golden
-@pytest.mark.parametrize("shape", [(1, 1, 5, 5)])
+@pytest.mark.parametrize("shape", [(1, 1, 5, 5)], ids=shape_str)
 @pytest.mark.parametrize("padding", [[0, 1, 2, 3, 4, 5, 6, 7]])
 @pytest.mark.parametrize("value", [0])
 def test_pad(shape: Shape, padding: List[int], value: int, request):
@@ -1401,7 +1413,7 @@ def test_pad(shape: Shape, padding: List[int], value: int, request):
     )
 
 
-@pytest.mark.parametrize("shape", [(32, 64)])
+@pytest.mark.parametrize("shape", [(32, 64)], ids=shape_str)
 @pytest.mark.parametrize("dim,begin,end,step", [(0, 0, 3, 1)])
 def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request):
     def index(
@@ -1420,7 +1432,7 @@ def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request)
     )
 
 
-@pytest.mark.parametrize("shape", [(4, 4)])
+@pytest.mark.parametrize("shape", [(4, 4)], ids=shape_str)
 @pytest.mark.parametrize("dim,begin,length,stride", [(1, 2, 2, 2)])
 def test_select(shape: Shape, dim: int, begin: int, length: int, stride: int, request):
     def select(
@@ -1664,7 +1676,7 @@ def test_callable_initialization_error_handling(shape: Shape, dtype: torch.dtype
         return result
 
 
-@pytest.mark.parametrize("shapes", [[(128, 128)]])
+@pytest.mark.parametrize("shapes", [[(128, 128)]], ids=shapes_list_str)
 @pytest.mark.parametrize("dim_arg", [[1]])
 def test_argmax(shapes, dim_arg, request):
     def argmax(
@@ -1682,7 +1694,7 @@ def test_argmax(shapes, dim_arg, request):
 
 
 @pytest.mark.xfail(reason="`reverse` doesn't have a legalization. See issue #2495")
-@pytest.mark.parametrize("shape", [(64, 64)])
+@pytest.mark.parametrize("shape", [(64, 64)], ids=shape_str)
 @pytest.mark.parametrize("dims", [[0, 1]])
 def test_reverse(shape: Shape, dims: List[int], request):
     def reverse(
@@ -1732,7 +1744,7 @@ def reduce_or(
 
 # Generated flatbuffer will currently fail to run due to only floats being supported by the runtime. See issue #1775.
 @pytest.mark.run_error
-@pytest.mark.parametrize("shape", [(4, 4)])
+@pytest.mark.parametrize("shape", [(4, 4)], ids=shape_str)
 @pytest.mark.parametrize("dim_args", [[0, 1]])
 def test_reduce_or(shape: Shape, dim_args: List[int], request):
     def reduce_or_wrapper(
@@ -1763,7 +1775,7 @@ def permute(
     )
 
 
-@pytest.mark.parametrize("shapes", [[(2, 3, 4)]])
+@pytest.mark.parametrize("shapes", [[(2, 3, 4)]], ids=shapes_list_str)
 @pytest.mark.parametrize("permutation", [[1, 2, 0]])
 def test_permute(shapes: List[Shape], permutation: List[int], request):
     # Create a wrapper function that captures permutation
@@ -1786,7 +1798,9 @@ def test_permute(shapes: List[Shape], permutation: List[int], request):
     )
 
 
-@pytest.mark.parametrize("shapes", [[(10, 64, 32, 3), (10, 128, 128, 3)]])
+@pytest.mark.parametrize(
+    "shapes", [[(10, 64, 32, 3), (10, 128, 128, 3)]], ids=shapes_list_str
+)
 @pytest.mark.parametrize("scale_factor", [[2, 4]])
 def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request):
     def upsample2d(
@@ -1858,7 +1872,7 @@ def test_typecast(
     )
 
 
-@pytest.mark.parametrize("shapes", [[(4, 4, 128, 128)]])
+@pytest.mark.parametrize("shapes", [[(4, 4, 128, 128)]], ids=shapes_list_str)
 @pytest.mark.parametrize("dim", [1])
 def test_cumsum(shapes: List[Shape], dim: int, request):
     def cumsum(
@@ -1882,7 +1896,9 @@ def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = N
 
 
 @pytest.mark.fails_golden
-@pytest.mark.parametrize("shapes", [[(1, 32, 64, 512), (1, 32, 3, 512)]])
+@pytest.mark.parametrize(
+    "shapes", [[(1, 32, 64, 512), (1, 32, 3, 512)]], ids=shapes_list_str
+)
 def test_fill_cache(shapes: List[Shape], request):
     def fill_cache(
         in0: Operand,
@@ -1913,7 +1929,7 @@ def softmax(
     )
 
 
-@pytest.mark.parametrize("shape", [(512, 1024)])
+@pytest.mark.parametrize("shape", [(512, 1024)], ids=shape_str)
 @pytest.mark.parametrize("dimension", [-1])
 @pytest.mark.parametrize("numeric_stable", [False, True])
 def test_softmax(shape: Shape, dimension: int, numeric_stable: bool, request):
@@ -1936,7 +1952,9 @@ def test_softmax(shape: Shape, dimension: int, numeric_stable: bool, request):
 
 
 @pytest.mark.run_error
-@pytest.mark.parametrize("shapes", [[(1, 32, 64, 512), (1, 32, 1, 512), (1,)]])
+@pytest.mark.parametrize(
+    "shapes", [[(1, 32, 64, 512), (1, 32, 1, 512), (1,)]], ids=shapes_list_str
+)
 @pytest.mark.parametrize("dtypes", [[torch.float32, torch.float32, torch.int32]])
 def test_update_cache(shapes: List[Shape], dtypes: List[torch.dtype], request):
     def update_cache(
@@ -1967,7 +1985,7 @@ def embedding(
     return builder.embedding(in0, in1, unit_attrs=unit_attrs)
 
 
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("scale", [0.1])
 @pytest.mark.parametrize("zero_point", [0])
 @pytest.mark.parametrize(
@@ -2000,7 +2018,7 @@ def test_quantize(
     )
 
 
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize(
     "input_dtype",
     [
@@ -2040,7 +2058,7 @@ def test_dequantize(
     )
 
 
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize(
     "input_dtype",
     [
@@ -2270,7 +2288,7 @@ hoisted_ternary_ops = [
 
 
 @x86_only
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("test_fn", hoisted_unary_ops)
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
 def test_cpu_hoistable_unary_ops(
@@ -2301,6 +2319,7 @@ def test_cpu_hoistable_unary_ops(
         [(128, 128), (128, 1)],  # Broadcasting first dimension
         [(128, 128, 64), (128, 1, 64)],  # 3D tensors with broadcasting
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("test_fn", hoisted_binary_ops)
@@ -2359,7 +2378,7 @@ def test_hoisted_permute(shapes, permutation, request, target: str):
 @pytest.mark.parametrize("dim_arg", [None, 0, 1])
 @pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize(
-    "shape", [(1, 1), (1, 10), (10, 1), (64, 32), (128, 64), (128, 128)]
+    "shape", [(1, 1), (1, 10), (10, 1), (64, 32), (128, 64), (128, 128)], ids=shape_str
 )
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
 def test_hoisted_max(shape, dim_arg, keep_dim, request, target: str):
@@ -2422,7 +2441,9 @@ def test_hoisted_slice(
 
 # Add test for hoisted where operation
 @x86_only
-@pytest.mark.parametrize("shapes", [[(64, 64), (64, 64), (64, 64)]])
+@pytest.mark.parametrize(
+    "shapes", [[(64, 64), (64, 64), (64, 64)]], ids=shapes_list_str
+)
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
 def test_hoisted_where(shapes, request, target: str):
     def where_wrapper(condition: Operand, x: Operand, y: Operand, builder: TTIRBuilder):
@@ -2454,6 +2475,7 @@ def test_hoisted_where(shapes, request, target: str):
         [(256, 256), (512, 128)],  # Power of 2 reshape
         [(32, 3, 224, 224), (32, 150528)],  # Large ML pattern: batch flatten
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize(
     "dtype", [torch.float32, torch.int32, torch.uint8], ids=["f32", "i32", "ui8"]
@@ -2535,7 +2557,7 @@ def test_hoisted_transpose(input_shape, dims, request, target: str):
 
 
 @x86_only
-@pytest.mark.parametrize("shape", [(1, 128, 128)])
+@pytest.mark.parametrize("shape", [(1, 128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dim", [0])
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
 def test_hoisted_squeeze(shape: Shape, dim: int, target: str, request):
@@ -2746,7 +2768,7 @@ def test_binary_ops(
 
 
 @pytest.mark.run_error
-@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("test_fn", [bitwise_and, bitwise_or, bitwise_xor])
 def test_bitwise_binary_ops(test_fn: Callable, shape: Shape, request):
     compile_ttir_to_flatbuffer(
@@ -2889,6 +2911,7 @@ def test_binary_eltwise_ops_implicit_broadcast(
         [(1, 4, 1), (1, 4, 768), (1, 1, 1)],
         [(1, 1, 1, 4), (1, 1, 1, 1), (1, 1, 1, 1)],
     ],
+    ids=shapes_list_str,
 )
 @pytest.mark.parametrize(
     "input_dtypes",
@@ -3078,7 +3101,7 @@ def test_slice(
 
 
 @x86_only
-@pytest.mark.parametrize("shape", [(4, 4)])
+@pytest.mark.parametrize("shape", [(4, 4)], ids=shape_str)
 @pytest.mark.parametrize("dim_args", [[0]])
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
 @pytest.mark.run_error  # Issue #3883.

--- a/test/python/golden/test_utils.py
+++ b/test/python/golden/test_utils.py
@@ -68,6 +68,21 @@ def shape_str(shape):
     return "x".join(map(str, shape))
 
 
+def shapes_list_str(shapes):
+    """
+    Converts a list of shapes to string, joined by "-".
+    Parameters
+    ----------
+    shapes : Sequence[*Union[Tuple[int, ...], List[int]]*]
+        Shapes to convert to string
+    Returns
+    -------
+    str
+        String representation of the shapes (e.g., '1x2-3x4' for input [(1, 2), (3, 4)])
+    """
+    return "-".join(shape_str(s) for s in shapes)
+
+
 def make_shard_shape(
     tensor_rank: int,
     shard_dims: Sequence[int],


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently the metal matmul tests are marked as failing, this could hide all kinds of regressions except for the crashing ones.
Due to the importance of this op, we should try our best to make sure it's properly validated in the CI.

### What's changed
Restrict the input range of the matmul tests to circumvent the f32 to tf32 accuracy loss issue.
Also add a helper function to display the exact shapes in the tests' names, so it's easier to guess why a test is failing.

### Checklist
- [x] New/Existing tests provide coverage for changes
