### PR TITLE
Ppadjin/global avg pool2d fix

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2883,7 +2883,6 @@ TEST_P(OpModelAvgPool2DParam, AvgPool2DParam) { RunTest(); }
 INSTANTIATE_TEST_SUITE_P(AvgPool2DTests, OpModelAvgPool2DParam,
                          pool2DTestValues);
 
-
 class OpModelGlobalAvgPool2dParam
     : public OpModelTest,
       public testing::WithParamInterface<
@@ -2993,11 +2992,9 @@ const auto globalAvgPool2dTestValues = testing::Values(
                                        BufferType::L1},
                     detail::ExpectedResult{true, 0, 0, 0, 0}));
 
-
 // Test fails: https://github.com/tenstorrent/tt-mlir/issues/5313
 INSTANTIATE_TEST_SUITE_P(GlobalAvgPool2dTests, OpModelGlobalAvgPool2dParam,
                          globalAvgPool2dTestValues);
-
 
 class OpModelLeakyReluParam : public OpModelTest,
                               public testing::WithParamInterface<


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5313

### Problem description
GlobalAvgPool2d unittest was failing on CI and was therefore flagged as skipped.

Now the test is fixed and can be put back in the CI unittest cycle.