### PR TITLE
[TTNN] Remove comparison ops int dtype workaround

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -409,8 +409,7 @@ binaryOpDTypeWorkaround(mlir::Operation *op, mlir::Type elementType) {
   // All remaining binary ops.
   // Tracked in :
   // https://github.com/issues/created?issue=tenstorrent%7Ctt-metal%7C25112
-  if (isa<ttnn::DivideOp, ttnn::PowTensorOp, ttnn::GreaterEqualOp,
-          ttnn::GreaterThanOp, ttnn::LessEqualOp, ttnn::LessThanOp>(op)) {
+  if (isa<ttnn::DivideOp, ttnn::PowTensorOp>(op)) {
     if (dType == mlir::tt::ttcore::DataType::Float32 ||
         dType == mlir::tt::ttcore::DataType::BFloat16 ||
         dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||


### PR DESCRIPTION
### Problem description
After metal added int32 support for comparison operations, we no longer have to use a workaround in that case.

### What's changed
Removed int32 workaround for comparison operations.

### Checklist
- [x] [TT-Xla: Test ( Suite: model-test-push.json )](https://github.com/tenstorrent/tt-xla/actions/runs/18384373534)
- [ ] [TT-Xla: Test ( Suite: basic-test.json )](https://github.com/tenstorrent/tt-xla/actions/runs/18384371160)
