### PR TITLE
Adding a reshape to `ttir.pooling` decomposition

### DIFF
--- a/test/ttmlir/Dialect/TTIR/Decomposition/avg_pool2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/avg_pool2d.mlir
@@ -106,20 +106,26 @@ module attributes {} {
   func.func @test_avgpool2d_2d_input_kernel_2x2_stride_2x2(%arg0: tensor<28x28xbf16>) -> tensor<14x14xbf16> {
     // CHECK-LABEL: func.func @test_avgpool2d_2d_input_kernel_2x2_stride_2x2(
     %0 = ttir.empty() : tensor<14x14xbf16>
-    // CHECK: %[[RESHAPE_INPUT:[0-9]+]] = "ttir.reshape"(%arg0
-    // CHECK-SAME: shape = array<i32: 1, 1, 28, 28>
+    // CHECK: %[[EMPTY_OUTPUT:[0-9]+]] = ttir.empty() : tensor<14x14xbf16>
+    // CHECK: %[[EMPTY_RESHAPE_INPUT:[0-9]+]] = ttir.empty() : tensor<1x1x28x28xbf16>
+    // CHECK: %[[RESHAPE_INPUT:[0-9]+]] = "ttir.reshape"(%arg0, %[[EMPTY_RESHAPE_INPUT]]
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 28 : i32, 28 : i32]
     // CHECK-SAME: (tensor<28x28xbf16>, tensor<1x1x28x28xbf16>)
     // CHECK-SAME: -> tensor<1x1x28x28xbf16>
-    // CHECK: %[[RESHAPE_OUTPUT:[0-9]+]] = "ttir.reshape"(
-    // CHECK-SAME: shape = array<i32: 1, 1, 14, 14>
+    // CHECK: %[[EMPTY_RESHAPE_OUTPUT:[0-9]+]] = ttir.empty() : tensor<1x1x14x14xbf16>
+    // CHECK: %[[RESHAPE_OUTPUT:[0-9]+]] = "ttir.reshape"(%[[EMPTY_OUTPUT]], %[[EMPTY_RESHAPE_OUTPUT]]
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 14 : i32, 14 : i32]
     // CHECK-SAME: (tensor<14x14xbf16>, tensor<1x1x14x14xbf16>)
     // CHECK-SAME: -> tensor<1x1x14x14xbf16>
-    // CHECK: %[[PERMUTE:[0-9]+]] = "ttir.permute"(%[[RESHAPE_INPUT]]
+    // CHECK: %[[EMPTY_PERMUTE:[0-9]+]] = ttir.empty() : tensor<1x28x28x1xbf16>
+    // CHECK: %[[PERMUTE:[0-9]+]] = "ttir.permute"(%[[RESHAPE_INPUT]], %[[EMPTY_PERMUTE]]
     // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
     // CHECK-SAME: (tensor<1x1x28x28xbf16>, tensor<1x28x28x1xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x1xbf16>
-    // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]],
+    // CHECK: %[[EMPTY_AVGPOOL:[0-9]+]] = ttir.empty() : tensor<1x14x14x1xbf16>
+    // CHECK: %[[AVGPOOL:[0-9]+]] = "ttir.avg_pool2d"(%[[PERMUTE]], %[[EMPTY_AVGPOOL]]
     // CHECK-SAME: ceil_mode = false
+    // CHECK-SAME: count_include_pad = true
     // CHECK-SAME: dilation = array<i32: 1, 1>
     // CHECK-SAME: kernel = array<i32: 2, 2>
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>
@@ -127,12 +133,14 @@ module attributes {} {
     // CHECK-SAME: (tensor<1x28x28x1xbf16>, tensor<1x14x14x1xbf16>)
     // CHECK-SAME: -> tensor<1x14x14x1xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Average>, window_dilations = array<i64: 1, 1>, window_dimensions = array<i64: 2, 2>, window_strides = array<i64: 2, 2>}> : (tensor<28x28xbf16>, tensor<14x14xbf16>) -> tensor<14x14xbf16>
-    // CHECK: %[[PERMUTE_BACK:[0-9]+]] = "ttir.permute"(%[[AVGPOOL]],
+    // CHECK: %[[EMPTY_PERMUTE_BACK:[0-9]+]] = ttir.empty() : tensor<1x1x14x14xbf16>
+    // CHECK: %[[PERMUTE_BACK:[0-9]+]] = "ttir.permute"(%[[AVGPOOL]], %[[EMPTY_PERMUTE_BACK]]
     // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     // CHECK-SAME: (tensor<1x14x14x1xbf16>, tensor<1x1x14x14xbf16>)
     // CHECK-SAME: -> tensor<1x1x14x14xbf16>
-    // CHECK: %[[RESHAPE_BACK:[0-9]+]] = "ttir.reshape"(%[[PERMUTE_BACK]]
-    // CHECK-SAME: shape = array<i32: 14, 14>
+    // CHECK: %[[EMPTY_RESHAPE_BACK:[0-9]+]] = ttir.empty() : tensor<14x14xbf16>
+    // CHECK: %[[RESHAPE_BACK:[0-9]+]] = "ttir.reshape"(%[[PERMUTE_BACK]], %[[EMPTY_RESHAPE_BACK]]
+    // CHECK-SAME: shape = [14 : i32, 14 : i32]
     // CHECK-SAME: (tensor<1x1x14x14xbf16>, tensor<14x14xbf16>)
     // CHECK-SAME: -> tensor<14x14xbf16>
     // CHECK: return %[[RESHAPE_BACK]] : tensor<14x14xbf16>

--- a/test/ttmlir/Dialect/TTIR/Decomposition/max_pool2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/max_pool2d.mlir
@@ -106,19 +106,24 @@ module attributes {} {
   func.func @test_maxpool2d_2d_input_kernel_2x2_stride_2x2(%arg0: tensor<28x28xbf16>) -> tensor<14x14xbf16> {
     // CHECK-LABEL: func.func @test_maxpool2d_2d_input_kernel_2x2_stride_2x2(
     %0 = ttir.empty() : tensor<14x14xbf16>
-    // CHECK: %[[RESHAPE_INPUT:[0-9]+]] = "ttir.reshape"(%arg0
-    // CHECK-SAME: shape = array<i32: 1, 1, 28, 28>
+    // CHECK: %[[EMPTY_OUTPUT:[0-9]+]] = ttir.empty() : tensor<14x14xbf16>
+    // CHECK: %[[EMPTY_RESHAPE_INPUT:[0-9]+]] = ttir.empty() : tensor<1x1x28x28xbf16>
+    // CHECK: %[[RESHAPE_INPUT:[0-9]+]] = "ttir.reshape"(%arg0, %[[EMPTY_RESHAPE_INPUT]]
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 28 : i32, 28 : i32]
     // CHECK-SAME: (tensor<28x28xbf16>, tensor<1x1x28x28xbf16>)
     // CHECK-SAME: -> tensor<1x1x28x28xbf16>
-    // CHECK: %[[RESHAPE_OUTPUT:[0-9]+]] = "ttir.reshape"(
-    // CHECK-SAME: shape = array<i32: 1, 1, 14, 14>
+    // CHECK: %[[EMPTY_RESHAPE_OUTPUT:[0-9]+]] = ttir.empty() : tensor<1x1x14x14xbf16>
+    // CHECK: %[[RESHAPE_OUTPUT:[0-9]+]] = "ttir.reshape"(%[[EMPTY_OUTPUT]], %[[EMPTY_RESHAPE_OUTPUT]]
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 14 : i32, 14 : i32]
     // CHECK-SAME: (tensor<14x14xbf16>, tensor<1x1x14x14xbf16>)
     // CHECK-SAME: -> tensor<1x1x14x14xbf16>
-    // CHECK: %[[PERMUTE:[0-9]+]] = "ttir.permute"(%[[RESHAPE_INPUT]]
+    // CHECK: %[[EMPTY_PERMUTE:[0-9]+]] = ttir.empty() : tensor<1x28x28x1xbf16>
+    // CHECK: %[[PERMUTE:[0-9]+]] = "ttir.permute"(%[[RESHAPE_INPUT]], %[[EMPTY_PERMUTE]]
     // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
     // CHECK-SAME: (tensor<1x1x28x28xbf16>, tensor<1x28x28x1xbf16>)
     // CHECK-SAME: -> tensor<1x28x28x1xbf16>
-    // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]],
+    // CHECK: %[[EMPTY_MAXPOOL:[0-9]+]] = ttir.empty() : tensor<1x14x14x1xbf16>
+    // CHECK: %[[MAXPOOL:[0-9]+]] = "ttir.max_pool2d"(%[[PERMUTE]], %[[EMPTY_MAXPOOL]]
     // CHECK-SAME: ceil_mode = false
     // CHECK-SAME: dilation = array<i32: 1, 1>
     // CHECK-SAME: kernel = array<i32: 2, 2>
@@ -127,12 +132,14 @@ module attributes {} {
     // CHECK-SAME: (tensor<1x28x28x1xbf16>, tensor<1x14x14x1xbf16>)
     // CHECK-SAME: -> tensor<1x14x14x1xbf16>
     %1 = "ttir.pooling"(%arg0, %0) <{base_dilations = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1>, window_dimensions = array<i64: 2, 2>, window_strides = array<i64: 2, 2>}> : (tensor<28x28xbf16>, tensor<14x14xbf16>) -> tensor<14x14xbf16>
-    // CHECK: %[[PERMUTE_BACK:[0-9]+]] = "ttir.permute"(%[[MAXPOOL]],
+    // CHECK: %[[EMPTY_PERMUTE_BACK:[0-9]+]] = ttir.empty() : tensor<1x1x14x14xbf16>
+    // CHECK: %[[PERMUTE_BACK:[0-9]+]] = "ttir.permute"(%[[MAXPOOL]], %[[EMPTY_PERMUTE_BACK]]
     // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     // CHECK-SAME: (tensor<1x14x14x1xbf16>, tensor<1x1x14x14xbf16>)
     // CHECK-SAME: -> tensor<1x1x14x14xbf16>
-    // CHECK: %[[RESHAPE_BACK:[0-9]+]] = "ttir.reshape"(%[[PERMUTE_BACK]]
-    // CHECK-SAME: shape = array<i32: 14, 14>
+    // CHECK: %[[EMPTY_RESHAPE_BACK:[0-9]+]] = ttir.empty() : tensor<14x14xbf16>
+    // CHECK: %[[RESHAPE_BACK:[0-9]+]] = "ttir.reshape"(%[[PERMUTE_BACK]], %[[EMPTY_RESHAPE_BACK]]
+    // CHECK-SAME: shape = [14 : i32, 14 : i32]
     // CHECK-SAME: (tensor<1x1x14x14xbf16>, tensor<14x14xbf16>)
     // CHECK-SAME: -> tensor<14x14xbf16>
     // CHECK: return %[[RESHAPE_BACK]] : tensor<14x14xbf16>


### PR DESCRIPTION
Currently, the `ttir.pooling` op only accepts 4D tensors as inputs. This PR adds a reshape so that the non-4D tensors can also go into the `ttir.pooling` op.

For example, ttir MLIR code looking like this:
```
  func.func @avg_pool_2d_example(%arg0: tensor<28x28xf32>) -> tensor<14x14xf32> {
    %0 = ttir.empty() : tensor<14x14xf32>

    %1 = "ttir.pooling"(%arg0, %0) <{
      base_dilations = array<i64: 1, 1>,
      operandSegmentSizes = array<i32: 1, 1>,
      padding = array<i64: 0, 0, 0, 0>,
      pooling_method = #ttir<pooling_method Average>,
      window_dilations = array<i64: 1, 1>,
      window_dimensions = array<i64: 2, 2>,
      window_strides = array<i64: 2, 2>
    }> : (tensor<28x28xf32>, tensor<14x14xf32>) -> tensor<14x14xf32>

    return %1 : tensor<14x14xf32>
  }
```
Will get translated to this:
```
      func.func @avg_pool_2d_example(%arg0: tensor<28x28xf32, #ttnn_layout>) -> tensor<14x14xf32, #ttnn_layout> {
        %0 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 28 : i32, 28 : i32]}> : (tensor<28x28xf32, #ttnn_layout>) -> tensor<1x1x28x28xf32, #ttnn_layout1>
        "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<28x28xf32, #ttnn_layout>) -> ()
        %1 = "ttnn.permute"(%0) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x1x28x28xf32, #ttnn_layout1>) -> tensor<1x28x28x1xf32, #ttnn_layout2>
        "ttnn.deallocate"(%0) <{force = false}> : (tensor<1x1x28x28xf32, #ttnn_layout1>) -> ()
        %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 784 : i32, 1 : i32]}> : (tensor<1x28x28x1xf32, #ttnn_layout2>) -> tensor<1x1x784x1xf32, #ttnn_layout3>
        "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x28x28x1xf32, #ttnn_layout2>) -> ()
        %3 = "ttnn.typecast"(%2) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x1x784x1xf32, #ttnn_layout3>) -> tensor<1x1x784x1xbf16, #ttnn_layout4>
        "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x1x784x1xf32, #ttnn_layout3>) -> ()
        %4 = "ttnn.to_layout"(%3) <{layout = #ttnn.layout<row_major>}> : (tensor<1x1x784x1xbf16, #ttnn_layout4>) -> tensor<1x1x784x1xbf16, #ttnn_layout5>
        "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x1x784x1xbf16, #ttnn_layout4>) -> ()
        %5 = "ttnn.avg_pool2d"(%4) <{batch_size = 1 : si32, ceil_mode = false, channels = 1 : si32, count_include_pad = true, dilation = array<i32: 1, 1>, in_place_halo = false, input_height = 28 : si32, input_width = 28 : si32, kernel_size = array<i32: 2, 2>, padding = array<i32: 0, 0>, stride = array<i32: 2, 2>}> : (tensor<1x1x784x1xbf16, #ttnn_layout5>) -> tensor<1x1x196x1xbf16, #ttnn_layout6>
        "ttnn.deallocate"(%4) <{force = false}> : (tensor<1x1x784x1xbf16, #ttnn_layout5>) -> ()
        %6 = "ttnn.to_layout"(%5) <{layout = #ttnn.layout<tile>}> : (tensor<1x1x196x1xbf16, #ttnn_layout6>) -> tensor<1x1x196x1xbf16, #ttnn_layout7>
        "ttnn.deallocate"(%5) <{force = false}> : (tensor<1x1x196x1xbf16, #ttnn_layout6>) -> ()
        %7 = "ttnn.typecast"(%6) <{dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x1x196x1xbf16, #ttnn_layout7>) -> tensor<1x1x196x1xf32, #ttnn_layout8>
        "ttnn.deallocate"(%6) <{force = false}> : (tensor<1x1x196x1xbf16, #ttnn_layout7>) -> ()
        %8 = "ttnn.reshape"(%7) <{shape = [1 : i32, 14 : i32, 14 : i32, 1 : i32]}> : (tensor<1x1x196x1xf32, #ttnn_layout8>) -> tensor<1x14x14x1xf32, #ttnn_layout9>
        "ttnn.deallocate"(%7) <{force = false}> : (tensor<1x1x196x1xf32, #ttnn_layout8>) -> ()
        %9 = "ttnn.permute"(%8) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x14x14x1xf32, #ttnn_layout9>) -> tensor<1x1x14x14xf32, #ttnn_layout1>
        "ttnn.deallocate"(%8) <{force = false}> : (tensor<1x14x14x1xf32, #ttnn_layout9>) -> ()
        %10 = "ttnn.reshape"(%9) <{shape = [14 : i32, 14 : i32]}> : (tensor<1x1x14x14xf32, #ttnn_layout1>) -> tensor<14x14xf32, #ttnn_layout>
        "ttnn.deallocate"(%9) <{force = false}> : (tensor<1x1x14x14xf32, #ttnn_layout1>) -> ()
        return %10 : tensor<14x14xf32, #ttnn_layout>
      }
```