### PR TITLE
EmitPy run script template update

### DIFF
--- a/tools/tt-alchemist/templates/python/local/run
+++ b/tools/tt-alchemist/templates/python/local/run
@@ -6,6 +6,12 @@ if [[ -z "${TT_MLIR_HOME}" ]]; then
     exit 1
 fi
 
+# Check if TT_METAL_HOME is set
+if [[ -z "${TT_METAL_HOME}" ]]; then
+    export TT_METAL_HOME="${TT_MLIR_HOME}/third_party/tt-metal/src/tt-metal"
+    echo "TT_METAL_HOME is not set. Setting it to ${TT_METAL_HOME}"
+fi
+
 # Confirm python3 exists
 if ! command -v python3 &> /dev/null; then
     echo "Error: python3 could not be found"
@@ -17,6 +23,8 @@ if [[ -z "${VIRTUAL_ENV}" ]]; then
     echo "Error: VIRTUAL_ENV environment variable is not set. Please activate your virtual environment."
     exit 1
 fi
+
+export PYTHONPATH="${PYTHONPATH}:${TT_METAL_HOME}/ttnn"
 
 # Run main.py
 echo "Running main.py..."


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In environments where TT_METAL_HOME is not set by default on env activation, we can't run the local emitpy solution, like in tt-xla.

### What's changed
Adding the ability to autodetect TT_METAL_HOME and ttnn PYTHONPATH based on the TT_MLIR_HOME environment variable.

### Checklist
- [ ] New/Existing tests provide coverage for changes
