### PR TITLE
New sharding rule for batchnorm inference op

### DIFF
--- a/env/patches/shardy.patch
+++ b/env/patches/shardy.patch
@@ -789,3 +789,45 @@ index 0000000..30a5cf9
 +include "shardy/dialect/sdy/ir/ops.td"
 +
 +#endif
+diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+index 47ce53e..63b2424 100644
+--- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
++++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+@@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
+         }
+         return builder.build();
+       })
++      .Case<stablehlo::BatchNormInferenceOp>(
++        [conservativePropagation](stablehlo::BatchNormInferenceOp bn) {
++          auto inTy  = llvm::cast<mlir::RankedTensorType>(bn.getOperand().getType());
++          auto outTy = llvm::cast<mlir::RankedTensorType>(bn.getResult().getType());
++
++          OpShardingRuleBuilder builder(bn);
++
++          const int64_t numOperands = static_cast<int64_t>(bn->getNumOperands());
++          llvm::SmallVector<int64_t> opDims(numOperands, kNullDim);
++
++          for (auto [dU, dimSize] : llvm::enumerate(inTy.getShape())) {
++            const int64_t d = static_cast<int64_t>(dU);
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[0] = d;
++            builder.addFactor(opDims, d, dimSize);
++          }
++
++          const int64_t featAxis = static_cast<int64_t>(bn.getFeatureIndex());
++          const int64_t C = outTy.getDimSize(featAxis);
++
++          for (int64_t paramIdx : {1LL, 2LL, 3LL, 4LL}) {
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[paramIdx] = 0;
++            auto factorType = conservativePropagation ? FactorType::kNeedReplication
++                                                        : FactorType::kPassThrough;
++            builder.addFactor(opDims, kNullDim, C,
++                  factorType, true);
++          }
++
++          return builder.build();
++        })
+       .Case<stablehlo::BitcastConvertOp>(
+           [](stablehlo::BitcastConvertOp bitcastConvert) {
+             ArrayRef<int64_t> inShape =


### PR DESCRIPTION
stablehlo.batch_norm_inference had no sharding rule in shardy dialect.

### Ticket
N/A

### Problem description
It fails compiling hardnet tensor parallel model when lowering stablehlo graph, on the op `stablehlo.batch_norm_inference`

### What's changed
Adding sharding rule for this op.

### Checklist
- [v] New/Existing tests provide coverage for changes
