### PR TITLE
Fix misc. changes post runtime integration PR

### DIFF
--- a/.github/test_matrix/pr-push-matrix.json
+++ b/.github/test_matrix/pr-push-matrix.json
@@ -24,7 +24,7 @@
 
   { "runs-on": ["n150","llmbox","n300","p150"],
         "image": "tracy",
-            "script": "builder.sh", "args": "test/python/golden" },
+            "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"] },
 
   { "runs-on": "n150",   "image": "speedy", "script": "builder.sh", "args": [ "test/python/golden/optimizer", "", "require-opmodel" ] },
   { "runs-on": "n150",   "image": "tracy",  "script": "ttrt.sh", "args": [ "perf", "Silicon/TTNN/n150/optimizer" ] },

--- a/.github/test_scripts/builder.sh
+++ b/.github/test_scripts/builder.sh
@@ -5,18 +5,33 @@
 
 # arg $1: path to pytest test files
 # arg $2: pytest marker expression to select tests to run
-# arg $3: additional flags for pytest
+# arg $3: "run-ttrt" or predefined additional flags for pytest
 
 set -e -o pipefail
 
+runttrt=""
 TTRT_ARGS=""
 PYTEST_ARGS=""
 
 [[ "$RUNS_ON" != "n150" ]] && PYTEST_ARGS="$PYTEST_ARGS --require-exact-mesh"
-[[ "$RUNS_ON" == "p150" ]] && PYTEST_ARGS="$PYTEST_ARGS --disable-eth-dispatch"
+[[ "$RUNS_ON" == "p150" ]] && PYTEST_ARGS="$PYTEST_ARGS --disable-eth-dispatch" && TTRT_ARGS="$TTRT_ARGS --disable-eth-dispatch"
 
 for flag in $3; do
+    [[ "$flag" == "run-ttrt" ]] && runttrt=1
     [[ "$flag" == "require-opmodel" ]] && PYTEST_ARGS="$PYTEST_ARGS --require-opmodel"
 done
 
 pytest "$1" -m "$2" $PYTEST_ARGS -v --junit-xml=$TEST_REPORT_PATH
+
+if [[ "$runttrt" == "1" ]]; then
+  if [ -d "ttir-builder-artifacts/emitpy" ]; then
+        ttrt emitpy $TTRT_ARGS ttir-builder-artifacts/emitpy/
+        cp emitpy_results.json ${TTRT_REPORT_PATH%_*}_ttir_${TTRT_REPORT_PATH##*_} || true
+        cp ttrt_report.xml ${TEST_REPORT_PATH%_*}_ttir_emitpy_${TEST_REPORT_PATH##*_} || true
+  fi
+  if [ -d "stablehlo-builder-artifacts/emitpy" ]; then
+      ttrt emitpy $TTRT_ARGS stablehlo-builder-artifacts/emitpy/
+      cp emitpy_results.json ${TTRT_REPORT_PATH%_*}_stablehlo_${TTRT_REPORT_PATH##*_} || true
+      cp ttrt_report.xml ${TEST_REPORT_PATH%_*}_stablehlo_emitpy_${TEST_REPORT_PATH##*_} || true
+  fi
+fi

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -37,8 +37,6 @@ def create_matmul_constrained_inputs(lhs_shape, rhs_shape):
     return matmul_constrained_inputs
 
 
-@pytest.mark.skip_config(["p150"], ["p300"])
-@pytest.mark.xfail(reason="fails golden")
 @pytest.mark.parametrize("m", [2])
 @pytest.mark.parametrize("k", [4])
 @pytest.mark.parametrize("n", [4])
@@ -62,7 +60,6 @@ def test_matmul_single_core_8otpc(m: int, k: int, n: int, target: str, request, 
 
     compile_and_execute_ttir(
         create_matmul_constrained_inputs(lhs, rhs),
-        matmul,
         [lhs, rhs],
         target=target,
         device=device,
@@ -74,7 +71,6 @@ def test_matmul_single_core_8otpc(m: int, k: int, n: int, target: str, request, 
     )
 
 
-@pytest.mark.xfail(reason="fails golden")
 @pytest.mark.parametrize("m", [3, 6, 9])
 @pytest.mark.parametrize("k", [4])
 @pytest.mark.parametrize("n", [3, 6])
@@ -109,8 +105,6 @@ def test_matmul_multi_core_8otpc(m: int, k: int, n: int, target: str, request, d
 
 
 @pytest.mark.skip_config(["ttmetal", "p150"], reason="See issue #5341")
-@pytest.mark.skip_config(["p150"], ["p300"])
-@pytest.mark.xfail(reason="fails golden")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -163,8 +157,6 @@ def test_matmul_ttnn_shapes_single_buffered(
 
 
 @pytest.mark.skip_config(["ttmetal", "p150"], reason="See issue #5341")
-@pytest.mark.skip_config(["p150"], ["p300"])
-@pytest.mark.xfail(reason="fails golden")
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
This is a change to fix misc. issues that cropped up as part of #4094 being merged. This includes:
- Changing some marks in `test_metal_matmul.py` to more closely follow the actual state of test runs
- Re-instate using `ttrt` for emitpy targets in `builder.sh`