### PR TITLE
D2M: cleanup and preparation for bcast

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -105,22 +105,6 @@ def TTKernel_ReduceType : I32EnumAttr<"ReduceType", "TTKernel Reduce Types",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
-def TTKernel_BcastTypeNone : I32EnumAttrCase<"None", 0, "bcast_type_none">;
-def TTKernel_BcastTypeCol : I32EnumAttrCase<"Col", 1, "bcast_type_col">;
-def TTKernel_BcastTypeRow : I32EnumAttrCase<"Row", 2, "bcast_type_row">;
-def TTKernel_BcastTypeScalar : I32EnumAttrCase<"Scalar", 3, "bcast_type_scalar">;
-
-def TTKernel_BcastType : I32EnumAttr<"BcastType", "TTKernel broadcast types",
-                         [
-                           TTKernel_BcastTypeNone,
-                           TTKernel_BcastTypeCol,
-                           TTKernel_BcastTypeRow,
-                           TTKernel_BcastTypeScalar
-                         ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt::ttkernel";
-}
-
 def TTKernel_ReduceDimRow : I32EnumAttrCase<"Row", 0, "reduce_dim_row">;
 def TTKernel_ReduceDimCol : I32EnumAttrCase<"Col", 1, "reduce_dim_col">;
 def TTKernel_ReduceDimScalar
@@ -130,6 +114,22 @@ def TTKernel_ReduceDim
     : I32EnumAttr<"ReduceDim", "TTKernel Reduce Dimensions",
                   [TTKernel_ReduceDimRow, TTKernel_ReduceDimCol,
                    TTKernel_ReduceDimScalar]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
+def TTKernel_BcastTypeNone :   I32EnumAttrCase<"None",   0, "none">;
+def TTKernel_BcastTypeCol :    I32EnumAttrCase<"Col",    1, "col">;
+def TTKernel_BcastTypeRow :    I32EnumAttrCase<"Row",    2, "row">;
+def TTKernel_BcastTypeScalar : I32EnumAttrCase<"Scalar", 3, "scalar">;
+
+def TTKernel_BcastType : I32EnumAttr<"BcastType", "TTKernel Broadcast Types",
+                         [
+                           TTKernel_BcastTypeNone,
+                           TTKernel_BcastTypeCol,
+                           TTKernel_BcastTypeRow,
+                           TTKernel_BcastTypeScalar
+                         ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";
 }

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -16,16 +16,13 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -404,7 +401,26 @@ private:
       std::is_same_v<TileOp, d2m::TileLtzOp> ||
       std::is_same_v<TileOp, d2m::TileLezOp>;
 
-private:
+  void createComputeRegion(mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
+                           mlir::ValueRange bbArgs,
+                           mlir::ConversionPatternRewriter &rewriter,
+                           mlir::Location loc, const size_t numInputs,
+                           const size_t numOutputs) const {
+    mlir::ValueRange operands = bbArgs.take_front(numInputs);
+    mlir::TypeRange resultTypes = bbArgs.take_back(numOutputs);
+
+    mlir::Value yield;
+    if constexpr (isComparisonOp) {
+      // For comparison ops, first subtract then compare with zero.
+      yield = bbBuilder.create<d2m::TileSubOp>(loc, resultTypes, operands);
+      yield = bbBuilder.create<TileOp>(loc, resultTypes, yield);
+    } else {
+      yield = bbBuilder.create<TileOp>(loc, resultTypes, operands);
+    }
+
+    bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
+  }
+
   LogicalResult
   matchAndRewrite(ConcreteOp op, typename ConcreteOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const final {
@@ -467,25 +483,8 @@ private:
             linalgIteratorTypes,
             [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
                 mlir::ValueRange bbArgs) {
-              mlir::Value yield;
-
-              if constexpr (isComparisonOp) {
-                // For comparison ops, first subtract then compare with zero.
-                mlir::Value subResult = bbBuilder.create<d2m::TileSubOp>(
-                    loc, /*resultTypes=*/bbArgs.take_back(numOutputs),
-                    /*operands=*/bbArgs.take_front(numInputs));
-                yield = bbBuilder.create<TileOp>(
-                    loc, /*resultTypes=*/bbArgs.take_back(numOutputs),
-                    /*operands=*/subResult);
-              } else {
-                // For regular elementwise ops, create TileOp directly.
-                yield = bbBuilder.create<TileOp>(
-                    loc,
-                    /* resultTypes */ bbArgs.take_back(numOutputs).getTypes(),
-                    /* operands */ bbArgs.take_front(numInputs));
-              }
-
-              bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
+              createComputeRegion(bbBuilder, bbLoc, bbArgs, rewriter, loc,
+                                  numInputs, numOutputs);
             });
 
         rewriter.create<d2m::YieldOp>(loc, linalgGeneric->getResults());

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -8,10 +8,7 @@
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/Attributes.h"
@@ -20,7 +17,6 @@
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/SmallVector.h"
@@ -664,7 +660,7 @@ public:
     auto zerosConst =
         rewriter.create<tosa::ConstOp>(op.getLoc(), resultType, zerosAttr);
 
-    // Multiply by ones to implicitly broadcast
+    // Add by zeros to implicitly broadcast.
     auto result = rewriter.create<tosa::AddOp>(op.getLoc(), resultType, input,
                                                zerosConst);
 

--- a/test/ttmlir/Conversion/D2MToTTKernel/single_tile_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/single_tile_ops.mlir
@@ -1,71 +1,104 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-insert-dst-register-access --lower-affine --d2m-generic-linearize-memref --lower-affine --convert-d2m-to-ttkernel --canonicalize -o %t.mlir %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-ttmetal-me-pipeline --convert-d2m-to-ttkernel --canonicalize -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 
 #l1_ = #ttcore.memory_space<l1>
+#map_ = affine_map<(d0, d1) -> (d0, d1)>
+#map1_ = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2_ = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map3_ = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel_ = #ttcore.iterator_type<parallel>
+#reduction_ = #ttcore.iterator_type<reduction>
+
+!ttype_f32 = !ttcore.tile<32x32, f32>
+!ttype_si32 = !ttcore.tile<32x32, si32>
+!ttype_bf16 = !ttcore.tile<32x32, bf16>
 
 module {
   //===----------------------------------------------------------------------===//
   // TTIR FPU operations
   //===----------------------------------------------------------------------===//
 
-  // CHECK-LABEL: func.func @test_matmul_lowering
-  func.func @test_matmul_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %2 = affine.load %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_matmul
-    // CHECK: ttkernel.mm_init
-    // CHECK: ttkernel.mm_init_short
-    // CHECK: ttkernel.matmul_tiles
-    %3 = "d2m.tile_matmul"(%0, %1, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_matmul_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                  %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                  %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map1_, #map2_, #map3_], iterator_types = [#parallel_, #parallel_, #reduction_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map1_, #map2_, #map3_], iterator_types = ["parallel", "parallel", "reduction"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_matmul
+        // CHECK: ttkernel.mm_block_init
+        // CHECK: ttkernel.mm_block_init_short
+        // CHECK: ttkernel.experimental::matmul_block
+        %0 = "d2m.tile_matmul"(%arg0, %arg1, %arg2) : (!ttype_f32, !ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_add_lowering
-  func.func @test_add_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_add
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.add_binary_tile_init
-    // CHECK: ttkernel.add_binary_tile
-    %2 = "d2m.tile_add"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_add_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_add
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.add_binary_tile_init
+        // CHECK: ttkernel.add_binary_tile
+        %0 = "d2m.tile_add"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_sub_lowering
-  func.func @test_sub_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_sub_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_mul_lowering
-  func.func @test_mul_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_mul
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.mul_binary_tile_init
-    // CHECK: ttkernel.mul_binary_tile
-    %2 = "d2m.tile_mul"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_mul_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_mul
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.mul_binary_tile_init
+        // CHECK: ttkernel.mul_binary_tile
+        %0 = "d2m.tile_mul"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
@@ -73,367 +106,499 @@ module {
   // TTIR SFPU operations
   //===----------------------------------------------------------------------===//
 
-  // CHECK-LABEL: func.func @test_max_lowering
-  func.func @test_max_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_max
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
-    // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
-    // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.max_tile_init
-    // CHECK: ttkernel.max_tile(%{{.+}}, %{{.+}})
-    %2 = "d2m.tile_maximum"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_max_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_max
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
+        // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
+        // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.max_tile_init
+        // CHECK: ttkernel.max_tile(%{{.+}}, %{{.+}})
+        %0 = "d2m.tile_maximum"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_div_lowering
-  func.func @test_div_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_div
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
-    // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
-    // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.div_binary_tile_init
-    // CHECK: ttkernel.div_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
-    %2 = "d2m.tile_div"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_div_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_div
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
+        // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
+        // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.div_binary_tile_init
+        // CHECK: ttkernel.div_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
+        %0 = "d2m.tile_div"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_recip_lowering
-  func.func @test_recip_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_recip
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.recip_tile_init
-    // CHECK: ttkernel.recip_tile
-    %1 = "d2m.tile_recip"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_recip_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                 %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_recip
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.recip_tile_init
+        // CHECK: ttkernel.recip_tile
+        %0 = "d2m.tile_recip"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_pow_lowering
-  func.func @test_pow_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_pow
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
-    // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
-    // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.power_binary_tile_init
-    // CHECK: ttkernel.power_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
-    %2 = "d2m.tile_pow"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %2, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_pow_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_pow
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %[[DST_IDX0:.+]]) :
+        // CHECK: ttkernel.copy_tile_init(%[[CB1:.+]]) :
+        // CHECK-NOT: ttkernel.copy_tile(%{{.+}}, %{{.+}}, %[[DST_IDX0]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB1]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.power_binary_tile_init
+        // CHECK: ttkernel.power_binary_tile(%{{.+}}, %{{.+}}, %{{.+}})
+        %0 = "d2m.tile_pow"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_exp_lowering
-  func.func @test_exp_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_exp
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.exp_tile_init
-    // CHECK: ttkernel.exp_tile
-    %1 = "d2m.tile_exp"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_exp_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_exp
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.exp_tile_init
+        // CHECK: ttkernel.exp_tile
+        %0 = "d2m.tile_exp"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_log_lowering
-  func.func @test_log_lowering(%arg0 : memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_log
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.log_tile_init
-    // CHECK: ttkernel.log_tile
-    %1 = "d2m.tile_log"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_log_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_log
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.log_tile_init
+        // CHECK: ttkernel.log_tile
+        %0 = "d2m.tile_log"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_cos_lowering
-  func.func @test_cos_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_cos
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.cos_tile_init
-    // CHECK: ttkernel.cos_tile
-    %1 = "d2m.tile_cos"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_cos_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_cos
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.cos_tile_init
+        // CHECK: ttkernel.cos_tile
+        %0 = "d2m.tile_cos"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_tan_lowering
-  func.func @test_tan_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_tan
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.tan_tile_init
-    // CHECK: ttkernel.tan_tile
-    %1 = "d2m.tile_tan"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_tan_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_tan
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.tan_tile_init
+        // CHECK: ttkernel.tan_tile
+        %0 = "d2m.tile_tan"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_negative_lowering
-  func.func @test_negative_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_neg
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.negative_tile_init
-    // CHECK: ttkernel.negative_tile
-    %1 = "d2m.tile_negative"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_negative_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                    %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_neg
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.negative_tile_init
+        // CHECK: ttkernel.negative_tile
+        %0 = "d2m.tile_negative"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_sqrt_lowering
-  func.func @test_sqrt_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sqrt
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.sqrt_tile_init
-    // CHECK: ttkernel.sqrt_tile
-    %1 = "d2m.tile_sqrt"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_sqrt_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sqrt
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.sqrt_tile_init
+        // CHECK: ttkernel.sqrt_tile
+        %0 = "d2m.tile_sqrt"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_rsqrt_lowering
-  func.func @test_rsqrt_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_rsqrt
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.rsqrt_tile_init
-    // CHECK: ttkernel.rsqrt_tile
-    %1 = "d2m.tile_rsqrt"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_rsqrt_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                 %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_rsqrt
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.rsqrt_tile_init
+        // CHECK: ttkernel.rsqrt_tile
+        %0 = "d2m.tile_rsqrt"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_sin_lowering
-  func.func @test_sin_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sin
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.sin_tile_init
-    // CHECK: ttkernel.sin_tile
-    %1 = "d2m.tile_sin"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_sin_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sin
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.sin_tile_init
+        // CHECK: ttkernel.sin_tile
+        %0 = "d2m.tile_sin"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_sigmoid_lowering
-  func.func @test_sigmoid_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sigmoid
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.sigmoid_tile_init
-    // CHECK: ttkernel.sigmoid_tile
-    %1 = "d2m.tile_sigmoid"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_sigmoid_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                   %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sigmoid
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.sigmoid_tile_init
+        // CHECK: ttkernel.sigmoid_tile
+        %0 = "d2m.tile_sigmoid"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_gelu_lowering
-  func.func @test_gelu_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_gelu
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.gelu_tile_init
-    // CHECK: ttkernel.gelu_tile
-    %1 = "d2m.tile_gelu"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_gelu_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_gelu
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.gelu_tile_init
+        // CHECK: ttkernel.gelu_tile
+        %0 = "d2m.tile_gelu"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_ceil_lowering
-  func.func @test_ceil_lowering(%arg0: memref<1x!ttcore.tile<32x32, bf16>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, bf16>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
-    // CHECK-NOT: d2m.tile_ceil
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.rounding_op_tile_init
-    // CHECK: ttkernel.ceil_tile
-    %1 = "d2m.tile_ceil"(%0) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
+  func.func @test_ceil_lowering(%in0: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>,
+                                %out: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_bf16, #l1_>, %cb1: memref<1x1x!ttype_bf16, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_bf16, #l1_>) outs(%cb1 : memref<1x1x!ttype_bf16, #l1_>) {
+      ^bb0(%arg0: !ttype_bf16, %arg1: !ttype_bf16):
+        // CHECK-NOT: d2m.tile_ceil
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.rounding_op_tile_init
+        // CHECK: ttkernel.ceil_tile
+        %0 = "d2m.tile_ceil"(%arg0) : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_bf16
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_ceil_lowering_f32
-  func.func @test_ceil_lowering_f32(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_ceil
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.rounding_op_tile_init
-    // CHECK: ttkernel.ceil_tile_float32
-    %1 = "d2m.tile_ceil"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_ceil_lowering_f32(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                    %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_ceil
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.rounding_op_tile_init
+        // CHECK: ttkernel.ceil_tile_float32
+        %0 = "d2m.tile_ceil"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_floor_lowering
-  func.func @test_floor_lowering(%arg0: memref<1x!ttcore.tile<32x32, bf16>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, bf16>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
-    // CHECK-NOT: d2m.tile_floor
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.rounding_op_tile_init
-    // CHECK: ttkernel.floor_tile
-    %1 = "d2m.tile_floor"(%0) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
+  func.func @test_floor_lowering(%in0: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>,
+                                 %out: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_bf16, #l1_>, %cb1: memref<1x1x!ttype_bf16, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_bf16, #l1_>) outs(%cb1 : memref<1x1x!ttype_bf16, #l1_>) {
+      ^bb0(%arg0: !ttype_bf16, %arg1: !ttype_bf16):
+        // CHECK-NOT: d2m.tile_floor
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.rounding_op_tile_init
+        // CHECK: ttkernel.floor_tile
+        %0 = "d2m.tile_floor"(%arg0) : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_bf16
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_floor_lowering_f32
-  func.func @test_floor_lowering_f32(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_floor
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.rounding_op_tile_init
-    // CHECK: ttkernel.floor_tile_float32
-    %1 = "d2m.tile_floor"(%0) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_floor_lowering_f32(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_f32, #l1_>) outs(%cb1 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32):
+        // CHECK-NOT: d2m.tile_floor
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.rounding_op_tile_init
+        // CHECK: ttkernel.floor_tile_float32
+        %0 = "d2m.tile_floor"(%arg0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_abs_lowering
-  func.func @test_abs_lowering(%arg0: memref<1x!ttcore.tile<32x32, bf16>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, bf16>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
-    // CHECK-NOT: d2m.tile_abs
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.abs_tile_init
-    // CHECK: ttkernel.abs_tile
-    %1 = "d2m.tile_abs"(%0) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
+  func.func @test_abs_lowering(%in0: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>,
+                               %out: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_bf16, #l1_>, %cb1: memref<1x1x!ttype_bf16, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_bf16, #l1_>) outs(%cb1 : memref<1x1x!ttype_bf16, #l1_>) {
+      ^bb0(%arg0: !ttype_bf16, %arg1: !ttype_bf16):
+        // CHECK-NOT: d2m.tile_abs
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.abs_tile_init
+        // CHECK: ttkernel.abs_tile
+        %0 = "d2m.tile_abs"(%arg0) : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_bf16
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_abs_i32_lowering
-  func.func @test_abs_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_abs
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.abs_tile_init
-    // CHECK: ttkernel.abs_tile_int32
-    %1 = "d2m.tile_abs"(%0) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_abs_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                   %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_si32, #l1_>) outs(%cb1 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32):
+        // CHECK-NOT: d2m.tile_abs
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.abs_tile_init
+        // CHECK: ttkernel.abs_tile_int32
+        %0 = "d2m.tile_abs"(%arg0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_logical_not_lowering
-  func.func @test_logical_not_lowering(%arg0: memref<1x!ttcore.tile<32x32, bf16>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, bf16>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
-    // CHECK-NOT: d2m.tile_logical_not
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.logical_not_unary_tile_init
-    // CHECK: ttkernel.logical_not_unary_tile
-    %1 = "d2m.tile_logical_not"(%0) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, bf16>, #l1_>
+  func.func @test_logical_not_lowering(%in0: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>,
+                                       %out: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_bf16, #l1_>, %cb1: memref<1x1x!ttype_bf16, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_bf16, #l1_>) outs(%cb1 : memref<1x1x!ttype_bf16, #l1_>) {
+      ^bb0(%arg0: !ttype_bf16, %arg1: !ttype_bf16):
+        // CHECK-NOT: d2m.tile_logical_not
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.logical_not_unary_tile_init
+        // CHECK: ttkernel.logical_not_unary_tile
+        %0 = "d2m.tile_logical_not"(%arg0) : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_bf16
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_logical_not_i32_lowering
-  func.func @test_logical_not_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_logical_not
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
-    // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
-    // CHECK: ttkernel.logical_not_unary_tile_init
-    // CHECK: ttkernel.logical_not_unary_tile_int32
-    %1 = "d2m.tile_logical_not"(%0) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %1, %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_logical_not_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                           %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_si32, #l1_>) outs(%cb1 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32):
+        // CHECK-NOT: d2m.tile_logical_not
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.copy_tile_init(%[[CB0:.+]]) :
+        // CHECK-NEXT: ttkernel.copy_tile(%[[CB0]], %{{.+}}, %{{.+}}) :
+        // CHECK: ttkernel.logical_not_unary_tile_init
+        // CHECK: ttkernel.logical_not_unary_tile_int32
+        %0 = "d2m.tile_logical_not"(%arg0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %0 : !ttype_si32
+      }
+    }
     return
   }
 
@@ -441,117 +606,153 @@ module {
   // TTIR Comparison operations
   //===----------------------------------------------------------------------===//
 
-  // CHECK-LABEL: func.func @test_equal_lowering
-  func.func @test_equal_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_eqz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.eqz_tile_init
-    // CHECK: ttkernel.eqz_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_eqz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_equal_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                 %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                 %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_eqz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.eqz_tile_init
+        // CHECK: ttkernel.eqz_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_eqz"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_not_equal_lowering
-  func.func @test_not_equal_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_nez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.nez_tile_init
-    // CHECK: ttkernel.nez_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_nez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_not_equal_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_nez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.nez_tile_init
+        // CHECK: ttkernel.nez_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_nez"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_greater_than_lowering
-  func.func @test_greater_than_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_gtz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.gtz_tile_init
-    // CHECK: ttkernel.gtz_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_gtz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_greater_than_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                        %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                        %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_gtz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.gtz_tile_init
+        // CHECK: ttkernel.gtz_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_gtz"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_greater_equal_lowering
-  func.func @test_greater_equal_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_gez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.gez_tile_init
-    // CHECK: ttkernel.gez_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_gez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_greater_equal_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_gez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.gez_tile_init
+        // CHECK: ttkernel.gez_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_gez"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_less_than_lowering
-  func.func @test_less_than_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_ltz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.ltz_tile_init
-    // CHECK: ttkernel.ltz_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_ltz"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_less_than_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_ltz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.ltz_tile_init
+        // CHECK: ttkernel.ltz_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_ltz"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_less_equal_lowering
-  func.func @test_less_equal_lowering(%arg0: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_lez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.lez_tile_init
-    // CHECK: ttkernel.lez_tile
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    %3 = "d2m.tile_lez"(%2) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @test_less_equal_lowering(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                      %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>,
+                                      %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_f32, #l1_>, %cb1: memref<1x1x!ttype_f32, #l1_>, %cb2: memref<1x1x!ttype_f32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_lez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.lez_tile_init
+        // CHECK: ttkernel.lez_tile
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        %1 = "d2m.tile_lez"(%0) : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
     return
   }
 
@@ -559,117 +760,153 @@ module {
   // TTIR Comparison operations (i32)
   //===----------------------------------------------------------------------===//
 
-  // CHECK-LABEL: func.func @test_equal_i32_lowering
-  func.func @test_equal_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_eqz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.eqz_tile_init
-    // CHECK: ttkernel.eqz_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_eqz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_equal_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_eqz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.eqz_tile_init
+        // CHECK: ttkernel.eqz_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_eqz"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_not_equal_i32_lowering
-  func.func @test_not_equal_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_nez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.nez_tile_init
-    // CHECK: ttkernel.nez_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_nez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_not_equal_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_nez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.nez_tile_init
+        // CHECK: ttkernel.nez_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_nez"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_greater_than_i32_lowering
-  func.func @test_greater_than_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_gtz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.gtz_tile_init
-    // CHECK: ttkernel.gtz_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_gtz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_greater_than_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                            %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                            %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_gtz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.gtz_tile_init
+        // CHECK: ttkernel.gtz_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_gtz"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_greater_equal_i32_lowering
-  func.func @test_greater_equal_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_gez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.gez_tile_init
-    // CHECK: ttkernel.gez_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_gez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_greater_equal_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                             %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                             %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_gez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.gez_tile_init
+        // CHECK: ttkernel.gez_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_gez"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_less_than_i32_lowering
-  func.func @test_less_than_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_ltz
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.ltz_tile_init
-    // CHECK: ttkernel.ltz_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_ltz"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_less_than_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                         %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_ltz
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.ltz_tile_init
+        // CHECK: ttkernel.ltz_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_ltz"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 
-  // CHECK-LABEL: func.func @test_less_equal_i32_lowering
-  func.func @test_less_equal_i32_lowering(%arg0: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg1: memref<1x!ttcore.tile<32x32, si32>, #l1_>, %arg2: memref<1x!ttcore.tile<32x32, si32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    %0 = affine.load %arg0[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    %1 = affine.load %arg1[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
-    // CHECK-NOT: d2m.tile_sub
-    // CHECK-NOT: d2m.tile_lez
-    // CHECK: ttkernel.init_sfpu
-    // CHECK: ttkernel.sub_binary_tile_init
-    // CHECK: ttkernel.sub_binary_tile
-    // CHECK: ttkernel.lez_tile_init
-    // CHECK: ttkernel.lez_tile_int32
-    %2 = "d2m.tile_sub"(%0, %1) : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    %3 = "d2m.tile_lez"(%2) : (!ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
-    // CHECK: ttkernel.pack_tile
-    affine.store %3, %arg2[%c0] : memref<1x!ttcore.tile<32x32, si32>, #l1_>
+  func.func @test_less_equal_i32_lowering(%in0: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                          %in1: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>,
+                                          %out: memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_si32, #ttcore.shard<4096x4096>, #l1_>)  {
+    ^compute0(%cb0: memref<1x1x!ttype_si32, #l1_>, %cb1: memref<1x1x!ttype_si32, #l1_>, %cb2: memref<1x1x!ttype_si32, #l1_>):
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_si32, #l1_>, memref<1x1x!ttype_si32, #l1_>) outs(%cb2 : memref<1x1x!ttype_si32, #l1_>) {
+      ^bb0(%arg0: !ttype_si32, %arg1: !ttype_si32, %arg2: !ttype_si32):
+        // CHECK-NOT: d2m.tile_sub
+        // CHECK-NOT: d2m.tile_lez
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        // CHECK: ttkernel.lez_tile_init
+        // CHECK: ttkernel.lez_tile_int32
+        %0 = "d2m.tile_sub"(%arg0, %arg1) : (!ttype_si32, !ttype_si32) -> !ttype_si32
+        %1 = "d2m.tile_lez"(%0) : (!ttype_si32) -> !ttype_si32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_si32
+      }
+    }
     return
   }
 }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -219,10 +219,10 @@ module {
       %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
       // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
-      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_row>}> : (!cb0_tiles, !cb1_tiles) -> ()
-      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_col>}> : (!cb0_tiles, !cb1_tiles) -> ()
-      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_scalar>}> : (!cb0_tiles, !cb1_tiles) -> ()
-      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<bcast_type_none>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<row>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<col>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<scalar>}> : (!cb0_tiles, !cb1_tiles) -> ()
+      "ttkernel.unary_bcast_init"(%in_cb, %out_cb) <{bcast_type = #ttkernel.bcast_type<none>}> : (!cb0_tiles, !cb1_tiles) -> ()
       // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
       // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
       // CHECK: call_opaque "unary_bcast_init"(%[[IN_CB]], %[[OUT_CB]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
@@ -238,10 +238,10 @@ module {
       // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
       // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
-      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_row>}> : (!cb0_tiles, index, index) -> ()
-      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_col>}> : (!cb0_tiles, index, index) -> ()
-      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_scalar>}> : (!cb0_tiles, index, index) -> ()
-      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<bcast_type_none>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<row>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<col>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<scalar>}> : (!cb0_tiles, index, index) -> ()
+      "ttkernel.unary_bcast"(%in_cb, %in_tile_index, %dst_index) <{bcast_type = #ttkernel.bcast_type<none>}> : (!cb0_tiles, index, index) -> ()
       // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::ROW">]}
       // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::COL">]}
       // CHECK: emitc.call_opaque "unary_bcast"(%[[IN_CB]], %[[IN_TILE_INDEX]], %[[DST_INDEX]]) {template_args = [#emitc.opaque<"BroadcastType::SCALAR">]}

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_eltwise.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_eltwise.mlir
@@ -6,29 +6,38 @@
 
 module {
   // CHECK-LABEL: func.func @binary
-  func.func @binary(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>,
-                    %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>,
-                    %arg2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
-    %0 = affine.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // Check that the operands are stored to dst memory space
-    // CHECK: %[[ARG0_VAL:.*]] = affine.load %arg0
-    // CHECK: affine.store %[[ARG0_VAL]], %[[DST]]
-    // CHECK: %[[DST0_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[ARG1_VAL:.*]] = affine.load %arg1
-    // CHECK: affine.store %[[ARG1_VAL]], %[[DST]]
-    // CHECK: %[[DST1_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[MAXIMUM_RESULT:.*]] = "d2m.tile_maximum"
-    %3 = "d2m.tile_maximum"(%0, %1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // Check that maximum result is stored back to dst memory space
-    // CHECK: affine.store %[[MAXIMUM_RESULT]], %[[DST]]
-    // Check that result is loaded from dst memory space
-    // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
-    // Check that final result is stored back to original #l1 memory space
-    // CHECK: affine.store %[[FINAL_VAL]], %arg2
-    affine.store %3, %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @binary(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                    %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                    %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %subview = memref.subview %cb0[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_1 = memref.subview %cb1[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_2 = memref.subview %cb2[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+      ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>, %arg2: !ttcore.tile<32x32, f32>):
+        // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
+        // Check that the operands are stored to dst memory space
+        // CHECK: %[[ARG0_VAL:.*]] = affine.load %[[ARG0:.*]]
+        // CHECK: affine.store %[[ARG0_VAL]], %[[DST]]
+        // CHECK: %[[ARG1_VAL:.*]] = affine.load %[[ARG1:.*]]
+        // CHECK: affine.store %[[ARG1_VAL]], %[[DST]]
+        // CHECK: %[[DST0_VAL:.*]] = affine.load %[[DST]]
+        // CHECK: %[[DST1_VAL:.*]] = affine.load %[[DST]]
+        // CHECK: %[[MAXIMUM_RESULT:.*]] = "d2m.tile_maximum"(%[[DST0_VAL]], %[[DST1_VAL]])
+        %0 = "d2m.tile_maximum"(%arg0, %arg1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        // Check that maximum result is stored back to dst memory space
+        // CHECK: affine.store %[[MAXIMUM_RESULT]], %[[DST]]
+        // Check that result is loaded from dst memory space
+        // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
+        // Check that final result is stored back to original #l1 memory space
+        // CHECK: affine.store %[[FINAL_VAL]], %[[ARG2:.*]]
+        linalg.yield %0 : !ttcore.tile<32x32, f32>
+      }
+    }
     return
   }
 

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
@@ -3,31 +3,39 @@
 
 #l1_ = #ttcore.memory_space<l1>
 module {
-  // Since there are no loops, this should remain tile_matmul and not be converted to tile_matmul_block
-  func.func private @no_loops(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
-    %0 = affine.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK: %[[ARG2_VAL:.*]] = affine.load %arg2
-    %2 = affine.load %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // Check that the third operand (accumulator) is stored to dst memory space
-    // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
-    // Check that the accumulator is loaded back from dst memory space for the matmul
-    // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"
-    %3 = "d2m.tile_matmul"(%0, %1, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // Check that matmul result is stored back to dst memory space
-    // CHECK: affine.store %[[MATMUL_RESULT]], %[[DST]]
-    // Check that result is loaded from dst memory space
-    // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
-    // Check that final result is stored back to original #l1 memory space
-    // CHECK: affine.store %[[FINAL_VAL]], %arg2
-    affine.store %3, %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @no_loops(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>, #ttcore.iterator_type<reduction>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %subview = memref.subview %cb0[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_1 = memref.subview %cb1[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_2 = memref.subview %cb2[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+      ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>, %arg2: !ttcore.tile<32x32, f32>):
+        // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
+        // CHECK: %[[GUARD_IDX:.*]] = d2m.iter_index
+        // CHECK: %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[GUARD_IDX]]
+        // CHECK: scf.if %[[NOT_FIRST]]
+        // CHECK: %[[ARG2_VAL:.*]] = affine.load %[[ARG2:.*]]
+        // Check that the third operand (accumulator) is stored to dst memory space
+        // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
+        // CHECK: "d2m.tile_matmul_block"
+        %0 = "d2m.tile_matmul"(%arg0, %arg1, %arg2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        // Check that result is loaded from dst memory space
+        // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
+        // Check that final result is stored back to original #l1 memory space
+        // CHECK: affine.store %[[FINAL_VAL]], %[[ARG2]]
+        linalg.yield %0 : !ttcore.tile<32x32, f32>
+      }
+    }
     return
   }
 
-  func.func private @generic_matmul(
+  func.func @generic_matmul(
     %in0: memref<1x1x3x3x!ttcore.tile<32x32, f16>, #ttcore.shard<6144x2048>, #l1_>,
     %in1: memref<1x1x3x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048>, #l1_>,
     %out0: memref<1x1x3x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048>, #l1_>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
@@ -3,31 +3,39 @@
 
 #l1_ = #ttcore.memory_space<l1>
 module {
-  // Since there are no loops, this should remain tile_matmul and not be converted to tile_matmul_block
-  func.func private @no_loops(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
-    %0 = affine.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK: %[[ARG2_VAL:.*]] = affine.load %arg2
-    %2 = affine.load %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // Check that the third operand (accumulator) is stored to dst memory space
-    // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
-    // Check that the accumulator is loaded back from dst memory space for the matmul
-    // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"
-    %3 = "d2m.tile_matmul"(%0, %1, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // Check that matmul result is stored back to dst memory space
-    // CHECK: affine.store %[[MATMUL_RESULT]], %[[DST]]
-    // Check that result is loaded from dst memory space
-    // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
-    // Check that final result is stored back to original #l1 memory space
-    // CHECK: affine.store %[[FINAL_VAL]], %arg2
-    affine.store %3, %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @no_loops(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>, #ttcore.iterator_type<reduction>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %subview = memref.subview %cb0[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_1 = memref.subview %cb1[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_2 = memref.subview %cb2[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+      ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>, %arg2: !ttcore.tile<32x32, f32>):
+        // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
+        // CHECK: %[[GUARD_IDX:.*]] = d2m.iter_index
+        // CHECK: %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[GUARD_IDX]]
+        // CHECK: scf.if %[[NOT_FIRST]]
+        // CHECK: %[[ARG2_VAL:.*]] = affine.load %[[ARG2:.*]]
+        // Check that the third operand (accumulator) is stored to dst memory space
+        // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
+        // CHECK: "d2m.tile_matmul_block"
+        %0 = "d2m.tile_matmul"(%arg0, %arg1, %arg2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        // Check that result is loaded from dst memory space
+        // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
+        // Check that final result is stored back to original #l1 memory space
+        // CHECK: affine.store %[[FINAL_VAL]], %[[ARG2]]
+        linalg.yield %0 : !ttcore.tile<32x32, f32>
+      }
+    }
     return
   }
 
-  func.func private @generic_matmul(
+  func.func @generic_matmul(
     %in0: memref<1x1x3x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096>, #l1_>,
     %in1: memref<1x1x3x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>,
     %out0: memref<1x1x3x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
@@ -3,30 +3,43 @@
 
 #l1_ = #ttcore.memory_space<l1>
 module {
-  func.func private @no_loops(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
-    %0 = affine.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK: %[[ARG2_VAL:.*]] = affine.load %arg2
-    %2 = affine.load %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // Check that the third operand (accumulator) is stored to dst memory space
-    // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
-    // Check that the accumulator is loaded back from dst memory space for the matmul
-    // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"
-    %3 = "d2m.tile_matmul"(%0, %1, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // Check that matmul result is stored back to dst memory space
-    // CHECK: affine.store %[[MATMUL_RESULT]], %[[DST]]
-    // Check that result is loaded from dst memory space
-    // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
-    // Check that final result is stored back to original #l1 memory space
-    // CHECK: affine.store %[[FINAL_VAL]], %arg2
-    affine.store %3, %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @no_loops(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>, #ttcore.iterator_type<reduction>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %subview = memref.subview %cb0[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_1 = memref.subview %cb1[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_2 = memref.subview %cb2[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+      ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>, %arg2: !ttcore.tile<32x32, f32>):
+        // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<4x1x1x!ttcore.tile<32x32, f32>, #dst>
+        // CHECK: %[[GUARD_IDX:.*]] = d2m.iter_index
+        // CHECK: %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[GUARD_IDX]]
+        // CHECK: scf.if %[[NOT_FIRST]]
+        // CHECK: %[[ARG2_VAL:.*]] = affine.load %[[ARG2:.*]]
+        // Check that the third operand (accumulator) is stored to dst memory space
+        // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
+        // Check that the accumulator is loaded back from dst memory space for the matmul
+        // CHECK: %[[ARG0_VAL:.*]] = affine.load %[[ARG0:.*]]
+        // CHECK: %[[ARG1_VAL:.*]] = affine.load %[[ARG1:.*]]
+        // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
+        // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"(%[[ARG0_VAL]], %[[ARG1_VAL]], %[[DST_VAL]])
+        %0 = "d2m.tile_matmul"(%arg0, %arg1, %arg2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        // Check that result is loaded from dst memory space
+        // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
+        // Check that final result is stored back to original #l1 memory space
+        // CHECK: affine.store %[[FINAL_VAL]], %[[ARG2]]
+        linalg.yield %0 : !ttcore.tile<32x32, f32>
+      }
+    }
     return
   }
 
-  func.func private @generic_matmul(
+  func.func @generic_matmul(
     %in0: memref<1x1x3x3x!ttcore.tile<32x32, f16>, #ttcore.shard<6144x2048>, #l1_>,
     %in1: memref<1x1x3x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048>, #l1_>,
     %out0: memref<1x1x3x2x!ttcore.tile<32x32, f16>, #ttcore.shard<4096x2048>, #l1_>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
@@ -3,30 +3,43 @@
 
 #l1_ = #ttcore.memory_space<l1>
 module {
-  func.func private @no_loops(%arg0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %arg2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) attributes {d2m.thread = #d2m.thread<compute>} {
-    %c0 = arith.constant 0 : index
-    // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
-    %0 = affine.load %arg0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    %1 = affine.load %arg1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // CHECK: %[[ARG2_VAL:.*]] = affine.load %arg2
-    %2 = affine.load %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
-    // Check that the third operand (accumulator) is stored to dst memory space
-    // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
-    // Check that the accumulator is loaded back from dst memory space for the matmul
-    // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
-    // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"
-    %3 = "d2m.tile_matmul"(%0, %1, %2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    // Check that matmul result is stored back to dst memory space
-    // CHECK: affine.store %[[MATMUL_RESULT]], %[[DST]]
-    // Check that result is loaded from dst memory space
-    // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
-    // Check that final result is stored back to original #l1 memory space
-    // CHECK: affine.store %[[FINAL_VAL]], %arg2
-    affine.store %3, %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+  func.func @no_loops(%in0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>,
+                      %out0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>, #ttcore.iterator_type<reduction>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>)
+        outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1_>) {
+    ^compute0(%cb0: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<1x1x!ttcore.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %subview = memref.subview %cb0[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_1 = memref.subview %cb1[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      %subview_2 = memref.subview %cb2[%c0, %c0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+      linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+      ^bb0(%arg0: !ttcore.tile<32x32, f32>, %arg1: !ttcore.tile<32x32, f32>, %arg2: !ttcore.tile<32x32, f32>):
+        // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<8x1x1x!ttcore.tile<32x32, f32>, #dst>
+        // CHECK: %[[GUARD_IDX:.*]] = d2m.iter_index
+        // CHECK: %[[NOT_FIRST:.*]] = arith.cmpi ne, %[[GUARD_IDX]]
+        // CHECK: scf.if %[[NOT_FIRST]]
+        // CHECK: %[[ARG2_VAL:.*]] = affine.load %[[ARG2:.*]]
+        // Check that the third operand (accumulator) is stored to dst memory space
+        // CHECK: affine.store %[[ARG2_VAL]], %[[DST]]
+        // Check that the accumulator is loaded back from dst memory space for the matmul
+        // CHECK: %[[ARG0_VAL:.*]] = affine.load %[[ARG0:.*]]
+        // CHECK: %[[ARG1_VAL:.*]] = affine.load %[[ARG1:.*]]
+        // CHECK: %[[DST_VAL:.*]] = affine.load %[[DST]]
+        // CHECK: %[[MATMUL_RESULT:.*]] = "d2m.tile_matmul"(%[[ARG0_VAL]], %[[ARG1_VAL]], %[[DST_VAL]])
+        %0 = "d2m.tile_matmul"(%arg0, %arg1, %arg2) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+        // Check that result is loaded from dst memory space
+        // CHECK: %[[FINAL_VAL:.*]] = affine.load %[[DST]]
+        // Check that final result is stored back to original #l1 memory space
+        // CHECK: affine.store %[[FINAL_VAL]], %[[ARG2]]
+        linalg.yield %0 : !ttcore.tile<32x32, f32>
+      }
+    }
     return
   }
 
-  func.func private @generic_matmul(
+  func.func @generic_matmul(
     %in0: memref<1x1x3x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096>, #l1_>,
     %in1: memref<1x1x3x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>,
     %out0: memref<1x1x3x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>


### PR DESCRIPTION
### Ticket
None

### Problem description
Break down the bcast PR into smaller ones, this one is mainly for cleanups.

### What's changed
* Remove redundant `bcast_type` that clutters the IR.
* Extract the logic that generates the compute region of `linalg.generic` into its own function.
* Remove support for `FuncOp` from the insert DST register pass as it's getting in the way more and more.
* Update the simple `FuncOp` tests to full `d2m.generic` equivalents (OMG so painful, but it's a one-time cost).

### Checklist
- [x] New/Existing tests provide coverage for changes
