### PR TITLE
Linear op fusion broadcast + reshape folding

### DIFF
--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
@@ -43,18 +43,43 @@ module {
 
 module {
   // dot_general op followed by reshape op before add op
-  func.func @dot_general_with_bias_3(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32> {
+  func.func @dot_general_with_bias_3(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
     // CHECK: func.func @dot_general_with_bias_3
-    // CHECK: "ttir.linear"(%arg0, %arg1, %1, %2)
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2, %0)
+    // CHECK-SAME: (tensor<68x1024xf32>, tensor<1024x1024xf32>, tensor<1024xf32>, tensor<68x1024xf32>) -> tensor<68x1024xf32>
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
     // CHECK-NOT: "ttir.add"
-    %0 = ttir.empty() : tensor<68x1024xf32>
-    %1 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<68x1024xf32>, tensor<1024x1024xf32>) -> tensor<68x1024xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<68x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    %0 = ttir.empty() : tensor<1x1x1024xf32>
+    %1 = "ttir.reshape"(%bias, %0) <{shape = [1 : i32, 1 : i32, 1024 : i32]}> : (tensor<1024xf32>, tensor<1x1x1024xf32>) -> tensor<1x1x1024xf32>
     %2 = ttir.empty() : tensor<2x34x1024xf32>
-    %3 = "ttir.reshape"(%1, %2) <{shape = [2 : i32, 34 : i32, 1024 : i32]}> : (tensor<68x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
-    %4 = ttir.empty() : tensor<2x34x1024xf32>
-    %5 = "ttir.add"(%3, %bias, %4) : (tensor<2x34x1024xf32>, tensor<2x34x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
-    return %5 : tensor<2x34x1024xf32>
+    %3 = "ttir.broadcast"(%1, %2) <{broadcast_dimensions = array<i64: 2, 34, 1>}> : (tensor<1x1x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    %4 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<68x1024xf32>, tensor<1024x1024xf32>) -> tensor<68x1024xf32>
+    %5 = ttir.empty() : tensor<2x34x1024xf32>
+    %6 = "ttir.reshape"(%4, %5) <{shape = [2 : i32, 34 : i32, 1024 : i32]}> : (tensor<68x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    %7 = ttir.empty() : tensor<2x34x1024xf32>
+    %8 = "ttir.add"(%6, %3, %7) : (tensor<2x34x1024xf32>, tensor<2x34x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    return %8 : tensor<2x34x1024xf32>
+  }
+}
+
+module {
+  func.func @dot_general_with_bias_4(%arg0: tensor<1576x2xf32>, %arg1: tensor<2x768xf32>, %bias: tensor<768xf32>) -> tensor<8x197x768xf32> {
+    // CHECK: func.func @dot_general_with_bias_4
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2, %0)
+    // CHECK-SAME: (tensor<1576x2xf32>, tensor<2x768xf32>, tensor<768xf32>, tensor<1576x768xf32>) -> tensor<1576x768xf32>
+    // CHECK-NOT: "ttir.dot_general"
+    // CHECK-NOT: "ttir.matmul"
+    // CHECK-NOT: "ttir.add"
+    // CHECK: "ttir.reshape"(%1, %2)
+    // CHECK-SAME: (tensor<1576x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+    %0 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<1576x2xf32>, tensor<2x768xf32>) -> tensor<1576x768xf32>
+    %1 = ttir.empty() : tensor<8x197x768xf32>
+    %2 = "ttir.reshape"(%0, %1) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<1576x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+    %3 = ttir.empty() : tensor<8x197x768xf32>
+    %4 = "ttir.add"(%2, %bias, %3) : (tensor<8x197x768xf32>, tensor<768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+    return %4 : tensor<8x197x768xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/matmul/linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/matmul/linear.mlir
@@ -12,6 +12,18 @@ module {
     return %1 : tensor<2x34x1024xf32>
   }
 
+  func.func @linear_with_implicit_broadcast_2(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1x1024xf32>) -> tensor<2x34x1024xf32> {
+    %0 = ttir.empty() : tensor<2x34x1024xf32>
+    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    return %1 : tensor<2x34x1024xf32>
+  }
+
+  func.func @linear_with_implicit_broadcast_3(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1x1x1024xf32>) -> tensor<2x34x1024xf32> {
+    %0 = ttir.empty() : tensor<2x34x1024xf32>
+    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1x1x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    return %1 : tensor<2x34x1024xf32>
+  }
+
   func.func @linear_with_batched_rhs_and_bias(%arg0: tensor<2x33x1024xf32>, %arg1: tensor<2x1024x1024xf32>, %bias: tensor<2x33x1024xf32>) -> tensor<2x33x1024xf32> {
     %0 = ttir.empty() : tensor<2x33x1024xf32>
     // this will be lowered to a matmul + add


### PR DESCRIPTION
### Ticket
#5366 

### Problem description
I had added a fusion pattern for matmul -> reshape -> add which does not work with 1d bias. 
It originally would take in a graph like the following:
matmul_AB = matmul(A, B)
reshape_AB = reshape(matmul_AB)
output = add (reshape_AB, bias)

and change it to:
reshape_bias = reshape(bias)
linear_output = linear(A, B, reshape_bias)
output = reshape(linear_output) 

However, this would not work in case where:
A: [1576, 2]
B: [2, 768]
bias: [768] 

Therefore, I introduced `FindOneDimensionalBias` function which finds the 1-dimensional bias in a valid matmul -> add or matmul -> reshape -> add sequence.

In matmul -> add: now I use the one dimensional bias as the bias input in linear op if it exists.
In matmul -> reshape -> add: one dimensional bias is required to be able to fuse. 

### What's changed
- Introduced `FindOneDimensionalBias` 
- Removed bias reshape from `matmul -> reshape -> add` 
- Using one dimensional bias in `matmul -> reshape -> add`
- Using one dimensional bias is `matmul -> add` if it exists
- Added test cases 

### Checklist
- [X] New/Existing tests provide coverage for changes
