### PR TITLE
Deduplicate and organize PYTHONPATHs

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -26,5 +26,5 @@ export PATH="$(pwd)/${BUILD_DIR:=build}/bin:$TTMLIR_TOOLCHAIN_DIR/bin:$TTMLIR_VE
 export TT_METAL_HOME="$(pwd)/third_party/tt-metal/src/tt-metal"
 export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal/build"
 export TT_MLIR_HOME="$(pwd)"
-export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/${BUILD_DIR:=build}/runtime/python:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
-export PYTHONPATH="${PYTHONPATH}:${TT_METAL_HOME}/ttnn:${TT_METAL_HOME}"  # These paths are needed for tracy (profiling)
+export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/${BUILD_DIR:=build}/runtime/python:$(pwd)/.local/toolchain/python_packages/mlir_core"
+export PYTHONPATH="${PYTHONPATH}:${TT_METAL_HOME}:${TT_METAL_HOME}/ttnn:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin"  # Metal paths

--- a/env/activate.fish
+++ b/env/activate.fish
@@ -17,5 +17,5 @@ set -gx PATH (pwd)/build/bin $TTMLIR_TOOLCHAIN_DIR/bin $TTMLIR_TOOLCHAIN_DIR/ven
 set -gx TT_METAL_HOME (pwd)/third_party/tt-metal/src/tt-metal
 set -gx TT_METAL_BUILD_HOME (pwd)/third_party/tt-metal/src/tt-metal/build
 set -gx TT_MLIR_HOME (pwd)
-set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/.local/toolchain/python_packages/mlir_core:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin:$TT_METAL_HOME/ttnn
-set -gx PYTHONPATH $PYTHONPATH:$TT_METAL_HOME/ttnn:$TT_METAL_HOME  # These paths are needed for tracy (profiling)
+set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/build/runtime/python:(pwd)/.local/toolchain/python_packages/mlir_core
+set -gx PYTHONPATH $PYTHONPATH:$TT_METAL_HOME:$TT_METAL_HOME/ttnn:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin  # Metal paths


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some PYTHONPATHs were duplicated.

### What's changed
- Deduplicated paths
- Separated metal-related paths from the rest
- Added a missing python path for fish shell


### Checklist
- [ ] New/Existing tests provide coverage for changes
