### PR TITLE
Change default runtime log level to Info

### DIFF
--- a/runtime/include/tt/runtime/detail/common/logger.h
+++ b/runtime/include/tt/runtime/detail/common/logger.h
@@ -237,12 +237,7 @@ private:
   std::ofstream log_file;
   std::ostream *fd = &std::cout;
   uint64_t mask = (1ULL << LogAlways);
-  Level min_level =
-#if defined(TT_RUNTIME_DEBUG) && (TT_RUNTIME_DEBUG == 1)
-      Level::Trace;
-#else
-      Level::Info;
-#endif
+  Level min_level = Level::Info;
 };
 
 template <typename... Args>


### PR DESCRIPTION
Even for debug builds, it's a bit noisy to have trace turned on by default.  Debug macro is enabled in CI as well bloating the logs.

To re-enable simply:
```bash
export TTMLIR_RUNTIME_LOGGER_LEVEL=Trace
```
