### PR TITLE
[EmitC Conversion] Add support for ConstEvalWrapper with zero argument

### DIFF
--- a/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
@@ -21,4 +21,18 @@ module {
     %9 = "ttir.multiply"(%1, %7, %8) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %9 : tensor<32x32xbf16>
   }
+
+  func.func @const_eval_no_input(%arg0: tensor<71x4x1xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<71x4x1xbf16> {
+    // CHECK: = ttcore.load_cached(@const_eval_no_input_const_eval_0, [])
+    %0 = "ttir.full"() <{fill_value = 32.0 : f32, shape = array<i32>}> : () -> tensor<bf16>
+    %1 = ttir.empty() : tensor<1x1xbf16>
+    %2 = "ttir.reshape"(%0, %1) <{shape = [1 : i32, 1 : i32]}> : (tensor<bf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
+    %3 = ttir.empty() : tensor<71x4xbf16>
+    %4 = "ttir.repeat"(%2, %3) <{repeat_dimensions = array<i64: 71, 4>}> : (tensor<1x1xbf16>, tensor<71x4xbf16>) -> tensor<71x4xbf16>
+    %5 = ttir.empty() : tensor<71x4x1xbf16>
+    %6 = "ttir.reshape"(%4, %5) <{shape = [71 : i32, 4 : i32, 1 : i32]}> : (tensor<71x4xbf16>, tensor<71x4x1xbf16>) -> tensor<71x4x1xbf16>
+    %7 = ttir.empty() : tensor<71x4x1xbf16>
+    %8 = "ttir.multiply"(%6, %arg0, %7) : (tensor<71x4x1xbf16>, tensor<71x4x1xbf16>, tensor<71x4x1xbf16>) -> tensor<71x4x1xbf16>
+    return %8 : tensor<71x4x1xbf16>
+  }
 }

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -126,7 +126,7 @@ void setDevice(ttnn::MeshDevice *device) { DeviceGetter::setInstance(device); }
 }
 
 // Wrapper to abstract const-eval logic out of runtime funcs to keep them
-// cleaner.  Invokes constEvalFunc iff outputs is empty.
+// cleaner. Invokes constEvalFunc iff outputs is empty.
 void constEvalFuncWrapper(
     std::function<std::vector<ttnn::Tensor>(std::vector<ttnn::Tensor>)>
         constEvalFunc,
@@ -134,6 +134,19 @@ void constEvalFuncWrapper(
     std::vector<ttnn::Tensor> *outputs) {
   if (outputs->empty()) {
     *outputs = constEvalFunc(inputs);
+  }
+}
+
+// Wrapper to abstract const-eval logic out of runtime funcs to keep them
+// cleaner. Invokes constEvalFunc iff outputs is empty.
+// This is an overload of constEvalFuncWrapper for const-eval functions that
+// take zero arguments.
+void constEvalFuncWrapperZeroArg(
+    std::function<std::vector<ttnn::Tensor>()> constEvalFunc,
+    // const std::vector<ttnn::Tensor> &inputs,
+    std::vector<ttnn::Tensor> *outputs) {
+  if (outputs->empty()) {
+    *outputs = constEvalFunc();
   }
 }
 


### PR DESCRIPTION
### Ticket
closes #5407

### Problem description
EmitC generates incorrect code when const-eval function does not require any input.

### What's changed
Add another case for EmitC conversion to handle ConstEval function with zero argument.

### Checklist
- [X] New/Existing tests provide coverage for changes
