### PR TITLE
[Multihost] Add missing distributed APIs for tt-xla integration

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -16,11 +16,6 @@ enum Arch: uint {
   Blackhole
 }
 
-enum DispatchCoreType: uint {
-  Worker,
-  Ethernet
-}
-
 enum DataType: uint16 {
   Float32,
   Float16,

--- a/runtime/include/tt/runtime/CMakeLists.txt
+++ b/runtime/include/tt/runtime/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(flatbuffer)
 add_subdirectory(detail)

--- a/runtime/include/tt/runtime/detail/CMakeLists.txt
+++ b/runtime/include/tt/runtime/detail/CMakeLists.txt
@@ -1,3 +1,1 @@
 add_subdirectory(distributed)
-
-add_custom_target(RUNTIME_FBS_GENERATION DEPENDS DISTRIBUTED_FBS)

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -7,6 +7,8 @@
 
 #include <optional>
 
+#include "ttmlir/Target/Common/Target.h"
+
 #define FMT_HEADER_ONLY
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/mesh_device.hpp"
@@ -18,14 +20,14 @@
 
 namespace tt::runtime::common {
 
-inline ::tt::tt_metal::DispatchCoreType
-getDispatchCoreType(std::optional<DispatchCoreType> dispatchCoreType) {
+inline ::tt::tt_metal::DispatchCoreType getDispatchCoreType(
+    std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType) {
 
   ::tt::tt_metal::DispatchCoreType type;
   if (dispatchCoreType.has_value()) {
-    if (dispatchCoreType == DispatchCoreType::ETH) {
+    if (dispatchCoreType == ::tt::runtime::DispatchCoreType::Ethernet) {
       type = ::tt::tt_metal::DispatchCoreType::ETH;
-    } else if (dispatchCoreType == DispatchCoreType::WORKER) {
+    } else if (dispatchCoreType == ::tt::runtime::DispatchCoreType::Worker) {
       type = ::tt::tt_metal::DispatchCoreType::WORKER;
     } else {
       LOG_FATAL("Unsupported dispatch core type");
@@ -41,7 +43,7 @@ getDispatchCoreType(std::optional<DispatchCoreType> dispatchCoreType) {
 }
 
 inline ::tt::tt_fabric::FabricConfig
-toTTFabricConfig(tt::runtime::FabricConfig cfg) {
+toMetalFabricConfig(tt::runtime::FabricConfig cfg) {
   switch (cfg) {
   case tt::runtime::FabricConfig::DISABLED:
     return ::tt::tt_fabric::FabricConfig::DISABLED;
@@ -105,18 +107,18 @@ inline ::tt::DataFormat toDataFormat(::tt::target::DataType dataType) {
   }
 }
 
-inline ::tt::runtime::Arch toRuntimeArch(::tt::ARCH arch) {
+inline ::tt::target::Arch toTargetArch(::tt::ARCH arch) {
   switch (arch) {
   case ::tt::ARCH::GRAYSKULL:
-    return ::tt::runtime::Arch::GRAYSKULL;
+    return ::tt::target::Arch::Grayskull;
   case ::tt::ARCH::WORMHOLE_B0:
-    return ::tt::runtime::Arch::WORMHOLE_B0;
+    return ::tt::target::Arch::Wormhole_b0;
   case ::tt::ARCH::BLACKHOLE:
-    return ::tt::runtime::Arch::BLACKHOLE;
+    return ::tt::target::Arch::Blackhole;
   case ::tt::ARCH::QUASAR:
-    return ::tt::runtime::Arch::QUASAR;
-  default:
-    LOG_FATAL("Unsupported device architecture");
+    LOG_FATAL("Quasar architecture is not supported");
+  case ::tt::ARCH::Invalid:
+    LOG_FATAL("Invalid architecture");
   }
 }
 

--- a/runtime/include/tt/runtime/detail/common/runtime_context.h
+++ b/runtime/include/tt/runtime/detail/common/runtime_context.h
@@ -6,6 +6,7 @@
 #define TT_RUNTIME_DETAIL_COMMON_RUNTIME_CONTEXT_H
 
 #include "tt/runtime/types.h"
+
 #include <atomic>
 #include <filesystem>
 
@@ -32,8 +33,8 @@ public:
   HostRuntime getCurrentHostRuntime() const;
   void setCurrentHostRuntime(const HostRuntime &runtime);
 
-  FabricConfig getCurrentFabricConfig() const;
-  void setCurrentFabricConfig(const FabricConfig &config);
+  ::tt::runtime::FabricConfig getCurrentFabricConfig() const;
+  void setCurrentFabricConfig(const tt::runtime::FabricConfig &config);
 
 private:
   RuntimeContext();
@@ -44,7 +45,8 @@ private:
 
   std::atomic<DeviceRuntime> currentDeviceRuntime_ = DeviceRuntime::Disabled;
   std::atomic<HostRuntime> currentHostRuntime_ = HostRuntime::Local;
-  std::atomic<FabricConfig> currentFabricConfig_ = FabricConfig::DISABLED;
+  std::atomic<tt::runtime::FabricConfig> currentFabricConfig_ =
+      tt::runtime::FabricConfig::DISABLED;
 };
 
 } // namespace tt::runtime

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -19,6 +19,13 @@ public:
           std::nullopt,
       const std::optional<::tt::runtime::Device> &deviceHandle = std::nullopt);
 
+  static uint64_t
+  buildSetFabricConfigCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::FabricConfig &fabricConfig);
+
+  static uint64_t
+  buildGetNumAvailableDevicesCommand(::flatbuffers::FlatBufferBuilder &fbb);
+
   static uint64_t buildOpenMeshDeviceCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::Device &deviceHandle,
@@ -28,11 +35,39 @@ public:
   buildCloseMeshDeviceCommand(::flatbuffers::FlatBufferBuilder &fbb,
                               const ::tt::runtime::Device &deviceHandle);
 
+  static uint64_t buildCreateSubMeshDeviceCommand(
+      ::flatbuffers::FlatBufferBuilder &fbb,
+      const ::tt::runtime::Device &parentMesh,
+      const ::tt::runtime::Device &subMesh,
+      const std::vector<uint32_t> &meshShape,
+      const std::optional<const std::vector<uint32_t>> &meshOffset =
+          std::nullopt);
+
+  static uint64_t
+  buildReleaseSubMeshDeviceCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                                   const ::tt::runtime::Device &subMesh);
+
+  static uint64_t
+  buildGetMeshShapeCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                           const ::tt::runtime::Device &deviceHandle);
+
   static uint64_t buildCreateHostTensorCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::Tensor &outputTensor, const void *data,
       const std::vector<uint32_t> &shape, const std::vector<uint32_t> &stride,
       uint32_t itemSize, ::tt::target::DataType dataType);
+
+  static uint64_t
+  buildGetTensorVolumeCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor);
+
+  static uint64_t
+  buildGetTensorRetainCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor);
+
+  static uint64_t
+  buildSetTensorRetainCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor, bool retain);
 
   static uint64_t
   buildGetLayoutCommand(::flatbuffers::FlatBufferBuilder &fbb,

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -90,14 +90,35 @@ public:
           std::nullopt,
       std::optional<::tt::runtime::Device> deviceHandle = std::nullopt);
 
+  void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig);
+
+  size_t getNumAvailableDevices();
+
   ::tt::runtime::Device
   openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options = {});
-  void closeMeshDevice(const ::tt::runtime::Device &parentMeshHandle);
+
+  void closeMeshDevice(::tt::runtime::Device &parentMeshHandle);
+
+  ::tt::runtime::Device createSubMeshDevice(
+      const ::tt::runtime::Device &parentMesh,
+      const std::vector<uint32_t> &meshShape,
+      const std::optional<const std::vector<uint32_t>> &meshOffset =
+          std::nullopt);
+
+  void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh);
+
+  std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &deviceHandle);
 
   ::tt::runtime::Tensor createOwnedHostTensor(
       const void *data, const std::vector<std::uint32_t> &shape,
       const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
       ::tt::target::DataType dataType);
+
+  std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);
+
+  bool getTensorRetain(const ::tt::runtime::Tensor &tensorHandle);
+
+  void setTensorRetain(const ::tt::runtime::Tensor &tensorHandle, bool retain);
 
   ::tt::runtime::Layout getLayout(const ::tt::runtime::Binary &executableHandle,
                                   std::uint32_t programIndex,
@@ -121,6 +142,9 @@ public:
   void
   memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
          std::optional<tt::target::DataType> targetDataType = std::nullopt);
+
+  void memcpy(const ::tt::runtime::Tensor &dstHandle,
+              const ::tt::runtime::Tensor &srcHandle);
 
   ShutdownResult shutdown();
 
@@ -155,39 +179,83 @@ private:
 
   void launchResponseHandler();
   void processResponseQueue();
+
   void handleErrorResponse(
       const ::tt::runtime::distributed::flatbuffer::ErrorResponse *response,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetSystemDescResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleSetFabricConfigResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetNumAvailableDevicesResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleOpenMeshDeviceResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleCloseMeshDeviceResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleCreateSubMeshDeviceResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleReleaseSubMeshDeviceResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetMeshShapeResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleCreateHostTensorResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetTensorVolumeResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetTensorRetainResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleSetTensorRetainResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetLayoutResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleToLayoutResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleSubmitResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetNumShardsResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleToHostResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleMemcpyResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleShutdownResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -17,14 +17,34 @@ SystemDesc getCurrentSystemDesc(
         std::nullopt,
     std::optional<::tt::runtime::Device> deviceHandle = std::nullopt);
 
+void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig);
+
+size_t getNumAvailableDevices();
+
 ::tt::runtime::Device openMeshDevice(const MeshDeviceOptions &options = {});
 
-void closeMeshDevice(::tt::runtime::Device parentMesh);
+void closeMeshDevice(::tt::runtime::Device &parentMesh);
+
+::tt::runtime::Device createSubMeshDevice(
+    const ::tt::runtime::Device &parentMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset =
+        std::nullopt);
+
+void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh);
+
+std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice);
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
+
+std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);
+
+bool getTensorRetain(::tt::runtime::Tensor tensorHandle);
+
+void setTensorRetain(::tt::runtime::Tensor tensorHandle, bool retain);
 
 ::tt::runtime::Layout getLayout(::tt::runtime::Binary executableHandle,
                                 std::uint32_t programIndex,
@@ -46,6 +66,9 @@ toHost(const ::tt::runtime::Tensor &tensorHandle, bool untilize = false,
 
 void memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
             std::optional<tt::target::DataType> targetDataType = std::nullopt);
+
+void memcpy(const ::tt::runtime::Tensor &dstHandle,
+            const ::tt::runtime::Tensor &srcHandle);
 
 } // namespace tt::runtime::distributed
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/CMakeLists.txt
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/CMakeLists.txt
@@ -5,4 +5,4 @@ set(DISTRIBUTED_FBS_GEN_SOURCES
   response.fbs
 )
 
-build_flatbuffers("distributed" "${DISTRIBUTED_FBS_GEN_SOURCES}" DISTRIBUTED_FBS FBS_GENERATION)
+build_flatbuffers("distributed" "${DISTRIBUTED_FBS_GEN_SOURCES}" DISTRIBUTED_FBS ${PROJECT_SOURCE_DIR}/runtime/include/ FBS_GENERATION RUNTIME_FBS)

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -1,12 +1,17 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
 include "ttmlir/Target/TTNN/binary.fbs";
+include "tt/runtime/flatbuffer/types.fbs";
 
 namespace tt.runtime.distributed.flatbuffer;
 
 table GetSystemDescCommand {
   device: tt.target.DeviceRef;
-  dispatch_core_type: tt.target.DispatchCoreType = null;
+  dispatch_core_type: tt.runtime.DispatchCoreType = null;
+}
+
+table SetFabricConfigCommand {
+  config: tt.runtime.FabricConfig;
 }
 
 table MeshDeviceOptions {
@@ -17,7 +22,10 @@ table MeshDeviceOptions {
   mesh_shape: [uint32];
   l1_small_size: uint64 = null;
   trace_region_size: uint64 = null;
-  dispatch_core_type: tt.target.DispatchCoreType = null;
+  dispatch_core_type: tt.runtime.DispatchCoreType = null;
+}
+
+table GetNumAvailableDevicesCommand {
 }
 
 table OpenMeshDeviceCommand {
@@ -29,6 +37,21 @@ table CloseMeshDeviceCommand {
   device: tt.target.DeviceRef;
 }
 
+table CreateSubMeshDeviceCommand {
+  parent_mesh: tt.target.DeviceRef;
+  submesh_global_id: uint32;
+  mesh_shape: [uint32];
+  mesh_offset: [uint32];
+}
+
+table ReleaseSubMeshDeviceCommand {
+  sub_mesh: tt.target.DeviceRef;
+}
+
+table GetMeshShapeCommand {
+  device: tt.target.DeviceRef;
+}
+
 table CreateHostTensorCommand {
   output_global_id: uint64;
   data: [ubyte];
@@ -36,6 +59,19 @@ table CreateHostTensorCommand {
   stride: [uint32];
   item_size: uint32;
   data_type: tt.target.DataType;
+}
+
+table GetTensorVolumeCommand {
+  tensor_global_id: uint64;
+}
+
+table GetTensorRetainCommand {
+  tensor_global_id: uint64;
+}
+
+table SetTensorRetainCommand {
+  tensor_global_id: uint64;
+  retain: bool;
 }
 
 table GetLayoutCommand {
@@ -86,9 +122,17 @@ table ShutdownCommand {
 
 union CommandType {
   GetSystemDescCommand,
+  SetFabricConfigCommand,
+  GetNumAvailableDevicesCommand,
   OpenMeshDeviceCommand,
   CloseMeshDeviceCommand,
+  CreateSubMeshDeviceCommand,
+  ReleaseSubMeshDeviceCommand,
+  GetMeshShapeCommand,
   CreateHostTensorCommand,
+  GetTensorVolumeCommand,
+  GetTensorRetainCommand,
+  SetTensorRetainCommand,
   GetLayoutCommand,
   ToLayoutCommand,
   SubmitCommand,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -14,6 +14,13 @@ table GetSystemDescResponse {
   system_desc: [ubyte]; // size-prefixed SystemDescRoot buffer
 }
 
+table SetFabricConfigResponse {
+}
+
+table GetNumAvailableDevicesResponse {
+  num_devices: uint32;
+}
+
 table OpenMeshDeviceResponse {
   device: tt.target.DeviceRef;
 }
@@ -21,7 +28,29 @@ table OpenMeshDeviceResponse {
 table CloseMeshDeviceResponse {
 }
 
+table CreateSubMeshDeviceResponse {
+  sub_mesh: tt.target.DeviceRef;
+}
+
+table ReleaseSubMeshDeviceResponse {
+}
+
+table GetMeshShapeResponse {
+  shape: [uint32];
+}
+
 table CreateHostTensorResponse {
+}
+
+table GetTensorVolumeResponse {
+  volume: uint32;
+}
+
+table GetTensorRetainResponse {
+  retain: bool;
+}
+
+table SetTensorRetainResponse {
 }
 
 table GetLayoutResponse {
@@ -50,9 +79,17 @@ table ShutdownResponse {
 union ResponseType {
   ErrorResponse,
   GetSystemDescResponse,
+  SetFabricConfigResponse,
+  GetNumAvailableDevicesResponse,
   OpenMeshDeviceResponse,
   CloseMeshDeviceResponse,
+  CreateSubMeshDeviceResponse,
+  ReleaseSubMeshDeviceResponse,
+  GetMeshShapeResponse,
   CreateHostTensorResponse,
+  GetTensorVolumeResponse,
+  GetTensorRetainResponse,
+  SetTensorRetainResponse,
   GetLayoutResponse,
   ToLayoutResponse,
   SubmitResponse,

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -59,36 +59,84 @@ private:
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::GetSystemDescCommand
               *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::SetFabricConfigCommand
+              *command);
+
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::
+                   GetNumAvailableDevicesCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::OpenMeshDeviceCommand
               *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::CloseMeshDeviceCommand
               *command);
+
+  void execute(
+      uint64_t commandId,
+      const ::tt::runtime::distributed::flatbuffer::CreateSubMeshDeviceCommand
+          *command);
+
+  void execute(
+      uint64_t commandId,
+      const ::tt::runtime::distributed::flatbuffer::ReleaseSubMeshDeviceCommand
+          *command);
+
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::GetMeshShapeCommand
+                   *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::CreateHostTensorCommand
               *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::GetTensorVolumeCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::GetTensorRetainCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::SetTensorRetainCommand
+              *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::GetLayoutCommand *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::ToLayoutCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::SubmitCommand *command);
+
   void execute(uint64_t commandId,
                const ::tt::runtime::distributed::flatbuffer::GetNumShardsCommand
                    *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::ToHostCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::MemcpyCommand *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::ShutdownCommand *command);

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -23,6 +23,14 @@ public:
                              uint64_t commandId,
                              const ::tt::runtime::SystemDesc &systemDesc);
 
+  static void
+  buildSetFabricConfigResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId);
+
+  static void
+  buildGetNumAvailableDevicesResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                      uint64_t commandId, size_t numDevices);
+
   static void buildOpenMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                           uint64_t commandId,
                                           const ::tt::runtime::Device &device);
@@ -32,8 +40,33 @@ public:
                                uint64_t commandId);
 
   static void
+  buildCreateSubMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                   uint64_t commandId,
+                                   const ::tt::runtime::Device &subMesh);
+
+  static void
+  buildReleaseSubMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                    uint64_t commandId);
+
+  static void buildGetMeshShapeResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                        uint64_t commandId,
+                                        const std::vector<uint32_t> &shape);
+
+  static void
   buildCreateHostTensorResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                 uint64_t commandId);
+
+  static void
+  buildGetTensorVolumeResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId, uint32_t volume);
+
+  static void
+  buildGetTensorRetainResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId, bool retain);
+
+  static void
+  buildSetTensorRetainResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId);
 
   static void buildGetLayoutResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                      uint64_t commandId);

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -81,7 +81,7 @@ DistributedHostBuffer getDistributedHostBuffer(::tt::runtime::Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -121,7 +121,7 @@ void readDeviceProfilerResults(Device device);
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -144,7 +144,7 @@ TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 bool getTensorRetain(::tt::runtime::Tensor tensor);
 void setTensorRetain(::tt::runtime::Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -188,7 +188,7 @@ void readDeviceProfilerResults(Device device);
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/flatbuffer/CMakeLists.txt
+++ b/runtime/include/tt/runtime/flatbuffer/CMakeLists.txt
@@ -1,0 +1,9 @@
+include(BuildFlatbuffers)
+
+set(RUNTIME_FBS_GEN_SOURCES
+  types.fbs
+)
+
+build_flatbuffers("runtime" "${RUNTIME_FBS_GEN_SOURCES}" RUNTIME_FBS FBS_GENERATION)
+
+add_custom_target(RUNTIME_FBS_GENERATION DEPENDS RUNTIME_FBS DISTRIBUTED_FBS)

--- a/runtime/include/tt/runtime/flatbuffer/flatbuffer.h
+++ b/runtime/include/tt/runtime/flatbuffer/flatbuffer.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_FLATBUFFER_FLATBUFFER_H
+#define TT_RUNTIME_FLATBUFFER_FLATBUFFER_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "tt/runtime/flatbuffer/types_generated.h"
+#pragma clang diagnostic pop
+
+#endif

--- a/runtime/include/tt/runtime/flatbuffer/types.fbs
+++ b/runtime/include/tt/runtime/flatbuffer/types.fbs
@@ -1,0 +1,21 @@
+namespace tt.runtime;
+
+enum DispatchCoreType: uint {
+  Worker,
+  Ethernet
+}
+
+enum FabricConfig: uint32 {
+  DISABLED,
+  FABRIC_1D,
+  FABRIC_1D_RING,
+  FABRIC_2D,
+  FABRIC_2D_TORUS_X,
+  FABRIC_2D_TORUS_Y,
+  FABRIC_2D_TORUS_XY,
+  FABRIC_2D_DYNAMIC,
+  FABRIC_2D_DYNAMIC_TORUS_X,
+  FABRIC_2D_DYNAMIC_TORUS_Y,
+  FABRIC_2D_DYNAMIC_TORUS_XY,
+  CUSTOM,
+}

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -17,7 +17,8 @@ namespace tt::runtime {
 namespace system_desc {
 
 SystemDesc getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType =
+        std::nullopt,
     std::optional<Device> meshDevice = std::nullopt);
 } // namespace system_desc
 
@@ -40,7 +41,8 @@ HostRuntime getCurrentHostRuntime();
 void setCurrentHostRuntime(const HostRuntime &runtime);
 
 SystemDesc getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType =
+        std::nullopt,
     std::optional<Device> meshDevice = std::nullopt);
 
 void launchDistributedRuntime(const DistributedOptions &options = {});
@@ -124,7 +126,7 @@ TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -174,7 +176,7 @@ This function gets the memory view per device
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -21,6 +21,8 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
 
+#include "tt/runtime/flatbuffer/flatbuffer.h"
+
 namespace tt::runtime {
 /*
 MemoryBlockTable is a list of memory blocks in the following format:
@@ -77,28 +79,6 @@ enum class DistributedMode {
   // across multiple hosts
   MultiProcess,
 };
-
-enum class DispatchCoreType {
-  WORKER,
-  ETH,
-};
-
-enum class FabricConfig {
-  DISABLED,
-  FABRIC_1D,
-  FABRIC_1D_RING,
-  FABRIC_2D,
-  FABRIC_2D_TORUS_X,
-  FABRIC_2D_TORUS_Y,
-  FABRIC_2D_TORUS_XY,
-  FABRIC_2D_DYNAMIC,
-  FABRIC_2D_DYNAMIC_TORUS_X,
-  FABRIC_2D_DYNAMIC_TORUS_Y,
-  FABRIC_2D_DYNAMIC_TORUS_XY,
-  CUSTOM,
-};
-
-enum class Arch { GRAYSKULL = 1, WORMHOLE_B0 = 2, BLACKHOLE = 3, QUASAR = 4 };
 
 namespace detail {
 
@@ -235,7 +215,8 @@ struct MeshDeviceOptions {
   std::optional<std::vector<uint32_t>> meshShape = std::nullopt;
   std::optional<size_t> l1SmallSize = std::nullopt;
   std::optional<size_t> traceRegionSize = std::nullopt;
-  std::optional<DispatchCoreType> dispatchCoreType = std::nullopt;
+  std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
+      std::nullopt;
 };
 
 class MultiProcessArgs {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -15,10 +15,7 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
 
-// Forward declarations
-namespace tt::runtime {
-enum class DispatchCoreType;
-} // namespace tt::runtime
+#include "tt/runtime/flatbuffer/flatbuffer.h"
 
 namespace tt::runtime::utils {
 
@@ -169,12 +166,6 @@ template <typename T>
 inline std::shared_ptr<void> unsafeBorrowShared(T *ptr) {
   return std::shared_ptr<void>(static_cast<void *>(ptr), [](void *) {});
 }
-
-::tt::target::DispatchCoreType
-fromRuntimeDispatchCoreType(::tt::runtime::DispatchCoreType dispatchCoreType);
-
-::tt::runtime::DispatchCoreType
-toRuntimeDispatchCoreType(::tt::target::DispatchCoreType dispatchCoreType);
 
 std::uint32_t dataTypeElementSize(::tt::target::DataType dataType);
 

--- a/runtime/lib/CMakeLists.txt
+++ b/runtime/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ set_property(TARGET TTBinary PROPERTY CXX_STANDARD 20)
 target_include_directories(TTBinary
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 add_dependencies(TTBinary FBS_GENERATION)
@@ -19,6 +20,7 @@ set_property(TARGET TTMLIRRuntime PROPERTY CXX_STANDARD 20)
 target_include_directories(TTMLIRRuntime
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -73,6 +75,12 @@ if (TTMLIR_ENABLE_RUNTIME)
     LIBRARY
       DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
       COMPONENT SharedLib
+  )
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/runtime/include/tt/runtime/flatbuffer
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tt/runtime
+    COMPONENT SharedLib
+    FILES_MATCHING
+    PATTERN "*.h"
   )
 endif()
 

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -43,6 +43,7 @@ set_property(TARGET TTRuntimeTypes PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeTypes
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeTypes PUBLIC coverage_config)
 
@@ -51,6 +52,7 @@ set_property(TARGET TTRuntimeUtils PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeUtils
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeUtils PUBLIC coverage_config)
 
@@ -59,6 +61,7 @@ set_property(TARGET TTRuntimeSysDesc PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeSysDesc
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -71,6 +74,7 @@ set_property(TARGET TTRuntimeContext PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeContext
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeContext PUBLIC coverage_config)
 
@@ -79,6 +83,7 @@ set_property(TARGET TTRuntimeSocket PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeSocket
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeSocket PUBLIC coverage_config)
 
@@ -87,6 +92,7 @@ set_property(TARGET TTRuntimeDebug PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeDebug
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeDebug PUBLIC coverage_config)
 
@@ -95,6 +101,7 @@ set_property(TARGET TTRuntimePerf PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimePerf
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>"
 )
 add_dependencies(TTRuntimePerf tt-metal)
@@ -105,6 +112,7 @@ set_property(TARGET TTRuntimeWorkarounds PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeWorkarounds
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeWorkarounds PUBLIC coverage_config)
 
@@ -113,5 +121,6 @@ set_property(TARGET TTRuntimeDylibs PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeDylibs
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeDylibs PUBLIC coverage_config)

--- a/runtime/lib/common/runtime_context.cpp
+++ b/runtime/lib/common/runtime_context.cpp
@@ -74,11 +74,13 @@ void RuntimeContext::setCurrentHostRuntime(const HostRuntime &runtime) {
   currentHostRuntime_.store(runtime, std::memory_order_relaxed);
 }
 
-FabricConfig RuntimeContext::getCurrentFabricConfig() const {
-  FabricConfig config = currentFabricConfig_.load(std::memory_order_relaxed);
+tt::runtime::FabricConfig RuntimeContext::getCurrentFabricConfig() const {
+  tt::runtime::FabricConfig config =
+      currentFabricConfig_.load(std::memory_order_relaxed);
   return config;
 }
-void RuntimeContext::setCurrentFabricConfig(const FabricConfig &config) {
+void RuntimeContext::setCurrentFabricConfig(
+    const tt::runtime::FabricConfig &config) {
   currentFabricConfig_.store(config, std::memory_order_relaxed);
 }
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -252,7 +252,8 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
 }
 
 static std::shared_ptr<::tt::tt_metal::distributed::MeshDevice>
-createNewMeshDevice(std::optional<DispatchCoreType> dispatchCoreType) {
+createNewMeshDevice(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType) {
 
   ::tt::tt_metal::DispatchCoreType type =
       tt::runtime::common::getDispatchCoreType(dispatchCoreType);
@@ -263,9 +264,9 @@ createNewMeshDevice(std::optional<DispatchCoreType> dispatchCoreType) {
       DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, type);
 }
 
-::tt::runtime::SystemDesc
-getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
-                     std::optional<Device> meshDevice) {
+::tt::runtime::SystemDesc getCurrentSystemDesc(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType,
+    std::optional<Device> meshDevice) {
 
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevicePtr;
   if (meshDevice.has_value()) {

--- a/runtime/lib/common/utils.cpp
+++ b/runtime/lib/common/utils.cpp
@@ -143,26 +143,6 @@ std::shared_ptr<void> callocShared(const size_t size) {
   return std::shared_ptr<void>(std::calloc(size, 1), std::free);
 }
 
-::tt::target::DispatchCoreType
-fromRuntimeDispatchCoreType(::tt::runtime::DispatchCoreType dispatchCoreType) {
-  switch (dispatchCoreType) {
-  case ::tt::runtime::DispatchCoreType::WORKER:
-    return ::tt::target::DispatchCoreType::Worker;
-  case ::tt::runtime::DispatchCoreType::ETH:
-    return ::tt::target::DispatchCoreType::Ethernet;
-  }
-}
-
-::tt::runtime::DispatchCoreType
-toRuntimeDispatchCoreType(::tt::target::DispatchCoreType dispatchCoreType) {
-  switch (dispatchCoreType) {
-  case ::tt::target::DispatchCoreType::Worker:
-    return ::tt::runtime::DispatchCoreType::WORKER;
-  case ::tt::target::DispatchCoreType::Ethernet:
-    return ::tt::runtime::DispatchCoreType::ETH;
-  }
-}
-
 std::uint32_t dataTypeElementSize(::tt::target::DataType dataType) {
   switch (dataType) {
   case ::tt::target::DataType::Float64:

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -9,6 +9,37 @@
 #include "tt/runtime/types.h"
 #include <atomic>
 
+#define BUILD_COMMAND_IMPL(CommandName, fbb, builderFunc, ...)                 \
+  [&]() -> uint64_t {                                                          \
+    uint64_t commandId = nextCommandId();                                      \
+    auto commandType = ::tt::runtime::distributed::flatbuffer::CommandType::   \
+        CommandName##Command;                                                  \
+                                                                               \
+    auto commandOffset = (builderFunc)((fbb)__VA_OPT__(, ) __VA_ARGS__);       \
+                                                                               \
+    auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(      \
+        (fbb), commandId, commandType, commandOffset.Union());                 \
+                                                                               \
+    ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer((fbb),         \
+                                                                command);      \
+                                                                               \
+    debug::verifyFlatbuffer((fbb), verifyFn);                                  \
+                                                                               \
+    return commandId;                                                          \
+  }()
+
+#define BUILD_COMMAND(CommandName, fbb, ...)                                   \
+  BUILD_COMMAND_IMPL(                                                          \
+      CommandName, fbb,                                                        \
+      ::tt::runtime::distributed::flatbuffer::Create##CommandName##Command,    \
+      __VA_ARGS__)
+
+#define BUILD_COMMAND_DIRECT(CommandName, fbb, ...)                            \
+  BUILD_COMMAND_IMPL(CommandName, fbb,                                         \
+                     ::tt::runtime::distributed::flatbuffer::                  \
+                         Create##CommandName##CommandDirect,                   \
+                     __VA_ARGS__)
+
 namespace tt::runtime::distributed::controller {
 
 using ::tt::runtime::DeviceRuntime;
@@ -28,32 +59,41 @@ uint64_t CommandFactory::buildGetSystemDescCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::GetSystemDescCommand;
-
   ::flatbuffers::Offset<::tt::target::DeviceRef> deviceRef = 0;
   if (deviceHandle.has_value()) {
     deviceRef =
         ::tt::target::CreateDeviceRef(fbb, deviceHandle.value().getGlobalId());
   }
 
-  std::optional<::tt::target::DispatchCoreType> fbDispatchCoreType =
+  std::optional<::tt::runtime::DispatchCoreType> fbDispatchCoreType =
       std::nullopt;
   if (dispatchCoreType.has_value()) {
-    fbDispatchCoreType = ::tt::runtime::utils::fromRuntimeDispatchCoreType(
-        dispatchCoreType.value());
+    fbDispatchCoreType = dispatchCoreType.value();
   }
 
-  auto getSystemDescCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateGetSystemDescCommand(
-          fbb, deviceRef, fbDispatchCoreType);
+  uint64_t commandId =
+      BUILD_COMMAND(GetSystemDesc, fbb, deviceRef, fbDispatchCoreType);
 
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, getSystemDescCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
+  return commandId;
+}
 
-  debug::verifyFlatbuffer(fbb, verifyFn);
+uint64_t CommandFactory::buildSetFabricConfigCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::FabricConfig &fabricConfig) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId = BUILD_COMMAND(SetFabricConfig, fbb, fabricConfig);
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildGetNumAvailableDevicesCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId = BUILD_COMMAND(GetNumAvailableDevices, fbb);
 
   return commandId;
 }
@@ -65,11 +105,10 @@ uint64_t CommandFactory::buildOpenMeshDeviceCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  std::optional<::tt::target::DispatchCoreType> fbDispatchCoreType =
+  std::optional<::tt::runtime::DispatchCoreType> fbDispatchCoreType =
       std::nullopt;
   if (meshDeviceOptions.dispatchCoreType.has_value()) {
-    fbDispatchCoreType = ::tt::runtime::utils::fromRuntimeDispatchCoreType(
-        meshDeviceOptions.dispatchCoreType.value());
+    fbDispatchCoreType = meshDeviceOptions.dispatchCoreType.value();
   }
 
   auto fbMeshDeviceOptions =
@@ -82,19 +121,8 @@ uint64_t CommandFactory::buildOpenMeshDeviceCommand(
           meshDeviceOptions.l1SmallSize, meshDeviceOptions.traceRegionSize,
           fbDispatchCoreType);
 
-  uint64_t commandId = nextCommandId();
-  auto commandType = ::tt::runtime::distributed::flatbuffer::CommandType::
-      OpenMeshDeviceCommand;
-
-  auto openMeshDeviceCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateOpenMeshDeviceCommand(
-          fbb, deviceHandle.getGlobalId(), fbMeshDeviceOptions);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, openMeshDeviceCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND(
+      OpenMeshDevice, fbb, deviceHandle.getGlobalId(), fbMeshDeviceOptions);
 
   return commandId;
 }
@@ -105,22 +133,58 @@ uint64_t CommandFactory::buildCloseMeshDeviceCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType = ::tt::runtime::distributed::flatbuffer::CommandType::
-      CloseMeshDeviceCommand;
+  auto deviceRef =
+      ::tt::target::CreateDeviceRef(fbb, deviceHandle.getGlobalId());
+
+  uint64_t commandId = BUILD_COMMAND(CloseMeshDevice, fbb, deviceRef);
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildCreateSubMeshDeviceCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Device &parentMesh,
+    const ::tt::runtime::Device &subMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  auto parentMeshRef =
+      ::tt::target::CreateDeviceRef(fbb, parentMesh.getGlobalId());
+  const std::vector<uint32_t> *meshOffsetPtr = nullptr;
+  if (meshOffset.has_value()) {
+    meshOffsetPtr = &meshOffset.value();
+  }
+
+  uint64_t commandId =
+      BUILD_COMMAND_DIRECT(CreateSubMeshDevice, fbb, parentMeshRef,
+                           subMesh.getGlobalId(), &meshShape, meshOffsetPtr);
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildReleaseSubMeshDeviceCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Device &subMesh) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  auto subMeshRef = ::tt::target::CreateDeviceRef(fbb, subMesh.getGlobalId());
+  uint64_t commandId = BUILD_COMMAND(ReleaseSubMeshDevice, fbb, subMeshRef);
+  return commandId;
+}
+
+uint64_t CommandFactory::buildGetMeshShapeCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Device &deviceHandle) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
   auto deviceRef =
       ::tt::target::CreateDeviceRef(fbb, deviceHandle.getGlobalId());
 
-  auto closeMeshDeviceCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateCloseMeshDeviceCommand(
-          fbb, deviceRef);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, closeMeshDeviceCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND(GetMeshShape, fbb, deviceRef);
 
   return commandId;
 }
@@ -133,10 +197,6 @@ uint64_t CommandFactory::buildCreateHostTensorCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType = ::tt::runtime::distributed::flatbuffer::CommandType::
-      CreateHostTensorCommand;
-
   std::uint64_t numElements =
       std::accumulate(shape.begin(), shape.end(), static_cast<std::uint64_t>(1),
                       std::multiplies<std::uint64_t>());
@@ -146,16 +206,45 @@ uint64_t CommandFactory::buildCreateHostTensorCommand(
   auto shapeVec = fbb.CreateVector<uint32_t>(shape.data(), shape.size());
   auto strideVec = fbb.CreateVector<uint32_t>(stride.data(), stride.size());
 
-  auto createHostTensorCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateCreateHostTensorCommand(
-          fbb, outputTensor.getGlobalId(), dataVec, shapeVec, strideVec,
-          itemSize, dataType);
+  uint64_t commandId =
+      BUILD_COMMAND(CreateHostTensor, fbb, outputTensor.getGlobalId(), dataVec,
+                    shapeVec, strideVec, itemSize, dataType);
 
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, createHostTensorCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
+  return commandId;
+}
 
-  debug::verifyFlatbuffer(fbb, verifyFn);
+uint64_t CommandFactory::buildGetTensorVolumeCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Tensor &tensor) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId =
+      BUILD_COMMAND(GetTensorVolume, fbb, tensor.getGlobalId());
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildGetTensorRetainCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Tensor &tensor) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId =
+      BUILD_COMMAND(GetTensorRetain, fbb, tensor.getGlobalId());
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildSetTensorRetainCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb, const ::tt::runtime::Tensor &tensor,
+    bool retain) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId =
+      BUILD_COMMAND(SetTensorRetain, fbb, tensor.getGlobalId(), retain);
 
   return commandId;
 }
@@ -167,23 +256,12 @@ uint64_t CommandFactory::buildGetLayoutCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::GetLayoutCommand;
-
   std::vector<uint8_t> binaryBytes;
   binary.storeToMemory(binaryBytes);
 
-  auto getLayoutCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateGetLayoutCommandDirect(
-          fbb, binary.id(), &binaryBytes, programIndex, inputIndex,
-          outputLayout.getGlobalId());
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, getLayoutCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND_DIRECT(
+      GetLayout, fbb, binary.id(), &binaryBytes, programIndex, inputIndex,
+      outputLayout.getGlobalId());
 
   return commandId;
 }
@@ -196,25 +274,14 @@ uint64_t CommandFactory::buildToLayoutCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::ToLayoutCommand;
-
   uint64_t inputGlobalId = inputTensor.getGlobalId();
   uint64_t outputGlobalId = outputTensor.getGlobalId();
 
   auto deviceRef = ::tt::target::CreateDeviceRef(fbb, device.getGlobalId());
 
-  auto toLayoutCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateToLayoutCommand(
-          fbb, inputGlobalId, outputGlobalId, deviceRef, layout.getGlobalId(),
-          retain);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, toLayoutCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId =
+      BUILD_COMMAND(ToLayout, fbb, inputGlobalId, outputGlobalId, deviceRef,
+                    layout.getGlobalId(), retain);
 
   return commandId;
 }
@@ -226,10 +293,6 @@ uint64_t CommandFactory::buildSubmitCommand(
     const std::vector<::tt::runtime::Tensor> &outputTensors) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
-
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::SubmitCommand;
 
   std::vector<uint64_t> inputGlobalIds;
   inputGlobalIds.reserve(inputTensors.size());
@@ -248,16 +311,9 @@ uint64_t CommandFactory::buildSubmitCommand(
 
   auto deviceRef = ::tt::target::CreateDeviceRef(fbb, device.getGlobalId());
 
-  auto submitCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateSubmitCommandDirect(
-          fbb, &inputGlobalIds, &outputGlobalIds, executable.id(), &binaryBytes,
-          programIndex, deviceRef);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, submitCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND_DIRECT(
+      Submit, fbb, &inputGlobalIds, &outputGlobalIds, executable.id(),
+      &binaryBytes, programIndex, deviceRef);
 
   return commandId;
 }
@@ -268,19 +324,7 @@ CommandFactory::buildGetNumShardsCommand(::flatbuffers::FlatBufferBuilder &fbb,
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::GetNumShardsCommand;
-
-  auto getNumShardsCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateGetNumShardsCommand(
-          fbb, tensor.getGlobalId());
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, getNumShardsCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND(GetNumShards, fbb, tensor.getGlobalId());
 
   return commandId;
 }
@@ -292,25 +336,15 @@ uint64_t CommandFactory::buildToHostCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::ToHostCommand;
-
   std::vector<uint64_t> outputGlobalIds;
   outputGlobalIds.reserve(outputTensors.size());
   std::transform(outputTensors.begin(), outputTensors.end(),
                  std::back_inserter(outputGlobalIds),
                  [](const auto &tensor) { return tensor.getGlobalId(); });
 
-  auto toHostCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateToHostCommandDirect(
-          fbb, inputTensor.getGlobalId(), &outputGlobalIds, untilize, blocking);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, toHostCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId =
+      BUILD_COMMAND_DIRECT(ToHost, fbb, inputTensor.getGlobalId(),
+                           &outputGlobalIds, untilize, blocking);
 
   return commandId;
 }
@@ -323,25 +357,14 @@ uint64_t CommandFactory::buildMemcpyCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::MemcpyCommand;
-
   uint64_t srcGlobalId = srcTensor.getGlobalId();
   std::optional<uint64_t> dstGlobalId = std::nullopt;
   if (dstTensor.has_value()) {
     dstGlobalId = dstTensor.value().getGlobalId();
   }
 
-  auto memcpyCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateMemcpyCommand(
-          fbb, srcGlobalId, dstGlobalId, dstDataType);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, memcpyCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId =
+      BUILD_COMMAND(Memcpy, fbb, srcGlobalId, dstGlobalId, dstDataType);
 
   return commandId;
 }
@@ -351,20 +374,13 @@ CommandFactory::buildShutdownCommand(::flatbuffers::FlatBufferBuilder &fbb) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = nextCommandId();
-  auto commandType =
-      ::tt::runtime::distributed::flatbuffer::CommandType::ShutdownCommand;
-
-  auto shutdownCommand =
-      ::tt::runtime::distributed::flatbuffer::CreateShutdownCommand(fbb);
-
-  auto command = ::tt::runtime::distributed::flatbuffer::CreateCommand(
-      fbb, commandId, commandType, shutdownCommand.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishCommandBuffer(fbb, command);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  uint64_t commandId = BUILD_COMMAND(Shutdown, fbb);
 
   return commandId;
 }
+
+#undef BUILD_COMMAND_IMPL
+#undef BUILD_COMMAND
+#undef BUILD_COMMAND_DIRECT
 
 } // namespace tt::runtime::distributed::controller

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -67,15 +67,44 @@ SystemDesc getCurrentSystemDesc(
                                                          deviceHandle);
 }
 
+void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig) {
+  assertControllerLaunched();
+  ControllerSingleton::get().setFabricConfig(fabricConfig);
+}
+
+size_t getNumAvailableDevices() {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getNumAvailableDevices();
+}
+
 ::tt::runtime::Device
 openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options) {
   assertControllerLaunched();
   return ControllerSingleton::get().openMeshDevice(options);
 }
 
-void closeMeshDevice(::tt::runtime::Device parentMesh) {
+void closeMeshDevice(::tt::runtime::Device &parentMesh) {
   assertControllerLaunched();
   ControllerSingleton::get().closeMeshDevice(parentMesh);
+}
+
+::tt::runtime::Device createSubMeshDevice(
+    const ::tt::runtime::Device &parentMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().createSubMeshDevice(parentMesh, meshShape,
+                                                        meshOffset);
+}
+
+void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh) {
+  assertControllerLaunched();
+  ControllerSingleton::get().releaseSubMeshDevice(subMesh);
+}
+
+std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getMeshShape(meshDevice);
 }
 
 ::tt::runtime::Tensor
@@ -85,6 +114,21 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,
                                                           itemsize, dataType);
+}
+
+std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getTensorVolume(tensorHandle);
+}
+
+bool getTensorRetain(::tt::runtime::Tensor tensorHandle) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getTensorRetain(tensorHandle);
+}
+
+void setTensorRetain(::tt::runtime::Tensor tensorHandle, bool retain) {
+  assertControllerLaunched();
+  ControllerSingleton::get().setTensorRetain(tensorHandle, retain);
 }
 
 ::tt::runtime::Layout getLayout(::tt::runtime::Binary executableHandle,
@@ -123,6 +167,12 @@ void memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
             std::optional<tt::target::DataType> targetDataType) {
   assertControllerLaunched();
   ControllerSingleton::get().memcpy(dst, srcHandle, targetDataType);
+}
+
+void memcpy(const ::tt::runtime::Tensor &dstHandle,
+            const ::tt::runtime::Tensor &srcHandle) {
+  assertControllerLaunched();
+  ControllerSingleton::get().memcpy(dstHandle, srcHandle);
 }
 
 } // namespace tt::runtime::distributed

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -15,6 +15,17 @@ namespace tt::runtime::distributed::worker {
 
 namespace fb = ::tt::runtime::distributed::flatbuffer;
 
+template <typename Builder, typename... Args>
+static std::unique_ptr<::flatbuffers::FlatBufferBuilder>
+buildResponse(const Builder &builderFunc, uint64_t commandId, Args &&...args) {
+
+  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  builderFunc(*responseBuilder, commandId, std::forward<Args>(args)...);
+
+  return responseBuilder;
+}
+
 static const fb::Command *getCommand(const SizedBuffer &command) {
   bool isDistributedCommand = fb::CommandBufferHasIdentifier(command.data());
   LOG_ASSERT(isDistributedCommand, "Command is not a distributed command");
@@ -103,13 +114,10 @@ void CommandExecutor::sendResponses() {
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetSystemDescCommand *command) {
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
       std::nullopt;
   if (command->dispatch_core_type()) {
-    dispatchCoreType = ::tt::runtime::utils::toRuntimeDispatchCoreType(
-        command->dispatch_core_type().value());
+    dispatchCoreType = command->dispatch_core_type().value();
   }
 
   std::optional<Device> device = std::nullopt;
@@ -121,16 +129,38 @@ void CommandExecutor::execute(uint64_t commandId,
       ::tt::runtime::system_desc::getCurrentSystemDesc(dispatchCoreType,
                                                        device);
 
-  ResponseFactory::buildGetSystemDescResponse(*responseBuilder, commandId,
-                                              systemDesc);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetSystemDescResponse, commandId,
+                    systemDesc);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::SetFabricConfigCommand *command) {
+
+  ::tt::runtime::setFabricConfig(command->config());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSetFabricConfigResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(
+    uint64_t commandId, const fb::GetNumAvailableDevicesCommand *command) {
+
+  size_t numDevices = ::tt::runtime::getNumAvailableDevices();
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetNumAvailableDevicesResponse,
+                    commandId, numDevices);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::OpenMeshDeviceCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   uint32_t deviceGlobalId = command->device_global_id();
   const fb::MeshDeviceOptions *options = command->options();
@@ -168,9 +198,7 @@ void CommandExecutor::execute(uint64_t commandId,
   }
 
   if (options->dispatch_core_type().has_value()) {
-    meshDeviceOptions.dispatchCoreType =
-        ::tt::runtime::utils::toRuntimeDispatchCoreType(
-            options->dispatch_core_type().value());
+    meshDeviceOptions.dispatchCoreType = options->dispatch_core_type().value();
   }
 
   ::tt::runtime::Device device =
@@ -180,8 +208,9 @@ void CommandExecutor::execute(uint64_t commandId,
 
   devicePool_.insert_or_assign(deviceGlobalId, device);
 
-  ResponseFactory::buildOpenMeshDeviceResponse(*responseBuilder, commandId,
-                                               device);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildOpenMeshDeviceResponse, commandId,
+                    device);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -189,26 +218,87 @@ void CommandExecutor::execute(uint64_t commandId,
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::CloseMeshDeviceCommand *command) {
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint32_t deviceGlobalId = command->device()->global_id();
 
   ::tt::runtime::Device device = devicePool_.at(deviceGlobalId);
+  LOG_ASSERT(device.getGlobalId() == deviceGlobalId,
+             "Parent mesh global id mismatch");
 
   ::tt::runtime::closeMeshDevice(device);
 
   devicePool_.erase(deviceGlobalId);
 
-  ResponseFactory::buildCloseMeshDeviceResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCloseMeshDeviceResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::CreateSubMeshDeviceCommand *command) {
+
+  ::tt::runtime::Device parentMesh =
+      devicePool_.at(command->parent_mesh()->global_id());
+  LOG_ASSERT(parentMesh.getGlobalId() == command->parent_mesh()->global_id(),
+             "Parent mesh global id mismatch");
+
+  std::vector<uint32_t> meshShape(command->mesh_shape()->begin(),
+                                  command->mesh_shape()->end());
+
+  std::optional<std::vector<uint32_t>> meshOffset = std::nullopt;
+  if (command->mesh_offset()) {
+    meshOffset = std::vector<uint32_t>(command->mesh_offset()->begin(),
+                                       command->mesh_offset()->end());
+  }
+
+  uint32_t subMeshGlobalId = command->submesh_global_id();
+  ::tt::runtime::Device subMesh =
+      ::tt::runtime::createSubMeshDevice(parentMesh, meshShape, meshOffset);
+  subMesh.setGlobalId(subMeshGlobalId);
+  devicePool_.insert_or_assign(subMeshGlobalId, subMesh);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCreateSubMeshDeviceResponse,
+                    commandId, subMesh);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::ReleaseSubMeshDeviceCommand *command) {
+
+  uint32_t subMeshGlobalId = command->sub_mesh()->global_id();
+
+  ::tt::runtime::Device subMesh = devicePool_.at(subMeshGlobalId);
+  LOG_ASSERT(subMesh.getGlobalId() == subMeshGlobalId,
+             "Submesh global id mismatch");
+
+  ::tt::runtime::releaseSubMeshDevice(subMesh);
+  devicePool_.erase(subMeshGlobalId);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildReleaseSubMeshDeviceResponse,
+                    commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetMeshShapeCommand *command) {
+
+  ::tt::runtime::Device device = devicePool_.at(command->device()->global_id());
+
+  std::vector<uint32_t> shape = ::tt::runtime::getMeshShape(device);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetMeshShapeResponse, commandId,
+                    shape);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::CreateHostTensorCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint64_t tensorGlobalId = command->output_global_id();
   const uint8_t *tensorData = command->data()->data();
   std::vector<uint32_t> shape(command->shape()->begin(),
@@ -225,15 +315,56 @@ void CommandExecutor::execute(uint64_t commandId,
 
   tensorPool_.insert_or_assign(tensorGlobalId, tensor);
 
-  ResponseFactory::buildCreateHostTensorResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCreateHostTensorResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetTensorVolumeCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  uint32_t volume = ::tt::runtime::getTensorVolume(tensor);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetTensorVolumeResponse, commandId,
+                    volume);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetTensorRetainCommand *command) {
+
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  bool retain = ::tt::runtime::getTensorRetain(tensor);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetTensorRetainResponse, commandId,
+                    retain);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::SetTensorRetainCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  ::tt::runtime::setTensorRetain(tensor, command->retain());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSetTensorRetainResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetLayoutCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   ::tt::runtime::Binary binary =
       getOrCreateBinary(command->binary(), command->binary_id());
@@ -244,15 +375,14 @@ void CommandExecutor::execute(uint64_t commandId,
   layout.setGlobalId(command->output_layout_id());
   layoutPool_.insert_or_assign(command->output_layout_id(), layout);
 
-  ResponseFactory::buildGetLayoutResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetLayoutResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::ToLayoutCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   uint64_t inputGlobalId = command->input_global_id();
   uint64_t outputGlobalId = command->output_global_id();
@@ -274,15 +404,14 @@ void CommandExecutor::execute(uint64_t commandId,
 
   tensorPool_.insert_or_assign(outputGlobalId, resultTensor);
 
-  ResponseFactory::buildToLayoutResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildToLayoutResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::SubmitCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   ::tt::runtime::Device device = devicePool_.at(command->device()->global_id());
 
@@ -309,29 +438,28 @@ void CommandExecutor::execute(uint64_t commandId,
                                  outputTensors[i]);
   }
 
-  ResponseFactory::buildSubmitResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSubmitResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetNumShardsCommand *command) {
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
   uint64_t tensorGlobalId = command->input_global_id();
   ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
 
   uint32_t numBuffers = ::tt::runtime::detail::getNumShards(tensor);
 
-  ResponseFactory::buildGetNumShardsResponse(*responseBuilder, commandId,
-                                             numBuffers);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetNumShardsResponse, commandId,
+                    numBuffers);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::ToHostCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   uint64_t inputGlobalId = command->input_global_id();
 
@@ -355,15 +483,14 @@ void CommandExecutor::execute(uint64_t commandId,
                                  outputTensors[i]);
   }
 
-  ResponseFactory::buildToHostResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildToHostResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::MemcpyCommand *command) {
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint64_t srcGlobalId = command->src_global_id();
   ::tt::runtime::Tensor srcTensor = tensorPool_.at(srcGlobalId);
 
@@ -391,8 +518,9 @@ void CommandExecutor::execute(uint64_t commandId,
     ::tt::runtime::memcpy(dstDataBuffer.value().data(), srcTensor, dstDataType);
   }
 
-  ResponseFactory::buildMemcpyResponse(*responseBuilder, commandId,
-                                       dstDataBuffer);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildMemcpyResponse, commandId,
+                    dstDataBuffer);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -402,8 +530,8 @@ void CommandExecutor::execute(uint64_t commandId,
 
   LOG_INFO("Shutdown command received, shutting down command executor");
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-  ResponseFactory::buildShutdownResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildShutdownResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 
@@ -420,6 +548,14 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
     return execute(command->command_id(),
                    command->type_as_GetSystemDescCommand());
   }
+  case fb::CommandType::SetFabricConfigCommand: {
+    return execute(command->command_id(),
+                   command->type_as_SetFabricConfigCommand());
+  }
+  case fb::CommandType::GetNumAvailableDevicesCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetNumAvailableDevicesCommand());
+  }
   case fb::CommandType::OpenMeshDeviceCommand: {
     return execute(command->command_id(),
                    command->type_as_OpenMeshDeviceCommand());
@@ -428,9 +564,33 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
     return execute(command->command_id(),
                    command->type_as_CloseMeshDeviceCommand());
   }
+  case fb::CommandType::CreateSubMeshDeviceCommand: {
+    return execute(command->command_id(),
+                   command->type_as_CreateSubMeshDeviceCommand());
+  }
+  case fb::CommandType::ReleaseSubMeshDeviceCommand: {
+    return execute(command->command_id(),
+                   command->type_as_ReleaseSubMeshDeviceCommand());
+  }
+  case fb::CommandType::GetMeshShapeCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetMeshShapeCommand());
+  }
   case fb::CommandType::CreateHostTensorCommand: {
     return execute(command->command_id(),
                    command->type_as_CreateHostTensorCommand());
+  }
+  case fb::CommandType::GetTensorVolumeCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetTensorVolumeCommand());
+  }
+  case fb::CommandType::GetTensorRetainCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetTensorRetainCommand());
+  }
+  case fb::CommandType::SetTensorRetainCommand: {
+    return execute(command->command_id(),
+                   command->type_as_SetTensorRetainCommand());
   }
   case fb::CommandType::GetLayoutCommand: {
     return execute(command->command_id(), command->type_as_GetLayoutCommand());

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -9,6 +9,34 @@
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 
+#define BUILD_RESPONSE_IMPL(ResponseName, fbb, commandId, builderFunc, ...)    \
+  do {                                                                         \
+    auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType:: \
+        ResponseName##Response;                                                \
+                                                                               \
+    auto responseOffset = (builderFunc)((fbb)__VA_OPT__(, ) __VA_ARGS__);      \
+                                                                               \
+    auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(    \
+        (fbb), (commandId), responseType, responseOffset.Union());             \
+                                                                               \
+    ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer((fbb),        \
+                                                                 response);    \
+                                                                               \
+    debug::verifyFlatbuffer((fbb), verifyFn);                                  \
+  } while (0)
+
+#define BUILD_RESPONSE(ResponseName, fbb, commandId, ...)                      \
+  BUILD_RESPONSE_IMPL(                                                         \
+      ResponseName, fbb, commandId,                                            \
+      ::tt::runtime::distributed::flatbuffer::Create##ResponseName##Response,  \
+      __VA_ARGS__)
+
+#define BUILD_RESPONSE_DIRECT(ResponseName, fbb, commandId, ...)               \
+  BUILD_RESPONSE_IMPL(ResponseName, fbb, commandId,                            \
+                      ::tt::runtime::distributed::flatbuffer::                 \
+                          Create##ResponseName##ResponseDirect,                \
+                      __VA_ARGS__)
+
 namespace tt::runtime::distributed::worker {
 
 using ::tt::runtime::DeviceRuntime;
@@ -22,18 +50,7 @@ void ResponseFactory::buildErrorResponse(::flatbuffers::FlatBufferBuilder &fbb,
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::ErrorResponse;
-
-  auto errorResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateErrorResponseDirect(
-          fbb, errorMessage.c_str());
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, errorResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE_DIRECT(Error, fbb, commandId, errorMessage.c_str());
 }
 
 void ResponseFactory::buildGetSystemDescResponse(
@@ -42,21 +59,25 @@ void ResponseFactory::buildGetSystemDescResponse(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType::
-      GetSystemDescResponse;
-
   std::vector<uint8_t> systemDescBuffer;
   systemDesc.storeToMemory(systemDescBuffer);
 
-  auto getSystemDescResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateGetSystemDescResponseDirect(
-          fbb, &systemDescBuffer);
+  BUILD_RESPONSE_DIRECT(GetSystemDesc, fbb, commandId, &systemDescBuffer);
+}
 
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, getSystemDescResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
+void ResponseFactory::buildSetFabricConfigResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(SetFabricConfig, fbb, commandId);
+}
+
+void ResponseFactory::buildGetNumAvailableDevicesResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+    size_t numDevices) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(GetNumAvailableDevices, fbb, commandId, numDevices);
 }
 
 void ResponseFactory::buildOpenMeshDeviceResponse(
@@ -67,105 +88,88 @@ void ResponseFactory::buildOpenMeshDeviceResponse(
 
   auto deviceRef = ::tt::target::CreateDeviceRef(fbb, device.getGlobalId());
 
-  auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType::
-      OpenMeshDeviceResponse;
-
-  auto openMeshDeviceResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateOpenMeshDeviceResponse(
-          fbb, deviceRef);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, openMeshDeviceResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(OpenMeshDevice, fbb, commandId, deviceRef);
 }
 
 void ResponseFactory::buildCloseMeshDeviceResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType::
-      CloseMeshDeviceResponse;
+  BUILD_RESPONSE(CloseMeshDevice, fbb, commandId);
+}
 
-  auto closeMeshDeviceResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateCloseMeshDeviceResponse(
-          fbb);
+void ResponseFactory::buildCreateSubMeshDeviceResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+    const ::tt::runtime::Device &subMesh) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, closeMeshDeviceResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
+  auto subMeshRef = ::tt::target::CreateDeviceRef(fbb, subMesh.getGlobalId());
+  BUILD_RESPONSE(CreateSubMeshDevice, fbb, commandId, subMeshRef);
+}
 
-  debug::verifyFlatbuffer(fbb, verifyFn);
+void ResponseFactory::buildReleaseSubMeshDeviceResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(ReleaseSubMeshDevice, fbb, commandId);
+}
+
+void ResponseFactory::buildGetMeshShapeResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+    const std::vector<uint32_t> &shape) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE_DIRECT(GetMeshShape, fbb, commandId, &shape);
 }
 
 void ResponseFactory::buildCreateHostTensorResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType::
-      CreateHostTensorResponse;
+  BUILD_RESPONSE(CreateHostTensor, fbb, commandId);
+}
 
-  auto createHostTensorResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateCreateHostTensorResponse(
-          fbb);
+void ResponseFactory::buildGetTensorVolumeResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+    uint32_t volume) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, createHostTensorResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
+  BUILD_RESPONSE(GetTensorVolume, fbb, commandId, volume);
+}
 
-  debug::verifyFlatbuffer(fbb, verifyFn);
+void ResponseFactory::buildGetTensorRetainResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId, bool retain) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(GetTensorRetain, fbb, commandId, retain);
+}
+
+void ResponseFactory::buildSetTensorRetainResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(SetTensorRetain, fbb, commandId);
 }
 
 void ResponseFactory::buildGetLayoutResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::GetLayoutResponse;
-
-  auto getLayoutResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateGetLayoutResponse(fbb);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, getLayoutResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(GetLayout, fbb, commandId);
 }
 
 void ResponseFactory::buildToLayoutResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::ToLayoutResponse;
-
-  auto toLayoutResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateToLayoutResponse(fbb);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, toLayoutResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(ToLayout, fbb, commandId);
 }
 
 void ResponseFactory::buildSubmitResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                           uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::SubmitResponse;
-
-  auto submitResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateSubmitResponse(fbb);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, submitResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(Submit, fbb, commandId);
 }
 
 void ResponseFactory::buildGetNumShardsResponse(
@@ -173,35 +177,14 @@ void ResponseFactory::buildGetNumShardsResponse(
     uint32_t numBuffers) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType = ::tt::runtime::distributed::flatbuffer::ResponseType::
-      GetNumShardsResponse;
-
-  auto getNumShardsResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateGetNumShardsResponse(
-          fbb, numBuffers);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, getNumShardsResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(GetNumShards, fbb, commandId, numBuffers);
 }
 
 void ResponseFactory::buildToHostResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                           uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::ToHostResponse;
-
-  auto toHostResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateToHostResponse(fbb);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, toHostResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(ToHost, fbb, commandId);
 }
 
 void ResponseFactory::buildMemcpyResponse(
@@ -210,40 +193,23 @@ void ResponseFactory::buildMemcpyResponse(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::MemcpyResponse;
-
   const std::vector<uint8_t> *dataPtr = nullptr;
   if (data.has_value()) {
     dataPtr = &data.value();
   }
 
-  auto memcpyResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateMemcpyResponseDirect(
-          fbb, dataPtr);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, memcpyResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE_DIRECT(Memcpy, fbb, commandId, dataPtr);
 }
 
 void ResponseFactory::buildShutdownResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  auto responseType =
-      ::tt::runtime::distributed::flatbuffer::ResponseType::ShutdownResponse;
-
-  auto shutdownResponse =
-      ::tt::runtime::distributed::flatbuffer::CreateShutdownResponse(fbb);
-
-  auto response = ::tt::runtime::distributed::flatbuffer::CreateResponse(
-      fbb, commandId, responseType, shutdownResponse.Union());
-  ::tt::runtime::distributed::flatbuffer::FinishResponseBuffer(fbb, response);
-
-  debug::verifyFlatbuffer(fbb, verifyFn);
+  BUILD_RESPONSE(Shutdown, fbb, commandId);
 }
+
+#undef BUILD_RESPONSE_IMPL
+#undef BUILD_RESPONSE
+#undef BUILD_RESPONSE_DIRECT
 
 } // namespace tt::runtime::distributed::worker

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -194,9 +194,9 @@ void setCurrentHostRuntime(const HostRuntime &runtime) {
   LOG_FATAL("Runtime is not enabled");
 }
 
-SystemDesc
-getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
-                     std::optional<Device> meshDevice) {
+SystemDesc getCurrentSystemDesc(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType,
+    std::optional<Device> meshDevice) {
 
   using RetType = SystemDesc;
   return DISPATCH_TO_CURRENT_RUNTIME(
@@ -458,8 +458,7 @@ std::uint32_t getTensorVolume(Tensor t) {
       [&]() -> RetType { return ::tt::runtime::ttnn::getTensorVolume(t); },
       [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorVolume(t); },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getTensorVolume",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getTensorVolume(t);
       });
 }
 
@@ -483,8 +482,7 @@ bool getTensorRetain(Tensor tensor) {
         return ::tt::runtime::ttmetal::getTensorRetain(tensor);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getTensorRetain",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getTensorRetain(tensor);
       });
 }
 
@@ -493,14 +491,11 @@ void setTensorRetain(Tensor tensor, bool retain) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::setTensorRetain(tensor, retain); },
       [&]() { ::tt::runtime::ttmetal::setTensorRetain(tensor, retain); },
-      [&]() {
-        detail::fatalNotImplemented("setTensorRetain",
-                                    HostRuntime::Distributed);
-      });
+      [&]() { ::tt::runtime::distributed::setTensorRetain(tensor, retain); });
 }
 
-Arch getArch() {
-  using RetType = Arch;
+tt::target::Arch getArch() {
+  using RetType = tt::target::Arch;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() -> RetType { return ::tt::runtime::ttnn::getArch(); },
       [&]() -> RetType { return ::tt::runtime::ttmetal::getArch(); },
@@ -542,8 +537,7 @@ size_t getNumAvailableDevices() {
         return ::tt::runtime::ttmetal::getNumAvailableDevices();
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getNumAvailableDevices",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getNumAvailableDevices();
       });
 }
 
@@ -583,8 +577,8 @@ Device createSubMeshDevice(
             parentMesh, meshShape, meshOffset);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("createSubMeshDevice",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::createSubMeshDevice(
+            parentMesh, meshShape, meshOffset);
       });
 }
 
@@ -593,10 +587,7 @@ void releaseSubMeshDevice(Device subMesh) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::releaseSubMeshDevice(subMesh); },
       [&]() { ::tt::runtime::ttmetal::releaseSubMeshDevice(subMesh); },
-      [&]() {
-        detail::fatalNotImplemented("releaseSubMeshDevice",
-                                    HostRuntime::Distributed);
-      });
+      [&]() { ::tt::runtime::distributed::releaseSubMeshDevice(subMesh); });
 }
 
 void reshapeMeshDevice(Device meshDevice,
@@ -625,7 +616,7 @@ std::vector<uint32_t> getMeshShape(Device meshDevice) {
         return ::tt::runtime::ttmetal::getMeshShape(meshDevice);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getMeshShape", HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getMeshShape(meshDevice);
       });
 }
 
@@ -916,7 +907,7 @@ void memcpy(void *dst, Tensor src,
       RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src, dstDataType); },
       [&]() { ::tt::runtime::ttmetal::memcpy(dst, src, dstDataType); },
       [&]() -> RetType {
-        return ::tt::runtime::distributed::memcpy(dst, src, dstDataType);
+        ::tt::runtime::distributed::memcpy(dst, src, dstDataType);
       });
 }
 
@@ -925,9 +916,7 @@ void memcpy(Tensor dst, Tensor src) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src); },
       [&]() { ::tt::runtime::ttmetal::memcpy(dst, src); },
-      [&]() -> RetType {
-        detail::fatalNotImplemented("memcpy", HostRuntime::Distributed);
-      });
+      [&]() -> RetType { ::tt::runtime::distributed::memcpy(dst, src); });
 }
 
 void deallocateTensor(Tensor &tensor, bool force) {
@@ -1070,7 +1059,7 @@ void updateTensorInPool(CallbackContext programContextHandle,
       });
 }
 
-void setFabricConfig(FabricConfig config) {
+void setFabricConfig(tt::runtime::FabricConfig config) {
   using RetType = void;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
@@ -1079,8 +1068,7 @@ void setFabricConfig(FabricConfig config) {
         return ::tt::runtime::ttmetal::setFabricConfig(config);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("setFabricConfig",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::setFabricConfig(config);
       });
 }
 

--- a/runtime/lib/ttmetal/CMakeLists.txt
+++ b/runtime/lib/ttmetal/CMakeLists.txt
@@ -20,6 +20,7 @@ set_property(TARGET TTRuntimeTTMetal PROPERTY CXX_STANDARD 20)
 target_compile_definitions(TTRuntimeTTMetal PUBLIC TT_RUNTIME_ENABLE_TTMETAL)
 target_include_directories(TTRuntimeTTMetal PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTMetal SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -229,8 +229,8 @@ void setTensorRetain(Tensor tensor, bool retain) {
   LOG_FATAL("setTensorRetain not implemented for metal runtime");
 }
 
-Arch getArch() {
-  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+tt::target::Arch getArch() {
+  return ::tt::runtime::common::toTargetArch(::tt::tt_metal::hal::get_arch());
 }
 
 void enablePersistentKernelCache() {
@@ -477,8 +477,8 @@ getMemoryView(Device deviceHandle) {
   return memoryMap;
 }
 
-void setFabricConfig(FabricConfig config) {
-  ::tt::tt_fabric::SetFabricConfig(common::toTTFabricConfig(config));
+void setFabricConfig(tt::runtime::FabricConfig config) {
+  ::tt::tt_fabric::SetFabricConfig(common::toMetalFabricConfig(config));
   RuntimeContext::instance().setCurrentFabricConfig(config);
 }
 

--- a/runtime/lib/ttnn/CMakeLists.txt
+++ b/runtime/lib/ttnn/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(TTRuntimeTTNN
 set_property(TARGET TTRuntimeTTNN PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeTTNN PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNN SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/lib/ttnn/debug/CMakeLists.txt
+++ b/runtime/lib/ttnn/debug/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNDebug PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNDebug SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -95,6 +95,7 @@ target_include_directories(TTRuntimeTTNNOps PRIVATE
 )
 target_include_directories(TTRuntimeTTNNOps PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -144,7 +144,7 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
   // If blackhole workarounds are enabled, only untilize on device if the
   // architecture is not blackhole
   if (::tt::runtime::workaround::Env::get().blackholeWorkarounds) {
-    untilizeOnDevice &= getArch() != ::tt::runtime::Arch::BLACKHOLE;
+    untilizeOnDevice &= getArch() != ::tt::target::Arch::Blackhole;
   }
   if (untilizeOnDevice) {
     ::ttnn::Tensor hostTensor = ::ttnn::from_device(
@@ -451,8 +451,8 @@ void setTensorRetain(::tt::runtime::Tensor tensor, bool retain) {
   return tensorWrapper.setRetain(retain);
 }
 
-Arch getArch() {
-  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+tt::target::Arch getArch() {
+  return ::tt::runtime::common::toTargetArch(::tt::tt_metal::hal::get_arch());
 }
 
 void enablePersistentKernelCache() {
@@ -706,8 +706,8 @@ getMemoryView(Device deviceHandle) {
   return memoryMap;
 }
 
-void setFabricConfig(FabricConfig config) {
-  ::tt::tt_fabric::SetFabricConfig(common::toTTFabricConfig(config));
+void setFabricConfig(tt::runtime::FabricConfig config) {
+  ::tt::tt_fabric::SetFabricConfig(common::toMetalFabricConfig(config));
   RuntimeContext::instance().setCurrentFabricConfig(config);
 }
 

--- a/runtime/lib/ttnn/types/CMakeLists.txt
+++ b/runtime/lib/ttnn/types/CMakeLists.txt
@@ -15,6 +15,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNTypes PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNTypes SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/lib/ttnn/utils/CMakeLists.txt
+++ b/runtime/lib/ttnn/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNUtils PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNUtils SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(_ttmlir_runtime
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -56,6 +57,7 @@ if (TTMLIR_ENABLE_RUNTIME)
     SYSTEM PRIVATE ${pybind11_INCLUDE_DIRS}
     PRIVATE
       ${PROJECT_SOURCE_DIR}/runtime/include
+      ${PROJECT_BINARY_DIR}/runtime/include
       ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
       ${PROJECT_SOURCE_DIR}/runtime/python/include
   )

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -255,8 +255,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       .value("MultiProcess", ::tt::runtime::DistributedMode::MultiProcess);
 
   nb::enum_<::tt::runtime::DispatchCoreType>(m, "DispatchCoreType")
-      .value("WORKER", ::tt::runtime::DispatchCoreType::WORKER)
-      .value("ETH", ::tt::runtime::DispatchCoreType::ETH);
+      .value("WORKER", ::tt::runtime::DispatchCoreType::Worker)
+      .value("ETH", ::tt::runtime::DispatchCoreType::Ethernet);
 
   nb::enum_<::tt::runtime::FabricConfig>(m, "FabricConfig")
       .value("DISABLED", ::tt::runtime::FabricConfig::DISABLED)
@@ -279,11 +279,10 @@ void registerRuntimeBindings(nb::module_ &m) {
              ::tt::runtime::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_XY)
       .value("CUSTOM", ::tt::runtime::FabricConfig::CUSTOM);
 
-  nb::enum_<::tt::runtime::Arch>(m, "Arch")
-      .value("GRAYSKULL", ::tt::runtime::Arch::GRAYSKULL)
-      .value("WORMHOLE_B0", ::tt::runtime::Arch::WORMHOLE_B0)
-      .value("BLACKHOLE", ::tt::runtime::Arch::BLACKHOLE)
-      .value("QUASAR", ::tt::runtime::Arch::QUASAR);
+  nb::enum_<::tt::target::Arch>(m, "Arch")
+      .value("GRAYSKULL", ::tt::target::Arch::Grayskull)
+      .value("WORMHOLE_B0", ::tt::target::Arch::Wormhole_b0)
+      .value("BLACKHOLE", ::tt::target::Arch::Blackhole);
 
   m.def("set_mlir_home", &tt::runtime::setMlirHome, nb::arg("mlir_home"),
         "Set the MLIR home directory");

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -14,6 +14,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNTestLib PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNTestLib SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -5,16 +5,19 @@
 import os
 import json
 import pytest
+import torch
 import ttrt
 import ttrt.runtime
 from ttrt.common.util import *
 from ...utils import (
     TT_MLIR_HOME,
     TT_METAL_HOME_EXTERNAL,
+    Storage,
     DeviceContext,
     ProgramTestConfig,
     ProgramTestRunner,
     subprocess_get_system_descriptor,
+    get_runtime_tensor_from_torch,
     get_torch_output_container,
     assert_pcc,
 )
@@ -26,12 +29,7 @@ FLATBUFFER_BASE_PATH = (
 RANK_BINDING_PATH = f"{TT_METAL_HOME_EXTERNAL}/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"
 
 
-@pytest.mark.xfail(
-    reason="TODO(#5320): System descriptor returned is local per host process, we need unification logic to merge them"
-)
-def test_system_desc(request):
-    system_desc_local = subprocess_get_system_descriptor(request)
-
+def launch_distributed_runtime():
     assert os.path.exists(
         RANK_BINDING_PATH
     ), f"Rank binding path not found: {RANK_BINDING_PATH}"
@@ -45,14 +43,96 @@ def test_system_desc(request):
     distributed_options = ttrt.runtime.DistributedOptions()
     distributed_options.mode = ttrt.runtime.DistributedMode.MultiProcess
     distributed_options.multi_process_args = mp_args
-
     ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Distributed)
     ttrt.runtime.launch_distributed_runtime(distributed_options)
+
+
+def shutdown_distributed_runtime():
+    ttrt.runtime.shutdown_distributed_runtime()
+    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Local)
+
+
+@pytest.mark.xfail(
+    reason="TODO(#5320): System descriptor returned is local per host process, we need unification logic to merge them"
+)
+def test_system_desc(request):
+    system_desc_local = subprocess_get_system_descriptor(request)
+
+    launch_distributed_runtime()
+
     system_desc = ttrt.runtime.get_current_system_desc()
     assert system_desc is not None
-    ttrt.runtime.shutdown_distributed_runtime()
+
+    shutdown_distributed_runtime()
 
     assert system_desc.as_json() == system_desc_local.as_json()
+
+
+def test_get_num_devices():
+    launch_distributed_runtime()
+
+    num_devices = ttrt.runtime.get_num_available_devices()
+    assert num_devices == 8
+
+    shutdown_distributed_runtime()
+
+
+@pytest.mark.parametrize("mesh_shape", ["1x8", "2x4"])
+def test_get_mesh_shape(mesh_shape):
+    launch_distributed_runtime()
+
+    mesh_shape_list = list(map(int, mesh_shape.split("x")))
+
+    with DeviceContext(mesh_shape=mesh_shape_list) as device:
+        device_mesh_shape = device.get_mesh_shape()
+        assert device_mesh_shape == mesh_shape_list
+
+    shutdown_distributed_runtime()
+
+
+def test_tensor_retain():
+    launch_distributed_runtime()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(1, 1), storage=Storage.Owned)
+    tensor.set_retain(True)
+
+    assert tensor.get_retain() == True
+
+    tensor.set_retain(False)
+    assert tensor.get_retain() == False
+
+    shutdown_distributed_runtime()
+
+
+def test_get_tensor_volume():
+    launch_distributed_runtime()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(177, 211), storage=Storage.Owned)
+    assert tensor.get_volume() == 177 * 211
+
+    shutdown_distributed_runtime()
+
+
+def test_memcpy():
+    launch_distributed_runtime()
+
+    ones_tensor = torch.ones(177, 211)
+    zeros_tensor = torch.zeros(177, 211)
+
+    tensor1 = get_runtime_tensor_from_torch(ones_tensor, storage=Storage.Owned)
+    tensor2 = get_runtime_tensor_from_torch(zeros_tensor, storage=Storage.Owned)
+
+    # Copy from tensor1 to tensor2
+    ttrt.runtime.memcpy(tensor2, tensor1)
+
+    output_torch_tensor = torch.randn(177, 211)
+
+    # Copy from tensor2 to output_torch_tensor
+    ttrt.runtime.memcpy(output_torch_tensor.data_ptr(), tensor2)
+
+    assert torch.allclose(output_torch_tensor, ones_tensor)
+
+    shutdown_distributed_runtime()
 
 
 @pytest.mark.parametrize("num_loops", [64])
@@ -88,18 +168,7 @@ def test_flatbuffer_execution(request, num_loops, mesh_shape):
 
     test_runner = ProgramTestRunner(test_config, binary, 0)
 
-    ttrt.runtime.set_mlir_home(TT_MLIR_HOME)
-    ttrt.runtime.set_metal_home(TT_METAL_HOME_EXTERNAL)
-
-    mp_args = ttrt.runtime.MultiProcessArgs.create(RANK_BINDING_PATH)
-    mp_args.with_allow_run_as_root(True)
-
-    distributed_options = ttrt.runtime.DistributedOptions()
-    distributed_options.mode = ttrt.runtime.DistributedMode.MultiProcess
-    distributed_options.multi_process_args = mp_args
-
-    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Distributed)
-    ttrt.runtime.launch_distributed_runtime(distributed_options)
+    launch_distributed_runtime()
 
     with DeviceContext(mesh_shape=mesh_shape_list) as device:
         inputs_runtime_with_layout, golden = test_runner.get_inputs_and_golden(
@@ -112,13 +181,103 @@ def test_flatbuffer_execution(request, num_loops, mesh_shape):
 
         outputs = []
         for i in range(num_loops):
-            output = test_runner.run_program(device, inputs_runtime_with_layout)
+            output = test_runner.submit_program(device, inputs_runtime_with_layout)
             outputs.append(output)
 
         for output in outputs:
             output_torch = get_torch_output_container(test_runner.program)
-            ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
             assert_pcc(output_torch, golden)
 
-    ttrt.runtime.shutdown_distributed_runtime()
-    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Local)
+    shutdown_distributed_runtime()
+
+
+@pytest.mark.parametrize("num_loops", [64])
+def test_flatbuffer_execution_dp(request, num_loops):
+    assert os.path.exists(
+        RANK_BINDING_PATH
+    ), f"Rank binding path not found: {RANK_BINDING_PATH}"
+
+    binary_path = os.path.join(FLATBUFFER_BASE_PATH, "simple_add_1x2.mlir.tmp.ttnn")
+
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+
+    test_config = ProgramTestConfig(
+        name="simple_add_dp",
+        expected_num_inputs=2,
+        compute_golden=lambda inputs: (inputs[0] + inputs[1]),
+        description="Simple add distributed data parallel test",
+    )
+
+    logger = Logger()
+    file_manager = FileManager(logger)
+    binary = Binary(logger, file_manager, binary_path)
+
+    curr_system_desc = json.loads(subprocess_get_system_descriptor(request).as_json())
+    binary_system_desc = binary.system_desc_dict
+
+    assert (
+        curr_system_desc["system_desc"] == binary_system_desc
+    ), "System descriptor mismatch"
+
+    test_runner = ProgramTestRunner(test_config, binary, 0)
+
+    launch_distributed_runtime()
+
+    with DeviceContext(mesh_shape=[2, 4]) as device:
+
+        submesh1 = ttrt.runtime.create_sub_mesh_device(
+            device, mesh_shape=[1, 2], mesh_offset=[0, 1]
+        )
+        submesh2 = ttrt.runtime.create_sub_mesh_device(
+            device, mesh_shape=[1, 2], mesh_offset=[1, 1]
+        )
+
+        (
+            inputs_runtime_with_layout_submesh1,
+            golden1,
+        ) = test_runner.get_inputs_and_golden(submesh1, borrow=False)
+        (
+            inputs_runtime_with_layout_submesh2,
+            golden2,
+        ) = test_runner.get_inputs_and_golden(submesh2, borrow=False)
+
+        # Synchronous back to back execution
+        for i in range(num_loops):
+            test_runner.run_program_and_compare_golden(
+                submesh1, inputs_runtime_with_layout_submesh1, golden1
+            )
+            test_runner.run_program_and_compare_golden(
+                submesh2, inputs_runtime_with_layout_submesh2, golden2
+            )
+
+        # Asynchronous data parallel execution
+        outputs_submesh1 = []
+        outputs_submesh2 = []
+        for i in range(num_loops):
+            output1 = test_runner.submit_program(
+                submesh1, inputs_runtime_with_layout_submesh1
+            )
+            output2 = test_runner.submit_program(
+                submesh2, inputs_runtime_with_layout_submesh2
+            )
+            outputs_submesh1.append(output1)
+            outputs_submesh2.append(output2)
+
+        for output in outputs_submesh1:
+            output_torch = get_torch_output_container(test_runner.program)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
+            assert_pcc(output_torch, golden1)
+
+        for output in outputs_submesh2:
+            output_torch = get_torch_output_container(test_runner.program)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
+            assert_pcc(output_torch, golden2)
+
+        ttrt.runtime.release_sub_mesh_device(submesh1)
+        ttrt.runtime.release_sub_mesh_device(submesh2)
+
+    shutdown_distributed_runtime()

--- a/runtime/test/ttnn/python/utils.py
+++ b/runtime/test/ttnn/python/utils.py
@@ -102,10 +102,13 @@ class ProgramTestRunner:
 
         return inputs_runtime_with_layout, golden
 
+    def submit_program(self, device, inputs):
+        return ttrt.runtime.submit(device, self.binary.fbb, self.program_index, inputs)[
+            0
+        ]
+
     def run_program(self, device, inputs, blocking_to_host=True):
-        output = ttrt.runtime.submit(
-            device, self.binary.fbb, self.program_index, inputs
-        )[0]
+        output = self.submit_program(device, inputs)
         output = ttrt.runtime.to_host(output, untilize=True, blocking=blocking_to_host)[
             0
         ]

--- a/test/ttmlir/Runtime/TTNN/llmbox/binary/simple_add_1x2.mlir
+++ b/test/ttmlir/Runtime/TTNN/llmbox/binary/simple_add_1x2.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,2" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
+  func.func public @main(%arg0: tensor<1024x2048xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<1024x2048xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<1024x2048xf32> {jax.result_info = "", ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %1 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x2048xf32>) -> tensor<1024x1024xf32>
+    // CHECK: "ttnn.mesh_shard"
+    %3 = "ttir.mesh_shard"(%arg1) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x2048xf32>) -> tensor<1024x1024xf32>
+    // CHECK: "ttnn.mesh_shard"
+    %4 = ttir.empty() : tensor<1024x1024xf32>
+    %5 = "ttir.add"(%1, %3, %4) : (tensor<1024x1024xf32>, tensor<1024x1024xf32>, tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+    %7 = "ttir.mesh_shard"(%5) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x1024xf32>) -> tensor<1024x2048xf32>
+    // CHECK: "ttnn.mesh_shard"
+    return %7 : tensor<1024x2048xf32>
+  }
+}


### PR DESCRIPTION

### Ticket
Part of #4485 

### Problem description
Now that we have the runtime worker and controller implemented, the next step is to have a POC test running from tt-xla through the distributed runtime

### What's changed
* Added a public facing `include/tt/runtime/flatbuffers/types.fbs` that contains flatbuffer implementations of runtime types. This is needed because many runtime types will now need to have a serialized form. Enum-types specifically can be completely moved to flatbuffer since they evaluate directly to C++ enums anyway.

* Implemented `createSubmeshDevice`, `releaseSubmeshDevice`, `getTensorRetain`, `setTensorRetain`, `getTensorVolume`, `getMeshShape`, `setFabricConfig`, `getNumAvailableDevices` through the distributed path. These APIs are needed by tt-xla.

* Added tests for the above APIs, as well as a data-parallel test running through submeshes now that `createSubmeshDevice`, `releaseSubmeshDevice` are implemented.

* Cleaned up and unified some command/response creation logic to eliminate code duplication.

### Checklist
- [ ] New/Existing tests provide coverage for changes
