### PR TITLE
[Multihost] Add missing distributed APIs for tt-xla integration

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -16,11 +16,6 @@ enum Arch: uint {
   Blackhole
 }
 
-enum DispatchCoreType: uint {
-  Worker,
-  Ethernet
-}
-
 enum DataType: uint16 {
   Float32,
   Float16,

--- a/runtime/include/tt/runtime/CMakeLists.txt
+++ b/runtime/include/tt/runtime/CMakeLists.txt
@@ -1,1 +1,4 @@
+add_subdirectory(flatbuffer)
 add_subdirectory(detail)
+
+add_custom_target(RUNTIME_FBS_GENERATION DEPENDS RUNTIME_FBS DISTRIBUTED_FBS)

--- a/runtime/include/tt/runtime/detail/CMakeLists.txt
+++ b/runtime/include/tt/runtime/detail/CMakeLists.txt
@@ -1,3 +1,1 @@
 add_subdirectory(distributed)
-
-add_custom_target(RUNTIME_FBS_GENERATION DEPENDS DISTRIBUTED_FBS)

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -7,6 +7,8 @@
 
 #include <optional>
 
+#include "ttmlir/Target/Common/Target.h"
+
 #define FMT_HEADER_ONLY
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/mesh_device.hpp"
@@ -18,14 +20,14 @@
 
 namespace tt::runtime::common {
 
-inline ::tt::tt_metal::DispatchCoreType
-getDispatchCoreType(std::optional<DispatchCoreType> dispatchCoreType) {
+inline ::tt::tt_metal::DispatchCoreType getDispatchCoreType(
+    std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType) {
 
   ::tt::tt_metal::DispatchCoreType type;
   if (dispatchCoreType.has_value()) {
-    if (dispatchCoreType == DispatchCoreType::ETH) {
+    if (dispatchCoreType == ::tt::runtime::DispatchCoreType::Ethernet) {
       type = ::tt::tt_metal::DispatchCoreType::ETH;
-    } else if (dispatchCoreType == DispatchCoreType::WORKER) {
+    } else if (dispatchCoreType == ::tt::runtime::DispatchCoreType::Worker) {
       type = ::tt::tt_metal::DispatchCoreType::WORKER;
     } else {
       LOG_FATAL("Unsupported dispatch core type");
@@ -41,7 +43,7 @@ getDispatchCoreType(std::optional<DispatchCoreType> dispatchCoreType) {
 }
 
 inline ::tt::tt_fabric::FabricConfig
-toTTFabricConfig(tt::runtime::FabricConfig cfg) {
+toMetalFabricConfig(tt::runtime::FabricConfig cfg) {
   switch (cfg) {
   case tt::runtime::FabricConfig::DISABLED:
     return ::tt::tt_fabric::FabricConfig::DISABLED;
@@ -105,18 +107,18 @@ inline ::tt::DataFormat toDataFormat(::tt::target::DataType dataType) {
   }
 }
 
-inline ::tt::runtime::Arch toRuntimeArch(::tt::ARCH arch) {
+inline ::tt::target::Arch toTargetArch(::tt::ARCH arch) {
   switch (arch) {
   case ::tt::ARCH::GRAYSKULL:
-    return ::tt::runtime::Arch::GRAYSKULL;
+    return ::tt::target::Arch::Grayskull;
   case ::tt::ARCH::WORMHOLE_B0:
-    return ::tt::runtime::Arch::WORMHOLE_B0;
+    return ::tt::target::Arch::Wormhole_b0;
   case ::tt::ARCH::BLACKHOLE:
-    return ::tt::runtime::Arch::BLACKHOLE;
+    return ::tt::target::Arch::Blackhole;
   case ::tt::ARCH::QUASAR:
-    return ::tt::runtime::Arch::QUASAR;
-  default:
-    LOG_FATAL("Unsupported device architecture");
+    LOG_FATAL("Quasar architecture is not supported");
+  case ::tt::ARCH::Invalid:
+    LOG_FATAL("Invalid architecture");
   }
 }
 

--- a/runtime/include/tt/runtime/detail/common/runtime_context.h
+++ b/runtime/include/tt/runtime/detail/common/runtime_context.h
@@ -6,6 +6,7 @@
 #define TT_RUNTIME_DETAIL_COMMON_RUNTIME_CONTEXT_H
 
 #include "tt/runtime/types.h"
+
 #include <atomic>
 #include <filesystem>
 
@@ -32,8 +33,8 @@ public:
   HostRuntime getCurrentHostRuntime() const;
   void setCurrentHostRuntime(const HostRuntime &runtime);
 
-  FabricConfig getCurrentFabricConfig() const;
-  void setCurrentFabricConfig(const FabricConfig &config);
+  ::tt::runtime::FabricConfig getCurrentFabricConfig() const;
+  void setCurrentFabricConfig(const tt::runtime::FabricConfig &config);
 
 private:
   RuntimeContext();
@@ -44,7 +45,8 @@ private:
 
   std::atomic<DeviceRuntime> currentDeviceRuntime_ = DeviceRuntime::Disabled;
   std::atomic<HostRuntime> currentHostRuntime_ = HostRuntime::Local;
-  std::atomic<FabricConfig> currentFabricConfig_ = FabricConfig::DISABLED;
+  std::atomic<tt::runtime::FabricConfig> currentFabricConfig_ =
+      tt::runtime::FabricConfig::DISABLED;
 };
 
 } // namespace tt::runtime

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -6,6 +6,7 @@
 #define TT_RUNTIME_DETAIL_DISTRIBUTED_CONTROLLER_COMMAND_FACTORY_H
 
 #include "flatbuffers/flatbuffers.h"
+#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/types.h"
 #include <string_view>
 
@@ -13,11 +14,23 @@ namespace tt::runtime::distributed::controller {
 
 class CommandFactory {
 public:
+  static uint64_t buildConfigureRuntimeContextCommand(
+      ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
+      const std::string &metalHome,
+      const ::tt::runtime::DeviceRuntime &currentDeviceRuntime);
+
   static uint64_t buildGetSystemDescCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const std::optional<::tt::runtime::DispatchCoreType> &dispatchCoreType =
           std::nullopt,
       const std::optional<::tt::runtime::Device> &deviceHandle = std::nullopt);
+
+  static uint64_t
+  buildSetFabricConfigCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::FabricConfig &fabricConfig);
+
+  static uint64_t
+  buildGetNumAvailableDevicesCommand(::flatbuffers::FlatBufferBuilder &fbb);
 
   static uint64_t buildOpenMeshDeviceCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
@@ -28,11 +41,43 @@ public:
   buildCloseMeshDeviceCommand(::flatbuffers::FlatBufferBuilder &fbb,
                               const ::tt::runtime::Device &deviceHandle);
 
+  static uint64_t buildCreateSubMeshDeviceCommand(
+      ::flatbuffers::FlatBufferBuilder &fbb,
+      const ::tt::runtime::Device &parentMesh,
+      const ::tt::runtime::Device &subMesh,
+      const std::vector<uint32_t> &meshShape,
+      const std::optional<const std::vector<uint32_t>> &meshOffset =
+          std::nullopt);
+
+  static uint64_t
+  buildReleaseSubMeshDeviceCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                                   const ::tt::runtime::Device &subMesh);
+
+  static uint64_t
+  buildGetMeshShapeCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                           const ::tt::runtime::Device &deviceHandle);
+
   static uint64_t buildCreateHostTensorCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::Tensor &outputTensor, const void *data,
       const std::vector<uint32_t> &shape, const std::vector<uint32_t> &stride,
       uint32_t itemSize, ::tt::target::DataType dataType);
+
+  static uint64_t
+  buildIsTensorAllocatedCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                                const ::tt::runtime::Tensor &tensor);
+
+  static uint64_t
+  buildGetTensorVolumeCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor);
+
+  static uint64_t
+  buildGetTensorRetainCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor);
+
+  static uint64_t
+  buildSetTensorRetainCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                              const ::tt::runtime::Tensor &tensor, bool retain);
 
   static uint64_t
   buildGetLayoutCommand(::flatbuffers::FlatBufferBuilder &fbb,
@@ -71,6 +116,10 @@ public:
       const ::tt::runtime::Tensor &srcTensor,
       const std::optional<::tt::runtime::Tensor> &dstTensor = std::nullopt,
       const std::optional<::tt::target::DataType> &dstDataType = std::nullopt);
+
+  static uint64_t
+  buildDeallocateTensorCommand(::flatbuffers::FlatBufferBuilder &fbb,
+                               const ::tt::runtime::Tensor &tensor, bool force);
 
   static uint64_t buildShutdownCommand(::flatbuffers::FlatBufferBuilder &fbb);
 };

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -14,12 +14,13 @@
 namespace tt::runtime::distributed::controller {
 
 enum class ControllerState : std::uint8_t {
-  Uninitialized,         // Initial state before any setup
-  ControllerSocketBound, // Controller socket bound to the local port
-  CommandLaunched,       // Subcommand process started (e.g. ttrun)
-  ConnectedToWorkers,    // Worker connections established
-  DispatcherReady,       // Command dispatcher is operational
-  ResponseHandlerReady,  // Response handler is operational
+  Uninitialized,            // Initial state before any setup
+  ControllerSocketBound,    // Controller socket bound to the local port
+  CommandLaunched,          // Subcommand process started (e.g. ttrun)
+  ConnectedToWorkers,       // Worker connections established
+  DispatcherReady,          // Command dispatcher is operational
+  ResponseHandlerReady,     // Response handler is operational
+  RuntimeContextConfigured, // Runtime context synced to the workers
   FullyOperational, // All components running, everything launched successfully
   ShuttingDown,     // Graceful shutdown in progress
   Shutdown,         // Shutdown state
@@ -90,14 +91,37 @@ public:
           std::nullopt,
       std::optional<::tt::runtime::Device> deviceHandle = std::nullopt);
 
+  void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig);
+
+  size_t getNumAvailableDevices();
+
   ::tt::runtime::Device
   openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options = {});
-  void closeMeshDevice(const ::tt::runtime::Device &parentMeshHandle);
+
+  void closeMeshDevice(::tt::runtime::Device &parentMeshHandle);
+
+  ::tt::runtime::Device createSubMeshDevice(
+      const ::tt::runtime::Device &parentMesh,
+      const std::vector<uint32_t> &meshShape,
+      const std::optional<const std::vector<uint32_t>> &meshOffset =
+          std::nullopt);
+
+  void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh);
+
+  std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &deviceHandle);
 
   ::tt::runtime::Tensor createOwnedHostTensor(
       const void *data, const std::vector<std::uint32_t> &shape,
       const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
       ::tt::target::DataType dataType);
+
+  bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle);
+
+  std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);
+
+  bool getTensorRetain(const ::tt::runtime::Tensor &tensorHandle);
+
+  void setTensorRetain(const ::tt::runtime::Tensor &tensorHandle, bool retain);
 
   ::tt::runtime::Layout getLayout(const ::tt::runtime::Binary &executableHandle,
                                   std::uint32_t programIndex,
@@ -121,6 +145,12 @@ public:
   void
   memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
          std::optional<tt::target::DataType> targetDataType = std::nullopt);
+
+  void memcpy(const ::tt::runtime::Tensor &dstHandle,
+              const ::tt::runtime::Tensor &srcHandle);
+
+  void deallocateTensor(::tt::runtime::Tensor &tensorHandle,
+                        bool force = false);
 
   ShutdownResult shutdown();
 
@@ -155,39 +185,97 @@ private:
 
   void launchResponseHandler();
   void processResponseQueue();
+
+  void configureRuntimeContext();
+
   void handleErrorResponse(
       const ::tt::runtime::distributed::flatbuffer::ErrorResponse *response,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleConfigureRuntimeContextResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetSystemDescResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleSetFabricConfigResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetNumAvailableDevicesResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleOpenMeshDeviceResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleCloseMeshDeviceResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleCreateSubMeshDeviceResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleReleaseSubMeshDeviceResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetMeshShapeResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleCreateHostTensorResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleIsTensorAllocatedResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetTensorVolumeResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleGetTensorRetainResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleSetTensorRetainResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetLayoutResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleToLayoutResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleSubmitResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleGetNumShardsResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleToHostResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleMemcpyResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleDeallocateTensorResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
   void handleShutdownResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -17,14 +17,36 @@ SystemDesc getCurrentSystemDesc(
         std::nullopt,
     std::optional<::tt::runtime::Device> deviceHandle = std::nullopt);
 
+void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig);
+
+size_t getNumAvailableDevices();
+
 ::tt::runtime::Device openMeshDevice(const MeshDeviceOptions &options = {});
 
-void closeMeshDevice(::tt::runtime::Device parentMesh);
+void closeMeshDevice(::tt::runtime::Device &parentMesh);
+
+::tt::runtime::Device createSubMeshDevice(
+    const ::tt::runtime::Device &parentMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset =
+        std::nullopt);
+
+void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh);
+
+std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice);
 
 ::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
+
+bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle);
+
+std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);
+
+bool getTensorRetain(::tt::runtime::Tensor tensorHandle);
+
+void setTensorRetain(::tt::runtime::Tensor tensorHandle, bool retain);
 
 ::tt::runtime::Layout getLayout(::tt::runtime::Binary executableHandle,
                                 std::uint32_t programIndex,
@@ -46,6 +68,11 @@ toHost(const ::tt::runtime::Tensor &tensorHandle, bool untilize = false,
 
 void memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
             std::optional<tt::target::DataType> targetDataType = std::nullopt);
+
+void memcpy(const ::tt::runtime::Tensor &dstHandle,
+            const ::tt::runtime::Tensor &srcHandle);
+
+void deallocateTensor(::tt::runtime::Tensor &tensorHandle, bool force = false);
 
 } // namespace tt::runtime::distributed
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/CMakeLists.txt
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/CMakeLists.txt
@@ -5,4 +5,4 @@ set(DISTRIBUTED_FBS_GEN_SOURCES
   response.fbs
 )
 
-build_flatbuffers("distributed" "${DISTRIBUTED_FBS_GEN_SOURCES}" DISTRIBUTED_FBS FBS_GENERATION)
+build_flatbuffers("distributed" "${DISTRIBUTED_FBS_GEN_SOURCES}" DISTRIBUTED_FBS ${PROJECT_SOURCE_DIR}/runtime/include/ FBS_GENERATION RUNTIME_FBS)

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -1,31 +1,53 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
 include "ttmlir/Target/TTNN/binary.fbs";
+include "tt/runtime/flatbuffer/types.fbs";
 
 namespace tt.runtime.distributed.flatbuffer;
 
-table GetSystemDescCommand {
-  device: tt.target.DeviceRef;
-  dispatch_core_type: tt.target.DispatchCoreType = null;
+// Configures the runtime context on the worker.
+// Fabric config should be set to the default value for the worker and
+// explicitly set by the runtime API if desired (which has other side effects).
+// Host runtime should be Local for the worker.
+table ConfigureRuntimeContextCommand {
+  mlir_home: string;
+  metal_home: string;
+  current_device_runtime: tt.runtime.flatbuffer.DeviceRuntime;
 }
 
-table MeshDeviceOptions {
-  mesh_offset: [uint32];
-  device_ids: [int];
-  num_hw_cqs: uint8;
-  enable_program_cache: bool;
-  mesh_shape: [uint32];
-  l1_small_size: uint64 = null;
-  trace_region_size: uint64 = null;
-  dispatch_core_type: tt.target.DispatchCoreType = null;
+table GetSystemDescCommand {
+  device: tt.target.DeviceRef;
+  dispatch_core_type: tt.runtime.flatbuffer.DispatchCoreType = null;
+}
+
+table SetFabricConfigCommand {
+  config: tt.runtime.flatbuffer.FabricConfig;
+}
+
+table GetNumAvailableDevicesCommand {
 }
 
 table OpenMeshDeviceCommand {
   device_global_id: uint32;
-  options: MeshDeviceOptions;
+  options: tt.runtime.flatbuffer.MeshDeviceOptions;
 }
 
 table CloseMeshDeviceCommand {
+  device: tt.target.DeviceRef;
+}
+
+table CreateSubMeshDeviceCommand {
+  parent_mesh: tt.target.DeviceRef;
+  submesh_global_id: uint32;
+  mesh_shape: [uint32];
+  mesh_offset: [uint32];
+}
+
+table ReleaseSubMeshDeviceCommand {
+  sub_mesh: tt.target.DeviceRef;
+}
+
+table GetMeshShapeCommand {
   device: tt.target.DeviceRef;
 }
 
@@ -36,6 +58,23 @@ table CreateHostTensorCommand {
   stride: [uint32];
   item_size: uint32;
   data_type: tt.target.DataType;
+}
+
+table IsTensorAllocatedCommand {
+  tensor_global_id: uint64;
+}
+
+table GetTensorVolumeCommand {
+  tensor_global_id: uint64;
+}
+
+table GetTensorRetainCommand {
+  tensor_global_id: uint64;
+}
+
+table SetTensorRetainCommand {
+  tensor_global_id: uint64;
+  retain: bool;
 }
 
 table GetLayoutCommand {
@@ -81,20 +120,36 @@ table MemcpyCommand {
   dst_data_type: tt.target.DataType = null;
 }
 
+table DeallocateTensorCommand {
+  tensor_global_id: uint64;
+  force: bool;
+}
+
 table ShutdownCommand {
 }
 
 union CommandType {
+  ConfigureRuntimeContextCommand,
   GetSystemDescCommand,
+  SetFabricConfigCommand,
+  GetNumAvailableDevicesCommand,
   OpenMeshDeviceCommand,
   CloseMeshDeviceCommand,
+  CreateSubMeshDeviceCommand,
+  ReleaseSubMeshDeviceCommand,
+  GetMeshShapeCommand,
   CreateHostTensorCommand,
+  IsTensorAllocatedCommand,
+  GetTensorVolumeCommand,
+  GetTensorRetainCommand,
+  SetTensorRetainCommand,
   GetLayoutCommand,
   ToLayoutCommand,
   SubmitCommand,
   GetNumShardsCommand,
   ToHostCommand,
   MemcpyCommand,
+  DeallocateTensorCommand,
   ShutdownCommand,
 }
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -10,8 +10,18 @@ table ErrorResponse {
   message: string;
 }
 
+table ConfigureRuntimeContextResponse {
+}
+
 table GetSystemDescResponse {
   system_desc: [ubyte]; // size-prefixed SystemDescRoot buffer
+}
+
+table SetFabricConfigResponse {
+}
+
+table GetNumAvailableDevicesResponse {
+  num_devices: uint32;
 }
 
 table OpenMeshDeviceResponse {
@@ -21,7 +31,33 @@ table OpenMeshDeviceResponse {
 table CloseMeshDeviceResponse {
 }
 
+table CreateSubMeshDeviceResponse {
+  sub_mesh: tt.target.DeviceRef;
+}
+
+table ReleaseSubMeshDeviceResponse {
+}
+
+table GetMeshShapeResponse {
+  shape: [uint32];
+}
+
 table CreateHostTensorResponse {
+}
+
+table IsTensorAllocatedResponse {
+  allocated: bool;
+}
+
+table GetTensorVolumeResponse {
+  volume: uint32;
+}
+
+table GetTensorRetainResponse {
+  retain: bool;
+}
+
+table SetTensorRetainResponse {
 }
 
 table GetLayoutResponse {
@@ -44,21 +80,35 @@ table MemcpyResponse {
   data: [ubyte];
 }
 
+table DeallocateTensorResponse {
+}
+
 table ShutdownResponse {
 }
 
 union ResponseType {
   ErrorResponse,
+  ConfigureRuntimeContextResponse,
   GetSystemDescResponse,
+  SetFabricConfigResponse,
+  GetNumAvailableDevicesResponse,
   OpenMeshDeviceResponse,
   CloseMeshDeviceResponse,
+  CreateSubMeshDeviceResponse,
+  ReleaseSubMeshDeviceResponse,
+  GetMeshShapeResponse,
   CreateHostTensorResponse,
+  IsTensorAllocatedResponse,
+  GetTensorVolumeResponse,
+  GetTensorRetainResponse,
+  SetTensorRetainResponse,
   GetLayoutResponse,
   ToLayoutResponse,
   SubmitResponse,
   GetNumShardsResponse,
   ToHostResponse,
   MemcpyResponse,
+  DeallocateTensorResponse,
   ShutdownResponse,
 }
 

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -55,40 +55,102 @@ private:
   void launchResponseSender();
   void sendResponses();
 
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::
+                   ConfigureRuntimeContextCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::GetSystemDescCommand
               *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::SetFabricConfigCommand
+              *command);
+
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::
+                   GetNumAvailableDevicesCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::OpenMeshDeviceCommand
               *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::CloseMeshDeviceCommand
               *command);
+
+  void execute(
+      uint64_t commandId,
+      const ::tt::runtime::distributed::flatbuffer::CreateSubMeshDeviceCommand
+          *command);
+
+  void execute(
+      uint64_t commandId,
+      const ::tt::runtime::distributed::flatbuffer::ReleaseSubMeshDeviceCommand
+          *command);
+
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::GetMeshShapeCommand
+                   *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::CreateHostTensorCommand
               *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::IsTensorAllocatedCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::GetTensorVolumeCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::GetTensorRetainCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::SetTensorRetainCommand
+              *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::GetLayoutCommand *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::ToLayoutCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::SubmitCommand *command);
+
   void execute(uint64_t commandId,
                const ::tt::runtime::distributed::flatbuffer::GetNumShardsCommand
                    *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::ToHostCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::MemcpyCommand *command);
+
+  void
+  execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::DeallocateTensorCommand
+              *command);
+
   void execute(
       uint64_t commandId,
       const ::tt::runtime::distributed::flatbuffer::ShutdownCommand *command);

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -17,11 +17,23 @@ public:
                                  uint64_t commandId,
                                  const std::string &errorMessage);
 
+  static void
+  buildConfigureRuntimeContextResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                       uint64_t commandId);
+
   // The fbb should already have the system desc root buffer built.
   static void
   buildGetSystemDescResponse(::flatbuffers::FlatBufferBuilder &fbb,
                              uint64_t commandId,
                              const ::tt::runtime::SystemDesc &systemDesc);
+
+  static void
+  buildSetFabricConfigResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId);
+
+  static void
+  buildGetNumAvailableDevicesResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                      uint64_t commandId, size_t numDevices);
 
   static void buildOpenMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                           uint64_t commandId,
@@ -32,8 +44,37 @@ public:
                                uint64_t commandId);
 
   static void
+  buildCreateSubMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                   uint64_t commandId,
+                                   const ::tt::runtime::Device &subMesh);
+
+  static void
+  buildReleaseSubMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                    uint64_t commandId);
+
+  static void buildGetMeshShapeResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                        uint64_t commandId,
+                                        const std::vector<uint32_t> &shape);
+
+  static void
   buildCreateHostTensorResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                 uint64_t commandId);
+
+  static void
+  buildIsTensorAllocatedResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                 uint64_t commandId, bool allocated);
+
+  static void
+  buildGetTensorVolumeResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId, uint32_t volume);
+
+  static void
+  buildGetTensorRetainResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId, bool retain);
+
+  static void
+  buildSetTensorRetainResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                               uint64_t commandId);
 
   static void buildGetLayoutResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                      uint64_t commandId);
@@ -54,6 +95,10 @@ public:
   static void buildMemcpyResponse(
       ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
       const std::optional<const std::vector<std::uint8_t>> &data);
+
+  static void
+  buildDeallocateTensorResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                uint64_t commandId);
 
   static void buildShutdownResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                     uint64_t commandId);

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -81,7 +81,7 @@ DistributedHostBuffer getDistributedHostBuffer(::tt::runtime::Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -121,7 +121,7 @@ void readDeviceProfilerResults(Device device);
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -144,7 +144,7 @@ TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 bool getTensorRetain(::tt::runtime::Tensor tensor);
 void setTensorRetain(::tt::runtime::Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -188,7 +188,7 @@ void readDeviceProfilerResults(Device device);
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/flatbuffer/CMakeLists.txt
+++ b/runtime/include/tt/runtime/flatbuffer/CMakeLists.txt
@@ -1,0 +1,7 @@
+include(BuildFlatbuffers)
+
+set(RUNTIME_FBS_GEN_SOURCES
+  types.fbs
+)
+
+build_flatbuffers("runtime" "${RUNTIME_FBS_GEN_SOURCES}" RUNTIME_FBS FBS_GENERATION)

--- a/runtime/include/tt/runtime/flatbuffer/flatbuffer.h
+++ b/runtime/include/tt/runtime/flatbuffer/flatbuffer.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_FLATBUFFER_FLATBUFFER_H
+#define TT_RUNTIME_FLATBUFFER_FLATBUFFER_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "tt/runtime/flatbuffer/types_generated.h"
+#pragma clang diagnostic pop
+
+#endif

--- a/runtime/include/tt/runtime/flatbuffer/types.fbs
+++ b/runtime/include/tt/runtime/flatbuffer/types.fbs
@@ -1,0 +1,43 @@
+namespace tt.runtime.flatbuffer;
+
+enum DispatchCoreType: uint {
+  Worker,
+  Ethernet
+}
+
+enum DeviceRuntime: uint32 {
+  Disabled,
+  TTNN,
+  TTMetal,
+}
+
+enum HostRuntime: uint32 {
+  Local,
+  Distributed,
+}
+
+enum FabricConfig: uint32 {
+  DISABLED,
+  FABRIC_1D,
+  FABRIC_1D_RING,
+  FABRIC_2D,
+  FABRIC_2D_TORUS_X,
+  FABRIC_2D_TORUS_Y,
+  FABRIC_2D_TORUS_XY,
+  FABRIC_2D_DYNAMIC,
+  FABRIC_2D_DYNAMIC_TORUS_X,
+  FABRIC_2D_DYNAMIC_TORUS_Y,
+  FABRIC_2D_DYNAMIC_TORUS_XY,
+  CUSTOM,
+}
+
+table MeshDeviceOptions {
+  mesh_offset: [uint32];
+  device_ids: [int];
+  num_hw_cqs: uint8;
+  enable_program_cache: bool;
+  mesh_shape: [uint32];
+  l1_small_size: uint64 = null;
+  trace_region_size: uint64 = null;
+  dispatch_core_type: DispatchCoreType = null;
+}

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -17,7 +17,8 @@ namespace tt::runtime {
 namespace system_desc {
 
 SystemDesc getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType =
+        std::nullopt,
     std::optional<Device> meshDevice = std::nullopt);
 } // namespace system_desc
 
@@ -40,7 +41,8 @@ HostRuntime getCurrentHostRuntime();
 void setCurrentHostRuntime(const HostRuntime &runtime);
 
 SystemDesc getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType =
+        std::nullopt,
     std::optional<Device> meshDevice = std::nullopt);
 
 void launchDistributedRuntime(const DistributedOptions &options = {});
@@ -124,7 +126,7 @@ TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
-Arch getArch();
+tt::target::Arch getArch();
 
 void enablePersistentKernelCache();
 void disablePersistentKernelCache();
@@ -174,7 +176,7 @@ This function gets the memory view per device
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device);
 
-void setFabricConfig(FabricConfig config);
+void setFabricConfig(tt::runtime::FabricConfig config);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -21,7 +21,15 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
 
+#include "tt/runtime/flatbuffer/flatbuffer.h"
+
 namespace tt::runtime {
+
+using ::tt::runtime::flatbuffer::DeviceRuntime;
+using ::tt::runtime::flatbuffer::DispatchCoreType;
+using ::tt::runtime::flatbuffer::FabricConfig;
+using ::tt::runtime::flatbuffer::HostRuntime;
+
 /*
 MemoryBlockTable is a list of memory blocks in the following format:
 [{"blockID": "0", "address": "0", "size": "0", "prevID": "0", "nextID": "0",
@@ -37,35 +45,12 @@ enum class MemoryBufferType {
   TRACE,
 };
 
-enum class DeviceRuntime {
-  Disabled,
-  TTNN,
-  TTMetal,
-};
-
 inline std::string toString(DeviceRuntime runtime) {
-  switch (runtime) {
-  case DeviceRuntime::TTNN:
-    return "TTNN";
-  case DeviceRuntime::TTMetal:
-    return "TTMetal";
-  case DeviceRuntime::Disabled:
-    return "Disabled";
-  }
+  return ::tt::runtime::flatbuffer::EnumNameDeviceRuntime(runtime);
 }
 
-enum class HostRuntime {
-  Local,
-  Distributed,
-};
-
 inline std::string toString(HostRuntime runtime) {
-  switch (runtime) {
-  case HostRuntime::Local:
-    return "Local";
-  case HostRuntime::Distributed:
-    return "Distributed";
-  }
+  return ::tt::runtime::flatbuffer::EnumNameHostRuntime(runtime);
 }
 
 enum class DistributedMode {
@@ -77,28 +62,6 @@ enum class DistributedMode {
   // across multiple hosts
   MultiProcess,
 };
-
-enum class DispatchCoreType {
-  WORKER,
-  ETH,
-};
-
-enum class FabricConfig {
-  DISABLED,
-  FABRIC_1D,
-  FABRIC_1D_RING,
-  FABRIC_2D,
-  FABRIC_2D_TORUS_X,
-  FABRIC_2D_TORUS_Y,
-  FABRIC_2D_TORUS_XY,
-  FABRIC_2D_DYNAMIC,
-  FABRIC_2D_DYNAMIC_TORUS_X,
-  FABRIC_2D_DYNAMIC_TORUS_Y,
-  FABRIC_2D_DYNAMIC_TORUS_XY,
-  CUSTOM,
-};
-
-enum class Arch { GRAYSKULL = 1, WORMHOLE_B0 = 2, BLACKHOLE = 3, QUASAR = 4 };
 
 namespace detail {
 
@@ -235,7 +198,8 @@ struct MeshDeviceOptions {
   std::optional<std::vector<uint32_t>> meshShape = std::nullopt;
   std::optional<size_t> l1SmallSize = std::nullopt;
   std::optional<size_t> traceRegionSize = std::nullopt;
-  std::optional<DispatchCoreType> dispatchCoreType = std::nullopt;
+  std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
+      std::nullopt;
 };
 
 class MultiProcessArgs {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -15,10 +15,7 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
 
-// Forward declarations
-namespace tt::runtime {
-enum class DispatchCoreType;
-} // namespace tt::runtime
+#include "tt/runtime/flatbuffer/flatbuffer.h"
 
 namespace tt::runtime::utils {
 
@@ -169,12 +166,6 @@ template <typename T>
 inline std::shared_ptr<void> unsafeBorrowShared(T *ptr) {
   return std::shared_ptr<void>(static_cast<void *>(ptr), [](void *) {});
 }
-
-::tt::target::DispatchCoreType
-fromRuntimeDispatchCoreType(::tt::runtime::DispatchCoreType dispatchCoreType);
-
-::tt::runtime::DispatchCoreType
-toRuntimeDispatchCoreType(::tt::target::DispatchCoreType dispatchCoreType);
 
 std::uint32_t dataTypeElementSize(::tt::target::DataType dataType);
 

--- a/runtime/lib/CMakeLists.txt
+++ b/runtime/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ set_property(TARGET TTBinary PROPERTY CXX_STANDARD 20)
 target_include_directories(TTBinary
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 add_dependencies(TTBinary FBS_GENERATION)
@@ -19,6 +20,7 @@ set_property(TARGET TTMLIRRuntime PROPERTY CXX_STANDARD 20)
 target_include_directories(TTMLIRRuntime
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -53,7 +55,7 @@ target_link_libraries(TTMLIRRuntime PUBLIC coverage_config)
 set_target_properties(TTMLIRRuntime PROPERTIES INSTALL_RPATH "$ORIGIN;${TTMETAL_LIBRARY_DIR}")
 set_target_properties(TTMLIRRuntime PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 
-add_dependencies(TTMLIRRuntime FBS_GENERATION)
+add_dependencies(TTMLIRRuntime FBS_GENERATION RUNTIME_FBS_GENERATION)
 
 if (TTMLIR_ENABLE_RUNTIME)
   set(TTMLIR_RUNTIME_PUBLIC_HEADERS
@@ -73,6 +75,12 @@ if (TTMLIR_ENABLE_RUNTIME)
     LIBRARY
       DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
       COMPONENT SharedLib
+  )
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/runtime/include/tt/runtime/flatbuffer
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tt/runtime
+    COMPONENT SharedLib
+    FILES_MATCHING
+    PATTERN "*.h"
   )
 endif()
 

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -43,24 +43,30 @@ set_property(TARGET TTRuntimeTypes PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeTypes
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeTypes PUBLIC coverage_config)
+add_dependencies(TTRuntimeTypes RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimeUtils STATIC utils.cpp)
 set_property(TARGET TTRuntimeUtils PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeUtils
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeUtils PUBLIC coverage_config)
+add_dependencies(TTRuntimeUtils RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimeSysDesc STATIC system_desc.cpp)
 set_property(TARGET TTRuntimeSysDesc PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeSysDesc
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
+add_dependencies(TTRuntimeSysDesc RUNTIME_FBS_GENERATION)
 
 target_include_directories(TTRuntimeSysDesc SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 add_dependencies(TTRuntimeSysDesc tt-metal FBS_GENERATION)
@@ -71,30 +77,37 @@ set_property(TARGET TTRuntimeContext PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeContext
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeContext PUBLIC coverage_config)
+add_dependencies(TTRuntimeContext RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimeSocket STATIC socket.cpp)
 set_property(TARGET TTRuntimeSocket PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeSocket
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeSocket PUBLIC coverage_config)
+add_dependencies(TTRuntimeSocket RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimeDebug STATIC debug.cpp)
 set_property(TARGET TTRuntimeDebug PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeDebug
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeDebug PUBLIC coverage_config)
+add_dependencies(TTRuntimeDebug RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimePerf STATIC perf.cpp)
 set_property(TARGET TTRuntimePerf PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimePerf
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
     "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>"
 )
 add_dependencies(TTRuntimePerf tt-metal)
@@ -105,13 +118,17 @@ set_property(TARGET TTRuntimeWorkarounds PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeWorkarounds
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeWorkarounds PUBLIC coverage_config)
+add_dependencies(TTRuntimeWorkarounds RUNTIME_FBS_GENERATION)
 
 add_library(TTRuntimeDylibs STATIC dylib.cpp)
 set_property(TARGET TTRuntimeDylibs PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeDylibs
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/runtime/include
 )
 target_link_libraries(TTRuntimeDylibs PUBLIC coverage_config)
+add_dependencies(TTRuntimeDylibs RUNTIME_FBS_GENERATION)

--- a/runtime/lib/common/runtime_context.cpp
+++ b/runtime/lib/common/runtime_context.cpp
@@ -74,11 +74,13 @@ void RuntimeContext::setCurrentHostRuntime(const HostRuntime &runtime) {
   currentHostRuntime_.store(runtime, std::memory_order_relaxed);
 }
 
-FabricConfig RuntimeContext::getCurrentFabricConfig() const {
-  FabricConfig config = currentFabricConfig_.load(std::memory_order_relaxed);
+tt::runtime::FabricConfig RuntimeContext::getCurrentFabricConfig() const {
+  tt::runtime::FabricConfig config =
+      currentFabricConfig_.load(std::memory_order_relaxed);
   return config;
 }
-void RuntimeContext::setCurrentFabricConfig(const FabricConfig &config) {
+void RuntimeContext::setCurrentFabricConfig(
+    const tt::runtime::FabricConfig &config) {
   currentFabricConfig_.store(config, std::memory_order_relaxed);
 }
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -252,7 +252,8 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
 }
 
 static std::shared_ptr<::tt::tt_metal::distributed::MeshDevice>
-createNewMeshDevice(std::optional<DispatchCoreType> dispatchCoreType) {
+createNewMeshDevice(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType) {
 
   ::tt::tt_metal::DispatchCoreType type =
       tt::runtime::common::getDispatchCoreType(dispatchCoreType);
@@ -263,9 +264,9 @@ createNewMeshDevice(std::optional<DispatchCoreType> dispatchCoreType) {
       DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, type);
 }
 
-::tt::runtime::SystemDesc
-getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
-                     std::optional<Device> meshDevice) {
+::tt::runtime::SystemDesc getCurrentSystemDesc(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType,
+    std::optional<Device> meshDevice) {
 
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevicePtr;
   if (meshDevice.has_value()) {

--- a/runtime/lib/common/utils.cpp
+++ b/runtime/lib/common/utils.cpp
@@ -143,26 +143,6 @@ std::shared_ptr<void> callocShared(const size_t size) {
   return std::shared_ptr<void>(std::calloc(size, 1), std::free);
 }
 
-::tt::target::DispatchCoreType
-fromRuntimeDispatchCoreType(::tt::runtime::DispatchCoreType dispatchCoreType) {
-  switch (dispatchCoreType) {
-  case ::tt::runtime::DispatchCoreType::WORKER:
-    return ::tt::target::DispatchCoreType::Worker;
-  case ::tt::runtime::DispatchCoreType::ETH:
-    return ::tt::target::DispatchCoreType::Ethernet;
-  }
-}
-
-::tt::runtime::DispatchCoreType
-toRuntimeDispatchCoreType(::tt::target::DispatchCoreType dispatchCoreType) {
-  switch (dispatchCoreType) {
-  case ::tt::target::DispatchCoreType::Worker:
-    return ::tt::runtime::DispatchCoreType::WORKER;
-  case ::tt::target::DispatchCoreType::Ethernet:
-    return ::tt::runtime::DispatchCoreType::ETH;
-  }
-}
-
 std::uint32_t dataTypeElementSize(::tt::target::DataType dataType) {
   switch (dataType) {
   case ::tt::target::DataType::Float64:

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -4,11 +4,11 @@
 
 #include "tt/runtime/detail/distributed/controller/controller.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/distributed/controller/command_factory.h"
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/detail/distributed/utils/utils.h"
 #include "tt/runtime/runtime.h"
-
 namespace tt::runtime::distributed::controller {
 
 namespace fb = ::tt::runtime::distributed::flatbuffer;
@@ -127,6 +127,8 @@ void Controller::launch(const ::tt::runtime::DistributedOptions &options) {
   launchCommandDispatcher();
   launchResponseHandler();
 
+  configureRuntimeContext();
+
   controllerState_.store(ControllerState::FullyOperational,
                          std::memory_order_relaxed);
 }
@@ -172,6 +174,41 @@ SystemDesc Controller::getCurrentSystemDesc(
   return *systemDescHandle;
 }
 
+void Controller::setFabricConfig(
+    const ::tt::runtime::FabricConfig &fabricConfig) {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildSetFabricConfigCommand(
+      *commandBuilder, fabricConfig);
+
+  pushToCommandAndResponseQueues(commandId,
+                                 fb::CommandType::SetFabricConfigCommand,
+                                 std::move(commandBuilder));
+}
+
+size_t Controller::getNumAvailableDevices() {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId =
+      CommandFactory::buildGetNumAvailableDevicesCommand(*commandBuilder);
+
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  std::shared_ptr<size_t> numDevicesHandle = std::make_shared<size_t>(0);
+  awaitingHandles->push_back(std::static_pointer_cast<void>(numDevicesHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::GetNumAvailableDevicesCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *numDevicesHandle;
+}
+
 ::tt::runtime::Device
 Controller::openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options) {
 
@@ -189,7 +226,7 @@ Controller::openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options) {
   return outputDeviceHandle;
 }
 
-void Controller::closeMeshDevice(const ::tt::runtime::Device &deviceHandle) {
+void Controller::closeMeshDevice(::tt::runtime::Device &deviceHandle) {
 
   auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
@@ -199,6 +236,63 @@ void Controller::closeMeshDevice(const ::tt::runtime::Device &deviceHandle) {
   pushToCommandAndResponseQueues(commandId,
                                  fb::CommandType::CloseMeshDeviceCommand,
                                  std::move(commandBuilder));
+}
+
+::tt::runtime::Device Controller::createSubMeshDevice(
+    const ::tt::runtime::Device &parentMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  ::tt::runtime::Device outputSubMeshHandle(getCurrentDeviceRuntime());
+
+  uint64_t commandId = CommandFactory::buildCreateSubMeshDeviceCommand(
+      *commandBuilder, parentMesh, outputSubMeshHandle, meshShape, meshOffset);
+
+  pushToCommandAndResponseQueues(commandId,
+                                 fb::CommandType::CreateSubMeshDeviceCommand,
+                                 std::move(commandBuilder));
+
+  return outputSubMeshHandle;
+}
+
+void Controller::releaseSubMeshDevice(const ::tt::runtime::Device &subMesh) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildReleaseSubMeshDeviceCommand(
+      *commandBuilder, subMesh);
+
+  pushToCommandAndResponseQueues(commandId,
+                                 fb::CommandType::ReleaseSubMeshDeviceCommand,
+                                 std::move(commandBuilder));
+}
+
+std::vector<uint32_t>
+Controller::getMeshShape(const ::tt::runtime::Device &deviceHandle) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId =
+      CommandFactory::buildGetMeshShapeCommand(*commandBuilder, deviceHandle);
+
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  std::shared_ptr<std::vector<uint32_t>> shapeHandle =
+      std::make_shared<std::vector<uint32_t>>();
+  awaitingHandles->push_back(std::static_pointer_cast<void>(shapeHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::GetMeshShapeCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *shapeHandle;
 }
 
 ::tt::runtime::Tensor Controller::createOwnedHostTensor(
@@ -219,6 +313,91 @@ void Controller::closeMeshDevice(const ::tt::runtime::Device &deviceHandle) {
                                  std::move(commandBuilder));
 
   return outputTensorHandle;
+}
+
+bool Controller::isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle) {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildIsTensorAllocatedCommand(
+      *commandBuilder, tensorHandle);
+
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  auto allocatedHandle = std::make_shared<bool>(false);
+  awaitingHandles->push_back(std::static_pointer_cast<void>(allocatedHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::IsTensorAllocatedCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *allocatedHandle;
+}
+
+std::uint32_t
+Controller::getTensorVolume(const ::tt::runtime::Tensor &tensorHandle) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildGetTensorVolumeCommand(
+      *commandBuilder, tensorHandle);
+
+  auto volumeHandle = std::make_shared<std::uint32_t>(0);
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  awaitingHandles->push_back(std::static_pointer_cast<void>(volumeHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::GetTensorVolumeCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *volumeHandle;
+}
+
+bool Controller::getTensorRetain(const ::tt::runtime::Tensor &tensorHandle) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildGetTensorRetainCommand(
+      *commandBuilder, tensorHandle);
+
+  auto retainHandle = std::make_shared<bool>(false);
+
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  awaitingHandles->push_back(std::static_pointer_cast<void>(retainHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::GetTensorRetainCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *retainHandle;
+}
+
+void Controller::setTensorRetain(const ::tt::runtime::Tensor &tensorHandle,
+                                 bool retain) {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildSetTensorRetainCommand(
+      *commandBuilder, tensorHandle, retain);
+
+  pushToCommandAndResponseQueues(commandId,
+                                 fb::CommandType::SetTensorRetainCommand,
+                                 std::move(commandBuilder));
 }
 
 ::tt::runtime::Layout
@@ -359,11 +538,38 @@ void Controller::memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
   awaitingFuture.wait();
 }
 
+void Controller::memcpy(const ::tt::runtime::Tensor &dstHandle,
+                        const ::tt::runtime::Tensor &srcHandle) {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId =
+      CommandFactory::buildMemcpyCommand(*commandBuilder, srcHandle, dstHandle);
+
+  pushToCommandAndResponseQueues(commandId, fb::CommandType::MemcpyCommand,
+                                 std::move(commandBuilder));
+}
+
+void Controller::deallocateTensor(::tt::runtime::Tensor &tensorHandle,
+                                  bool force) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId = CommandFactory::buildDeallocateTensorCommand(
+      *commandBuilder, tensorHandle, force);
+
+  pushToCommandAndResponseQueues(commandId,
+                                 fb::CommandType::DeallocateTensorCommand,
+                                 std::move(commandBuilder));
+}
+
 void Controller::pushToCommandAndResponseQueues(
     uint64_t commandId, const fb::CommandType &commandType,
     std::unique_ptr<::flatbuffers::FlatBufferBuilder> commandBuilder,
     std::unique_ptr<std::vector<std::shared_ptr<void>>> awaitingHandles,
     std::unique_ptr<std::promise<void>> awaitingPromise) {
+  LOG_DEBUG("Pushing command id: ", commandId,
+            " and command type: ", fb::EnumNameCommandType(commandType),
+            " to command and response queues");
   // Need to push to the response queue first to ensure the command response is
   // waited for before the command is dispatched
   awaitingResponseQueue_.push(std::make_unique<AwaitingResponseQueueEntry>(
@@ -480,6 +686,28 @@ void Controller::processResponseQueue() {
   }
 }
 
+void Controller::configureRuntimeContext() {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  auto commandId = CommandFactory::buildConfigureRuntimeContextCommand(
+      *commandBuilder, ::tt::runtime::RuntimeContext::instance().getMlirHome(),
+      ::tt::runtime::RuntimeContext::instance().getMetalHome(),
+      ::tt::runtime::RuntimeContext::instance().getCurrentDeviceRuntime());
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::ConfigureRuntimeContextCommand,
+      std::move(commandBuilder), /*awaitingHandles=*/nullptr,
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  controllerState_.store(ControllerState::RuntimeContextConfigured,
+                         std::memory_order_relaxed);
+}
+
 // TODO (#5136): Need better error handling for when an error occurs
 // Currently we just log a fatal error and exit the program
 void Controller::handleErrorResponse(
@@ -495,6 +723,27 @@ void Controller::handleErrorResponse(
 
   LOG_FATAL("Error response received with message: ",
             response->message()->c_str());
+}
+
+void Controller::handleConfigureRuntimeContextResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::ConfigureRuntimeContextResponse);
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+
+  DEBUG_ASSERT(
+      !awaitingHandles,
+      "ConfigureRuntimeContext: There shouldn't be any awaiting handles");
+
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  awaitingPromise->set_value();
 }
 
 void Controller::handleGetSystemDescResponse(
@@ -533,6 +782,52 @@ void Controller::handleGetSystemDescResponse(
   awaitingPromise->set_value();
 }
 
+void Controller::handleSetFabricConfigResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::SetFabricConfigResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse, "SetFabricConfig");
+}
+
+void Controller::handleGetNumAvailableDevicesResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::GetNumAvailableDevicesResponse);
+
+  // Number of devices is local to each host process, so we need to sum them up
+  uint32_t numDevices = 0;
+  for (const SizedBuffer &responseBuffer : responseBuffers) {
+    const fb::GetNumAvailableDevicesResponse *response =
+        getResponse(responseBuffer)->type_as_GetNumAvailableDevicesResponse();
+    numDevices += response->num_devices();
+  }
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+
+  DEBUG_ASSERT(
+      awaitingHandles && awaitingHandles->size() == 1,
+      "GetNumAvailableDevices: Awaiting handles must be populated and contain "
+      "exactly one handle");
+
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<size_t> numDevicesHandle =
+      std::static_pointer_cast<size_t>(awaitingHandles->at(0));
+  *numDevicesHandle = numDevices;
+
+  awaitingPromise->set_value();
+}
+
 void Controller::handleOpenMeshDeviceResponse(
     const std::vector<SizedBuffer> &responseBuffers,
     std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
@@ -555,6 +850,61 @@ void Controller::handleCloseMeshDeviceResponse(
                             fb::ResponseType::CloseMeshDeviceResponse);
 
   debug::assertNoAwaitingState(*awaitingResponse, "CloseMeshDevice");
+}
+
+void Controller::handleCreateSubMeshDeviceResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::CreateSubMeshDeviceResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse, "CreateSubMeshDevice");
+}
+
+void Controller::handleReleaseSubMeshDeviceResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::ReleaseSubMeshDeviceResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse, "ReleaseSubMeshDevice");
+}
+
+void Controller::handleGetMeshShapeResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::GetMeshShapeResponse);
+
+  const fb::GetMeshShapeResponse *response =
+      getResponse(responseBuffers[0])->type_as_GetMeshShapeResponse();
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+
+  DEBUG_ASSERT(awaitingHandles && awaitingHandles->size() == 1,
+               "GetMeshShape: Awaiting handles must be populated and contain "
+               "exactly one handle");
+
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<std::vector<uint32_t>> shapeHandle =
+      std::static_pointer_cast<std::vector<uint32_t>>(awaitingHandles->at(0));
+
+  for (const uint32_t &dim : *response->shape()) {
+    shapeHandle->push_back(dim);
+  }
+
+  awaitingPromise->set_value();
 }
 
 void Controller::handleGetNumShardsResponse(
@@ -597,6 +947,97 @@ void Controller::handleCreateHostTensorResponse(
                             fb::ResponseType::CreateHostTensorResponse);
 
   debug::assertNoAwaitingState(*awaitingResponse, "CreateHostTensor");
+}
+
+void Controller::handleIsTensorAllocatedResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::IsTensorAllocatedResponse);
+
+  const fb::IsTensorAllocatedResponse *response =
+      getResponse(responseBuffers[0])->type_as_IsTensorAllocatedResponse();
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+  DEBUG_ASSERT(
+      awaitingHandles && awaitingHandles->size() == 1,
+      "IsTensorAllocated: Awaiting handles must be populated and contain "
+      "exactly one handle");
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<bool> allocatedHandle =
+      std::static_pointer_cast<bool>(awaitingHandles->at(0));
+  *allocatedHandle = response->allocated();
+
+  awaitingPromise->set_value();
+}
+
+void Controller::handleGetTensorVolumeResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::GetTensorVolumeResponse);
+
+  const fb::GetTensorVolumeResponse *response =
+      getResponse(responseBuffers[0])->type_as_GetTensorVolumeResponse();
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+  DEBUG_ASSERT(
+      awaitingHandles && awaitingHandles->size() == 1,
+      "GetTensorVolume: Awaiting handles must be populated and contain "
+      "exactly one handle");
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<std::uint32_t> volumeHandle =
+      std::static_pointer_cast<std::uint32_t>(awaitingHandles->at(0));
+  *volumeHandle = response->volume();
+
+  awaitingPromise->set_value();
+}
+
+void Controller::handleGetTensorRetainResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::GetTensorRetainResponse);
+
+  const fb::GetTensorRetainResponse *response =
+      getResponse(responseBuffers[0])->type_as_GetTensorRetainResponse();
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+  DEBUG_ASSERT(
+      awaitingHandles && awaitingHandles->size() == 1,
+      "GetTensorRetain: Awaiting handles must be populated and contain "
+      "exactly one handle");
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<bool> retainHandle =
+      std::static_pointer_cast<bool>(awaitingHandles->at(0));
+  *retainHandle = response->retain();
+  awaitingPromise->set_value();
+}
+
+void Controller::handleSetTensorRetainResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::SetTensorRetainResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse, "SetTensorRetain");
 }
 
 void Controller::handleGetLayoutResponse(
@@ -679,6 +1120,18 @@ void Controller::handleMemcpyResponse(
   awaitingPromise->set_value();
 }
 
+void Controller::handleDeallocateTensorResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::DeallocateTensorResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse, "DeallocateTensor");
+}
+
 void Controller::handleShutdownResponse(
     const std::vector<SizedBuffer> &responseBuffers,
     std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
@@ -701,9 +1154,21 @@ void Controller::handleResponse(
     const std::vector<SizedBuffer> &responseBuffers,
     std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
   switch (awaitingResponse->commandType) {
+  case fb::CommandType::ConfigureRuntimeContextCommand: {
+    return handleConfigureRuntimeContextResponse(responseBuffers,
+                                                 std::move(awaitingResponse));
+  }
   case fb::CommandType::GetSystemDescCommand: {
     return handleGetSystemDescResponse(responseBuffers,
                                        std::move(awaitingResponse));
+  }
+  case fb::CommandType::SetFabricConfigCommand: {
+    return handleSetFabricConfigResponse(responseBuffers,
+                                         std::move(awaitingResponse));
+  }
+  case fb::CommandType::GetNumAvailableDevicesCommand: {
+    return handleGetNumAvailableDevicesResponse(responseBuffers,
+                                                std::move(awaitingResponse));
   }
   case fb::CommandType::OpenMeshDeviceCommand: {
     return handleOpenMeshDeviceResponse(responseBuffers,
@@ -713,6 +1178,18 @@ void Controller::handleResponse(
     return handleCloseMeshDeviceResponse(responseBuffers,
                                          std::move(awaitingResponse));
   }
+  case fb::CommandType::CreateSubMeshDeviceCommand: {
+    return handleCreateSubMeshDeviceResponse(responseBuffers,
+                                             std::move(awaitingResponse));
+  }
+  case fb::CommandType::ReleaseSubMeshDeviceCommand: {
+    return handleReleaseSubMeshDeviceResponse(responseBuffers,
+                                              std::move(awaitingResponse));
+  }
+  case fb::CommandType::GetMeshShapeCommand: {
+    return handleGetMeshShapeResponse(responseBuffers,
+                                      std::move(awaitingResponse));
+  }
   case fb::CommandType::CreateHostTensorCommand: {
     return handleCreateHostTensorResponse(responseBuffers,
                                           std::move(awaitingResponse));
@@ -720,6 +1197,22 @@ void Controller::handleResponse(
   case fb::CommandType::GetLayoutCommand: {
     return handleGetLayoutResponse(responseBuffers,
                                    std::move(awaitingResponse));
+  }
+  case fb::CommandType::IsTensorAllocatedCommand: {
+    return handleIsTensorAllocatedResponse(responseBuffers,
+                                           std::move(awaitingResponse));
+  }
+  case fb::CommandType::GetTensorVolumeCommand: {
+    return handleGetTensorVolumeResponse(responseBuffers,
+                                         std::move(awaitingResponse));
+  }
+  case fb::CommandType::GetTensorRetainCommand: {
+    return handleGetTensorRetainResponse(responseBuffers,
+                                         std::move(awaitingResponse));
+  }
+  case fb::CommandType::SetTensorRetainCommand: {
+    return handleSetTensorRetainResponse(responseBuffers,
+                                         std::move(awaitingResponse));
   }
   case fb::CommandType::ToLayoutCommand: {
     return handleToLayoutResponse(responseBuffers, std::move(awaitingResponse));
@@ -736,6 +1229,10 @@ void Controller::handleResponse(
   }
   case fb::CommandType::MemcpyCommand: {
     return handleMemcpyResponse(responseBuffers, std::move(awaitingResponse));
+  }
+  case fb::CommandType::DeallocateTensorCommand: {
+    return handleDeallocateTensorResponse(responseBuffers,
+                                          std::move(awaitingResponse));
   }
   case fb::CommandType::ShutdownCommand: {
     return handleShutdownResponse(responseBuffers, std::move(awaitingResponse));

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -67,15 +67,44 @@ SystemDesc getCurrentSystemDesc(
                                                          deviceHandle);
 }
 
+void setFabricConfig(const ::tt::runtime::FabricConfig &fabricConfig) {
+  assertControllerLaunched();
+  ControllerSingleton::get().setFabricConfig(fabricConfig);
+}
+
+size_t getNumAvailableDevices() {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getNumAvailableDevices();
+}
+
 ::tt::runtime::Device
 openMeshDevice(const ::tt::runtime::MeshDeviceOptions &options) {
   assertControllerLaunched();
   return ControllerSingleton::get().openMeshDevice(options);
 }
 
-void closeMeshDevice(::tt::runtime::Device parentMesh) {
+void closeMeshDevice(::tt::runtime::Device &parentMesh) {
   assertControllerLaunched();
   ControllerSingleton::get().closeMeshDevice(parentMesh);
+}
+
+::tt::runtime::Device createSubMeshDevice(
+    const ::tt::runtime::Device &parentMesh,
+    const std::vector<uint32_t> &meshShape,
+    const std::optional<const std::vector<uint32_t>> &meshOffset) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().createSubMeshDevice(parentMesh, meshShape,
+                                                        meshOffset);
+}
+
+void releaseSubMeshDevice(const ::tt::runtime::Device &subMesh) {
+  assertControllerLaunched();
+  ControllerSingleton::get().releaseSubMeshDevice(subMesh);
+}
+
+std::vector<uint32_t> getMeshShape(const ::tt::runtime::Device &meshDevice) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getMeshShape(meshDevice);
 }
 
 ::tt::runtime::Tensor
@@ -85,6 +114,26 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,
                                                           itemsize, dataType);
+}
+
+bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().isTensorAllocated(tensorHandle);
+}
+
+std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getTensorVolume(tensorHandle);
+}
+
+bool getTensorRetain(::tt::runtime::Tensor tensorHandle) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getTensorRetain(tensorHandle);
+}
+
+void setTensorRetain(::tt::runtime::Tensor tensorHandle, bool retain) {
+  assertControllerLaunched();
+  ControllerSingleton::get().setTensorRetain(tensorHandle, retain);
 }
 
 ::tt::runtime::Layout getLayout(::tt::runtime::Binary executableHandle,
@@ -123,6 +172,17 @@ void memcpy(void *dst, const ::tt::runtime::Tensor &srcHandle,
             std::optional<tt::target::DataType> targetDataType) {
   assertControllerLaunched();
   ControllerSingleton::get().memcpy(dst, srcHandle, targetDataType);
+}
+
+void memcpy(const ::tt::runtime::Tensor &dstHandle,
+            const ::tt::runtime::Tensor &srcHandle) {
+  assertControllerLaunched();
+  ControllerSingleton::get().memcpy(dstHandle, srcHandle);
+}
+
+void deallocateTensor(::tt::runtime::Tensor &tensorHandle, bool force) {
+  assertControllerLaunched();
+  ControllerSingleton::get().deallocateTensor(tensorHandle, force);
 }
 
 } // namespace tt::runtime::distributed

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -4,6 +4,7 @@
 
 #include "tt/runtime/detail/distributed/worker/command_executor.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/common/socket.h"
 #include "tt/runtime/detail/distributed/worker/response_factory.h"
 #include "tt/runtime/runtime.h"
@@ -14,6 +15,17 @@
 namespace tt::runtime::distributed::worker {
 
 namespace fb = ::tt::runtime::distributed::flatbuffer;
+
+template <typename Builder, typename... Args>
+static std::unique_ptr<::flatbuffers::FlatBufferBuilder>
+buildResponse(const Builder &builderFunc, uint64_t commandId, Args &&...args) {
+
+  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  builderFunc(*responseBuilder, commandId, std::forward<Args>(args)...);
+
+  return responseBuilder;
+}
 
 static const fb::Command *getCommand(const SizedBuffer &command) {
   bool isDistributedCommand = fb::CommandBufferHasIdentifier(command.data());
@@ -100,16 +112,30 @@ void CommandExecutor::sendResponses() {
   }
 }
 
+void CommandExecutor::execute(
+    uint64_t commandId, const fb::ConfigureRuntimeContextCommand *command) {
+
+  ::tt::runtime::RuntimeContext::instance().setMlirHome(
+      command->mlir_home()->c_str());
+  ::tt::runtime::RuntimeContext::instance().setMetalHome(
+      command->metal_home()->c_str());
+  ::tt::runtime::RuntimeContext::instance().setCurrentDeviceRuntime(
+      command->current_device_runtime());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildConfigureRuntimeContextResponse,
+                    commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetSystemDescCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
       std::nullopt;
   if (command->dispatch_core_type()) {
-    dispatchCoreType = ::tt::runtime::utils::toRuntimeDispatchCoreType(
-        command->dispatch_core_type().value());
+    dispatchCoreType = command->dispatch_core_type().value();
   }
 
   std::optional<Device> device = std::nullopt;
@@ -121,8 +147,32 @@ void CommandExecutor::execute(uint64_t commandId,
       ::tt::runtime::system_desc::getCurrentSystemDesc(dispatchCoreType,
                                                        device);
 
-  ResponseFactory::buildGetSystemDescResponse(*responseBuilder, commandId,
-                                              systemDesc);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetSystemDescResponse, commandId,
+                    systemDesc);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::SetFabricConfigCommand *command) {
+
+  ::tt::runtime::setFabricConfig(command->config());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSetFabricConfigResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(
+    uint64_t commandId, const fb::GetNumAvailableDevicesCommand *command) {
+
+  size_t numDevices = ::tt::runtime::getNumAvailableDevices();
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetNumAvailableDevicesResponse,
+                    commandId, numDevices);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -130,10 +180,9 @@ void CommandExecutor::execute(uint64_t commandId,
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::OpenMeshDeviceCommand *command) {
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint32_t deviceGlobalId = command->device_global_id();
-  const fb::MeshDeviceOptions *options = command->options();
+  const ::tt::runtime::flatbuffer::MeshDeviceOptions *options =
+      command->options();
 
   ::tt::runtime::MeshDeviceOptions meshDeviceOptions;
   if (options->mesh_offset()) {
@@ -168,9 +217,7 @@ void CommandExecutor::execute(uint64_t commandId,
   }
 
   if (options->dispatch_core_type().has_value()) {
-    meshDeviceOptions.dispatchCoreType =
-        ::tt::runtime::utils::toRuntimeDispatchCoreType(
-            options->dispatch_core_type().value());
+    meshDeviceOptions.dispatchCoreType = options->dispatch_core_type().value();
   }
 
   ::tt::runtime::Device device =
@@ -180,8 +227,9 @@ void CommandExecutor::execute(uint64_t commandId,
 
   devicePool_.insert_or_assign(deviceGlobalId, device);
 
-  ResponseFactory::buildOpenMeshDeviceResponse(*responseBuilder, commandId,
-                                               device);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildOpenMeshDeviceResponse, commandId,
+                    device);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -189,26 +237,87 @@ void CommandExecutor::execute(uint64_t commandId,
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::CloseMeshDeviceCommand *command) {
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint32_t deviceGlobalId = command->device()->global_id();
 
   ::tt::runtime::Device device = devicePool_.at(deviceGlobalId);
+  LOG_ASSERT(device.getGlobalId() == deviceGlobalId,
+             "Parent mesh global id mismatch");
 
   ::tt::runtime::closeMeshDevice(device);
 
   devicePool_.erase(deviceGlobalId);
 
-  ResponseFactory::buildCloseMeshDeviceResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCloseMeshDeviceResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::CreateSubMeshDeviceCommand *command) {
+
+  ::tt::runtime::Device parentMesh =
+      devicePool_.at(command->parent_mesh()->global_id());
+  LOG_ASSERT(parentMesh.getGlobalId() == command->parent_mesh()->global_id(),
+             "Parent mesh global id mismatch");
+
+  std::vector<uint32_t> meshShape(command->mesh_shape()->begin(),
+                                  command->mesh_shape()->end());
+
+  std::optional<std::vector<uint32_t>> meshOffset = std::nullopt;
+  if (command->mesh_offset()) {
+    meshOffset = std::vector<uint32_t>(command->mesh_offset()->begin(),
+                                       command->mesh_offset()->end());
+  }
+
+  uint32_t subMeshGlobalId = command->submesh_global_id();
+  ::tt::runtime::Device subMesh =
+      ::tt::runtime::createSubMeshDevice(parentMesh, meshShape, meshOffset);
+  subMesh.setGlobalId(subMeshGlobalId);
+  devicePool_.insert_or_assign(subMeshGlobalId, subMesh);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCreateSubMeshDeviceResponse,
+                    commandId, subMesh);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::ReleaseSubMeshDeviceCommand *command) {
+
+  uint32_t subMeshGlobalId = command->sub_mesh()->global_id();
+
+  ::tt::runtime::Device subMesh = devicePool_.at(subMeshGlobalId);
+  LOG_ASSERT(subMesh.getGlobalId() == subMeshGlobalId,
+             "Submesh global id mismatch");
+
+  ::tt::runtime::releaseSubMeshDevice(subMesh);
+  devicePool_.erase(subMeshGlobalId);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildReleaseSubMeshDeviceResponse,
+                    commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetMeshShapeCommand *command) {
+
+  ::tt::runtime::Device device = devicePool_.at(command->device()->global_id());
+
+  std::vector<uint32_t> shape = ::tt::runtime::getMeshShape(device);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetMeshShapeResponse, commandId,
+                    shape);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::CreateHostTensorCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint64_t tensorGlobalId = command->output_global_id();
   const uint8_t *tensorData = command->data()->data();
   std::vector<uint32_t> shape(command->shape()->begin(),
@@ -225,15 +334,72 @@ void CommandExecutor::execute(uint64_t commandId,
 
   tensorPool_.insert_or_assign(tensorGlobalId, tensor);
 
-  ResponseFactory::buildCreateHostTensorResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCreateHostTensorResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::IsTensorAllocatedCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+
+  bool allocated =
+      tensorPool_.contains(tensorGlobalId)
+          ? ::tt::runtime::isTensorAllocated(tensorPool_.at(tensorGlobalId))
+          : false;
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildIsTensorAllocatedResponse, commandId,
+                    allocated);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetTensorVolumeCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  uint32_t volume = ::tt::runtime::getTensorVolume(tensor);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetTensorVolumeResponse, commandId,
+                    volume);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetTensorRetainCommand *command) {
+
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  bool retain = ::tt::runtime::getTensorRetain(tensor);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetTensorRetainResponse, commandId,
+                    retain);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::SetTensorRetainCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  ::tt::runtime::setTensorRetain(tensor, command->retain());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSetTensorRetainResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetLayoutCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   ::tt::runtime::Binary binary =
       getOrCreateBinary(command->binary(), command->binary_id());
@@ -244,15 +410,14 @@ void CommandExecutor::execute(uint64_t commandId,
   layout.setGlobalId(command->output_layout_id());
   layoutPool_.insert_or_assign(command->output_layout_id(), layout);
 
-  ResponseFactory::buildGetLayoutResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetLayoutResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::ToLayoutCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   uint64_t inputGlobalId = command->input_global_id();
   uint64_t outputGlobalId = command->output_global_id();
@@ -274,15 +439,14 @@ void CommandExecutor::execute(uint64_t commandId,
 
   tensorPool_.insert_or_assign(outputGlobalId, resultTensor);
 
-  ResponseFactory::buildToLayoutResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildToLayoutResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::SubmitCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   ::tt::runtime::Device device = devicePool_.at(command->device()->global_id());
 
@@ -309,29 +473,28 @@ void CommandExecutor::execute(uint64_t commandId,
                                  outputTensors[i]);
   }
 
-  ResponseFactory::buildSubmitResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSubmitResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetNumShardsCommand *command) {
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
   uint64_t tensorGlobalId = command->input_global_id();
   ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
 
   uint32_t numBuffers = ::tt::runtime::detail::getNumShards(tensor);
 
-  ResponseFactory::buildGetNumShardsResponse(*responseBuilder, commandId,
-                                             numBuffers);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetNumShardsResponse, commandId,
+                    numBuffers);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::ToHostCommand *command) {
-
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
   uint64_t inputGlobalId = command->input_global_id();
 
@@ -355,15 +518,14 @@ void CommandExecutor::execute(uint64_t commandId,
                                  outputTensors[i]);
   }
 
-  ResponseFactory::buildToHostResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildToHostResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
 
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::MemcpyCommand *command) {
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
   uint64_t srcGlobalId = command->src_global_id();
   ::tt::runtime::Tensor srcTensor = tensorPool_.at(srcGlobalId);
 
@@ -391,8 +553,27 @@ void CommandExecutor::execute(uint64_t commandId,
     ::tt::runtime::memcpy(dstDataBuffer.value().data(), srcTensor, dstDataType);
   }
 
-  ResponseFactory::buildMemcpyResponse(*responseBuilder, commandId,
-                                       dstDataBuffer);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildMemcpyResponse, commandId,
+                    dstDataBuffer);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::DeallocateTensorCommand *command) {
+  uint64_t tensorGlobalId = command->tensor_global_id();
+  ::tt::runtime::Tensor tensor = tensorPool_.at(tensorGlobalId);
+
+  if (::tt::runtime::getTensorRetain(tensor)) {
+    LOG_WARNING("Tensor is retained, will not be deallocated");
+  } else {
+    ::tt::runtime::deallocateTensor(tensor, command->force());
+    tensorPool_.erase(tensorGlobalId);
+  }
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildDeallocateTensorResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -402,8 +583,8 @@ void CommandExecutor::execute(uint64_t commandId,
 
   LOG_INFO("Shutdown command received, shutting down command executor");
 
-  auto responseBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-  ResponseFactory::buildShutdownResponse(*responseBuilder, commandId);
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildShutdownResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 
@@ -416,9 +597,21 @@ void CommandExecutor::execute(uint64_t commandId,
 
 void CommandExecutor::executeCommand(const fb::Command *command) {
   switch (command->type_type()) {
+  case fb::CommandType::ConfigureRuntimeContextCommand: {
+    return execute(command->command_id(),
+                   command->type_as_ConfigureRuntimeContextCommand());
+  }
   case fb::CommandType::GetSystemDescCommand: {
     return execute(command->command_id(),
                    command->type_as_GetSystemDescCommand());
+  }
+  case fb::CommandType::SetFabricConfigCommand: {
+    return execute(command->command_id(),
+                   command->type_as_SetFabricConfigCommand());
+  }
+  case fb::CommandType::GetNumAvailableDevicesCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetNumAvailableDevicesCommand());
   }
   case fb::CommandType::OpenMeshDeviceCommand: {
     return execute(command->command_id(),
@@ -428,9 +621,37 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
     return execute(command->command_id(),
                    command->type_as_CloseMeshDeviceCommand());
   }
+  case fb::CommandType::CreateSubMeshDeviceCommand: {
+    return execute(command->command_id(),
+                   command->type_as_CreateSubMeshDeviceCommand());
+  }
+  case fb::CommandType::ReleaseSubMeshDeviceCommand: {
+    return execute(command->command_id(),
+                   command->type_as_ReleaseSubMeshDeviceCommand());
+  }
+  case fb::CommandType::GetMeshShapeCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetMeshShapeCommand());
+  }
   case fb::CommandType::CreateHostTensorCommand: {
     return execute(command->command_id(),
                    command->type_as_CreateHostTensorCommand());
+  }
+  case fb::CommandType::IsTensorAllocatedCommand: {
+    return execute(command->command_id(),
+                   command->type_as_IsTensorAllocatedCommand());
+  }
+  case fb::CommandType::GetTensorVolumeCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetTensorVolumeCommand());
+  }
+  case fb::CommandType::GetTensorRetainCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetTensorRetainCommand());
+  }
+  case fb::CommandType::SetTensorRetainCommand: {
+    return execute(command->command_id(),
+                   command->type_as_SetTensorRetainCommand());
   }
   case fb::CommandType::GetLayoutCommand: {
     return execute(command->command_id(), command->type_as_GetLayoutCommand());
@@ -450,6 +671,10 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
   }
   case fb::CommandType::MemcpyCommand: {
     return execute(command->command_id(), command->type_as_MemcpyCommand());
+  }
+  case fb::CommandType::DeallocateTensorCommand: {
+    return execute(command->command_id(),
+                   command->type_as_DeallocateTensorCommand());
   }
   case fb::CommandType::ShutdownCommand: {
     return execute(command->command_id(), command->type_as_ShutdownCommand());

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -194,9 +194,9 @@ void setCurrentHostRuntime(const HostRuntime &runtime) {
   LOG_FATAL("Runtime is not enabled");
 }
 
-SystemDesc
-getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
-                     std::optional<Device> meshDevice) {
+SystemDesc getCurrentSystemDesc(
+    std::optional<tt::runtime::DispatchCoreType> dispatchCoreType,
+    std::optional<Device> meshDevice) {
 
   using RetType = SystemDesc;
   return DISPATCH_TO_CURRENT_RUNTIME(
@@ -379,8 +379,7 @@ bool isTensorAllocated(Tensor tensor) {
         return ::tt::runtime::ttmetal::isTensorAllocated(tensor);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("isTensorAllocated",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::isTensorAllocated(tensor);
       });
 }
 
@@ -458,8 +457,7 @@ std::uint32_t getTensorVolume(Tensor t) {
       [&]() -> RetType { return ::tt::runtime::ttnn::getTensorVolume(t); },
       [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorVolume(t); },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getTensorVolume",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getTensorVolume(t);
       });
 }
 
@@ -483,8 +481,7 @@ bool getTensorRetain(Tensor tensor) {
         return ::tt::runtime::ttmetal::getTensorRetain(tensor);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getTensorRetain",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getTensorRetain(tensor);
       });
 }
 
@@ -493,14 +490,11 @@ void setTensorRetain(Tensor tensor, bool retain) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::setTensorRetain(tensor, retain); },
       [&]() { ::tt::runtime::ttmetal::setTensorRetain(tensor, retain); },
-      [&]() {
-        detail::fatalNotImplemented("setTensorRetain",
-                                    HostRuntime::Distributed);
-      });
+      [&]() { ::tt::runtime::distributed::setTensorRetain(tensor, retain); });
 }
 
-Arch getArch() {
-  using RetType = Arch;
+tt::target::Arch getArch() {
+  using RetType = tt::target::Arch;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() -> RetType { return ::tt::runtime::ttnn::getArch(); },
       [&]() -> RetType { return ::tt::runtime::ttmetal::getArch(); },
@@ -542,8 +536,7 @@ size_t getNumAvailableDevices() {
         return ::tt::runtime::ttmetal::getNumAvailableDevices();
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getNumAvailableDevices",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getNumAvailableDevices();
       });
 }
 
@@ -583,8 +576,8 @@ Device createSubMeshDevice(
             parentMesh, meshShape, meshOffset);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("createSubMeshDevice",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::createSubMeshDevice(
+            parentMesh, meshShape, meshOffset);
       });
 }
 
@@ -593,10 +586,7 @@ void releaseSubMeshDevice(Device subMesh) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::releaseSubMeshDevice(subMesh); },
       [&]() { ::tt::runtime::ttmetal::releaseSubMeshDevice(subMesh); },
-      [&]() {
-        detail::fatalNotImplemented("releaseSubMeshDevice",
-                                    HostRuntime::Distributed);
-      });
+      [&]() { ::tt::runtime::distributed::releaseSubMeshDevice(subMesh); });
 }
 
 void reshapeMeshDevice(Device meshDevice,
@@ -625,7 +615,7 @@ std::vector<uint32_t> getMeshShape(Device meshDevice) {
         return ::tt::runtime::ttmetal::getMeshShape(meshDevice);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("getMeshShape", HostRuntime::Distributed);
+        return ::tt::runtime::distributed::getMeshShape(meshDevice);
       });
 }
 
@@ -916,7 +906,7 @@ void memcpy(void *dst, Tensor src,
       RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src, dstDataType); },
       [&]() { ::tt::runtime::ttmetal::memcpy(dst, src, dstDataType); },
       [&]() -> RetType {
-        return ::tt::runtime::distributed::memcpy(dst, src, dstDataType);
+        ::tt::runtime::distributed::memcpy(dst, src, dstDataType);
       });
 }
 
@@ -925,9 +915,7 @@ void memcpy(Tensor dst, Tensor src) {
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src); },
       [&]() { ::tt::runtime::ttmetal::memcpy(dst, src); },
-      [&]() -> RetType {
-        detail::fatalNotImplemented("memcpy", HostRuntime::Distributed);
-      });
+      [&]() -> RetType { ::tt::runtime::distributed::memcpy(dst, src); });
 }
 
 void deallocateTensor(Tensor &tensor, bool force) {
@@ -936,8 +924,7 @@ void deallocateTensor(Tensor &tensor, bool force) {
       RetType, [&]() { ::tt::runtime::ttnn::deallocateTensor(tensor, force); },
       [&]() { ::tt::runtime::ttmetal::deallocateTensor(tensor, force); },
       [&]() -> RetType {
-        detail::fatalNotImplemented("deallocateTensor",
-                                    HostRuntime::Distributed);
+        ::tt::runtime::distributed::deallocateTensor(tensor, force);
       });
 }
 
@@ -1070,7 +1057,7 @@ void updateTensorInPool(CallbackContext programContextHandle,
       });
 }
 
-void setFabricConfig(FabricConfig config) {
+void setFabricConfig(tt::runtime::FabricConfig config) {
   using RetType = void;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
@@ -1079,8 +1066,7 @@ void setFabricConfig(FabricConfig config) {
         return ::tt::runtime::ttmetal::setFabricConfig(config);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("setFabricConfig",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::setFabricConfig(config);
       });
 }
 

--- a/runtime/lib/ttmetal/CMakeLists.txt
+++ b/runtime/lib/ttmetal/CMakeLists.txt
@@ -20,9 +20,10 @@ set_property(TARGET TTRuntimeTTMetal PROPERTY CXX_STANDARD 20)
 target_compile_definitions(TTRuntimeTTMetal PUBLIC TT_RUNTIME_ENABLE_TTMETAL)
 target_include_directories(TTRuntimeTTMetal PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTMetal SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 target_link_libraries(TTRuntimeTTMetal PUBLIC TTMETAL_LIBRARY DEVICE_LIBRARY)
 target_link_libraries(TTRuntimeTTMetal PUBLIC coverage_config)
-add_dependencies(TTRuntimeTTMetal TTMETAL_LIBRARY DEVICE_LIBRARY tt-metal FBS_GENERATION)
+add_dependencies(TTRuntimeTTMetal TTMETAL_LIBRARY DEVICE_LIBRARY tt-metal FBS_GENERATION RUNTIME_FBS_GENERATION)

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -229,8 +229,8 @@ void setTensorRetain(Tensor tensor, bool retain) {
   LOG_FATAL("setTensorRetain not implemented for metal runtime");
 }
 
-Arch getArch() {
-  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+tt::target::Arch getArch() {
+  return ::tt::runtime::common::toTargetArch(::tt::tt_metal::hal::get_arch());
 }
 
 void enablePersistentKernelCache() {
@@ -477,8 +477,8 @@ getMemoryView(Device deviceHandle) {
   return memoryMap;
 }
 
-void setFabricConfig(FabricConfig config) {
-  ::tt::tt_fabric::SetFabricConfig(common::toTTFabricConfig(config));
+void setFabricConfig(tt::runtime::FabricConfig config) {
+  ::tt::tt_fabric::SetFabricConfig(common::toMetalFabricConfig(config));
   RuntimeContext::instance().setCurrentFabricConfig(config);
 }
 

--- a/runtime/lib/ttnn/CMakeLists.txt
+++ b/runtime/lib/ttnn/CMakeLists.txt
@@ -23,9 +23,10 @@ add_library(TTRuntimeTTNN
 set_property(TARGET TTRuntimeTTNN PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeTTNN PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNN SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 target_link_libraries(TTRuntimeTTNN PUBLIC TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
 target_link_libraries(TTRuntimeTTNN PUBLIC coverage_config)
-add_dependencies(TTRuntimeTTNN TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
+add_dependencies(TTRuntimeTTNN TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils RUNTIME_FBS_GENERATION)

--- a/runtime/lib/ttnn/debug/CMakeLists.txt
+++ b/runtime/lib/ttnn/debug/CMakeLists.txt
@@ -13,9 +13,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNDebug PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNDebug SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-add_dependencies(TTRuntimeTTNNDebug TTRuntimeTTNNUtils)
+add_dependencies(TTRuntimeTTNNDebug TTRuntimeTTNNUtils RUNTIME_FBS_GENERATION)
 target_link_libraries(TTRuntimeTTNNDebug PUBLIC TTRuntimeTTNNUtils)
 target_link_libraries(TTRuntimeTTNNDebug PUBLIC coverage_config)

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -95,6 +95,7 @@ target_include_directories(TTRuntimeTTNNOps PRIVATE
 )
 target_include_directories(TTRuntimeTTNNOps PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -103,4 +104,4 @@ target_link_libraries(TTRuntimeTTNNOps PUBLIC TTNN_LIBRARY TTRuntimeTTNNDebug TT
 target_link_libraries(TTRuntimeTTNNOps PUBLIC coverage_config)
 
 
-add_dependencies(TTRuntimeTTNNOps TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNTypes TTRuntimeTTNNDebug)
+add_dependencies(TTRuntimeTTNNOps TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNTypes TTRuntimeTTNNDebug RUNTIME_FBS_GENERATION)

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -144,7 +144,7 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
   // If blackhole workarounds are enabled, only untilize on device if the
   // architecture is not blackhole
   if (::tt::runtime::workaround::Env::get().blackholeWorkarounds) {
-    untilizeOnDevice &= getArch() != ::tt::runtime::Arch::BLACKHOLE;
+    untilizeOnDevice &= getArch() != ::tt::target::Arch::Blackhole;
   }
   if (untilizeOnDevice) {
     ::ttnn::Tensor hostTensor = ::ttnn::from_device(
@@ -451,8 +451,8 @@ void setTensorRetain(::tt::runtime::Tensor tensor, bool retain) {
   return tensorWrapper.setRetain(retain);
 }
 
-Arch getArch() {
-  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+tt::target::Arch getArch() {
+  return ::tt::runtime::common::toTargetArch(::tt::tt_metal::hal::get_arch());
 }
 
 void enablePersistentKernelCache() {
@@ -706,8 +706,8 @@ getMemoryView(Device deviceHandle) {
   return memoryMap;
 }
 
-void setFabricConfig(FabricConfig config) {
-  ::tt::tt_fabric::SetFabricConfig(common::toTTFabricConfig(config));
+void setFabricConfig(tt::runtime::FabricConfig config) {
+  ::tt::tt_fabric::SetFabricConfig(common::toMetalFabricConfig(config));
   RuntimeContext::instance().setCurrentFabricConfig(config);
 }
 

--- a/runtime/lib/ttnn/types/CMakeLists.txt
+++ b/runtime/lib/ttnn/types/CMakeLists.txt
@@ -15,9 +15,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNTypes PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNTypes SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-add_dependencies(TTRuntimeTTNNTypes TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNDebug)
+add_dependencies(TTRuntimeTTNNTypes TTNN_LIBRARY tt-metal FBS_GENERATION RUNTIME_FBS_GENERATION TTRuntimeTTNNDebug)
 target_link_libraries(TTRuntimeTTNNTypes PUBLIC TTNN_LIBRARY TTRuntimeTTNNDebug)
 target_link_libraries(TTRuntimeTTNNTypes PUBLIC coverage_config)

--- a/runtime/lib/ttnn/utils/CMakeLists.txt
+++ b/runtime/lib/ttnn/utils/CMakeLists.txt
@@ -13,9 +13,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNUtils PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNUtils SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-add_dependencies(TTRuntimeTTNNUtils TTNN_LIBRARY tt-metal FBS_GENERATION)
+add_dependencies(TTRuntimeTTNNUtils TTNN_LIBRARY tt-metal FBS_GENERATION RUNTIME_FBS_GENERATION)
 target_link_libraries(TTRuntimeTTNNUtils PUBLIC TTNN_LIBRARY PRIVATE TTRuntimeTypes)
 target_link_libraries(TTRuntimeTTNNUtils PUBLIC coverage_config)

--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(_ttmlir_runtime
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 
@@ -56,6 +57,7 @@ if (TTMLIR_ENABLE_RUNTIME)
     SYSTEM PRIVATE ${pybind11_INCLUDE_DIRS}
     PRIVATE
       ${PROJECT_SOURCE_DIR}/runtime/include
+      ${PROJECT_BINARY_DIR}/runtime/include
       ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
       ${PROJECT_SOURCE_DIR}/runtime/python/include
   )

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -255,8 +255,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       .value("MultiProcess", ::tt::runtime::DistributedMode::MultiProcess);
 
   nb::enum_<::tt::runtime::DispatchCoreType>(m, "DispatchCoreType")
-      .value("WORKER", ::tt::runtime::DispatchCoreType::WORKER)
-      .value("ETH", ::tt::runtime::DispatchCoreType::ETH);
+      .value("WORKER", ::tt::runtime::DispatchCoreType::Worker)
+      .value("ETH", ::tt::runtime::DispatchCoreType::Ethernet);
 
   nb::enum_<::tt::runtime::FabricConfig>(m, "FabricConfig")
       .value("DISABLED", ::tt::runtime::FabricConfig::DISABLED)
@@ -279,11 +279,10 @@ void registerRuntimeBindings(nb::module_ &m) {
              ::tt::runtime::FabricConfig::FABRIC_2D_DYNAMIC_TORUS_XY)
       .value("CUSTOM", ::tt::runtime::FabricConfig::CUSTOM);
 
-  nb::enum_<::tt::runtime::Arch>(m, "Arch")
-      .value("GRAYSKULL", ::tt::runtime::Arch::GRAYSKULL)
-      .value("WORMHOLE_B0", ::tt::runtime::Arch::WORMHOLE_B0)
-      .value("BLACKHOLE", ::tt::runtime::Arch::BLACKHOLE)
-      .value("QUASAR", ::tt::runtime::Arch::QUASAR);
+  nb::enum_<::tt::target::Arch>(m, "Arch")
+      .value("GRAYSKULL", ::tt::target::Arch::Grayskull)
+      .value("WORMHOLE_B0", ::tt::target::Arch::Wormhole_b0)
+      .value("BLACKHOLE", ::tt::target::Arch::Blackhole);
 
   m.def("set_mlir_home", &tt::runtime::setMlirHome, nb::arg("mlir_home"),
         "Set the MLIR home directory");

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -14,10 +14,11 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
 endif()
 target_include_directories(TTRuntimeTTNNTestLib PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_BINARY_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNTestLib SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-add_dependencies(TTRuntimeTTNNTestLib TTRuntimeTTNNUtils FBS_GENERATION)
+add_dependencies(TTRuntimeTTNNTestLib TTRuntimeTTNNUtils FBS_GENERATION RUNTIME_FBS_GENERATION)
 target_link_libraries(TTRuntimeTTNNTestLib PUBLIC TTRuntimeTTNNUtils)
 
 set(TTMLIR_RUNTIME_TEST_TTNN_PUBLIC_HEADERS

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -5,16 +5,19 @@
 import os
 import json
 import pytest
+import torch
 import ttrt
 import ttrt.runtime
 from ttrt.common.util import *
 from ...utils import (
     TT_MLIR_HOME,
     TT_METAL_HOME_EXTERNAL,
+    Storage,
     DeviceContext,
     ProgramTestConfig,
     ProgramTestRunner,
     subprocess_get_system_descriptor,
+    get_runtime_tensor_from_torch,
     get_torch_output_container,
     assert_pcc,
 )
@@ -26,12 +29,7 @@ FLATBUFFER_BASE_PATH = (
 RANK_BINDING_PATH = f"{TT_METAL_HOME_EXTERNAL}/tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"
 
 
-@pytest.mark.xfail(
-    reason="TODO(#5320): System descriptor returned is local per host process, we need unification logic to merge them"
-)
-def test_system_desc(request):
-    system_desc_local = subprocess_get_system_descriptor(request)
-
+def launch_distributed_runtime():
     assert os.path.exists(
         RANK_BINDING_PATH
     ), f"Rank binding path not found: {RANK_BINDING_PATH}"
@@ -45,14 +43,112 @@ def test_system_desc(request):
     distributed_options = ttrt.runtime.DistributedOptions()
     distributed_options.mode = ttrt.runtime.DistributedMode.MultiProcess
     distributed_options.multi_process_args = mp_args
-
     ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Distributed)
     ttrt.runtime.launch_distributed_runtime(distributed_options)
+
+
+def shutdown_distributed_runtime():
+    ttrt.runtime.shutdown_distributed_runtime()
+    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Local)
+
+
+@pytest.mark.xfail(
+    reason="TODO(#5320): System descriptor returned is local per host process, we need unification logic to merge them"
+)
+def test_system_desc(request):
+    system_desc_local = subprocess_get_system_descriptor(request)
+
+    launch_distributed_runtime()
+
     system_desc = ttrt.runtime.get_current_system_desc()
     assert system_desc is not None
-    ttrt.runtime.shutdown_distributed_runtime()
+
+    shutdown_distributed_runtime()
 
     assert system_desc.as_json() == system_desc_local.as_json()
+
+
+def test_get_num_devices():
+    launch_distributed_runtime()
+
+    num_devices = ttrt.runtime.get_num_available_devices()
+    assert num_devices == 8
+
+    shutdown_distributed_runtime()
+
+
+@pytest.mark.parametrize("mesh_shape", ["1x8"])
+def test_get_mesh_shape(mesh_shape):
+    launch_distributed_runtime()
+
+    mesh_shape_list = list(map(int, mesh_shape.split("x")))
+
+    with DeviceContext(mesh_shape=mesh_shape_list) as device:
+        device_mesh_shape = device.get_mesh_shape()
+        assert device_mesh_shape == mesh_shape_list
+
+    shutdown_distributed_runtime()
+
+
+def test_tensor_retain():
+    launch_distributed_runtime()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(1, 1), storage=Storage.Owned)
+    tensor.set_retain(True)
+
+    assert tensor.get_retain() == True
+
+    tensor.set_retain(False)
+    assert tensor.get_retain() == False
+
+    shutdown_distributed_runtime()
+
+
+def test_get_tensor_volume():
+    launch_distributed_runtime()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(177, 211), storage=Storage.Owned)
+    assert tensor.get_volume() == 177 * 211
+
+    shutdown_distributed_runtime()
+
+
+def test_memcpy():
+    launch_distributed_runtime()
+
+    ones_tensor = torch.ones(177, 211)
+    zeros_tensor = torch.zeros(177, 211)
+
+    tensor1 = get_runtime_tensor_from_torch(ones_tensor, storage=Storage.Owned)
+    tensor2 = get_runtime_tensor_from_torch(zeros_tensor, storage=Storage.Owned)
+
+    # Copy from tensor1 to tensor2
+    ttrt.runtime.memcpy(tensor2, tensor1)
+
+    output_torch_tensor = torch.randn(177, 211)
+
+    # Copy from tensor2 to output_torch_tensor
+    ttrt.runtime.memcpy(output_torch_tensor.data_ptr(), tensor2)
+
+    assert torch.allclose(output_torch_tensor, ones_tensor)
+
+    shutdown_distributed_runtime()
+
+
+def test_deallocate():
+    launch_distributed_runtime()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(177, 211), storage=Storage.Owned)
+
+    ttrt.runtime.deallocate_tensor(tensor)
+    assert not tensor.is_allocated()
+
+    tensor = get_runtime_tensor_from_torch(torch.randn(177, 211), storage=Storage.Owned)
+    tensor.set_retain(True)
+    ttrt.runtime.deallocate_tensor(tensor)
+    assert tensor.is_allocated()
+
+    shutdown_distributed_runtime()
 
 
 @pytest.mark.parametrize("num_loops", [64])
@@ -88,18 +184,7 @@ def test_flatbuffer_execution(request, num_loops, mesh_shape):
 
     test_runner = ProgramTestRunner(test_config, binary, 0)
 
-    ttrt.runtime.set_mlir_home(TT_MLIR_HOME)
-    ttrt.runtime.set_metal_home(TT_METAL_HOME_EXTERNAL)
-
-    mp_args = ttrt.runtime.MultiProcessArgs.create(RANK_BINDING_PATH)
-    mp_args.with_allow_run_as_root(True)
-
-    distributed_options = ttrt.runtime.DistributedOptions()
-    distributed_options.mode = ttrt.runtime.DistributedMode.MultiProcess
-    distributed_options.multi_process_args = mp_args
-
-    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Distributed)
-    ttrt.runtime.launch_distributed_runtime(distributed_options)
+    launch_distributed_runtime()
 
     with DeviceContext(mesh_shape=mesh_shape_list) as device:
         inputs_runtime_with_layout, golden = test_runner.get_inputs_and_golden(
@@ -112,13 +197,103 @@ def test_flatbuffer_execution(request, num_loops, mesh_shape):
 
         outputs = []
         for i in range(num_loops):
-            output = test_runner.run_program(device, inputs_runtime_with_layout)
+            output = test_runner.submit_program(device, inputs_runtime_with_layout)
             outputs.append(output)
 
         for output in outputs:
             output_torch = get_torch_output_container(test_runner.program)
-            ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
             assert_pcc(output_torch, golden)
 
-    ttrt.runtime.shutdown_distributed_runtime()
-    ttrt.runtime.set_current_host_runtime(ttrt.runtime.HostRuntime.Local)
+    shutdown_distributed_runtime()
+
+
+@pytest.mark.parametrize("num_loops", [64])
+def test_flatbuffer_execution_dp(request, num_loops):
+    assert os.path.exists(
+        RANK_BINDING_PATH
+    ), f"Rank binding path not found: {RANK_BINDING_PATH}"
+
+    binary_path = os.path.join(FLATBUFFER_BASE_PATH, "simple_add_1x2.mlir.tmp.ttnn")
+
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+
+    test_config = ProgramTestConfig(
+        name="simple_add_dp",
+        expected_num_inputs=2,
+        compute_golden=lambda inputs: (inputs[0] + inputs[1]),
+        description="Simple add distributed data parallel test",
+    )
+
+    logger = Logger()
+    file_manager = FileManager(logger)
+    binary = Binary(logger, file_manager, binary_path)
+
+    curr_system_desc = json.loads(subprocess_get_system_descriptor(request).as_json())
+    binary_system_desc = binary.system_desc_dict
+
+    assert (
+        curr_system_desc["system_desc"] == binary_system_desc
+    ), "System descriptor mismatch"
+
+    test_runner = ProgramTestRunner(test_config, binary, 0)
+
+    launch_distributed_runtime()
+
+    with DeviceContext(mesh_shape=[2, 4]) as device:
+
+        submesh1 = ttrt.runtime.create_sub_mesh_device(
+            device, mesh_shape=[1, 2], mesh_offset=[0, 1]
+        )
+        submesh2 = ttrt.runtime.create_sub_mesh_device(
+            device, mesh_shape=[1, 2], mesh_offset=[1, 1]
+        )
+
+        (
+            inputs_runtime_with_layout_submesh1,
+            golden1,
+        ) = test_runner.get_inputs_and_golden(submesh1, borrow=False)
+        (
+            inputs_runtime_with_layout_submesh2,
+            golden2,
+        ) = test_runner.get_inputs_and_golden(submesh2, borrow=False)
+
+        # Synchronous back to back execution
+        for i in range(num_loops):
+            test_runner.run_program_and_compare_golden(
+                submesh1, inputs_runtime_with_layout_submesh1, golden1
+            )
+            test_runner.run_program_and_compare_golden(
+                submesh2, inputs_runtime_with_layout_submesh2, golden2
+            )
+
+        # Asynchronous data parallel execution
+        outputs_submesh1 = []
+        outputs_submesh2 = []
+        for i in range(num_loops):
+            output1 = test_runner.submit_program(
+                submesh1, inputs_runtime_with_layout_submesh1
+            )
+            output2 = test_runner.submit_program(
+                submesh2, inputs_runtime_with_layout_submesh2
+            )
+            outputs_submesh1.append(output1)
+            outputs_submesh2.append(output2)
+
+        for output in outputs_submesh1:
+            output_torch = get_torch_output_container(test_runner.program)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
+            assert_pcc(output_torch, golden1)
+
+        for output in outputs_submesh2:
+            output_torch = get_torch_output_container(test_runner.program)
+            output_host = ttrt.runtime.to_host(output, untilize=True, blocking=True)[0]
+            ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
+            assert_pcc(output_torch, golden2)
+
+        ttrt.runtime.release_sub_mesh_device(submesh1)
+        ttrt.runtime.release_sub_mesh_device(submesh2)
+
+    shutdown_distributed_runtime()

--- a/runtime/test/ttnn/python/utils.py
+++ b/runtime/test/ttnn/python/utils.py
@@ -102,10 +102,13 @@ class ProgramTestRunner:
 
         return inputs_runtime_with_layout, golden
 
+    def submit_program(self, device, inputs):
+        return ttrt.runtime.submit(device, self.binary.fbb, self.program_index, inputs)[
+            0
+        ]
+
     def run_program(self, device, inputs, blocking_to_host=True):
-        output = ttrt.runtime.submit(
-            device, self.binary.fbb, self.program_index, inputs
-        )[0]
+        output = self.submit_program(device, inputs)
         output = ttrt.runtime.to_host(output, untilize=True, blocking=blocking_to_host)[
             0
         ]

--- a/test/ttmlir/Runtime/TTNN/llmbox/binary/simple_add_1x2.mlir
+++ b/test/ttmlir/Runtime/TTNN/llmbox/binary/simple_add_1x2.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,2" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
+  func.func public @main(%arg0: tensor<1024x2048xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<1024x2048xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<1024x2048xf32> {jax.result_info = "", ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %1 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x2048xf32>) -> tensor<1024x1024xf32>
+    // CHECK: "ttnn.mesh_shard"
+    %3 = "ttir.mesh_shard"(%arg1) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x2048xf32>) -> tensor<1024x1024xf32>
+    // CHECK: "ttnn.mesh_shard"
+    %4 = ttir.empty() : tensor<1024x1024xf32>
+    %5 = "ttir.add"(%1, %3, %4) : (tensor<1024x1024xf32>, tensor<1024x1024xf32>, tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+    %7 = "ttir.mesh_shard"(%5) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 2, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1024x1024xf32>) -> tensor<1024x2048xf32>
+    // CHECK: "ttnn.mesh_shard"
+    return %7 : tensor<1024x2048xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
Part of #4485 

### Problem description
Now that we have the runtime worker and controller implemented, the next step is to have a POC test running from tt-xla through the distributed runtime

### What's changed
* Added a public facing `include/tt/runtime/flatbuffers/types.fbs` that contains flatbuffer implementations of runtime types. This is needed because many runtime types will now need to have a serialized form. Enum-types specifically can be completely moved to flatbuffer since they evaluate directly to C++ enums anyway.

* Implemented `createSubmeshDevice`, `releaseSubmeshDevice`, `getTensorRetain`, `setTensorRetain`, `getTensorVolume`, `getMeshShape`, `setFabricConfig`, `getNumAvailableDevices`, `deallocateTensor`, `isTensorAllocated` through the distributed path. These APIs are needed by tt-xla.

* Added tests for the above APIs, as well as a data-parallel test running through submeshes now that `createSubmeshDevice`, `releaseSubmeshDevice` are implemented.

* Cleaned up and unified some command/response creation logic to eliminate code duplication.

### Checklist
- [X] New/Existing tests provide coverage for changes
