### PR TITLE
Formatting generated code

### DIFF
--- a/tools/tt-alchemist/csrc/include/utils.hpp
+++ b/tools/tt-alchemist/csrc/include/utils.hpp
@@ -35,6 +35,8 @@ bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
 bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
                  CodeGenerationTarget target,
                  const std::string &pipelineOptions = "");
+
+void formatCode(const fs::path &dirOrFilePath, CodeGenerationTarget target);
 } // namespace tt::alchemist::utils
 
 #endif // TT_ALCHEMIST_UTILS_HPP

--- a/tools/tt-alchemist/csrc/lib/generate_cpp.cpp
+++ b/tools/tt-alchemist/csrc/lib/generate_cpp.cpp
@@ -121,6 +121,8 @@ bool TTAlchemist::generateCpp(const std::string &input_file,
 
   cppFile.close();
 
+  utils::formatCode(cppFilePath, utils::CodeGenerationTarget::Cpp);
+
   return true;
 }
 

--- a/tools/tt-alchemist/csrc/lib/generate_python.cpp
+++ b/tools/tt-alchemist/csrc/lib/generate_python.cpp
@@ -117,16 +117,7 @@ bool TTAlchemist::generatePython(const std::string &input_file,
 
   pythonFile.close();
 
-  // Format the generated Python code using black
-  //
-  std::string formatCommand = "black " + pythonFilePath.string() + " 2>&1";
-  int formatResult = std::system(formatCommand.c_str());
-  if (formatResult != 0) {
-    std::cout << "Warning: Failed to format Python file with black (exit code: "
-              << formatResult << ")" << std::endl;
-    std::cout << "The generated Python code is still available at: "
-              << pythonFilePath << std::endl;
-  }
+  utils::formatCode(pythonFilePath, utils::CodeGenerationTarget::Python);
 
   return true;
 }

--- a/tools/tt-alchemist/csrc/lib/utils.cpp
+++ b/tools/tt-alchemist/csrc/lib/utils.cpp
@@ -77,4 +77,30 @@ bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
   std::string pipelineName = getPipelineName(module, target);
   return runPipeline(pm, module, pipelineName, pipelineOptions);
 }
+
+void formatCode(const fs::path &filePath, CodeGenerationTarget target) {
+  if (target == CodeGenerationTarget::Python) {
+    std::string formatCommand = "black --quiet " + filePath.string() + " 2>&1";
+    int formatResult = std::system(formatCommand.c_str());
+    if (formatResult != 0) {
+      std::cout
+          << "Warning: Failed to format Python file with black (exit code: "
+          << formatResult << ")" << std::endl;
+      std::cout << "The generated Python code is still available at: "
+                << filePath << std::endl;
+    }
+  } else if (target == CodeGenerationTarget::Cpp) {
+    std::string formatCommand =
+        "clang-format -i " + filePath.string() + " > /dev/null 2>&1";
+    int formatResult = std::system(formatCommand.c_str());
+    if (formatResult != 0) {
+      std::cout
+          << "Warning: Failed to format C++ file with clang-format (exit code: "
+          << formatResult << ")" << std::endl;
+      std::cout << "The generated C++ code is still available at: " << filePath
+                << std::endl;
+    }
+  }
+}
+
 } // namespace tt::alchemist::utils

--- a/tools/tt-alchemist/python/pyproject.toml
+++ b/tools/tt-alchemist/python/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
   "click>=7.0",
   "black>=22.3.0",
+  "clang-format>=18.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, the Python code that has been emitted is somewhat unreadable as it contains long and unformatted lines.

### What's changed
Added the ability in the tt-alchemist tool to format the output Python code using black.

Example of newly generated code:
```Python
import ttnn
import my_get_device
import utils


def forward(v1):
    v2 = v1[0]
    v3 = v1[1]
    v4 = v1[2]
    v5 = v1[3]
    v6 = v1[4]
    v7 = v1[5]
    v8 = v1[6]
    v9 = ttnn.linear(
        v2,
        v3,
        bias=v4,
        transpose_a=False,
        transpose_b=False,
        memory_config=ttnn.MemoryConfig(
            ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
        ),
    )
    ttnn.deallocate(v4, False)
    ttnn.deallocate(v3, False)
    ttnn.deallocate(v2, False)
    v10 = ttnn.relu(
        v9,
        memory_config=ttnn.MemoryConfig(
            ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
        ),
    )
    ttnn.deallocate(v9, False)
    v11 = ttnn.linear(
        v10,
        v5,
        bias=v6,
        transpose_a=False,
        transpose_b=False,
        memory_config=ttnn.MemoryConfig(
            ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
        ),
    )
    ttnn.deallocate(v10, False)
    ttnn.deallocate(v6, False)
    ttnn.deallocate(v5, False)
    v12 = ttnn.relu(
        v11,
        memory_config=ttnn.MemoryConfig(
            ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
        ),
    )
    ttnn.deallocate(v11, False)
    v13 = ttnn.linear(
        v12,
        v7,
        bias=v8,
        transpose_a=False,
        transpose_b=False,
        memory_config=ttnn.MemoryConfig(
            ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None
        ),
    )
    ttnn.deallocate(v12, False)
    ttnn.deallocate(v8, False)
    ttnn.deallocate(v7, False)
    v14 = [v13]
    return v14


def create_inputs_for_forward():
    v1 = my_get_device.DeviceGetter.get_device()
    v2 = ttnn.ones(
        shape=ttnn.Shape([1, 784]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v3 = ttnn.ones(
        shape=ttnn.Shape([784, 512]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v4 = ttnn.ones(
        shape=ttnn.Shape([1, 512]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v5 = ttnn.ones(
        shape=ttnn.Shape([512, 512]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v6 = ttnn.ones(
        shape=ttnn.Shape([1, 512]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v7 = ttnn.ones(
        shape=ttnn.Shape([512, 10]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v8 = ttnn.ones(
        shape=ttnn.Shape([1, 10]),
        dtype=ttnn.DataType.FLOAT32,
        layout=ttnn.Layout.TILE,
        device=v1,
    )
    v9 = [v2, v3, v4, v5, v6, v7, v8]
    return v9


def main():
    v1 = create_inputs_for_forward()
    v2 = forward(v1)
    v3 = 0
    return v3


if __name__ == "__main__":
    main()

```

### Checklist
- [ ] New/Existing tests provide coverage for changes
