### PR TITLE
Chisel docs update

### DIFF
--- a/runtime/tools/chisel/README.md
+++ b/runtime/tools/chisel/README.md
@@ -19,6 +19,8 @@ Short utilities built on **tt::runtime** for inspecting, executing, and debuggin
   - Useful for checking if the device ops works correctly and also if the decompositions are done correctly.
 
 ### Quick Start
+To run chisel, tt-mlir must be built with `-DTTMLIR_ENABLE_RUNTIME=ON` and `-DTT_RUNTIME_DEBUG=ON` flags.
+
 - First install the chisel
 
 ```bash


### PR DESCRIPTION
### Ticket
Closes #5439 

### Problem description
Without `-DTT_RUNTIME_DEBUG=ON`, Chisel was running without preop and postop hooks that trigger all Chisel functionalities.

### What's changed
Updated docs to specify enabling the mentioned build flag.
