### PR TITLE
[EmitPy] Add MeshShapeAttr conversion; propagate to get_device

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -1295,6 +1295,28 @@ struct EmitPyTypeConverter<::ttnn::operations::unary::UnaryWithParam> {
 };
 
 template <>
+struct EmitPyTypeConverter<mlir::tt::ttnn::MeshShapeAttr> {
+  static std::optional<std::string> convert(mlir::Attribute attr) {
+    if (auto meshShapeAttr =
+            mlir::dyn_cast_if_present<mlir::tt::ttnn::MeshShapeAttr>(attr)) {
+      return convert(meshShapeAttr);
+    }
+    return {};
+  }
+
+  static std::string convert(mlir::tt::ttnn::MeshShapeAttr meshShapeAttr) {
+    std::string buf;
+    llvm::raw_string_ostream rso(buf);
+    rso << "(";
+    rso << EmitPyTypeConverter<int64_t>::convert(meshShapeAttr.getY());
+    rso << ", ";
+    rso << EmitPyTypeConverter<int64_t>::convert(meshShapeAttr.getX());
+    rso << ")";
+    return buf;
+  }
+};
+
+template <>
 struct EmitPyTypeConverter<::ttnn::operations::conv::conv2d::Conv2dConfig> {
   static std::optional<std::string> convert(mlir::Attribute attr) {
     if (auto conv2dConfigAttr =

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -848,7 +848,11 @@ public:
     ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::GetDeviceOp> emitter(
         getDeviceOp, adaptor, rewriter);
 
-    emitter.replaceOp(*this, {});
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(getDeviceOp.getMeshShapeAttr()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -17,19 +17,36 @@ ttnn.point_to_point = ttnn_supplemental.point_to_point
 
 class DeviceGetter:
     _instance = None
+    _mesh_shape = None
     l1_small_size = 1 << 15
 
     def __init__(self):
         raise RuntimeError("This is Singleton, invoke get_device() instead.")
 
     @classmethod
-    def get_device(cls):
+    def get_device(cls, mesh_shape):
         if cls._instance == None:
+            if (
+                not isinstance(mesh_shape, (list, tuple))
+                or len(mesh_shape) == 0
+                or not all(isinstance(x, int) and x > 0 for x in mesh_shape)
+            ):
+                raise ValueError(
+                    f"mesh_shape must be a non-empty list or tuple of positive integers, got {mesh_shape}"
+                )
+            cls._mesh_shape = mesh_shape
             cls._instance = ttnn.open_mesh_device(
-                mesh_shape=ttnn.MeshShape(1, 1),
+                mesh_shape=ttnn.MeshShape(mesh_shape),
                 l1_small_size=cls.l1_small_size,
             )
             print(f"Device: {cls._instance}")
+
+        # Compare requested mesh_shape with _mesh_shape used to initialize the device
+        if tuple(cls._mesh_shape) != tuple(mesh_shape):
+            raise ValueError(
+                f"Device already initialized with mesh_shape={cls._mesh_shape}, but got mesh_shape={mesh_shape}"
+            )
+
         return cls._instance
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5355
Partially addressed: EmitPy is covered, while EmitC is TBD

### Problem description
Generated Py code would always open a single chip device, even when IR represents a mesh.

### What's changed
Added conversion for `MeshShapeAttr` in TTNN->EmitPy and updated alchemist template.

### Checklist
- [ ] New/Existing tests provide coverage for changes
