### PR TITLE
[TTIR Builder] Added Constant Op support (#4942)

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1056,6 +1056,42 @@ def test_ones(shape: Shape, request, device):
     )
 
 
+@pytest.mark.parametrize(
+    "tensor",
+    [
+        torch.tensor(1, dtype=torch.uint8),
+        torch.tensor([1, 2, 3, 4], dtype=torch.uint16),
+        torch.tensor([1, 2, 3, 4], dtype=torch.uint32),
+        torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+        torch.tensor([0.0, 0.0, 1.0], dtype=torch.bfloat16),
+        torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32),
+        torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32),
+    ],
+    ids=[
+        "scalar_int-uint8",
+        "1d_int-uint16",
+        "1d_int-uint32",
+        "2d_int-int32",
+        "1d_float-bf16",
+        "1d_float-f32",
+        "torch_float_tensor-float32",
+    ],
+)
+def test_constant(tensor, request, device):
+    def constant(builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
+        return builder.constant(tensor, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        constant,
+        [],
+        [],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
 @pytest.mark.parametrize("shape", [(16, 16)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -2320,6 +2320,24 @@ def ones_golden(**kwargs) -> BuilderGoldenTensor:
     return BuilderGoldenTensor({0: torch.ones(size)}, (1, 1))
 
 
+def constant_golden(**kwargs) -> BuilderGoldenTensor:
+    """
+    Golden function for constant operation with TTIR parameter names.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Keyword arguments including 'value'
+
+    Returns
+    -------
+    BuilderGoldenTensor
+        Constant tensor
+    """
+    value = kwargs.get("value", [1])
+    return BuilderGoldenTensor({0: value}, (1, 1))
+
+
 def reverse_golden(input_tensor: BuilderGoldenTensor, **kwargs) -> BuilderGoldenTensor:
     """
     Golden function for reverse operation with TTIR parameter names.
@@ -2890,6 +2908,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # Tensor creation
     ttir.ZerosOp: zeros_golden,
     ttir.OnesOp: ones_golden,
+    ttir.ConstantOp: constant_golden,
     ttir.ArangeOp: arange_golden,
     # Quantization operations
     ttir.QuantizeOp: quantize_golden,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4942

### Problem description
TTIR builder lacked support for constant op.

### What's changed
- Added `constant` op in `tools/builder/ttir/ttir_builder.py`
- Added `constant_golden` in `tools/builder/base/builder_golden.py`
- Added `test_constant` in `test/python/golden/test_ttir_ops.py`