### PR TITLE
Fix builder optests output

### DIFF
--- a/.github/test_scripts/builder.sh
+++ b/.github/test_scripts/builder.sh
@@ -21,7 +21,7 @@ for flag in $3; do
     [[ "$flag" == "require-opmodel" ]] && PYTEST_ARGS="$PYTEST_ARGS --require-opmodel"
 done
 
-pytest "$1" -m "$2" $PYTEST_ARGS -v --junit-xml=$TEST_REPORT_PATH
+pytest "$1" -m "$2" $PYTEST_ARGS -v --junit-xml=${TTRT_REPORT_PATH%_*}_builder_${TTRT_REPORT_PATH##*_}
 
 if [[ "$runttrt" == "1" ]]; then
   if [ -d "ttir-builder-artifacts/emitpy" ]; then


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5409

### Problem description
Optest analytics is not collected due to changes in CI

### What's changed
Collect optest analytics based (also) on file name 

### Checklist
- [ ] New/Existing tests provide coverage for changes
