### PR TITLE
Mapped the ttir.floor op to torch.floor

### DIFF
--- a/runtime/tools/chisel/chisel/utils/mapping.py
+++ b/runtime/tools/chisel/chisel/utils/mapping.py
@@ -560,4 +560,5 @@ ttir_to_torch_mapping = {
     "ttir.argmax": OpMapping(
         custom_argmax, {"dim_arg": "dim", "keep_dim": "keepdim"}, unpack_inputs=False
     ),
+    "ttir.floor": OpMapping(torch.floor, unpack_inputs=False),
 }


### PR DESCRIPTION
### Ticket
[5481](https://github.com/tenstorrent/tt-mlir/issues/5481)

### Problem description
While running MLIR files in the Chisel tool to debug the PCC drop in the model, I encountered the following error. FYI, in the input MLIR file contains the operation ttir.floor.

error:
`ValueError: Unknown op: ttir.floor.
`
Log file:
[floor_log.log](https://github.com/user-attachments/files/23150771/floor_log.log)

### What's changed
Added an entry in **mapping.py** to map the **ttir.floor** operation to **torch.floor**

### Checklist
- [ ] New/Existing tests provide coverage for changes
