### PR TITLE
mapped the ttir.batch_norm_inference op to torch.nn.functional.batch_norm

### DIFF
--- a/runtime/tools/chisel/chisel/utils/mapping.py
+++ b/runtime/tools/chisel/chisel/utils/mapping.py
@@ -410,6 +410,25 @@ def custom_argmax(x, dim=[], keepdim=False):
     return x
 
 
+def custom_batch_norm(
+    input, running_mean, running_var, weight, bias, *, epsilon=1e-5, training=False, **_
+):
+    # Flatten 4D tensors to 1D if necessary
+    if running_mean.ndim != 1:
+        running_mean = running_mean.flatten()
+    if running_var.ndim != 1:
+        running_var = running_var.flatten()
+    if weight is not None and weight.ndim != 1:
+        weight = weight.flatten()
+    if bias is not None and bias.ndim != 1:
+        bias = bias.flatten()
+
+    out = torch.nn.functional.batch_norm(
+        input, running_mean, running_var, weight, bias, training=training, eps=epsilon
+    )
+    return out
+
+
 ttir_to_torch_mapping = {
     # do nothing
     "ttir.empty": OpMapping(lambda x=None, *args, **kwargs: None),
@@ -557,6 +576,7 @@ ttir_to_torch_mapping = {
         },
         unpack_inputs=False,
     ),
+    "ttir.batch_norm_inference": OpMapping(custom_batch_norm),
     "ttir.argmax": OpMapping(
         custom_argmax, {"dim_arg": "dim", "keep_dim": "keepdim"}, unpack_inputs=False
     ),


### PR DESCRIPTION
### Ticket
[5480](https://github.com/tenstorrent/tt-mlir/issues/5480)

### Problem description
While running MLIR files in the Chisel tool to debug the PCC drop in the model, I encountered the following error. FYI, in the input MLIR file contains the operation ttir.batch_norm.

error:
`ValueError: Unknown op: ttir.batch_norm.inference.
`
I’ve attached the log file for your reference.
[batch_norm_output.log](https://github.com/user-attachments/files/23138578/batch_norm_output.log)


### What's changed

- Added an entry in **mapping.py** to map the **ttir.batch_norm_inference**  operation to **torch.nn.functional.batch_norm**.

- For the above mentioned function, all parameters are in 4 dimensional function,
```
Operation ASM: %34 = "ttir.batch_norm_inference"(%24, %30, %32, %26, %28, %33) <{dimension = 1 : i32, epsilon = 9.99999974E-6 : f32}> : (tensor<1x128x256x256xbf16>, tensor<1x128x1x1xbf16>, tensor<1x128x1x1xbf16>, tensor<1x128x1x1xbf16>, tensor<1x128x1x1xbf16>, tensor<1x128x256x256xbf16>) -> tensor<1x128x256x256xbf16> loc("-":37:11)
Input names: ['%24', '%30', '%32', '%26', '%28']
input: torch.Size([1, 128, 256, 256])
running_mean: torch.Size([1, 128, 1, 1])
running_var: torch.Size([1, 128, 1, 1])
weight: torch.Size([1, 128, 1, 1])
bias: torch.Size([1, 128, 1, 1])
input dtype torch.bfloat16
running_mean dtype torch.bfloat16
running var dtypr torch.bfloat16

```
i have encountered the below error
```
File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/utils/debug.py", line 17, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/core/context.py", line 359, in postop
    self.executor.execute_golden(op_location, debug_str)
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/core/golden_executor.py", line 153, in execute_golden
    self.execute(op)
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/core/golden_executor.py", line 108, in execute
    op_result = mapping(op, inputs)
                ^^^^^^^^^^^^^^^^^^^
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/utils/mapping.py", line 124, in __call__
    result = self.torch_op(*result_inputs, **torch_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/utils/mapping.py", line 434, in custom_batch_norm
    out = torch.nn.functional.batch_norm(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/torch/nn/functional.py", line 2822, in batch_norm
    return torch.batch_norm(
           ^^^^^^^^^^^^^^^^^
RuntimeError: TensorAccessor expected 1 dims but tensor has 4
```
Since running_mean, running_var, weight, and bias must be 1D tensors, I flattened them to ensure they have the correct shape.

I have attached the log file for reference:
[batch_norm_shape_error.log](https://github.com/user-attachments/files/23150517/batch_norm_shape_error.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
