### PR TITLE
Changed the output dtype of the full operation from float32 to bfloat16

### DIFF
--- a/runtime/tools/chisel/chisel/utils/mapping.py
+++ b/runtime/tools/chisel/chisel/utils/mapping.py
@@ -368,7 +368,7 @@ def custom_fill_cache(
 
 
 def custom_full(*args, **kwargs):
-    return torch.full(kwargs["size"], kwargs["fill_value"])
+    return torch.full(kwargs["size"], kwargs["fill_value"], dtype=torch.bfloat16)
 
 
 def custom_update_cache(


### PR DESCRIPTION
### Ticket
[5489](https://github.com/tenstorrent/tt-mlir/issues/5489)

### Problem description
Encountered the following runtime error while running MLIR files in Chisel:
```
File "/opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/utils/mapping.py", line 207, in custom_conv2d
    result = torch.nn.functional.conv2d(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Input type (torch.FloatTensor) and weight type (CPUBFloat16Type) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
> /opt/ttmlir-toolchain/venv/lib/python3.11/site-packages/chisel/utils/debug.py(25)wrapper()
```

Upon debugging, I found that the issue was caused by the torch.full operation. The custom full function did not specify an output data type, which caused it to default to float32. However, the function’s output is required to be in torch.bfloat16.

To investigate further, I printed all keyword arguments for the custom_full function and confirmed that there was no data_type parameter. Therefore, I explicitly defined the output of the full operation to use torch.bfloat16.

```
Operation ASM: %17 = "ttir.full"() <{fill_value = 0.000000e+00 : f32, shape = array<i32: 1, 256, 128, 128>}> : () -> tensor<1x256x128x128xbf16> loc("-":20:11)
Input names: []
kwargs {'fill_value': 0.0, 'size': [1, 256, 128, 128]}
output custom_full torch.float32
Output shape: %17 = torch.Size([1, 256, 128, 128])

```
I have attached the logs for further reference.
[out.log](https://github.com/user-attachments/files/23126534/out.log)


### What's changed
In the custom_full function, I have added the dtype argument as torch.bfloat16 and ensured that the output is returned in the expected data type.

### Checklist
- [ ] New/Existing tests provide coverage for changes
