### PR TITLE
TypeError when returning 0-d tensor from ttir.gt

### DIFF
--- a/runtime/tools/chisel/chisel/utils/mapping.py
+++ b/runtime/tools/chisel/chisel/utils/mapping.py
@@ -390,7 +390,10 @@ def custom_embeding(input, weight):
 
 
 def custom_comparison_operator(input: torch.Tensor, other: torch.Tensor, torch_op):
-    return torch_op(input, other).to(dtype=input.dtype)
+    result = torch_op(input, other).to(dtype=input.dtype)
+    if result.dim() == 0:
+        result = result.unsqueeze(0)
+    return result
 
 
 def custom_argmax(x, dim=[], keepdim=False):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5484
### Problem description
The phi3/causal_lm/pytorch-microsoft/Phi-3-mini-128k-instruct model, chisel execution fails with:
`TypeError: iteration over a 0-d tensor`

The PyTorch mapping is calling the comparison operator, and a 0-dimensional (scalar) tensor is returned. Attempting to iterate over this tensor causes the error.

### What's changed
In custom_comparison_operator, added a condition if the result is a 0-d tensor (scalar), add a dimension

### Log
[TypeError_gt.log](https://github.com/user-attachments/files/23126355/TypeError_gt.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes

