### PR TITLE
add pass to duplicate const-fed broadcasts and decouple sharding

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -124,6 +124,27 @@ def AnalyzeMeshPass : Pass<"analyze-mesh", "::mlir::ModuleOp">
   ];
 }
 
+def DecoupleConstFanoutPass : Pass<
+    "decouple-const-fanout", "::mlir::ModuleOp"> {
+  let summary = "Duplicate const-fed, value-preserving ops per-use to decouple propagation";
+  let description = [{
+    Duplicate const-fed, value-preserving ops per-use to avoid cross-path
+    coupling in sharding/shape propagation. Runs before sharding passes.
+
+    Initial target: `stablehlo.broadcast_in_dim` whose operand is a constant
+    (or rank-0 scalar) and whose result has multiple uses.
+
+    This keeps each consumer path independent, preventing one path's sharding
+    needs (e.g., via `maximum`) from affecting another path (e.g., `add` with
+    replicated bias).
+  }];
+
+  let dependentDialects = [
+    "::mlir::func::FuncDialect",
+    "::mlir::stablehlo::StablehloDialect"
+  ];
+}
+
 def WrapUnderManualComputationPass : Pass<"wrap-under-manual-computation", "::mlir::ModuleOp">
 {
   let summary = "Wrap all operations within a sdy manual computation op.";

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -34,6 +34,8 @@ void createStableHLOPipeline(OpPassManager &pm,
   analyzeMeshOptions.automaticArgAnalysis = options.automaticArgAnalysis;
   pm.addPass(createAnalyzeMeshPass(analyzeMeshOptions));
 
+  pm.addPass(createDecoupleConstFanoutPass());
+
   // Apply sharding constraints.
   pm.nest<mlir::func::FuncOp>().addPass(
       mlir::sdy::createApplyShardingConstraintsPass());

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   AnalyzeMesh.cpp
   ApplyArgumentShardStatus.cpp
   ConvertXlaSdyToSdy.cpp
+  DecoupleConstFanout.cpp
   ShardyCCLToStableHLOCCLPatterns.cpp
   UnsolvedGraphPasses.cpp
   UpdateGlobalToLocalShapes.cpp

--- a/lib/Dialect/StableHLO/Transforms/DecoupleConstFanout.cpp
+++ b/lib/Dialect/StableHLO/Transforms/DecoupleConstFanout.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "shardy/dialect/sdy/ir/utils.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+
+#include "llvm/Support/Error.h"
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_DECOUPLECONSTFANOUTPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+// Clone definition op of value each of its uses and connect independent results
+static void cloneDefPerUse(Value v, IRRewriter &rewriter) {
+  llvm::SmallVector<OpOperand *> uses = llvm::to_vector(
+      llvm::map_range(v.getUses(), [](OpOperand &use) { return &use; }));
+
+  // Keep first use as is, clone for rest
+  for (OpOperand *use : llvm::drop_begin(uses)) {
+    rewriter.setInsertionPoint(use->getOwner());
+    Operation *clone = rewriter.clone(*v.getDefiningOp());
+    use->set(clone->getResult(0));
+  }
+}
+
+template <typename T>
+static void duplicateConstFedOps(func::FuncOp func, IRRewriter &rewriter) {
+  SmallVector<T> targets;
+
+  func.walk([&](T op) {
+    Value src = op.getOperand();
+
+    // Condition 1) source is constant feed
+    if (!isa_and_nonnull<mlir::stablehlo::ConstantOp>(src.getDefiningOp())) {
+      return;
+    }
+
+    // Condition 2) result has multiple uses
+    if (op.getResult().getNumUses() < 2) {
+      return;
+    }
+    targets.push_back(op);
+  });
+
+  for (auto op : targets) {
+    rewriter.setInsertionPoint(op);
+    cloneDefPerUse(op.getResult(), rewriter);
+  }
+}
+
+// Returns true if any block argument carries explicit sharding (i.e. any dim
+// has non-empty axes), as opposed to being fully replicated.
+static bool hasExplicitlyShardedArguments(func::FuncOp funcOp) {
+  for (BlockArgument arg : funcOp.getArguments()) {
+    if (auto tensorSharding = mlir::sdy::getSharding(arg)) {
+      for (const auto &dimSharding : tensorSharding.getDimShardings()) {
+        // we consider [{?}] as sharded
+        if (!dimSharding.getAxes().empty()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false; // either no sharding attrs or all replicated
+}
+
+struct DecoupleConstFanoutPass
+    : public impl::DecoupleConstFanoutPassBase<DecoupleConstFanoutPass> {
+public:
+  using impl::DecoupleConstFanoutPassBase<
+      DecoupleConstFanoutPass>::DecoupleConstFanoutPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+    IRRewriter rewriter(ctx);
+
+    module.walk([&](func::FuncOp func) {
+      // Skip functions without explicitly sharded arguments
+      if (!hasExplicitlyShardedArguments(func)) {
+        return;
+      }
+
+      // TODO(sshon): Right now we copy every constant-fed op with multiple
+      // uses. But actually it is only necessary to duplicate those whose uses
+      // are in sharding conflicts. But we don't have a way to detect sharding
+      // conflict as we rely on sharding propagation pass from upstream. Once we
+      // have a way to detect sharding conflict, we can limit the duplication
+      // only to those ops with sharding conflicts.
+      duplicateConstFedOps<::mlir::stablehlo::BroadcastInDimOp>(func, rewriter);
+    });
+  }
+};
+} // namespace mlir::tt::stablehlo

--- a/test/ttmlir/Dialect/StableHLO/decouple_constant_fanout/broadcast_in_dim_clone.mlir
+++ b/test/ttmlir/Dialect/StableHLO/decouple_constant_fanout/broadcast_in_dim_clone.mlir
@@ -1,0 +1,33 @@
+// REQUIRES: stablehlo
+// This file incorporates work covered by the following copyright and permission notice:
+// SPDX-FileCopyrightText: Copyright (c) 2024 The Shardy Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @SyncTensorsGraph.27 attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2048xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>} loc("p0.1"), %arg1: tensor<2048x2048xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>} loc("p1.2"), %arg2: tensor<2048xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>} loc("p2.4"), %arg3: tensor<2048x2048xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>} loc("p3.5"), %arg4: tensor<2048x2048xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<2048x2048xbf16> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
+    // CHECK: %[[CST:.*]] = stablehlo.constant
+    %0 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<bf16>) -> tensor<2048x2048xbf16>
+    // CHECK: %[[B_FULL:.*]] = stablehlo.broadcast_in_dim %[[CST]]{{.*}}
+    %1 = stablehlo.transpose %arg3, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "bf16[2048,2048]{0,1}"} : (tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+    %2 = stablehlo.dot_general %arg4, %1, contracting_dims = [1] x [0] : (tensor<2048x2048xbf16>, tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+    %3 = stablehlo.broadcast_in_dim %arg2, dims = [1] : (tensor<2048xbf16>) -> tensor<2048x2048xbf16>
+    %4 = stablehlo.add %2, %3 : tensor<2048x2048xbf16>
+    // CHECK: %[[MAX1_IN:.*]] = stablehlo.add
+    // CHECK: %[[B_MID:.*]] = stablehlo.broadcast_in_dim %[[CST]]{{.*}}
+    // CHECK: %[[MAX1:.*]] = stablehlo.maximum %[[MAX1_IN]], %[[B_MID]]
+    %5 = stablehlo.maximum %4, %0 : tensor<2048x2048xbf16>
+    %6 = stablehlo.transpose %arg1, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "bf16[2048,2048]{0,1}"} : (tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+    %7 = stablehlo.dot_general %5, %6, contracting_dims = [1] x [0] : (tensor<2048x2048xbf16>, tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+    %8 = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<2048xbf16>) -> tensor<2048x2048xbf16>
+    %9 = stablehlo.add %7, %8 : tensor<2048x2048xbf16>
+    // CHECK: %[[MAX2_IN:.*]] = stablehlo.add %{{.*}}, %{{.*}} : tensor<2048x2048xbf16>
+    // CHECK: %{{.*}} = stablehlo.maximum %[[MAX2_IN]], %[[B_FULL]]
+    %10 = stablehlo.maximum %9, %0 : tensor<2048x2048xbf16>
+    return %10 : tensor<2048x2048xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
#5290 

### Problem description
[Provide context for the problem.](https://github.com/tenstorrent/tt-mlir/issues/5290#issuecomment-3438999880)

In short: a single stablehlo.broadcast_in_dim fed by a constant is shared by multiple users that end up with incompatible sharding requirements. The propagation logic then couples these paths, forcing shard alignment and introducing unnecessary collectives (e.g., all-reduce / all-slice) downstream.

### What's changed
This patch duplicates the const-fed broadcast per use, so each consumer can carry its own, independent sharding. That breaks the coupling, prevents redundant CCL ops, and preserves the intended sharding (e.g., keeping bias replicated while other paths shard).

Notes:
- Currently targets `broadcast_in_dim`; other const-fed ops can be added later if needed.


### Checklist
- [ ] New/Existing tests provide coverage for changes
