### PR TITLE
Adding emitpy silicon tests for data movement ops

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -295,28 +295,6 @@ def min(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = No
     return builder.min(in0, unit_attrs=unit_attrs)
 
 
-def reshape(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
-    # Calculate total elements in the input tensor
-    input_shape = builder.get_shape(in0)
-    total_elements = 1
-    for dim in input_shape:
-        total_elements *= dim
-
-    # Reshape to a 1D tensor with all elements
-    new_shape = [int(total_elements)]  # This must be a list of integers
-    return builder.reshape(in0, new_shape, unit_attrs=unit_attrs)
-
-
-def transpose(
-    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
-):
-    return builder.transpose(in0, unit_attrs=unit_attrs)
-
-
-def squeeze(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
-    return builder.squeeze(in0, unit_attrs=unit_attrs)
-
-
 @pytest.mark.xfail(reason="Fails Golden")
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dim_arg", [0])
@@ -348,17 +326,6 @@ def broadcast(
     )
 
 
-def concat(
-    in0: Operand,
-    in1: Operand,
-    in2: Operand,
-    dim: int,
-    builder: TTIRBuilder,
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.concat([in0, in1, in2], dim=dim, unit_attrs=unit_attrs)
-
-
 @pytest.mark.parametrize("shape", [(1, 1, 32)], ids=shape_str)
 @pytest.mark.parametrize("broadcast_dimensions", [[1, 16, 1]])
 def test_broadcast(shape: Shape, broadcast_dimensions: List[int], request, device):
@@ -376,133 +343,6 @@ def test_broadcast(shape: Shape, broadcast_dimensions: List[int], request, devic
     compile_and_execute_ttir(
         broadcast_wrapper,
         [shape],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize("shape", [(1, 128, 128, 1)], ids=shape_str)
-@pytest.mark.parametrize("dim", [0])
-def test_squeeze(shape: Shape, dim: int, request, device):
-    def squeeze(
-        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
-    ):
-        return builder.squeeze(in0, dim, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        squeeze,
-        [shape],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
-@pytest.mark.parametrize("dim", [0])
-def test_unsqueeze(shape: Shape, dim: int, request, device):
-    def unsqueeze(
-        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
-    ):
-        return builder.unsqueeze(in0, dim, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        unsqueeze,
-        [shape],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize("shape", [(1, 32, 32), (2, 16, 16), (1, 1, 64)], ids=shape_str)
-@pytest.mark.parametrize("dims", [[32, 1, 1], [1, 2, 2], [2, 3, 4], [1, 1, 1]])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.int32], ids=["f32", "i32"])
-def test_repeat(shape: Shape, dims: List[int], dtype, request, device):
-    def repeat(
-        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
-    ):
-        return builder.repeat(in0, dims=dims, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        repeat,
-        [shape],
-        [dtype],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [
-            (1, 8, 1, 12, 64),
-            (1, 8, 1, 12, 64),
-        ]
-    ],
-    ids=shapes_list_str,
-)
-@pytest.mark.parametrize("dim", [0])
-@pytest.mark.parametrize("repeats", [1])
-def test_repeat_interleave(
-    shapes: List[Shape], repeats: int, dim: int, request, device
-):
-    def repeat_interleave(
-        in0: Operand,
-        in1: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return builder.repeat_interleave(
-            in0, in1, repeats=repeats, dim=dim, unit_attrs=unit_attrs
-        )
-
-    compile_and_execute_ttir(
-        repeat_interleave,
-        shapes,
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [
-            (64, 128),
-            (32, 128),
-            (16, 128),
-        ]
-    ],
-    ids=shapes_list_str,
-)
-@pytest.mark.parametrize("dim", [0])
-def test_concat(shapes: List[Shape], dim: int, request, device):
-    # Create a wrapper function that captures dim
-    def concat_wrapper(
-        in0: Operand,
-        in1: Operand,
-        in2: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return concat(in0, in1, in2, dim, builder, unit_attrs)
-
-    # Set the name for better test identification.
-    concat_wrapper.__name__ = "concat"
-
-    compile_and_execute_ttir(
-        concat_wrapper,
-        shapes,
         test_base=request.node.name,
         device=device,
         output_root=request.config.getoption("--path"),
@@ -953,27 +793,6 @@ def test_batch_norm(
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 5, 5)], ids=shape_str)
-@pytest.mark.parametrize("padding", [[0, 1, 2, 3, 4, 5, 6, 7]])
-@pytest.mark.parametrize("value", [0])
-def test_pad(shape: Shape, padding: List[int], value: int, request, device):
-    def pad(
-        in0: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return builder.pad(in0, padding=padding, value=value, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        pad,
-        inputs_shapes=[shape],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
 @pytest.mark.parametrize("shape", [(32, 64)], ids=shape_str)
 @pytest.mark.parametrize("dim,begin,end,step", [(0, 0, 3, 1)])
 def test_index(
@@ -1376,43 +1195,6 @@ def test_reduce_or(shape: Shape, dim_args: List[int], request, device):
     )
 
 
-def permute(
-    in0: Operand,
-    builder: TTIRBuilder,
-    permutation: List[int],
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.permute(
-        in0,
-        permutation=permutation,
-        unit_attrs=unit_attrs,
-    )
-
-
-@pytest.mark.parametrize("shapes", [[(2, 3, 4)]], ids=shapes_list_str)
-@pytest.mark.parametrize("permutation", [[1, 2, 0]])
-def test_permute(shapes: List[Shape], permutation: List[int], request, device):
-    # Create a wrapper function that captures permutation
-    def permute_wrapper(
-        in0: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return permute(in0, builder, permutation, unit_attrs)
-
-    # Set the name for better test identification
-    permute_wrapper.__name__ = "permute"
-
-    compile_and_execute_ttir(
-        permute_wrapper,
-        shapes,
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
 @pytest.mark.parametrize(
     "shapes", [[(10, 64, 32, 3), (10, 128, 128, 3)]], ids=shapes_list_str
 )
@@ -1457,50 +1239,6 @@ def test_arange(
         device=device,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
-@pytest.mark.parametrize(
-    "from_type,to_type",
-    [
-        pytest.param(
-            torch.int32, torch.float32, marks=pytest.mark.xfail(reason="Golden failure")
-        ),
-        pytest.param(
-            torch.float32, torch.int32, marks=pytest.mark.xfail(reason="Golden failure")
-        ),
-        (torch.bfloat16, torch.float32),
-        (torch.float32, torch.bfloat16),
-    ],
-    ids=["i32-f32", "f32-i32", "bf16-f32", "f32-bf16"],
-)
-@pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
-def test_typecast(
-    shape: Shape,
-    from_type: torch.dtype,
-    to_type: torch.dtype,
-    target: str,
-    request,
-    device,
-):
-    def typecast(
-        in0: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return builder.typecast(in0, output_type=to_type, unit_attrs=unit_attrs)
-
-    pipeline_options = []
-    compile_and_execute_ttir(
-        typecast,
-        [shape],
-        [from_type],
-        test_base=request.node.name,
-        device=device,
-        system_desc_path=request.config.getoption("--sys-desc"),
-        target=target,
-        pipeline_options=pipeline_options,
     )
 
 
@@ -1888,14 +1626,7 @@ hoisted_single_operand_ops = [
             reason="Softmax does not lower to loops properly https://github.com/tenstorrent/tt-mlir/issues/3232"
         ),
     ),
-    create_hoisted_single_operand_op(reshape, "reshape"),
-    create_hoisted_single_operand_op(transpose, "transpose"),
     create_hoisted_single_operand_op(mean, "mean"),
-]
-
-
-hoisted_ternary_ops = [
-    create_hoisted_concat_op(concat, "concat"),
 ]
 
 
@@ -2045,44 +1776,6 @@ def test_hoisted_where(shapes, request, target: str, device):
         shapes,
         test_base=request.node.name,
         target=target,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        # [input_shape, output_shape]
-        [(128, 128), (16384,)],  # Flatten 2D to 1D
-        [(24,), (2, 3, 4)],  # Unflatten 1D to 3D
-        [(2, 3, 4), (6, 4)],  # 3D to 2D reshape
-        [(128, 128), (64, 256)],  # 2D to 2D different arrangement
-        [(1, 1, 1), (1,)],  # Edge case: all dimensions are 1
-        [(10,), (10,)],  # Identity reshape
-        [(64, 512), (64, 1, 512)],  # Common ML pattern: expand dims
-        [(256, 256), (512, 128)],  # Power of 2 reshape
-        [(32, 3, 224, 224), (32, 150528)],  # Large ML pattern: batch flatten
-    ],
-    ids=shapes_list_str,
-)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float32, torch.int64, torch.int32, torch.uint8],
-    ids=["f32", "i64", "i32", "ui8"],
-)
-def test_reshape(shapes, dtype: torch.dtype, request, device):
-    input_shape, output_shape = shapes
-
-    def reshape_wrapper(in0: Operand, builder: TTIRBuilder):
-        return builder.reshape(in0, output_shape)
-
-    compile_and_execute_ttir(
-        reshape_wrapper,
-        [input_shape],
-        [dtype],
-        test_base=request.node.name,
         device=device,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
@@ -2302,13 +1995,6 @@ def test_matmul(
 @pytest.mark.parametrize(
     "test_fn,inputs_shapes,inputs_dtypes",
     [
-        (transpose, [(64, 32)], [torch.float32]),
-        pytest.param(
-            reshape,
-            [(64, 32)],
-            [torch.float32],
-            marks=[pytest.mark.skip_config(["ttmetal"])],
-        ),
         pytest.param(
             embedding,
             [(33, 32), (512, 128)],
@@ -2335,49 +2021,6 @@ def test_unique_ops(
         system_desc_path=request.config.getoption("--sys-desc"),
         target=target,
         device=device,
-    )
-
-
-def slice(
-    in0: Operand,
-    begins: List[int],
-    ends: List[int],
-    step: Optional[List[int]] = None,
-    builder: TTIRBuilder = None,
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.slice(in0, begins, ends, step, unit_attrs=unit_attrs)
-
-
-@pytest.mark.parametrize(
-    "shape,begins,ends,step",
-    [
-        ((64, 64), [0, 0], [32, 32], None),
-        ((64, 64), [10, 20], [50, 60], [1, 1]),
-        ((64, 64, 64), [10, 20, 30], [50, 60, 64], [2, 2, 1]),
-    ],
-    ids=["basic_slice", "explicit_step", "3d_slice"],
-)
-def test_slice(
-    shape: Shape,
-    begins: List[int],
-    ends: List[int],
-    step: List[int],
-    request,
-    device,
-):
-    def slice_op(
-        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
-    ):
-        return slice(in0, begins, ends, step, builder, unit_attrs)
-
-    compile_and_execute_ttir(
-        slice_op,
-        [shape],
-        test_base=request.node.name,
-        device=device,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -1,0 +1,539 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from typing import List, Optional
+from conftest import x86_only
+from builder.base.builder import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_utils import compile_and_execute_ttir
+from test_utils import (
+    shapes_list_str,
+    shape_str,
+)
+
+pytestmark = pytest.mark.frontend("ttir")
+
+# Concat tests
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
+            (64, 128),
+            (32, 128),
+            (16, 128),
+        ]
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize("dim", [0])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_concat(shapes: List[Shape], dim: int, target: str, request, device):
+    def concat_wrapper(
+        in0: Operand,
+        in1: Operand,
+        in2: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.concat([in0, in1, in2], dim, unit_attrs)
+
+    # Set the name for better test identification.
+    concat_wrapper.__name__ = "concat"
+
+    compile_and_execute_ttir(
+        concat_wrapper,
+        shapes,
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+@x86_only
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
+            (64, 128),
+            (32, 128),
+            (16, 128),
+        ]
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize("dim", [0])
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
+@pytest.mark.xfail(reason="Compile failure on CPU target")
+def test_cpu_hoistable_concat_op(
+    shapes: List[Shape],
+    dim: int,
+    request,
+    target: str,
+    device,
+):
+    def hoisted_concat_wrapper(
+        in0: Operand,
+        in1: Operand,
+        in2: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.concat([in0, in1, in2], dim, unit_attrs=["ttir.should_hoist"])
+
+    hoisted_concat_wrapper.__name__ = "hoisted_concat"
+
+    """Test unary ops that support CPU hoisting"""
+    compile_and_execute_ttir(
+        hoisted_concat_wrapper,
+        inputs_shapes=shapes,
+        test_base=f"{request.node.name}",
+        target=target,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+# Pad tests
+@pytest.mark.parametrize("shape", [(1, 1, 5, 5)], ids=shape_str)
+@pytest.mark.parametrize("padding", [[0, 1, 2, 3, 4, 5, 6, 7]])
+@pytest.mark.parametrize("value", [0])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_pad(
+    shape: Shape, padding: List[int], value: int, target: str, request, device
+):
+    def pad_wrapper(
+        in0: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.pad(in0, padding=padding, value=value, unit_attrs=unit_attrs)
+
+    pad_wrapper.__name__ = "pad"
+
+    compile_and_execute_ttir(
+        pad_wrapper,
+        inputs_shapes=[shape],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# Permute tests
+@pytest.mark.parametrize("shapes", [[(2, 3, 4)]], ids=shapes_list_str)
+@pytest.mark.parametrize("permutation", [[1, 2, 0]])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_permute(
+    shapes: List[Shape], permutation: List[int], target: str, request, device
+):
+    def permute_wrapper(
+        in0: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.permute(
+            in0,
+            permutation=permutation,
+            unit_attrs=unit_attrs,
+        )
+
+    permute_wrapper.__name__ = "permute"
+
+    compile_and_execute_ttir(
+        permute_wrapper,
+        shapes,
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# RepeatInterleave tests
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
+            (1, 8, 1, 12, 64),
+            (1, 8, 1, 12, 64),
+        ]
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize("dim", [0])
+@pytest.mark.parametrize("repeats", [1])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_repeat_interleave(
+    shapes: List[Shape], repeats: int, dim: int, target: str, request, device
+):
+    def repeat_interleave_wrapper(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.repeat_interleave(
+            in0, in1, repeats=repeats, dim=dim, unit_attrs=unit_attrs
+        )
+
+    repeat_interleave_wrapper.__name__ = "repeat_interleave"
+
+    compile_and_execute_ttir(
+        repeat_interleave_wrapper,
+        shapes,
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# Repeat tests
+@pytest.mark.parametrize("shape", [(1, 32, 32), (2, 16, 16), (1, 1, 64)], ids=shape_str)
+@pytest.mark.parametrize("dims", [[32, 1, 1], [1, 2, 2], [2, 3, 4], [1, 1, 1]])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.int32], ids=["f32", "i32"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_repeat(shape: Shape, dims: List[int], dtype, target: str, request, device):
+    def repeat_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.repeat(in0, dims=dims, unit_attrs=unit_attrs)
+
+    repeat_wrapper.__name__ = "repeat"
+
+    compile_and_execute_ttir(
+        repeat_wrapper,
+        [shape],
+        [dtype],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# Reshape tests
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # [input_shape, output_shape]
+        [(128, 128), (16384,)],  # Flatten 2D to 1D
+        [(24,), (2, 3, 4)],  # Unflatten 1D to 3D
+        [(2, 3, 4), (6, 4)],  # 3D to 2D reshape
+        [(128, 128), (64, 256)],  # 2D to 2D different arrangement
+        [(1, 1, 1), (1,)],  # Edge case: all dimensions are 1
+        [(10,), (10,)],  # Identity reshape
+        [(64, 512), (64, 1, 512)],  # Common ML pattern: expand dims
+        [(256, 256), (512, 128)],  # Power of 2 reshape
+        [(32, 3, 224, 224), (32, 150528)],  # Large ML pattern: batch flatten
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.int64, torch.int32, torch.uint8],
+    ids=["f32", "i64", "i32", "ui8"],
+)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_reshape(shapes, dtype: torch.dtype, target: str, request, device):
+    input_shape, output_shape = shapes
+
+    def reshape_wrapper(in0: Operand, builder: TTIRBuilder):
+        return builder.reshape(in0, output_shape)
+
+    reshape_wrapper.__name__ = "reshape"
+
+    compile_and_execute_ttir(
+        reshape_wrapper,
+        [input_shape],
+        [dtype],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+@pytest.mark.parametrize("shape", [(1, 128, 128, 1)], ids=shape_str)
+@pytest.mark.parametrize("dim", [0])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_squeeze(shape: Shape, dim: int, target: str, request, device):
+    def squeeze_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.squeeze(in0, dim, unit_attrs=unit_attrs)
+
+    squeeze_wrapper.__name__ = "squeeze"
+
+    compile_and_execute_ttir(
+        squeeze_wrapper,
+        [shape],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
+@pytest.mark.parametrize("dim", [0])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_unsqueeze(shape: Shape, dim: int, target: str, request, device):
+    def unsqueeze_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.unsqueeze(in0, dim, unit_attrs=unit_attrs)
+
+    unsqueeze_wrapper.__name__ = "unsqueeze"
+
+    compile_and_execute_ttir(
+        unsqueeze_wrapper,
+        [shape],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+@x86_only
+@pytest.mark.parametrize("shapes", [[(128, 128), (16384,)]], ids=shapes_list_str)
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
+def test_cpu_hoistable_reshape_op(
+    shapes: List[Shape],
+    request,
+    target: str,
+    device,
+):
+    input_shape, output_shape = shapes
+
+    def hoisted_reshape_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.reshape(
+            in0, shape=output_shape, unit_attrs=["ttir.should_hoist"]
+        )
+
+    hoisted_reshape_wrapper.__name__ = "hoisted_reshape"
+
+    """Test unary ops that support CPU hoisting"""
+    compile_and_execute_ttir(
+        hoisted_reshape_wrapper,
+        inputs_shapes=[input_shape],
+        test_base=f"{request.node.name}",
+        target=target,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+# Slice tests
+@pytest.mark.parametrize(
+    "shape,begins,ends,step",
+    [
+        ((64, 64), [0, 0], [32, 32], None),
+        ((64, 64), [10, 20], [50, 60], [1, 1]),
+        ((64, 64, 64), [10, 20, 30], [50, 60, 64], [2, 2, 1]),
+    ],
+    ids=["basic_slice", "explicit_step", "3d_slice"],
+)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_slice(
+    shape: Shape,
+    begins: List[int],
+    ends: List[int],
+    step: List[int],
+    target: str,
+    request,
+    device,
+):
+    def slice_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.slice(in0, begins, ends, step, unit_attrs=unit_attrs)
+
+    slice_wrapper.__name__ = "slice"
+
+    compile_and_execute_ttir(
+        slice_wrapper,
+        [shape],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# Sort tests
+@pytest.mark.parametrize("shape", [(1, 64, 64)], ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+@pytest.mark.parametrize("descending", [True, False])
+@pytest.mark.parametrize("stable", [True, False])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_sort(
+    shape: Shape,
+    dtype: torch.dtype,
+    dim: int,
+    descending: bool,
+    stable: bool,
+    target: str,
+    request,
+    device,
+):
+    if dim == 0:
+        pytest.skip(
+            "Sorting along batch dimension is not supported: https://github.com/tenstorrent/tt-metal/issues/31187"
+        )
+
+    def sort_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        sort_0 = builder.sort(
+            in0, dim=dim, descending=descending, stable=stable, unit_attrs=unit_attrs
+        )
+        # Calculate golden for values and indices
+        in0_golden = builder._get_golden_tensor(in0)
+
+        values, indicies = torch.sort(
+            in0_golden, dim=dim, descending=descending, stable=stable
+        )
+        builder.set_goldens_from_builder_tensor(
+            {in0: in0_golden}, {sort_0.values: values}
+        )
+
+        return sort_0.values  # Return only sorted values for testing
+
+    sort_wrapper.__name__ = "sort"
+
+    compile_and_execute_ttir(
+        sort_wrapper,
+        [shape],
+        [dtype],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+# Transpose tests
+@pytest.mark.parametrize("shape", [(64, 32)], ids=shape_str)
+@pytest.mark.parametrize("transpose_dims", [(0, 1)])
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitpy"])
+def test_transpose(
+    shape: Shape, transpose_dims: List[int], target: str, request, device
+):
+    def transpose_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.transpose(
+            in0, dim0=transpose_dims[0], dim1=transpose_dims[1], unit_attrs=unit_attrs
+        )
+
+    transpose_wrapper.__name__ = "transpose"
+
+    compile_and_execute_ttir(
+        transpose_wrapper,
+        [shape],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+@x86_only
+@pytest.mark.parametrize("shape", [(32, 64, 128)], ids=shape_str)
+@pytest.mark.parametrize("transpose_dims", [(0, 1)])
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
+def test_cpu_hoistable_transpose_op(
+    shape: Shape,
+    transpose_dims: List[int],
+    request,
+    target: str,
+    device,
+):
+    def hoisted_transpose_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        return builder.transpose(
+            in0,
+            dim0=transpose_dims[0],
+            dim1=transpose_dims[1],
+            unit_attrs=["ttir.should_hoist"],
+        )
+
+    hoisted_transpose_wrapper.__name__ = "hoisted_transpose"
+
+    """Test unary ops that support CPU hoisting"""
+    compile_and_execute_ttir(
+        hoisted_transpose_wrapper,
+        inputs_shapes=[shape],
+        test_base=f"{request.node.name}",
+        target=target,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+# Typecast tests
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
+@pytest.mark.parametrize(
+    "from_type,to_type",
+    [
+        (torch.int32, torch.float32),
+        (torch.float32, torch.int32),
+        (torch.bfloat16, torch.float32),
+        (torch.float32, torch.bfloat16),
+    ],
+    ids=["i32-f32", "f32-i32", "bf16-f32", "f32-bf16"],
+)
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitpy"])
+def test_typecast(
+    shape: Shape,
+    from_type: torch.dtype,
+    to_type: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    if from_type == torch.float32 and to_type == torch.int32 and target == "ttmetal":
+        pytest.xfail("ttmetal does not support int32 to float32 typecast")
+
+    def typecast(
+        in0: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.typecast(in0, output_type=to_type, unit_attrs=unit_attrs)
+
+    pipeline_options = []
+    compile_and_execute_ttir(
+        typecast,
+        [shape],
+        [from_type],
+        test_base=request.node.name,
+        device=device,
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        pipeline_options=pipeline_options,
+    )

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -1973,6 +1973,31 @@ def transpose_golden(
     return torch.transpose(input_tensor, dim0, dim1)
 
 
+def sort_golden(input_tensor: BuilderGoldenTensor, **kwargs) -> BuilderGoldenTensor:
+    """
+    Golden function for sort operation with TTIR parameter names.
+
+    Parameters
+    ----------
+    input_tensor : BuilderGoldenTensor
+        Input tensor
+    **kwargs : dict
+        Keyword arguments including 'dim', 'descending', and 'stable'
+
+    Returns
+    -------
+    BuilderGoldenTensor
+        Sorted tensor (values only, indices are discarded)
+    """
+    dim = kwargs.get("dim", -1)
+    descending = kwargs.get("descending", False)
+    stable = kwargs.get("stable", False)
+    values, indices = torch.sort(
+        input_tensor, dim=dim, descending=descending, stable=stable
+    )
+    return values
+
+
 def concat_golden(input_tensors: BuilderGoldenTensor, **kwargs) -> BuilderGoldenTensor:
     """
     Golden function for concat operation with TTIR parameter names.
@@ -2878,6 +2903,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.ReduceAndOp: reduce_and_golden,
     ttir.ReduceOrOp: reduce_or_golden,
     # Tensor manipulation
+    ttir.SortOp: sort_golden,
     ttir.TransposeOp: transpose_golden,
     ttir.ConcatOp: concat_golden,
     ttir.RepeatOp: repeat_golden,

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -2546,6 +2546,61 @@ class TTIRBuilder(Builder):
             unit_attrs=unit_attrs,
         )
 
+    def sort(
+        self,
+        in0: Operand,
+        dim: int = -1,
+        descending: bool = False,
+        stable: bool = False,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpView:
+        """
+        Creates ``ttir.sort``.
+
+        *Tensor sort operation.*
+
+        Sorts the elements of a tensor along a specified dimension.
+
+        Parameters
+        ----------
+        in0 : Operand
+            Input tensor
+        dim : int, optional
+            Dimension along which to sort (default: -1, the last dimension)
+        descending : bool, optional
+            If True, sorts in descending order (default: False)
+        stable : bool, optional
+            If True, uses a stable sorting algorithm (default: False)
+        unit_attrs : *Optional[List[str]]*, optional
+            Optional list of unit attributes
+
+        Returns
+        -------
+        (*OpView*)
+            Sorted tensor
+        """
+        ttir_kwargs = {"dim": dim, "descending": descending, "stable": stable}
+        golden_kwargs = {"dim": dim, "descending": descending, "stable": stable}
+
+        return self._op_proxy(
+            ttir.SortOp,
+            [in0],
+            ttir_kwargs=ttir_kwargs,
+            output_create_fn=lambda shape, type: (
+                self._empty(shape, type),
+                self._empty(shape, self._get_type_from_torch_dtype(torch.int32)),
+            ),
+            organize_ttir_args=lambda i, o, _: (
+                self._get_type(o[0]),
+                self._get_type(o[1]),
+                i[0],
+                [o[0], o[1]],
+            ),
+            golden_kwargs=golden_kwargs,
+            organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
+            unit_attrs=unit_attrs,
+        )
+
     def transpose(
         self,
         in0: Operand,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
EmitPy integration lacks silicon testing for data movement ops.

### What's changed
This update adds builder tests for data movement operations and includes some refactoring of the tests, which have been organized into a separate folder.

### Checklist
- [x] New/Existing tests provide coverage for changes
