### PR TITLE
Adding load tensor wrapper to adjust tensor spec after loading it

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3552,7 +3552,7 @@ private:
   }
 
   std::string getPrefixSwapPattern() const override {
-    return "::tt::tt_metal::load_tensor_flatbuffer";
+    return "ttnn::loadTensor";
   }
 
 public:
@@ -3566,9 +3566,17 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::LoadTensorOp> emitter(
         srcOp, adaptor, rewriter);
 
+    RankedTensorType resultType = srcOp.getResult().getType();
+    mlir::tt::ttnn::TTNNLayoutAttr layoutAttr =
+        mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(resultType.getEncoding());
+
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getFilePath()),
+        emitter.emit(layoutAttr.getLayout()),
+        emitter.emit(mlir::tt::ttcore::elementTypeToDataType(
+            layoutAttr.getScalarElementType())),
         emitter.emit(srcOp.getDevice()),
+        emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2262,6 +2262,14 @@ public:
 namespace {
 class LoadTensorOpConversionPattern
     : public TTNNToEmitPyBaseOpConversionPattern<mlir::tt::ttnn::LoadTensorOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return mlir::tt::ttnn::LoadTensorOp::getOperationName().str();
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "utils.load_tensor";
+  }
+
 public:
   using TTNNToEmitPyBaseOpConversionPattern<
       mlir::tt::ttnn::LoadTensorOp>::TTNNToEmitPyBaseOpConversionPattern;
@@ -2273,9 +2281,17 @@ public:
     ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::LoadTensorOp> emitter(
         srcOp, adaptor, rewriter);
 
+    RankedTensorType resultType = srcOp.getResult().getType();
+    mlir::tt::ttnn::TTNNLayoutAttr layoutAttr =
+        mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(resultType.getEncoding());
+
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getFilePath()),
-        emitter.emit(srcOp.getDevice(), "device"),
+        emitter.emit(layoutAttr.getLayout()),
+        emitter.emit(mlir::tt::ttcore::elementTypeToDataType(
+            layoutAttr.getScalarElementType())),
+        emitter.emit(srcOp.getDevice()),
+        emitter.emit(emitter.getMemoryConfig(srcOp.getResult())),
     };
 
     emitter.replaceOp(*this, args);

--- a/test/ttmlir/EmitC/TTNN/load_input/load_input.mlir
+++ b/test/ttmlir/EmitC/TTNN/load_input/load_input.mlir
@@ -11,24 +11,24 @@
 // RUN: FileCheck %s --check-prefix=CUSTOM-FULL --input-file=%t.custom_full.mlir
 
 module {
-  // DEFAULT: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // DEFAULT: "ttnn::loadTensor"
   // DEFAULT-SAME: args = [#emitc.opaque<"\22arg0.tensorbin\22"
-  // DEFAULT-NEXT: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // DEFAULT-NEXT: "ttnn::loadTensor"
   // DEFAULT-SAME: args = [#emitc.opaque<"\22arg1.tensorbin\22"
 
-  // CUSTOM-DIR: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-DIR: "ttnn::loadTensor"
   // CUSTOM-DIR-SAME: args = [#emitc.opaque<"\22tensors/arg0.tensorbin\22"
-  // CUSTOM-DIR-NEXT: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-DIR-NEXT: "ttnn::loadTensor"
   // CUSTOM-DIR-SAME: args = [#emitc.opaque<"\22tensors/arg1.tensorbin\22"
 
-  // CUSTOM-PREFIX: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-PREFIX: "ttnn::loadTensor"
   // CUSTOM-PREFIX-SAME: args = [#emitc.opaque<"\22input0.tensorbin\22"
-  // CUSTOM-PREFIX-NEXT: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-PREFIX-NEXT: "ttnn::loadTensor"
   // CUSTOM-PREFIX-SAME: args = [#emitc.opaque<"\22input1.tensorbin\22"
 
-  // CUSTOM-FULL: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-FULL: "ttnn::loadTensor"
   // CUSTOM-FULL-SAME: args = [#emitc.opaque<"\22tensors/input0.tensorbin\22"
-  // CUSTOM-FULL-NEXT: "::tt::tt_metal::load_tensor_flatbuffer"(%0
+  // CUSTOM-FULL-NEXT: "ttnn::loadTensor"
   // CUSTOM-FULL-SAME: args = [#emitc.opaque<"\22tensors/input1.tensorbin\22"
   func.func @add(%arg0 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<input> }) -> tensor<32x32xbf16> {
     %0 = ttir.empty() : tensor<32x32xbf16>

--- a/test/ttmlir/EmitC/TTNN/load_input/load_input_local/ttnn_load_input_tensors.mlir
+++ b/test/ttmlir/EmitC/TTNN/load_input/load_input_local/ttnn_load_input_tensors.mlir
@@ -1,6 +1,6 @@
 // This test isn't intended as an llvm-lit test. It's part of the CI job. You can test it locally by running (assuming your working directory is the root of the project):
 // source env/activate
-// cd test/ttmlir/EmitC/TTNN/load_input
+// cd test/ttmlir/EmitC/TTNN/load_input/load_input_local
 // tt-alchemist generate-cpp --pipeline-options 'load-input-tensors-from-disk=true' ttnn_load_input_tensors.mlir --output load_input_cpp --standalone
 // cp arg0.tensorbin arg1.tensorbin load_input_cpp
 // cd !$

--- a/test/ttmlir/EmitPy/TTNN/load_input/load_input.mlir
+++ b/test/ttmlir/EmitPy/TTNN/load_input/load_input.mlir
@@ -11,24 +11,24 @@
 // RUN: FileCheck %s --check-prefix=CUSTOM-FULL --input-file=%t.custom_full.mlir
 
 module {
-  // DEFAULT: "ttnn.load_tensor"
+  // DEFAULT: load_tensor
   // DEFAULT-SAME: args = [#emitpy.opaque<"\22arg0.tensorbin\22"
-  // DEFAULT-NEXT: "ttnn.load_tensor"
+  // DEFAULT-NEXT: load_tensor
   // DEFAULT-SAME: args = [#emitpy.opaque<"\22arg1.tensorbin\22"
 
-  // CUSTOM-DIR: "ttnn.load_tensor"
+  // CUSTOM-DIR: load_tensor
   // CUSTOM-DIR-SAME: args = [#emitpy.opaque<"\22tensors/arg0.tensorbin\22"
-  // CUSTOM-DIR-NEXT: "ttnn.load_tensor"
+  // CUSTOM-DIR-NEXT: load_tensor
   // CUSTOM-DIR-SAME: args = [#emitpy.opaque<"\22tensors/arg1.tensorbin\22"
 
-  // CUSTOM-PREFIX: "ttnn.load_tensor"
+  // CUSTOM-PREFIX: load_tensor
   // CUSTOM-PREFIX-SAME: args = [#emitpy.opaque<"\22input0.tensorbin\22"
-  // CUSTOM-PREFIX-NEXT: "ttnn.load_tensor"
+  // CUSTOM-PREFIX-NEXT: load_tensor
   // CUSTOM-PREFIX-SAME: args = [#emitpy.opaque<"\22input1.tensorbin\22"
 
-  // CUSTOM-FULL: "ttnn.load_tensor"
+  // CUSTOM-FULL: load_tensor
   // CUSTOM-FULL-SAME: args = [#emitpy.opaque<"\22tensors/input0.tensorbin\22"
-  // CUSTOM-FULL-NEXT: "ttnn.load_tensor"
+  // CUSTOM-FULL-NEXT: load_tensor
   // CUSTOM-FULL-SAME: args = [#emitpy.opaque<"\22tensors/input1.tensorbin\22"
   func.func @add(%arg0 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<input> }) -> tensor<32x32xbf16> {
     %0 = ttir.empty() : tensor<32x32xbf16>

--- a/test/ttmlir/EmitPy/TTNN/load_input/load_input_local/ttnn_load_input_tensors.mlir
+++ b/test/ttmlir/EmitPy/TTNN/load_input/load_input_local/ttnn_load_input_tensors.mlir
@@ -1,6 +1,6 @@
 // This test isn't intended as an llvm-lit test. It's part of the CI job. You can test it locally by running (assuming your working directory is the root of the project):
 // source env/activate
-// cd test/ttmlir/EmitPy/TTNN/load_input
+// cd test/ttmlir/EmitPy/TTNN/load_input/load_input_local
 // tt-alchemist generate-python --pipeline-options 'load-input-tensors-from-disk=true' ttnn_load_input_tensors.mlir --output load_input_py
 // cp arg0.tensorbin arg1.tensorbin load_input_py
 // cd !$

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -143,6 +143,29 @@ uint32_t getScalarFromTensor(const ttnn::Tensor &tensor) {
   return *buf.begin();
 }
 
+::ttnn::Tensor loadTensor(const std::string &filePath, ttnn::Layout layout,
+                          ttnn::DataType dtype, ttnn::MeshDevice *device,
+                          ttnn::MemoryConfig memoryConfig) {
+  ::ttnn::Tensor loadedTensor =
+      ::tt::tt_metal::load_tensor_flatbuffer(filePath);
+
+  assert(loadedTensor.device() == nullptr && "loaded tensor must be on host");
+
+  if (loadedTensor.dtype() != dtype) {
+    loadedTensor = ::ttnn::to_dtype(loadedTensor, dtype);
+  }
+
+  if (loadedTensor.layout() != layout) {
+    loadedTensor = ::ttnn::to_layout(loadedTensor, layout);
+  }
+
+  if (device != nullptr) {
+    loadedTensor = ::ttnn::to_device(loadedTensor, device, memoryConfig);
+  }
+
+  return loadedTensor;
+}
+
 } // namespace ttnn
 
 #endif // TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -143,6 +143,29 @@ uint32_t getScalarFromTensor(const ttnn::Tensor &tensor) {
   return *buf.begin();
 }
 
+::ttnn::Tensor loadTensor(const std::string &filePath, ttnn::Layout layout,
+                          ttnn::DataType dtype, ttnn::MeshDevice *device,
+                          ttnn::MemoryConfig memoryConfig) {
+  ::ttnn::Tensor loadedTensor =
+      ::tt::tt_metal::load_tensor_flatbuffer(filePath);
+
+  assert(loadedTensor.device() == nullptr && "loaded tensor must be on host");
+
+  if (loadedTensor.dtype() != dtype) {
+    loadedTensor = ::ttnn::to_dtype(loadedTensor, dtype);
+  }
+
+  if (loadedTensor.layout() != layout) {
+    loadedTensor = ::ttnn::to_layout(loadedTensor, layout);
+  }
+
+  if (device != nullptr) {
+    loadedTensor = ::ttnn::to_device(loadedTensor, device, memoryConfig);
+  }
+
+  return loadedTensor;
+}
+
 } // namespace ttnn
 
 #endif // TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP

--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -56,3 +56,18 @@ def get_scalar_from_tensor(tensor: ttnn.Tensor) -> int:
 
     host_tensor = ttnn.from_device(tensor)
     return host_tensor.item()
+
+
+def load_tensor(file_path: str, layout, dtype, device, memory_config) -> ttnn.Tensor:
+    loaded_tensor = ttnn.load_tensor(file_path)
+
+    assert loaded_tensor.device() is None, "loaded tensor must be on host"
+
+    if loaded_tensor.dtype != dtype:
+        loaded_tensor = ttnn.to_dtype(loaded_tensor, dtype)
+    if loaded_tensor.layout != layout:
+        loaded_tensor = ttnn.to_layout(loaded_tensor, layout)
+    if device is not None:
+        loaded_tensor = ttnn.to_device(loaded_tensor, device, memory_config)
+
+    return loaded_tensor

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -162,6 +162,29 @@ uint32_t getScalarFromTensor(const ttnn::Tensor &tensor) {
   return *buf.begin();
 }
 
+::ttnn::Tensor loadTensor(const std::string &filePath, ttnn::Layout layout,
+                          ttnn::DataType dtype, ttnn::MeshDevice *device,
+                          ttnn::MemoryConfig memoryConfig) {
+  ::ttnn::Tensor loadedTensor =
+      ::tt::tt_metal::load_tensor_flatbuffer(filePath);
+
+  assert(loadedTensor.device() == nullptr && "loaded tensor must be on host");
+
+  if (loadedTensor.dtype() != dtype) {
+    loadedTensor = ::ttnn::to_dtype(loadedTensor, dtype);
+  }
+
+  if (loadedTensor.layout() != layout) {
+    loadedTensor = ::ttnn::to_layout(loadedTensor, layout);
+  }
+
+  if (device != nullptr) {
+    loadedTensor = ::ttnn::to_device(loadedTensor, device, memoryConfig);
+  }
+
+  return loadedTensor;
+}
+
 } // namespace ttnn
 
 #endif // TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, when we load the tensor from a flatbuffer in the codegen path, we don't guarantee that the forward function arguments are in a proper tensor spec.

### What's changed
Added load tensor wrapper helper functions in utils that convert the loaded tensor layout to a required spec. This is currently a bit hacky, but as soon as we extend the EmitPy dialect with the following:
- https://github.com/tenstorrent/tt-mlir/issues/5494

We will be able to remove the utility function and generate the function in the main file. Also, I opened this issue on the Metal side to extend their load tensor API:
https://github.com/tenstorrent/tt-metal/issues/31131

### Checklist
- [ ] New/Existing tests provide coverage for changes
