### PR TITLE
Add macOS build support with runtime stubs

### DIFF
--- a/docs/src/pykernel.md
+++ b/docs/src/pykernel.md
@@ -573,6 +573,62 @@ When developing with PyKernel, follow these best practices:
 
 8. **Document parameters**: Clearly document the expected parameters for your PyKernel operation
 
+## Running tt-mlir pykernel on macOS
+
+Quick guide for building and running pykernel on macOS without runtime support (no hardware execution).
+
+**Setup**
+
+You'll need a system descriptor file. Grab one from a real system or use a mock one:
+```bash
+export SYSTEM_DESC_PATH=$(pwd)/system_desc.ttsys
+```
+
+**Build Configuration**
+
+Configure with runtime disabled:
+```bash
+cmake -G Ninja -B build \
+    -DTTMLIR_ENABLE_RUNTIME=OFF \
+    -DTTMLIR_ENABLE_STABLEHLO=OFF \
+    -DTT_RUNTIME_ENABLE_PERF_TRACE=OFF \
+    -DTTMLIR_ENABLE_BINDINGS_PYTHON=ON \
+    -DTTMLIR_ENABLE_DEBUG_STRINGS=OFF \
+    -DTTMLIR_ENABLE_EXPLORER=OFF \
+    -DTTMLIR_ENABLE_RUNTIME_TESTS=OFF \
+    -DTTMLIR_ENABLE_PYKERNEL=ON \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_BUILD_PARALLEL_LEVEL=4 \
+    -DFLATBUFFERS_COMPILER=/opt/homebrew/bin/flatc
+```
+
+**Build**
+
+```bash
+source env/activate
+cmake --build build
+```
+
+**Run Example**
+
+```bash
+export SYSTEM_DESC_PATH=$(pwd)/system_desc.ttsys
+source env/activate
+python test/pykernel/gen/custom_dm_matmul.py
+```
+
+**What works**
+
+The full compilation pipeline (Python → D2M → MLIR → TTKernel → EmitC) will run successfully. Hardware execution will not work due to no runtime support, but you can develop and test the compiler itself.
+
+- Full MLIR compilation pipeline
+- Kernel code generation
+- All compiler passes
+- No actual hardware execution (requires runtime + Tenstorrent hardware)
+
 ## Summary
 
 PyKernel provides a flexible and powerful way to implement custom operations for Tenstorrent hardware. By following the pattern outlined in this guide, you can create your own operations that integrate seamlessly with the TTNN framework.

--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -15,6 +15,11 @@ if (TTMLIR_ENABLE_RUNTIME_TESTS)
   list(APPEND TTMLIR_RUNTIME_PYTHON_SRCS runtime/test.cpp)
 endif()
 
+# Add macOS stubs when runtime is disabled but pykernel is enabled
+if (APPLE AND NOT TTMLIR_ENABLE_RUNTIME AND TTMLIR_ENABLE_PYKERNEL)
+  list(APPEND TTMLIR_RUNTIME_PYTHON_SRCS runtime/stubs_macos.cpp)
+endif()
+
 nanobind_add_module(
   _ttmlir_runtime
   ${TTMLIR_RUNTIME_PYTHON_SRCS}

--- a/runtime/python/runtime/stubs_macos.cpp
+++ b/runtime/python/runtime/stubs_macos.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stub implementations for macOS to allow pykernel to build without runtime
+// These should never be called - they trap if invoked
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+
+#include "tt/runtime/debug.h"
+#include "tt/runtime/perf.h"
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
+#include "tt/runtime/workarounds.h"
+#include <cstdlib>
+
+#pragma clang diagnostic pop
+
+namespace tt::runtime {
+
+// Stub for Flatbuffer::loadFromPath
+Flatbuffer Flatbuffer::loadFromPath(const char *path) { __builtin_trap(); }
+
+// Stub for SystemDesc::loadFromPath
+SystemDesc SystemDesc::loadFromPath(const char *path) { __builtin_trap(); }
+
+// Stub for Binary::loadFromPath
+Binary Binary::loadFromPath(const char *path) { __builtin_trap(); }
+
+namespace workaround {
+
+// Stub for workaround::Env::get
+const Env &Env::get(bool swapBinaryOperands,
+                    bool readUpdateIndexFromDeviceForKVCache,
+                    bool traceImplicitFromDevice, bool blackholeWorkarounds) {
+  __builtin_trap();
+}
+
+} // namespace workaround
+
+// Stubs for MultiProcessArgs constructor and methods
+MultiProcessArgs::MultiProcessArgs(std::string_view rankBindingPath)
+    : rankBindingPath_(rankBindingPath), tagOutput_(false),
+      allowRunAsRoot_(false) {}
+
+MultiProcessArgs &
+MultiProcessArgs::withHosts(const std::vector<std::string> &hosts) {
+  __builtin_trap();
+}
+
+MultiProcessArgs &MultiProcessArgs::withHostsFilePath(std::string_view path) {
+  __builtin_trap();
+}
+
+std::string MultiProcessArgs::getRankBindingPath() const { __builtin_trap(); }
+
+MultiProcessArgs &MultiProcessArgs::withRankFilePath(std::string_view path) {
+  __builtin_trap();
+}
+
+MultiProcessArgs &MultiProcessArgs::withMcaOptions(
+    const std::map<std::string, std::string> &mcaOptions) {
+  __builtin_trap();
+}
+
+MultiProcessArgs &MultiProcessArgs::withTagOutput(bool tagOutput) {
+  __builtin_trap();
+}
+
+MultiProcessArgs &MultiProcessArgs::withAllowRunAsRoot(bool allowRunAsRoot) {
+  __builtin_trap();
+}
+
+MultiProcessArgs &MultiProcessArgs::withExtraMpiArgs(
+    const std::vector<std::string> &extraMpiArgs) {
+  __builtin_trap();
+}
+
+std::string MultiProcessArgs::toArgString() const { __builtin_trap(); }
+
+namespace perf {
+
+// Stubs for perf::Env methods
+void Env::tracyLogOpLocation(const std::string &locInfo) const {
+  __builtin_trap();
+}
+
+void Env::tracyLogInputLayoutConversion(bool conversionNeeded) const {
+  __builtin_trap();
+}
+
+void Env::tracyLogConstEvalProgram(bool constEvalOp) const { __builtin_trap(); }
+
+void Env::tracyLogProgramMetadata(const std::string &metaData) const {
+  __builtin_trap();
+}
+
+void Env::setProgramMetadata(const std::string &programMetadata) {
+  __builtin_trap();
+}
+
+} // namespace perf
+
+namespace debug {
+
+// Stub for debug::Env::get
+const Env &Env::get(bool dumpKernelsToDisk, bool loadKernelsFromDisk,
+                    bool useLocForKernelName, std::string kernelSourceDir,
+                    bool deviceAddressValidation, bool blockingCQ) {
+  __builtin_trap();
+}
+
+// Stub for debug::Hooks::get
+const Hooks &Hooks::get(std::optional<Hooks::CallbackFn> preOperatorCallback,
+                        std::optional<Hooks::CallbackFn> postOperatorCallback) {
+  __builtin_trap();
+}
+
+// Stubs for debug::Stats methods
+Stats &Stats::get() { __builtin_trap(); }
+
+void Stats::incrementStat(const std::string &stat, std::int64_t value) {
+  __builtin_trap();
+}
+
+std::int64_t Stats::getStat(const std::string &stat) const { __builtin_trap(); }
+
+void Stats::removeStat(const std::string &stat) { __builtin_trap(); }
+
+void Stats::clear() { __builtin_trap(); }
+
+std::string Stats::toString() const { __builtin_trap(); }
+
+} // namespace debug
+
+// Stubs for Flatbuffer methods
+std::string Flatbuffer::asJson() const { __builtin_trap(); }
+bool Flatbuffer::checkSchemaHash() const { __builtin_trap(); }
+std::string Flatbuffer::getFileIdentifier() const { __builtin_trap(); }
+std::string Flatbuffer::getSchemaHash() const { __builtin_trap(); }
+std::string Flatbuffer::getTTMLIRGitHash() const { __builtin_trap(); }
+std::string Flatbuffer::getVersion() const { __builtin_trap(); }
+void Flatbuffer::store(const char *path) const { __builtin_trap(); }
+
+// Stubs for Binary methods
+Binary::Binary(std::shared_ptr<void> handle)
+    : Flatbuffer(handle), binaryId(0), tensorCache(nullptr) {}
+std::string Binary::getMlirAsJson() const { __builtin_trap(); }
+std::uint32_t Binary::getNumPrograms() const { __builtin_trap(); }
+std::string Binary::getProgramInputsAsJson(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+const std::pair<std::uint32_t, std::uint32_t>
+Binary::getProgramMeshShape(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+std::string Binary::getProgramName(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+std::string Binary::getProgramOpsAsJson(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+std::string Binary::getProgramOutputsAsJson(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+std::string Binary::getSystemDescAsJson() const { __builtin_trap(); }
+bool Binary::isProgramPrivate(std::uint32_t programIndex) const {
+  __builtin_trap();
+}
+std::unordered_map<std::uint32_t, const ::tt::target::GoldenTensor *>
+Binary::getDebugInfoGolden(std::string &loc) const {
+  __builtin_trap();
+}
+
+// Stubs for runtime functions
+void closeMeshDevice(Device parentMesh) { __builtin_trap(); }
+void deallocateBuffers(Device device) { __builtin_trap(); }
+void deallocateTensor(Tensor &tensor, bool force) { __builtin_trap(); }
+void disablePersistentKernelCache() { __builtin_trap(); }
+void dumpMemoryReport(Device device) { __builtin_trap(); }
+void enablePersistentKernelCache() { __builtin_trap(); }
+tt::target::Arch getArch() { __builtin_trap(); }
+std::vector<DeviceRuntime> getAvailableDeviceRuntimes() { __builtin_trap(); }
+std::vector<HostRuntime> getAvailableHostRuntimes() { __builtin_trap(); }
+DeviceRuntime getCurrentDeviceRuntime() { __builtin_trap(); }
+HostRuntime getCurrentHostRuntime() { __builtin_trap(); }
+std::vector<int> getDeviceIds(Device meshDevice) { __builtin_trap(); }
+size_t getDramSizePerChannel(Device meshDevice) { __builtin_trap(); }
+size_t getL1SizePerCore(Device meshDevice) { __builtin_trap(); }
+size_t getL1SmallSize(Device meshDevice) { __builtin_trap(); }
+Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
+                 std::uint32_t inputIndex) {
+  __builtin_trap();
+}
+std::unordered_map<MemoryBufferType, MemoryView> getMemoryView(Device device) {
+  __builtin_trap();
+}
+std::vector<std::uint32_t> getMeshShape(Device meshDevice) { __builtin_trap(); }
+size_t getNumAvailableDevices() { __builtin_trap(); }
+size_t getNumDramChannels(Device meshDevice) { __builtin_trap(); }
+size_t getNumHwCqs(Device meshDevice) { __builtin_trap(); }
+std::string getOpDebugString(OpContext opContextHandle) { __builtin_trap(); }
+std::vector<TensorRef> getOpInputRefs(OpContext opContextHandle,
+                                      CallbackContext programContextHandle) {
+  __builtin_trap();
+}
+std::string getOpLocInfo(OpContext opContextHandle) { __builtin_trap(); }
+std::optional<TensorRef> getOpOutputRef(OpContext opContextHandle,
+                                        CallbackContext programContextHandle) {
+  __builtin_trap();
+}
+std::unordered_map<std::uint32_t, Tensor>
+getOpOutputTensor(OpContext opContextHandle,
+                  CallbackContext programContextHandle) {
+  __builtin_trap();
+}
+std::vector<std::byte> getTensorDataBuffer(Tensor tensor) { __builtin_trap(); }
+tt::target::DataType getTensorDataType(Tensor tensor) { __builtin_trap(); }
+TensorDesc getTensorDesc(Tensor tensor) { __builtin_trap(); }
+std::uint32_t getTensorElementSize(Tensor tensor) { __builtin_trap(); }
+bool getTensorRetain(Tensor tensor) { __builtin_trap(); }
+std::vector<std::uint32_t> getTensorShape(Tensor tensor) { __builtin_trap(); }
+std::vector<std::uint32_t> getTensorStride(Tensor tensor) { __builtin_trap(); }
+std::uint32_t getTensorVolume(Tensor tensor) { __builtin_trap(); }
+size_t getTraceRegionSize(Device meshDevice) { __builtin_trap(); }
+bool isProgramCacheEnabled(Device meshDevice) { __builtin_trap(); }
+bool isTensorAllocated(Tensor tensor) { __builtin_trap(); }
+void launchDistributedRuntime(const DistributedOptions &options) {
+  __builtin_trap();
+}
+void memcpy(Tensor dst, Tensor src) { __builtin_trap(); }
+Device openMeshDevice(const MeshDeviceOptions &options) { __builtin_trap(); }
+void readDeviceProfilerResults(Device device) { __builtin_trap(); }
+void releaseSubMeshDevice(Device subMesh) { __builtin_trap(); }
+void releaseTrace(Device meshDevice, std::uint64_t binaryId,
+                  size_t mainProgramId) {
+  __builtin_trap();
+}
+std::optional<Tensor>
+retrieveTensorFromPool(CallbackContext programContextHandle,
+                       TensorRef tensorRef, bool untilize) {
+  __builtin_trap();
+}
+void setCompatibleDeviceRuntime(const Binary &binary) { __builtin_trap(); }
+void setCurrentDeviceRuntime(const DeviceRuntime &runtime) { __builtin_trap(); }
+void setCurrentHostRuntime(const HostRuntime &runtime) { __builtin_trap(); }
+void setFabricConfig(FabricConfig config) { __builtin_trap(); }
+void setTensorRetain(Tensor tensor, bool retain) { __builtin_trap(); }
+void shutdownDistributedRuntime() { __builtin_trap(); }
+std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
+  __builtin_trap();
+}
+void updateTensorInPool(CallbackContext programContextHandle,
+                        TensorRef tensorRef, Tensor srcTensor) {
+  __builtin_trap();
+}
+void wait(Event event) { __builtin_trap(); }
+
+} // namespace tt::runtime


### PR DESCRIPTION
### Problem description
Currently, you cannot run the compiler pipeline on macOS due to missing runtime (linker errors). This stubs out the runtime so that you can still run the compiler + passes on macOS.

### What's changed
* Added a stub file
* Integrated into build
* Docs
