### PR TITLE
Add support for 64-bit integer in TTIR builder

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2067,7 +2067,9 @@ def test_hoisted_where(shapes, request, target: str, device):
     ids=shapes_list_str,
 )
 @pytest.mark.parametrize(
-    "dtype", [torch.float32, torch.int32, torch.uint8], ids=["f32", "i32", "ui8"]
+    "dtype",
+    [torch.float32, torch.int64, torch.int32, torch.uint8],
+    ids=["f32", "i64", "i32", "ui8"],
 )
 def test_reshape(shapes, dtype: torch.dtype, request, device):
     input_shape, output_shape = shapes

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -208,6 +208,8 @@ class Builder:
                 return DataType.UInt32
             case torch.int32 | torch.qint32:
                 return DataType.Int32
+            case torch.int64:
+                return DataType.Int32
             case torch.float32 | None:
                 return DataType.Float32
 


### PR DESCRIPTION
### Ticket
closes #5523 

### Problem description
TTIR builder does not have a case for int64 data type and uses the default option (float32) instead. Which causes low PCC error due to mismatched datatype.

### What's changed
Add int64 golden support for TTIR builder class

### Checklist
- [X] New/Existing tests provide coverage for changes
