### PR TITLE
Use llmbox from Civ2

### DIFF
--- a/.github/scripts/python/generate_test_matrix.py
+++ b/.github/scripts/python/generate_test_matrix.py
@@ -186,6 +186,11 @@ def main(input_filename, target_duration, component_filter):
 
     test_matrix = final_test_matrix
 
+    # Add "sh-run": true to tests where runs-on == "n300-llmbox"
+    for test in test_matrix:
+        if test.get("runs-on") == "n300-llmbox":
+            test["sh-run"] = True
+
     # Save the test matrix to a file
     with open("_test_matrix.json", "w") as f:
         json.dump(test_matrix, f, indent=2)

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -3,11 +3,11 @@
         "image": ["speedy","tracy"],
             "script": "unit.sh" },
 
-  { "runs-on": ["n150","n300","llmbox"],
+  { "runs-on": ["n150","n300","n300-llmbox"],
         "image": "speedy",
             "script": "ttrt.sh", "args": ["run", "Silicon"] },
 
-  { "runs-on": ["n150","n300","llmbox"],
+  { "runs-on": ["n150","n300","n300-llmbox"],
         "image": "tracy",
             "script": "ttrt.sh", "args": ["perf", "Silicon/TTNN/$RUNS_ON/perf"] },
 
@@ -22,7 +22,7 @@
   { "runs-on": "n150",   "image": "tracy",  "script": "pytest.sh", "args": "tools/explorer/test/run_tests.py", "reqs": "--force-reinstall $BUILD_DIR/bin/wheels/tt_adapter*.whl $BUILD_DIR/bin/wheels/ai_edge_model_explorer*.whl" },
   { "runs-on": "n150",   "image": "tracy",  "script": "pytest.sh", "args": "runtime/tools/chisel/test", "reqs": "-e runtime/tools/chisel/", "if": "chisel" },
 
-  { "runs-on": ["n150","llmbox","n300","p150"],
+  { "runs-on": ["n150","n300-llmbox","n300","p150"],
         "image": "tracy",
             "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"] },
 
@@ -32,7 +32,7 @@
   { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n150" },
   { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
   { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
-  { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
+  { "runs-on": "n300-llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
   { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh", "if": "emitc" },
   { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Queuing times are high on Civ1 llmbox, use llmbox from Civ2

### What's changed
Generate test matrix that uses Civ2 llmbox.

### Checklist
- [ ] New/Existing tests provide coverage for changes
