### PR TITLE
[D2M] Fix bug in GridSelection

### DIFF
--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -110,7 +110,6 @@ def test_matmul_multi_core_8otpc(m: int, k: int, n: int, target: str, request, d
 def test_matmul_p150_grid_selection_compile_only(target: str, request, device):
     from builder.base.builder_utils import compile_ttir_to_flatbuffer
 
-    tile_size = 32
     lhs = (1024, 1024)
     rhs = (1024, 1024)
 

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_transpose.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_transpose.mlir
@@ -10,11 +10,3 @@ func.func @transpose(%arg0: tensor<512x256xf32>) -> tensor<256x512xf32> {
   // CHECK: call_opaque "transpose_wh_tile"
   return %1 : tensor<256x512xf32>
 }
-
-func.func @transpose_square(%arg0: tensor<512x512xf32>) -> tensor<512x512xf32> {
-  %0 = ttir.empty() : tensor<512x512xf32>
-  %1 = "ttir.transpose"(%arg0, %0) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<512x256xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
-  // CHECK: call_opaque "transpose_wh_init"
-  // CHECK: call_opaque "transpose_wh_tile"
-  return %1 : tensor<512x512xf32>
-}


### PR DESCRIPTION
### Problem description
In my GridSelection changes, I ensured that the actual grid selection used a squared grid, but missed passing this to the dim_alignments calculation, which broke `test_metal_matmul.py` on non-square grid chips, apparently.

### What's changed
Quick clean-up to ensure we always use the square-ified grid for grid decisions in GridSelection.cpp (including dim_alignment calculations).

### Checklist
- [x] New/Existing tests provide coverage for changes
- [X] Manually confirmed this fixes issues on a 8x10 WH locally--not sure how to make sure this is exercised in CI
