### PR TITLE
ttrt: fix atol rtol reference in ttrt run.py

### DIFF
--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -947,8 +947,8 @@ class Run:
                                     _, _, cal_pcc, _ = get_atol_rtol_pcc(
                                         golden_tensor_torch,
                                         output_tensor_torch,
-                                        self["atol"],
-                                        self["rtol"],
+                                        self["--atol"],
+                                        self["--rtol"],
                                         self.logging,
                                     )
                                     pcc_fail = (


### PR DESCRIPTION
### Problem description
Used wrong key when referencing atol/rtol thresholds in previous PR. 

### What's changed
Fix the strings to references these correctly. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
