### PR TITLE
Fix ttrt tests

### DIFF
--- a/.github/test_scripts/ttrt.sh
+++ b/.github/test_scripts/ttrt.sh
@@ -9,6 +9,10 @@
 
 set -e -o pipefail
 
+echo "Generating tests"
+llvm-lit --filter="Silicon" $BUILD_DIR/test
+
+echo "Running TTRT tests"
 eval ttrt "$1" "$BUILD_DIR/test/ttmlir/$2" "$3"
 cp ${1}_results.json ${TTRT_REPORT_PATH} || true
 cp ttrt_report.xml $TEST_REPORT_PATH || true


### PR DESCRIPTION
### Ticket
slack

### Problem description
ttrt tests doesn't execute in some cases

### What's changed
Without lit running before ttrt tests there are no tests generated to run.
Added lit run before running ttrt tests.
This is a quick fix to enable tests to run. Will be fixed in a separate PR. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
