### PR TITLE
Change L1_SMALL_SIZE to 64KB

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -9,7 +9,7 @@
 
 namespace tt::constants {
 
-// Default L1 small size to use for the ttnn runtime (32kb).
+// Default L1 small size to use for the ttnn runtime (64kb).
 // This reserves a region of L1 memory for L1_SMALL buffers used by convs.
 constexpr static std::size_t L1_SMALL_SIZE = 1 << 16;
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4292,8 +4292,8 @@ TEST_F(OpModelBase, FillCacheOpInterface) {
 
 TEST_F(OpModelBase, UpdateCacheOpInterface) {
   // Test UpdateCacheOp with cache, input, and update_index tensors
-  llvm::SmallVector<int64_t> cacheShape = {1, 32, 64, 512};
-  llvm::SmallVector<int64_t> inputShape = {1, 32, 3, 512};
+  llvm::SmallVector<int64_t> cacheShape = {1, 32, 64, 256};
+  llvm::SmallVector<int64_t> inputShape = {1, 32, 3, 256};
   llvm::SmallVector<int64_t> updateIndexShape = {1};
 
   auto cacheTensor = createEmptyTensor(cacheShape);
@@ -4317,9 +4317,9 @@ TEST_F(OpModelBase, UpdateCacheOpInterface) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
         constraints;
     // Basic validation that constraints are reasonable
-    EXPECT_EQ(cbSize, 1310720);
+    EXPECT_EQ(cbSize, 655360);
     EXPECT_EQ(l1PeakSize, 0);
-    EXPECT_EQ(outputSize, 32768);
+    EXPECT_EQ(outputSize, 16384);
   } else {
     FAIL() << "Missing constraints for UpdateCacheOp; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;


### PR DESCRIPTION
### Ticket
Closes #5556

### Problem description
UNet was failing on n150 tt-forge benchmark with Optimizer enabled.

### What's changed
Changed L1_SMALL_SIZE to 1 << 16.
Lowered CB size in `getOpRuntime` unit test for `UpdateCacheOp` that was failing due to very large CB.