### PR TITLE
Skip JIT layout tests to unblock CI

### DIFF
--- a/test/ttnn-jit/test_layouts.py
+++ b/test/ttnn-jit/test_layouts.py
@@ -68,6 +68,7 @@ def abs(input_tensor):
     return ttnn.abs(input_tensor)
 
 
+@pytest.mark.skip(reason="Failing non-deterministicly in CI. Issue: #5550")
 @pytest.mark.parametrize(
     "h , w, max_grid",
     BLOCK_SHARDED_SHAPE_GRIDS,
@@ -90,6 +91,7 @@ def test_l1_block_sharded_shapes(device, h, w, max_grid, op):
     )
 
 
+@pytest.mark.skip(reason="Failing non-deterministicly in CI. Issue: #5550")
 @pytest.mark.parametrize(
     "h , w",
     DRAM_INTERLEAVED_SHAPE_GRIDS,


### PR DESCRIPTION
### Ticket
#5551 

### Problem description
JIT layout tests are failing. The specific failing unit test is non-deterministic

### What's changed
Disabling the unit tests to unblock CI. Issue filed #5550 
