### PR TITLE
Add d2m-builder-artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,7 @@ tracy_*.tracy
 test/lit.site.cfg.py
 
 # Builder Test Default Artifact Paths
-/ttir-builder-artifacts/
-/ttnn-builder-artifacts/
-/stablehlo-builder-artifacts/
+/*-builder-artifacts/
 
 # TTNN and TTMetal flatbuffers
 *.ttnn


### PR DESCRIPTION
`d2m-builder-artifacts` wasn't gitgnored. Added a `*-builder-artifacts` that should catch all builder artifacts.