### PR TITLE
Fix token for community/forked builds

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Run Tests
       shell: bash
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN || github.token}}
         TTRT_LOGGER_LEVEL: "WARNING"
         LOGURU_LEVEL: "ERROR"
         TT_METAL_LOGGER_LEVEL: "FATAL"


### PR DESCRIPTION
### Ticket
slack

### Problem description
In community builds from forks there is a problem with download.

### What's changed
Workflow uses github token from secrets which is unavailable for forked builds.
Use default token if secrets are unavailable.

### Checklist
- [ ] New/Existing tests provide coverage for changes
