### PR TITLE
[Builder] Added multi return support to the builder #5074

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -211,3 +211,32 @@ def test_tan(shape: Shape, dtype: torch.dtype, target: str, request, device):
         target=target,
         device=device,
     )
+
+
+@pytest.mark.parametrize("shapes", [[(64, 64), (64, 64), (64, 64)]], ids=["64x64"])
+@pytest.mark.parametrize("dtypes", [[torch.float32] * 3], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_stablehlo_multi_return_support(
+    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+):
+    def multi_return_model(
+        in0: Operand, in1: Operand, in2: Operand, builder: StableHLOBuilder
+    ):
+        builder.set_graph_level_check(True)
+
+        add_result = builder.add(in0, in1)
+        exp_result = builder.exp(in2)
+        sqrt_result = builder.sqrt(exp_result)
+
+        return exp_result, sqrt_result
+
+    compile_and_execute_shlo(
+        multi_return_model,
+        shapes,
+        dtypes,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        device=device,
+    )

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -258,6 +258,33 @@ def _emitpy_to_executable(module, filepath: str, golden_map, module_cache):
         f.write(cpp)
 
 
+def _convert_to_mlir_value(obj):
+    if hasattr(obj, "operation") and hasattr(obj.operation, "results"):
+        results = obj.operation.results
+        if len(results) == 1:
+            return results[0]
+        else:
+            return results
+    elif hasattr(obj, "type"):
+        return obj
+    else:
+        return obj
+
+
+def _process_multi_return_result(result):
+    if hasattr(result, "__iter__") and not isinstance(result, str):
+        converted_results = []
+        for item in result:
+            converted = _convert_to_mlir_value(item)
+            if hasattr(converted, "__iter__") and not hasattr(converted, "type"):
+                converted_results.extend(converted)
+            else:
+                converted_results.append(converted)
+        return tuple(converted_results)
+    else:
+        return _convert_to_mlir_value(result)
+
+
 def _create_custom_ttir_pipeline_fn(
     pipeline: str, verify: bool = True, print_ir: Union[bool, str] = False
 ) -> Callable:
@@ -470,7 +497,7 @@ def build_module(
                 builder._set_goldens(output_goldens)
                 builder._set_output_ordering(outputs)
 
-                return result
+                return _process_multi_return_result(result)
 
         print(f"`{fn.__name__}` successfully transformed into a MLIR module.")
         base = fn.__name__ if base is None else base
@@ -1885,7 +1912,8 @@ def experimental_build_stablehlo_module(
                 stablehlo_builder._set_goldens(output_goldens)
                 stablehlo_builder._set_output_ordering(outputs)
 
-                return result
+                # Convert OpView objects to MLIR Values for multi-return support
+                return _process_multi_return_result(result)
 
             # Create named meshes and add them to the module
             named_mesh_list = []


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4376

### Problem description
PR on behalf of user @Gmin2 ([#5704](https://github.com/tenstorrent/tt-mlir/pull/5074))+ some fixes.

### What's changed
- Updated `compile_ttir_to_flatbuffer ` to `compile_and_execute_ttir` in `test/python/golden/test_ttir_ops.py::test_multi_return_support` and `test/python/golden/test_ttir_ops.py::test_triple_return_support`
- Updated `compile_stablehlo_to_flatbuffer ` to `compile_and_execute_shlo` in `test/python/golden/test_stablehlo_ops.py::test_stablehlo_multi_return_support`
- replaced unsupported ops in `test/python/golden/test_stablehlo_ops.py::test_stablehlo_multi_return_support`


