### PR TITLE
[ttnn.jit] enable_cache flag + re-enable layout tests w/o cache

### DIFF
--- a/test/ttnn-jit/test_layouts.py
+++ b/test/ttnn-jit/test_layouts.py
@@ -54,9 +54,7 @@ def run_op_test(
     print("inputs", inputs)
     golden_op = _get_ttnn_op(op)
 
-    op_jit = ttnn_jit.jit(
-        debug=True, max_grid=max_grid, enable_cache=False
-    )(op)
+    op_jit = ttnn_jit.jit(debug=True, max_grid=max_grid)(op)
     output_tensor = op_jit(*inputs)
     golden_tensor = (golden_op or op)(*inputs)
 

--- a/test/ttnn-jit/test_program_cache.py
+++ b/test/ttnn-jit/test_program_cache.py
@@ -4,6 +4,7 @@
 
 import ttnn
 import torch
+import pytest
 
 from ttnn_jit.api import jit
 
@@ -14,6 +15,7 @@ def abs(input_tensor):
     return ttnn.abs(input_tensor)
 
 
+@pytest.mark.skip(reason="Cache is not working as intended")
 def test_program_cache(device):
     """
     Test program caching behavior for ttnn-jit.

--- a/tools/ttnn-jit/api.py
+++ b/tools/ttnn-jit/api.py
@@ -12,7 +12,7 @@ def jit(
     max_grid: tuple[int, int] = (7, 7),
     compile_only: bool = False,
     debug: bool = False,
-    enable_cache: bool = True,
+    enable_cache: bool = False,
 ):
     """
     Sets up the decorated function to be JIT compiled through D2M.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5550#issuecomment-3462833326

### Problem description
ND error in tests due to JitCache

### What's changed
- Add flag that disables JitCache (for now) 
- re-enable `test_layout.py tests`

Qualified by running entire `pytest test/ttnn-jit/test_layouts.py -v -ra` 10 times in loop and seeing no failures.

Also ran 5x CI pipelines with no failures observed
