### PR TITLE
[ttnn.jit] change `max_grid` to be from (1, 1) to (8,8)

### DIFF
--- a/test/ttnn-jit/test_eltwise.py
+++ b/test/ttnn-jit/test_eltwise.py
@@ -16,19 +16,19 @@ from utils import (
 )
 
 BLOCK_SHARDED_SHAPE_GRIDS = [
-    (32, 32, (0, 0)),
-    (32, 64, (0, 0)),
-    (64, 64, (0, 0)),
-    (128, 128, (0, 0)),
-    (256, 256, (7, 7)),
-    (512, 512, (7, 7)),
-    (512, 1024, (7, 7)),
-    (1024, 1024, (7, 7)),
-    (1024, 2048, (7, 7)),
+    (32, 32, (1, 1)),
+    (32, 64, (1, 1)),
+    (64, 64, (1, 1)),
+    (128, 128, (1, 1)),
+    (256, 256, (8, 8)),
+    (512, 512, (8, 8)),
+    (512, 1024, (8, 8)),
+    (1024, 1024, (8, 8)),
+    (1024, 2048, (8, 8)),
     # Ensure non-square grid dims are interpreted correctly.
-    (64, 128, (3, 0)),
-    (64, 128, (0, 1)),
-    (96, 128, (3, 2)),
+    (64, 128, (4, 1)),
+    (64, 128, (1, 2)),
+    (96, 128, (4, 3)),
 ]
 
 DRAM_INTERLEAVED_SHAPES = [
@@ -165,7 +165,7 @@ def test_unary_op_dram(device, h, w, dtype, op):
     if op in [log, ceil, floor, logical_not] and dtype == torch.float32:
         pytest.xfail("failing allclose for some shapes for float32")
 
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     run_op_test(
         device,
         h,
@@ -218,7 +218,7 @@ def test_unary_op_l1(device, h, w, max_grid, dtype, op):
     DRAM_INTERLEAVED_SHAPES,
 )
 def test_bitwise_unary_op_dram(device, h, w, dtype, op):
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     run_op_test(
         device,
         h,
@@ -495,7 +495,7 @@ def test_interop_jit_and_ttnn_to_binary_l1(
     DRAM_INTERLEAVED_SHAPES,
 )
 def test_interop_jit_to_ttnn_unary_dram(device, h, w, dtype, jit_op, ttnn_unary_op):
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     input_tensor = create_dram_tensor(device, h, w, dtype)
 
     # Interop path
@@ -531,7 +531,7 @@ def test_interop_two_jit_to_ttnn_binary_dram(
     if jit_op2 == log and dtype == torch.float32:
         pytest.xfail("Failing all_close, getting nan values mismatching with golden")
 
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     input1 = create_dram_tensor(device, h, w, dtype)
     input2 = create_dram_tensor(device, h, w, dtype)
 
@@ -569,7 +569,7 @@ def test_interop_two_jit_to_ttnn_binary_dram(
 def test_interop_jit_and_ttnn_to_binary_dram(
     device, h, w, dtype, jit_op, ttnn_binary_op
 ):
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     input_tensor = create_dram_tensor(device, h, w, dtype)
     ttnn_tensor = create_dram_tensor(device, h, w, dtype)
 

--- a/test/ttnn-jit/test_layouts.py
+++ b/test/ttnn-jit/test_layouts.py
@@ -18,11 +18,11 @@ from utils import (
 # Generates all shapes with 1 to 4 tiles per core in each dimension, with every grid from single core to 8x8.
 # TTNN grids are (Width, Height), while tensor shapes are (Height, Width).
 BLOCK_SHARDED_SHAPE_GRIDS = [
-    (h * 32 * (grid_h + 1), w * 32 * (grid_w + 1), (grid_w, grid_h))
+    (h * 32 * grid_h, w * 32 * grid_w, (grid_w, grid_h))
     for h in range(1, 5)
     for w in range(1, 5)
-    for grid_h in range(8)
-    for grid_w in range(8)
+    for grid_h in range(1, 9)
+    for grid_w in range(1, 9)
 ]
 
 # TODO (5415): These grids fail for all shapes.
@@ -99,7 +99,7 @@ def test_l1_block_sharded_shapes(device, h, w, max_grid, op):
 )
 @pytest.mark.parametrize("op", [abs])
 def test_dram_interleaved_shapes(device, h, w, op):
-    max_grid = (0, 0)
+    max_grid = (1, 1)
     run_op_test(
         device,
         h,

--- a/test/ttnn-jit/test_program_cache.py
+++ b/test/ttnn-jit/test_program_cache.py
@@ -29,30 +29,30 @@ def test_program_cache(device):
     h2, w2 = 512, 512
 
     # Create operations with different JIT parameters
-    op_single_core = jit(backend="ttnn", max_grid=(0, 0))(abs)
-    op_full_grid = jit(backend="ttnn", max_grid=(7, 7))(abs)
+    op_single_core = jit(max_grid=(1, 1))(abs)
+    op_full_grid = jit(max_grid=(8, 8))(abs)
 
     assert op_single_core.num_entries == 0, "No entries should be in the cache"
     assert op_full_grid.num_entries == 0, "No entries should be in the cache"
 
     tensor_single_h1_w1_bf16_0 = create_sharded_tile_tensor(
-        device, h1, w1, (0, 0), torch.bfloat16
+        device, h1, w1, (1, 1), torch.bfloat16
     )
     tensor_single_h1_w1_bf16_1 = create_sharded_tile_tensor(
-        device, h1, w1, (0, 0), torch.bfloat16
+        device, h1, w1, (1, 1), torch.bfloat16
     )
     tensor_single_h1_w1_fp32 = create_sharded_tile_tensor(
-        device, h1, w1, (0, 0), torch.float32
+        device, h1, w1, (1, 1), torch.float32
     )
     tensor_single_h2_w2_bf16 = create_sharded_tile_tensor(
-        device, h2, w2, (0, 0), torch.bfloat16
+        device, h2, w2, (1, 1), torch.bfloat16
     )
 
     tensor_full_h1_w1_bf16_0 = create_sharded_tile_tensor(
-        device, h1, w1, (7, 7), torch.bfloat16
+        device, h1, w1, (8, 8), torch.bfloat16
     )
     tensor_full_h1_w1_bf16_1 = create_sharded_tile_tensor(
-        device, h1, w1, (7, 7), torch.bfloat16
+        device, h1, w1, (8, 8), torch.bfloat16
     )
 
     tensor_dram_h1_w1_bf16_0 = create_dram_tensor(device, h1, w1, torch.bfloat16)

--- a/test/ttnn-jit/utils.py
+++ b/test/ttnn-jit/utils.py
@@ -68,13 +68,13 @@ def create_sharded_tile_tensor(device, h, w, max_grid, dtype, int_max=0):
         torch_tensor = torch.randn((h, w), dtype=dtype)
 
     start_coord = ttnn.CoreCoord(0, 0)
-    end_coord = ttnn.CoreCoord(max_grid[0], max_grid[1])
+    end_coord = ttnn.CoreCoord(max_grid[0] - 1, max_grid[1] - 1)
     core_range = ttnn.CoreRange(start_coord, end_coord)
     core_range_set = ttnn.CoreRangeSet([core_range])
 
     # TTNN grids are (Width, Height), while tensor shapes are (Height, Width).
-    shard_shape_x = h if max_grid[1] == 0 else h // (max_grid[1] + 1)
-    shard_shape_y = w if max_grid[0] == 0 else w // (max_grid[0] + 1)
+    shard_shape_x = h // (max_grid[1])
+    shard_shape_y = w // (max_grid[0])
 
     shard_spec = ttnn.ShardSpec(
         grid=core_range_set,

--- a/tools/ttnn-jit/_src/jit.py
+++ b/tools/ttnn-jit/_src/jit.py
@@ -41,6 +41,10 @@ class JitFunction:
         self.compile_only = compile_only
         self.debug = debug
 
+        assert (
+            1 <= max_grid[0] <= 8 and 1 <= max_grid[1] <= 8
+        ), f"max_grid must be between (1, 1) and (8, 8), got {max_grid}"
+
         self.out_dir = os.path.join("generated", "pykernels")
         os.makedirs(self.out_dir, exist_ok=True)
 

--- a/tools/ttnn-jit/_src/ttir_ast.py
+++ b/tools/ttnn-jit/_src/ttir_ast.py
@@ -119,8 +119,8 @@ class TTIRCompiler(ast.NodeVisitor):
 
             # Create ttcore grid atttr based off max_grid passed by user
             # Can't pull grid info from tensor unless it's sharded
-            grid_size_x = self.max_grid[0] + 1
-            grid_size_y = self.max_grid[1] + 1
+            grid_size_x = self.max_grid[0]
+            grid_size_y = self.max_grid[1]
 
             # TTNN writes grids as (width, height) but compiler expects (height, width)
             grid = ttcore.ir.GridAttr.get(self.ctx, [grid_size_y, grid_size_x])
@@ -144,7 +144,7 @@ class TTIRCompiler(ast.NodeVisitor):
             return ttnn_layout
         else:
             assert (
-                self.max_grid[0] == 0 and self.max_grid[1] == 0
+                self.max_grid[0] == 1 and self.max_grid[1] == 1
             ), "The grid for DRAM interleaved tensors is always 1x1"
             buffer_type = ttnn.ir.BufferTypeAttr.get(self.ctx, ttnn.BufferType.DRAM)
             grid = ttcore.ir.GridAttr.get(self.ctx, [1, 1])

--- a/tools/ttnn-jit/api.py
+++ b/tools/ttnn-jit/api.py
@@ -10,7 +10,7 @@ from ttnn_jit._src.jit import JitFunction
 
 def jit(
     backend: Literal["ttnn", "metal"] = "ttnn",
-    max_grid: tuple[int, int] = (7, 7),
+    max_grid: tuple[int, int] = (8, 8),
     compile_only: bool = False,
     debug: bool = False,
 ):


### PR DESCRIPTION

### Problem description
`max_grid being from (0, 0) to (7, 7) is confusing.

### What's changed
- changed it to be from (1, 1) to (8, 8)
- updated tests

### Checklist
- [x] New/Existing tests provide coverage for changes
