### PR TITLE
GridSelection recreates d2m.generic and preserves original thread type

### DIFF
--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -497,7 +497,8 @@ static void recreateGenericOp(d2m::GenericOp genericOp) {
                       .getUnderlying());
             }
           }
-        });
+        },
+        /*singleThreadType=*/genericOp.getRegionThreadType(0));
 
     genericOp.replaceAllUsesWith(newGenericOp);
     genericOp.erase();


### PR DESCRIPTION
### Problem description
When the GridSelection pass recreates the d2m.generic, it uses the builder overload that defaults the thread type to compute, such that datamovement regions get rewritten as compute.

### What's changed
Title above.
