### PR TITLE
[TTIR BUILDER] preserve bias in conv2d

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -585,6 +585,59 @@ def test_conv2d(
     "shapes",
     [
         [
+            (12, 224, 224, 3),
+            (32, 3, 3, 3),
+        ]
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize("input_dtypes", [[torch.bfloat16, torch.bfloat16]])
+@pytest.mark.parametrize(
+    "stride,padding,dilation,groups", [([2, 1], [1, 1], [1, 1], 1)]
+)
+def test_conv2d_no_bias(
+    shapes: List[Shape],
+    input_dtypes: List[Union[torch.dtype, TypeInfo]],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
+    groups: int,
+    request,
+    device,
+):
+    def conv2d_no_bias(
+        in0: Operand,
+        weight: Operand,
+        builder: TTIRBuilder,
+        *,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        return builder.conv2d(
+            in0,
+            weight,
+            bias=None,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            unit_attrs=unit_attrs,
+        )
+
+    compile_and_execute_ttir(
+        conv2d_no_bias,
+        shapes,
+        input_dtypes,
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
             (1, 32, 32, 64),
             (64, 32, 3, 3),
             (1, 1, 1, 64),

--- a/tools/builder/base/builder_golden.py
+++ b/tools/builder/base/builder_golden.py
@@ -355,7 +355,6 @@ def cbrt_golden(x: BuilderGoldenTensor) -> BuilderGoldenTensor:
 def conv2d_golden(
     input_tensor: BuilderGoldenTensor,
     weight: BuilderGoldenTensor,
-    bias: Optional[BuilderGoldenTensor] = None,
     **kwargs,
 ) -> BuilderGoldenTensor:
     """
@@ -382,6 +381,7 @@ def conv2d_golden(
         Result of 2D convolution with layout transformation
     """
     # ttir can handle a broadcastable bias in the shape [1, 1, 1, C_out], but PyTorch requires the bias to be rank 1: [C_out].
+    bias = kwargs.get("bias", None)
     if bias is not None:
         bias = bias.squeeze()  # Removes all dims of size 1
 

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -2941,9 +2941,10 @@ class TTIRBuilder(Builder):
         """
         if not bias:
             bias = None
+        golden_bias = self._get_golden_tensor(bias) if bias is not None else None
         return self._op_proxy(
             ttir.Conv2dOp,
-            [in0, weight, bias],
+            [in0, weight],
             ttir_kwargs={
                 "stride": (
                     IntegerAttr.get(IntegerType.get_signed(32), stride)
@@ -2961,6 +2962,14 @@ class TTIRBuilder(Builder):
                     else DenseI32ArrayAttr.get(dilation)
                 ),
                 "groups": groups,
+                "bias": bias,
+            },
+            golden_kwargs={
+                "stride": stride,
+                "padding": padding,
+                "dilation": dilation,
+                "groups": groups,
+                "bias": golden_bias,
             },
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1], o),
             unit_attrs=unit_attrs,


### PR DESCRIPTION
### Ticket
NA

### Problem description
`ttir.conv2d` was dropping the optional bias operand

### What's changed
- updated `ttir.conv2d`, it now preserves the bias operand
- updated `conv2d_golden`
- added `test_conv2d_no_bias`

### Checklist