### PR TITLE
[MLA] make SiluOp valid for sharding

### DIFF
--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -94,8 +94,8 @@ void DFShardingPolicy::run() {
         // the current op.
         bool validForSharding =
             llvm::isa<ttnn::Conv2dOp, ttnn::AddOp, ttnn::MultiplyOp,
-                      ttnn::ReluOp, ttnn::Relu6Op, ttnn::TypecastOp,
-                      ttnn::MinimumOp>(currentOp) &&
+                      ttnn::ReluOp, ttnn::Relu6Op, ttnn::SiluOp,
+                      ttnn::TypecastOp, ttnn::MinimumOp>(currentOp) &&
             legalConfigs.lookup(currentOp).size() > 0;
 
         if (validForSharding) {


### PR DESCRIPTION
### Ticket
[Add sharding support for ttnn.silu #5509](https://github.com/tenstorrent/tt-mlir/issues/5509)

### What's changed
This PR adds sharding support for `ttnn.silu`. Out of the 11 benchmark models evaluated, only YOLO_v9 is affected, as it is the only one utilizing `ttnn.silu` operations.

- Local benchmarking with `ttrt run --benchmark` in TT-MLIR showed an approximate 5% improvement.
- CI runs on TT-XLA showed a 3% decrease in performance.

These differences are within the range of measurement noise and observed flakiness. Overall, sharding `ttnn.silu` does not negatively impact performance, but more precise measurements are required to determine any significant positive or negative effects. The expectation is for improved performance, consistent with typical Unary operation behavior when comparing L1 sharded to DRAM interleaved.

### Checklist
- [ ] New/Existing tests provide coverage for changes