### PR TITLE
Disabling pad test for emitpy to unblock CI

### DIFF
--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -106,6 +106,9 @@ def test_cpu_hoistable_concat_op(
 def test_pad(
     shape: Shape, padding: List[int], value: int, target: str, request, device
 ):
+    if target == "emitpy":
+        pytest.skip("Pad python fails during runtime. #5603")
+
     def pad_wrapper(
         in0: Operand,
         builder: TTIRBuilder,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We have a failure for this test on main.

### What's changed
Disabling this test to unblock the main CI. We will handle the investigation later.

### Checklist
- [ ] New/Existing tests provide coverage for changes
