### PR TITLE
Revert "Removing Conv2d Slice Config workaround (#5498)"

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV2DSLICECONFIGREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV2DSLICECONFIGREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Set Conv2dSliceConfig to L1Full with 0 slices as a workaround.
+// This configuration is a safe default that avoids potential issues
+// with slicing while ensuring compatibility with existing models.
+// Metal issue tracking this workaround:
+// https://github.com/tenstorrent/tt-metal/issues/29981
+class Conv2dSliceConfigRewritePattern
+    : public mlir::OpRewritePattern<ttnn::Conv2dOp> {
+public:
+  using mlir::OpRewritePattern<ttnn::Conv2dOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttnn::Conv2dOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV2DSLICECONFIGREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/ConcatOpDecompositionRewritePattern.cpp
         Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
         Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
+        Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+mlir::LogicalResult Conv2dSliceConfigRewritePattern::matchAndRewrite(
+    ttnn::Conv2dOp srcOp, PatternRewriter &rewriter) const {
+  if (srcOp.getConv2dSliceConfig()) {
+    // Conv2dSliceConfig is already set, no need to apply the workaround.
+    return failure();
+  }
+
+  auto conv2dSliceConfigAttr = mlir::tt::ttnn::Conv2dSliceConfigAttr::get(
+      rewriter.getContext(), mlir::tt::ttnn::Conv2dSliceType::L1Full, 0);
+
+  rewriter.modifyOpInPlace(
+      srcOp, [&]() { srcOp.setConv2dSliceConfigAttr(conv2dSliceConfigAttr); });
+
+  return success();
+}
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dEnableKernelStrideFoldingRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dSliceConfigRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
@@ -571,6 +572,7 @@ public:
               Conv2dEnableKernelStrideFoldingRewritePattern<Conv2dOp>,
           workarounds::decomposition::
               Conv2dEnableKernelStrideFoldingRewritePattern<ConvTranspose2dOp>,
+          workarounds::decomposition::Conv2dSliceConfigRewritePattern,
           workarounds::decomposition::ConcatenateHeadsOpRewritePattern>(
           &getContext());
 

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv2d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv2d.mlir
@@ -5,6 +5,7 @@ module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
     %0 = ttir.empty() : tensor<1x32x32x64xbf16>
     // CHECK: %[[C:.*]] = "ttnn.conv2d"
+    // CHECK-SAME: conv2d_slice_config = #ttnn.conv2d_slice_config<l1_full, 0>
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 1, 1>,


### PR DESCRIPTION
## TL;DR

This PR https://github.com/tenstorrent/tt-mlir/pull/5498 caused the test `test/ttmlir/Silicon/TTNN/n150/conv/large_conv2d_2.mlir` to fail, so we're reverting this PR until it is fixed

