### PR TITLE
Fix ttnn.jit python crash in CI

### DIFF
--- a/.github/test_scripts/pykernel.sh
+++ b/.github/test_scripts/pykernel.sh
@@ -13,14 +13,9 @@ ln -sf $INSTALL_DIR/tt-metal third_party/tt-metal/src/tt-metal
 if [ ! -d "$BUILD_DIR/python_packages/ttnn_jit" ]; then
     ln -sf $WORK_DIR/tools/ttnn-jit $BUILD_DIR/python_packages/ttnn_jit
 fi
-if [ ! -d "$BUILD_DIR/python_packages/ttnn_jit/runtime" ]; then
-    ln -sf $BUILD_DIR/python_packages/ttrt/runtime $BUILD_DIR/python_packages/ttnn_jit/runtime
-    mv $BUILD_DIR/python_packages/ttnn_jit/runtime/__init__.py $BUILD_DIR/python_packages/ttnn_jit/runtime/.__init__
-fi
 
 echo "Running PyKernel/ttnn-jit tests..."
 pytest -v $WORK_DIR/test/pykernel/demo/test.py $WORK_DIR/test/ttnn-jit/ --junit-xml=$TEST_REPORT_PATH
 
 # cleanup
 rm -rf third_party/tt-metal
-mv $BUILD_DIR/python_packages/ttnn_jit/runtime/.__init__ $BUILD_DIR/python_packages/ttnn_jit/runtime/__init__.py || true


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5551

### Problem description
python module initialization crashing
broken run: https://github.com/tenstorrent/tt-mlir/actions/runs/18939107901/job/54073713301
fixed run: https://github.com/tenstorrent/tt-mlir/actions/runs/18947585576

