### PR TITLE
Uplift third_party/tt-metal to 879ead61546e571ae0d31d207a56865fd403abc6 2025-10-30

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -4599,7 +4599,7 @@ const auto quantizeOpTestValues = testing::Values(
         detail::TestTensor{
             {32, 64}, TensorMemoryLayout::Interleaved, BufferType::L1},
         std::nullopt,
-        detail::ExpectedResult{true, 14336, 10240, 22528,
+        detail::ExpectedResult{true, 12288, 10240, 22528,
                                4096}}, // note: combined peak < cb+l1 peak
     QuantizeOpParam{
         detail::TestTensor{
@@ -4611,7 +4611,7 @@ const auto quantizeOpTestValues = testing::Values(
         detail::TestTensor{
             {32, 64}, TensorMemoryLayout::Interleaved, BufferType::L1},
         std::make_optional<int32_t>(1),
-        detail::ExpectedResult{true, 18432, 12288, 28672,
+        detail::ExpectedResult{true, 16384, 12288, 28672,
                                4096}}, // note: combined peak < cb+l1 peak
     QuantizeOpParam{
         detail::TestTensor{
@@ -4623,7 +4623,7 @@ const auto quantizeOpTestValues = testing::Values(
         detail::TestTensor{
             {128, 256}, TensorMemoryLayout::Interleaved, BufferType::L1},
         std::make_optional<int32_t>(1),
-        detail::ExpectedResult{true, 18432, 12288, 28672,
+        detail::ExpectedResult{true, 16384, 12288, 28672,
                                4096}}, // note: combined peak < cb+l1 peak
 
     // === DRAM Memory Tests ===
@@ -4637,7 +4637,7 @@ const auto quantizeOpTestValues = testing::Values(
         detail::TestTensor{
             {512, 1024}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
         std::make_optional<int32_t>(1),
-        detail::ExpectedResult{true, 18432, 0, 18432, 0}},
+        detail::ExpectedResult{true, 16384, 0, 16384, 0}},
 
     // === Mixed Memory Configuration Tests ===
     QuantizeOpParam{
@@ -4650,7 +4650,7 @@ const auto quantizeOpTestValues = testing::Values(
         detail::TestTensor{
             {64, 128}, TensorMemoryLayout::Interleaved, BufferType::L1},
         std::make_optional<int32_t>(1),
-        detail::ExpectedResult{true, 18432, 10240, 26624,
+        detail::ExpectedResult{true, 16384, 10240, 26624,
                                4096}}); // note: combined peak < cb+l1 peak
 
 INSTANTIATE_TEST_SUITE_P(QuantizeTests, OpModelQuantizeParam,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1976,8 +1976,7 @@ INSTANTIATE_TEST_SUITE_P(MinimumTests, OpModelMinimumParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(DivideTests, OpModelDivideParam,
-                         generateBinaryEltwiseParams(
-                             binaryEltwiseParams, /*extraCbRequirement=*/2048));
+                         generateBinaryEltwiseParams(binaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(EqualTests, OpModelEqualParam,
                          generateBinaryEltwiseParams(binaryEltwiseParams));

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -482,8 +482,8 @@ TEST_P(BinaryBitwiseOpModelTest, TestOpInterface) {
 const ExpectedResult binaryExpected{true, 12288, 2048, 14336, 2048};
 // Some binary ops (such as logicalOr, etc.) require extra circular
 // buffer memory which is captured via the following expected values:
-const ExpectedResult binaryExpected_extraCb2048{true, 12288 + 2048, 2048, 16384,
-                                                2048};
+[[maybe_unused]] const ExpectedResult binaryExpected_extraCb2048{
+    true, 12288 + 2048, 2048, 16384, 2048};
 const ExpectedResult binaryExpected_extraCb4096{true, 12288 + 4096, 2048, 18432,
                                                 2048};
 const ExpectedResult binaryExpected_extraCb4096_extraPeak30720{

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -480,7 +480,7 @@ TEST_P(BinaryBitwiseOpModelTest, TestOpInterface) {
 
 // The default expected result for binary operations:
 const ExpectedResult binaryExpected{true, 12288, 2048, 14336, 2048};
-// Some binary ops (such as divide, logicalOr, etc.) require extra circular
+// Some binary ops (such as logicalOr, etc.) require extra circular
 // buffer memory which is captured via the following expected values:
 const ExpectedResult binaryExpected_extraCb2048{true, 12288 + 2048, 2048, 16384,
                                                 2048};
@@ -569,7 +569,7 @@ const std::vector<BinaryOpTestParams> binaryOpTestParams = {
     {"Add", createAdd, binaryExpected},
     {"Subtract", createSubtract, binaryExpected},
     {"Multiply", createMultiply, binaryExpected},
-    {"Divide", createDivide, binaryExpected_extraCb2048},
+    {"Divide", createDivide, binaryExpected},
     {"Equal", createEqual, binaryExpected},
     {"NotEqual", createNotEqual, binaryExpected},
     {"GreaterEqual", createGE, binaryExpected},
@@ -4376,9 +4376,9 @@ TEST_F(OpModelBase, QuantizeOpInterface) {
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
       constraintsExp.get();
 
-  EXPECT_GE(cbSize, 18432);
+  EXPECT_GE(cbSize, 16384);
   EXPECT_GE(l1PeakSize, 12288);
-  EXPECT_GE(totalPeakSize, 28672); // smaller than 18432+12288
+  EXPECT_GE(totalPeakSize, 28672); // smaller than 16384+12288
   EXPECT_GE(outputSize, 4096);
 
   ASSERT_TRUE(outputLayout);
@@ -4433,9 +4433,9 @@ TEST_F(OpModelBase, QuantizeOpInterfaceNullOutput) {
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
       constraintsExp.get();
 
-  EXPECT_GE(cbSize, 18432);
+  EXPECT_GE(cbSize, 16384);
   EXPECT_GE(l1PeakSize, 12288);
-  EXPECT_GE(totalPeakSize, 28672); // smaller than 18432+12288
+  EXPECT_GE(totalPeakSize, 28672); // smaller than 16384+12288
   EXPECT_GE(outputSize, 4096);
 
   ASSERT_TRUE(outputLayout);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "6132b083e541174ccd2835d106880df52394e89c")
+set(TT_METAL_VERSION "879ead61546e571ae0d31d207a56865fd403abc6")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 879ead61546e571ae0d31d207a56865fd403abc6



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (basic + models)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):