### PR TITLE
[EmitC] Disable const eval for creation ops

### DIFF
--- a/test/ttmlir/EmitC/TTNN/tensor/full.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/full.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
 // RUN: ttmlir-opt --ttnn-tuplify-tensors="tuplify-input-if-empty=true" --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
 // RUN: ttmlir-opt --ttnn-tuplify-tensors="tuplify-input-if-empty=true" --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
 // RUN: ttmlir-opt --ttnn-tuplify-tensors="tuplify-input-if-empty=true" --convert-ttnn-to-emitc -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir


### PR DESCRIPTION
CI on main is failing on EmitC tests for creation ops: https://github.com/tenstorrent/tt-mlir/actions/runs/18967854611/job/54168404536

Temporarily disable const eval for creation ops in EmitC tests to unblock CI.