### PR TITLE
Disable emitc.sh ttrt tests due to hang

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -34,7 +34,6 @@
   { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
   { "runs-on": "n300-llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
   { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
-  { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
   { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" }


### PR DESCRIPTION
### Ticket
Closes #5633 

### Problem description
Skipping hanging testgroup introduced in #5299 but possibly uncaught by bugged test infra not triggering emitc tests, patched by #5622 but now exposing hangs into main.

### What's changed
Disable new ttrt emitc testgroup.

### Checklist
- [x] New/Existing tests provide coverage for changes
