### PR TITLE
Enable program cache by default

### DIFF
--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -194,7 +194,7 @@ struct MeshDeviceOptions {
   std::vector<uint32_t> meshOffset{0, 0};
   std::vector<int> deviceIds{};
   size_t numHWCQs = 1;
-  bool enableProgramCache = false;
+  bool enableProgramCache = true;
   std::optional<std::vector<uint32_t>> meshShape = std::nullopt;
   std::optional<size_t> l1SmallSize = std::nullopt;
   std::optional<size_t> traceRegionSize = std::nullopt;


### PR DESCRIPTION
### Problem description
Program cache set to on by default in tt-xla and ttnn, we should do the same in runtime.

### What's changed
Enable program cache by default in tt-mlir runtime.

### Checklist
- [X] New/Existing tests provide coverage for changes
