### PR TITLE
Fixing linearOp workaround to include transpose attributes

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h
@@ -11,7 +11,9 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// Rewrite pattern for decomposing batched LinearOp into MatMulOp + AddOp.
+// Workaround: Decompose batched LinearOp (with bias) into MatMulOp + AddOp.
+// ttnn::linear doesn't support batched weight tensors when bias is present.
+// See: https://github.com/tenstorrent/tt-metal/issues/31634
 class LinearOpRewritePattern : public mlir::OpRewritePattern<ttnn::LinearOp> {
 public:
   using OpRewritePattern::OpRewritePattern;

--- a/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
@@ -66,6 +66,7 @@ module {
     %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{transpose_a = true}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<128x128xbf16>, tensor<128x128xbf16>) -> tensor<128x128xbf16>
     return %1 : tensor<128x128xbf16>
   }
+
   func.func @linear_2d_2d_transpose_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     %0 = ttir.empty() : tensor<64x64xbf16>
     // CHECK: "ttnn.linear"
@@ -77,6 +78,7 @@ module {
     %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{transpose_b = true}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
     return %1 : tensor<64x64xbf16>
   }
+
   func.func @linear_2d_tranpose_2d_transpose(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<128x128xbf16>) -> tensor<128x128xbf16> {
     %0 = ttir.empty() : tensor<128x128xbf16>
     // CHECK: "ttnn.linear"
@@ -87,5 +89,25 @@ module {
     // CHECK-SAME: tensor<128x128xbf16
     %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{transpose_a = true, transpose_b = true}> : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<128x128xbf16>, tensor<128x128xbf16>) -> tensor<128x128xbf16>
     return %1 : tensor<128x128xbf16>
+  }
+
+  func.func @main_batch_linear_with_bias_right_transpose(%arg_a : tensor<12x24x64xf32>, %arg_b : tensor<12x24x64xf32>, %arg_bias : tensor<12x24x24xf32>) -> tensor<12x24x24xf32>{
+    %0 = ttir.empty() : tensor<12x24x24xf32>
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: transpose_a = false
+    // CHECK-SAME: transpose_b = true
+    // CHECK: "ttnn.add"
+    %1 = "ttir.linear"(%arg_a, %arg_b, %arg_bias, %0) <{transpose_a = false, transpose_b = true}> : (tensor<12x24x64xf32>, tensor<12x24x64xf32>, tensor<12x24x24xf32>, tensor<12x24x24xf32>) -> tensor<12x24x24xf32>
+    return %1 : tensor<12x24x24xf32>
+  }
+
+  func.func @main_batch_linear_with_bias_left_transpose(%arg_a : tensor<12x24x64xf32>, %arg_b : tensor<12x24x64xf32>, %arg_bias : tensor<12x64x64xf32>) -> tensor<12x64x64xf32>{
+    %0 = ttir.empty() : tensor<12x64x64xf32>
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: transpose_a = true
+    // CHECK-SAME: transpose_b = false
+    // CHECK: "ttnn.add"
+    %1 = "ttir.linear"(%arg_a, %arg_b, %arg_bias, %0) <{transpose_a = true, transpose_b = false}> : (tensor<12x24x64xf32>, tensor<12x24x64xf32>, tensor<12x64x64xf32>, tensor<12x64x64xf32>) -> tensor<12x64x64xf32>
+    return %1 : tensor<12x64x64xf32>
   }
 }


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/5645
Closes https://github.com/tenstorrent/tt-mlir/issues/5662

### Problem description
Linear op workaround fails to calculate output shape when transpose attributes are provided to the op.

### What's changed
Handle the shape calculation when inputs are transposed. Added a test to verify the new behavior.

### Checklist
- [x] New/Existing tests provide coverage for changes
