### PR TITLE
Adding pipeline option to disable workaround pass

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -215,10 +215,11 @@ struct TTIRToTTNNBackendPipelineOptions
 
   // Option to enable/disable the workaround pass.
   //
-  Option<bool> workaroundsEnabled{
-      *this, "enable-workaround-pass",
-      llvm::cl::desc("An option to disable/enable the whole workaround pass."),
-      llvm::cl::init(true)};
+  Option<bool> disableWorkarounds{
+      *this, "disable-workarounds",
+      llvm::cl::desc("An option to disable/enable the whole workaround pass. "
+                     "If set to true, the workaround pass is disabled."),
+      llvm::cl::init(false)};
 
   Option<bool> layoutWorkaroundsEnabled{
       *this, "enable-layout-workaround-pass",

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -130,7 +130,7 @@ void createTTNNPipelineWorkaroundPass(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
 
   // If the workaround pass is disabled, skip adding it.
-  if (!options.workaroundsEnabled) {
+  if (options.disableWorkarounds) {
     return;
   }
 

--- a/test/python/golden/ttir_ops/workarounds/test_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/test_workarounds.py
@@ -63,5 +63,5 @@ def test_linear_without_workaround(
         system_desc_path=request.config.getoption("--sys-desc"),
         target=target,
         device=device,
-        pipeline_options=["enable-workaround-pass=false"],
+        pipeline_options=["disable-workarounds=true"],
     )


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/5648

### Problem description
We didn't have the option to disable workaround passes in the ttir-to-ttnn pipeline. It is useful for a developer to write tests without any workarounds applied and to mark those tests with xfail.

### What's changed
Introduced a pipeline option to enable a workaround pass. This option defaults to true but can be set to false in builder tests. One builder test was added to demonstrate this usage.

### Checklist
- [x] New/Existing tests provide coverage for changes
