### PR TITLE
Change tensor layout before changing dtype

### DIFF
--- a/tools/tt-alchemist/templates/python/local/utils.py
+++ b/tools/tt-alchemist/templates/python/local/utils.py
@@ -63,10 +63,10 @@ def load_tensor(file_path: str, layout, dtype, device, memory_config) -> ttnn.Te
 
     assert loaded_tensor.device() is None, "loaded tensor must be on host"
 
-    if loaded_tensor.dtype != dtype:
-        loaded_tensor = ttnn.to_dtype(loaded_tensor, dtype)
     if loaded_tensor.layout != layout:
         loaded_tensor = ttnn.to_layout(loaded_tensor, layout)
+    if loaded_tensor.dtype != dtype:
+        loaded_tensor = ttnn.to_dtype(loaded_tensor, dtype)
     if device is not None:
         loaded_tensor = ttnn.to_device(loaded_tensor, device, memory_config)
 


### PR DESCRIPTION
### Ticket
#5705

### Problem description
Changing tensor's dtype to block format before changing to `TILE` layout format (i.e. if it's `ROW_MAJOR`) will break.

### What's changed
Changed the ordering.

### Checklist
- [ ] New/Existing tests provide coverage for changes
