### PR TITLE
[d2m] bfp8 support and other typecast fixes

### DIFF
--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -64,8 +64,6 @@ Type getRegionLargestDstElemType(Region &region) {
 
   Type largestType = nullptr;
   region.walk([&](OperandLoadStoreRegisterOpInterface op) {
-    // Only the typecast op has different input & output types, but it's a DST
-    // in-place op so we simply check all the operands of all the compute ops.
     for (Value v : op.getOperation()->getOperands()) {
       Type t = ttcore::getOperandInnerElementType(v);
 
@@ -74,6 +72,18 @@ Type getRegionLargestDstElemType(Region &region) {
         largestType = t;
       }
 
+      if (largestType && getTypeNumberOfBits(largestType) >= 32u) {
+        return WalkResult::interrupt();
+      }
+    }
+    // Check output type for typecast operations that cast to a larger type.
+    if (op.getOperation()->getNumResults() > 0) {
+      Type outputType =
+          ttcore::getOperandInnerElementType(op.getOperation()->getResult(0));
+      if (!largestType || (getTypeNumberOfBits(outputType) >
+                           getTypeNumberOfBits(largestType))) {
+        largestType = outputType;
+      }
       if (largestType && getTypeNumberOfBits(largestType) >= 32u) {
         return WalkResult::interrupt();
       }

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -1536,22 +1536,23 @@ uint64_t TileType::getSizeBytes() const {
     return getHeight() * getWidth() * 2;
   case DataType::BFP_Float8:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 1024;
+    // 1024 + 64 (1 byte of shared exponent for every 16 elements)
+    return 1088;
   case DataType::BFP_BFloat8:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 1024;
+    return 1088;
   case DataType::BFP_Float4:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 512;
+    return 576;
   case DataType::BFP_BFloat4:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 512;
+    return 576;
   case DataType::BFP_Float2:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 256;
+    return 320;
   case DataType::BFP_BFloat2:
     assert(getHeight() == 32 && getWidth() == 32);
-    return 256;
+    return 320;
   case DataType::UInt32:
   case DataType::Int32:
     return getHeight() * getWidth() * 4;

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -102,6 +102,8 @@ inline ::tt::DataFormat toDataFormat(::tt::target::DataType dataType) {
     return ::tt::DataFormat::UInt8;
   case ::tt::target::DataType::Int32:
     return ::tt::DataFormat::Int32;
+  case ::tt::target::DataType::BFP_BFloat8:
+    return ::tt::DataFormat::Bfp8_b;
   default:
     LOG_FATAL("Unsupported data type");
   }


### PR DESCRIPTION
Changes to properly support bfp8 typecasts and typecasting to a larger type.

### What's changed
Hardcoded size in bytes for block floating point types was not taking shared exponent size into account.

Changed `getRegionLargestDstElemType` to also take output type into account. Without this there's an issue when typecasting to a larger type, leading to incorrect values for `dstCapacity`.