### PR TITLE
Don't package dep wheels

### DIFF
--- a/tools/tt-alchemist/csrc/CMakeLists.txt
+++ b/tools/tt-alchemist/csrc/CMakeLists.txt
@@ -171,7 +171,7 @@ add_custom_target(build-wheel-tt-alchemist
     ${PYTHON_BUILD_DIR}/tt_alchemist/lib/libdevice.so
     ${PYTHON_BUILD_DIR}/tt_alchemist/lib/libtracy.so.0.10.0
     tt_alchemist_copy_templates
-  COMMAND ${Python3_EXECUTABLE} -m pip wheel -w ${CMAKE_CURRENT_BINARY_DIR}/dist ${PYTHON_BUILD_DIR} --quiet
+  COMMAND ${Python3_EXECUTABLE} -m pip wheel --no-deps -w ${CMAKE_CURRENT_BINARY_DIR}/dist ${PYTHON_BUILD_DIR} --quiet
   WORKING_DIRECTORY ${PYTHON_BUILD_DIR}
   COMMENT "Building tt-alchemist wheel"
 )


### PR DESCRIPTION
### Ticket
Ad-hoc fix

### Problem description
Specific version of clang-format was packaged into tt-alchemist wheel. In downstream projects, like tt-xla, installation of tt-alchemist wheel would then cause that specific packaged installation to install, but would fail if there was another version there already.

```
Processing ./dist/black-25.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl
Processing ./dist/clang_format-21.1.2-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
Processing ./dist/clang_format-21.1.5-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
Processing ./dist/click-8.3.0-py3-none-any.whl
Processing ./dist/mypy_extensions-1.1.0-py3-none-any.whl
Processing ./dist/packaging-25.0-py3-none-any.whl
Processing ./dist/pathspec-0.12.1-py3-none-any.whl
Processing ./dist/platformdirs-4.5.0-py3-none-any.whl
Processing ./dist/pytokens-0.2.0-py3-none-any.whl
Processing ./dist/pytokens-0.3.0-py3-none-any.whl
Processing ./dist/tt_alchemist-0.1.0-py3-none-any.whl
ERROR: Cannot install clang-format 21.1.2 (from /localdev/svuckovic/_workspace/repos/tt-xla/third_party/tt-mlir/src/tt-mlir/build/tools/tt-alchemist/csrc/dist/clang_format-21.1.2-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) and clang-format 21.1.5 (from /localdev/svuckovic/_workspace/repos/tt-xla/third_party/tt-mlir/src/tt-mlir/build/tools/tt-alchemist/csrc/dist/clang_format-21.1.5-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested clang-format 21.1.2 (from /localdev/svuckovic/_workspace/repos/tt-xla/third_party/tt-mlir/src/tt-mlir/build/tools/tt-alchemist/csrc/dist/clang_format-21.1.2-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl)
    The user requested clang-format 21.1.5 (from /localdev/svuckovic/_workspace/repos/tt-xla/third_party/tt-mlir/src/tt-mlir/build/tools/tt-alchemist/csrc/dist/clang_format-21.1.5-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl)

Additionally, some packages in these conflicts have no matching distributions available for your environment:
    clang-format

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```

### What's changed
clang-format and other deps of tt-alchemist are not packaged into the wheel, but are just specified to be installed so that this error doesn't occur in downstream projects.

### Checklist
- [ ] New/Existing tests provide coverage for changes
