### PR TITLE
Uplift third_party/tt-metal to 094a4ed 2025-11-06

### DIFF
--- a/runtime/lib/ttmetal/meshshard_utils.cpp
+++ b/runtime/lib/ttmetal/meshshard_utils.cpp
@@ -18,7 +18,7 @@ namespace tt::runtime::ttmetal::meshshard_utils {
 namespace target = ::tt::target;
 namespace tt_metal = ::tt::tt_metal;
 namespace distributed = ::tt::tt_metal::distributed;
-namespace xtensor = ::ttnn::experimental::xtensor;
+namespace xtensor = ::tt::tt_metal::experimental::xtensor;
 
 // Copy from increment_indices() in ttnn/tensor/xtensor/partition.cpp.
 static bool incrementIndices(const ttsl::SmallVector<int> &limits,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "094a4ed")
+set(TT_METAL_VERSION "094a4ed7d519a3d099831c0345ffa2a6d13f5b94")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "c4d49e9d2b9117bcef4f5cf732fad41ca0bf7054")
+set(TT_METAL_VERSION "094a4ed")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 094a4ed



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-fe/actions/runs/19152242067
  - [ ] [tt-xla (basic + models)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/19152245918
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):