### PR TITLE
Fix ToLayoutOp folding to preserve DRAM staging when ops are in between

### DIFF
--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -5,6 +5,7 @@
 #ifndef TTMLIR_SUPPORT_LOGGER_H
 #define TTMLIR_SUPPORT_LOGGER_H
 
+#include "mlir/IR/Operation.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -17,6 +18,16 @@
 #include <type_traits>
 
 namespace ttmlir {
+
+inline std::string opToString(mlir::Operation *op) {
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  mlir::OpPrintingFlags flags;
+  flags.elideLargeElementsAttrs();
+  op->print(os, flags);
+  os.flush();
+  return s;
+}
 
 // Log components for different components
 enum class LogComponent { Optimizer, OpValidation, Allocator, Test, General };

--- a/test/unittests/Support/CMakeLists.txt
+++ b/test/unittests/Support/CMakeLists.txt
@@ -13,4 +13,5 @@ target_include_directories(TTMLIRSupportTests
 target_link_libraries(TTMLIRSupportTests
   PRIVATE
     MLIRSupport
+    MLIRIR
 )


### PR DESCRIPTION
## Problem description

This commit fixes a bug in the ToLayoutOp consecutive folding optimization that was incorrectly eliminating DRAM staging operations, potentially causing memory allocation issues.

The `foldConsecutiveToLayoutOp` function was merging consecutive ToLayoutOps without considering whether there were operations between them that depended on DRAM staging for memory pressure management.

Before fix (incorrect folding):
```
    relu -> %148 (L1 block-sharded)
      |-> to_layout -> %149 (DRAM interleaved)
      |    [other ops that were scheduled assuming DRAM]
      |    '-> to_layout -> %153 (L1 block-sharded)
      |         '-> conv2d_2
      '-> to_layout -> %150 (L1 width-sharded)
           '-> conv2d_1
```

After canonicalization, %149 was incorrectly folded away:
```
    relu -> %148 (L1 block-sharded)
      |-> to_layout -> %153 (L1 block-sharded) [X] WRONG
      |    '-> conv2d_2
      '-> to_layout -> %150 (L1 width-sharded)
           '-> conv2d_1
```

This breaks memory staging because the ops in between were analyzed/scheduled assuming the tensor would be in DRAM. Folding bypasses DRAM and keeps the tensor in L1, causing memory pressure the optimizer didn't account for.


## Change 

Added a check in `foldConsecutiveToLayoutOp` to reject folding when:
1. There are operations between the producer and consumer ToLayoutOps, AND
2. Producer moves to DRAM buffer type, AND
3. Consumer moves to L1 buffer type

Piggy-backed fix in Optimizer:
- Try skipping spill to DRAM on the *nearest* forked branch in the schedule.

### Testing

Tested on full resnet50, where we end up with 4 more spill to dram (to_memory_config) ops. Perf dropped by ~10 fps measured by `ttrt` benchmarking.

