### PR TITLE
Add StableHLO DynamicSlice operation support to builder ecosystem

### DIFF
--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1563,6 +1563,180 @@ def index_golden(
     return torch.index_select(input_tensor, dim=dim, index=index)
 
 
+def gather_golden(
+    input_tensor: GoldenMapTensor,
+    start_indices_tensor: GoldenMapTensor,
+    **kwargs,
+) -> GoldenMapTensor:
+    """
+    Golden function for gather operation with TTIR parameter names.
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Input tensor to gather from
+    start_indices_tensor : GoldenMapTensor
+        Tensor containing starting indices
+    **kwargs : dict
+        Keyword arguments including gather attributes as MLIR attributes
+
+    Returns
+    -------
+    GoldenMapTensor
+        Gathered tensor
+    """
+
+    # helpers
+    def _isGoldenMapTensor(x):
+        return isinstance(x, GoldenMapTensor)
+
+    def _first_shard(x):
+        return x.shard_at(0) if _isGoldenMapTensor(x) else x
+
+    def _assert_replicated(t):
+        ref = t.shard_at(0)
+        for device_id, shard in t.shard_map.items():
+            if not torch.equal(shard, ref):
+                raise ValueError("gather golden expects replicated tensors")
+
+    # ----- unpack attrs -----
+    offset_dims = unpack_mlir_attr(kwargs.get("offset_dims", []))
+    collapsed_slice_dims = unpack_mlir_attr(kwargs.get("collapsed_slice_dims", []))
+    operand_batching_dims = unpack_mlir_attr(kwargs.get("operand_batching_dims", []))
+    start_indices_batching_dims = unpack_mlir_attr(
+        kwargs.get("start_indices_batching_dims", [])
+    )
+    start_index_map = unpack_mlir_attr(kwargs.get("start_index_map", []))
+    index_vector_dim = unpack_mlir_attr(kwargs.get("index_vector_dim", 0))
+    slice_sizes = unpack_mlir_attr(kwargs.get("slice_sizes", []))
+    indices_are_sorted = unpack_mlir_attr(kwargs.get("indices_are_sorted", False))
+
+    x = input_tensor
+    idx = start_indices_tensor
+    device = x.device if hasattr(x, "device") else None
+
+    # validate/comute using shard-0 (torch), then slice the wrapper
+    if _isGoldenMapTensor(idx):
+        _assert_replicated(idx)
+    x0 = _first_shard(x)
+    idx0 = _first_shard(idx)
+
+    # ---- validate attrs ----
+    rank = x0.dim()
+    assert len(slice_sizes) == rank, "slice_sizes must match operand dimensions"
+    assert set(collapsed_slice_dims) == set(
+        start_index_map
+    ), "gathe golden assumes collapsed_slice_dims == start_index_map"
+    assert (
+        len(operand_batching_dims) == 0 and len(start_indices_batching_dims) == 0
+    ), "Batching dims not supported in this golden"
+    for d in collapsed_slice_dims:
+        assert slice_sizes[d] == 1, "collapsed dims must have slice size 1"
+
+    if idx0.dim() == 0:
+        idx0 = idx0.unsqueeze(0)
+    if len(start_index_map) == 1 and index_vector_dim == idx0.ndim:
+        pass
+    else:
+        # Expect the conventional "last dim holds the vector"
+        assert (
+            index_vector_dim == idx0.ndim - 1
+        ), "This golden expects index_vector_dim == last dimension for multi-d indices"
+
+    # Determine batch shape and flatten indices to [B, K]
+    if idx0.ndim == 1:  # simple path, K == 1
+        batch_shape = idx0.shape  # [N]
+        K = 1
+        idx_flat0 = idx0.reshape(-1, 1).long()
+    else:
+        K = idx0.shape[-1]
+        assert K == len(
+            start_index_map
+        ), "index vector length must match start_index_map"
+        batch_shape = idx0.shape[:-1]
+        idx_flat0 = idx0.reshape(-1, K).long()
+
+    # Bounds check (might help avoid segfaults)
+    for d in range(rank):
+        if d not in start_index_map:
+            assert slice_sizes[d] <= x0.size(d), "slice size too large for operand"
+    for k, d in enumerate(start_index_map):
+        valid_max = x0.size(d) - slice_sizes[d]
+        if torch.any(idx_flat0[:, k] < 0) or torch.any(idx_flat0[:, k] > valid_max):
+            print(d)
+            raise IndexError(
+                "gather start indices out of bounds for operand dim {}".format(d)
+            )
+
+    # Build the natural slice_shape (operand order, skipping collapsed dims)
+    slice_dims_natural = [d for d in range(rank) if d not in collapsed_slice_dims]
+    natural_slice_shape = [slice_sizes[d] for d in slice_dims_natural]
+
+    # Number of non-collapsed dims must match offset_dims count
+    assert len(slice_dims_natural) == len(
+        offset_dims
+    ), "offset_dims must have one entry per non-collapsed slice dim"
+
+    # For each batch vector of indices, slice x accordingly
+    B = int(torch.tensor(batch_shape).prod()) if len(batch_shape) > 0 else 1
+    slices = []
+    for b in range(B):
+        starts = [0] * rank
+        ends = [0] * rank
+        # Fill starts/ends from index vector for mapped dims
+        for k, d in enumerate(start_index_map):
+            starts[d] = int(idx_flat0[b, k].item())
+            ends[d] = starts[d] + slice_sizes[d]
+        # For the other dims, start at 0 (or clamp) and take slice_sizes[d]
+        for d in range(rank):
+            if d not in start_index_map:
+                starts[d] = 0
+                ends[d] = slice_sizes[d]
+
+        # Build the per-dim slice
+        slicer = tuple(slice(starts[d], ends[d]) for d in range(rank))
+        sub = x[slicer]  # shape equals slice_sizes in operand order
+
+        # Remove collapsed dims (size-1) to get natural slice shape
+        if len(collapsed_slice_dims) > 0:
+            sub = sub.squeeze(dim=tuple(sorted(collapsed_slice_dims)))
+
+        slices.append(sub)
+
+    # Stack over batch
+    if len(slices) == 1 and batch_shape == ():
+        gathered = slices[0]
+    else:
+        gathered = torch.stack(slices, dim=0).reshape(
+            *batch_shape, *natural_slice_shape
+        )
+
+    # position the slice dims inside the result according to offset_dims.
+    # Current order: [B0, B1, ..., Slice0, Slice1, ...]
+    batch_rank = len(batch_shape)
+    slice_rank = len(natural_slice_shape)
+    result_rank = batch_rank + slice_rank
+
+    remaining_positions = [p for p in range(result_rank) if p not in offset_dims]
+    assert (
+        len(remaining_positions) == batch_rank
+    ), "offset_dims inconsistent with batch rank"
+
+    desired_index_for_current = [None] * result_rank
+    # map batch dims
+    for b_i in range(batch_rank):
+        desired_index_for_current[b_i] = remaining_positions[b_i]
+    # map slice dims
+    for s_i in range(slice_rank):
+        desired_index_for_current[batch_rank + s_i] = offset_dims[s_i]
+
+    # Permute if needed
+    if desired_index_for_current != list(range(result_rank)):
+        gathered = gathered.permute(*desired_index_for_current)
+
+    return gathered.to(device=device)
+
+
 def tilize_golden(
     input_tensor: GoldenMapTensor, tilize=True, **kwargs
 ) -> GoldenMapTensor:
@@ -2133,6 +2307,58 @@ def index_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
 
     indices = torch.arange(begin, end, step, device=input_tensor.device)
     return torch.index_select(input_tensor, dim, indices)
+
+
+def dynamic_slice_golden(
+    input_tensor: GoldenMapTensor,
+    **kwargs,
+) -> GoldenMapTensor:
+    """
+    Golden function for dynamic_slice operation.
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Input tensor to slice
+    *start_indices_tensors : GoldenMapTensor
+        One tensor per dimension, each providing the start index for that dimension.
+        Scalars or rank-1 tensors are supported; values are interpreted as integers.
+    **kwargs : dict
+        Keyword arguments including 'slice_sizes' as MLIR attribute
+
+    Returns
+    -------
+    GoldenMapTensor
+        Dynamically sliced tensor
+    """
+
+    start_indices_tensors = unpack_mlir_attr(kwargs.get("start_indices", []))
+    slice_sizes = unpack_mlir_attr(kwargs.get("slice_sizes", []))
+    rank = len(slice_sizes)
+    assert rank == len(start_indices_tensors), "start_indices_tensors must match rank"
+
+    # Extract start indices (use shard-0 for validation)
+    starts: List[int] = []
+    x0 = input_tensor.shard_at(0)
+    for d, st in enumerate(start_indices_tensors):
+        val0 = st if not isinstance(st, GoldenMapTensor) else st.shard_at(0)
+        starts.append(val0)
+
+        # Bounds check
+        max_valid = x0.size(d) - slice_sizes[d]
+        if starts[d] < 0 or starts[d] > max_valid:
+            raise IndexError(
+                f"dynamic_slice start index out of bounds for dim {d}: {starts[d]} not in [0,{max_valid}]"
+            )
+
+    # Build slices
+    slicers = tuple(slice(starts[d], starts[d] + slice_sizes[d]) for d in range(rank))
+
+    shard_map = {}
+    for device_id, shard in input_tensor.shard_map.items():
+        shard_map[device_id] = shard[slicers]
+
+    return GoldenMapTensor(shard_map, input_tensor.mesh_shape)
 
 
 def repeat_interleave_golden(
@@ -3871,8 +4097,7 @@ def stablehlo_constant_golden(value: DenseElementsAttr) -> GoldenMapTensor:
         value = value.get_splat_value()
         torch_tensor = torch.full(shape, value.value, dtype=dtype)
     else:
-        flat_values = [elem for elem in value]
-        torch_tensor = torch.tensor(flat_values, dtype=dtype).reshape(shape)
+        torch_tensor = torch.tensor(np.array(value), dtype=dtype).reshape(shape)
 
     return GoldenMapTensor({0: torch_tensor.reshape(shape)}, (1, 1))
 
@@ -5123,6 +5348,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.ShiftRightLogicalOp: stablehlo_shift_right_logical_golden,
     stablehlo.ReverseOp: stablehlo_reverse_golden,
     stablehlo.DotGeneralOp: dot_general_golden,
+    stablehlo.DynamicSliceOp: dynamic_slice_golden,
     stablehlo.DynamicUpdateSliceOp: stablehlo_dynamic_update_slice_golden,
     # StableHLO tensor manipulation operations
     stablehlo.TransposeOp: stablehlo_transpose_golden,


### PR DESCRIPTION
### Ticket
Close #4879 

### Problem description
Add StableHLO Slice operation support to builder ecosystem

### What's changed

1. StableHLO Builder (tools/builder/stablehlo/stablehlo_builder.py)
stablehlo.DynamicSliceOp requires constant input, so stablehlo.constant is created in the same style as ttir.constant.

2. Golden Function Mapping (tools/golden/mapping.py)
3. Test Implementation (test/python/golden/test_stablehlo_ops.py)
4. Builder (tools/builder/base/builder.py)
The second operand of stablehlo.DynamicSliceOp, start_indices, is a variable number of scalar integer tensors, so it needs to be treated as a List.


### Checklist
- [ ] New/Existing tests provide coverage for changes
