### PR TITLE
Fix use-after-free in permute-reduce EIO pattern

### DIFF
--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
@@ -47,9 +47,16 @@ public:
         /*inverseDimPermute=*/true);
 
     SmallVector<Operation *> users(op->getUsers());
+    // All users should be identical TMs before we start
+    // replacing them. We must not reference `permuteUser` during/after
+    // replacements, as it will be erased on its turn.
+    assert(llvm::all_of(users,
+                        [&](Operation *user) {
+                          return checkIdenticalTms(permuteUser, user);
+                        }) &&
+           "shouldCommute should have ensured identical TM users");
+
     for (auto *user : users) {
-      assert(checkIdenticalTms(permuteUser, user) &&
-             "shouldCommute should have ensured this is true");
       rewriter.replaceOp(user, newReduce);
     }
   }


### PR DESCRIPTION
`llvm-lit` test failed on macos build https://github.com/tenstorrent/tt-mlir/actions/runs/19220308155/job/54937104945

The issue is that we `replaceOp` in each iteration, at some point we also replace `permuteUser` which we use subsequently in `checkIdenticalTms`.

Workflow on which I tested the change: https://github.com/tenstorrent/tt-mlir/actions/runs/19227210017/job/54957089590