### PR TITLE
Fix cache ttmlir-toolchain action timeout

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /opt/ttmlir-toolchain
-        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}-${{ inputs.sdk }}
+        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**', '!env/build/**') }}-${{ inputs.sdk }}
 
     - name: 'Build ttmlir-toolchain'
       if: steps.cache-toolchain.outputs.cache-hit != 'true'


### PR DESCRIPTION
`Post build and cache ttmlir-toolchain` action on `build-macos` job is failing due to timeout of hashing https://github.com/tenstorrent/tt-mlir/actions/runs/19227210017/job/54969760013. Previously it used to hash the whole `env` dir, which included `env/build`. Since `env/build` is an artifact there is no need for it to be included in the hash calculation.