### PR TITLE
Adding emitpy reduction tests

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -966,11 +966,8 @@ def TTNN_ProdOp : TTNN_Op<"prod"> {
 
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-      mlir::Type elementType = getInput().getType().getElementType();
-      bool allDimensions = !getDimArg();
       return
-        wa::TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds(
-                                                    elementType, allDimensions);
+        wa::TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds();
     }
   }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -313,9 +313,7 @@ public:
   createReductionOpOperandsWorkarounds(mlir::Operation *op);
 
   // Create workaround for reduce (full) product op operands.
-  static TTNNOperandsWorkarounds
-  createReduceProdOpOperandsWorkarounds(mlir::Type elementType,
-                                        bool allDimensions);
+  static TTNNOperandsWorkarounds createReduceProdOpOperandsWorkarounds();
 
   // Create workarounds for sort op operands.
   static TTNNOperandsWorkarounds

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -318,9 +318,9 @@ public:
     std::optional<::mlir::ArrayAttr> dimArg = op.getDimArg();
     int64_t size = dimArg ? dimArg->size() : inputRank;
 
-    // [TODO](mmanzoor) Decompose ttnn.prod op into multiple ttnn.prod to handle
-    // reduction along multiple dimensions.
-    // https://github.com/tenstorrent/tt-mlir/issues/1861
+    // Multi-dimensional reductions (except for reducing all dimensions) should
+    // be decomposed in the decomposition pass, so size should be 1 or inputRank
+    // here.
     if ((size > 1) && (size < inputRank)) {
       return rewriter.notifyMatchFailure(
           op, "tt-metal only supports reduce(prod) along one dimension or all "

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -744,13 +744,9 @@ TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(
 // Factory method to create a set of workarounds for reduce product op operands.
 // tt-metal only supports full product reduction for bfloat16 data type.
 TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds(
-    mlir::Type elementType, bool allDimensions) {
-  bool isDataTypeWARequired = allDimensions && !elementType.isBF16();
+TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds() {
   TTNNOperandWorkarounds bf16Workaround;
-  if (isDataTypeWARequired) {
-    bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
-  }
+  bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(bf16Workaround)

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -75,7 +75,7 @@ def test_sum(
 @pytest.mark.skip_config(["p150"], ["p300"])
 @pytest.mark.parametrize("m", [4, 8, 16])
 @pytest.mark.parametrize("n", [2, 4, 8])
-@pytest.mark.parametrize("dim_arg", [0, 1])
+@pytest.mark.parametrize("dim_arg", [[0], [1]])
 @pytest.mark.parametrize("keep_dim", [True])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_max(

--- a/test/python/golden/ttir_ops/reduction/test_reduction.py
+++ b/test/python/golden/ttir_ops/reduction/test_reduction.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from typing import Callable, List, Optional
+from conftest import x86_only
+from builder.base.builder import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_utils import compile_and_execute_ttir
+from test_utils import (
+    Marks,
+    shapes_list_str,
+)
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+reduction_op_names = [
+    "argmax",
+    "max",
+    "mean",
+    "min",
+    "prod",
+    "reduce_and" | Marks(pytest.mark.skip(reason="Builder test not supported #5792")),
+    "reduce_or" | Marks(pytest.mark.skip(reason="Builder test not supported #5792")),
+    "sum",
+]
+
+
+keep_dim_options = [
+    True,
+    False,
+]
+
+
+dim_arg_options = [
+    [2],
+    [1, 2],
+    None,
+]
+
+
+@pytest.mark.parametrize("shapes", [[(32, 128, 128)]], ids=shapes_list_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("keep_dim", keep_dim_options)
+@pytest.mark.parametrize("dim_arg", dim_arg_options)
+@pytest.mark.parametrize("reduction_op_name", reduction_op_names)
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_reduction_ops(
+    shapes,
+    dtype: torch.dtype,
+    keep_dim: bool,
+    dim_arg: Optional[List[int]],
+    reduction_op_name: str,
+    target: str,
+    request,
+    device,
+):
+
+    if (
+        reduction_op_name == "max"
+        or reduction_op_name == "min"
+        or reduction_op_name == "mean"
+        or reduction_op_name == "sum"
+    ) and dim_arg is None:
+        request.node.add_marker(
+            pytest.xfail(
+                reason="Fails Golden, see issue https://github.com/tenstorrent/tt-metal/issues/32274"
+            )
+        )
+
+    if reduction_op_name == "argmax" and dim_arg is not None and len(dim_arg) > 1:
+        request.node.add_marker(
+            pytest.xfail(
+                reason="Fails in TTIR compilation, see issue https://github.com/tenstorrent/tt-mlir/issues/5791"
+            )
+        )
+
+    if reduction_op_name == "prod" and dim_arg is None and keep_dim is True:
+        request.node.add_marker(
+            pytest.xfail(
+                reason="Fails in ttnn runtime, see issue https://github.com/tenstorrent/tt-metal/issues/32279"
+            )
+        )
+
+    def reduction_op_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        reduction_op_builder_map = {
+            "argmax": builder.argmax,
+            "max": builder.max,
+            "mean": builder.mean,
+            "min": builder.min,
+            "prod": builder.prod,
+            "reduce_and": builder.reduce_and,
+            "reduce_or": builder.reduce_or,
+            "sum": builder.sum,
+        }
+
+        reduction_func = reduction_op_builder_map.get(reduction_op_name)
+
+        return reduction_func(
+            in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
+        )
+
+    reduction_op_wrapper.__name__ = f"{reduction_op_name}"
+
+    compile_and_execute_ttir(
+        reduction_op_wrapper,
+        inputs_shapes=shapes,
+        inputs_types=[dtype],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+
+
+reduction_op_cpu_hoisted_names = [
+    "argmax",
+    "max",
+    "mean",
+    "min"
+    | Marks(
+        pytest.mark.xfail(reason="Not supported in CPU hoisted mode, see issue #5810")
+    ),
+    "prod",
+    "reduce_and" | Marks(pytest.mark.xfail(reason="Builder test not supported #5792")),
+    "reduce_or" | Marks(pytest.mark.xfail(reason="Builder test not supported #5792")),
+    "sum",
+]
+
+
+@x86_only
+@pytest.mark.parametrize("shapes", [[(32, 128, 128)]], ids=shapes_list_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("keep_dim", keep_dim_options)
+@pytest.mark.parametrize("dim_arg", dim_arg_options)
+@pytest.mark.parametrize("reduction_op_name", reduction_op_cpu_hoisted_names)
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_reduction_cpu_hoisted_ops(
+    shapes,
+    dtype: torch.dtype,
+    keep_dim: bool,
+    dim_arg: Optional[List[int]],
+    reduction_op_name: str,
+    target: str,
+    request,
+    device,
+):
+    if reduction_op_name == "argmax" and dim_arg is not None and len(dim_arg) > 1:
+        request.node.add_marker(
+            pytest.xfail(reason="Fails in TTIR compilation, see issue #5791")
+        )
+    elif reduction_op_name == "argmax":
+        request.node.add_marker(
+            pytest.xfail(reason="Not supported in CPU hoisted mode, see issue #5809")
+        )
+
+    if (
+        (reduction_op_name == "max" or reduction_op_name == "sum")
+        and (dim_arg is None or len(dim_arg) != 1)
+        and keep_dim == False
+    ):
+        request.node.add_marker(
+            pytest.mark.xfail(
+                reason="Not supported in CPU hoisted mode, see issues #5811",
+            )
+        )
+
+    if reduction_op_name == "prod" and (dim_arg is None or len(dim_arg) == 1):
+        request.node.add_marker(
+            pytest.xfail(reason="Not supported in CPU hoisted mode, see issue #5812")
+        )
+
+    def reduction_op_cpu_hoisted_wrapper(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
+        reduction_op_builder_map = {
+            "argmax": builder.argmax,
+            "max": builder.max,
+            "mean": builder.mean,
+            "min": builder.min,
+            "prod": builder.prod,
+            "reduce_and": builder.reduce_and,
+            "reduce_or": builder.reduce_or,
+            "sum": builder.sum,
+        }
+
+        reduction_func = reduction_op_builder_map.get(reduction_op_name)
+
+        return reduction_func(
+            in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=["ttir.should_hoist"]
+        )
+
+    reduction_op_cpu_hoisted_wrapper.__name__ = f"{reduction_op_name}_cpu_hoisted"
+
+    compile_and_execute_ttir(
+        reduction_op_cpu_hoisted_wrapper,
+        inputs_shapes=shapes,
+        inputs_types=[dtype],
+        test_base=request.node.name,
+        device=device,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_prod.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_prod.mlir
@@ -8,8 +8,8 @@ module attributes {} {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
+    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }
@@ -32,8 +32,8 @@ module attributes {} {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
+    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
     return %1 : tensor<128x4xf32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_prod_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_prod_op.mlir
@@ -11,8 +11,8 @@ module @jit_reduce_prod attributes {} {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
+    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
     return %0 : tensor<128x32x4xf32>
   }
@@ -22,8 +22,8 @@ module @jit_reduce_prod attributes {} {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 2
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x10xf32,
+    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x10xbf16,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x10xf32>
     return %0 : tensor<128x10xf32>
   }
@@ -33,8 +33,8 @@ module @jit_reduce_prod attributes {} {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
+    // CHECK-SAME: (tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_prod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_prod.mlir
@@ -11,8 +11,8 @@ module {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_prod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_prod.mlir
@@ -11,8 +11,8 @@ module {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }
@@ -23,8 +23,8 @@ module {
     // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x1x32x4xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xf32>, tensor<128x1x32x4xf32>) -> tensor<128x1x32x4xf32>
     return %1 : tensor<128x1x32x4xf32>
   }

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -2043,7 +2043,7 @@ class TTIRBuilder(Builder):
     def argmax(
         self,
         in0: Operand,
-        dim_arg: List[int],
+        dim_arg: List[int] = None,
         keep_dim: bool = False,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -2082,7 +2082,7 @@ class TTIRBuilder(Builder):
     def sum(
         self,
         in0: Operand,
-        dim_arg: List[int] = [0],
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -2131,7 +2131,7 @@ class TTIRBuilder(Builder):
     def mean(
         self,
         in0: Operand,
-        dim_arg: List[int] = [0],
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -2169,7 +2169,7 @@ class TTIRBuilder(Builder):
     def max(
         self,
         in0: Operand,
-        dim_arg: int = None,
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -2196,32 +2196,18 @@ class TTIRBuilder(Builder):
         (*OpView*)
             Tensor with maximum values
         """
-        # Handle ttir and golden function arguments for edge cases
-        ttir_kwargs = {"keep_dim": keep_dim}
-        input_shape = list(self.get_shape(in0))
-        ndim = len(input_shape)
-        if dim_arg is not None:
-            golden_kwargs = {"dim_arg": dim_arg, "keep_dim": keep_dim}
-            ttir_kwargs["dim_arg"] = [dim_arg]
-            output_shape = input_shape.copy()
-            output_shape[dim_arg] = 1
-        else:
-            golden_kwargs = {"dim_arg": None, "keep_dim": keep_dim}
-            output_shape = [1] * ndim
-
+        kwargs = {"dim_arg": dim_arg, "keep_dim": keep_dim}
         return self._op_proxy(
             ttir.MaxOp,
             [in0],
-            golden_kwargs=golden_kwargs,
-            ttir_kwargs=ttir_kwargs,
-            output_shape=output_shape,
+            ttir_kwargs=kwargs,
             unit_attrs=unit_attrs,
         )
 
     def min(
         self,
         in0: Operand,
-        dim_arg: int = None,
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
@@ -2248,19 +2234,11 @@ class TTIRBuilder(Builder):
         (*OpView*)
             Tensor with minimum values
         """
-        # Handle ttir and golden function arguments for edge cases
-        ttir_kwargs = {"keep_dim": keep_dim}
-        output_shape = [1] * len(self.get_shape(in0))
-        if dim_arg:
-            ttir_kwargs["dim_arg"] = [dim_arg]
-        if not keep_dim:
-            output_shape = torch.Size([1])
-
+        kwargs = {"dim_arg": dim_arg, "keep_dim": keep_dim}
         return self._op_proxy(
             ttir.MinOp,
             [in0],
-            ttir_kwargs=ttir_kwargs,
-            output_shape=output_shape,
+            ttir_kwargs=kwargs,
             unit_attrs=unit_attrs,
         )
 
@@ -2268,8 +2246,8 @@ class TTIRBuilder(Builder):
     def reduce_and(
         self,
         in0: Operand,
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
-        dim_args: Optional[List] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         """
@@ -2298,7 +2276,7 @@ class TTIRBuilder(Builder):
         return self._op_proxy(
             ttir.ReduceAndOp,
             [in0],
-            ttir_kwargs={"dim_arg": dim_args, "keep_dim": keep_dim},
+            ttir_kwargs={"dim_arg": dim_arg, "keep_dim": keep_dim},
             unit_attrs=unit_attrs,
         )
 
@@ -2306,8 +2284,8 @@ class TTIRBuilder(Builder):
     def reduce_or(
         self,
         in0: Operand,
+        dim_arg: List[int] = None,
         keep_dim: bool = True,
-        dim_args: Optional[List] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         """
@@ -2336,7 +2314,7 @@ class TTIRBuilder(Builder):
         return self._op_proxy(
             ttir.ReduceOrOp,
             [in0],
-            ttir_kwargs={"dim_arg": dim_args, "keep_dim": keep_dim},
+            ttir_kwargs={"dim_arg": dim_arg, "keep_dim": keep_dim},
             unit_attrs=unit_attrs,
             output_type=F32Type.get(self._ctx),
         )
@@ -2344,7 +2322,7 @@ class TTIRBuilder(Builder):
     def prod(
         self,
         in0: Operand,
-        dim_arg: List[int],
+        dim_arg: List[int] = None,
         keep_dim: bool = False,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We don't have reduction tests for EmitPy.

### What's changed
Restructured reduction builder tests:
- Move reduction tests under a separate file
- File issues for currently non-supported cases
- Added emitpy execution target in tests

### Checklist
- [x] New/Existing tests provide coverage for changes
