### PR TITLE
[TTIRFusing] Add RepVGGConvSumFusionPattern

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1187,8 +1187,8 @@ private:
 
     // Pad the 1x1 weight to 3x3 by adding zeros around it
     SmallVector<int32_t> paddingValues = {0, 0, 0, 0, 1, 1, 1, 1};
-    return utils::createDPSOp<PadOp>(
-        rewriter, ttmlir::utils::appendLocationSuffix(conv.getLoc(), "_pad"),
+    return rewriter.create<PadOp>(
+        ttmlir::utils::appendLocationSuffix(conv.getLoc(), "_pad"),
         weight3x3Type, weight1x1, rewriter.getDenseI32ArrayAttr(paddingValues),
         rewriter.getF32FloatAttr(0.0));
   }
@@ -1204,8 +1204,7 @@ private:
     // Move additional weight UD chain before conv to ensure it is before addOp.
     moveUDChainBefore(additionalWeight, conv);
 
-    auto combinedWeight = utils::createDPSOp<AddOp>(
-        rewriter,
+    auto combinedWeight = rewriter.create<AddOp>(
         ttmlir::utils::appendLocationSuffix(conv.getLoc(), "_weight_add"),
         existingWeight.getType(), additionalWeight, existingWeight);
     rewriter.modifyOpInPlace(
@@ -1225,10 +1224,9 @@ private:
       // Move bias2 UD chain before conv1 to ensure it is before addOp.
       moveUDChainBefore(bias2, conv1);
 
-      auto combinedBias = utils::createDPSOp<AddOp>(
-          rewriter,
-          ttmlir::utils::appendLocationSuffix(bias1.getLoc(), "_bias_add"),
-          bias1.getType(), bias2, bias1);
+      auto combinedBias = rewriter.create<AddOp>(
+          ttmlir::utils::appendLocationSuffix(conv1.getLoc(), "_bias_add"),
+          bias1.getType(), bias1, bias2);
       rewriter.modifyOpInPlace(
           conv1, [&]() { conv1.getBiasMutable().assign(combinedBias); });
     } else if (bias2) {

--- a/test/ttmlir/Dialect/TTIR/fusing/repvgg_conv_sum_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/repvgg_conv_sum_fusing.mlir
@@ -9,17 +9,15 @@ module {
             %arg3: tensor<128x128x1x1xbf16>,    // weight2 - 1x1
             %arg4: tensor<1x1x1x128xbf16>       // bias2
     ) -> tensor<1x1x400x128xbf16> {
+        // CHECK-LABEL: func.func @add_convs_3x3_and_1x1
         // CHECK: %[[PAD:.*]] = "ttir.pad"(%arg3
         // CHECK: %[[ADD1:.*]] = "ttir.add"(%[[PAD]], %arg1
-        // CHECK: %[[ADD2:.*]] = "ttir.add"(%arg4, %arg2
+        // CHECK: %[[ADD2:.*]] = "ttir.add"(%arg2, %arg4
         // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %[[ADD1]], %[[ADD2]]
         // CHECK: return %[[CONV]]
-        %0 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %2 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %3 = "ttir.conv2d"(%arg0, %arg3, %arg4, %2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %4 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %5 = "ttir.add"(%1, %3, %4) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %3 = "ttir.conv2d"(%arg0, %arg3, %arg4) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %5 = "ttir.add"(%1, %3) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
         return %5 : tensor<1x1x400x128xbf16>
     }
     func.func @add_convs_1x1_and_3x3(
@@ -29,17 +27,15 @@ module {
         %arg3: tensor<128x128x1x1xbf16>,
         %arg4: tensor<1x1x1x128xbf16>
     ) -> tensor<1x1x400x128xbf16> {
+        // CHECK-LABEL: func.func @add_convs_1x1_and_3x3
         // CHECK: %[[PAD:.*]] = "ttir.pad"(%arg3
         // CHECK: %[[ADD1:.*]] = "ttir.add"(%[[PAD]], %arg1
-        // CHECK: %[[ADD2:.*]] = "ttir.add"(%arg4, %arg2
+        // CHECK: %[[ADD2:.*]] = "ttir.add"(%arg2, %arg4
         // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %[[ADD1]], %[[ADD2]]
         // CHECK: return %[[CONV]]
-        %0 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %2 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %3 = "ttir.conv2d"(%arg0, %arg3, %arg4, %2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %4 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %5 = "ttir.add"(%3, %1, %4) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %3 = "ttir.conv2d"(%arg0, %arg3, %arg4) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %5 = "ttir.add"(%3, %1) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
         return %5 : tensor<1x1x400x128xbf16>
     }
     // If one conv has other users, fusion should not happen.
@@ -50,16 +46,13 @@ module {
         %arg3: tensor<128x128x1x1xbf16>,
         %arg4: tensor<1x1x1x128xbf16>
     ) -> tensor<1x1x400x128xbf16> {
+        // CHECK-LABEL: func.func @add_convs_3x3_and_1x1_more_users
         // CHECK: %[[ADD:.*]] = "ttir.add"
         // CHECK: return %[[ADD]]
-        %0 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %2 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %3 = "ttir.sqrt"(%1, %2) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %4 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %5 = "ttir.conv2d"(%arg0, %arg3, %arg4, %4) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %6 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %7 = "ttir.add"(%3, %5, %6) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %3 = "ttir.sqrt"(%1) : (tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %5 = "ttir.conv2d"(%arg0, %arg3, %arg4) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %7 = "ttir.add"(%3, %5) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
         return %7 : tensor<1x1x400x128xbf16>
     }
     // If convs have different inputs, fusion should not happen.
@@ -71,14 +64,12 @@ module {
         %arg4: tensor<128x128x1x1xbf16>,
         %arg5: tensor<1x1x1x128xbf16>
     ) -> tensor<1x1x400x128xbf16> {
+        // CHECK-LABEL: func.func @add_convs_different_inputs
         // CHECK: %[[ADD:.*]] = "ttir.add"
         // CHECK: return %[[ADD]]
-        %0 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %1 = "ttir.conv2d"(%arg0, %arg2, %arg3, %0) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %2 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %3 = "ttir.conv2d"(%arg1, %arg4, %arg5, %2) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
-        %4 = ttir.empty() : tensor<1x1x400x128xbf16>
-        %5 = "ttir.add"(%1, %3, %4) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %1 = "ttir.conv2d"(%arg0, %arg2, %arg3) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %3 = "ttir.conv2d"(%arg1, %arg4, %arg5) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 20, input_width = 20>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x400x128xbf16>, tensor<128x128x1x1xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x400x128xbf16>
+        %5 = "ttir.add"(%1, %3) : (tensor<1x1x400x128xbf16>, tensor<1x1x400x128xbf16>) -> tensor<1x1x400x128xbf16>
         return %5 : tensor<1x1x400x128xbf16>
     }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/5248)

### Problem description
Inspired by [RepVGG](https://arxiv.org/pdf/2101.03697), the YOLOv9 model includes a block where the same input is passed into two separate convs (3×3 and 1×1 kernels), whose outputs are summed and then passed through a silu activation:
```
 w1  b1  input   w2 b2
 |   |  /     \  |  |
 conv2d        conv2d
        \     /
          add
           |
          silu
```
During inference, those convs are intended to be fused as a single one.
### What's changed
To fuse two convs, they have to have same kernel size, padding, and other attributes. 
Using the fact that
```
                                            |0 0 0|
conv(w = [c], pading = 0, ...) <=> conv(w = |0 c 0|, padding = 1, ...)
                                            |0 0 0|
```
we rewrite original graph as:
```
      w2  inp
      |    |
w1   pad   |   b1   b2
 \   /     |    \   /
  add      |     add
   \___ conv2d ___/
       with silu
```
having only one op on activation path.

This is done in `RepVGGConvSumFusionPattern`.

Since these convs in yolov9 models from torch-xla also have batch norms, this can work only if they are decomposed and fused with convs, which for now happens only when `enable-fusing-conv2d-with-multiply-pattern` flag is on ([#4628](https://github.com/tenstorrent/tt-mlir/issues/4628))

### Checklist
- [x] New/Existing tests provide coverage for changes
