### PR TITLE
Add workaround for ttnn.mesh_shard op when operand is scalar

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MESHSHARDSCALAROPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MESHSHARDSCALAROPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+class MeshShardScalarOpRewritePattern
+    : public mlir::OpRewritePattern<ttnn::MeshShardOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttnn::MeshShardOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MESHSHARDSCALAROPREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
         Workarounds/Decomposition/LinearOpRewritePattern.cpp
+        Workarounds/Decomposition/MeshShardScalarOpRewritePattern.cpp
         Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.cpp
         Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
         Workarounds/Decomposition/ScatterOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+LogicalResult MeshShardScalarOpRewritePattern::matchAndRewrite(
+    mlir::tt::ttnn::MeshShardOp sourceOperation,
+    mlir::PatternRewriter &rewriter) const {
+
+  mlir::Value meshShardInput = sourceOperation.getInput();
+  auto rankedInputType =
+      llvm::dyn_cast<mlir::RankedTensorType>(meshShardInput.getType());
+  if (!rankedInputType) {
+    return failure(); // Only handle ranked tensors here.
+  }
+
+  // If the operand is not a scalar (rank-0), leave it untouched.
+  if (rankedInputType.getRank() != 0) {
+    return failure();
+  }
+
+  mlir::Location location = sourceOperation.getLoc();
+
+  // 1) Build the 1D shape [1] for the temporary reshape.
+  llvm::SmallVector<int64_t, 1> oneDimShape = {1};
+
+  // 2) Reshape scalar -> [1].
+  // Prefer your existing helper if available, to keep layout handling
+  // identical.
+  auto typedInput =
+      llvm::cast<mlir::TypedValue<mlir::RankedTensorType>>(meshShardInput);
+  auto preReshape = ttir_to_ttnn::utils::generateReshape(
+      typedInput, oneDimShape, rewriter,
+      ttmlir::utils::appendLocationSuffix(location, "_reshapeInputTo1D"));
+
+  // 3) Create MeshShardOp on 1D input. We must produce a 1D result type as
+  // well.
+  //    We mirror the original result's element-type/encoding but with [1]
+  //    shape.
+  auto originalResultType =
+      llvm::cast<mlir::RankedTensorType>(sourceOperation.getResult().getType());
+  mlir::RankedTensorType oneDimResultType =
+      originalResultType.getEncoding()
+          ? mlir::RankedTensorType::get(oneDimShape,
+                                        originalResultType.getElementType(),
+                                        originalResultType.getEncoding())
+          : mlir::RankedTensorType::get(oneDimShape,
+                                        originalResultType.getElementType());
+
+  // Some MeshShardOp builders require explicit attributes. To be robust against
+  // signature changes, recreate the operation via a generic OperationState that
+  // clones all attributes and substitutes the operand/result type.
+  mlir::OperationState state(location, sourceOperation->getName());
+  state.addOperands({preReshape.getResult(), sourceOperation.getDevice()});
+  state.addAttributes(sourceOperation->getAttrs());
+  state.addTypes(oneDimResultType);
+  mlir::Operation *oneDimMeshShardOp = rewriter.create(state);
+
+  // 4) Reshape [1] -> scalar (rank-0) to recover the original result rank.
+  auto typedOneDimResult = llvm::cast<mlir::TypedValue<mlir::RankedTensorType>>(
+      oneDimMeshShardOp->getResult(0));
+  auto postReshape = ttir_to_ttnn::utils::generateReshape(
+      typedOneDimResult, /*targetShape=*/llvm::ArrayRef<int64_t>{}, rewriter,
+      ttmlir::utils::appendLocationSuffix(location, "_reshapeOutputToScalar"));
+
+  // 5) Replace the original MeshShardOp with the reshaped result.
+  rewriter.replaceOp(sourceOperation, postReshape);
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -22,6 +22,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ExplicateOperandBroadcastsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MeshShardScalarOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.h"
@@ -575,7 +576,8 @@ public:
               Conv2dEnableKernelStrideFoldingRewritePattern<ConvTranspose2dOp>,
           workarounds::decomposition::Conv2dSliceConfigRewritePattern,
           workarounds::decomposition::ConcatenateHeadsOpRewritePattern,
-          workarounds::decomposition::PagedUpdateCacheOpRewritePattern>(
+          workarounds::decomposition::PagedUpdateCacheOpRewritePattern,
+          workarounds::decomposition::MeshShardScalarOpRewritePattern>(
           &getContext());
 
       runRewritePatterns(std::move(patterns),

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/mesh_shard_scalar_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/mesh_shard_scalar_workaround.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-layout  --convert-ttir-to-ttnn --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module @SyncTensorsGraph.30 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<f32>) -> (tensor<f32>) {
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: -> tensor<1xf32
+    // CHECK: "ttnn.mesh_shard"
+    // CHECK-SAME: -> tensor<1xf32
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: -> tensor<f32
+    %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: -1>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #ttcore.shard_type<replicate>}> : (tensor<f32>) -> tensor<f32>
+    return %0: tensor<f32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1993

### Problem description
TT-Metal currently assumes that the operand of a mesh_shard op is a non-scalar tensor (i.e., not 0-dim). This causes an error when a scalar tensor is provided.

### What's changed
This PR addresses the issue by inserting a reshape from a scalar (0-dim) tensor to a 1-D tensor before the mesh_shard op, and then reshaping it back to a scalar afterward.

### Checklist
- [ ] New/Existing tests provide coverage for changes
