### PR TITLE
Ignore covered-switch-default warning to support clang-18

### DIFF
--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -5,7 +5,12 @@
 #include <atomic>
 #include <fstream>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+
 #include "flatbuffers/idl.h"
+
+#pragma clang diagnostic pop
 
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/types/program_desc_cache.h"


### PR DESCRIPTION
Resolves these errors under clang-18:

```
/opt/ttmlir-toolchain/include/flatbuffers/idl.h:159:5: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
    159 |     default: FLATBUFFERS_ASSERT(0);
        |     ^
  /opt/ttmlir-toolchain/include/flatbuffers/idl.h:170:5: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
    170 |     default: FLATBUFFERS_ASSERT(0);
        |     ^
  /opt/ttmlir-toolchain/include/flatbuffers/idl.h:181:5: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
    181 |     default: FLATBUFFERS_ASSERT(0);
```
