### PR TITLE
Find nanobind when running in Python3 virtual env

### DIFF
--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 include(GoogleTest)
 
-# TODO: can this be up-leveled to runtime/CMakeLists.txt?
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 if (NOT Python3_LIBRARIES)
   message(FATAL_ERROR "python libraries not found")


### PR DESCRIPTION
Nanobind cmake config looks for `Python::Module`:
```
if (NOT TARGET Python::Module)
  message(FATAL_ERROR "You must invoke 'find_package(Python COMPONENTS Interpreter Development REQUIRED)' prior to including nanobind.")
endif()
```
But `find_package(Python3...)` (which is already used elsewhere in the project) defines `Python3::Module`. This patch creates some alias variables so that `nanobind` finds the correct version of Python. I suspect that these variables are created by some other include (possibly LLVM?) that we are not using on the Triton side which is why we run into the fatal error copied above. If they are already defined I opted to leave the current definition.