### PR TITLE
Enable matmul sharding

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MemReconfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemReconfig.h
@@ -61,13 +61,13 @@ private:
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      const MemReconfigEntry &memReconfigEntry) {
-  os << "ReshardOutputConfigMap: ";
+  os << "ReshardOutputConfigMap:\n";
   for (const auto &[idx, value] : memReconfigEntry.reshardOutputConfigMap) {
     os << "(" << idx << ": ";
     for (const auto &config : value) {
       os << config.outputLayout << ", ";
     }
-    os << ")";
+    os << ")\n";
   }
   os << " SelectedReshardOutputConfigBitIndex: "
      << memReconfigEntry.selectedReshardOutputConfigBitIndex;

--- a/include/ttmlir/Dialect/TTNN/Transforms/OptimizerPassesWrapper.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/OptimizerPassesWrapper.h
@@ -20,6 +20,8 @@ namespace mlir::tt::ttnn {
 struct OptimizerPassesWrapperOptions {
   // External device pointer (if provided by frontend)
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> devicePtr = nullptr;
+  // Tensor L1 usage cap (fraction of available L1 memory)
+  float tensorL1UsageCap = 0.95f;
 };
 
 // Creates a pass that wraps Optimizer passes with device lifecycle management.

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
@@ -5,7 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTNN_UTILS_OPTIMIZERUTILS_H
 #define TTMLIR_DIALECT_TTNN_UTILS_OPTIMIZERUTILS_H
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <vector>
 
 namespace mlir::tt::ttnn::optimizer_utils {
 
@@ -30,6 +35,26 @@ AffineMap createSingleDeviceVirtualToPhysicalAffineMap(
     MLIRContext *context,
     const mlir::tt::ttnn::TensorMemoryLayout &tensorMemoryLayout,
     const llvm::ArrayRef<int64_t> physicalGridShape = {8, 8});
+
+// Returns unique op-specific attributes from a list of OpConfigs.
+// Deduplicates by comparing OpConfig::OpSpecificAttrs values.
+std::vector<mlir::tt::ttnn::OpConfig::OpSpecificAttrs>
+getUniqueOpSpecificAttrs(const std::vector<mlir::tt::ttnn::OpConfig> &configs);
+
+// Returns unique test configs for Matmul/Linear ops.
+// Generates Cartesian product of unique (bufferType, memLayout) pairs
+// with unique op-specific attrs, using ignorePhysicalLayout.
+llvm::SmallVector<mlir::tt::ttnn::OpConfig> getUniqueTestConfigsForMatmulLinear(
+    const std::vector<mlir::tt::ttnn::OpConfig> &consumerConfigs);
+
+// Returns unique test configs for validation.
+// - For non-Matmul/Linear ops: Only unique op-specific attrs (no output layout
+//   needed).
+// - For Matmul/Linear ops: Cartesian product of unique (bufferType, memLayout)
+//   pairs with unique op-specific attrs, using ignorePhysicalLayout
+llvm::SmallVector<mlir::tt::ttnn::OpConfig> getUniqueTestConfigs(
+    const std::vector<mlir::tt::ttnn::OpConfig> &consumerConfigs,
+    bool isMatmulOrLinear);
 
 } // namespace mlir::tt::ttnn::optimizer_utils
 

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -15,6 +15,16 @@
 
 namespace mlir::tt::ttnn::utils {
 
+// Attribute name for storing tensor L1 usage cap during optimizer passes.
+// This attribute is set by OptimizerPassesWrapper and read by validation
+// and analysis passes to avoid parameter threading through pass infrastructure.
+inline constexpr llvm::StringLiteral g_TensorL1UsageCapAttrName =
+    "ttnn.tensor_l1_usage_cap";
+
+// Helper function to retrieve tensor L1 usage cap from module attribute.
+// Returns the configured cap if found, otherwise returns the default value.
+float getTensorL1UsageCap(Operation *op, float defaultValue = 0.95f);
+
 bool isTensorOnDevice(::mlir::RankedTensorType tensorType);
 
 // Map ttcore::MemorySpace to ttnn::BufferType

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -94,8 +94,7 @@ struct ValidationResult {
 // "NotSupported" is not an error - it indicates expected limitations.
 ValidationResult validateOperation(Operation *op,
                                    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                                   const OpConfig &config,
-                                   float tensorL1UsageCap);
+                                   const OpConfig &config);
 
 // Test multiple attributes with all layouts.
 // op: Operation to validate.
@@ -106,10 +105,11 @@ ValidationResult validateOperation(Operation *op,
 //                   only validation is performed without matching to reference.
 // Returns: Vector of ValidationResults, one per op config tested.
 // Each ValidationResult can have different status - check individually.
-std::vector<ValidationResult> validateWithMultipleAttributes(
-    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-    llvm::ArrayRef<OpConfig> opConfigs,
-    llvm::ArrayRef<OpConfig> referenceConfigs, float tensorL1UsageCap);
+std::vector<ValidationResult>
+validateWithMultipleAttributes(Operation *op,
+                               llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                               llvm::ArrayRef<OpConfig> opConfigs,
+                               llvm::ArrayRef<OpConfig> referenceConfigs);
 
 } // namespace op_constraint_validation
 

--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -30,7 +30,14 @@ inline std::string opToString(mlir::Operation *op) {
 }
 
 // Log components for different components
-enum class LogComponent { Optimizer, OpValidation, Allocator, Test, General };
+enum class LogComponent {
+  Optimizer,
+  DFShardingPolicy,
+  OpValidation,
+  Allocator,
+  Test,
+  General
+};
 
 // Log levels in order of verbosity
 enum class LogLevel {
@@ -44,6 +51,8 @@ inline constexpr const char *getLogComponentStr(LogComponent type) {
   switch (type) {
   case LogComponent::Optimizer:
     return "optimizer";
+  case LogComponent::DFShardingPolicy:
+    return "df-sharding-policy";
   case LogComponent::OpValidation:
     return "op-validation";
   case LogComponent::Allocator:

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -94,8 +94,9 @@ void DFShardingPolicy::run() {
         // the current op.
         bool validForSharding =
             llvm::isa<ttnn::Conv2dOp, ttnn::AddOp, ttnn::MultiplyOp,
-                      ttnn::ReluOp, ttnn::Relu6Op, ttnn::SiluOp,
-                      ttnn::TypecastOp, ttnn::MinimumOp>(currentOp) &&
+                      ttnn::ReluOp, ttnn::Relu6Op, ttnn::TypecastOp,
+                      ttnn::MatmulOp, ttnn::LinearOp, ttnn::MinimumOp>(
+                currentOp) &&
             legalConfigs.lookup(currentOp).size() > 0;
 
         if (validForSharding) {
@@ -114,7 +115,7 @@ void DFShardingPolicy::run() {
             if (nextOp->getOperand(0).getDefiningOp() != currentOp) {
               // Only continue chain if nextOp uses currentOp as first operand.
               // Here we break the chain if not.
-              TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
+              TTMLIR_DEBUG(ttmlir::LogComponent::DFShardingPolicy,
                            "Breaking L1 chain at op {} as it is not first "
                            "operand of next op {}",
                            currentOp->getName(), nextOp->getName());
@@ -143,7 +144,7 @@ void DFShardingPolicy::run() {
   }
 
   for ([[maybe_unused]] L1ChainConfig &l1ChainConfig : *l1ChainConfigs) {
-    TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer, "L1 chain config {}",
+    TTMLIR_DEBUG(ttmlir::LogComponent::DFShardingPolicy, "L1 chain config {}",
                  l1ChainConfig);
   }
 
@@ -166,7 +167,7 @@ void DFShardingPolicy::run() {
         overrideReshardEdges, overrideOutputLayout);
 
     if (l1ChainConfig.getState() == L1ChainState::Failed) {
-      TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
+      TTMLIR_DEBUG(ttmlir::LogComponent::DFShardingPolicy,
                    "Failed to resolve L1 chain config {}", l1ChainConfig);
       progressTracker.finishL1Chain(firstOp, chainIndex, false);
       continue;
@@ -184,8 +185,8 @@ void DFShardingPolicy::run() {
       l1ChainConfig.spillEndToDRAM = true;
     }
 
-    TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer, "Resolved L1 chain config {}",
-                 l1ChainConfig);
+    TTMLIR_DEBUG(ttmlir::LogComponent::DFShardingPolicy,
+                 "Resolved L1 chain config {}", l1ChainConfig);
 
     progressTracker.finishL1Chain(firstOp, chainIndex, true);
   }

--- a/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
@@ -35,7 +35,7 @@ ShardSolver L1ChainConfig::resolveWithSolver(
   // Generate reshard specs where needed.
   //
   ShardSolver shardSolver(tensorTypePossibleLayouts, legalConfigs, opL1MemSpecs,
-                          l1ChainedOps, usableL1CacheSize, overrideReshardEdges,
+                          l1ChainedOps, overrideReshardEdges,
                           overrideOutputLayout);
 
   state = shardSolver.resolve() ? L1ChainState::Resolved : L1ChainState::Failed;

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -91,6 +91,7 @@ void createTTNNPipelineAnalysisPasses(
     // Wrap all Optimizer passes with device lifecycle management.
     OptimizerPassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
+    wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
 
     ttnn::TTNNOperationValidationAndFallbackOptions validationOptions{
         options.tensorL1UsageCap};

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -8,7 +8,9 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
@@ -18,6 +20,20 @@
 #include <optional>
 
 namespace mlir::tt::ttnn::utils {
+
+float getTensorL1UsageCap(Operation *op, float defaultValue) {
+  // Walk up to find the module operation that has the attribute
+  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+
+  if (moduleOp) {
+    if (auto attr =
+            moduleOp->getAttrOfType<FloatAttr>(g_TensorL1UsageCapAttrName)) {
+      return attr.getValueAsDouble();
+    }
+  }
+
+  return defaultValue;
+}
 
 bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {
   auto ttnnLayoutAttr =

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
@@ -1,30 +1,31 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" -o mnist_sharding_ttnn.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" -o mnist_sharding_ttnn.mlir -mlir-print-local-scope %s
 // RUN: FileCheck %s --input-file=mnist_sharding_ttnn.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn mnist_sharding_ttnn.mlir
-// XFAIL: *
-// UNSUPPORTED: true
-// TODO(rpavlovicTT): #https://github.com/tenstorrent/tt-metal/issues/21846 re-enable
+
+// CHECK: %[[MATMUL1:.*]] = "ttnn.matmul"
+// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
+// CHECK: %[[ADD1:.*]] = "ttnn.add"(%[[MATMUL1]]
+// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
+// CHECK: %[[RELU:.*]] = "ttnn.relu"(%[[ADD1]]
+// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
+// CHECK: %[[MATMUL2:.*]] = "ttnn.matmul"(%[[RELU]]
+// CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
+// CHECK: %[[ADD2:.*]] = "ttnn.add"(%[[MATMUL2]]
+// CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
 
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
-    // CHECK-DAG: #[[LAYOUT_10:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x8, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, <width_sharded>>
-    // CHECK-DAG: #[[LAYOUT_11:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_>, <width_sharded>>
     %0 = ttir.empty() : tensor<1x256xf32> loc(#loc8)
-    // TODO(#3242): Revert to sharded layout we are able to query backend for matmul.
     %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
     %2 = ttir.empty() : tensor<1x256xf32> loc(#loc9)
-    // CHECK: %{{.*}} = "ttnn.linear"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_10]]>
     %3 = "ttir.add"(%1, %arg3, %2) : (tensor<1x256xf32>, tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc9)
     %4 = ttir.empty() : tensor<1x256xf32> loc(#loc10)
-    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_10]]>
     %5 = "ttir.relu"(%3, %4) : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
     %6 = ttir.empty() : tensor<1x10xf32> loc(#loc11)
-    // TODO(#3242): Revert to sharded layout we are able to query backend for matmul.
     %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
     %8 = ttir.empty() : tensor<1x10xf32> loc(#loc12)
-    // CHECK: %{{.*}} = "ttnn.linear"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_11]]>
     %9 = "ttir.add"(%7, %arg1, %8) : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc12)
     %10 = ttir.empty() : tensor<1x10xf32> loc(#loc13)
     %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc13)

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(OptimizerTests
     MLIRTTNNDialect
     MLIRTTTransforms
     MLIRTTNNAnalysis
+    MLIRTTNNValidation
 )

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -151,7 +151,6 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   llvm::DenseMap<mlir::Operation *, std::vector<OpConfig>> legalConfigs;
   std::vector<OpL1MemSpec> opL1MemSpecs;
   llvm::DenseSet<mlir::Operation *> l1ChainedOps;
-  constexpr unsigned usableL1CacheSize = 1024 * 1024;
   llvm::DenseSet<Edge> overrideReshardEdges;
   llvm::StringMap<OutputLayoutOverrideParams> overrideOutputLayout;
 
@@ -270,9 +269,8 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   // them because custom checkShardCompatible function will handle all the
   // checks.
   ShardSolver shardSolver(/*tensorTypePossibleLayouts=*/nullptr, legalConfigs,
-                          opL1MemSpecs, l1ChainedOps, usableL1CacheSize,
-                          overrideReshardEdges, overrideOutputLayout,
-                          checkShardCompatible);
+                          opL1MemSpecs, l1ChainedOps, overrideReshardEdges,
+                          overrideOutputLayout, checkShardCompatible);
 
   ASSERT_TRUE(shardSolver.resolve());
 

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -41,11 +41,19 @@ public:
     mlir::tt::ttcore::registerDevice(module.get());
     mlir::tt::ttnn::op_model::SingletonDeviceContext::getInstance()
         .openDevice();
+
+    // Set default L1 usage cap to 100% for all tests
+    setL1UsageCap(1.0f);
   }
 
   void TearDown() override {
     mlir::tt::ttnn::op_model::SingletonDeviceContext::getInstance()
         .closeInstance();
+  }
+
+  void setL1UsageCap(float cap) {
+    module->getOperation()->setAttr(utils::g_TensorL1UsageCapAttrName,
+                                    builder.getF32FloatAttr(cap));
   }
 
   TTNNLayoutAttr createTiledLayout(const llvm::ArrayRef<int64_t> &tensorShape,
@@ -113,10 +121,9 @@ TEST_F(OpConstraintValidationTest, ValidateOperationRealAddOp) {
   auto addOp = createMockAddOp();
   auto layouts = ttnn::utils::extractInputLayouts(addOp);
   OpConfig config = createTestConfig();
-  float tensorL1UsageCap = 1.0f;
 
-  auto result = op_constraint_validation::validateOperation(
-      addOp, layouts, config, tensorL1UsageCap);
+  auto result =
+      op_constraint_validation::validateOperation(addOp, layouts, config);
 
   // This should either succeed or fail gracefully (not crash)
   // The exact result depends on OpModel implementation
@@ -138,11 +145,10 @@ TEST_F(OpConstraintValidationTest, ValidateWithMultipleAttributesRealAddOp) {
 
   // Create 10 empty attributes
   std::vector<OpConfig> configs(10);
-  float tensorL1UsageCap = 1.0f;
 
   // Test with null reference configs (should succeed if validation passes)
   auto results = op_constraint_validation::validateWithMultipleAttributes(
-      addOp, layouts, configs, /*referenceConfigs=*/{}, tensorL1UsageCap);
+      addOp, layouts, configs, /*referenceConfigs=*/{});
 
   EXPECT_EQ(results.size(), 10);
   // Each result should have a valid status
@@ -202,11 +208,10 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
   // Extract layouts and create config
   auto layouts = ttnn::utils::extractInputLayouts(updateCacheOp);
   OpConfig config = createTestConfig();
-  float tensorL1UsageCap = 1.0f;
 
   // Validate the operation
-  auto result = op_constraint_validation::validateOperation(
-      updateCacheOp, layouts, config, tensorL1UsageCap);
+  auto result = op_constraint_validation::validateOperation(updateCacheOp,
+                                                            layouts, config);
 
   // Should fail because update_index has wrong type (BF16 instead of uint32)
   EXPECT_TRUE(result.isError());
@@ -234,7 +239,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
   // Extract layouts and validate
   auto validLayouts = ttnn::utils::extractInputLayouts(validUpdateCacheOp);
   auto validResult = op_constraint_validation::validateOperation(
-      validUpdateCacheOp, validLayouts, config, tensorL1UsageCap);
+      validUpdateCacheOp, validLayouts, config);
 
   // Should succeed with uint32 type
   EXPECT_TRUE(validResult.isSuccess());
@@ -266,10 +271,9 @@ TEST_F(OpConstraintValidationTest, ValidationStatusNotImplemented) {
 
   auto layouts = ttnn::utils::extractInputLayouts(scatterOp);
   OpConfig config = createTestConfig();
-  float tensorL1UsageCap = 1.0f;
 
-  auto result = op_constraint_validation::validateOperation(
-      scatterOp, layouts, config, tensorL1UsageCap);
+  auto result =
+      op_constraint_validation::validateOperation(scatterOp, layouts, config);
 
   // Should return NotImplemented
   EXPECT_TRUE(result.isNotImplemented());
@@ -328,15 +332,14 @@ TEST_F(OpConstraintValidationTest, ValidationStatusMetalBackendError) {
 
   auto layouts = ttnn::utils::extractInputLayouts(toLayoutOp);
   OpConfig config(outputLayout, OpConfig::OpSpecificAttrs{});
-  float tensorL1UsageCap = 1.0f;
 
   // Expected error message contains:
   // tt-metal/ttnn/core/tensor/layout/tensor_layout.cpp:111:
   // (physical_shard_shape.height() % tile_shape[0] == 0 &&
   // physical_shard_shape.width() % tile_shape[1] == 0)
   // info: Physical shard shape (1, 1024) must be tile {32, 32} sized!
-  auto result = op_constraint_validation::validateOperation(
-      toLayoutOp, layouts, config, tensorL1UsageCap);
+  auto result =
+      op_constraint_validation::validateOperation(toLayoutOp, layouts, config);
 
   // Should return MetalBackendError due to incompatible layouts
   EXPECT_EQ(result.status,
@@ -372,11 +375,11 @@ TEST_F(OpConstraintValidationTest, ValidationStatusOutOfMemoryError) {
   auto layouts = ttnn::utils::extractInputLayouts(addOp);
   OpConfig config(layout, OpConfig::OpSpecificAttrs{});
 
-  // Set very restrictive L1 usage cap (0.1% of L1)
-  float tensorL1UsageCap = 0.001f;
+  // Set very restrictive L1 usage cap (0.1% of L1) to trigger OOM
+  setL1UsageCap(0.001f);
 
-  auto result = op_constraint_validation::validateOperation(
-      addOp, layouts, config, tensorL1UsageCap);
+  auto result =
+      op_constraint_validation::validateOperation(addOp, layouts, config);
 
   // Should return OutOfMemoryError
   EXPECT_EQ(result.status,
@@ -406,10 +409,8 @@ TEST_F(OpConstraintValidationTest, ValidationStatusUnmatchedReferenceConfig) {
                                      TensorMemoryLayout::Interleaved);
   referenceConfigs.emplace_back(refLayout, OpConfig::OpSpecificAttrs{});
 
-  float tensorL1UsageCap = 1.0f;
-
   auto results = op_constraint_validation::validateWithMultipleAttributes(
-      addOp, layouts, testConfigs, referenceConfigs, tensorL1UsageCap);
+      addOp, layouts, testConfigs, referenceConfigs);
 
   // Should have one result
   ASSERT_EQ(results.size(), 1);


### PR DESCRIPTION
This change enables matmul/linear ops for sharding in optimizer pass. For matmul/linear ops we can't just pass NULL mem config with sharded input because TTNN actually defaults to DRAM interleaved matmul in such case. Instead, we provide partial memory config with only buffer type (L1) and memory layout (WS, HS, BS) and let TTNN do its part then.

Code cleanup:
- Removed old CheckShardCompatible in favor of new op constraint validation lib
- Fixed interleaved->sharded check and reshard check to use new API
- Now reshard saves all viable config paths instead of first one only
- Keeping old customCheckShardCompatible for testing purposes
- Removed tensorL1UsageCap requirement by constraint validation lib, instead we attach it to the IR and use it as module's attribute

### Ticket
Closes #5562 

