### PR TITLE
Implement `skip_exec_config` mark

### DIFF
--- a/test/python/golden/pytest.ini
+++ b/test/python/golden/pytest.ini
@@ -7,3 +7,4 @@ markers =
   llmbox: mark test as running on llmbox
   frontend(fe_name): denotes which builder frontend this uses (ttir vs shlo)
   skip_config(config, ... reason=None): skip test if all of the specified targets/backends per config are present
+  skip_exec(config, ... reason=None): compile test but skip execution if all of the specified targets/backends per config are present. The test function must retrieve the skip_exec flag with 'skip_exec = getattr(request.node, "skip_exec", False)' and pass it to compile_and_execute_* functions. The test will be marked as xfail when conditions match.


### PR DESCRIPTION
### Ticket
Closes #5590

### Problem description
Implements a `skip_exec_config` similar to `skip_config` that allows you to conditionally skip the execution of a compiled flatbuffer. 

### How to use
This change requires a small change to any test that uses it to grab the `skip_exec` bool from the test node state. E.G.:
```python
  @pytest.mark.skip_exec(["ttmetal", "n300"], reason="Hangs on n300 with ttmetal backend")
  @pytest.mark.parametrize("shape", [(128, 128)])
  @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
  def test_my_op(shape, target, request, device):
      def my_op_fn(in0, builder):
          return builder.some_op(in0)

      # Retrieve skip_exec flag from test node
      skip_exec = getattr(request.node, 'skip_exec', False)

      compile_and_execute_ttir(
          my_op_fn,
          [shape],
          test_base=request.node.name,
          device=device,
          target=target,
          skip_exec=skip_exec,  # Pass the flag here
          # ... other parameters
      )
```