### PR TITLE
Change runner from 'docker-builder' to 'builder' for temp workaround

### DIFF
--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -48,7 +48,7 @@ jobs:
   build-image:
     needs: check-if-docker-exist
     if: needs.check-if-docker-exist.outputs.docker-image == ''
-    runs-on: docker-builder
+    runs-on: builder
     outputs:
       docker-image: ${{ steps.build.outputs.docker-image }}
       docker-tag: ${{ steps.build.outputs.docker-tag }}


### PR DESCRIPTION
### Ticket
Slack DevEx ticket

### Problem description
There are issues with the runner `forge-builder-5`, but I can't find another runner with the label `docker-builder`.

<img width="1151" height="443" alt="image" src="https://github.com/user-attachments/assets/f1baa186-708f-495a-b7e9-cd1e78f420cd" />

https://github.com/tenstorrent/tt-mlir/actions/runs/19304270673/job/55339782267

I also don't have permissions to change the labels of our other forge builder runners.

<img width="1146" height="488" alt="image" src="https://github.com/user-attachments/assets/aa3f68e6-e4ef-4a76-82c0-c852099ba9a0" />


As a temp solution, I have switched this to a builder box to unblock devs for today.


