### PR TITLE
Add tests for eltwise ops with mesh tensors in ttnn jit

### DIFF
--- a/test/ttnn-jit/conftest.py
+++ b/test/ttnn-jit/conftest.py
@@ -5,6 +5,7 @@
 import pytest
 import ttnn
 import torch
+from loguru import logger
 
 
 @pytest.fixture(scope="module")
@@ -12,6 +13,146 @@ def device():
     d = ttnn.open_device(device_id=0)
     yield d
     ttnn.close_device(d)
+
+
+# Reset fabric config to DISABLED if not None, and do nothing otherwise
+# Temporarily require previous state to be passed in as even setting it to DISABLED might be unstable
+# This is to ensure that we don't propagate the instability to the rest of CI
+def reset_fabric(fabric_config):
+    if fabric_config:
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
+# Set fabric config to passed in value
+# Do nothing if not set
+# Must be called before creating the mesh device
+def set_fabric(fabric_config, reliability_mode=None, fabric_tensix_config=None):
+    # If fabric_config is not None, set it to fabric_config
+    if fabric_config:
+        if reliability_mode is None:
+            reliability_mode = ttnn.FabricReliabilityMode.STRICT_INIT
+
+        # Apply default logic for fabric_tensix_config,
+        # fabric_tensix_config is used for enabling tensix extensions for the fabric router,
+        # some sender channels in the fabric router are moved to the fabric tensix extension
+        # (currently the extension is mux kernel, can have other kernels in future as well).
+        if fabric_tensix_config is None:
+            fabric_tensix_config = get_default_fabric_tensix_config()
+
+        ttnn.set_fabric_config(
+            fabric_config, reliability_mode, None, fabric_tensix_config
+        )  # num_planes
+
+
+def get_default_fabric_tensix_config():
+    # Default to MUX for Blackhole when fabric is enabled, DISABLED otherwise
+    if ttnn.device.is_blackhole():
+        return ttnn.FabricTensixConfig.MUX
+    else:
+        return ttnn.FabricTensixConfig.DISABLED
+
+
+def get_updated_device_params(device_params):
+    new_device_params = device_params.copy()
+
+    dispatch_core_axis = new_device_params.pop("dispatch_core_axis", None)
+    dispatch_core_type = new_device_params.pop("dispatch_core_type", None)
+    fabric_tensix_config = new_device_params.get("fabric_tensix_config", None)
+
+    if ttnn.device.is_blackhole():
+        # If fabric_tensix_config is not specified but fabric_config is specified on Blackhole,
+        # default to MUX mode
+        fabric_config = new_device_params.get("fabric_config", None)
+        if fabric_config and not fabric_tensix_config:
+            fabric_tensix_config = ttnn.FabricTensixConfig.MUX
+            dispatch_core_axis = ttnn.DispatchCoreAxis.ROW
+            new_device_params["fabric_tensix_config"] = fabric_tensix_config
+            logger.warning(
+                "Blackhole with fabric enabled, defaulting to fabric_tensix_config=MUX and use DispatchCoreAxis.ROW"
+            )
+        elif not fabric_config and not fabric_tensix_config:
+            if dispatch_core_axis == ttnn.DispatchCoreAxis.ROW:
+                logger.warning(
+                    "when fabric_tensix_config disabled, blackhole arch does not support DispatchCoreAxis.ROW, using DispatchCoreAxis.COL instead."
+                )
+                dispatch_core_axis = ttnn.DispatchCoreAxis.COL
+
+    dispatch_core_config = ttnn.DispatchCoreConfig(
+        dispatch_core_type, dispatch_core_axis, fabric_tensix_config
+    )
+    new_device_params["dispatch_core_config"] = dispatch_core_config
+
+    return new_device_params
+
+
+@pytest.fixture(scope="function")
+def mesh_device(request, device_params):
+    """
+    Pytest fixture to set up a device mesh for tests.
+
+    If `request.param` is an integer, it specifies the number of devices to use (up to available devices).
+    If `request.param` is a tuple, it defines the 2D grid dimensions (rows, columns) for TG, e.g., (8, 4) creates
+    a devish mesh grid of 8 rows and 4 columns, totaling 32 devices. The total number of devices should not exceed available devices.
+
+    Args:
+        request: Pytest request object.
+        silicon_arch_name: Name of the silicon architecture.
+        device_params: Additional device configuration parameters.
+
+    Yields:
+        mesh_device: Initialized device mesh object.
+    """
+
+    request.node.pci_ids = ttnn.get_pcie_device_ids()
+
+    try:
+        param = request.param
+    except (ValueError, AttributeError):
+        # Get number of devices from the system mesh descriptor.
+        param = ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size()
+
+    if isinstance(param, tuple):
+        grid_dims = param
+        assert (
+            len(grid_dims) == 2
+        ), "Device mesh grid shape should have exactly two elements."
+        num_devices_requested = grid_dims[0] * grid_dims[1]
+        if (
+            not ttnn.using_distributed_env()
+            and num_devices_requested > ttnn.get_num_devices()
+        ):
+            pytest.skip(
+                "Requested more devices than available. Test not applicable for machine"
+            )
+        mesh_shape = ttnn.MeshShape(*grid_dims)
+    else:
+        if not ttnn.using_distributed_env() and param > ttnn.get_num_devices():
+            pytest.skip(
+                "Requested more devices than available. Test not applicable for machine"
+            )
+        mesh_shape = ttnn.MeshShape(1, param)
+
+    updated_device_params = get_updated_device_params(device_params)
+    fabric_config = updated_device_params.pop("fabric_config", None)
+    fabric_tensix_config = updated_device_params.pop("fabric_tensix_config", None)
+    reliability_mode = updated_device_params.pop("reliability_mode", None)
+    set_fabric(fabric_config, reliability_mode, fabric_tensix_config)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, **updated_device_params)
+
+    logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
+    yield mesh_device
+
+    for submesh in mesh_device.get_submeshes():
+        ttnn.close_mesh_device(submesh)
+
+    ttnn.close_mesh_device(mesh_device)
+    reset_fabric(fabric_config)
+    del mesh_device
+
+
+@pytest.fixture(scope="function")
+def device_params(request):
+    return getattr(request, "param", {})
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/ttnn-jit/test_mesh_tensor_eltwise.py
+++ b/test/ttnn-jit/test_mesh_tensor_eltwise.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn_jit
+import ttnn
+import torch
+
+import pytest
+
+from utils import (
+    all_close_check,
+    memory_configs_equal,
+    create_dram_tensor,
+)
+
+DRAM_INTERLEAVED_SHAPES = [
+    (32, 32),
+    (2048, 2048),
+    (1024, 32),
+    (32, 1024),
+]
+
+# eltwise unary
+def exp(input_tensor):
+    return ttnn.exp(input_tensor)
+
+
+# eltwise unary composite
+def cosh(input_tensor):
+    e_pos_x = ttnn.exp(input_tensor)
+    e_neg_x = ttnn.exp(ttnn.neg(input_tensor))
+    nr_term = ttnn.add(e_pos_x, e_neg_x)
+    output = ttnn.multiply(nr_term, 0.5)
+    return output
+
+
+# eltwise binary
+def add(a, b):
+    return ttnn.add(a, b)
+
+
+@pytest.mark.parametrize("shape", DRAM_INTERLEAVED_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    "op, num_inputs, check_interop",
+    [(exp, 1, False), (add, 2, False), (cosh, 1, False), (cosh, 1, True)],
+)
+@pytest.mark.parametrize("graph_capture", [True])
+@pytest.mark.parametrize(
+    "device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}], indirect=True
+)  # col dispatch axis fails
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_mapper_func, dim_arg",
+    [
+        (ttnn.ReplicateTensorToMesh, None),
+        (ttnn.ShardTensorToMesh, 0),
+        (ttnn.ShardTensorToMesh, 1),
+        (ttnn.ShardTensor2dMesh, (None, 0)),
+        (ttnn.ShardTensor2dMesh, (None, 1)),
+        (ttnn.ShardTensor2dMesh, (0, None)),
+        (ttnn.ShardTensor2dMesh, (1, None)),
+        (ttnn.ShardTensor2dMesh, (0, 1)),
+        (ttnn.ShardTensor2dMesh, (1, 0)),
+    ],
+)
+def test_mesh_tensor_eltwise(
+    shape,
+    dtype,
+    op,
+    num_inputs,
+    check_interop,
+    graph_capture,
+    mesh_device,
+    mesh_mapper_func,
+    dim_arg,
+):
+
+    if mesh_mapper_func == ttnn.ReplicateTensorToMesh:
+        mesh_mapper = mesh_mapper_func(mesh_device=mesh_device)
+    elif mesh_mapper_func == ttnn.ShardTensorToMesh:
+        mesh_mapper = mesh_mapper_func(mesh_device=mesh_device, dim=dim_arg)
+    else:
+        mesh_mapper = mesh_mapper_func(
+            mesh_device=mesh_device, mesh_shape=mesh_device.shape, dims=dim_arg
+        )
+
+    inputs = [
+        create_dram_tensor(
+            mesh_device, shape, dtype, int_max=0, mesh_mapper=mesh_mapper
+        )
+        for i in range(num_inputs)
+    ]
+
+    # JIT path
+    max_grid = (0, 0)  # always use 1x1 grid for DRAM interleaved tensors
+    enable_cache = False
+    op_jit = ttnn_jit.jit(
+        debug=True,
+        max_grid=max_grid,
+        enable_cache=enable_cache,
+        graph_capture=graph_capture,
+    )(op)
+    interop_result = op_jit(*inputs)
+
+    # Golden path (regular ttnn)
+    golden_result = op(*inputs)
+
+    # Run a regular ttnn op (ttnn.sum) using jit output to check interop between ttnn jit and ttnn
+    if check_interop:
+        interop_result = ttnn.sum(interop_result, dim=0)
+        golden_result = ttnn.sum(golden_result, dim=0)
+
+    assert memory_configs_equal(
+        interop_result.memory_config(), golden_result.memory_config()
+    )
+
+    # compare each device shard
+    interop_result_shards = ttnn.get_device_tensors(interop_result.cpu())
+    golden_result_shards = ttnn.get_device_tensors(golden_result.cpu())
+    assert len(interop_result_shards) == len(golden_result_shards)
+    for interop_result_shard, golden_result_shard in zip(
+        interop_result_shards, golden_result_shards
+    ):
+        assert interop_result_shard.shape == golden_result_shard.shape
+        assert all_close_check(interop_result_shard, golden_result_shard)

--- a/test/ttnn-jit/utils.py
+++ b/test/ttnn-jit/utils.py
@@ -34,7 +34,7 @@ def memory_configs_equal(memory_config1, memory_config2):
     )
 
 
-def create_dram_tensor(device, shape, dtype, int_max=0):
+def create_dram_tensor(device, shape, dtype, int_max=0, mesh_mapper=None):
     if not (dtype.is_floating_point or dtype.is_complex):
         # recreate spatial coverage of fp [0,1] in randn and give some overflow headroom
         high_val = int_max if int_max else torch.iinfo(dtype).max // 2
@@ -53,6 +53,7 @@ def create_dram_tensor(device, shape, dtype, int_max=0):
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=memory_config,
+        mesh_mapper=mesh_mapper,
     )
 
 


### PR DESCRIPTION
This also add mesh device fixtures and an option to set mesh_mapper in create_dram_tensor, both for use in the tests.

### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-mlir/issues/5743

### Checklist
- [x] New/Existing tests provide coverage for changes
