### PR TITLE
Fix macOS build

### DIFF
--- a/test/unittests/lib/CMakeLists.txt
+++ b/test/unittests/lib/CMakeLists.txt
@@ -1,13 +1,13 @@
 
 # TestUtils lib provides extensions to gtest functionality.
 
+set(TESTLIB TTMLIRTestUtils)
+add_library(${TESTLIB})
+
 if (NOT GTest_FOUND)
   message(WARNING "GTest not found")
   return()
 endif()
-
-set(TESTLIB TTMLIRTestUtils)
-add_library(${TESTLIB})
 
 # TestUtils lib sources.
 


### PR DESCRIPTION
Instead of searching for the gtest package (which is typically provided by LLVM) just check for its existence and early out if not available.
