### PR TITLE
Switch docker build to civ2

### DIFF
--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -48,7 +48,7 @@ jobs:
   build-image:
     needs: check-if-docker-exist
     if: needs.check-if-docker-exist.outputs.docker-image == ''
-    runs-on: docker-builder
+    runs-on: tt-ubuntu-2204-large-stable
     outputs:
       docker-image: ${{ steps.build.outputs.docker-image }}
       docker-tag: ${{ steps.build.outputs.docker-tag }}


### PR DESCRIPTION
### Ticket
Slack

### Problem description
Building docker images on our builder machines has multiple problems.
1. permissions of the files are wrong (files belong to user `root` and user `ubuntu` is trying to remove them)
2. after I fixed 1. another issue popped up after ~20mins of building, the builder machine ran out of memory and crashed and went offline

### What's changed
I'm switching to simply building the docker image on the civ2 runner (even if not ideal) because more errors could pop up along the way and docker build has been broken for too many days.

I am going to make a new PR with all the proper fixes for **enabling the docker build to execute on our builder machines** when that is ready.

### Checklist
- [ ] New/Existing tests provide coverage for changes

<img width="933" height="311" alt="image" src="https://github.com/user-attachments/assets/ea28dd79-7ade-48fa-8e6b-f53b6a927a2b" />
