### PR TITLE
[ttnn.jit] Remove buffers from `ProgramDescCache` hash calculation

### DIFF
--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -290,19 +290,8 @@ void run(const ::tt::target::ttnn::GenericOp *op, ProgramContext &context) {
 
   auto *programDesc = op->program();
 
-  // Note: need to hash tensor buffers: even if we override the arg here during
-  // ProgramDescriptor creation, once the Program is cached, in ttnn, it won't
-  // matter, unless we implement `override_runtime_arguments` in ttnn.generic
-  // op.
-  std::vector<void *> tensorBuffers(ioTensors.size());
-  std::vector<uint32_t> tensorBufferAddresses(ioTensors.size());
-  for (size_t i = 0; i < ioTensors.size(); ++i) {
-    tensorBuffers[i] = ioTensors[i].buffer();
-    tensorBufferAddresses[i] = ioTensors[i].buffer()->address();
-  }
   std::size_t hash = ttsl::hash::hash_objects_with_default_seed(
-      programDesc, programDescCache, ioTensors, tensorBuffers,
-      tensorBufferAddresses);
+      programDesc, programDescCache, ioTensors);
   std::shared_ptr<void> cachedPtr = programDescCache->get(hash);
 
   std::shared_ptr<::tt::tt_metal::ProgramDescriptor> programDescriptor;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Follow up to https://github.com/tenstorrent/tt-mlir/pull/5636

### What's changed
Now that `override_runtime_args` is implemented in https://github.com/tenstorrent/tt-metal/pull/31692, can remove tensor buffers from hash calculation.

Note: need to wait for metal uplift PR before merging

Qualified by running `test/ttnn-jit/test_layouts.py` and `test/ttnn-jit/test_program_cache.py` 50 times in loop (with the metal change on branch)
### Checklist
- [ ] New/Existing tests provide coverage for changes
