### PR TITLE
Added support for dynamically loading resnet builder ops.

### DIFF
--- a/runtime/tools/chisel/test/test_main_cli.py
+++ b/runtime/tools/chisel/test/test_main_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "ttir_path, function_name",
     [

--- a/test/python/golden/experimental/test_mpmd_ops.py
+++ b/test/python/golden/experimental/test_mpmd_ops.py
@@ -25,7 +25,7 @@ def multiple_meshes(
     builder: StableHLOBuilder,
     unit_attrs: Optional[List[str]] = None,
 ):
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    return builder.add(in0, in1)
 
 
 @pytest.mark.parametrize(

--- a/test/python/golden/test_composite_functions.py
+++ b/test/python/golden/test_composite_functions.py
@@ -40,38 +40,38 @@ def digamma_composite(
         torch.full(shape, 0.021092796092796094).to(dtype),
         torch.full(shape, 0.08333333333333333).to(dtype),
     ]
-    constants = [builder.constant(i, unit_attrs=unit_attrs) for i in constant_tensors]
+    constants = [builder.constant(i) for i in constant_tensors]
 
     # create builder output
     recip = builder.reciprocal(x, unit_attrs=unit_attrs)
-    term1 = builder.multiply(recip, constants[0], unit_attrs=unit_attrs)
+    term1 = builder.multiply(recip, constants[0])
 
-    recip_square = builder.multiply(recip, recip, unit_attrs=unit_attrs)
-    term2 = builder.multiply(recip_square, constants[1], unit_attrs=unit_attrs)
+    recip_square = builder.multiply(recip, recip)
+    term2 = builder.multiply(recip_square, constants[1])
     intermediate2 = builder.subtract(term1, term2)
 
-    recip_pow_4 = builder.multiply(recip_square, recip_square, unit_attrs=unit_attrs)
-    term3 = builder.multiply(recip_pow_4, constants[2], unit_attrs=unit_attrs)
+    recip_pow_4 = builder.multiply(recip_square, recip_square)
+    term3 = builder.multiply(recip_pow_4, constants[2])
     intermediate3 = builder.add(intermediate2, term3)
 
-    recip_pow_6 = builder.multiply(recip_pow_4, recip_square, unit_attrs=unit_attrs)
-    term4 = builder.multiply(recip_pow_6, constants[3], unit_attrs=unit_attrs)
+    recip_pow_6 = builder.multiply(recip_pow_4, recip_square)
+    term4 = builder.multiply(recip_pow_6, constants[3])
     intermediate4 = builder.subtract(intermediate3, term4)
 
-    recip_pow_8 = builder.multiply(recip_pow_6, recip_square, unit_attrs=unit_attrs)
-    term5 = builder.multiply(recip_pow_8, constants[4], unit_attrs=unit_attrs)
+    recip_pow_8 = builder.multiply(recip_pow_6, recip_square)
+    term5 = builder.multiply(recip_pow_8, constants[4])
     intermediate5 = builder.add(intermediate4, term5)
 
-    recip_pow_10 = builder.multiply(recip_pow_8, recip_square, unit_attrs=unit_attrs)
-    term6 = builder.multiply(recip_pow_10, constants[5], unit_attrs=unit_attrs)
+    recip_pow_10 = builder.multiply(recip_pow_8, recip_square)
+    term6 = builder.multiply(recip_pow_10, constants[5])
     intermediate6 = builder.subtract(intermediate5, term6)
 
-    recip_pow_12 = builder.multiply(recip_pow_10, recip_square, unit_attrs=unit_attrs)
-    term7 = builder.multiply(recip_pow_12, constants[6], unit_attrs=unit_attrs)
+    recip_pow_12 = builder.multiply(recip_pow_10, recip_square)
+    term7 = builder.multiply(recip_pow_12, constants[6])
     intermediate7 = builder.add(intermediate6, term7)
 
-    recip_pow_14 = builder.multiply(recip_pow_12, recip_square, unit_attrs=unit_attrs)
-    term8 = builder.multiply(recip_pow_14, constants[7], unit_attrs=unit_attrs)
+    recip_pow_14 = builder.multiply(recip_pow_12, recip_square)
+    term8 = builder.multiply(recip_pow_14, constants[7])
     intermediate8 = builder.subtract(intermediate7, term8)
 
     log_x = builder.log(x)
@@ -107,7 +107,7 @@ def lgamma_composite(
         torch.full(shape, 0.918938531357171).to(dtype),
         # torch.full(shape, 0.0).to(dtype),
     ]
-    constants = [builder.constant(i, unit_attrs=unit_attrs) for i in constant_tensors]
+    constants = [builder.constant(i) for i in constant_tensors]
 
     # input = x - 1.0
     input_val = builder.subtract(x, constants[6], unit_attrs=unit_attrs)
@@ -115,72 +115,53 @@ def lgamma_composite(
     # Build temp accumulator
     # z1 = 1/(input + 1.0) * 76.18009172947146
     z1 = builder.multiply(
-        builder.reciprocal(
-            builder.add(input_val, constants[6], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
-        ),
+        builder.reciprocal(builder.add(input_val, constants[6])),
         constants[0],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(z1, constants[6], unit_attrs=unit_attrs)
+    temp = builder.add(z1, constants[6])
 
     # z1 = 1/(input + 2.0) * -86.50532032941677
     z1 = builder.multiply(
-        builder.reciprocal(
-            builder.add(input_val, constants[7], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
-        ),
+        builder.reciprocal(builder.add(input_val, constants[7])),
         constants[1],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+    temp = builder.add(temp, z1)
 
     # z1 = 1/(input + 3.0) * 24.01409824083091
     z1 = builder.multiply(
         builder.reciprocal(
-            builder.add(input_val, constants[8], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
+            builder.add(
+                input_val,
+                constants[8],
+            )
         ),
         constants[2],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+    temp = builder.add(temp, z1)
 
     # z1 = 1/(input + 4.0) * -1.231739572450155
     z1 = builder.multiply(
-        builder.reciprocal(
-            builder.add(input_val, constants[9], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
-        ),
+        builder.reciprocal(builder.add(input_val, constants[9])),
         constants[3],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+    temp = builder.add(temp, z1)
 
     # z1 = 1/(input + 5.0) * 0.1208650973866179e-2
     z1 = builder.multiply(
-        builder.reciprocal(
-            builder.add(input_val, constants[10], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
-        ),
+        builder.reciprocal(builder.add(input_val, constants[10])),
         constants[4],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+    temp = builder.add(temp, z1)
 
     # z1 = 1/(input + 6.0) * -0.5395239384953e-5
     z1 = builder.multiply(
-        builder.reciprocal(
-            builder.add(input_val, constants[11], unit_attrs=unit_attrs),
-            unit_attrs=unit_attrs,
-        ),
+        builder.reciprocal(builder.add(input_val, constants[11])),
         constants[5],
-        unit_attrs=unit_attrs,
     )
-    temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+    temp = builder.add(temp, z1)
 
     # t = input + 5.5
-    t = builder.add(input_val, constants[12], unit_attrs=unit_attrs)
+    t = builder.add(input_val, constants[12])
     t_log = builder.log(t, unit_attrs=unit_attrs)
 
     # temp_log = log(temp)
@@ -188,17 +169,12 @@ def lgamma_composite(
 
     # result = (input + 0.5) * t_log + 0.918938531357171
     result = builder.add(
-        builder.multiply(
-            builder.add(input_val, constants[13], unit_attrs=unit_attrs),
-            t_log,
-            unit_attrs=unit_attrs,
-        ),
+        builder.multiply(builder.add(input_val, constants[13]), t_log),
         constants[14],
-        unit_attrs=unit_attrs,
     )
 
     # result = result + temp_log
-    result = builder.add(result, temp_log, unit_attrs=unit_attrs)
+    result = builder.add(result, temp_log)
 
     # result = result - t
     result = builder.subtract(result, t, unit_attrs=unit_attrs)
@@ -224,7 +200,7 @@ def multigammaln_composite(
         torch.full(shape, 1.5).to(dtype),
         torch.full(shape, 3.434189657547).to(dtype),
     ]
-    constants = [builder.constant(i, unit_attrs=unit_attrs) for i in constant_tensors]
+    constants = [builder.constant(i) for i in constant_tensors]
 
     # result = lgamma(x) + lgamma(x - 0.5) + lgamma(x - 1.0) + lgamma(x - 1.5) + 3.434189657547
     # Note: We use lgamma_composite for the intermediate lgamma calculations
@@ -245,10 +221,10 @@ def multigammaln_composite(
         x_minus_1_5, shape, dtype, builder, unit_attrs=unit_attrs
     )
 
-    result = builder.add(lgamma_x, lgamma_x_0_5, unit_attrs=unit_attrs)
-    result = builder.add(result, lgamma_x_1_0, unit_attrs=unit_attrs)
-    result = builder.add(result, lgamma_x_1_5, unit_attrs=unit_attrs)
-    result = builder.add(result, constants[3], unit_attrs=unit_attrs)
+    result = builder.add(lgamma_x, lgamma_x_0_5)
+    result = builder.add(result, lgamma_x_1_0)
+    result = builder.add(result, lgamma_x_1_5)
+    result = builder.add(result, constants[3])
 
     return result
 
@@ -267,28 +243,22 @@ def polygamma_composite(
     if k == 2 or k == 4 or k == 6 or k == 8 or k == 10:
         fact_val *= -1.0
 
-    k_der_builder = builder.constant(
-        torch.full(shape, k_der).to(dtype), unit_attrs=unit_attrs
-    )
+    k_der_builder = builder.constant(torch.full(shape, k_der).to(dtype))
     temp = builder.reciprocal(builder.pow(x, k_der_builder), unit_attrs=unit_attrs)
     for i in range(1, 11):
-        i_builder = builder.constant(
-            torch.full(shape, i).to(dtype), unit_attrs=unit_attrs
-        )
+        i_builder = builder.constant(torch.full(shape, i).to(dtype))
         z1 = builder.reciprocal(
             builder.pow(
-                builder.add(x, i_builder, unit_attrs=unit_attrs),
+                builder.add(x, i_builder),
                 k_der_builder,
                 unit_attrs=unit_attrs,
             ),
             unit_attrs=unit_attrs,
         )
-        temp = builder.add(temp, z1, unit_attrs=unit_attrs)
+        temp = builder.add(temp, z1)
 
-    fact_val_builder = builder.constant(
-        torch.full(shape, fact_val).to(dtype), unit_attrs=unit_attrs
-    )
-    result = builder.multiply(temp, fact_val_builder, unit_attrs=unit_attrs)
+    fact_val_builder = builder.constant(torch.full(shape, fact_val).to(dtype))
+    result = builder.multiply(temp, fact_val_builder)
     return result
 
 
@@ -499,9 +469,7 @@ def test_glu_split(
         builder: TTIRBuilder,
         unit_attrs: List[str] = None,
     ):
-        result = builder.multiply(
-            x1, builder.sigmoid(x2, unit_attrs=unit_attrs), unit_attrs=unit_attrs
-        )
+        result = builder.multiply(x1, builder.sigmoid(x2, unit_attrs=unit_attrs))
 
         return result
 
@@ -537,9 +505,7 @@ def test_reglu_split(
         builder: TTIRBuilder,
         unit_attrs: List[str] = None,
     ):
-        result = builder.multiply(
-            x1, builder.relu(x2, unit_attrs=unit_attrs), unit_attrs=unit_attrs
-        )
+        result = builder.multiply(x1, builder.relu(x2, unit_attrs=unit_attrs))
 
         return result
 
@@ -575,9 +541,7 @@ def test_geglu_split(
         builder: TTIRBuilder,
         unit_attrs: List[str] = None,
     ):
-        result = builder.multiply(
-            x1, builder.gelu(x2, unit_attrs=unit_attrs), unit_attrs=unit_attrs
-        )
+        result = builder.multiply(x1, builder.gelu(x2, unit_attrs=unit_attrs))
 
         return result
 
@@ -613,9 +577,7 @@ def test_swiglu_split(
         builder: TTIRBuilder,
         unit_attrs: List[str] = None,
     ):
-        result = builder.multiply(
-            x1, builder.silu(x2, unit_attrs=unit_attrs), unit_attrs=unit_attrs
-        )
+        result = builder.multiply(x1, builder.silu(x2, unit_attrs=unit_attrs))
 
         return result
 

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -27,9 +27,7 @@ def create_reductions_constrained_inputs(input_shape, reduce_type, dim_arg, keep
         in_tensor = (in_tensor * scale).round() / scale
         builder.set_goldens(inputs={in0: in_tensor})
         if reduce_type == "sum":
-            return builder.sum(
-                in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
-            )
+            return builder.sum(in0, dim_arg=dim_arg, keep_dim=keep_dim)
         elif reduce_type == "max":
             return builder.max(
                 in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs

--- a/test/python/golden/test_shardy_ops.py
+++ b/test/python/golden/test_shardy_ops.py
@@ -38,7 +38,7 @@ def sharding_constraint(
     )
 
     builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    return builder.add(in0, in1)
 
 
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
@@ -93,7 +93,7 @@ def test_op_sharding_annotation(
     ):
         builder.set_graph_level_check(True)
         sharding_attr = builder.create_sharding_attr_from_tuples("mesh", sharding)
-        return builder.add(in0, in1, unit_attrs=unit_attrs, sharding_attr=sharding_attr)
+        return builder.add(in0, in1, sharding_attr=sharding_attr)
 
     compile_and_execute_shlo(
         op_sharding_annotation,
@@ -139,7 +139,7 @@ def test_input_annotation(
             ],
         )
         builder.arg_attrs[in0] = {"sdy.sharding": tensor_sharding_attr}
-        return builder.add(in0, in1, unit_attrs=unit_attrs)
+        return builder.add(in0, in1)
 
     compile_and_execute_shlo(
         input_annotation,

--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -38,7 +38,7 @@ def sharding_constraint(
     )
 
     builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    return builder.add(in0, in1)
 
 
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -21,7 +21,7 @@ def add(
     unit_attrs: Optional[List[str]] = None,
 ):
     builder.set_graph_level_check(True)
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    return builder.add(in0, in1)
 
 
 def clamp(
@@ -377,7 +377,6 @@ def test_dot_general(
             contract_dims_lhs,
             batch_dims_rhs,
             contract_dims_rhs,
-            unit_attrs=unit_attrs,
         )
 
     compile_and_execute_shlo(

--- a/test/python/golden/test_ttir_fusing.py
+++ b/test/python/golden/test_ttir_fusing.py
@@ -110,7 +110,7 @@ def test_batch_norm_decomposition(
             unit_attrs=unit_attrs,
         )
 
-        batch_norm_0 = builder.batch_norm(
+        batch_norm_0 = builder.batch_norm_inference(
             conv2d_0,
             bn_scale,
             bn_offset,
@@ -118,7 +118,6 @@ def test_batch_norm_decomposition(
             bn_variance,
             epsilon=epsilon,
             dimension=dimension,
-            unit_attrs=unit_attrs,
         )
 
         builder.set_goldens(
@@ -330,7 +329,7 @@ def test_conv_silu_decomposed_fusing(
 
         # Add builder ops for x * sigmoid(x)
         sigmoid_op = builder.sigmoid(conv, unit_attrs=unit_attrs)
-        silu_decomposed = builder.multiply(conv, sigmoid_op, unit_attrs=unit_attrs)
+        silu_decomposed = builder.multiply(conv, sigmoid_op)
 
         builder.set_goldens(
             {

--- a/test/python/golden/test_ttir_parse_split_ops.py
+++ b/test/python/golden/test_ttir_parse_split_ops.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import Callable, List, Optional, Tuple, Union
+from collections import OrderedDict
+from functools import reduce
+import operator
+
+from builder.base.builder_utils import build_module, load_mlir_file, split_mlir_file
+
+pytestmark = pytest.mark.frontend("ttir")
+
+resnet_ops_ir = """module {
+  func.func @model(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>, %arg2: tensor<32x32xf32>, %arg3: tensor<12x3x224x224xf32>, %arg4: tensor<64x3x7x7xf32>, %arg5: tensor<12x64x112x112xf32>, %arg6: tensor<64xf32>, %arg7: tensor<64xf32>, %arg8: tensor<64xf32>, %arg9: tensor<64xf32>, %arg10: tensor<12x64x114x114xf32>) -> tensor<1x1024xf32> {
+    %0 = \"ttir.constant\"() <{value = dense<-1.19942093> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
+    %1 = ttir.empty() : tensor<32x34xf32>
+    %2 = \"ttir.pad\"(%arg0, %1) <{padding = array<i32: 0, 0, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<32x32xf32>, tensor<32x34xf32>) -> tensor<32x34xf32>
+    %3 = \"ttir.dot_general\"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = \"ttir.permute\"(%arg0, %4) <{permutation = array<i64: 1, 0>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = \"ttir.broadcast\"(%arg0, %6) <{broadcast_dimensions = array<i64: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = \"ttir.add\"(%arg0, %arg1, %8) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %10 = ttir.empty() : tensor<32xf32>
+    %11 = \"ttir.sum\"(%9, %10) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<32x32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %12 = ttir.empty() : tensor<32x32xf32>
+    %13 = \"ttir.multiply\"(%11, %arg2, %12) : (tensor<32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %14 = ttir.empty() : tensor<32x32xf32>
+    %15 = \"ttir.maximum\"(%13, %arg0, %14) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %16 = ttir.empty() : tensor<1x1024xf32>
+    %17 = \"ttir.reshape\"(%arg0, %16) <{shape = [1 : i32, 1024 : i32]}> : (tensor<32x32xf32>, tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    %18 = ttir.empty() : tensor<12x64x112x112xf32>
+    %19 = \"ttir.convolution\"(%arg3, %arg4, %18) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2x3, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 1, 1>, padding = array<i64: 3, 3, 3, 3>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 2, 2>}> : (tensor<12x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<12x64x112x112xf32>) -> tensor<12x64x112x112xf32>
+    %20 = ttir.empty() : tensor<12x64x112x112xf32>
+    %21 = \"ttir.batch_norm_inference\"(%arg5, %arg6, %arg7, %arg8, %arg9, %20) <{dimension = 1 : i32, epsilon = 9.99999974E-6 : f32}> : (tensor<12x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<12x64x112x112xf32>) -> tensor<12x64x112x112xf32>
+    %22 = ttir.empty() : tensor<12x31x56x114xf32>
+    %23 = \"ttir.pooling\"(%arg10, %22) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 2, 2>}> : (tensor<12x64x114x114xf32>, tensor<12x31x56x114xf32>) -> tensor<12x31x56x114xf32>
+    return %17 : tensor<1x1024xf32>
+  }
+}"""
+
+
+@pytest.mark.parametrize("mlir_text", [resnet_ops_ir])
+def test_resnet_ops(mlir_text: str, request, device):
+    mlir_module, builder = load_mlir_file(mlir_text)
+    builder_module_list = split_mlir_file(mlir_module, builder)

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -111,7 +111,7 @@ def test_pad(
         builder: TTIRBuilder,
         unit_attrs: Optional[List[str]] = None,
     ):
-        return builder.pad(in0, padding=padding, value=value, unit_attrs=unit_attrs)
+        return builder.pad(in0, padding=padding, value=value)
 
     pad_wrapper.__name__ = "pad"
 
@@ -141,7 +141,6 @@ def test_permute(
         return builder.permute(
             in0,
             permutation=permutation,
-            unit_attrs=unit_attrs,
         )
 
     permute_wrapper.__name__ = "permute"

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
@@ -84,7 +84,7 @@ def maximum(
     builder: TTIRBuilder,
     unit_attrs: Optional[List[str]] = None,
 ):
-    return builder.maximum(in0, in1, unit_attrs=unit_attrs)
+    return builder.maximum(in0, in1)
 
 
 def minimum(
@@ -508,7 +508,7 @@ def test_unaligned_shapes_add(
         tensor_lhs *= signs_lhs
         tensor_rhs *= signs_rhs
         builder.set_goldens(inputs={in0: tensor_lhs, in1: tensor_rhs})
-        return builder.add(in0, in1, unit_attrs=unit_attrs)
+        return builder.add(in0, in1)
 
     compile_and_execute_ttir(
         add,

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -54,7 +54,7 @@ def build_ttir(
     cos_unsqueezed = builder.reshape(cos_input, shape=unsqueezed_shape)
 
     # Multiply input with sin
-    unrotated = builder.multiply(input, cos_unsqueezed, unit_attrs=unit_attrs)
+    unrotated = builder.multiply(input, cos_unsqueezed)
 
     last_dim = input.type.shape[-1]
     half_dim = last_dim // 2
@@ -79,10 +79,10 @@ def build_ttir(
     sin_unsqueezed = builder.reshape(sin_input, shape=unsqueezed_shape)
 
     # Multiply rotated with broadcasted cos
-    rotated = builder.multiply(input_rotated, sin_unsqueezed, unit_attrs=unit_attrs)
+    rotated = builder.multiply(input_rotated, sin_unsqueezed)
 
     # Add the two products
-    return builder.add(unrotated, rotated, unit_attrs=unit_attrs)
+    return builder.add(unrotated, rotated)
 
 
 @pytest.mark.parametrize(

--- a/test/python/golden/ttir_ops/reduction/test_reduction.py
+++ b/test/python/golden/ttir_ops/reduction/test_reduction.py
@@ -100,9 +100,7 @@ def test_reduction_ops(
 
         reduction_func = reduction_op_builder_map.get(reduction_op_name)
 
-        return reduction_func(
-            in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
-        )
+        return reduction_func(in0, dim_arg=dim_arg, keep_dim=keep_dim)
 
     reduction_op_wrapper.__name__ = f"{reduction_op_name}"
 

--- a/test/python/golden/ttnn_ops/eltwise/test_ttnn_binary.py
+++ b/test/python/golden/ttnn_ops/eltwise/test_ttnn_binary.py
@@ -29,7 +29,7 @@ def add(
     builder: TTNNBuilder,
     unit_attrs: Optional[List[str]] = None,
 ):
-    return builder.add(in0, in1, unit_attrs=unit_attrs)
+    return builder.add(in0, in1)
 
 
 def atan2(
@@ -83,7 +83,7 @@ def maximum(
     builder: TTNNBuilder,
     unit_attrs: Optional[List[str]] = None,
 ):
-    return builder.maximum(in0, in1, unit_attrs=unit_attrs)
+    return builder.maximum(in0, in1)
 
 
 def minimum(
@@ -101,7 +101,7 @@ def multiply(
     builder: TTNNBuilder,
     unit_attrs: Optional[List[str]] = None,
 ):
-    return builder.multiply(in0, in1, unit_attrs=unit_attrs)
+    return builder.multiply(in0, in1)
 
 
 def remainder(

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -155,6 +155,9 @@ class Builder:
     def get_shape(self, input: Operand) -> Shape:
         return self._get_type(input).shape
 
+    def get_type(self, input: Operand) -> Type:
+        return self._get_type(input).element_type
+
     def set_goldens(
         self,
         inputs: Dict[Operand, Union[Callable, torch.tensor, Dict[int : torch.tensor]]],
@@ -182,29 +185,6 @@ class Builder:
     ):
         self._set_goldens(self._create_builder_golden_from_torch_tensor(operands))
         self.set_goldens_to_check(operands.keys())
-
-        print("*************** Goldens to store ***************")
-        print(f"  Count: {len(self._goldens_to_store)}")
-        for operand in self._goldens_to_store:
-            print(
-                f"  - {operand.name if hasattr(operand, 'name') else type(operand).__name__}"
-            )
-
-        print("\n*************** Operand to loc ***************")
-        for operand, loc in self._operand_to_loc.items():
-            op_str = (
-                operand.name if hasattr(operand, "name") else type(operand).__name__
-            )
-            print(f"  {op_str}: {loc}")
-
-        print("\n*************** Goldens ***************")
-        print(f"  Total goldens: {len(self._goldens)}")
-        for operand, golden in self._goldens.items():
-            op_str = (
-                operand.name if hasattr(operand, "name") else type(operand).__name__
-            )
-            shape_str = str(golden.shape) if hasattr(golden, "shape") else "?"
-            print(f"  {op_str} -> shape={shape_str}")
 
     def set_goldens_to_check(self, operands: List[Operand], override: bool = False):
         if override:
@@ -495,6 +475,12 @@ class Builder:
         operand: Operand,
     ) -> GoldenMapTensor:
         return self._goldens[operand]
+
+    def _get_golden_tensors(
+        self,
+        operands: List[Operand],
+    ) -> List[GoldenMapTensor]:
+        return [self._goldens[operand] for operand in operands]
 
     def _set_input_ordering(self, inputs: List[Operand]):
         self._ordered_inputs = inputs

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional, Tuple, Union, Literal, Dict
 from collections import OrderedDict
 
 from ttmlir.ir import *
-from ttmlir.dialects import func, ttcore, ttnn
+from ttmlir.dialects import func, ttcore, ttnn, ttir
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
@@ -1912,6 +1912,42 @@ def execute_fb(
         print(f"output tensors for program={program_index}")
         for tensor in program.output_tensors:
             logging.debug(f"{tensor}\n")
+
+
+def load_mlir_file(
+    mlir_text: str,
+    target: Literal["ttir", "ttnn", "d2m", "stablehlo"] = "ttir",
+) -> (Module, Builder):
+    ctx = Context()
+    module = Module.parse(mlir_text, ctx)
+
+    with ctx:
+        if target == "ttir":
+            builder, module = TTIRBuilder.from_module(ctx, module)
+        else:
+            raise NotImplementedError(
+                "Loading MLIR files is only supported for ttir currently."
+            )
+
+    return builder, module
+
+
+def split_mlir_file(
+    module: Module,
+    builder: Builder,
+    target: Literal["ttir", "ttnn", "d2m", "stablehlo"] = "ttir",
+) -> List[Tuple[Module, Builder]]:
+    ctx = Context()
+
+    with ctx:
+        if target == "ttir":
+            modules_and_builders = TTIRBuilder.split_module(ctx, module, builder)
+        else:
+            raise NotImplementedError(
+                "Splitting MLIR files is only supported for ttir currently."
+            )
+
+    return modules_and_builders
 
 
 # ----- Experimental Public APIs -----

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -18,15 +18,7 @@ import operator
 import torch
 import torch.nn.functional
 from ttmlir.dialects import ttir, stablehlo, d2m, ttnn
-from ttmlir.ir import (
-    Attribute,
-    ArrayAttr,
-    IntegerAttr,
-    IntegerType,
-    BoolAttr,
-    DenseI32ArrayAttr,
-    DenseI64ArrayAttr,
-)
+from ttmlir.ir import *
 
 
 class GoldenMapTensor:
@@ -326,6 +318,8 @@ def unpack_mlir_attr(attr):
         return list(attr)
     if isinstance(attr, (int, bool)):
         return attr
+    if isinstance(attr, FloatAttr):
+        return attr.value
     raise ValueError(f"Unexpected attribute type: {type(attr)}")
 
 
@@ -497,158 +491,6 @@ def conv_transpose2d_golden(
     return result
 
 
-def convolution_golden(
-    input_tensor: GoldenMapTensor,
-    weight: GoldenMapTensor,
-    bias: Optional[GoldenMapTensor] = None,
-    **kwargs,
-) -> GoldenMapTensor:
-    """
-    Custom golden function for generalized convolution operation.
-    This function handles the ttir.convolution operation by transforming it to match
-    PyTorch's conv2d expectations, handling arbitrary input layouts via the convolution_layout.
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor for convolution
-    weight : GoldenMapTensor
-        Convolution weight tensor
-    bias : GoldenMapTensor, optional
-        Optional bias tensor (default: None)
-    **kwargs : dict
-        Keyword arguments containing:
-        - window_strides: List[int] - Stride for convolution (default: [1, 1])
-        - padding: List[int] - Padding in [top, left, bottom, right] format (default: [0, 0, 0, 0])
-        - input_dilation: List[int] - Input dilation (default: [1, 1])
-        - weight_dilation: List[int] - Weight dilation (default: [1, 1])
-        - window_reversal: List[bool] - Window reversal (default: [False, False])
-        - convolution_layout: Attribute - Dimension numbering specification
-        - feature_group_count: int - Number of feature groups (default: 1)
-        - batch_group_count: int - Number of batch groups (default: 1)
-    Returns
-    -------
-    GoldenMapTensor
-        Result of convolution operation
-    """
-    # Extract convolution-specific parameters
-    window_strides = unpack_mlir_attr(kwargs.get("window_strides", [1, 1]))
-    padding = unpack_mlir_attr(kwargs.get("padding", [0, 0, 0, 0]))
-    input_dilation = unpack_mlir_attr(kwargs.get("input_dilation", [1, 1]))
-    weight_dilation = unpack_mlir_attr(kwargs.get("weight_dilation", [1, 1]))
-    feature_group_count = kwargs.get("feature_group_count", 1)
-    batch_group_count = kwargs.get("batch_group_count", 1)
-    convolution_layout = kwargs.get("convolution_layout", None)
-
-    # Note: For simplicity, we assume batch_group_count == 1 (not handling batch groups in golden)
-    if batch_group_count != 1:
-        raise ValueError(
-            f"Golden function does not support batch_group_count > 1, got {batch_group_count}"
-        )
-
-    # Handle layout transformation
-    # Parse convolution_layout to determine current tensor layout
-    # PyTorch expects input in NCHW format and weights in [O, I, H, W] format
-    if convolution_layout is not None:
-        # Get the layout dimensions from the attribute
-        # The attribute has methods like getInputBatchDimension(), getInputFeatureDimension(), etc.
-        input_batch_dim = convolution_layout.input_batch_dimension
-        input_feature_dim = convolution_layout.input_feature_dimension
-        input_spatial_dims = list(convolution_layout.input_spatial_dimensions)
-
-        # Current layout is defined by the positions
-        # We need to permute to NCHW: [batch, feature, spatial_0, spatial_1, ...]
-        current_layout = [None] * input_tensor.ndim
-        current_layout[input_batch_dim] = 0  # batch goes to position 0
-        current_layout[input_feature_dim] = 1  # feature goes to position 1
-        for i, spatial_dim in enumerate(input_spatial_dims):
-            current_layout[spatial_dim] = (
-                2 + i
-            )  # spatial dims go to positions 2, 3, ...
-
-        # Check if we need to permute (i.e., if current_layout != [0, 1, 2, 3, ...])
-        if current_layout != list(range(input_tensor.ndim)):
-            # Create inverse permutation to go from current layout to NCHW
-            permutation = [current_layout.index(i) for i in range(input_tensor.ndim)]
-            input_tensor = input_tensor.permute(permutation)
-
-        # Similarly for output, we need to know how to permute back
-        output_batch_dim = convolution_layout.output_batch_dimension
-        output_feature_dim = convolution_layout.output_feature_dimension
-        output_spatial_dims = list(convolution_layout.output_spatial_dimensions)
-
-        # Output permutation: from NCHW back to output layout
-        output_permutation = [None] * (len(output_spatial_dims) + 2)
-        output_permutation[output_batch_dim] = 0
-        output_permutation[output_feature_dim] = 1
-        for i, spatial_dim in enumerate(output_spatial_dims):
-            output_permutation[spatial_dim] = 2 + i
-
-    # Extract only spatial dimensions from strides and dilations
-    # TTIR uses 4D strides/dilations [batch, channel, height, width]
-    # PyTorch conv2d expects 2D [height, width]
-    if len(window_strides) == 4:
-        stride = [window_strides[2], window_strides[3]]  # Extract spatial dims
-    elif len(window_strides) == 2:
-        stride = window_strides
-    else:
-        stride = [1, 1]
-
-    if len(weight_dilation) == 4:
-        dilation = [weight_dilation[2], weight_dilation[3]]  # Extract spatial dims
-    elif len(weight_dilation) == 2:
-        dilation = weight_dilation
-    else:
-        dilation = [1, 1]
-
-    # Convert padding from [top, left, bottom, right] to PyTorch format [height, width]
-    # PyTorch expects symmetric padding, so we check if padding is symmetric
-    if len(padding) == 4:
-        top, left, bottom, right = padding
-        if top == bottom and left == right:
-            torch_padding = [top, left]
-        else:
-            # For asymmetric padding, we need to manually pad the input
-            import torch.nn.functional as F
-
-            # PyTorch F.pad expects padding in reverse order: [left, right, top, bottom]
-            manual_padding = [left, right, top, bottom]
-            input_tensor = F.pad(input_tensor, manual_padding, mode="constant", value=0)
-            torch_padding = [0, 0]
-    elif len(padding) == 2:
-        torch_padding = padding
-    else:
-        torch_padding = [0, 0]
-
-    # Handle bias
-    if bias is not None:
-        bias = bias.squeeze()
-
-    # Now input_tensor is in NCHW format, call PyTorch conv2d directly
-    groups = feature_group_count
-
-    result = torch.nn.functional.conv2d(
-        input_tensor,
-        weight,
-        bias=bias,
-        stride=tuple(stride) if isinstance(stride, list) else stride,
-        padding=tuple(torch_padding)
-        if isinstance(torch_padding, list)
-        else torch_padding,
-        dilation=tuple(dilation) if isinstance(dilation, list) else dilation,
-        groups=groups,
-    )
-
-    # Permute output back to the expected output layout if needed
-    if convolution_layout is not None and output_permutation != list(
-        range(result.ndim)
-    ):
-        # Create permutation from NCHW to output layout
-        inverse_output_perm = [output_permutation.index(i) for i in range(result.ndim)]
-        result = result.permute(inverse_output_perm)
-
-    return result
-
-
 def max_pool2d_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
     """
     Custom golden function for max_pool2d with layout transformation.
@@ -779,113 +621,6 @@ def avg_pool2d_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTenso
     result = maxpool_object(input_tensor)
     result = result.transpose(-3, -2).transpose(-2, -1)
     return result
-
-
-def pooling_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
-    """
-    Custom golden function for generalized pooling operation.
-    This function handles the ttir.PoolingOp by decomposing it into appropriate
-    2D pooling operations (max, average, or sum pooling) based on the pooling_method
-    attribute. It supports flexible window dimensions and automatically determines
-    spatial dimensions for pooling.
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor for pooling
-    **kwargs : dict
-        Keyword arguments containing:
-        - pooling_method: Attribute - Pooling method (Max, Average, or Sum)
-        - window_dimensions: List[int] - Pooling window size for each dimension (default: [1, 1, 1, 1])
-        - window_strides: List[int] - Stride for pooling operation (default: [1, 1, 1, 1])
-        - padding: List[int] - Padding in flat format [dim0_low, dim0_high, dim1_low, dim1_high, ...]
-                               (default: [0, 0, 0, 0, 0, 0, 0, 0] for 4D tensor)
-        - window_dilations: List[int] - Dilation for pooling operation (default: [1, 1, 1, 1])
-    Returns
-    -------
-    GoldenMapTensor
-        Result of pooling operation
-    Notes
-    -----
-    - Spatial dimensions are automatically detected as dimensions with window_dimensions > 1
-    - If no spatial dimensions are detected, defaults to last two dimensions
-    - Padding format is converted from flat array [dim0_low, dim0_high, ...] to
-      [top, left, bottom, right] for PyTorch compatibility
-    - Sum pooling is computed as average pooling multiplied by kernel size
-    """
-    # Extract pooling-specific parameters
-    pooling_method = kwargs.get("pooling_method")
-    window_dimensions = unpack_mlir_attr(kwargs.get("window_dimensions"))
-    window_strides = unpack_mlir_attr(kwargs.get("window_strides"))
-    padding = unpack_mlir_attr(kwargs.get("padding"))
-    window_dilations = unpack_mlir_attr(kwargs.get("window_dilations"))
-
-    # Find spatial dimensions (those with window_dimensions > 1)
-    spatial_dim_indices = [i for i, dim in enumerate(window_dimensions) if dim > 1]
-
-    # Validate spatial dimensions
-    if len(spatial_dim_indices) == 0 or len(spatial_dim_indices) > 2:
-        raise ValueError(
-            f"Pooling with {len(spatial_dim_indices)} spatial dimensions not supported. "
-            f"Expected 1 or 2 spatial dimensions."
-        )
-
-    # Default to last two dimensions if window dimensions are all 1
-    num_dims = len(window_dimensions)
-    if len(spatial_dim_indices) < 2:
-        spatial_dim_indices = [num_dims - 2, num_dims - 1]
-
-    # Extract kernel, stride, dilation, and padding for the spatial dimensions
-    kernel = [window_dimensions[i] for i in spatial_dim_indices]
-    stride = [window_strides[i] for i in spatial_dim_indices]
-    dilation = [window_dilations[i] for i in spatial_dim_indices]
-
-    # Convert padding from flat array to [top, left, bottom, right] format
-    # padding is [dim0_low, dim0_high, dim1_low, dim1_high, dim2_low, dim2_high, dim3_low, dim3_high]
-    pool_padding = [
-        padding[2 * spatial_dim_indices[0]],  # top
-        padding[2 * spatial_dim_indices[1]],  # left
-        padding[2 * spatial_dim_indices[0] + 1],  # bottom
-        padding[2 * spatial_dim_indices[1] + 1],  # right
-    ]
-
-    # Get pooling method enum value
-    pooling_method_str = str(pooling_method)
-
-    # Call the appropriate golden function based on pooling method
-    if "Max" in pooling_method_str:
-        return max_pool2d_golden(
-            input_tensor,
-            kernel=kernel,
-            stride=stride,
-            padding=pool_padding,
-            dilation=dilation,
-            ceil_mode=False,
-        )
-    elif "Average" in pooling_method_str:
-        return avg_pool2d_golden(
-            input_tensor,
-            kernel=kernel,
-            stride=stride,
-            padding=pool_padding,
-            dilation=dilation,
-            ceil_mode=False,
-            count_include_pad=True,
-        )
-    elif "Sum" in pooling_method_str:
-        # Sum pooling = average pooling * kernel size
-        result = avg_pool2d_golden(
-            input_tensor,
-            kernel=kernel,
-            stride=stride,
-            padding=pool_padding,
-            dilation=dilation,
-            ceil_mode=False,
-            count_include_pad=True,
-        )
-        kernel_size = kernel[0] * kernel[1]
-        return torch.mul(result, kernel_size)
-    else:
-        raise ValueError(f"Unknown pooling method: {pooling_method_str}")
 
 
 def batch_norm_golden(
@@ -1701,34 +1436,6 @@ def embedding_golden(
     return embedding(golden_input)
 
 
-def pad_golden(input_tensor: GoldenMapTensor, padding, value) -> GoldenMapTensor:
-    """
-    Custom golden function for pad operation with dimension reformatting.
-
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor to pad
-    padding : List[int]
-        Padding specification
-    value : Union[int, float]
-        Value to use for padding
-
-    Returns
-    -------
-    GoldenMapTensor
-        Padded tensor
-    """
-    # Reformatting padding dimensions for golden tensor:
-    golden_padding = []
-    for i in range(len(padding) // 2):
-        golden_padding.append(padding[-((2 * i) + 2)])
-        golden_padding.append(padding[-((2 * i) + 1)])
-    return torch.nn.functional.pad(
-        input_tensor, pad=golden_padding, mode="constant", value=value
-    )
-
-
 def select_golden(
     input_tensor: GoldenMapTensor, dim, begin, length, stride
 ) -> GoldenMapTensor:
@@ -2181,31 +1888,6 @@ def get_dimension_size_golden(
         )
 
     return output_tensor
-
-
-def sum_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
-    """
-    Golden function for sum operation with TTIR parameter names.
-
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor to sum
-    **kwargs : dict
-        Keyword arguments containing:
-        - dim_arg: List[int] - Dimensions to reduce over (default: [0])
-        - keep_dim: bool - If True, retains reduced dimensions with length 1 (default: True)
-
-    Returns
-    -------
-    GoldenMapTensor
-        Summed tensor
-    """
-    # Get parameters from ttir_kwargs
-    dim_arg = kwargs.get("dim_arg", [0])
-    keep_dim = kwargs.get("keep_dim", True)
-    # Convert to torch.sum format
-    return torch.sum(input_tensor, dim=dim_arg, keepdim=keep_dim)
 
 
 def mean_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
@@ -2746,27 +2428,6 @@ def ones_golden(**kwargs) -> GoldenMapTensor:
     return GoldenMapTensor({0: torch.ones(size)}, (1, 1))
 
 
-def constant_golden(**kwargs) -> GoldenMapTensor:
-    """
-    Golden function for constant operation with TTIR parameter names.
-
-    Parameters
-    ----------
-    **kwargs : dict
-        Keyword arguments including 'value'
-
-    Returns
-    -------
-    GoldenMapTensor
-        Constant tensor
-    """
-    value = kwargs.get("value", [1])
-    # Convert value to torch tensor if it's not already one
-    if not isinstance(value, torch.Tensor):
-        value = torch.tensor(value)
-    return GoldenMapTensor({0: value}, (1, 1))
-
-
 def reverse_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
     """
     Golden function for reverse operation with TTIR parameter names.
@@ -3179,38 +2840,6 @@ def collective_broadcast_golden(
     )
 
 
-def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
-    """
-    Get the golden function for a given TTIR operation class.
-
-    Parameters
-    ----------
-    ttir_op_class : type
-        The TTIR operation class (e.g., ttir.AbsOp)
-    **kwargs
-        Additional keyword arguments for specialized operation selection
-
-    Returns
-    -------
-    Optional[Callable]
-        The corresponding golden function, or None if not found
-    """
-
-    # Handle special cases with parameters
-    if (
-        ttir_op_class == ttir.ToLayoutOp or ttir_op_class == d2m.ToLayoutOp
-    ) and "tilize" in kwargs:
-        if kwargs["tilize"]:
-            return tilize_golden
-        else:
-            return untilize_golden
-
-    if ttir_op_class in GOLDEN_MAPPINGS:
-        return GOLDEN_MAPPINGS[ttir_op_class]
-
-    return None
-
-
 def stablehlo_and_golden(
     input_tensor: BuilderGoldenTensor, other_tensor: BuilderGoldenTensor, **kwargs
 ) -> BuilderGoldenTensor:
@@ -3319,32 +2948,406 @@ def stablehlo_not_golden(
         return torch.bitwise_not(input_tensor)
 
 
-"""
-Dictionary mapping TTIR operation classes to their corresponding golden functions.
+def ttir_add_golden(lhs: GoldenMapTensor, rhs: GoldenMapTensor) -> GoldenMapTensor:
+    return torch.add(lhs, rhs)
 
-This dictionary provides a centralized mapping between TTIR operation types and their
-PyTorch-based golden reference implementations. Each key is a TTIR operation class
-(e.g., ttir.AbsOp) and each value is the corresponding golden function that computes
-the expected output for that operation.
 
-The mapping supports:
-    - Elementwise unary operations (abs, ceil, cos, etc.)
-    - Elementwise binary operations (add, multiply, subtract, etc.)
-    - Elementwise ternary operations (where, select, etc.)
-    - Comparison operations (eq, ne, lt, gt, etc.)
-    - Bitwise operations (and, or, xor, not)
-    - Reduction operations (sum, mean, max, min, etc.)
-    - Tensor manipulation (transpose, concat, reshape, etc.)
-    - Neural network operations (matmul, embedding, conv2d, etc.)
-    - Layout operations (to_layout, view_layout)
-    - Quantization operations (quantize, dequantize, requantize)
-    - Collective communication operations (all_gather, all_reduce, etc.)
+def ttir_sum_golden(
+    input_tensor: GoldenMapTensor, dim_arg_attr: ArrayAttr, keep_dim_attr: BoolAttr
+) -> GoldenMapTensor:
+    dim_arg = unpack_mlir_attr(dim_arg_attr)
+    keep_dim = unpack_mlir_attr(keep_dim_attr)
+    return torch.sum(input_tensor, dim=dim_arg, keepdim=keep_dim)
 
-Usage:
-    golden_fn = GOLDEN_MAPPINGS.get(ttir.AbsOp)
-    if golden_fn:
-        result = golden_fn(input_tensor)
-"""
+
+def ttir_multiply_golden(lhs: GoldenMapTensor, rhs: GoldenMapTensor) -> GoldenMapTensor:
+    return torch.multiply(lhs, rhs)
+
+
+def ttir_maximum_golden(lhs: GoldenMapTensor, rhs: GoldenMapTensor) -> GoldenMapTensor:
+    return torch.maximum(lhs, rhs)
+
+
+def ttir_reshape_golden(
+    input_tensor: GoldenMapTensor, shape_attr: ArrayAttr
+) -> GoldenMapTensor:
+    new_shape = unpack_mlir_attr(shape_attr)
+    return torch.reshape(input_tensor, new_shape)
+
+
+def ttir_broadcast_golden(
+    input_tensor: GoldenMapTensor, broadcast_dimensions_attr: DenseI64ArrayAttr
+) -> GoldenMapTensor:
+    broadcast_dimensions = unpack_mlir_attr(broadcast_dimensions_attr)
+    input_shape = input_tensor.shape
+
+    shape = []
+    for i in range(len(broadcast_dimensions)):
+        if broadcast_dimensions[i] != 1:
+            shape.append(broadcast_dimensions[i])
+        else:
+            shape.append(input_shape[i])
+
+    return torch.broadcast_to(input_tensor, shape)
+
+
+def ttir_permute_golden(
+    input_tensor: GoldenMapTensor, permutation_attr: DenseI64ArrayAttr
+) -> GoldenMapTensor:
+    permutation = unpack_mlir_attr(permutation_attr)
+    return torch.permute(input_tensor, permutation)
+
+
+def ttir_dot_general_golden(
+    lhs: GoldenMapTensor,
+    rhs: GoldenMapTensor,
+    batch_dims_lhs_attr: DenseI64ArrayAttr,
+    contract_dims_lhs_attr: DenseI64ArrayAttr,
+    batch_dims_rhs_attr: DenseI64ArrayAttr,
+    contract_dims_rhs_attr: DenseI64ArrayAttr,
+) -> GoldenMapTensor:
+    batch_dims_lhs = unpack_mlir_attr(batch_dims_lhs_attr)
+    contract_dims_lhs = unpack_mlir_attr(contract_dims_lhs_attr)
+    batch_dims_rhs = unpack_mlir_attr(batch_dims_rhs_attr)
+    contract_dims_rhs = unpack_mlir_attr(contract_dims_rhs_attr)
+
+    non_batch_dims_lhs = [d for d in range(lhs.dim()) if d not in batch_dims_lhs]
+    non_batch_dims_rhs = [d for d in range(rhs.dim()) if d not in batch_dims_rhs]
+
+    # Compute output shape
+    lhs_shape = list(lhs.shape)
+    rhs_shape = list(rhs.shape)
+    batch_shape = [lhs_shape[d] for d in batch_dims_lhs]
+    non_contract_lhs = [d for d in non_batch_dims_lhs if d not in contract_dims_lhs]
+    non_contract_rhs = [d for d in non_batch_dims_rhs if d not in contract_dims_rhs]
+    out_shape = (
+        batch_shape
+        + [lhs_shape[d] for d in non_contract_lhs]
+        + [rhs_shape[d] for d in non_contract_rhs]
+    )
+
+    transposed_lhs = torch.permute(lhs, (batch_dims_lhs + non_batch_dims_lhs))
+    transposed_rhs = torch.permute(rhs, (batch_dims_rhs + non_batch_dims_rhs))
+    result = lhs.zeros_like_builder(out_shape)
+
+    dim_ranges = []
+    for i in range(len(batch_dims_lhs)):
+        dim_ranges.append([j for j in range(list(lhs.shape)[i])])
+
+    import itertools
+
+    batch_indices = list(itertools.product(*dim_ranges))
+    for index in batch_indices:
+        for device_id, shard in result.shard_map.items():
+            transposed_lhs_slice = transposed_lhs.shard_at(device_id)[index]
+            transposed_rhs_slice = transposed_rhs.shard_at(device_id)[index]
+            dot_dims_lhs = [d - len(index) for d in contract_dims_lhs]
+            dot_dims_rhs = [d - len(index) for d in contract_dims_rhs]
+            out_index = index
+            shard[out_index] = torch.tensordot(
+                transposed_lhs_slice,
+                transposed_rhs_slice,
+                dims=(dot_dims_lhs, dot_dims_rhs),
+            )
+    return result
+
+
+def ttir_pad_golden(
+    input_tensor: GoldenMapTensor, padding: DenseI32ArrayAttr, value: FloatAttr
+) -> GoldenMapTensor:
+    padding = unpack_mlir_attr(padding)
+    value = unpack_mlir_attr(value)
+
+    golden_padding = []
+    for i in range(len(padding) // 2):
+        golden_padding.append(padding[-((2 * i) + 2)])
+        golden_padding.append(padding[-((2 * i) + 1)])
+
+    return torch.nn.functional.pad(
+        input_tensor, pad=golden_padding, mode="constant", value=value
+    )
+
+
+def ttir_constant_golden(value: DenseElementsAttr) -> GoldenMapTensor:
+    def splat_dense_attr_to_torch(elem_type: Type):
+        dtype = torch.float32
+
+        if isinstance(elem_type, FloatType):
+            if elem_type.width == 16:
+                dtype = torch.float16
+            elif elem_type.width == 32:
+                dtype = torch.float32
+            elif elem_type.width == 64:
+                dtype = torch.float64
+        elif isinstance(elem_type, IntegerType):
+            if elem_type.width == 8:
+                dtype = torch.int8
+            elif elem_type.width == 16:
+                dtype = torch.int16
+            elif elem_type.width == 32:
+                dtype = torch.int32
+            elif elem_type.width == 64:
+                dtype = torch.int64
+
+        return dtype
+
+    shape = list(value.type.shape)
+    dtype = splat_dense_attr_to_torch(value.type)
+
+    if value.is_splat:
+        value = value.get_splat_value()
+        torch_tensor = torch.full(shape, value.value, dtype=dtype)
+    else:
+        assert False, "Non-splat constants are not supported in golden functions."
+
+    return GoldenMapTensor({0: torch_tensor.reshape(shape)}, (1, 1))
+
+
+def ttir_convolution_golden(
+    input_tensor: GoldenMapTensor,
+    weight: GoldenMapTensor,
+    bias: Optional[GoldenMapTensor],
+    window_strides_attr: DenseI64ArrayAttr,
+    padding_attr: DenseI64ArrayAttr,
+    input_dilation_attr: DenseI64ArrayAttr,
+    weight_dilation_attr: DenseI64ArrayAttr,
+    window_reversal_attr: DenseBoolArrayAttr,
+    convolution_layout_attr: Attribute,
+    feature_group_count_attr: IntegerAttr,
+    batch_group_count_attr: IntegerAttr,
+) -> GoldenMapTensor:
+    # Extract convolution-specific parameters
+    window_strides = unpack_mlir_attr(window_strides_attr)
+    padding = unpack_mlir_attr(padding_attr)
+    input_dilation = unpack_mlir_attr(input_dilation_attr)
+    weight_dilation = unpack_mlir_attr(weight_dilation_attr)
+    feature_group_count = unpack_mlir_attr(feature_group_count_attr)
+    batch_group_count = unpack_mlir_attr(batch_group_count_attr)
+    convolution_layout = None
+
+    # Note: For simplicity, we assume batch_group_count == 1 (not handling batch groups in golden)
+    if batch_group_count != 1:
+        raise ValueError(
+            f"Golden function does not support batch_group_count > 1, got {batch_group_count}"
+        )
+
+    # Handle layout transformation
+    # Parse convolution_layout to determine current tensor layout
+    # PyTorch expects input in NCHW format and weights in [O, I, H, W] format
+    if convolution_layout is not None:
+        # Get the layout dimensions from the attribute
+        # The attribute has methods like getInputBatchDimension(), getInputFeatureDimension(), etc.
+        input_batch_dim = convolution_layout.input_batch_dimension
+        input_feature_dim = convolution_layout.input_feature_dimension
+        input_spatial_dims = list(convolution_layout.input_spatial_dimensions)
+
+        # Current layout is defined by the positions
+        # We need to permute to NCHW: [batch, feature, spatial_0, spatial_1, ...]
+        current_layout = [None] * input_tensor.ndim
+        current_layout[input_batch_dim] = 0  # batch goes to position 0
+        current_layout[input_feature_dim] = 1  # feature goes to position 1
+        for i, spatial_dim in enumerate(input_spatial_dims):
+            current_layout[spatial_dim] = (
+                2 + i
+            )  # spatial dims go to positions 2, 3, ...
+
+        # Check if we need to permute (i.e., if current_layout != [0, 1, 2, 3, ...])
+        if current_layout != list(range(input_tensor.ndim)):
+            # Create inverse permutation to go from current layout to NCHW
+            permutation = [current_layout.index(i) for i in range(input_tensor.ndim)]
+            input_tensor = input_tensor.permute(permutation)
+
+        # Similarly for output, we need to know how to permute back
+        output_batch_dim = convolution_layout.output_batch_dimension
+        output_feature_dim = convolution_layout.output_feature_dimension
+        output_spatial_dims = list(convolution_layout.output_spatial_dimensions)
+
+        # Output permutation: from NCHW back to output layout
+        output_permutation = [None] * (len(output_spatial_dims) + 2)
+        output_permutation[output_batch_dim] = 0
+        output_permutation[output_feature_dim] = 1
+        for i, spatial_dim in enumerate(output_spatial_dims):
+            output_permutation[spatial_dim] = 2 + i
+
+    # Extract only spatial dimensions from strides and dilations
+    # TTIR uses 4D strides/dilations [batch, channel, height, width]
+    # PyTorch conv2d expects 2D [height, width]
+    if len(window_strides) == 4:
+        stride = [window_strides[2], window_strides[3]]  # Extract spatial dims
+    elif len(window_strides) == 2:
+        stride = window_strides
+    else:
+        stride = [1, 1]
+
+    if len(weight_dilation) == 4:
+        dilation = [weight_dilation[2], weight_dilation[3]]  # Extract spatial dims
+    elif len(weight_dilation) == 2:
+        dilation = weight_dilation
+    else:
+        dilation = [1, 1]
+
+    # Convert padding from [top, left, bottom, right] to PyTorch format [height, width]
+    # PyTorch expects symmetric padding, so we check if padding is symmetric
+    if len(padding) == 4:
+        top, left, bottom, right = padding
+        if top == bottom and left == right:
+            torch_padding = [top, left]
+        else:
+            # For asymmetric padding, we need to manually pad the input
+            import torch.nn.functional as F
+
+            # PyTorch F.pad expects padding in reverse order: [left, right, top, bottom]
+            manual_padding = [left, right, top, bottom]
+            input_tensor = F.pad(input_tensor, manual_padding, mode="constant", value=0)
+            torch_padding = [0, 0]
+    elif len(padding) == 2:
+        torch_padding = padding
+    else:
+        torch_padding = [0, 0]
+
+    # Handle bias
+    if bias is not None:
+        bias = bias.squeeze()
+
+    # Now input_tensor is in NCHW format, call PyTorch conv2d directly
+    groups = feature_group_count
+
+    result = torch.nn.functional.conv2d(
+        input_tensor,
+        weight,
+        bias=bias,
+        stride=tuple(stride) if isinstance(stride, list) else stride,
+        padding=tuple(torch_padding)
+        if isinstance(torch_padding, list)
+        else torch_padding,
+        dilation=tuple(dilation) if isinstance(dilation, list) else dilation,
+        groups=groups,
+    )
+
+    # Permute output back to the expected output layout if needed
+    if convolution_layout is not None and output_permutation != list(
+        range(result.ndim)
+    ):
+        # Create permutation from NCHW to output layout
+        inverse_output_perm = [output_permutation.index(i) for i in range(result.ndim)]
+        result = result.permute(inverse_output_perm)
+
+    return result
+
+
+def ttir_pooling_golden(
+    input_tensor: GoldenMapTensor,
+    pooling_method_attr: Attribute,
+    window_dimensions_attr: DenseI64ArrayAttr,
+    window_strides_attr: DenseI64ArrayAttr,
+    base_dilations_attr: DenseI64ArrayAttr,
+    window_dilations_attr: DenseI64ArrayAttr,
+    padding_attr: DenseI64ArrayAttr,
+) -> GoldenMapTensor:
+    pooling_method = pooling_method_attr
+    window_dimensions = unpack_mlir_attr(window_dimensions_attr)
+    window_strides = unpack_mlir_attr(window_strides_attr)
+    base_dilations = unpack_mlir_attr(base_dilations_attr)
+    window_dilations = unpack_mlir_attr(window_dilations_attr)
+    padding = unpack_mlir_attr(padding_attr)
+
+    # Find spatial dimensions (those with window_dimensions > 1)
+    spatial_dim_indices = [i for i, dim in enumerate(window_dimensions) if dim > 1]
+
+    # Validate spatial dimensions
+    if len(spatial_dim_indices) == 0 or len(spatial_dim_indices) > 2:
+        raise ValueError(
+            f"Pooling with {len(spatial_dim_indices)} spatial dimensions not supported. "
+            f"Expected 1 or 2 spatial dimensions."
+        )
+
+    # Default to last two dimensions if window dimensions are all 1
+    num_dims = len(window_dimensions)
+    if len(spatial_dim_indices) < 2:
+        spatial_dim_indices = [num_dims - 2, num_dims - 1]
+
+    # Extract kernel, stride, dilation, and padding for the spatial dimensions
+    kernel = [window_dimensions[i] for i in spatial_dim_indices]
+    stride = [window_strides[i] for i in spatial_dim_indices]
+    dilation = [window_dilations[i] for i in spatial_dim_indices]
+
+    # Convert padding from flat array to [top, left, bottom, right] format
+    # padding is [dim0_low, dim0_high, dim1_low, dim1_high, dim2_low, dim2_high, dim3_low, dim3_high]
+    pool_padding = [
+        padding[2 * spatial_dim_indices[0]],  # top
+        padding[2 * spatial_dim_indices[1]],  # left
+        padding[2 * spatial_dim_indices[0] + 1],  # bottom
+        padding[2 * spatial_dim_indices[1] + 1],  # right
+    ]
+
+    # Get pooling method enum value
+    pooling_method_str = str(pooling_method)
+
+    # Call the appropriate golden function based on pooling method
+    if "Max" in pooling_method_str:
+        return max_pool2d_golden(
+            input_tensor,
+            kernel=kernel,
+            stride=stride,
+            padding=pool_padding,
+            dilation=dilation,
+            ceil_mode=False,
+        )
+    elif "Average" in pooling_method_str:
+        return avg_pool2d_golden(
+            input_tensor,
+            kernel=kernel,
+            stride=stride,
+            padding=pool_padding,
+            dilation=dilation,
+            ceil_mode=False,
+            count_include_pad=True,
+        )
+    elif "Sum" in pooling_method_str:
+        # Sum pooling = average pooling * kernel size
+        result = avg_pool2d_golden(
+            input_tensor,
+            kernel=kernel,
+            stride=stride,
+            padding=pool_padding,
+            dilation=dilation,
+            ceil_mode=False,
+            count_include_pad=True,
+        )
+        kernel_size = kernel[0] * kernel[1]
+        return torch.mul(result, kernel_size)
+    else:
+        raise ValueError(f"Unknown pooling method: {pooling_method_str}")
+
+
+def ttir_batch_norm_inference_golden(
+    input_tensor: GoldenMapTensor,
+    scale: GoldenMapTensor,
+    offset: GoldenMapTensor,
+    mean: GoldenMapTensor,
+    variance: GoldenMapTensor,
+    epsilon_attr: FloatAttr,
+    dimension_attr: IntegerAttr,
+) -> GoldenMapTensor:
+    epsilon = unpack_mlir_attr(epsilon_attr)
+    dim = unpack_mlir_attr(dimension_attr)
+    perm = list(range(input_tensor.ndim))
+    perm[1], perm[dim] = perm[dim], perm[1]
+    input_tensor = input_tensor.permute(perm)
+    result = torch.nn.functional.batch_norm(
+        input_tensor,
+        running_mean=mean,
+        running_var=variance,
+        weight=scale,
+        bias=offset,
+        training=False,
+        eps=epsilon,
+    )
+    inv_perm = [perm.index(i) for i in range(len(perm))]
+    result = result.permute(inv_perm)
+    return result
+
+
 GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # ----- TTIR OPS -----
     # Elementwise unary operations
@@ -3375,12 +3378,12 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.Expm1Op: torch.expm1,
     ttir.ExpOp: torch.exp,
     # Elementwise binary operations
-    ttir.AddOp: torch.add,
+    ttir.AddOp: ttir_add_golden,
     ttir.Atan2Op: torch.atan2,
-    ttir.MultiplyOp: torch.multiply,
+    ttir.MultiplyOp: ttir_multiply_golden,
     ttir.SubtractOp: torch.subtract,
     ttir.DivOp: torch.div,
-    ttir.MaximumOp: torch.maximum,
+    ttir.MaximumOp: ttir_maximum_golden,
     ttir.MinimumOp: torch.minimum,
     ttir.RemainderOp: torch.remainder,
     ttir.PowOp: torch.pow,
@@ -3406,7 +3409,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.BitwiseXorOp: torch.bitwise_xor,
     ttir.BitwiseNotOp: torch.bitwise_not,
     # Reduction operations
-    ttir.SumOp: sum_golden,
+    ttir.SumOp: ttir_sum_golden,
     ttir.MeanOp: mean_golden,
     ttir.MaxOp: max_golden,
     ttir.MinOp: min_golden,
@@ -3419,16 +3422,16 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.ConcatOp: concat_golden,
     ttir.RepeatOp: repeat_golden,
     ttir.RepeatInterleaveOp: repeat_interleave_golden,
-    ttir.ReshapeOp: reshape_golden,
+    ttir.ReshapeOp: ttir_reshape_golden,
     ttir.SqueezeOp: squeeze_golden,
     ttir.UnsqueezeOp: unsqueeze_golden,
     ttir.ReverseOp: reverse_golden,
-    ttir.PermuteOp: permute_golden,
+    ttir.PermuteOp: ttir_permute_golden,
     ttir.ClampScalarOp: clamp_scalar_golden,
     ttir.ClampTensorOp: clamp_tensor_golden,
     ttir.CumSumOp: cumsum_golden,
-    ttir.BroadcastOp: torch.broadcast_to,
-    ttir.PadOp: pad_golden,
+    ttir.BroadcastOp: ttir_broadcast_golden,
+    ttir.PadOp: ttir_pad_golden,
     ttir.IndexSelectOp: select_golden,
     ttir.IndexOp: index_golden,
     ttir.SliceStaticOp: slice_golden,
@@ -3438,14 +3441,14 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.MatmulOp: matmul_golden,
     ttir.EmbeddingOp: embedding_golden,
     ttir.Upsample2dOp: upsample2d_golden,
-    ttir.BatchNormInferenceOp: batch_norm_golden,
+    ttir.BatchNormInferenceOp: ttir_batch_norm_inference_golden,
     ttir.RMSNormOp: rms_norm_golden,
     # Type operations
     ttir.TypecastOp: typecast_golden,
     # Tensor creation
     ttir.ZerosOp: zeros_golden,
     ttir.OnesOp: ones_golden,
-    ttir.ConstantOp: constant_golden,
+    ttir.ConstantOp: ttir_constant_golden,
     ttir.ArangeOp: arange_golden,
     # Quantization operations
     ttir.QuantizeOp: quantize_golden,
@@ -3455,13 +3458,13 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.CbrtOp: cbrt_golden,
     ttir.Conv2dOp: conv2d_golden,
     ttir.ConvTranspose2dOp: conv_transpose2d_golden,
-    ttir.ConvolutionOp: convolution_golden,
+    ttir.ConvolutionOp: ttir_convolution_golden,
     ttir.MaxPool2dOp: max_pool2d_golden,
     ttir.AvgPool2dOp: avg_pool2d_golden,
-    ttir.PoolingOp: pooling_golden,
+    ttir.PoolingOp: ttir_pooling_golden,
     ttir.ArgMaxOp: argmax_golden,
     ttir.LinearOp: linear_golden,
-    ttir.DotGeneralOp: dot_general_golden,
+    ttir.DotGeneralOp: ttir_dot_general_golden,
     # Layout operations (identity functions) — accept and ignore extra kwargs like reinterpretLayout
     ttir.ToLayoutOp: (lambda x, **kwargs: x),
     # Cache operations
@@ -3581,3 +3584,35 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.ClampScalarOp: clamp_scalar_golden,
     ttnn.ClampTensorOp: clamp_tensor_golden,
 }
+
+
+def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
+    """
+    Get the golden function for a given TTIR operation class.
+
+    Parameters
+    ----------
+    ttir_op_class : type
+        The TTIR operation class (e.g., ttir.AbsOp)
+    **kwargs
+        Additional keyword arguments for specialized operation selection
+
+    Returns
+    -------
+    Optional[Callable]
+        The corresponding golden function, or None if not found
+    """
+
+    # Handle special cases with parameters
+    if (
+        ttir_op_class == ttir.ToLayoutOp or ttir_op_class == d2m.ToLayoutOp
+    ) and "tilize" in kwargs:
+        if kwargs["tilize"]:
+            return tilize_golden
+        else:
+            return untilize_golden
+
+    if ttir_op_class in GOLDEN_MAPPINGS:
+        return GOLDEN_MAPPINGS[ttir_op_class]
+
+    assert False, f"No golden function found for TTIR operation: {ttir_op_class}"

--- a/tools/scripts/parted.py
+++ b/tools/scripts/parted.py
@@ -118,5 +118,5 @@ if __name__ == "__main__":
 
     with Context() as ctx, open(args.mlir, "r") as mlir_fd:
         ctx.allow_unregistered_dialects = True
-        module = Module.parse(mlir_fd.read(), ctx)
+        module = Module.parse(mlir_fd.read())
         print(parted(module))


### PR DESCRIPTION
This is a massive refactor effort. The changes can be summarized as follows:

For all ttir ops found in Resnet, the underlying builder op has changed

- remove op_proxy to allow for more explicit build
- add @tag decorator to dynamically create ttir.op <-> builder op mapping
- add @parse decorator to dynamically create the ttir.op from another parsed op from a module
- add @split decorator to dynamically split an op from a module to create independent single op modules

These changes also fully support the golden infrastructure.

Future changes will be made to reduce code bloat once working functionality of ops are in.