### PR TITLE
Fix to-memory-config bug

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
@@ -71,14 +71,19 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
       ttnn::MemoryConfigAttr::get(desiredInputLayout, grid);
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto toMemoryConfigOp = rewriter.create<ttnn::ToMemoryConfigOp>(
-      op.getLoc(), memoryConfigedInputType, op.getInput(), inputMemoryConfig);
+  auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      op.getLoc(), memoryConfigedInputType, op.getInput(),
+      tt::ttnn::Layout::Tile,
+      ttcore::DataTypeAttr::get(
+          rewriter.getContext(),
+          ttcore::elementTypeToDataType(inputElementType)),
+      inputMemoryConfig);
 
   // Replace the original PagedUpdateCacheOp with one which takes our properly
   // configured input tensor.
   auto pagedUpdateCacheOp = rewriter.create<ttnn::PagedUpdateCacheOp>(
-      op.getLoc(), op.getCache(), toMemoryConfigOp.getResult(),
-      op.getUpdateIndex(), op.getShareCache(), op.getPageTable());
+      op.getLoc(), op.getCache(), toLayoutOp.getResult(), op.getUpdateIndex(),
+      op.getShareCache(), op.getPageTable());
 
   rewriter.replaceOp(op, pagedUpdateCacheOp);
   return success();


### PR DESCRIPTION
### Problem description
When optimizer is on, the `ttnn.to_memory_config` op inserted by `PagedUpdateCacheOpRewritePattern` workaround has its output type altered to be different than the memory config attr possessed by the op. Using `ttnn.to_layout` in the workaround instead of `ttnn.to_memory_config` resolves this issue.

### What's changed
- Use `ttnn.to_layout` to specify the shard spec and memory config of the fill value in `PagedUpdateCacheOpRewritePattern`

### Checklist
- [X] New/Existing tests provide coverage for changes
