### PR TITLE
Additional builder op refactoring for resnet ops

### DIFF
--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -1506,7 +1506,7 @@ def compile_ttir_module_to_flatbuffer(
     module_dump: bool = True,
     argument_types_string: Optional[str] = None,
     custom_pipeline: Optional[Union[Callable, str]] = None,
-    pipeline_options: List[str] = [],
+    pipeline_options: List[str] = None,
     print_ir: Union[bool, str] = False,
     goldens: Dict[Operand, GoldenMapTensor] = None,
 ):
@@ -1592,6 +1592,10 @@ def compile_ttir_module_to_flatbuffer(
     ValueError
         If an unsupported target is specified
     """
+
+    if pipeline_options is None:
+        pipeline_options = []
+
     if type(custom_pipeline) is str:
         custom_pipeline = _create_custom_ttir_pipeline_fn(
             custom_pipeline, print_ir=print_ir

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2901,7 +2901,7 @@ def ttir_reshape_golden(
     input_tensor: GoldenMapTensor, shape_attr: ArrayAttr
 ) -> GoldenMapTensor:
     new_shape = unpack_mlir_attr(shape_attr)
-    return torch.reshape(input_tensor, new_shape)
+    return torch.reshape(input_tensor, new_shape).clone()
 
 
 def ttir_broadcast_golden(


### PR DESCRIPTION
Continuation from PR: https://github.com/tenstorrent/tt-mlir/pull/5892 and https://github.com/tenstorrent/tt-mlir/pull/5930

Fixed some errors related to pipeline options and storing output goldens in flatbuffer.
Additional op support for @parse and @split functionality.