### PR TITLE
loosening generic/dma verifiers for dma-only generics

### DIFF
--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -124,6 +124,12 @@ mlir::LogicalResult DMAOp::verify() {
     return emitOpError("operands must have the same post-index rank");
   }
 
+  if (!std::equal(srcType.getShape().begin() + srcIndices,
+                  srcType.getShape().end(),
+                  dstType.getShape().begin() + dstIndices)) {
+    return emitOpError("operands must have the same post-index shape");
+  }
+
   if (getSrcAffineMap() && !isSrcRemote()) {
     return emitOpError("if src affine map is provided, src must be remote");
   }


### PR DESCRIPTION
### What's changed
To enable DMA-only generics with different sizes for input/output shards, the GenericOp verifier has been refactored to exit early.