### PR TITLE
Fix CIv2: Enable TRACY_TIMER_FALLBACK and set no_proxy for explorer tests and ttrt perf

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -121,6 +121,10 @@ jobs:
       run: |
         # Run Tests
         source env/activate
+
+        MACHINE_IP=$(hostname -I | awk '{print $1}')
+        export no_proxy="${no_proxy:+$no_proxy,}localhost,${MACHINE_IP}"
+        export NO_PROXY="${NO_PROXY:+$NO_PROXY,}localhost,${MACHINE_IP}"
         export WORK_DIR="$(pwd)"
         export BUILD_DIR="${{ steps.strings.outputs.build-output-dir }}"
         export INSTALL_DIR="${{ steps.strings.outputs.install-output-dir }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 
 if (TT_RUNTIME_ENABLE_PERF_TRACE)
   add_compile_options(-DTRACY_ENABLE=ON)
+  add_compile_options(-DTRACY_TIMER_FALLBACK=ON)
 endif()
 
 if (NOT DEFINED ENV{TTMLIR_TOOLCHAIN_DIR})


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5702

### Problem description
Explorer test `test_execute_and_check_perf_data_exists` fails in CIv2 with missing `perf_data` overlay due to:

#### Issue 1: CIv2 Network Restrictions
- CIv2's proxy intercepts network connections and redirects them to `HTTP_PROXY`
- 1a. Explorer Server can't be discovered because localhost is redirected
  - Model explorer Flask server binds to `localhost:PORT`. Test client uses `requests.get(localhost)` → urllib3 checks `no_proxy` env var → doesn't find match → routes through proxy → connection fails
- 1b. Tracy Server can't be discovered because machine IP is redirected
  - Tracy C++ client binds to machine IP via `gethostbyname(gethostname())`. Assuming something in CIv2 intercepts the TCP connection and checks `NO_PROXY` env var → doesn't find match → routes through proxy → connection fails

#### Issue 2: Tracy Timestamp Units Mismatch
- Explorer tests fail with missing `perf_data` overlay
- Overlay depends on Tracy profiling information correlating MLIR operations with Metal device operations
- Correlation fails when tt-mlir's `MLIR_OP_LOCATION` messages don't align with tt-metal's `TT_DNN_DEVICE_OP` messages in `tracy_ops_data.csv`
- Misalignment occurs when Tracy server sorts messages by incorrect timestamp
- Sorting error stems from timestamp units mismatch between tt-metal and tt-mlir:
  - tt-metal uses `clock_gettime()` → nanoseconds
  - tt-mlir uses `rdtsc` → CPU cycles (~2.3x larger values)
- Units mismatch stems from two root causes:
  - Environment: CIv2 uses `kvm-clock` clocksource (available: kvm-clock, acpi_pm), CIv1 uses `tsc` (available: tsc, kvm-clock, acpi_pm)
  - Compile options: tt-metal has `TRACY_TIMER_FALLBACK` compile option enabled, tt-mlir doesn't
    - Even though both link to the same tracy shared library, compile options are not inherited
- This worked fine in CIv1 because `tsc` is available, so tracy's runtime check for HardwareSupportsInvariantTSC returns true for tt-metal, and was hardcoded true for tt-mlir

### What's changed
#### Fix for Issue 1 (Network Restrictions):
- Add `localhost` (fixes 1a) and machine IP (fixes 1b) to bypass list `no_proxy` and `NO_PROXY` env vars in test workflow 
- Not added to more targeted python test script because it needs to be accessed by different processes like tracy server, model explorer, etc.

#### Fix for Issue 2 (Timestamp Units Mismatch):
- Added `TRACY_TIMER_FALLBACK=ON` to ensure consistent timer source between tt-mlir and tt-metal
- Ideally, tt-mlir would use `find_package(Tracy)` to automatically inherit tt-metal's Tracy compile definitions (including `TRACY_TIMER_FALLBACK`)

Impact: Explorer tests now pass in CIv2, ttrt perf should correctly produce perf_data as well
TODO: Don't know if this fix needs to be repeated in frontend projects when we use CI v2 there

### Checklist
- [x] Existing test `test_execute_and_check_perf_data_exists` validates the fix
  - [CI passes for CIv2 machine](https://github.com/tenstorrent/tt-mlir/actions/runs/19536248834/job/55931383507#step:15:342)
