### PR TITLE
D2M: Implicit broadcast for 2D inputs

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -359,7 +359,7 @@ def D2M_TileLogicalNotOp : D2M_GenericRegionComputeUnaryDstOp<"tile_logical_not"
     let results = (outs TTCore_Tile:$result);
 }
 
-def D2M_TileEqzOp : D2M_GenericRegionComputeUnaryDstOp<"tile_eqz"> {
+def D2M_TileEqzOp : D2M_GenericRegionComputeUnaryDstOp<"tile_eqz", D2M_TileComputeOpTraitBundle> {
     let summary = "D2M Tile Eqz Op";
     let description = [{
         The `tile_eqz` operation checks if each element in the input tile == 0
@@ -429,7 +429,7 @@ def D2M_TileMaximumOp : D2M_GenericRegionComputeBinaryDstOp<"tile_maximum", D2M_
     let results = (outs TTCore_Tile:$result);
 }
 
-def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum"> {
+def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Sum Op";
   let description = [{
         The `tile_reduce_sum` operation computes the sum of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- sum<dims>(A * B, C)
@@ -451,7 +451,7 @@ def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum"> {
   }];
 }
 
-def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max"> {
+def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Max Op";
   let description = [{
         The `tile_reduce_max` operation computes the max of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- max<dims>(A * B, C)
@@ -471,6 +471,18 @@ def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max"> {
       return true;
     }
   }];
+}
+
+// TODO(#5968): fusion w/ implicit bcast causes multiple failure scenarios.
+def D2M_TileBcastOp : D2M_GenericRegionComputeOp<"tile_bcast", [Pure, D2M_SkipOpEltwiseFusionTrait]> {
+  let summary = "D2M Tile Broadcast Op";
+  let description = [{
+    The `tile_bcast` operation broadcasts a row/col/scalar tile into a full tile.
+  }];
+
+  let arguments = (ins TTCore_Tile:$input,
+                       D2M_TileBcastTypeAttr:$bcast_type);
+  let results = (outs TTCore_Tile:$result);
 }
 
 def D2M_PackerMaskResetOp : D2M_GenericRegionComputeOp<"packer_mask_reset"> {

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
@@ -12,6 +12,8 @@ include "ttmlir/Dialect/D2M/IR/D2MBase.td"
 // Enum-backed attribute wrappers
 def D2M_ReduceDimAttr : EnumAttr<D2M_Dialect, D2M_ReduceDim, "reduce_dim">;
 
+def D2M_TileBcastTypeAttr : EnumAttr<D2M_Dialect, D2M_TileBcastType, "tile_bcast_type">;
+
 def D2M_ThreadAttr : AttrDef<D2M_Dialect, "Thread", [], "::mlir::Attribute"> {
   let mnemonic = "thread";
   let summary = "Thread information for a generic op.";

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsEnums.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsEnums.td
@@ -21,6 +21,38 @@ def D2M_ReduceDim : I32EnumAttr<"ReduceDim", "D2M ReduceDim", [
   let cppNamespace = "::mlir::tt::d2m";
 }
 
+def D2M_TileBcastTypeNone   : I32EnumAttrCase<"None",   0, "none">;
+def D2M_TileBcastTypeCol    : I32EnumAttrCase<"Col",    1, "col">;
+def D2M_TileBcastTypeRow    : I32EnumAttrCase<"Row",    2, "row">;
+def D2M_TileBcastTypeScalar : I32EnumAttrCase<"Scalar", 3, "scalar">;
+
+def D2M_TileBcastType : I32EnumAttr<"TileBcastType", "D2M TileBcastType", [
+  D2M_TileBcastTypeNone,
+  D2M_TileBcastTypeCol,
+  D2M_TileBcastTypeRow,
+  D2M_TileBcastTypeScalar
+]> {
+  let summary = "D2M tile-level broadcast types.";
+  let description = [{
+    The type of the input shape (not the direction) of a unary tile-level
+    broadcast operation.
+
+    For type Col, the input should be a single tile with a filled 0-column and
+    zeros elsewhere.
+
+    For type Row, the input should be a single tile with a filled 0-row and
+    zeros elsewhere.
+
+    For type Scalar, the input should be a single tile with a filled single
+    value at location [0,0], and zeros elsewhere.
+
+    The output will be a full tile filled with the broadcasted input values.
+  }];
+
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::d2m";
+}
+
 // D2M ThreadType mirrors D2M thread type and is used by D2M_ThreadAttr
 def D2M_ThreadTypeCompute : I32EnumAttrCase<"Compute", 0, "compute">;
 def D2M_ThreadTypeDatamovement : I32EnumAttrCase<"Datamovement", 1, "datamovement">;

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -8,7 +8,6 @@
 #include "ttmlir/Dialect/D2M/Analysis/CBProducerConsumer.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
-#include "ttmlir/Dialect/D2M/IR/D2MTraits.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Utils.h"
@@ -348,6 +347,7 @@ struct OpMap {};
 // clang-format off
 using ComputeOpMap = OpMap<
   // FPU.
+  std::pair<d2m::TileBcastOp,       std::pair<ttkernel::UnaryBcastInitOp,          ttkernel::UnaryBcastTileOp>>,
   std::pair<d2m::TileMatmulOp,      std::pair<ttkernel::MatmulInitOp,              ttkernel::MatmulTilesOp>>,
   std::pair<d2m::TileMatmulBlockOp, std::pair<ttkernel::MatmulBlockInitOp,         ttkernel::ExperimentalMatmulBlockOp>>,
 
@@ -560,6 +560,28 @@ public:
       rewriter.create<ttkernel::ReduceTileOp>(
           op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(),
           adaptor.getC(), reduce_type, kernel_reduce_dim);
+    } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileBcastOp>) {
+      ttkernel::BcastType bcastType = ttkernel::BcastType::None;
+      switch (op.getBcastType()) {
+      case d2m::TileBcastType::Col:
+        bcastType = ttkernel::BcastType::Col;
+        break;
+      case d2m::TileBcastType::Row:
+        bcastType = ttkernel::BcastType::Row;
+        break;
+      case d2m::TileBcastType::Scalar:
+        bcastType = ttkernel::BcastType::Scalar;
+        break;
+      case d2m::TileBcastType::None:
+        bcastType = ttkernel::BcastType::None;
+        break;
+      }
+      auto cb = getCB(rewriter, op.getInput());
+      auto dstIdx = getDstIdxFromResult(op.getResult());
+      rewriter.create<ttkernel::UnaryBcastInitOp>(op->getLoc(), cb, cb,
+                                                  bcastType);
+      rewriter.create<ttkernel::UnaryBcastTileOp>(
+          op->getLoc(), cb, adaptor.getInput(), dstIdx, bcastType);
     } else if constexpr (arity == 2) {
       auto dstIdx = getDstIdxFromResult(op.getResult());
       rewriter.create<InitOp>(op->getLoc(), getCB(rewriter, op.getLhs()),
@@ -1558,6 +1580,7 @@ void populateD2MToTTKernelPatterns(
                ttkernel::MemRefSubviewRewriter,
 
                // FPU.
+               ttkernel::D2MFPUOpsRewriter<d2m::TileBcastOp>,
                ttkernel::D2MFPUOpsRewriter<d2m::TileMatmulOp>,
                ttkernel::D2MFPUOpsRewriter<d2m::TileMatmulBlockOp>,
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -6,9 +6,7 @@
 
 #include "ttmlir/Dialect/D2M/Analysis/CBProducerConsumer.h"
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
-#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"

--- a/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
+++ b/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
@@ -13,9 +13,9 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Casting.h"
+
 #include <tuple>
 
 namespace mlir::tt::d2m {

--- a/lib/Dialect/D2M/Transforms/GenericTileComputeLoops.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericTileComputeLoops.cpp
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/D2M/Utils/Utils.h"
-
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -134,9 +133,9 @@ struct D2MGenericComputeRewriter : public OpRewritePattern<linalg::GenericOp> {
                                  : WalkResult::interrupt();
     });
 
-    assert(op.getRegion().hasOneBlock());
-    assert(op.getOutputs().size() == 1 &&
-           "Only one output tensor is supported");
+    TT_assert(op.getRegion().hasOneBlock());
+    TT_assertv(op.getOutputs().size() == 1u,
+               "Only one output tensor is supported");
     auto outputTensor =
         mlir::cast<MemRefType>(op.getOutputs().front().getType());
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -49,53 +49,88 @@ public:
       : OpRewritePattern<GenericOp>(ctx), useTileMatmul(useTileMatmul),
         maxDstPhysicalSizeTiles(maxDstPhysicalSizeTiles) {};
 
-  template <typename OpT>
-  using OpAndIndexOffset = std::pair<OpT, int64_t>;
+  // Records a CB<->DST affine.load/store op, which DST slice it accesses, and
+  // some special considerations for looping over the tensor shard while doing
+  // DST accumulation/broadcast. The CB->load->bcast->DST sequence is also
+  // modeled as a CB->DST load.
+  template <typename LoadOrStoreTy>
+  struct LoadStoreRecord {
+    LoadOrStoreTy loadStore = nullptr;
+    std::optional<d2m::TileBcastOp> bcast = std::nullopt;
+    int dstSlice = -1;
+    std::set<int64_t> guardDims = {};
 
-  // Stores dst loads/stores, organized by common loop nests.
+    LoadStoreRecord(LoadOrStoreTy loadStore,
+                    std::optional<d2m::TileBcastOp> bcast, int dstSlice,
+                    const std::set<int64_t> &guardDims)
+        : loadStore(loadStore), bcast(bcast), dstSlice(dstSlice),
+          guardDims(guardDims) {}
+  };
+
+  // Stores all DST<->CB loads/stores that are under the same affine loop nest.
   struct CopyInfo {
-    void push_back(affine::AffineLoadOp load, int64_t indexOffset) {
-      loads.emplace_back(load, indexOffset);
+    void record(affine::AffineLoadOp load, int dstSlice,
+                const std::set<int64_t> &guardDims) {
+      loads.emplace_back(load, std::nullopt, dstSlice, guardDims);
     }
 
-    void push_back(affine::AffineStoreOp store, int64_t indexOffset) {
-      stores.emplace_back(store, indexOffset);
+    void record(affine::AffineLoadOp load, d2m::TileBcastOp bcast, int dstSlice,
+                const std::set<int64_t> &guardDims) {
+      loads.emplace_back(load, bcast, dstSlice, guardDims);
     }
 
-    SmallVector<int64_t> guardIndices;
-    SmallVector<OpAndIndexOffset<affine::AffineLoadOp>> loads;
-    SmallVector<OpAndIndexOffset<affine::AffineStoreOp>> stores;
+    void record(affine::AffineStoreOp store, int dstSlice,
+                const std::set<int64_t> &) {
+      // Guards are only useful for load loops atm.
+      stores.emplace_back(store, std::nullopt, dstSlice, std::set<int64_t>{});
+    }
+
+    SmallVector<LoadStoreRecord<affine::AffineLoadOp>> loads;
+    SmallVector<LoadStoreRecord<affine::AffineStoreOp>> stores;
   };
 
   using CopyInfoMap = DenseMap<Operation *, CopyInfo>;
 
+  // Maps a compute op whose result will be consumed by another compute op, to
+  // its assigned DST slice and its ancestor loop nest.
+  struct DstIntermediateResult {
+    int dstSlice;
+    Operation *outermostLoop;
+  };
+  using DstIntermediatesMap = DenseMap<Operation *, DstIntermediateResult>;
+
+  struct DstAccessCollection {
+    CopyInfoMap copyInfos;
+    DstIntermediatesMap dstIntermediates;
+  };
+
   class DstSliceAllocationState {
   public:
-    int64_t allocate() { return nextSliceIndex++; }
+    int allocate() { return nextSliceIndex++; }
 
     void setStoreToDst() { storedToDst = true; }
     bool didStoreToDst() { return storedToDst; }
-    int64_t getCurrSliceIndex() { return nextSliceIndex - 1; }
+    int getCurrSliceIndex() { return nextSliceIndex - 1; }
 
   private:
-    int64_t nextSliceIndex = 0;
+    int nextSliceIndex = 0;
     bool storedToDst = false;
   };
 
-  LogicalResult matchAndRewrite(GenericOp op,
+  LogicalResult matchAndRewrite(GenericOp gOp,
                                 PatternRewriter &rewriter) const final {
     bool modified = false;
-    for (unsigned regionIndex = 0; regionIndex < op.getNumRegions();
+    for (unsigned regionIndex = 0; regionIndex < gOp.getNumRegions();
          regionIndex++) {
-      if (op.getRegionThreadType(regionIndex) != ThreadType::Compute) {
+      if (gOp.getRegionThreadType(regionIndex) != ThreadType::Compute) {
         continue;
       }
 
-      Region *genericRegion = &op.getRegion(regionIndex);
+      Region *genericRegion = &gOp.getRegion(regionIndex);
       Block &block = genericRegion->getBlocks().front();
 
       // Check if this region has any operations that this pass can handle.
-      OperationTypes opTypes = getOperationTypes(op, regionIndex);
+      OperationTypes opTypes = getOperationTypes(gOp, regionIndex);
       if (!opTypes.hasComputeOps && !opTypes.hasLinalgGeneric &&
           !opTypes.hasMarkedAffineLoops) {
         return failure();
@@ -103,7 +138,7 @@ public:
 
       Type largestDstType = utils::getRegionLargestDstElemType(*genericRegion);
       const unsigned dstCapacity =
-          ttcore::getOpChipDescAttr(op).getDstLogicalSizeTiles(
+          ttcore::getOpChipDescAttr(gOp).getDstLogicalSizeTiles(
               largestDstType, false, maxDstPhysicalSizeTiles);
 
       // Process linalg.generic ops that were not converted by LinalgToAffine
@@ -114,9 +149,9 @@ public:
               // Only use tile matmul block rewrite when not in explicit
               // datamovement form. Explicit datamovement form should fall
               // through to regular linalg-to-affine conversion.
-              if (!op.isExplicitDatamovementForm()) {
+              if (!gOp.isExplicitDatamovementForm()) {
                 if (rewriteTileMatmulAsTileMatmulBlock(
-                        rewriter, op, *genericRegion, linalgGenericOp,
+                        rewriter, gOp, *genericRegion, linalgGenericOp,
                         dstCapacity, modified)) {
                   return WalkResult::interrupt();
                 }
@@ -131,8 +166,8 @@ public:
 
       if (walkResult.wasInterrupted()) {
         return rewriter.notifyMatchFailure(
-            op, "linalg.generic operations were not converted to affine "
-                "loops");
+            gOp, "linalg.generic operations were not converted to affine "
+                 "loops");
       }
 
       // Process affine loops marked by LinalgToAffine pass.
@@ -148,14 +183,14 @@ public:
         // Insert DST register access for this loop nest.
         Region &dstRegisterAccessRegion = forOp.getRegion();
         modified |= insertDstRegisterAccess(
-            rewriter, op, dstRegisterAccessRegion, dstCapacity, forOp);
+            rewriter, gOp, dstRegisterAccessRegion, dstCapacity, forOp);
       });
     }
     return success(modified);
   }
 
   static bool
-  insertDstRegisterAccess(PatternRewriter &rewriter, GenericOp op,
+  insertDstRegisterAccess(PatternRewriter &rewriter, GenericOp gOp,
                           Region &region, unsigned dstCapacity,
                           Operation *outermostInnerComputeLoop = nullptr) {
     assert(region.getBlocks().size() == 1);
@@ -163,26 +198,26 @@ public:
       return false;
     }
 
-    Location loc = op.getLoc();
+    Location loc = gOp.getLoc();
 
-    // 1. Collect all loads/stores to dst organized by loop nest.
-    auto [copyInfos, dstAllocation] =
-        collectDstAccesses(op, region, outermostInnerComputeLoop);
+    // 1. Collect relevant DST accesses, grouped under their common loop nests.
+    auto [copyInfos, dstIntermediates] =
+        collectDstAccesses(gOp, region, outermostInnerComputeLoop);
     if (copyInfos.empty()) {
       return false;
     }
 
-    // 2. Insert acquire dst.
+    // 2. Determine DST slicing and insert acquire_dst.
     AcquireDstOp acquireDst =
         insertAcquireDst(rewriter, loc, region, copyInfos,
                          outermostInnerComputeLoop, dstCapacity);
     Value dst = acquireDst.getResult();
 
-    // 3. Generate data copy loops to/from dst and output cb.
+    // 3. Generate data copy affine loops for DST I/O.
     dataCopyGenerate(rewriter, loc, dst, copyInfos);
 
-    // 4. Rewrite stores to use dst register based on allocation.
-    insertDstRegisterAllocation(rewriter, loc, dst, dstAllocation);
+    // 4. Fix the passing of intermediate results through the DST.
+    fixDstIntermediateResults(rewriter, loc, dst, dstIntermediates);
 
     return true;
   }
@@ -191,11 +226,11 @@ public:
     return !region.getOps<AcquireDstOp>().empty();
   }
 
-  static OperationTypes getOperationTypes(GenericOp op, unsigned regionIndex) {
+  static OperationTypes getOperationTypes(GenericOp gOp, unsigned regionIndex) {
     OperationTypes types;
-    types.hasComputeOps = op.hasComputeOpsInRegion(regionIndex);
+    types.hasComputeOps = gOp.hasComputeOpsInRegion(regionIndex);
 
-    Region *genericRegion = &op.getRegion(regionIndex);
+    Region *genericRegion = &gOp.getRegion(regionIndex);
     Block &block = genericRegion->getBlocks().front();
 
     block.walk([&](Operation *op) {
@@ -211,36 +246,32 @@ public:
     return types;
   }
 
-  static std::pair<MemRefType, int64_t>
+  static std::pair<MemRefType, int>
   inferCbInfoFromAllAccesses(const CopyInfoMap &copyInfos) {
     MemRefType canonicalType = nullptr;
-    int64_t maxDstSliceIdx = -1;
+    int maxDstSlice = -1;
+
+    auto updateCanonicalType = [&](MemRefType memref, int idx) {
+      if (canonicalType == nullptr) {
+        canonicalType = memref;
+      } else {
+        TT_assertv(memref.getShape() == canonicalType.getShape(),
+                   "Multiple interpretations of DST not supported.");
+      }
+      maxDstSlice = std::max(maxDstSlice, idx);
+    };
 
     for (auto [loopNest, copyInfo] : copyInfos) {
-      for (auto &[loadOp, idx] : copyInfo.loads) {
-        if (canonicalType == nullptr) {
-          canonicalType = loadOp.getMemRefType();
-        } else {
-          TT_assertv(loadOp.getMemRefType().getShape() ==
-                         canonicalType.getShape(),
-                     "Multiple interpretations of DST not supported.");
-        }
-        maxDstSliceIdx = std::max(maxDstSliceIdx, idx);
+      for (auto &[loadOp, bcastOp, idx, guardDims] : copyInfo.loads) {
+        updateCanonicalType(loadOp.getMemRefType(), idx);
       }
-      for (auto &[storeOp, idx] : copyInfo.stores) {
-        if (canonicalType == nullptr) {
-          canonicalType = storeOp.getMemRefType();
-        } else {
-          TT_assertv(storeOp.getMemRefType().getShape() ==
-                         canonicalType.getShape(),
-                     "Multiple interpretations of DST not supported.");
-        }
-        maxDstSliceIdx = std::max(maxDstSliceIdx, idx);
+      for (auto &[storeOp, bcastOp, idx, guardDims] : copyInfo.stores) {
+        updateCanonicalType(storeOp.getMemRefType(), idx);
       }
     }
     TT_assert(canonicalType != nullptr);
-    TT_assert(maxDstSliceIdx >= 0);
-    return {canonicalType, maxDstSliceIdx};
+    TT_assert(maxDstSlice >= 0);
+    return {canonicalType, maxDstSlice};
   }
 
   static AcquireDstOp insertAcquireDst(PatternRewriter &rewriter, Location loc,
@@ -255,12 +286,12 @@ public:
       rewriter.setInsertionPointToStart(&region.front());
     }
 
-    auto [cbType, maxDstSliceIdx] = inferCbInfoFromAllAccesses(copyInfos);
+    auto [cbType, maxDstSlice] = inferCbInfoFromAllAccesses(copyInfos);
     // Calculate dst shape as N slices of cb shape.
     const int64_t volume = ttmlir::utils::volume(cbType.getShape());
     TT_assert(volume <= dstCapacity);
     const int64_t numDstSlices = dstCapacity / volume;
-    TT_assertv(maxDstSliceIdx < numDstSlices,
+    TT_assertv(maxDstSlice < numDstSlices,
                "Insufficient DST capacity for all operands.");
     SmallVector<int64_t> dstShape({numDstSlices});
     dstShape.append(cbType.getShape().begin(), cbType.getShape().end());
@@ -274,73 +305,58 @@ public:
     return rewriter.create<AcquireDstOp>(loc, dstType);
   }
 
-  // Walk all compute ops in the region and collect all dst accesses organized
-  // by loop nest. Also maintain dst register allocation state such that
-  // multiple operands get unique dst indices. Currently this routine only does
-  // register allocation for loads and just assumes that stores get exclusive
-  // access. Returns a map of loop nest -> copy info, which contains a list of
-  // loads and stores to copy into hoisted loop nests.
-
-  // Maps each D2MGenericRegionComputeOpTrait operation result to a dest
-  // register slice index and its containing loop nest.
-  struct DstRegisterInfo {
-    int64_t dstSliceIndex;
-    Operation *outermostLoop;
-  };
-  using DstRegisterAllocation = DenseMap<Operation *, DstRegisterInfo>;
-
-  // Struct to hold the results of dst access collection.
-  struct DstAccessCollection {
-    CopyInfoMap copyInfos;
-    DstRegisterAllocation dstAllocation;
-  };
-
-  // Return both the copy nest info and dst allocation info.
+  // Walk all compute ops in the region and collect:
+  // 1. CB->DST->ComputeOp loads.
+  // 2. CB->DST->ComputeOp load-bcasts.
+  // 3. ComputeOp->DST->CB stores.
+  // 4. ComputeOp->DST->ComputeOp intermediates.
+  // Loads & stores are organized under their common loop nests.
+  // Implements a simple linear DST slice allocator such that multiple operands
+  // get unique DST slices. Currently this routine only does allocation for
+  // loads and assumes that stores get exclusive access.
   static DstAccessCollection
-  collectDstAccesses(GenericOp op, Region &region,
+  collectDstAccesses(GenericOp gOp, Region &region,
                      Operation *outermostInnerComputeLoop) {
     CopyInfoMap copyInfos;
     DstSliceAllocationState dstSliceAllocationState;
-    DstRegisterAllocation dstRegisterAllocation;
+    DstIntermediatesMap dstIntermediates;
     region.walk([&](OperandLoadStoreRegisterOpInterface computeOp) {
-      // We're generating loads and stores for dst, so we can ignore loads and
-      // stores that are already on dst.
+      // Filter out non CB<->DST loads & stores.
       auto notDstMemspace = [](auto op) {
         return op && ttcore::getMemorySpace(op.getMemRef()) !=
                          ttcore::MemorySpace::RegisterDst;
       };
 
-      // Collect loads to this op.
+      // Collect CB->DST loads for this op's operands.
       for (int64_t operandIdx : computeOp.getOperandsLoadFromDstRegister()) {
-        // Skip scalar operands - they don't need to be loaded from dst
+        // Skip scalar operands - they don't need to be loaded from dst.
         if (computeOp.isScalarOperand(operandIdx)) {
           continue;
         }
 
-        if (auto potentialLoad = computeOp->getOperand(operandIdx)
-                                     .getDefiningOp<affine::AffineLoadOp>();
-            notDstMemspace(potentialLoad)) {
-          collectDstAccess<affine::AffineLoadOp>(
-              op, potentialLoad, copyInfos, dstSliceAllocationState.allocate(),
+        auto potentialLoad = computeOp->getOperand(operandIdx)
+                                 .getDefiningOp<affine::AffineLoadOp>();
+        if (potentialLoad && notDstMemspace(potentialLoad)) {
+          collectDstLoadOrStore<affine::AffineLoadOp>(
+              gOp, potentialLoad, copyInfos, dstSliceAllocationState.allocate(),
               outermostInnerComputeLoop);
         }
       }
 
-      // Collect stores from this op.
+      const bool dstRegInPlace = computeOp.getDstRegInPlace();
+
       for (auto *user : computeOp->getUsers()) {
         if (auto potentialStore = mlir::dyn_cast<affine::AffineStoreOp>(user);
             notDstMemspace(potentialStore)) {
-
+          // Collect DST->CB stores for this op's operands.
           assert(!dstSliceAllocationState.didStoreToDst() &&
                  "Multiple stores from last op to dst not supported");
 
-          auto dstRegInPlace = computeOp.getDstRegInPlace();
+          // For ops that support tile+scalar, check if rhs is a scalar.
+          const bool rhsIsScalar = computeOp.isScalarOperand(1);
 
-          // For ops that support tile+scalar, check if rhs is a scalar
-          bool rhsIsScalar = computeOp.isScalarOperand(1);
-
-          int64_t dstSliceIndex = -1;
-          // If op has scalar rhs, treat it as in-place (unary-like behavior)
+          int dstSlice = -1;
+          // If op has scalar rhs, treat it as in-place (unary-like behavior).
           if (dstRegInPlace || rhsIsScalar) {
             bool isUnaryOp = computeOp->getNumOperands() == 1;
             bool isTileMatmul = mlir::isa<d2m::TileMatmulOp>(computeOp);
@@ -353,39 +369,47 @@ public:
                 "ops "
                 "would reference wrong tile, but those ops should be setting "
                 "output tile.");
-            dstSliceIndex = dstSliceAllocationState.getCurrSliceIndex();
+            dstSlice = dstSliceAllocationState.getCurrSliceIndex();
           } else {
-            dstSliceIndex = dstSliceAllocationState.allocate();
+            dstSlice = dstSliceAllocationState.allocate();
             dstSliceAllocationState.setStoreToDst();
           }
-          collectDstAccess<affine::AffineStoreOp>(op, potentialStore, copyInfos,
-                                                  dstSliceIndex,
-                                                  outermostInnerComputeLoop);
-
-        }
-        // If the user isn't a store, it must be another compute consumer and we
-        // need to set or allocate a dest register intermediate for it.
-        else {
+          collectDstLoadOrStore<affine::AffineStoreOp>(
+              gOp, potentialStore, copyInfos, dstSlice,
+              outermostInnerComputeLoop);
+        } else {
+          // The consumer is another compute op, set or allocate an intermediate
+          // DST slice for it.
           assert(user->hasTrait<D2MGenericRegionComputeOpTrait>());
           assert(computeOp->hasOneUse() &&
                  "Currently we do not support multiple "
                  "users in the same compute dst region.");
           assert(computeOp->getNumResults() == 1);
-          assert(!dstRegisterAllocation.contains(computeOp));
+          assert(!dstIntermediates.contains(computeOp));
 
           // If op stores to dst in place or has scalar rhs, we don't need to
           // allocate a new dst register, just use the current dst index.
-          int32_t allocatedIndex =
+          int dstSlice =
               (computeOp.getDstRegInPlace() || computeOp.isScalarOperand(1))
                   ? dstSliceAllocationState.getCurrSliceIndex()
                   : dstSliceAllocationState.allocate();
 
-          dstRegisterAllocation[computeOp] = {allocatedIndex,
-                                              outermostInnerComputeLoop};
+          // Exception: the CB load of the load-bcast pair won't be captured by
+          // the CB->DST load handling loop above.
+          if (mlir::isa<d2m::TileBcastOp>(computeOp)) {
+            auto loadOp =
+                computeOp->getOperand(0).getDefiningOp<affine::AffineLoadOp>();
+            TT_assert(loadOp != nullptr);
+            auto bcastOp = mlir::cast<d2m::TileBcastOp>(computeOp);
+            collectDstLoadThenBcast(gOp, loadOp, bcastOp, copyInfos, dstSlice,
+                                    outermostInnerComputeLoop);
+          } else {
+            dstIntermediates[computeOp] = {dstSlice, outermostInnerComputeLoop};
+          }
         }
       }
     });
-    return {copyInfos, dstRegisterAllocation};
+    return {copyInfos, dstIntermediates};
   }
 
   static BlockArgument lookThroughSubView(Value memref) {
@@ -400,35 +424,63 @@ public:
     return mlir::dyn_cast<BlockArgument>(memref);
   }
 
-  // Collect a single load or store to dst organized by loop nest.
-  template <typename LoadOrStoreOp>
-  static void collectDstAccess(GenericOp op, LoadOrStoreOp loadOrStore,
-                               CopyInfoMap &copyInfos,
-                               int64_t nextDstSliceIndex,
-                               Operation *outermostInnerComputeLoop) {
+  // Collect a single load or store and determine its loop guard.
+  template <typename LoadOrStoreTy>
+  static void collectDstLoadOrStore(GenericOp gOp, LoadOrStoreTy loadOrStore,
+                                    CopyInfoMap &copyInfos, int dstSlice,
+                                    Operation *outermostInnerComputeLoop) {
     if (!outermostInnerComputeLoop) {
       // If there is no outermostInnerComputeLoop, the common ancestor is the
       // operation itself.
       outermostInnerComputeLoop = loadOrStore;
     }
 
-    auto [iter, inserted] = copyInfos.try_emplace(outermostInnerComputeLoop);
-    CopyInfo &copyInfo = iter->second;
-    copyInfo.push_back(loadOrStore, nextDstSliceIndex);
+    auto [iter, _] = copyInfos.try_emplace(outermostInnerComputeLoop);
     BlockArgument blockArg = lookThroughSubView(loadOrStore.getMemRef());
-    SmallVector<int64_t> guardIndices =
-        (blockArg && !op.isExplicitDatamovementForm())
-            ? op.getNonParticipatingLoopDims(blockArg.getArgNumber())
-            : SmallVector<int64_t>{};
-    if (inserted) {
-      // First access in this loop nest - set the guard indices.
-      copyInfo.guardIndices = guardIndices;
-    } else {
-      // Subsequent access - verify guard indices are the same.
-      assert(
-          guardIndices == copyInfo.guardIndices &&
-          "Expected same guard indices across all accesses in this loop nest.");
+
+    std::set<int64_t> guardDims = {};
+    if (blockArg && !gOp.isExplicitDatamovementForm()) {
+      auto nonParticipatingLoopDims =
+          gOp.getNonParticipatingLoopDims(blockArg.getArgNumber());
+      auto iteratorTypes = gOp.getIteratorTypesValue();
+
+      for (int64_t dim : nonParticipatingLoopDims) {
+        TT_assert(iteratorTypes[dim] == ttcore::IteratorType::Reduction);
+        guardDims.insert(dim);
+      }
     }
+
+    iter->second.record(loadOrStore, dstSlice, guardDims);
+  }
+
+  // Collect a load-bcast pair.
+  static void collectDstLoadThenBcast(GenericOp gOp,
+                                      affine::AffineLoadOp loadOp,
+                                      d2m::TileBcastOp bcastOp,
+                                      CopyInfoMap &copyInfos, int dstSlice,
+                                      Operation *outermostInnerComputeLoop) {
+    if (!outermostInnerComputeLoop) {
+      // If there is no outermostInnerComputeLoop, the common ancestor is the
+      // operation itself.
+      outermostInnerComputeLoop = loadOp;
+    }
+
+    auto [iter, _] = copyInfos.try_emplace(outermostInnerComputeLoop);
+    BlockArgument blockArg = lookThroughSubView(loadOp.getMemRef());
+
+    std::set<int64_t> guardDims = {};
+    if (blockArg && !gOp.isExplicitDatamovementForm()) {
+      auto nonParticipatingLoopDims =
+          gOp.getNonParticipatingLoopDims(blockArg.getArgNumber());
+      auto iteratorTypes = gOp.getIteratorTypesValue();
+
+      for (int64_t dim : nonParticipatingLoopDims) {
+        TT_assert(iteratorTypes[dim] == ttcore::IteratorType::Parallel);
+        guardDims.insert(dim);
+      }
+    }
+
+    iter->second.record(loadOp, bcastOp, dstSlice, guardDims);
   }
 
   /*
@@ -440,7 +492,7 @@ public:
     inside it.
   */
   static bool rewriteTileMatmulAsTileMatmulBlock(
-      PatternRewriter &rewriter, GenericOp op, Region &region,
+      PatternRewriter &rewriter, GenericOp gOp, Region &region,
       linalg::GenericOp linalgGenericOp, unsigned dstCapacity, bool &modified) {
     assert(linalgGenericOp.getInputs().size() == 2 &&
            "Expected exactly 2 input for tile matmul");
@@ -459,7 +511,7 @@ public:
     }
     rewriter.eraseOp(linalgGenericOp);
     modified |= insertDstRegisterAccess(
-        rewriter, op, region, dstCapacity,
+        rewriter, gOp, region, dstCapacity,
         !linalgLoops.value().empty() ? linalgLoops.value().front() : nullptr);
 
     Operation *outerLoop = linalgLoops.value()[0];
@@ -470,11 +522,13 @@ public:
     for (Operation *loopOp : llvm::reverse(linalgLoops.value())) {
       rewriter.eraseOp(loopOp);
     }
-    rewriter.create<d2m::TileMatmulBlockOp>(op.getLoc(), inputAMemref,
+    rewriter.create<d2m::TileMatmulBlockOp>(gOp.getLoc(), inputAMemref,
                                             inputBMemref, outputCMemref);
     return true;
   }
 
+  // Consumes the recorded load/store info to generate two data copy loops: one
+  // for loads and one for stores.
   static void dataCopyGenerate(PatternRewriter &rewriter, Location loc,
                                Value dst, const CopyInfoMap &copyInfos) {
     for (const auto &[loopNestOrOp, copyInfo] : copyInfos) {
@@ -482,42 +536,78 @@ public:
       rewriter.setInsertionPointAfter(loopNestOrOp);
       auto insertionPointAfterLoopNest = rewriter.saveInsertionPoint();
 
+      // Step 1: generate affine copy loop for loads & load-bcasts.
       rewriter.setInsertionPoint(loopNestOrOp);
-      auto guard = insertGuardForLoopNest(rewriter, loc, copyInfo.guardIndices);
-      if (guard) {
-        rewriter.setInsertionPointToStart(&guard.getThenRegion().front());
-      }
-      dataCopyGenerate<affine::AffineLoadOp>(
-          rewriter, loopNestOrOp, copyInfo.loads,
-          // Load/store dst access generation.
-          [&](PatternRewriter &rewriter, Location loc, Value cb,
+      // Insert CB->DST load in the cloned loop skeleton, with proper guards.
+      auto loadAccessGenerator =
+          [&](PatternRewriter &rewriter,
+              LoadStoreRecord<affine::AffineLoadOp> record,
               AffineMap l1AccessMap, ValueRange l1AccessIndices,
               AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-            auto l1Load = rewriter.create<affine::AffineLoadOp>(
+            auto loc = record.loadStore.getLoc();
+            Value cb = record.loadStore.getMemref();
+            const bool isBcastGuard = record.bcast.has_value();
+            auto guard = createLoadLoopGuard(rewriter, loc, record.guardDims,
+                                             isBcastGuard);
+            if (guard) {
+              rewriter.setInsertionPointToStart(&guard.getThenRegion().front());
+            }
+            auto cbLoad = rewriter.create<affine::AffineLoadOp>(
                 loc, cb, l1AccessMap, l1AccessIndices);
-            rewriter.create<affine::AffineStoreOp>(
-                loc, l1Load.getResult(), dst, dstAccessMap, dstAccessIndices);
-          },
-          // Replacement of the original load with one from dst.
-          [&](PatternRewriter &rewriter, affine::AffineLoadOp op,
-              AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-            rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
-                op, dst, dstAccessMap, dstAccessIndices);
-          });
+            Value valueToStore = cbLoad.getResult();
 
+            if (isBcastGuard) {
+              rewriter.setInsertionPointAfter(cbLoad);
+              auto *clonedBcast =
+                  rewriter.clone(*(record.bcast->getOperation()));
+              clonedBcast->setOperand(0, valueToStore);
+              valueToStore = clonedBcast->getResult(0);
+            }
+
+            rewriter.create<affine::AffineStoreOp>(
+                loc, valueToStore, dst, dstAccessMap, dstAccessIndices);
+
+            if (guard) {
+              rewriter.setInsertionPointAfter(guard);
+            }
+          };
+
+      // Replace the original load with one from the DST.
+      auto loadAccessRewriter =
+          [&](PatternRewriter &rewriter,
+              LoadStoreRecord<affine::AffineLoadOp> record,
+              AffineMap dstAccessMap, ValueRange dstAccessIndices) {
+            auto dstLoad = rewriter.create<affine::AffineLoadOp>(
+                record.loadStore.getLoc(), dst, dstAccessMap, dstAccessIndices);
+            if (record.bcast.has_value()) {
+              // Keep the original load in case another bcastOp uses it.
+              record.bcast->getResult().replaceAllUsesWith(dstLoad.getResult());
+              rewriter.eraseOp(*record.bcast);
+            } else {
+              rewriter.replaceOp(record.loadStore, dstLoad.getResult());
+            }
+          };
+
+      createCopyLoop<affine::AffineLoadOp>(rewriter, loopNestOrOp,
+                                           copyInfo.loads, loadAccessGenerator,
+                                           loadAccessRewriter);
+
+      // Step 2: generate affine copy loop for stores.
       rewriter.restoreInsertionPoint(insertionPointAfterLoopNest);
-      dataCopyGenerate<affine::AffineStoreOp>(
-          rewriter, loopNestOrOp, copyInfo.stores,
-          // Load/store dst access generation.
-          [&](PatternRewriter &rewriter, Location loc, Value cb,
+      // Insert DST->CB store in the cloned loop skeleton.
+      auto storeAccessGenerator =
+          [&](PatternRewriter &rewriter,
+              LoadStoreRecord<affine::AffineStoreOp> record,
               AffineMap l1AccessMap, ValueRange l1AccessIndices,
               AffineMap dstAccessMap, ValueRange dstAccessIndices) {
+            auto loc = record.loadStore.getLoc();
+            Value cb = record.loadStore.getMemref();
             auto dstLoad = rewriter.create<affine::AffineLoadOp>(
                 loc, dst, dstAccessMap, dstAccessIndices);
             Value valueToStore = dstLoad.getResult();
 
-            // Insert dst reinterpret cast if destination CB type differs
-            // from dst type
+            // Insert DST reinterpret cast if destination CB type differs from
+            // DST type.
             auto cbType = mlir::cast<MemRefType>(cb.getType());
             if (valueToStore.getType() != cbType.getElementType()) {
               valueToStore = rewriter
@@ -528,60 +618,93 @@ public:
 
             rewriter.create<affine::AffineStoreOp>(
                 loc, valueToStore, cb, l1AccessMap, l1AccessIndices);
-          },
-          // Replacement of the original store with one from dst.
-          [&](PatternRewriter &rewriter, affine::AffineStoreOp op,
+          };
+
+      // Replace the original store with one to the DST.
+      auto storeAccessRewriter =
+          [&](PatternRewriter &rewriter,
+              LoadStoreRecord<affine::AffineStoreOp> record,
               AffineMap dstAccessMap, ValueRange dstAccessIndices) {
-            Value valueToStore = op.getValue();
-            // Insert dst reinterpret cast if value type differs from dst
-            // type
+            Value valueToStore = record.loadStore.getValue();
+            // Insert DST reinterpret cast if value type differs from DST type.
             auto dstType = mlir::cast<MemRefType>(dst.getType());
             if (valueToStore.getType() != dstType.getElementType()) {
-              valueToStore =
-                  rewriter
-                      .create<d2m::DstReinterpretCastOp>(
-                          op.getLoc(), dstType.getElementType(), valueToStore)
-                      .getResult();
+              valueToStore = rewriter
+                                 .create<d2m::DstReinterpretCastOp>(
+                                     record.loadStore.getLoc(),
+                                     dstType.getElementType(), valueToStore)
+                                 .getResult();
             }
             rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
-                op, valueToStore, dst, dstAccessMap, dstAccessIndices);
-          });
+                record.loadStore, valueToStore, dst, dstAccessMap,
+                dstAccessIndices);
+          };
+
+      createCopyLoop<affine::AffineStoreOp>(
+          rewriter, loopNestOrOp, copyInfo.stores, storeAccessGenerator,
+          storeAccessRewriter);
     }
   }
 
-  static scf::IfOp insertGuardForLoopNest(PatternRewriter &rewriter,
-                                          Location loc,
-                                          ArrayRef<int64_t> guardIndices) {
-    if (guardIndices.empty()) {
+  // Generates two types of load loop guards for initializing a DST tile.
+  // - Bcast: do the CB->DST initialization load only when all the bcast dims
+  //   are at the 1st iter. Enables efficient tile reuse.
+  // - Accum: skip the CB->DST reload unless any of the reduction dims is not
+  //   at the 1st iter. So the accumulation starts with an all-zeros DST tile.
+  static scf::IfOp createLoadLoopGuard(PatternRewriter &rewriter, Location loc,
+                                       const std::set<int64_t> &guardDims,
+                                       const bool isBcastGuard) {
+    if (guardDims.empty()) {
       return nullptr;
     }
+
+    // Initial condition:
+    // - Bcast: load-if-all, start with true and disable when false shows up.
+    // - Accum: skip-unless-any, start with false and enable when true shows up.
+    Value guard =
+        rewriter
+            .create<arith::ConstantOp>(loc, rewriter.getI1Type(),
+                                       rewriter.getBoolAttr(isBcastGuard))
+            .getResult();
+
+    // Check:
+    // - Bcast: IS 1st iter?
+    // - Accum: NOT 1st iter?
+    const auto cmpPredicate =
+        isBcastGuard ? arith::CmpIPredicate::eq : arith::CmpIPredicate::ne;
+
     auto zero = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getIndexType(),
         rewriter.getIntegerAttr(rewriter.getIndexType(), 0));
-    auto cmp = rewriter
-                   .create<arith::ConstantOp>(loc, rewriter.getI1Type(),
-                                              rewriter.getBoolAttr(false))
-                   .getResult();
-    for (int64_t index : guardIndices) {
-      auto iterIndex = rewriter.create<d2m::IterIndexOp>(loc, index);
-      auto ne = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
-                                               iterIndex, zero);
-      cmp = rewriter.create<arith::OrIOp>(loc, cmp, ne).getResult();
+
+    for (int64_t idx : guardDims) {
+      Value iterIdx = rewriter.create<d2m::IterIndexOp>(loc, idx);
+      Value cmp =
+          rewriter.create<arith::CmpIOp>(loc, cmpPredicate, iterIdx, zero);
+      // Aggregation:
+      if (isBcastGuard) {
+        // - Bcast: load if ALL(&&) bcast dims ARE at the 1st iter.
+        guard = rewriter.create<arith::AndIOp>(loc, guard, cmp).getResult();
+      } else {
+        // - Accum: reload if ANY(||) reduce dims is NOT at the 1st iter.
+        guard = rewriter.create<arith::OrIOp>(loc, guard, cmp).getResult();
+      }
     }
-    return rewriter.create<scf::IfOp>(loc, cmp);
+
+    return rewriter.create<scf::IfOp>(loc, guard);
   }
 
-  template <typename LoadStoreOpTy>
-  static void dataCopyGenerate(
+  template <typename LoadOrStoreTy>
+  static void createCopyLoop(
       PatternRewriter &rewriter, Operation *loopNestOrOp,
-      ArrayRef<OpAndIndexOffset<LoadStoreOpTy>> loadStoreOps,
-      llvm::function_ref<void(PatternRewriter &, Location, Value, AffineMap,
-                              ValueRange, AffineMap, ValueRange)>
-          loadStoreDstAccessGenerator,
-      llvm::function_ref<void(PatternRewriter &, LoadStoreOpTy, AffineMap,
-                              ValueRange)>
-          dstAccessReplacement) {
-    if (loadStoreOps.empty()) {
+      ArrayRef<LoadStoreRecord<LoadOrStoreTy>> loadStoreRecords,
+      llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
+                              AffineMap, ValueRange, AffineMap, ValueRange)>
+          dstAccessGenerator,
+      llvm::function_ref<void(PatternRewriter &, LoadStoreRecord<LoadOrStoreTy>,
+                              AffineMap, ValueRange)>
+          dstAccessRewriter) {
+    if (loadStoreRecords.empty()) {
       return;
     }
 
@@ -598,8 +721,9 @@ public:
       });
     }
 
-    for (auto [loadStore, dstSliceIndex] : loadStoreOps) {
-      Block *fromScope = loadStore->getBlock();
+    for (auto record : loadStoreRecords) {
+      // Find insertion point in the cloned loop.
+      Block *fromScope = record.loadStore->getBlock();
       Block *toScope = irMapper.lookupOrNull(fromScope);
       if (toScope) {
         Operation *terminator = toScope->getTerminator();
@@ -610,28 +734,28 @@ public:
         }
       }
 
+      auto loadStoreLoc = record.loadStore.getLoc();
+      auto loadStoreIndices = record.loadStore.getIndices();
+      auto loadStoreMap = record.loadStore.getMap();
+
       // Generate the data copy loop for the load store.
       {
         auto [l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices] =
-            buildIndices(rewriter, loadStore.getLoc(), irMapper,
-                         loadStore.getIndices(), dstSliceIndex,
-                         loadStore.getMap());
-        loadStoreDstAccessGenerator(
-            rewriter, loadStore.getLoc(), loadStore.getMemRef(), l1AccessMap,
-            l1AccessIndices, dstAccessMap, dstAccessIndices);
+            buildIndices(rewriter, loadStoreLoc, irMapper, loadStoreIndices,
+                         record.dstSlice, loadStoreMap);
+        dstAccessGenerator(rewriter, record, l1AccessMap, l1AccessIndices,
+                           dstAccessMap, dstAccessIndices);
       }
 
       // Replace the original load store with one from dst.
       {
         // Empty IR mapper because we want to preserve original loop vars.
         mlir::IRMapping dummyIRMapper;
-        rewriter.setInsertionPoint(loadStore);
+        rewriter.setInsertionPoint(record.loadStore);
         auto [l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices] =
-            buildIndices(rewriter, loadStore.getLoc(), dummyIRMapper,
-                         loadStore.getIndices(), dstSliceIndex,
-                         loadStore.getMap());
-        dstAccessReplacement(rewriter, loadStore, dstAccessMap,
-                             dstAccessIndices);
+            buildIndices(rewriter, loadStoreLoc, dummyIRMapper,
+                         loadStoreIndices, record.dstSlice, loadStoreMap);
+        dstAccessRewriter(rewriter, record, dstAccessMap, dstAccessIndices);
       }
     }
   }
@@ -655,9 +779,9 @@ public:
   }
 
   // Rewrite stores to use dst register based on allocation map.
-  static void insertDstRegisterAllocation(
-      PatternRewriter &rewriter, Location loc, Value dst,
-      const DstRegisterAllocation &dstRegisterAllocation) {
+  static void
+  fixDstIntermediateResults(PatternRewriter &rewriter, Location loc, Value dst,
+                            const DstIntermediatesMap &dstIntermediates) {
     auto dstType = dyn_cast<MemRefType>(dst.getType());
     if (!dstType) {
       return;
@@ -665,8 +789,8 @@ public:
     const unsigned dstRank = dstType.getRank();
 
     // Iterate directly through dst register allocation entries.
-    for (const auto &[op, dstInfo] : dstRegisterAllocation) {
-      int64_t dstSliceIndex = dstInfo.dstSliceIndex;
+    for (const auto &[op, dstInfo] : dstIntermediates) {
+      int dstSlice = dstInfo.dstSlice;
       SmallVector<Value> loopInductionVars =
           extractLoopInductionVars(dstInfo.outermostLoop);
 
@@ -675,10 +799,10 @@ public:
 
       SmallVector<Value> storeIndices;
 
-      // Build store indices: [dstSliceIndex, loop_vars..., 0, 0, ...] using
-      // loop induction variables for the dimensions that correspond to loops.
+      // Build store indices: [dstSlice, loop_vars..., 0, 0, ...] using loop
+      // induction variables for the dimensions that correspond to loops.
       storeIndices.push_back(
-          rewriter.create<arith::ConstantIndexOp>(loc, dstSliceIndex));
+          rewriter.create<arith::ConstantIndexOp>(loc, dstSlice));
 
       // Use induction variables from the allocation.
       storeIndices.append(loopInductionVars);
@@ -750,7 +874,7 @@ public:
                     SmallVector<Value>>
   buildIndices(PatternRewriter &rewriter, Location loc,
                const mlir::IRMapping &irMapper, ValueRange currentIndices,
-               int64_t dstSliceIndex, AffineMap map) {
+               int dstSlice, AffineMap map) {
     AffineMap l1AccessMap = map;
     SmallVector<Value> l1AccessIndices =
         llvm::to_vector(llvm::map_range(currentIndices, [&](Value index) {
@@ -758,7 +882,7 @@ public:
         }));
 
     AffineMap dstAccessMap = map.insertResult(
-        getAffineConstantExpr(dstSliceIndex, rewriter.getContext()), 0);
+        getAffineConstantExpr(dstSlice, rewriter.getContext()), 0);
     SmallVector<Value> dstAccessIndices = l1AccessIndices;
     return {l1AccessMap, l1AccessIndices, dstAccessMap, dstAccessIndices};
   }

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
@@ -581,6 +581,82 @@ def test_cpu_hoistable_binary_ops(
     )
 
 
+implicit_bcast_inner_2D_shapes = [
+    (32, 32),
+    (32, 96),
+    (96, 32),
+    (96, 96),
+    (416, 32),
+    (32, 416),
+    (416, 96),
+    (96, 416),
+    (416, 416),
+]
+
+
+@pytest.mark.parametrize("shape", implicit_bcast_inner_2D_shapes, ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_implicit_bcast_inner_2D(
+    shape: Shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    shape_F = shape
+    shape_C = (shape_F[0], 1)
+    shape_R = (1, shape_F[1])
+    shape_S = (1, 1)
+
+    # Avoid too many test entries, test LHS & RHS bcast together.
+    def bcast_all_cases(
+        in_F0: Operand,
+        in_C0: Operand,
+        in_R0: Operand,
+        in_S0: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        tensor_F0 = torch.rand(shape_F, dtype=dtype) * 2.0 - 1.0
+        tensor_C0 = torch.rand(shape_C, dtype=dtype) * 2.0 - 1.0
+        tensor_R0 = torch.rand(shape_R, dtype=dtype) * 2.0 - 1.0
+        tensor_S0 = torch.rand(shape_S, dtype=dtype) - 0.5
+
+        builder.set_goldens(
+            inputs={
+                in_F0: tensor_F0,
+                in_C0: tensor_C0,
+                in_R0: tensor_R0,
+                in_S0: tensor_S0,
+            }
+        )
+
+        in_R1 = builder.add(
+            builder.add(in_S0, in_R0, unit_attrs=unit_attrs),
+            in_S0,
+            unit_attrs=unit_attrs,
+        )
+        in_C1 = builder.subtract(
+            in_S0,
+            builder.subtract(in_C0, in_S0, unit_attrs=unit_attrs),
+            unit_attrs=unit_attrs,
+        )
+        in_F1 = builder.add(in_C1, in_R1, unit_attrs=unit_attrs)
+        return builder.add(in_F1, in_S0, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        bcast_all_cases,
+        [shape, shape_C, shape_R, shape_S],
+        [dtype, dtype, dtype, dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        device=device,
+    )
+
+
 # Binary eltwise ops with implicit broadcasting
 # There are operations that still do not support Int32 tracked here: https://github.com/tenstorrent/tt-metal/issues/25112.
 @pytest.mark.parametrize(

--- a/test/ttmlir/Conversion/D2MToTTKernel/single_tile_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/single_tile_ops.mlir
@@ -114,6 +114,154 @@ module {
     return
   }
 
+  func.func @test_bcast_lowering_col(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                     %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%arg0_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg1_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg2_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>):
+      %cb0 = d2m.wait %arg0_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb1 = d2m.wait %arg1_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb2 = d2m.reserve %arg2_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_bcast
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <col>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <col>)
+        %0 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type col>}> : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.add_binary_tile_init
+        // CHECK: ttkernel.add_binary_tile
+        %1 = "d2m.tile_add"(%0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
+    return
+  }
+
+  func.func @test_bcast_lowering_row(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                     %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                     %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%arg0_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg1_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg2_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>):
+      %cb0 = d2m.wait %arg0_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb1 = d2m.wait %arg1_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb2 = d2m.reserve %arg2_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_bcast
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <row>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <row>)
+        %0 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type row>}> : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        %1 = "d2m.tile_sub"(%0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
+    return
+  }
+
+  func.func @test_bcast_lowering_scalar(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                        %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                        %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%arg0_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg1_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg2_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>):
+      %cb0 = d2m.wait %arg0_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb1 = d2m.wait %arg1_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb2 = d2m.reserve %arg2_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_bcast
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <scalar>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <scalar>)
+        %0 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type scalar>}> : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.mul_binary_tile_init
+        // CHECK: ttkernel.mul_binary_tile
+        %1 = "d2m.tile_mul"(%0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
+    return
+  }
+
+  func.func @test_bcast_lowering_none(%in0: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                      %in1: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>,
+                                      %out: memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0, %in1 : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_f32, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%arg0_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg1_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>, %arg2_cb: !d2m.cb<memref<1x1x!ttype_f32, #l1_>>):
+      %cb0 = d2m.wait %arg0_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb1 = d2m.wait %arg1_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      %cb2 = d2m.reserve %arg2_cb : !d2m.cb<memref<1x1x!ttype_f32, #l1_>> -> memref<1x1x!ttype_f32, #l1_>
+      linalg.generic {indexing_maps = [#map_, #map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0, %cb1 : memref<1x1x!ttype_f32, #l1_>, memref<1x1x!ttype_f32, #l1_>) outs(%cb2 : memref<1x1x!ttype_f32, #l1_>) {
+      ^bb0(%arg0: !ttype_f32, %arg1: !ttype_f32, %arg2: !ttype_f32):
+        // CHECK-NOT: d2m.tile_bcast
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <none>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <none>)
+        %0 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type none>}> : (!ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.div_binary_tile_init
+        // CHECK: ttkernel.div_binary_tile
+        %1 = "d2m.tile_div"(%0, %arg1) : (!ttype_f32, !ttype_f32) -> !ttype_f32
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %1 : !ttype_f32
+      }
+    }
+    return
+  }
+
+  func.func @test_bcast_lowering_many(%in0: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048, 1>, #l1_>,
+                                      %out: memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048, 1>, #l1_>) {
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map_, #map_], iterator_types = [#parallel_, #parallel_], threads = [#d2m.thread<compute>]}
+        ins(%in0 : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048, 1>, #l1_>)
+        outs(%out : memref<1x1x1x1x!ttype_bf16, #ttcore.shard<2048x2048, 1>, #l1_>)  {
+    ^compute0(%arg0_cb: !d2m.cb<memref<1x1x!ttype_bf16, #l1_>>, %arg1_cb: !d2m.cb<memref<1x1x!ttype_bf16, #l1_>>):
+      %cb0 = d2m.wait %arg0_cb : !d2m.cb<memref<1x1x!ttype_bf16, #l1_>> -> memref<1x1x!ttype_bf16, #l1_>
+      %cb1 = d2m.reserve %arg1_cb : !d2m.cb<memref<1x1x!ttype_bf16, #l1_>> -> memref<1x1x!ttype_bf16, #l1_>
+      linalg.generic {indexing_maps = [#map_, #map_], iterator_types = ["parallel", "parallel"]} ins(%cb0 : memref<1x1x!ttype_bf16, #l1_>) outs(%cb1 : memref<1x1x!ttype_bf16, #l1_>) {
+      ^bb0(%arg0: !ttype_bf16, %arg1: !ttype_bf16):
+        // CHECK-NOT: d2m.tile_bcast
+        // CHECK: ttkernel.init_sfpu
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <col>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <col>)
+        %0 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type col>}> : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <row>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <row>)
+        %1 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type row>}> : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <scalar>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <scalar>)
+        %2 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type scalar>}> : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.unary_bcast_init(%{{.*}}, %{{.*}}, <none>)
+        // CHECK: ttkernel.unary_bcast(%{{.*}}, %{{.*}}, %{{.*}}, <none>)
+        %3 = "d2m.tile_bcast"(%arg0) <{bcast_type = #d2m<tile_bcast_type none>}> : (!ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.add_binary_tile_init
+        // CHECK: ttkernel.add_binary_tile
+        %4 = "d2m.tile_add"(%0, %1) : (!ttype_bf16, !ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.sub_binary_tile_init
+        // CHECK: ttkernel.sub_binary_tile
+        %5 = "d2m.tile_sub"(%2, %3) : (!ttype_bf16, !ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.mul_binary_tile_init
+        // CHECK: ttkernel.mul_binary_tile
+        %6 = "d2m.tile_mul"(%4, %5) : (!ttype_bf16, !ttype_bf16) -> !ttype_bf16
+        // CHECK: ttkernel.pack_tile
+        linalg.yield %6 : !ttype_bf16
+      }
+    }
+    return
+  }
+
   //===----------------------------------------------------------------------===//
   // TTIR SFPU operations
   //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/D2M/Transforms/eltwise_fusion_skip_implicit_bcast.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/eltwise_fusion_skip_implicit_bcast.mlir
@@ -1,0 +1,33 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttmetal-fe-pipeline --d2m-elementwise-fusion %s | FileCheck %s
+
+module {
+  func.func @check_fusion_disabled(%arg1: tensor<32x1xbf16>, %arg2: tensor<1x32xbf16>, %arg3: tensor<1x1xbf16>) -> tensor<32x32xbf16> {
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_add
+    %0 = ttir.empty() : tensor<1x32xbf16>
+    %1 = "ttir.add"(%arg3, %arg2, %0) : (tensor<1x1xbf16>, tensor<1x32xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_sub
+    %2 = ttir.empty() : tensor<1x32xbf16>
+    %3 = "ttir.subtract"(%1, %arg3, %2) : (tensor<1x32xbf16>, tensor<1x1xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_add
+    %4 = ttir.empty() : tensor<32x1xbf16>
+    %5 = "ttir.add"(%arg1, %arg3, %4) : (tensor<32x1xbf16>, tensor<1x1xbf16>, tensor<32x1xbf16>) -> tensor<32x1xbf16>
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_sub
+    %6 = ttir.empty() : tensor<32x1xbf16>
+    %7 = "ttir.subtract"(%arg3, %5, %6) : (tensor<1x1xbf16>, tensor<32x1xbf16>, tensor<32x1xbf16>) -> tensor<32x1xbf16>
+    // CHECK: d2m.generic
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_bcast
+    // CHECK: d2m.tile_add
+    %8 = ttir.empty() : tensor<32x32xbf16>
+    %9 = "ttir.add"(%7, %3, %8) : (tensor<32x1xbf16>, tensor<1x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %9 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
@@ -1,0 +1,221 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-linalg-to-affine --d2m-insert-dst-register-access --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#l1_ = #ttcore.memory_space<l1>
+
+module {
+  // CHECK-LABEL: func.func @bcast_col
+  func.func @bcast_col(%in0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                       %in1: memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                       %out0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    %alloc = memref.alloc() {address = 102208 : i64, alignment = 16 : i64} : memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    %stream = "d2m.stream_layout"(%in1, %alloc) : (memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>) -> memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<3x3>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %stream : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>)
+        outs(%out0 : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%cb0: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb1: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb2: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>):
+      %0 = d2m.wait %cb0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %1 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = d2m.reserve %cb2 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1_9 = arith.constant 1 : index
+      %c1_10 = arith.constant 1 : index
+      %c0_11 = arith.constant 0 : index
+      %c1_12 = arith.constant 1 : index
+      %c1_13 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1_9 step %c1_10 {
+        scf.for %arg3 = %c0_11 to %c1_12 step %c1_13 {
+          %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_1 = memref.subview %1[%arg2, 0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
+          // CHECK-NEXT: %[[GUARD:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
+          // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
+          // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type col>}>
+          // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: affine.load %dst
+          // CHECK: affine.load %dst
+          // CHECK: d2m.tile_add
+          linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %in_1: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %3 = "d2m.tile_bcast"(%in_1) <{bcast_type = #d2m<tile_bcast_type col>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %4 = "d2m.tile_add"(%in, %3) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %4 : !ttcore.tile<32x32, f32>
+          }
+        }
+      }
+    }
+    memref.dealloc %alloc : memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    return
+  }
+
+  // CHECK-LABEL: func.func @bcast_row
+  func.func @bcast_row(%in0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                       %in1: memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                       %out0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    %alloc = memref.alloc() {address = 102208 : i64, alignment = 16 : i64} : memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    %stream = "d2m.stream_layout"(%in1, %alloc) : (memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>) -> memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<3x3>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %stream : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>)
+        outs(%out0 : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%cb0: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb1: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb2: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>):
+      %0 = d2m.wait %cb0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %1 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = d2m.reserve %cb2 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1_9 = arith.constant 1 : index
+      %c1_10 = arith.constant 1 : index
+      %c0_11 = arith.constant 0 : index
+      %c1_12 = arith.constant 1 : index
+      %c1_13 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1_9 step %c1_10 {
+        scf.for %arg3 = %c0_11 to %c1_12 step %c1_13 {
+          %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_1 = memref.subview %1[0, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
+          // CHECK-NEXT: %[[GUARD:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
+          // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
+          // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type row>}>
+          // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: affine.load %dst
+          // CHECK: affine.load %dst
+          // CHECK: d2m.tile_add
+          linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %in_1: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %3 = "d2m.tile_bcast"(%in_1) <{bcast_type = #d2m<tile_bcast_type row>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %4 = "d2m.tile_add"(%in, %3) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %4 : !ttcore.tile<32x32, f32>
+          }
+        }
+      }
+    }
+    memref.dealloc %alloc : memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    return
+  }
+
+  // CHECK-LABEL: func.func @bcast_scalar
+  func.func @bcast_scalar(%in0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                          %in1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                          %out0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    %alloc = memref.alloc() {address = 102208 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    %stream = "d2m.stream_layout"(%in1, %alloc) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>) -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<3x3>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<compute>]}
+        ins(%in0, %stream : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>)
+        outs(%out0 : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%cb0: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb1: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb2: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>):
+      %0 = d2m.wait %cb0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %1 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = d2m.reserve %cb2 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1_9 = arith.constant 1 : index
+      %c1_10 = arith.constant 1 : index
+      %c0_11 = arith.constant 0 : index
+      %c1_12 = arith.constant 1 : index
+      %c1_13 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1_9 step %c1_10 {
+        scf.for %arg3 = %c0_11 to %c1_12 step %c1_13 {
+          %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_1 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
+          // CHECK-NEXT: %[[GUARD0:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
+          // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
+          // CHECK-NEXT: %[[GUARD1:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
+          // CHECK-NEXT: %[[GUARD:.*]] = arith.andi %[[GUARD0]], %[[GUARD1]] : i1
+          // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
+          // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type scalar>}>
+          // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: affine.load %dst
+          // CHECK: affine.load %dst
+          // CHECK: d2m.tile_add
+          linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_>) outs(%subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %in_1: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %3 = "d2m.tile_bcast"(%in_1) <{bcast_type = #d2m<tile_bcast_type scalar>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %4 = "d2m.tile_add"(%in, %3) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %4 : !ttcore.tile<32x32, f32>
+          }
+        }
+      }
+    }
+    memref.dealloc %alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    return
+  }
+
+  // CHECK-LABEL: func.func @bcast_dual
+  func.func @bcast_dual(%in0: memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                        %in1: memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>,
+                        %out0: memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>) {
+    %alloc = memref.alloc() {address = 102208 : i64, alignment = 16 : i64} : memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    %stream = "d2m.stream_layout"(%in0, %alloc) : (memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>) -> memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>
+    %alloc_1 = memref.alloc() {address = 110400 : i64, alignment = 16 : i64} : memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    %stream_1 = "d2m.stream_layout"(%in1, %alloc_1) : (memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>, memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>) -> memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<3x3>, indexing_maps = [affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<compute>]}
+        ins(%stream, %stream_1 : memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>, memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #l1_>)
+        outs(%out0 : memref<3x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1_>)  {
+    ^compute0(%cb0: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb1: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>, %cb2: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1_>>):
+      %0 = d2m.wait %cb0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %1 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %2 = d2m.reserve %cb2 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1_>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      %c0 = arith.constant 0 : index
+      %c1_12 = arith.constant 1 : index
+      %c1_13 = arith.constant 1 : index
+      %c0_14 = arith.constant 0 : index
+      %c1_15 = arith.constant 1 : index
+      %c1_16 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1_12 step %c1_13 {
+        scf.for %arg3 = %c0_14 to %c1_15 step %c1_16 {
+          %subview = memref.subview %0[%arg2, 0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_1 = memref.subview %1[0, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
+          // CHECK: affine.for
+          // CHECK: affine.for
+
+          // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
+          // CHECK-NEXT: %[[GUARD1:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
+          // CHECK-NEXT: scf.if %[[GUARD1]]
+          // CHECK-NEXT: %[[L1_TILE1:.*]] = affine.load
+          // CHECK-NEXT: %[[DST_TILE1:.*]] = "d2m.tile_bcast"(%[[L1_TILE1]]) <{bcast_type = #d2m<tile_bcast_type col>}>
+          // CHECK-NEXT: affine.store %[[DST_TILE1]], %dst
+
+          // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
+          // CHECK-NEXT: %[[GUARD0:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
+          // CHECK-NEXT: scf.if %[[GUARD0]]
+          // CHECK-NEXT: %[[L1_TILE0:.*]] = affine.load
+          // CHECK-NEXT: %[[DST_TILE0:.*]] = "d2m.tile_bcast"(%[[L1_TILE0]]) <{bcast_type = #d2m<tile_bcast_type row>}>
+          // CHECK-NEXT: affine.store %[[DST_TILE0]], %dst
+
+          // CHECK: affine.for
+          // CHECK: affine.for
+          // CHECK: affine.load %dst
+          // CHECK: affine.load %dst
+          // CHECK: d2m.tile_add
+          linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%subview, %subview_1 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) outs(%subview_2 : memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %in_1: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %3 = "d2m.tile_bcast"(%in) <{bcast_type = #d2m<tile_bcast_type col>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %4 = "d2m.tile_bcast"(%in_1) <{bcast_type = #d2m<tile_bcast_type row>}> : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            %5 = "d2m.tile_add"(%3, %4) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %5 : !ttcore.tile<32x32, f32>
+          }
+        }
+      }
+    }
+    memref.dealloc %alloc : memref<3x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    memref.dealloc %alloc_1 : memref<1x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 2>, #l1_>
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
@@ -57,14 +57,14 @@ module {
       // CHECK: %[[blockOut:.*]] = memref.cast {{%.*}} : memref<3x2x!ttcore.tile<32x32, f16>, #l1> to memref<3x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1>
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f16>, #dst>
 
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
+
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
-
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f16>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
@@ -57,14 +57,14 @@ module {
       // CHECK: %[[blockOut:.*]] = memref.cast {{%.*}} : memref<3x2x!ttcore.tile<32x32, f32>, #l1> to memref<3x2x!ttcore.tile<32x32, f32>, strided<[2, 1], offset: ?>, #l1>
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f32>, #dst>
 
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
+
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
-
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f32>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
@@ -58,14 +58,14 @@ module {
       // CHECK: %[[C0:.*]] = arith.constant 0 : index
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f16>, #dst>
 
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
+
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
-
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f16>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
@@ -58,14 +58,14 @@ module {
       // CHECK: %[[C0:.*]] = arith.constant 0 : index
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f32>, #dst>
 
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
+
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
-
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f32>, #l1>


### PR DESCRIPTION
### Ticket
Related-To: #3023

### What's changed
* When implicit bcast is detected in eltwise binary ops, an `unary_bcast` op is inserted to do sub-tile bcast on the row/col/scalar operand(s).
* Additionally, tensor collapsing is disabled for implicit bcast situations.
* The insert DST access pass is extended to support broadcast-style guard indices, in addition to the accumulation-style guard indices for reduce & matmul.
* All guards now reside in the same cloned affine load loop, each has its own condition for the guard.

### Known limitations
* 2D only.
* Fusion with other eltwise ops is disabled, otherwise the fusion pass generates ill-formed IR that triggers assertions in downstream passes. #5927 wasn't able to fix the issue. Track in #5968.
* When some (not all) inputs/output of a `ttir.add` op is the result of a implicit bcast op, the lower toLayout pass doesn't know how to handle the mismatching collapsed & uncollapsed tensor layouts. #5540 Could help.

### Checklist
- [x] New/Existing tests provide coverage for changes
