### PR TITLE
Fix broken CI test

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -7,6 +7,9 @@
         "image": "tracy",
             "script": "ttrt.sh", "args": ["perf", "Silicon/TTNN/$RUNS_ON/perf"] },
 
+  { "runs-on": "n150",
+        "image": "tracy",
+            "script": "test-ttrt.sh" },
 
   { "runs-on": "n150",
         "image": "tracy",
@@ -20,8 +23,17 @@
             "script": "builder.sh", "args": ["test/python/golden", "", "run-ttrt"] },
 
   { "runs-on": "n150",   "image": "tracy",  "script": "op_model_ttrt.sh", "args": "perf" },
+  { "runs-on": "n150",   "image": "speedy",  "script": "op_model_ttrt.sh", "args": "run" },
+  { "runs-on": "n150",   "image": "speedy", "script": "op_model.sh" },
 
+  { "runs-on": "n150",   "image": "speedy", "script": "builder.sh", "args": [ "test/python/golden/optimizer", "", "require-opmodel" ] },
+  { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n150" },
+  { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
+  { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
+  { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
+  { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
+  { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}
 ]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5942

### Problem description
alchemist.sh is silently failing on CI.

### What's changed
`set -e -o pipefail` to proc failure + turn off the offending test, it never should've been enabled in the first place.

### Checklist
- [x] New/Existing tests provide coverage for changes
