### PR TITLE
Add memory state printing API and debug prints in submit

### DIFF
--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -13,6 +13,12 @@
 
 #include "tt/runtime/types.h"
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+#define RUNTIME_DEBUG_MAYBE_INLINE
+#else
+#define RUNTIME_DEBUG_MAYBE_INLINE inline __attribute__((always_inline))
+#endif
+
 namespace tt::runtime::debug {
 
 struct Env {
@@ -175,6 +181,19 @@ void verifyFlatbuffer(const ::flatbuffers::FlatBufferBuilder &fbb,
   assert(valid && "Failed to verify flatbuffer");
 #endif
 }
+
+RUNTIME_DEBUG_MAYBE_INLINE void
+logMemoryState(const std::unordered_map<tt::runtime::MemoryBufferType,
+                                        tt::runtime::MemoryView> &memoryState,
+               std::string_view prefix = "")
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    ;
+#else
+{
+}
+#endif
+
+#undef RUNTIME_DEBUG_MAYBE_INLINE
 
 } // namespace tt::runtime::debug
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -45,14 +45,6 @@ enum class MemoryBufferType {
   TRACE,
 };
 
-inline std::string toString(DeviceRuntime runtime) {
-  return ::tt::runtime::flatbuffer::EnumNameDeviceRuntime(runtime);
-}
-
-inline std::string toString(HostRuntime runtime) {
-  return ::tt::runtime::flatbuffer::EnumNameHostRuntime(runtime);
-}
-
 enum class DistributedMode {
   // Single process on the local host,
   // mainly for testing and debugging
@@ -62,6 +54,27 @@ enum class DistributedMode {
   // across multiple hosts
   MultiProcess,
 };
+
+inline std::string toString(DeviceRuntime runtime) {
+  return ::tt::runtime::flatbuffer::EnumNameDeviceRuntime(runtime);
+}
+
+inline std::string toString(HostRuntime runtime) {
+  return ::tt::runtime::flatbuffer::EnumNameHostRuntime(runtime);
+}
+
+inline std::string toString(MemoryBufferType bufferType) {
+  switch (bufferType) {
+  case MemoryBufferType::DRAM:
+    return "DRAM";
+  case MemoryBufferType::L1:
+    return "L1";
+  case MemoryBufferType::L1_SMALL:
+    return "L1_SMALL";
+  case MemoryBufferType::TRACE:
+    return "TRACE";
+  }
+}
 
 namespace detail {
 
@@ -188,6 +201,8 @@ struct MemoryView {
   size_t totalBytesFreePerBank = 0;
   size_t largestContiguousBytesFreePerBank = 0;
   MemoryBlockTable blockTable;
+
+  std::string toString() const;
 };
 
 struct MeshDeviceOptions {

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(TTRuntimeDebug
     ${PROJECT_SOURCE_DIR}/runtime/include
     ${PROJECT_BINARY_DIR}/runtime/include
 )
+target_link_libraries(TTRuntimeDebug PUBLIC TTRuntimeTypes)
 target_link_libraries(TTRuntimeDebug PUBLIC coverage_config)
 add_dependencies(TTRuntimeDebug RUNTIME_FBS_GENERATION)
 

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 
 #include "tt/runtime/debug.h"
+#include "tt/runtime/detail/common/logger.h"
 
 namespace tt::runtime::debug {
 
@@ -74,6 +75,22 @@ std::string Stats::toString() const {
   oss << "\t" << this << "\n";
   oss << "}";
   return oss.str();
+}
+
+void logMemoryState(
+    const std::unordered_map<tt::runtime::MemoryBufferType,
+                             tt::runtime::MemoryView> &memoryState,
+    std::string_view prefix) {
+  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
+      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
+      tt::runtime::MemoryBufferType::L1_SMALL,
+      tt::runtime::MemoryBufferType::TRACE};
+
+  LOG_DEBUG(prefix);
+  for (const auto &memoryType : MEMORY_TYPES) {
+    LOG_DEBUG("Device ", toString(memoryType),
+              " memory state: ", memoryState.at(memoryType).toString());
+  }
 }
 
 } // namespace tt::runtime::debug

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -7,8 +7,31 @@
 #include "tt/runtime/detail/common/runtime_context.h"
 
 #include <atomic>
+#include <iomanip>
+#include <sstream>
 
 namespace tt::runtime {
+
+std::string MemoryView::toString() const {
+  constexpr size_t MB = 1024 * 1024;
+  std::ostringstream oss;
+  // KB precision for MB values
+  oss << std::fixed << std::setprecision(3);
+
+  oss << "MemoryView{";
+  oss << "numBanks: " << numBanks << ", ";
+  oss << "totalBytesPerBank: " << (static_cast<double>(totalBytesPerBank) / MB)
+      << " MB, ";
+  oss << "totalBytesAllocatedPerBank: "
+      << (static_cast<double>(totalBytesAllocatedPerBank) / MB) << " MB, ";
+  oss << "totalBytesFreePerBank: "
+      << (static_cast<double>(totalBytesFreePerBank) / MB) << " MB, ";
+  oss << "largestContiguousBytesFreePerBank: "
+      << (static_cast<double>(largestContiguousBytesFreePerBank) / MB) << " MB";
+  oss << "}";
+
+  return oss.str();
+}
 
 MultiProcessArgs &
 MultiProcessArgs::withHosts(const std::vector<std::string> &hosts) {

--- a/runtime/lib/ttnn/CMakeLists.txt
+++ b/runtime/lib/ttnn/CMakeLists.txt
@@ -27,6 +27,6 @@ target_include_directories(TTRuntimeTTNN PUBLIC
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNN SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-target_link_libraries(TTRuntimeTTNN PUBLIC TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
+target_link_libraries(TTRuntimeTTNN PUBLIC TTRuntimeTypes TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
 target_link_libraries(TTRuntimeTTNN PUBLIC coverage_config)
-add_dependencies(TTRuntimeTTNN TTRuntimeTTNNOps TTRuntimeTTNNTypes TTRuntimeTTNNUtils RUNTIME_FBS_GENERATION)
+add_dependencies(TTRuntimeTTNN RUNTIME_FBS_GENERATION)

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -38,6 +38,15 @@ namespace tt::runtime::ttnn {
 
 using ::tt::runtime::DeviceRuntime;
 
+namespace debug {
+static void logDeviceMemoryState(const Device &device,
+                                 std::string_view prefix) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  ::tt::runtime::debug::logMemoryState(getMemoryView(device), prefix);
+#endif
+}
+} // namespace debug
+
 static tt::runtime::MemoryView
 createMemoryView(const tt::tt_metal::detail::MemoryView &memoryView) {
   return tt::runtime::MemoryView{
@@ -1726,11 +1735,19 @@ std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs) {
 
-  ProgramExecutor executor(deviceHandle, executableHandle, programIndex,
-                           inputs);
-  executor.execute();
+  debug::logDeviceMemoryState(deviceHandle,
+                              "Device memory state before submit");
+
+  std::unique_ptr<ProgramExecutor> executor = std::make_unique<ProgramExecutor>(
+      deviceHandle, executableHandle, programIndex, inputs);
+
+  executor->execute();
   std::vector<::tt::runtime::Tensor> outputTensors =
-      executor.gatherOutputTensors();
+      executor->gatherOutputTensors();
+
+  executor.reset();
+
+  debug::logDeviceMemoryState(deviceHandle, "Device memory state after submit");
 
   return outputTensors;
 }

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -650,5 +650,8 @@ void registerRuntimeBindings(nb::module_ &m) {
 
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
+
+  m.def("log_memory_state", &::tt::runtime::debug::logMemoryState,
+        nb::arg("memory_state"), nb::arg("prefix") = "");
 }
 } // namespace tt::runtime::python

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -60,6 +60,7 @@ try:
         WorkaroundEnv,
         get_op_loc_info,
         unregister_hooks,
+        log_memory_state,
         FabricConfig,
     )
 except ModuleNotFoundError:


### PR DESCRIPTION
### Describe the problem
We are lacking device memory state profiling in runtime

### What's changed
Added a public debug API to print device memory state, added device memory state printing in submit guarded by `TT_RUNTIME_DEBUG`

Example:
```
2025-11-20 20:45:47,960 - INFO - set log file=
2025-11-20 20:45:47,960 - INFO - setting artifacts folder path=/localdev/jnie/tt-mlir/ttrt-artifacts
                 Always |    DEBUG | Device grid size = { 8, 8 }
2025-11-20 20:45:48,508 - INFO - PASS: getting system_desc passed
2025-11-20 20:45:48,508 - INFO - results saved to=query_results.json
                 Always |    DEBUG | Device grid size = { 8, 8 }
2025-11-20 20:45:48,733 - INFO - evaluating binary=./build/test/ttmlir/Silicon/TTNN/n300/runtime/Output/add.mlir.tmp.ttnn
                 Always |    DEBUG | Device memory state before submit
                 Always |    DEBUG | Device DRAM memory state: MemoryView{numBanks: 12, totalBytesPerBank: 1024.000 MB, totalBytesAllocatedPerBank: 0.008 MB, totalBytesFreePerBank: 1023.992 MB, largestContiguousBytesFreePerBank: 1023.992 MB}
                 Always |    DEBUG | Device L1 memory state: MemoryView{numBanks: 64, totalBytesPerBank: 1.270 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 1.270 MB, largestContiguousBytesFreePerBank: 1.270 MB}
                 Always |    DEBUG | Device L1_SMALL memory state: MemoryView{numBanks: 64, totalBytesPerBank: 0.062 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 0.062 MB, largestContiguousBytesFreePerBank: 0.062 MB}
                 Always |    DEBUG | Device TRACE memory state: MemoryView{numBanks: 12, totalBytesPerBank: 0.000 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 0.000 MB, largestContiguousBytesFreePerBank: 0.000 MB}
            RuntimeTTNN |    DEBUG | Starting execution of program: add
            RuntimeTTNN |    DEBUG | Executing operation: %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>>, tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>>) -> tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>> loc("/localdev/jnie/tt-mlir/build/test/ttmlir/Silicon/TTNN/n300/runtime/Output/add.mlir.tmp.mlir":9:14)
            RuntimeTTNN |    DEBUG | Executing operation: "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>>) -> () loc("/localdev/jnie/tt-mlir/build/test/ttmlir/Silicon/TTNN/n300/runtime/Output/add.mlir.tmp.mlir":10:9)
            RuntimeTTNN |    DEBUG | Executing operation: "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttnn.buffer_type<dram>>, <interleaved>>>) -> () loc("/localdev/jnie/tt-mlir/build/test/ttmlir/Silicon/TTNN/n300/runtime/Output/add.mlir.tmp.mlir":11:9)
            RuntimeTTNN |    DEBUG | Finished execution of program: add
                 Always |    DEBUG | Device memory state after submit
                 Always |    DEBUG | Device DRAM memory state: MemoryView{numBanks: 12, totalBytesPerBank: 1024.000 MB, totalBytesAllocatedPerBank: 0.012 MB, totalBytesFreePerBank: 1023.988 MB, largestContiguousBytesFreePerBank: 1023.988 MB}
                 Always |    DEBUG | Device L1 memory state: MemoryView{numBanks: 64, totalBytesPerBank: 1.270 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 1.270 MB, largestContiguousBytesFreePerBank: 1.270 MB}
                 Always |    DEBUG | Device L1_SMALL memory state: MemoryView{numBanks: 64, totalBytesPerBank: 0.062 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 0.062 MB, largestContiguousBytesFreePerBank: 0.062 MB}
                 Always |    DEBUG | Device TRACE memory state: MemoryView{numBanks: 12, totalBytesPerBank: 0.000 MB, totalBytesAllocatedPerBank: 0.000 MB, totalBytesFreePerBank: 0.000 MB, largestContiguousBytesFreePerBank: 0.000 MB}
2025-11-20 20:45:48,801 - INFO - e2e_duration_nanoseconds_submit = 63516053
2025-11-20 20:45:48,801 - INFO - e2e_duration_nanoseconds_output = 194458
2025-11-20 20:45:48,801 - INFO - total_e2e_duration_nanoseconds_submit_plus_output = 63710511
2025-11-20 20:45:48,806 - WARNING - no binaries found to run - returning early
2025-11-20 20:45:48,806 - INFO - PASS: test case=./build/test/ttmlir/Silicon/TTNN/n300/runtime/Output/add.mlir.tmp.ttnn
2025-11-20 20:45:48,806 - INFO - results saved to=run_results.json
```

### Checklist
- [X] New/Existing tests provide coverage for changes
