### PR TITLE
[CI] Use newest gh from github

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -80,5 +80,4 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt update \
     && apt install -y gh \
-    && gh --version \
-    && rm -rf /var/lib/apt/lists/*
+    && gh --version


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3222

### Problem description
Apt repo in ubuntu 22.04 has very old version of gh.

### What's changed
Install newest gh from github.

### Checklist
- [ ] New/Existing tests provide coverage for changes
