### PR TITLE
Add new sharding rule for paged SDPA decode op

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -15,6 +15,9 @@ namespace mlir::tt::stablehlo {
 static constexpr llvm::StringLiteral sdpaTargetName =
     "tt.scaled_dot_product_attention";
 
+static constexpr llvm::StringLiteral pagedSdpaDecodeTargetName =
+    "tt.paged_scaled_dot_product_attention_decode";
+
 static mlir::sdy::OpShardingRuleAttr
 getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
   auto qType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
@@ -63,6 +66,75 @@ getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
       .build();
 }
 
+static mlir::sdy::OpShardingRuleAttr
+getPagedSdpaDecodeShardingRule(mlir::stablehlo::CustomCallOp op) {
+  // We assume the StableHLO custom call has the following operands:
+  //  0: query        [batch, num_users, num_heads, ...]
+  //  1: key          [num_blocks_total, num_heads, block_size, head_size]
+  //  2: value        [num_blocks_total, num_heads, block_size, head_size]
+  //  3+: optional operands (page_table, attention_mask, cur_pos_tensor,
+  //  attention_sink, ...)
+  //
+  // Sharding rule:
+  // - query / key / value: shard along num_heads dimension
+  // - everything else: replicated
+  // - results: inherit num_heads sharding (same dim as in lowering)
+
+  auto qType = llvm::cast<RankedTensorType>(op.getOperand(0).getType());
+  auto kType = llvm::cast<RankedTensorType>(op.getOperand(1).getType());
+  auto vType = llvm::cast<RankedTensorType>(op.getOperand(2).getType());
+  auto outType = llvm::cast<RankedTensorType>(op.getResult(0).getType());
+
+  // We currently expect the output to have the same logical layout as Q.
+  // (e.g., [1, num_users, num_heads, head_size])
+  if (qType.getShape() != outType.getShape()) {
+    op.getOperation()->emitWarning()
+        << "Paged SDPA decode: Q and output shapes must match.";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto checkQKVLayout = [](RankedTensorType ty) -> bool {
+    if (ty.getRank() != 4) {
+      return false;
+    }
+    return true;
+  };
+
+  if (!checkQKVLayout(qType) || !checkQKVLayout(kType) ||
+      !checkQKVLayout(vType)) {
+    // If K/V layout is not what we expect, be conservative.
+    op.getOperation()->emitWarning()
+        << "Paged SDPA decode: K/V layouts are unexpected, q rank: "
+        << qType.getRank() << ", key rank: " << kType.getRank()
+        << ", value rank: " << vType.getRank();
+    return mlir::sdy::OpShardingRuleBuilder::buildPointwise(op);
+  }
+
+  const int64_t qHeadDim = 2;  // Q / Out: [1, U, H, D]
+  const int64_t kvHeadDim = 1; // K / V:   [B, H, S, D]
+  const int64_t outHeadDim = 2;
+  auto qShape = qType.getShape();
+  int64_t headSize = qShape[qHeadDim];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+  SmallVector<int64_t> headOperandDims(op.getNumOperands(),
+                                       mlir::sdy::kNullDim);
+  SmallVector<int64_t> headResultDims(op.getNumResults(), mlir::sdy::kNullDim);
+
+  // 0: Q
+  headOperandDims[0] = qHeadDim;
+  // 1: K
+  headOperandDims[1] = kvHeadDim;
+  // 2: V
+  headOperandDims[2] = kvHeadDim;
+  // result 0: output
+  headResultDims[0] = outHeadDim;
+
+  builder.addFactor(headOperandDims, headResultDims, headSize,
+                    mlir::sdy::FactorType::kPassThrough);
+  return builder.build();
+}
+
 struct StablehloCustomCallShardingModel
     : public mlir::sdy::ShardingRuleOpInterface::ExternalModel<
           StablehloCustomCallShardingModel, ::mlir::stablehlo::CustomCallOp> {
@@ -100,6 +172,7 @@ private:
                                       mlir::stablehlo::CustomCallOp)>>
       customCallShardingRules = {
           {sdpaTargetName, getSDPAShardingRule},
+          {pagedSdpaDecodeTargetName, getPagedSdpaDecodeShardingRule},
       };
 };
 

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_paged_sdpa_decode.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_paged_sdpa_decode.mlir
@@ -1,0 +1,37 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt -split-input-file --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @PagedSDPADecodeHeadSharding attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<4xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_0"}, %arg1: tensor<4x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_1"}, %arg2: tensor<4x8x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_2"}, %arg3: tensor<4x8x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_3"}, %arg4: tensor<1x4x8x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_4"}) -> tensor<1x4x8x16xbf16> {
+    %0 = stablehlo.reshape %arg1 : (tensor<4x2xi64>) -> tensor<1x4x2xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1x4x2xi64>) -> tensor<4x2xi64>
+    %2 = stablehlo.reshape %arg0 : (tensor<4xi64>) -> tensor<1x1x4xi64>
+    %3 = stablehlo.reshape %2 : (tensor<1x1x4xi64>) -> tensor<4xi64>
+    // CHECK: stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode
+    // CHECK-SAME: tensor<1x4x4x16xbf16>, tensor<4x4x32x16xbf16>, tensor<4x4x32x16xbf16>
+    // CHECK-SAME: -> tensor<1x4x4x16xbf16>
+    %4 = stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode(%arg4, %arg3, %arg2, %1, %3) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "False", has_attention_sink = "False", has_cur_pos_tensor = "True", is_causal = "True", scale = "1.0"}} : (tensor<1x4x8x16xbf16>, tensor<4x8x32x16xbf16>, tensor<4x8x32x16xbf16>, tensor<4x2xi64>, tensor<4xi64>) -> tensor<1x4x8x16xbf16>
+    return %4 : tensor<1x4x8x16xbf16>
+  }
+}
+
+// -----
+
+module @PagedSDPADecodeNonHeadShardingOnV attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<4xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_0"}, %arg1: tensor<4x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_1"}, %arg2: tensor<4x8x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_2"}, %arg3: tensor<4x8x32x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_3"}, %arg4: tensor<1x4x8x16xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "args_4"}) -> tensor<1x4x8x16xbf16> {
+    %0 = stablehlo.reshape %arg1 : (tensor<4x2xi64>) -> tensor<1x4x2xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1x4x2xi64>) -> tensor<4x2xi64>
+    %2 = stablehlo.reshape %arg0 : (tensor<4xi64>) -> tensor<1x1x4xi64>
+    %3 = stablehlo.reshape %2 : (tensor<1x1x4xi64>) -> tensor<4xi64>
+    // CHECK: stablehlo.all_to_all
+    // CHECK-SAME: tensor<4x8x16x16xbf16>
+    // CHECK-SAME: -> tensor<4x4x32x16xbf16>
+    // CHECK: stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode
+    // CHECK-SAME: tensor<1x4x4x16xbf16>, tensor<4x4x32x16xbf16>, tensor<4x4x32x16xbf16>
+    // CHECK-SAME: -> tensor<1x4x4x16xbf16>
+    %4 = stablehlo.custom_call @tt.paged_scaled_dot_product_attention_decode(%arg4, %arg3, %arg2, %1, %3) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "False", has_attention_sink = "False", has_cur_pos_tensor = "True", is_causal = "True", scale = "1.0"}} : (tensor<1x4x8x16xbf16>, tensor<4x8x32x16xbf16>, tensor<4x8x32x16xbf16>, tensor<4x2xi64>, tensor<4xi64>) -> tensor<1x4x8x16xbf16>
+    return %4 : tensor<1x4x8x16xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Lack of sharding on paged SDPA decode op

### What's changed
Adding sharding rule for this custom op.
This shards along the head dimension, which is effective for cache sharding.

### Checklist
- [ ] New/Existing tests provide coverage for changes
