### PR TITLE
Change linear op rewrite pattern 

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
@@ -14,20 +14,40 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// static bool isBatchedLinearOp(ttnn::LinearOp linearOp) {
-//   RankedTensorType inputBType = linearOp.getB().getType();
-//   auto inputBShape = inputBType.getShape();
-//   int64_t rank = inputBShape.size();
-//
-//   // if rank <= 2, it cannot be batched. Return false.
-//   // Check if batched: any dimension before the last 2 has size > 1.
-//   // i.e. <1x3x128x32xbf16> is batched because of 3.
-//   // i.e. <1x1x128x32xbf16> is not batched because all dims before last 2
-//   are 1.
-//   // i.e. <128xbf16> is not batched because rank < 2.
-//   return rank > 2 && llvm::any_of(inputBShape.drop_back(2),
-//                                   [](int64_t dim) { return dim > 1; });
-// }
+static bool isBatchedLinearOp(ttnn::LinearOp linearOp) {
+  RankedTensorType inputBType = linearOp.getB().getType();
+  auto inputBShape = inputBType.getShape();
+  int64_t rank = inputBShape.size();
+
+  // if rank <= 2, it cannot be batched. Return false.
+  // Check if batched: any dimension before the last 2 has size > 1.
+  // i.e. <1x3x128x32xbf16> is batched because of 3.
+  // i.e. <1x1x128x32xbf16> is not batched because all dims before last 2 are 1.
+  // i.e. <128xbf16> is not batched because rank < 2.
+  return rank > 2 && llvm::any_of(inputBShape.drop_back(2),
+                                  [](int64_t dim) { return dim > 1; });
+}
+
+// Helper function to check if bias is effectively 1D
+// Returns true if bias has only one non-unit dimension (e.g., <64>, <1x64>,
+// <1x1x64>).
+// Expects every dimension except last to be either 1 or absent.
+static bool isNotEffectively1DBias(TypedValue<RankedTensorType> bias) {
+  if (!bias) {
+    return false;
+  }
+
+  RankedTensorType biasType = bias.getType();
+  if (!biasType) {
+    return false;
+  }
+
+  auto biasShape = biasType.getShape();
+  auto rank = biasType.getRank();
+
+  return rank > 1 && llvm::any_of(biasShape.drop_back(1),
+                                  [](int64_t dim) { return dim > 1; });
+}
 
 // Calculate the output shape of a matmul operation following tt-metal's logic.
 // Reference: ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -37,13 +57,38 @@ computeMatmulOutputShape(llvm::ArrayRef<int64_t> shapeA, bool transposeA,
   int64_t rankA = shapeA.size();
   int64_t rankB = shapeB.size();
 
-  // if (rankA == 1 || rankB == 1) {
-  //   TT_assertv(false,
-  //              "Should not reach linear op workaround if rankA or rankB is
-  //              1");
-  // }
-
   SmallVector<int64_t> outputShape;
+
+  // Handle rank 1 cases
+  if (rankA == 1 && rankB == 1) {
+    // vector dot vector -> scalar (but represented as 1D tensor with size 1)
+    outputShape.push_back(1);
+    return outputShape;
+  }
+
+  if (rankA == 1) {
+    // vector-matrix: (K,) x (..., K, N) -> (..., N)
+    // Result shape is all batch dims from B plus the last dim
+    outputShape.append(shapeB.begin(), shapeB.end() - 2);
+    outputShape.push_back(transposeB ? shapeB[rankB - 2] : shapeB[rankB - 1]);
+    return outputShape;
+  }
+
+  if (rankB == 1) {
+    // matrix-vector: (..., M, K) x (K,) -> (..., M)
+    // Result shape is all dims from A except the last (contraction) dim
+    if (transposeA) {
+      // If A is transposed, the contraction dim is second-to-last, keep last
+      outputShape.append(shapeA.begin(), shapeA.end() - 2);
+      outputShape.push_back(shapeA[rankA - 1]);
+    } else {
+      // Normal case: contraction dim is last, keep all but last
+      outputShape.append(shapeA.begin(), shapeA.end() - 1);
+    }
+    return outputShape;
+  }
+
+  // Both inputs are at least rank 2
   SmallVector<int64_t> batchShapeA(shapeA.begin(), shapeA.end() - 2);
   SmallVector<int64_t> batchShapeB(shapeB.begin(), shapeB.end() - 2);
   mlir::OpTrait::util::getBroadcastedShape(batchShapeA, batchShapeB,
@@ -72,6 +117,18 @@ LogicalResult
 LinearOpRewritePattern::matchAndRewrite(ttnn::LinearOp srcOp,
                                         PatternRewriter &rewriter) const {
 
+  // Only decompose if bias exists AND (bias is non-1D OR input B is batched)
+  if (!srcOp.getBias()) {
+    return failure();
+  }
+
+  bool biasIsNon1D = isNotEffectively1DBias(srcOp.getBias());
+  bool inputBIsBatched = isBatchedLinearOp(srcOp);
+
+  if (!biasIsNon1D && !inputBIsBatched) {
+    return failure();
+  }
+
   RankedTensorType inputAType = srcOp.getA().getType();
   RankedTensorType inputBType = srcOp.getB().getType();
   RankedTensorType outputType = srcOp.getResult().getType();
@@ -90,21 +147,55 @@ LinearOpRewritePattern::matchAndRewrite(ttnn::LinearOp srcOp,
   auto dataTypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
       rewriter.getContext(), outputEncoding.getDataType());
 
-  // Step 1: Create MatMul operation
+  // Step 1: Create MatMul operation.
+
   MatmulOp matmulOp = rewriter.create<ttnn::MatmulOp>(
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_decomp_matmul"),
       matmulOutputType, srcOp.getA(), srcOp.getB(), srcOp.getTransposeA(),
       srcOp.getTransposeB(),
-      /*matmul_program_config=*/mlir::Attribute(), /*activation=*/nullptr);
+      /*matmul_program_config=*/mlir::Attribute(),
+      /*activation=*/nullptr);
 
-  // Step 2: Create Add operation with bias
+  // Step 2: Create Add operation with bias.
   AddOp addOp = rewriter.create<ttnn::AddOp>(
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_decomp_add"),
       outputType, matmulOp.getResult(), srcOp.getBias(),
       /*dtype=*/dataTypeAttr,
       /*memory_config=*/ttnn::MemoryConfigAttr());
 
-  rewriter.replaceOp(srcOp, addOp.getResult());
+  // Step 3: If original linear op had activation, apply it to the add result.
+  if (srcOp.getActivation()) {
+    std::string activationStr = srcOp.getActivation()->str();
+
+    // Map activation string to operation name
+    StringAttr opName;
+    if (activationStr == "relu") {
+      opName = StringAttr::get(rewriter.getContext(), "ttnn.relu");
+    } else if (activationStr == "sigmoid") {
+      opName = StringAttr::get(rewriter.getContext(), "ttnn.sigmoid");
+    } else if (activationStr == "gelu") {
+      opName = StringAttr::get(rewriter.getContext(), "ttnn.gelu");
+    } else if (activationStr == "tanh") {
+      opName = StringAttr::get(rewriter.getContext(), "ttnn.tanh");
+    } else {
+      matmulOp.emitError()
+          << "Unsupported activation type in LinearOp decomposition: "
+          << activationStr;
+      return failure();
+    }
+
+    // Create activation op using generic Operation::create
+    Operation *activationOp =
+        rewriter.create(ttmlir::utils::appendLocationSuffix(
+                            srcOp.getLoc(), "_decomp_" + activationStr),
+                        opName,
+                        /*operands=*/ValueRange{addOp.getResult()},
+                        /*types=*/TypeRange{outputType});
+
+    rewriter.replaceOp(srcOp, activationOp->getResult(0));
+  } else {
+    rewriter.replaceOp(srcOp, addOp.getResult());
+  }
 
   return success();
 }

--- a/runtime/test/ttnn/python/n150/test_intermidate_tensor_manipulation.py
+++ b/runtime/test/ttnn/python/n150/test_intermidate_tensor_manipulation.py
@@ -87,7 +87,6 @@ def is_callback_enabled():
     return debug_stats != "DebugStats Disabled"
 
 
-@pytest.mark.skip(reason="See https://github.com/tenstorrent/tt-mlir/issues/5789")
 def test_intermidate_tensor_manipulation(helper: Helper, request):
     binary_path = os.path.join(FLATBUFFER_BASE_PATH, "linear.mlir.tmp.ttnn")
     assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"

--- a/test/python/golden/test_ttnn_fusing.py
+++ b/test/python/golden/test_ttnn_fusing.py
@@ -84,9 +84,6 @@ def test_matmul_activation_fusing(
     ), f"Standalone {activation_name} operation should be fused"
 
 
-@pytest.mark.xfail(
-    reason="Fails golden, see https://github.com/tenstorrent/tt-mlir/issues/5789"
-)
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/test/python/golden/test_ttnn_ops.py
+++ b/test/python/golden/test_ttnn_ops.py
@@ -58,9 +58,6 @@ def test_clamp_tensor(shapes: List[Shape], request, device):
     )
 
 
-@pytest.mark.skip(
-    reason="Segfault, see https://github.com/tenstorrent/tt-mlir/issues/5789"
-)
 @pytest.mark.parametrize(
     "shapes", [[(10, 64, 32), (32, 128), (1,)]], ids=shapes_list_str
 )
@@ -221,9 +218,6 @@ def test_matmul(
     )
 
 
-@pytest.mark.skip(
-    reason="Segfault, see https://github.com/tenstorrent/tt-mlir/issues/5789"
-)
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/test/ttmlir/Dialect/TTNN/Transforms/Fusing/linear_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Fusing/linear_fusing.mlir
@@ -1,6 +1,5 @@
 // RUN: ttmlir-opt --ttnn-fusing -o %t %s
 // RUN: FileCheck %s --input-file=%t
-// UNSUPPORTED: true
 
 // Test fusing sigmoid activation into linear operation
 module {

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/linear_op_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/linear_op_workaround.mlir
@@ -31,4 +31,54 @@ module  {
     %result = "ttnn.linear"(%arg0, %arg1, %bias) : (tensor<1x3x64x128xbf16>, tensor<1x3x128x32xbf16>, tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16>
     return %result : tensor<14x4x3x64x32xbf16>
   }
+  func.func @linear_with_sigmoid(%arg0: tensor<100x384xbf16>, %arg1: tensor<4x384xbf16>, %arg2: tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16> {
+    // CHECK-LABEL: func.func @linear_with_sigmoid
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: -> tensor<100x4xbf16
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: -> tensor<1x100x4xbf16
+    // CHECK: "ttnn.sigmoid"
+    %result = "ttnn.linear"(%arg0, %arg1, %arg2) <{activation = "sigmoid", transpose_a = false, transpose_b = true}> : (tensor<100x384xbf16>, tensor<4x384xbf16>, tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16>
+    return %result : tensor<1x100x4xbf16>
+  }
+  func.func @linear_with_relu(%arg0: tensor<100x384xbf16>, %arg1: tensor<4x384xbf16>, %arg2: tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16> {
+    // CHECK-LABEL: func.func @linear_with_relu
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: -> tensor<100x4xbf16
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: -> tensor<1x100x4xbf16
+    // CHECK: "ttnn.relu"
+    %result = "ttnn.linear"(%arg0, %arg1, %arg2) <{activation = "relu", transpose_a = false, transpose_b = true}> : (tensor<100x384xbf16>, tensor<4x384xbf16>, tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16>
+    return %result : tensor<1x100x4xbf16>
+  }
+  func.func @linear_with_gelu(%arg0: tensor<100x384xbf16>, %arg1: tensor<4x384xbf16>, %arg2: tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16> {
+    // CHECK-LABEL: func.func @linear_with_gelu
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: -> tensor<100x4xbf16
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: -> tensor<1x100x4xbf16
+    // CHECK: "ttnn.gelu"
+    %result = "ttnn.linear"(%arg0, %arg1, %arg2) <{activation = "gelu", transpose_a = false, transpose_b = true}> : (tensor<100x384xbf16>, tensor<4x384xbf16>, tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16>
+    return %result : tensor<1x100x4xbf16>
+  }
+  func.func @linear_with_tanh(%arg0: tensor<100x384xbf16>, %arg1: tensor<4x384xbf16>, %arg2: tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16> {
+    // CHECK-LABEL: func.func @linear_with_tanh
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: -> tensor<100x4xbf16
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: -> tensor<1x100x4xbf16
+    // CHECK: "ttnn.tanh"
+    %result = "ttnn.linear"(%arg0, %arg1, %arg2) <{activation = "tanh", transpose_a = false, transpose_b = true}> : (tensor<100x384xbf16>, tensor<4x384xbf16>, tensor<1x100x4xbf16>) -> tensor<1x100x4xbf16>
+    return %result : tensor<1x100x4xbf16>
+  }
+  func.func @linear_with_batched_bias(%arg0: tensor<2x33x1024xf32>, %arg1: tensor<1024x1024xf32>, %arg2: tensor<2x1x1xf32>) -> tensor<2x33x1024xf32>{
+    // CHECK-LABEL: func.func @linear_with_batched_bias
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: -> tensor<2x33x1024xf32
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: -> tensor<2x33x1024xf32
+    %result = "ttnn.linear"(%arg0, %arg1, %arg2) <{transpose_a = false, transpose_b = false}> : (tensor<2x33x1024xf32>, tensor<1024x1024xf32>, tensor<2x1x1xf32>) -> tensor<2x33x1024xf32>
+    return %result : tensor<2x33x1024xf32>
+  }
+
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_adjust_deallocs.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_adjust_deallocs.mlir
@@ -1,8 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t %s
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-adjust-deallocs -o %t2 %s
-// RUN: [ "$(cat %t | grep -c ttnn.deallocate)" -eq 3 ]
-// RUN: [ "$(cat %t2 | grep -c ttnn.deallocate)" -eq 1 ]
-// UNSUPPORTED: true
+// RUN: [ "$(cat %t | grep -c ttnn.deallocate)" -eq 4 ]
+// RUN: [ "$(cat %t2 | grep -c ttnn.deallocate)" -eq 2 ]
 //
 // Test for --ttnn-adjust-deallocs pass.
 // The test runs the --ttir-to-ttnn-backend-pipeline twice, and follows up with --ttnn-adjust-deallocs for the second run.
@@ -10,10 +9,8 @@
 
 module {
   func.func @matmul_with_bias(%arg0: tensor<784x1096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}, %arg1: tensor<1096x784xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<784x784xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<784x784xbf16> {
-    %0 = ttir.empty() : tensor<784x784xbf16>
-    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<784x1096xbf16>, tensor<1096x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
-    %2 = ttir.empty() : tensor<784x784xbf16>
-    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<784x784xbf16>, tensor<784x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
-    return %3 : tensor<784x784xbf16>
+    %0 = "ttir.matmul"(%arg0, %arg1) : (tensor<784x1096xbf16>, tensor<1096x784xbf16>) -> tensor<784x784xbf16>
+    %1 = "ttir.add"(%0, %arg2) : (tensor<784x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
+    return %1 : tensor<784x784xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
@@ -1,15 +1,14 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
-// UNSUPPORTED: true
 
 module {
-  func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.linear"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
+    // CHECK-SAME: tensor<64xbf16
     // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
-    return %1 : tensor<64x64xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -3,7 +3,6 @@
 // RUN: FileCheck %s --input-file=%t
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
-    %0 = ttir.empty() : tensor<1x32x32x64xbf16>
     // CHECK: "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<
     // CHECK-SAME: weights_dtype = bf16
     // CHECK-SAME: activation = <op_type = relu>
@@ -17,13 +16,13 @@ module {
     // CHECK-SAME: output_layout = row_major
     // CHECK-SAME: enable_act_double_buffer = false
     // CHECK-SAME: enable_weights_double_buffer = false
-    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2)
             <{
               stride = array<i32: 1, 1>,
               padding = array<i32: 1, 1>,
               dilation = 1: i32,
               groups = 1: i32
-            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16> loc(#loc2)
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> loc(#loc2)
     return %1 : tensor<1x32x32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/all_l1_interleaved_policy.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/all_l1_interleaved_policy.mlir
@@ -1,18 +1,19 @@
 // REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved tensor-l1-usage-cap=0.75" -o %t %s
 // RUN: FileCheck %s --input-file=%t
-// UNSUPPORTED: true
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<64x96xbf16>, %arg3: tensor<96x32xbf16>, %arg4: tensor<64x32xbf16>) -> tensor<64x32xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
     // CHECK: #[[LAYOUT_L1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1>, <interleaved>>
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
     %1 = "ttir.matmul"(%arg0, %arg1) : (tensor<64x128xbf16>, tensor<128x96xbf16>) -> tensor<64x96xbf16>
-    // CHECK: %{{.*}} = "ttnn.linear"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
     %3 = "ttir.add"(%1, %arg2) : (tensor<64x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>
     // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
     %5 = "ttir.relu"(%3) : (tensor<64x96xbf16>) -> tensor<64x96xbf16>
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_L1]]>
     %7 = "ttir.matmul"(%5, %arg3) : (tensor<64x96xbf16>, tensor<96x32xbf16>) -> tensor<64x32xbf16>
-    // CHECK: %{{.*}} = "ttnn.linear"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_L1]]>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_L1]]>
     %9 = "ttir.add"(%7, %arg4) : (tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
     // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_L1]]>
     %11 = "ttir.relu"(%9) : (tensor<64x32xbf16>) -> tensor<64x32xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
@@ -1,7 +1,6 @@
 // REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved tensor-l1-usage-cap=0.75" -o %t %s
 // RUN: FileCheck %s --input-file=%t
-// UNSUPPORTED: true
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/max_legal_layouts_override_32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/max_legal_layouts_override_32.mlir
@@ -5,15 +5,14 @@ module attributes {} {
   func.func @forward(%arg0: tensor<16x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<16x32x32x64xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
     // CHECK: #[[LAYOUT_L1:.*]] = #ttnn.ttnn_layout<{{.*}}#[[L1_]]>
-    %0 = ttir.empty() : tensor<16x32x32x64xbf16>
     // CHECK: {{.*}} = "ttnn.conv2d"{{.*}}#[[LAYOUT_L1]]>
-    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2)
             <{
                 stride = 1: i32,
                 padding = 1: i32,
                 dilation = 1: i32,
                 groups = 1: i32
-            }> : (tensor<16x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<16x32x32x64xbf16>) -> tensor<16x32x32x64xbf16>
+            }> : (tensor<16x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>) -> tensor<16x32x32x64xbf16>
     %3 = "ttir.add"(%1, %1) : (tensor<16x32x32x64xbf16>, tensor<16x32x32x64xbf16>) -> tensor<16x32x32x64xbf16>
     return %3 : tensor<16x32x32x64xbf16>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/deallocate.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/deallocate.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
-// UNSUPPORTED: true
 #loc = loc("Dealloc":4294967295:0)
 module @"dealloc_test" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("Dealloc":4294967295:0), %arg1: tensor<1x10xf32> loc("Dealloc":4294967295:0), %arg2: tensor<256x10xf32> loc("Dealloc":4294967295:0), %arg3: tensor<1x256xf32> loc("Dealloc":4294967295:0), %arg4: tensor<784x256xf32> loc("Dealloc":4294967295:0)) -> tensor<1x10xf32> {

--- a/test/ttmlir/Silicon/TTNN/n150/matmul/linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/matmul/linear.mlir
@@ -1,61 +1,59 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
-// UNSUPPORTED: true
+
 module {
   func.func @linear(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32> {
-    %0 = ttir.empty() : tensor<2x34x1024xf32>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<2x34x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
-    return %1 : tensor<2x34x1024xf32>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    return %0 : tensor<2x34x1024xf32>
   }
   func.func @linear_with_implicit_broadcast(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
-    %0 = ttir.empty() : tensor<2x34x1024xf32>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
-    return %1 : tensor<2x34x1024xf32>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1024xf32>) -> tensor<2x34x1024xf32>
+    return %0 : tensor<2x34x1024xf32>
+  }
+  func.func @linear_with_implicit_broadcast_2(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x1x1xf32>) -> tensor<2x34x1024xf32> {
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<2x1x1xf32>) -> tensor<2x34x1024xf32>
+    return %0 : tensor<2x34x1024xf32>
+  }
+  func.func @linear_with_implicit_broadcast_3(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1x34x1xf32>) -> tensor<2x34x1024xf32> {
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1x34x1xf32>) -> tensor<2x34x1024xf32>
+    return %0 : tensor<2x34x1024xf32>
   }
 
-  func.func @linear_with_implicit_broadcast_2(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x2x34x1024xf32>) -> tensor<2x2x34x1024xf32> {
-    %0 = ttir.empty() : tensor<2x2x34x1024xf32>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<2x2x34x1024xf32>, tensor<2x2x34x1024xf32>) -> tensor<2x2x34x1024xf32>
-    return %1 : tensor<2x2x34x1024xf32>
+  func.func @linear_with_implicit_broadcast_4(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x2x34x1024xf32>) -> tensor<2x2x34x1024xf32> {
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<2x2x34x1024xf32>) -> tensor<2x2x34x1024xf32>
+    return %0 : tensor<2x2x34x1024xf32>
   }
 
   func.func @linear_with_batched_rhs_and_bias(%arg0: tensor<2x33x1024xf32>, %arg1: tensor<2x1024x1024xf32>, %bias: tensor<2x33x1024xf32>) -> tensor<2x33x1024xf32> {
-    %0 = ttir.empty() : tensor<2x33x1024xf32>
-    // this will be lowered to a matmul + add
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{batch_dims_lhs = array<i64: 0>, batch_dims_rhs = array<i64: 0>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 1>}> : (tensor<2x33x1024xf32>, tensor<2x1024x1024xf32>, tensor<2x33x1024xf32>, tensor<2x33x1024xf32>) -> tensor<2x33x1024xf32>
-    return %1 : tensor<2x33x1024xf32>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) <{batch_dims_lhs = array<i64: 0>, batch_dims_rhs = array<i64: 0>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 1>}> : (tensor<2x33x1024xf32>, tensor<2x1024x1024xf32>, tensor<2x33x1024xf32>) -> tensor<2x33x1024xf32>
+    return %0 : tensor<2x33x1024xf32>
   }
 
   func.func @linear_bias_broadcast(%arg0: tensor<4x3x64x128xbf16>, %arg1: tensor<4x3x128x32xbf16>, %bias: tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16> {
-    %0 = ttir.empty() : tensor<14x4x3x64x32xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<4x3x64x128xbf16>, tensor<4x3x128x32xbf16>, tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16>
     // this will be lowered to a matmul + add
     // Bias broadcasts from [14, 4, 3, 64, 32] (adds leading batch dim 14)
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<4x3x64x128xbf16>, tensor<4x3x128x32xbf16>, tensor<14x4x3x64x32xbf16>, tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16>
-    return %1 : tensor<14x4x3x64x32xbf16>
+    return %0 : tensor<14x4x3x64x32xbf16>
   }
 
   func.func @linear_nd_nd_bias_broadcast(%arg0: tensor<1x1x64x128xbf16>, %arg1: tensor<1x1x128x32xbf16>, %bias: tensor<4x3x64x32xbf16>) -> tensor<4x3x64x32xbf16> {
-    %0 = ttir.empty() : tensor<4x3x64x32xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<1x1x64x128xbf16>, tensor<1x1x128x32xbf16>, tensor<4x3x64x32xbf16>) -> tensor<4x3x64x32xbf16>
     // The expected output shape is [1, 1, 64, 32] with leading batch dims broadcasted to [4, 3, 64, 32] due to bias.
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<1x1x64x128xbf16>, tensor<1x1x128x32xbf16>, tensor<4x3x64x32xbf16>, tensor<4x3x64x32xbf16>) -> tensor<4x3x64x32xbf16>
-    return %1 : tensor<4x3x64x32xbf16>
+    return %0 : tensor<4x3x64x32xbf16>
   }
 
   func.func @linear_nd_nd_bias_broadcast_matmul(%arg0: tensor<1x3x64x128xbf16>, %arg1: tensor<1x3x128x32xbf16>, %bias: tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16> {
-    %0 = ttir.empty() : tensor<14x4x3x64x32xbf16>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<1x3x64x128xbf16>, tensor<1x3x128x32xbf16>, tensor<14x4x3x64x32xbf16>, tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16>
-    return %1 : tensor<14x4x3x64x32xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<1x3x64x128xbf16>, tensor<1x3x128x32xbf16>, tensor<14x4x3x64x32xbf16>) -> tensor<14x4x3x64x32xbf16>
+    return %0 : tensor<14x4x3x64x32xbf16>
   }
 
   func.func @linear_1d_lhs(%arg0: tensor<1024xf32>, %arg1: tensor<1x1024x1024xf32>, %bias: tensor<1x1024xf32>) -> tensor<1x1024xf32> {
-    %0 = ttir.empty() : tensor<1x1024xf32>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0): (tensor<1024xf32>, tensor<1x1024x1024xf32>, tensor<1x1024xf32>, tensor<1x1024xf32>) -> tensor<1x1024xf32>
-    return %1 : tensor<1x1024xf32>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<1024xf32>, tensor<1x1024x1024xf32>, tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    return %0 : tensor<1x1024xf32>
   }
 
   func.func @linear_with_1d_rhs(%arg0: tensor<2x33x1024xf32>, %arg1: tensor<1024xf32>, %bias: tensor<2x33xf32>) -> tensor<2x33xf32> {
-    %0 = ttir.empty() : tensor<2x33xf32>
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) : (tensor<2x33x1024xf32>, tensor<1024xf32>, tensor<2x33xf32>, tensor<2x33xf32>) -> tensor<2x33xf32>
-    return %1 : tensor<2x33xf32>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x33x1024xf32>, tensor<1024xf32>, tensor<2x33xf32>) -> tensor<2x33xf32>
+    return %0 : tensor<2x33xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/mixed_precision/linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/mixed_precision/linear.mlir
@@ -13,7 +13,7 @@ module {
   func.func @linear_with_implicit_broadcast(%arg0: tensor<2x34x1024xf32>, %arg1: tensor<1024x1024xf32> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
     // CHECK-LABEL: func.func @linear_with_implicit_broadcast
     // CHECK: %[[BFP8_WEIGHT:.*]] = ttcore.load_cached({{.*}}, [%arg1]) : {{.*}} -> tensor<{{.*}}bfp_bf8{{.*}}>
-    // CHECK: "ttnn.matmul"(%arg0, %[[BFP8_WEIGHT]])
+    // CHECK: "ttnn.linear"(%arg0, %[[BFP8_WEIGHT]], %arg2)
     %1 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<2x34x1024xf32>, tensor<1024x1024xf32>, tensor<1024xf32>) -> tensor<2x34x1024xf32>
     return %1 : tensor<2x34x1024xf32>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_linear.mlir
@@ -2,7 +2,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o mnist_linear_out.mlir %s
 // RUN: FileCheck %s --input-file=mnist_linear_out.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn mnist_linear_out.mlir
-// UNSUPPORTED: true
 #loc = loc("MNISTLinear":0:0)
 module @MNISTLinear attributes {} {
   func.func @forward(%arg0: tensor<1x784xf32> {ttir.name = "input_1"} loc("MNISTLinear":0:0), %arg1: tensor<784x256xf32> {ttir.name = "l1.weight"} loc("MNISTLinear":0:0), %arg2: tensor<256xf32> {ttir.name = "l1.bias"} loc("MNISTLinear":0:0), %arg3: tensor<256x10xf32> {ttir.name = "l2.weight"} loc("MNISTLinear":0:0), %arg4: tensor<10xf32> {ttir.name = "l2.bias"} loc("MNISTLinear":0:0)) -> (tensor<1x10xf32> {ttir.name = "MNISTLinear.output_softmax_9"}) {

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
@@ -3,15 +3,11 @@
 // RUN: FileCheck %s --input-file=mnist_sharding_ttnn.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn mnist_sharding_ttnn.mlir
 
-// CHECK: %[[MATMUL1:.*]] = "ttnn.matmul"
+// CHECK: %[[LINEAR1:.*]] = "ttnn.linear"
 // CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
-// CHECK: %[[ADD1:.*]] = "ttnn.add"(%[[MATMUL1]]
+// CHECK: %[[RELU:.*]] = "ttnn.relu"(%[[LINEAR1]]
 // CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
-// CHECK: %[[RELU:.*]] = "ttnn.relu"(%[[ADD1]]
-// CHECK-SAME: -> tensor<1x256xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
-// CHECK: %[[MATMUL2:.*]] = "ttnn.matmul"(%[[RELU]]
-// CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
-// CHECK: %[[ADD2:.*]] = "ttnn.add"(%[[MATMUL2]]
+// CHECK: %[[LINEAR2:.*]] = "ttnn.linear"(%[[RELU]]
 // CHECK-SAME: -> tensor<1x10xf32, #ttnn.ttnn_layout<{{.*}}<width_sharded>>>
 
 #loc = loc("MNISTLinear":4294967295:0)

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_linear.mlir
@@ -1,16 +1,15 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
-// UNSUPPORTED: true
 
 module {
-  func.func @linear(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @linear(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.linear"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
+    // CHECK-SAME: tensor<64xbf16
     // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %1 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64xbf16>) -> tensor<64x64xbf16>
     return %1 : tensor<64x64xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_linear.mlir
@@ -1,38 +1,69 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
-// UNSUPPORTED: true
 
 module {
-  func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.linear"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
+    // CHECK-SAME: tensor<64xbf16
     // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
+  }
+
+  func.func @simple_linear_with_2d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    // CHECK: "ttnn.matmul"
+    // CHECK: "ttnn.add"
     %0 = "ttir.linear"(%arg0, %arg1, %bias) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
     return %0 : tensor<64x64xbf16>
   }
 
-
-  func.func @linear_transpose_lhs(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<128x128xbf16>) -> tensor<128x128xbf16> {
+  func.func @linear_transpose_lhs_1d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<128xbf16>) -> tensor<128x128xbf16> {
     // CHECK: "ttnn.linear"
     // CHECK-SAME: transpose_a = true
     // CHECK-SAME: transpose_b = false
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<128xbf16
     // CHECK-SAME: tensor<128x128xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{transpose_a = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<128x128xbf16>, tensor<128x128xbf16>) -> tensor<128x128xbf16>
-    return %1 : tensor<128x128xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) <{transpose_a = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<128xbf16>) -> tensor<128x128xbf16>
+    return %0 : tensor<128x128xbf16>
   }
 
-  func.func @linear_transpose_second(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @linear_transpose_lhs_2d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<128x128xbf16>) -> tensor<128x128xbf16> {
+    // CHECK: "ttnn.matmul"
+    // CHECK-SAME: transpose_a = true
+    // CHECK-SAME: transpose_b = false
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<128x128xbf16
+    // CHECK: "ttnn.add"
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) <{transpose_a = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<128x128xbf16>) -> tensor<128x128xbf16>
+    return %0 : tensor<128x128xbf16>
+  }
+
+  func.func @linear_transpose_second_1d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<64xbf16>) -> tensor<64x64xbf16> {
+    // CHECK: "ttnn.linear"
+    // CHECK-SAME: transpose_a = false
+    // CHECK-SAME: transpose_b = true
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64xbf16
+    // CHECK-SAME: tensor<64x64xbf16
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) <{transpose_b = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
+  }
+
+  func.func @linear_transpose_second_2d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: transpose_a = false
     // CHECK-SAME: transpose_b = true
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %bias, %0) <{transpose_b = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
-    return %1 : tensor<64x64xbf16>
+    %0 = "ttir.linear"(%arg0, %arg1, %bias) <{transpose_b = true}>: (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/5813
https://github.com/tenstorrent/tt-mlir/issues/6016

### Problem description
[During uplift 2 weeks ago](https://github.com/tenstorrent/tt-mlir/pull/5744), default tt-metal/ttnn linear op behaviour has changed. linear op is now mapping [PyTorch Linear](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html) This means that linear op bias needs to be 1d (or view, like 1x1x64)

@ctodTT relaxed the conditions to linear op workaround so that all linear ops would be broken down into matmul and add. However, this means no linear op is running as a linear op, even if they have 1d bias.

### What's changed
Linear op workaround is changed such that:
- only linear ops with non 1d bias or batched b input are broken down into matmul + add
- activation is passed from linear to matmul op correctly (previously, this was not passed)
- Tests marked unsupported or skipped are reinstated. 

### Checklist
- [Performance Benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/19769666488 ): 
    - Errors seen are the same errors seen in other performance benchmark runs. I.e. (Circular buffer error, cv2 not found)
- [Model test push](https://github.com/tenstorrent/tt-xla/actions/runs/19769681564)
- [Basic Test](https://github.com/tenstorrent/tt-xla/actions/runs/19769684308)
- [Model Test Passing](https://github.com/tenstorrent/tt-xla/actions/runs/19772587791)