### PR TITLE
Add jit tests on CI for llmbox (t3k)

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -33,7 +33,7 @@
   { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
   { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
-  { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
+  { "runs-on": ["n150","llmbox"], "image": "tracy",  "script": "pykernel.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}
 ]


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-mlir/issues/5743

### Problem description
This is needed to run the tests under test/ttnn-jit/test_mesh_tensor_eltwise.py (which require a T3K/llmbox)

### What's changed
`.github/settings/tests.json` updated to add llmbox for script running ttnn-jit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
