### PR TITLE
Add missing pytest mark of only_config

### DIFF
--- a/test/python/golden/pytest.ini
+++ b/test/python/golden/pytest.ini
@@ -7,4 +7,5 @@ markers =
   llmbox: mark test as running on llmbox
   frontend(fe_name): denotes which builder frontend this uses (ttir vs shlo)
   skip_config(config, ... reason=None): skip test if all of the specified targets/backends per config are present
+  only_config(config, ... reason=None): only run test if all of the specified targets/backends per config are present
   skip_exec(config, ... reason=None): compile test but skip execution if all of the specified targets/backends per config are present. The test function must retrieve the skip_exec flag with 'skip_exec = getattr(request.node, "skip_exec", False)' and pass it to compile_and_execute_* functions. The test will be marked as xfail when conditions match.


### PR DESCRIPTION
### Problem description
Noticed this warning:
```
test/python/golden/test_metal_matmul.py:108
  /localdev/gfeng/mlir/test/python/golden/test_metal_matmul.py:108: PytestUnknownMarkWarning: Unknown pytest.mark.only_config - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.only_config(["ttmetal", "p150"])
```

### What's changed
Added the mark `only_config` which works in the opposite way of `skip_config`.
