### PR TITLE
Add memory log level and memory logs correspondingly

### DIFF
--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -182,17 +182,6 @@ void verifyFlatbuffer(const ::flatbuffers::FlatBufferBuilder &fbb,
 #endif
 }
 
-RUNTIME_DEBUG_MAYBE_INLINE void
-logMemoryState(const std::unordered_map<tt::runtime::MemoryBufferType,
-                                        tt::runtime::MemoryView> &memoryState,
-               std::string_view prefix = "")
-#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-    ;
-#else
-{
-}
-#endif
-
 #undef RUNTIME_DEBUG_MAYBE_INLINE
 
 } // namespace tt::runtime::debug

--- a/runtime/include/tt/runtime/detail/common/runtime_context.h
+++ b/runtime/include/tt/runtime/detail/common/runtime_context.h
@@ -36,6 +36,9 @@ public:
   ::tt::runtime::FabricConfig getCurrentFabricConfig() const;
   void setCurrentFabricConfig(const tt::runtime::FabricConfig &config);
 
+  MemoryLogLevel getMemoryLogLevel() const;
+  void setMemoryLogLevel(const MemoryLogLevel &logLevel);
+
 private:
   RuntimeContext();
   ~RuntimeContext() = default;
@@ -47,6 +50,7 @@ private:
   std::atomic<HostRuntime> currentHostRuntime_ = HostRuntime::Local;
   std::atomic<tt::runtime::FabricConfig> currentFabricConfig_ =
       tt::runtime::FabricConfig::DISABLED;
+  std::atomic<MemoryLogLevel> memoryLogLevel_ = MemoryLogLevel::NONE;
 };
 
 } // namespace tt::runtime

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -14,10 +14,15 @@ namespace tt::runtime::distributed::controller {
 
 class CommandFactory {
 public:
+  static uint64_t buildSetMemoryLogLevelCommand(
+      ::flatbuffers::FlatBufferBuilder &fbb,
+      const ::tt::runtime::MemoryLogLevel &memoryLogLevel);
+
   static uint64_t buildConfigureRuntimeContextCommand(
       ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
       const std::string &metalHome,
-      const ::tt::runtime::DeviceRuntime &currentDeviceRuntime);
+      const ::tt::runtime::DeviceRuntime &currentDeviceRuntime,
+      const ::tt::runtime::MemoryLogLevel &memoryLogLevel);
 
   static uint64_t buildGetSystemDescCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -86,6 +86,8 @@ public:
   void setWorkerShutdownTimeout(const std::chrono::seconds &timeout);
 
   // Runtime APIs
+  void setMemoryLogLevel(const MemoryLogLevel &logLevel);
+
   SystemDesc getCurrentSystemDesc(
       std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
           std::nullopt,
@@ -198,6 +200,10 @@ private:
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 
   void handleConfigureRuntimeContextResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleSetMemoryLogLevelResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -12,6 +12,8 @@ namespace tt::runtime::distributed {
 void launchDistributedRuntime(const DistributedOptions &options = {});
 void shutdownDistributedRuntime();
 
+void setMemoryLogLevel(const MemoryLogLevel &logLevel);
+
 SystemDesc getCurrentSystemDesc(
     std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
         std::nullopt,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -13,6 +13,11 @@ table ConfigureRuntimeContextCommand {
   mlir_home: string;
   metal_home: string;
   current_device_runtime: tt.runtime.flatbuffer.DeviceRuntime;
+  memory_log_level: tt.runtime.flatbuffer.MemoryLogLevel;
+}
+
+table SetMemoryLogLevelCommand {
+  memory_log_level: tt.runtime.flatbuffer.MemoryLogLevel;
 }
 
 table GetSystemDescCommand {
@@ -142,6 +147,7 @@ table ShutdownCommand {
 
 union CommandType {
   ConfigureRuntimeContextCommand,
+  SetMemoryLogLevelCommand,
   GetSystemDescCommand,
   SetFabricConfigCommand,
   GetNumAvailableDevicesCommand,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -13,6 +13,9 @@ table ErrorResponse {
 table ConfigureRuntimeContextResponse {
 }
 
+table SetMemoryLogLevelResponse {
+}
+
 table GetSystemDescResponse {
   system_desc: [ubyte]; // size-prefixed SystemDescRoot buffer
 }
@@ -92,6 +95,7 @@ table ShutdownResponse {
 union ResponseType {
   ErrorResponse,
   ConfigureRuntimeContextResponse,
+  SetMemoryLogLevelResponse,
   GetSystemDescResponse,
   SetFabricConfigResponse,
   GetNumAvailableDevicesResponse,

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -66,6 +66,11 @@ private:
 
   void
   execute(uint64_t commandId,
+          const ::tt::runtime::distributed::flatbuffer::SetMemoryLogLevelCommand
+              *command);
+
+  void
+  execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::SetFabricConfigCommand
               *command);
 

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -18,6 +18,10 @@ public:
                                  const std::string &errorMessage);
 
   static void
+  buildSetMemoryLogLevelResponse(::flatbuffers::FlatBufferBuilder &fbb,
+                                 uint64_t commandId);
+
+  static void
   buildConfigureRuntimeContextResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                        uint64_t commandId);
 

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -133,6 +133,9 @@ void *getRawHostDataPtr(const ::ttnn::Tensor &tensor);
     const ::ttnn::Layout &layout = ::ttnn::Layout::ROW_MAJOR,
     const ::ttnn::MemoryConfig &memoryConfig = ::ttnn::DRAM_MEMORY_CONFIG);
 
+std::unordered_map<::tt::runtime::MemoryBufferType, ::tt::runtime::MemoryView>
+getMemoryView(Device deviceHandle);
+
 template <typename T>
 inline ::ttnn::Tensor createTTNNTensor(
     const void *rawData, const ::ttnn::Shape &shape,

--- a/runtime/include/tt/runtime/flatbuffer/types.fbs
+++ b/runtime/include/tt/runtime/flatbuffer/types.fbs
@@ -27,6 +27,11 @@ enum FabricConfig: uint32 {
   CUSTOM,
 }
 
+enum MemoryLogLevel: uint32 (bit_flags) {
+  Program,
+  Operation,
+}
+
 table MeshDeviceOptions {
   mesh_offset: [uint32];
   device_ids: [int];

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -30,6 +30,7 @@ uint32_t getNumShards(Tensor tensor);
 
 void setMlirHome(std::string_view mlirHome);
 void setMetalHome(std::string_view metalHome);
+void setMemoryLogLevel(const MemoryLogLevel &logLevel);
 
 std::vector<DeviceRuntime> getAvailableDeviceRuntimes();
 DeviceRuntime getCurrentDeviceRuntime();

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -12,8 +12,6 @@
 #include <optional>
 #include <vector>
 
-#include "tt/runtime/utils.h"
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #include "ttmlir/Target/Common/debug_info_generated.h"
@@ -29,6 +27,7 @@ using ::tt::runtime::flatbuffer::DeviceRuntime;
 using ::tt::runtime::flatbuffer::DispatchCoreType;
 using ::tt::runtime::flatbuffer::FabricConfig;
 using ::tt::runtime::flatbuffer::HostRuntime;
+using ::tt::runtime::flatbuffer::MemoryLogLevel;
 
 /*
 MemoryBlockTable is a list of memory blocks in the following format:
@@ -180,14 +179,9 @@ struct TensorDesc {
              const ::tt::target::DataType dataType,
              const std::optional<uint32_t> itemsize = {},
              const std::optional<std::vector<uint32_t>> &stride = {},
-             const std::optional<uint64_t> physicalVolume = {})
-      : shape(shape), dataType(dataType) {
-    this->itemsize = itemsize.value_or(utils::dataTypeElementSize(dataType));
-    this->stride = stride.value_or(utils::calculateStride(shape));
-    this->physicalVolume = physicalVolume.value_or(volume());
-  }
+             const std::optional<uint64_t> physicalVolume = {});
 
-  size_t volume() const { return utils::product(shape.cbegin(), shape.cend()); }
+  size_t volume() const;
 
   size_t sizeBytes() const { return physicalVolume * itemsize; }
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -16,6 +16,7 @@
 #pragma clang diagnostic pop
 
 #include "tt/runtime/flatbuffer/flatbuffer.h"
+#include "tt/runtime/types.h"
 
 namespace tt::runtime::utils {
 
@@ -173,6 +174,12 @@ bool isSupportedDataType(::tt::target::DataType dataType);
 
 ::tt::target::DataType
 getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType);
+
+void logMemoryStateIfNeeded(
+    const std::unordered_map<tt::runtime::MemoryBufferType,
+                             tt::runtime::MemoryView> &memoryState,
+    ::tt::runtime::MemoryLogLevel level = ::tt::runtime::MemoryLogLevel::ANY,
+    std::string_view prefix = "");
 
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 inline std::vector<uint32_t> calculateStride(const std::vector<T> &shape) {

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -77,22 +77,6 @@ std::string Stats::toString() const {
   return oss.str();
 }
 
-void logMemoryState(
-    const std::unordered_map<tt::runtime::MemoryBufferType,
-                             tt::runtime::MemoryView> &memoryState,
-    std::string_view prefix) {
-  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
-      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
-      tt::runtime::MemoryBufferType::L1_SMALL,
-      tt::runtime::MemoryBufferType::TRACE};
-
-  LOG_DEBUG(prefix);
-  for (const auto &memoryType : MEMORY_TYPES) {
-    LOG_DEBUG("Device ", toString(memoryType),
-              " memory state: ", memoryState.at(memoryType).toString());
-  }
-}
-
 } // namespace tt::runtime::debug
 
 #endif

--- a/runtime/lib/common/runtime_context.cpp
+++ b/runtime/lib/common/runtime_context.cpp
@@ -84,4 +84,11 @@ void RuntimeContext::setCurrentFabricConfig(
   currentFabricConfig_.store(config, std::memory_order_relaxed);
 }
 
+MemoryLogLevel RuntimeContext::getMemoryLogLevel() const {
+  return memoryLogLevel_.load(std::memory_order_relaxed);
+}
+
+void RuntimeContext::setMemoryLogLevel(const MemoryLogLevel &logLevel) {
+  memoryLogLevel_.store(logLevel, std::memory_order_relaxed);
+}
 } // namespace tt::runtime

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -5,12 +5,28 @@
 #include "tt/runtime/types.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
+#include "tt/runtime/utils.h"
 
 #include <atomic>
 #include <iomanip>
 #include <sstream>
 
 namespace tt::runtime {
+
+TensorDesc::TensorDesc(const std::vector<uint32_t> &shape,
+                       const ::tt::target::DataType dataType,
+                       const std::optional<uint32_t> itemsize,
+                       const std::optional<std::vector<uint32_t>> &stride,
+                       const std::optional<uint64_t> physicalVolume)
+    : shape(shape), dataType(dataType) {
+  this->itemsize = itemsize.value_or(utils::dataTypeElementSize(dataType));
+  this->stride = stride.value_or(utils::calculateStride(shape));
+  this->physicalVolume = physicalVolume.value_or(volume());
+}
+
+size_t TensorDesc::volume() const {
+  return utils::product(shape.cbegin(), shape.cend());
+}
 
 std::string MemoryView::toString() const {
   constexpr size_t MB = 1024 * 1024;

--- a/runtime/lib/common/utils.cpp
+++ b/runtime/lib/common/utils.cpp
@@ -4,6 +4,7 @@
 
 #include "tt/runtime/utils.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/types.h"
 
 namespace tt::runtime::utils {
@@ -306,6 +307,32 @@ void handleBufferCast(const void *oldBuffer, void *newBuffer,
         "Unhandled buffer cast case: From " +
         std::string(target::EnumNameDataType(oldDataType)) + " to " +
         std::string(target::EnumNameDataType(newDataType)));
+  }
+}
+
+void logMemoryStateIfNeeded(
+    const std::unordered_map<tt::runtime::MemoryBufferType,
+                             tt::runtime::MemoryView> &memoryState,
+    ::tt::runtime::MemoryLogLevel level, std::string_view prefix) {
+  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
+      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
+      tt::runtime::MemoryBufferType::L1_SMALL,
+      tt::runtime::MemoryBufferType::TRACE};
+
+  ::tt::runtime::MemoryLogLevel currentLogLevel =
+      ::tt::runtime::RuntimeContext::instance().getMemoryLogLevel();
+
+  if (!(currentLogLevel & level)) {
+    return;
+  }
+
+  if (!prefix.empty()) {
+    LOG_INFO(prefix);
+  }
+
+  for (const auto &memoryType : MEMORY_TYPES) {
+    LOG_INFO("Device ", toString(memoryType),
+             " memory state: ", memoryState.at(memoryType).toString());
   }
 }
 

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -7,7 +7,9 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/types.h"
+
 #include <atomic>
+#include <numeric>
 
 #define BUILD_COMMAND_IMPL(CommandName, fbb, builderFunc, ...)                 \
   [&]() -> uint64_t {                                                          \
@@ -46,16 +48,28 @@ static uint64_t nextCommandId() {
   return commandIdCounter.fetch_add(1, std::memory_order_relaxed);
 }
 
-uint64_t CommandFactory::buildConfigureRuntimeContextCommand(
-    ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
-    const std::string &metalHome,
-    const ::tt::runtime::DeviceRuntime &currentDeviceRuntime) {
+uint64_t CommandFactory::buildSetMemoryLogLevelCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId =
-      BUILD_COMMAND_DIRECT(ConfigureRuntimeContext, fbb, mlirHome.c_str(),
-                           metalHome.c_str(), currentDeviceRuntime);
+  uint64_t commandId = BUILD_COMMAND(SetMemoryLogLevel, fbb, memoryLogLevel);
+
+  return commandId;
+}
+
+uint64_t CommandFactory::buildConfigureRuntimeContextCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
+    const std::string &metalHome,
+    const ::tt::runtime::DeviceRuntime &currentDeviceRuntime,
+    const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId = BUILD_COMMAND_DIRECT(
+      ConfigureRuntimeContext, fbb, mlirHome.c_str(), metalHome.c_str(),
+      currentDeviceRuntime, memoryLogLevel);
 
   return commandId;
 }

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -59,6 +59,11 @@ void shutdownDistributedRuntime() {
   ControllerSingleton::shutdown();
 }
 
+void setMemoryLogLevel(const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
+  assertControllerLaunched();
+  ControllerSingleton::get().setMemoryLogLevel(memoryLogLevel);
+}
+
 SystemDesc getCurrentSystemDesc(
     std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType,
     std::optional<::tt::runtime::Device> deviceHandle) {

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -121,10 +121,23 @@ void CommandExecutor::execute(
       command->metal_home()->c_str());
   ::tt::runtime::RuntimeContext::instance().setCurrentDeviceRuntime(
       command->current_device_runtime());
+  ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
+      command->memory_log_level());
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
       buildResponse(ResponseFactory::buildConfigureRuntimeContextResponse,
                     commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::SetMemoryLogLevelCommand *command) {
+  ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
+      command->memory_log_level());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildSetMemoryLogLevelResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -632,6 +645,10 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
   case fb::CommandType::ConfigureRuntimeContextCommand: {
     return execute(command->command_id(),
                    command->type_as_ConfigureRuntimeContextCommand());
+  }
+  case fb::CommandType::SetMemoryLogLevelCommand: {
+    return execute(command->command_id(),
+                   command->type_as_SetMemoryLogLevelCommand());
   }
   case fb::CommandType::GetSystemDescCommand: {
     return execute(command->command_id(),

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -48,6 +48,14 @@ void ResponseFactory::buildErrorResponse(::flatbuffers::FlatBufferBuilder &fbb,
   BUILD_RESPONSE_DIRECT(Error, fbb, commandId, errorMessage.c_str());
 }
 
+void ResponseFactory::buildSetMemoryLogLevelResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(SetMemoryLogLevel, fbb, commandId);
+}
+
 void ResponseFactory::buildConfigureRuntimeContextResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -126,6 +126,23 @@ void setMetalHome(std::string_view metalHome) {
   LOG_FATAL("runtime is not enabled");
 }
 
+void setMemoryLogLevel(const MemoryLogLevel &logLevel) {
+  using RetType = void;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
+            logLevel);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
+            logLevel);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::distributed::setMemoryLogLevel(logLevel);
+      });
+}
+
 std::vector<DeviceRuntime> getAvailableDeviceRuntimes() {
   std::vector<DeviceRuntime> runtimes;
 #if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -165,6 +165,13 @@ std::vector<::tt::runtime::Tensor> ProgramExecutor::gatherOutputTensors() {
 }
 
 void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
+
+  ::tt::runtime::utils::logMemoryStateIfNeeded(
+      utils::getMemoryView(getContext().getDeviceHandle()),
+      ::tt::runtime::MemoryLogLevel::Operation,
+      std::string("Device memory state before operation ") +
+          ::tt::target::ttnn::EnumNameOpType(op->type_type()));
+
   switch (op->type_type()) {
   case ::tt::target::ttnn::OpType::GetDeviceOp: {
     return operations::context::run(op->type_as_GetDeviceOp(), getContext());

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -6,6 +6,7 @@
 
 #include "tt/runtime/detail/common/common.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/types/program_desc_cache.h"
 #include "tt/runtime/detail/ttnn/types/trace_cache.h"
@@ -18,6 +19,19 @@
 namespace tt::runtime::ttnn::utils {
 
 using ::tt::runtime::DeviceRuntime;
+
+static tt::runtime::MemoryView
+createMemoryView(const tt::tt_metal::detail::MemoryView &memoryView) {
+  return tt::runtime::MemoryView{
+      .numBanks = memoryView.num_banks,
+      .totalBytesPerBank = memoryView.total_bytes_per_bank,
+      .totalBytesAllocatedPerBank = memoryView.total_bytes_allocated_per_bank,
+      .totalBytesFreePerBank = memoryView.total_bytes_free_per_bank,
+      .largestContiguousBytesFreePerBank =
+          memoryView.largest_contiguous_bytes_free_per_bank,
+      .blockTable = memoryView.block_table,
+  };
+}
 
 // TODO (bug #701)
 // Currently the memory layout/location in flatbuffer is incorrect
@@ -507,6 +521,12 @@ std::vector<const tt::target::ttnn::TensorRef *> convertFbTensorRefsToVector(
   return stdVector;
 }
 
+void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
+  ::tt::tt_metal::HostBuffer hostBuffer =
+      ::tt::tt_metal::host_buffer::get_host_buffer(tensor);
+  return static_cast<void *>(hostBuffer.view_bytes().data());
+}
+
 ::ttnn::TensorSpec createTensorSpec(const ::ttnn::Shape &shape,
                                     const ::ttnn::DataType &dataType,
                                     const ::ttnn::Layout &layout,
@@ -516,10 +536,31 @@ std::vector<const tt::target::ttnn::TensorRef *> convertFbTensorRefsToVector(
   return tensorSpec;
 }
 
-void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
-  ::tt::tt_metal::HostBuffer hostBuffer =
-      ::tt::tt_metal::host_buffer::get_host_buffer(tensor);
-  return static_cast<void *>(hostBuffer.view_bytes().data());
+std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
+getMemoryView(Device deviceHandle) {
+  std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
+      memoryMap;
+  ::ttnn::MeshDevice &meshDevice =
+      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+
+  auto dramMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::DRAM);
+  auto l1MemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::L1);
+  auto l1SmallMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::L1_SMALL);
+  auto traceMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::TRACE);
+
+  memoryMap[tt::runtime::MemoryBufferType::DRAM] =
+      createMemoryView(dramMemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::L1] = createMemoryView(l1MemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::L1_SMALL] =
+      createMemoryView(l1SmallMemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::TRACE] =
+      createMemoryView(traceMemoryView);
+
+  return memoryMap;
 }
 
 } // namespace tt::runtime::ttnn::utils

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -292,10 +292,18 @@ void registerRuntimeBindings(nb::module_ &m) {
       .value("WORMHOLE_B0", ::tt::target::Arch::Wormhole_b0)
       .value("BLACKHOLE", ::tt::target::Arch::Blackhole);
 
+  nb::enum_<::tt::runtime::MemoryLogLevel>(m, "MemoryLogLevel", nb::is_flag())
+      .value("NONE", ::tt::runtime::MemoryLogLevel::NONE)
+      .value("PROGRAM", ::tt::runtime::MemoryLogLevel::Program)
+      .value("OPERATION", ::tt::runtime::MemoryLogLevel::Operation)
+      .value("ANY", ::tt::runtime::MemoryLogLevel::ANY);
+
   m.def("set_mlir_home", &tt::runtime::setMlirHome, nb::arg("mlir_home"),
         "Set the MLIR home directory");
   m.def("set_metal_home", &tt::runtime::setMetalHome, nb::arg("metal_home"),
         "Set the Metal home directory");
+  m.def("set_memory_log_level", &tt::runtime::setMemoryLogLevel,
+        nb::arg("log_level"), "Set the memory log level");
   m.def("get_current_device_runtime", &tt::runtime::getCurrentDeviceRuntime,
         "Get the backend device runtime type");
   m.def("get_available_device_runtimes",
@@ -642,8 +650,5 @@ void registerRuntimeBindings(nb::module_ &m) {
 
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
-
-  m.def("log_memory_state", &::tt::runtime::debug::logMemoryState,
-        nb::arg("memory_state"), nb::arg("prefix") = "");
 }
 } // namespace tt::runtime::python

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -14,6 +14,7 @@ try:
         DeviceRuntime,
         HostRuntime,
         DispatchCoreType,
+        MemoryLogLevel,
         DebugEnv,
         PerfEnv,
         DebugHooks,
@@ -24,6 +25,7 @@ try:
         DistributedMode,
         set_mlir_home,
         set_metal_home,
+        set_memory_log_level,
         get_current_device_runtime,
         set_current_device_runtime,
         set_compatible_device_runtime,
@@ -60,7 +62,6 @@ try:
         WorkaroundEnv,
         get_op_loc_info,
         unregister_hooks,
-        log_memory_state,
         FabricConfig,
     )
 except ModuleNotFoundError:


### PR DESCRIPTION
### Problem description
Currently the only memory debug logs are on the program level #5967, we want to support more comprehensive logging.

### What's changed
Added `MemoryLogLevel` bit flag that describes the memory logging level, and runtime API `setMemoryLogLevel` to configure the logging level. Currently there are 2 levels:
* Program: This will log at the beginning and end of program execution. Useful for debugging memory footprint across program runs.
* Operation: This will log at the beginning of each operation within the program. Useful for debugging memory footprint within a program run, e.g. OOM errors.

### Checklist
- [X] New/Existing tests provide coverage for changes
