### PR TITLE
[ttnn.jit] Add Tests for Mixed Legacy Sharding Types

### DIFF
--- a/test/ttnn-jit/test_mixed_legacy_sharding_types.py
+++ b/test/ttnn-jit/test_mixed_legacy_sharding_types.py
@@ -16,9 +16,6 @@ from utils import (
     run_op_test,
 )
 
-# WIthout support for JIT'ed binary ops with inputs with differing sharding grids,
-# much of the testing here should be expected to fail. The trivial case is when
-# max_grid = (0, 0) for both inputs ->
 HEIGHT_WIDTH_SHARDED_SHAPE_GRIDS = [
     ((32, 32), (0, 0)),
     ((32, 64), (0, 0)),


### PR DESCRIPTION
### Ticket
#6023 [ttnn.jit] Test mixing legacy sharding types

### Problem description
Add tests for JIT'ed binary ops with operands with mixed legacy sharding types. Ex. `ttnn.add(A, B)` where A is height sharded and B is block sharded.

### What's changed
Added test file `test_mixed_legacy_sharding_types.py` in `test/ttnn-jit/`.
There are 3 cases for mixed inputs which are tested here: 

- Height Sharded and Width Sharded Operands
- Height Sharded and Block Sharded Operands
- Width Sharded and Block Sharded Operands

Test coverage includes tensors of different rank, dtype, and tests on graph capture / ast. 

### Checklist
- [x] New/Existing tests provide coverage for changes
