### PR TITLE
Fixing creation of bfloat16 tensors in ttnn runtime

### DIFF
--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -363,7 +363,8 @@ static ::ttnn::Tensor toTTNNTensorImpl(
   std::vector<T> dataVec(numElements);
   for (size_t i = 0; i < numElements; i++) {
     if constexpr (std::is_same_v<T, bfloat16>) {
-      uint16_t raw = ::flatbuffers::IndirectHelper<uint16_t>::Read(input->data(), i);
+      uint16_t raw =
+          ::flatbuffers::IndirectHelper<uint16_t>::Read(input->data(), i);
       dataVec[i] = std::bit_cast<bfloat16>(raw);
     } else {
       dataVec[i] = ::flatbuffers::IndirectHelper<T>::Read(input->data(), i);


### PR DESCRIPTION
This PR fixes the creation of bfloat16 tesnors from flatbuffer values.

The original code used the bfloat16 constructor to create values from the raw uint16_t data read from the flatbuffer. The constructor interprets the uint16_t as a numeric value to convert to bfloat16 format. However, the flatbuffer data already contains the raw bit representation of the bfloat16 value, leading to incorrect results. The PR now changes this logic to a  direct bitwise reinterpretation without any numeric conversion, which means that the uint16_t representation of the bfloat16 will now be correct.