### PR TITLE
Revert "Add memory log level and memory logs correspondingly (#6037)"

### DIFF
--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -182,6 +182,17 @@ void verifyFlatbuffer(const ::flatbuffers::FlatBufferBuilder &fbb,
 #endif
 }
 
+RUNTIME_DEBUG_MAYBE_INLINE void
+logMemoryState(const std::unordered_map<tt::runtime::MemoryBufferType,
+                                        tt::runtime::MemoryView> &memoryState,
+               std::string_view prefix = "")
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    ;
+#else
+{
+}
+#endif
+
 #undef RUNTIME_DEBUG_MAYBE_INLINE
 
 } // namespace tt::runtime::debug

--- a/runtime/include/tt/runtime/detail/common/runtime_context.h
+++ b/runtime/include/tt/runtime/detail/common/runtime_context.h
@@ -36,9 +36,6 @@ public:
   ::tt::runtime::FabricConfig getCurrentFabricConfig() const;
   void setCurrentFabricConfig(const tt::runtime::FabricConfig &config);
 
-  MemoryLogLevel getMemoryLogLevel() const;
-  void setMemoryLogLevel(const MemoryLogLevel &logLevel);
-
 private:
   RuntimeContext();
   ~RuntimeContext() = default;
@@ -50,7 +47,6 @@ private:
   std::atomic<HostRuntime> currentHostRuntime_ = HostRuntime::Local;
   std::atomic<tt::runtime::FabricConfig> currentFabricConfig_ =
       tt::runtime::FabricConfig::DISABLED;
-  std::atomic<MemoryLogLevel> memoryLogLevel_ = MemoryLogLevel::NONE;
 };
 
 } // namespace tt::runtime

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -14,15 +14,10 @@ namespace tt::runtime::distributed::controller {
 
 class CommandFactory {
 public:
-  static uint64_t buildSetMemoryLogLevelCommand(
-      ::flatbuffers::FlatBufferBuilder &fbb,
-      const ::tt::runtime::MemoryLogLevel &memoryLogLevel);
-
   static uint64_t buildConfigureRuntimeContextCommand(
       ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
       const std::string &metalHome,
-      const ::tt::runtime::DeviceRuntime &currentDeviceRuntime,
-      const ::tt::runtime::MemoryLogLevel &memoryLogLevel);
+      const ::tt::runtime::DeviceRuntime &currentDeviceRuntime);
 
   static uint64_t buildGetSystemDescCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -86,8 +86,6 @@ public:
   void setWorkerShutdownTimeout(const std::chrono::seconds &timeout);
 
   // Runtime APIs
-  void setMemoryLogLevel(const MemoryLogLevel &logLevel);
-
   SystemDesc getCurrentSystemDesc(
       std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
           std::nullopt,
@@ -200,10 +198,6 @@ private:
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 
   void handleConfigureRuntimeContextResponse(
-      const std::vector<SizedBuffer> &responseBuffers,
-      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
-
-  void handleSetMemoryLogLevelResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -12,8 +12,6 @@ namespace tt::runtime::distributed {
 void launchDistributedRuntime(const DistributedOptions &options = {});
 void shutdownDistributedRuntime();
 
-void setMemoryLogLevel(const MemoryLogLevel &logLevel);
-
 SystemDesc getCurrentSystemDesc(
     std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
         std::nullopt,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -13,11 +13,6 @@ table ConfigureRuntimeContextCommand {
   mlir_home: string;
   metal_home: string;
   current_device_runtime: tt.runtime.flatbuffer.DeviceRuntime;
-  memory_log_level: tt.runtime.flatbuffer.MemoryLogLevel;
-}
-
-table SetMemoryLogLevelCommand {
-  memory_log_level: tt.runtime.flatbuffer.MemoryLogLevel;
 }
 
 table GetSystemDescCommand {
@@ -147,7 +142,6 @@ table ShutdownCommand {
 
 union CommandType {
   ConfigureRuntimeContextCommand,
-  SetMemoryLogLevelCommand,
   GetSystemDescCommand,
   SetFabricConfigCommand,
   GetNumAvailableDevicesCommand,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -13,9 +13,6 @@ table ErrorResponse {
 table ConfigureRuntimeContextResponse {
 }
 
-table SetMemoryLogLevelResponse {
-}
-
 table GetSystemDescResponse {
   system_desc: [ubyte]; // size-prefixed SystemDescRoot buffer
 }
@@ -95,7 +92,6 @@ table ShutdownResponse {
 union ResponseType {
   ErrorResponse,
   ConfigureRuntimeContextResponse,
-  SetMemoryLogLevelResponse,
   GetSystemDescResponse,
   SetFabricConfigResponse,
   GetNumAvailableDevicesResponse,

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -66,11 +66,6 @@ private:
 
   void
   execute(uint64_t commandId,
-          const ::tt::runtime::distributed::flatbuffer::SetMemoryLogLevelCommand
-              *command);
-
-  void
-  execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::SetFabricConfigCommand
               *command);
 

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -18,10 +18,6 @@ public:
                                  const std::string &errorMessage);
 
   static void
-  buildSetMemoryLogLevelResponse(::flatbuffers::FlatBufferBuilder &fbb,
-                                 uint64_t commandId);
-
-  static void
   buildConfigureRuntimeContextResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                        uint64_t commandId);
 

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -133,9 +133,6 @@ void *getRawHostDataPtr(const ::ttnn::Tensor &tensor);
     const ::ttnn::Layout &layout = ::ttnn::Layout::ROW_MAJOR,
     const ::ttnn::MemoryConfig &memoryConfig = ::ttnn::DRAM_MEMORY_CONFIG);
 
-std::unordered_map<::tt::runtime::MemoryBufferType, ::tt::runtime::MemoryView>
-getMemoryView(Device deviceHandle);
-
 template <typename T>
 inline ::ttnn::Tensor createTTNNTensor(
     const void *rawData, const ::ttnn::Shape &shape,

--- a/runtime/include/tt/runtime/flatbuffer/types.fbs
+++ b/runtime/include/tt/runtime/flatbuffer/types.fbs
@@ -27,11 +27,6 @@ enum FabricConfig: uint32 {
   CUSTOM,
 }
 
-enum MemoryLogLevel: uint32 (bit_flags) {
-  Program,
-  Operation,
-}
-
 table MeshDeviceOptions {
   mesh_offset: [uint32];
   device_ids: [int];

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -30,7 +30,6 @@ uint32_t getNumShards(Tensor tensor);
 
 void setMlirHome(std::string_view mlirHome);
 void setMetalHome(std::string_view metalHome);
-void setMemoryLogLevel(const MemoryLogLevel &logLevel);
 
 std::vector<DeviceRuntime> getAvailableDeviceRuntimes();
 DeviceRuntime getCurrentDeviceRuntime();

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -12,6 +12,8 @@
 #include <optional>
 #include <vector>
 
+#include "tt/runtime/utils.h"
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #include "ttmlir/Target/Common/debug_info_generated.h"
@@ -27,7 +29,6 @@ using ::tt::runtime::flatbuffer::DeviceRuntime;
 using ::tt::runtime::flatbuffer::DispatchCoreType;
 using ::tt::runtime::flatbuffer::FabricConfig;
 using ::tt::runtime::flatbuffer::HostRuntime;
-using ::tt::runtime::flatbuffer::MemoryLogLevel;
 
 /*
 MemoryBlockTable is a list of memory blocks in the following format:
@@ -179,9 +180,14 @@ struct TensorDesc {
              const ::tt::target::DataType dataType,
              const std::optional<uint32_t> itemsize = {},
              const std::optional<std::vector<uint32_t>> &stride = {},
-             const std::optional<uint64_t> physicalVolume = {});
+             const std::optional<uint64_t> physicalVolume = {})
+      : shape(shape), dataType(dataType) {
+    this->itemsize = itemsize.value_or(utils::dataTypeElementSize(dataType));
+    this->stride = stride.value_or(utils::calculateStride(shape));
+    this->physicalVolume = physicalVolume.value_or(volume());
+  }
 
-  size_t volume() const;
+  size_t volume() const { return utils::product(shape.cbegin(), shape.cend()); }
 
   size_t sizeBytes() const { return physicalVolume * itemsize; }
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -16,7 +16,6 @@
 #pragma clang diagnostic pop
 
 #include "tt/runtime/flatbuffer/flatbuffer.h"
-#include "tt/runtime/types.h"
 
 namespace tt::runtime::utils {
 
@@ -174,12 +173,6 @@ bool isSupportedDataType(::tt::target::DataType dataType);
 
 ::tt::target::DataType
 getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType);
-
-void logMemoryStateIfNeeded(
-    const std::unordered_map<tt::runtime::MemoryBufferType,
-                             tt::runtime::MemoryView> &memoryState,
-    ::tt::runtime::MemoryLogLevel level = ::tt::runtime::MemoryLogLevel::ANY,
-    std::string_view prefix = "");
 
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 inline std::vector<uint32_t> calculateStride(const std::vector<T> &shape) {

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -77,6 +77,22 @@ std::string Stats::toString() const {
   return oss.str();
 }
 
+void logMemoryState(
+    const std::unordered_map<tt::runtime::MemoryBufferType,
+                             tt::runtime::MemoryView> &memoryState,
+    std::string_view prefix) {
+  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
+      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
+      tt::runtime::MemoryBufferType::L1_SMALL,
+      tt::runtime::MemoryBufferType::TRACE};
+
+  LOG_DEBUG(prefix);
+  for (const auto &memoryType : MEMORY_TYPES) {
+    LOG_DEBUG("Device ", toString(memoryType),
+              " memory state: ", memoryState.at(memoryType).toString());
+  }
+}
+
 } // namespace tt::runtime::debug
 
 #endif

--- a/runtime/lib/common/runtime_context.cpp
+++ b/runtime/lib/common/runtime_context.cpp
@@ -84,11 +84,4 @@ void RuntimeContext::setCurrentFabricConfig(
   currentFabricConfig_.store(config, std::memory_order_relaxed);
 }
 
-MemoryLogLevel RuntimeContext::getMemoryLogLevel() const {
-  return memoryLogLevel_.load(std::memory_order_relaxed);
-}
-
-void RuntimeContext::setMemoryLogLevel(const MemoryLogLevel &logLevel) {
-  memoryLogLevel_.store(logLevel, std::memory_order_relaxed);
-}
 } // namespace tt::runtime

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -5,28 +5,12 @@
 #include "tt/runtime/types.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
-#include "tt/runtime/utils.h"
 
 #include <atomic>
 #include <iomanip>
 #include <sstream>
 
 namespace tt::runtime {
-
-TensorDesc::TensorDesc(const std::vector<uint32_t> &shape,
-                       const ::tt::target::DataType dataType,
-                       const std::optional<uint32_t> itemsize,
-                       const std::optional<std::vector<uint32_t>> &stride,
-                       const std::optional<uint64_t> physicalVolume)
-    : shape(shape), dataType(dataType) {
-  this->itemsize = itemsize.value_or(utils::dataTypeElementSize(dataType));
-  this->stride = stride.value_or(utils::calculateStride(shape));
-  this->physicalVolume = physicalVolume.value_or(volume());
-}
-
-size_t TensorDesc::volume() const {
-  return utils::product(shape.cbegin(), shape.cend());
-}
 
 std::string MemoryView::toString() const {
   constexpr size_t MB = 1024 * 1024;

--- a/runtime/lib/common/utils.cpp
+++ b/runtime/lib/common/utils.cpp
@@ -4,7 +4,6 @@
 
 #include "tt/runtime/utils.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/types.h"
 
 namespace tt::runtime::utils {
@@ -307,32 +306,6 @@ void handleBufferCast(const void *oldBuffer, void *newBuffer,
         "Unhandled buffer cast case: From " +
         std::string(target::EnumNameDataType(oldDataType)) + " to " +
         std::string(target::EnumNameDataType(newDataType)));
-  }
-}
-
-void logMemoryStateIfNeeded(
-    const std::unordered_map<tt::runtime::MemoryBufferType,
-                             tt::runtime::MemoryView> &memoryState,
-    ::tt::runtime::MemoryLogLevel level, std::string_view prefix) {
-  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
-      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
-      tt::runtime::MemoryBufferType::L1_SMALL,
-      tt::runtime::MemoryBufferType::TRACE};
-
-  ::tt::runtime::MemoryLogLevel currentLogLevel =
-      ::tt::runtime::RuntimeContext::instance().getMemoryLogLevel();
-
-  if (!(currentLogLevel & level)) {
-    return;
-  }
-
-  if (!prefix.empty()) {
-    LOG_INFO(prefix);
-  }
-
-  for (const auto &memoryType : MEMORY_TYPES) {
-    LOG_INFO("Device ", toString(memoryType),
-             " memory state: ", memoryState.at(memoryType).toString());
   }
 }
 

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -7,9 +7,7 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/types.h"
-
 #include <atomic>
-#include <numeric>
 
 #define BUILD_COMMAND_IMPL(CommandName, fbb, builderFunc, ...)                 \
   [&]() -> uint64_t {                                                          \
@@ -48,28 +46,16 @@ static uint64_t nextCommandId() {
   return commandIdCounter.fetch_add(1, std::memory_order_relaxed);
 }
 
-uint64_t CommandFactory::buildSetMemoryLogLevelCommand(
-    ::flatbuffers::FlatBufferBuilder &fbb,
-    const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
-
-  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
-
-  uint64_t commandId = BUILD_COMMAND(SetMemoryLogLevel, fbb, memoryLogLevel);
-
-  return commandId;
-}
-
 uint64_t CommandFactory::buildConfigureRuntimeContextCommand(
     ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
     const std::string &metalHome,
-    const ::tt::runtime::DeviceRuntime &currentDeviceRuntime,
-    const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
+    const ::tt::runtime::DeviceRuntime &currentDeviceRuntime) {
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = BUILD_COMMAND_DIRECT(
-      ConfigureRuntimeContext, fbb, mlirHome.c_str(), metalHome.c_str(),
-      currentDeviceRuntime, memoryLogLevel);
+  uint64_t commandId =
+      BUILD_COMMAND_DIRECT(ConfigureRuntimeContext, fbb, mlirHome.c_str(),
+                           metalHome.c_str(), currentDeviceRuntime);
 
   return commandId;
 }

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -10,7 +10,6 @@
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/detail/distributed/utils/utils.h"
 #include "tt/runtime/runtime.h"
-#include "tt/runtime/utils.h"
 namespace tt::runtime::distributed::controller {
 
 namespace fb = ::tt::runtime::distributed::flatbuffer;
@@ -227,18 +226,6 @@ void Controller::setReadTimeout(const std::chrono::seconds &timeout) {
 
 void Controller::setWorkerShutdownTimeout(const std::chrono::seconds &timeout) {
   workerShutdownTimeout_ = timeout;
-}
-
-void Controller::setMemoryLogLevel(const MemoryLogLevel &logLevel) {
-
-  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
-
-  uint64_t commandId =
-      CommandFactory::buildSetMemoryLogLevelCommand(*commandBuilder, logLevel);
-
-  pushToCommandAndResponseQueues(commandId,
-                                 fb::CommandType::SetMemoryLogLevelCommand,
-                                 std::move(commandBuilder));
 }
 
 SystemDesc Controller::getCurrentSystemDesc(
@@ -808,8 +795,7 @@ void Controller::configureRuntimeContext() {
   auto commandId = CommandFactory::buildConfigureRuntimeContextCommand(
       *commandBuilder, ::tt::runtime::RuntimeContext::instance().getMlirHome(),
       ::tt::runtime::RuntimeContext::instance().getMetalHome(),
-      ::tt::runtime::RuntimeContext::instance().getCurrentDeviceRuntime(),
-      ::tt::runtime::RuntimeContext::instance().getMemoryLogLevel());
+      ::tt::runtime::RuntimeContext::instance().getCurrentDeviceRuntime());
 
   auto awaitingPromise = std::make_unique<std::promise<void>>();
   std::future<void> awaitingFuture = awaitingPromise->get_future();
@@ -861,18 +847,6 @@ void Controller::handleConfigureRuntimeContextResponse(
   DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
 
   awaitingPromise->set_value();
-}
-
-void Controller::handleSetMemoryLogLevelResponse(
-    const std::vector<SizedBuffer> &responseBuffers,
-    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
-
-  debug::checkResponsesIdentical(responseBuffers);
-
-  debug::checkResponseTypes(responseBuffers,
-                            fb::ResponseType::SetMemoryLogLevelResponse);
-
-  debug::assertNoAwaitingState(*awaitingResponse, "SetMemoryLogLevel");
 }
 
 void Controller::handleGetSystemDescResponse(
@@ -1303,10 +1277,6 @@ void Controller::handleResponse(
   case fb::CommandType::ConfigureRuntimeContextCommand: {
     return handleConfigureRuntimeContextResponse(responseBuffers,
                                                  std::move(awaitingResponse));
-  }
-  case fb::CommandType::SetMemoryLogLevelCommand: {
-    return handleSetMemoryLogLevelResponse(responseBuffers,
-                                           std::move(awaitingResponse));
   }
   case fb::CommandType::GetSystemDescCommand: {
     return handleGetSystemDescResponse(responseBuffers,

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -59,11 +59,6 @@ void shutdownDistributedRuntime() {
   ControllerSingleton::shutdown();
 }
 
-void setMemoryLogLevel(const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
-  assertControllerLaunched();
-  ControllerSingleton::get().setMemoryLogLevel(memoryLogLevel);
-}
-
 SystemDesc getCurrentSystemDesc(
     std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType,
     std::optional<::tt::runtime::Device> deviceHandle) {

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -121,23 +121,10 @@ void CommandExecutor::execute(
       command->metal_home()->c_str());
   ::tt::runtime::RuntimeContext::instance().setCurrentDeviceRuntime(
       command->current_device_runtime());
-  ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
-      command->memory_log_level());
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
       buildResponse(ResponseFactory::buildConfigureRuntimeContextResponse,
                     commandId);
-
-  responseQueue_.push(std::move(responseBuilder));
-}
-
-void CommandExecutor::execute(uint64_t commandId,
-                              const fb::SetMemoryLogLevelCommand *command) {
-  ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
-      command->memory_log_level());
-
-  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
-      buildResponse(ResponseFactory::buildSetMemoryLogLevelResponse, commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -645,10 +632,6 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
   case fb::CommandType::ConfigureRuntimeContextCommand: {
     return execute(command->command_id(),
                    command->type_as_ConfigureRuntimeContextCommand());
-  }
-  case fb::CommandType::SetMemoryLogLevelCommand: {
-    return execute(command->command_id(),
-                   command->type_as_SetMemoryLogLevelCommand());
   }
   case fb::CommandType::GetSystemDescCommand: {
     return execute(command->command_id(),

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -48,14 +48,6 @@ void ResponseFactory::buildErrorResponse(::flatbuffers::FlatBufferBuilder &fbb,
   BUILD_RESPONSE_DIRECT(Error, fbb, commandId, errorMessage.c_str());
 }
 
-void ResponseFactory::buildSetMemoryLogLevelResponse(
-    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
-
-  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
-
-  BUILD_RESPONSE(SetMemoryLogLevel, fbb, commandId);
-}
-
 void ResponseFactory::buildConfigureRuntimeContextResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -126,23 +126,6 @@ void setMetalHome(std::string_view metalHome) {
   LOG_FATAL("runtime is not enabled");
 }
 
-void setMemoryLogLevel(const MemoryLogLevel &logLevel) {
-  using RetType = void;
-  return DISPATCH_TO_CURRENT_RUNTIME(
-      RetType,
-      [&]() -> RetType {
-        return ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
-            logLevel);
-      },
-      [&]() -> RetType {
-        return ::tt::runtime::RuntimeContext::instance().setMemoryLogLevel(
-            logLevel);
-      },
-      [&]() -> RetType {
-        return ::tt::runtime::distributed::setMemoryLogLevel(logLevel);
-      });
-}
-
 std::vector<DeviceRuntime> getAvailableDeviceRuntimes() {
   std::vector<DeviceRuntime> runtimes;
 #if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -165,13 +165,6 @@ std::vector<::tt::runtime::Tensor> ProgramExecutor::gatherOutputTensors() {
 }
 
 void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
-
-  ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(getContext().getDeviceHandle()),
-      ::tt::runtime::MemoryLogLevel::Operation,
-      std::string("Device memory state before operation ") +
-          ::tt::target::ttnn::EnumNameOpType(op->type_type()));
-
   switch (op->type_type()) {
   case ::tt::target::ttnn::OpType::GetDeviceOp: {
     return operations::context::run(op->type_as_GetDeviceOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -38,6 +38,28 @@ namespace tt::runtime::ttnn {
 
 using ::tt::runtime::DeviceRuntime;
 
+namespace debug {
+static void logDeviceMemoryState(const Device &device,
+                                 std::string_view prefix) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  ::tt::runtime::debug::logMemoryState(getMemoryView(device), prefix);
+#endif
+}
+} // namespace debug
+
+static tt::runtime::MemoryView
+createMemoryView(const tt::tt_metal::detail::MemoryView &memoryView) {
+  return tt::runtime::MemoryView{
+      .numBanks = memoryView.num_banks,
+      .totalBytesPerBank = memoryView.total_bytes_per_bank,
+      .totalBytesAllocatedPerBank = memoryView.total_bytes_allocated_per_bank,
+      .totalBytesFreePerBank = memoryView.total_bytes_free_per_bank,
+      .largestContiguousBytesFreePerBank =
+          memoryView.largest_contiguous_bytes_free_per_bank,
+      .blockTable = memoryView.block_table,
+  };
+}
+
 template <typename T>
 static ::ttnn::Tensor createBorrowedTTNNTensor(void *rawData,
                                                const ::ttnn::Shape &shape) {
@@ -666,7 +688,29 @@ void readDeviceProfilerResults(Device deviceHandle) {
 
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device deviceHandle) {
-  return utils::getMemoryView(deviceHandle);
+  std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
+      memoryMap;
+  ::ttnn::MeshDevice &meshDevice =
+      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+
+  auto dramMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::DRAM);
+  auto l1MemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::L1);
+  auto l1SmallMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::L1_SMALL);
+  auto traceMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::TRACE);
+
+  memoryMap[tt::runtime::MemoryBufferType::DRAM] =
+      createMemoryView(dramMemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::L1] = createMemoryView(l1MemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::L1_SMALL] =
+      createMemoryView(l1SmallMemoryView);
+  memoryMap[tt::runtime::MemoryBufferType::TRACE] =
+      createMemoryView(traceMemoryView);
+
+  return memoryMap;
 }
 
 void setFabricConfig(tt::runtime::FabricConfig config) {
@@ -1699,10 +1743,8 @@ std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs) {
 
-  ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(deviceHandle),
-      ::tt::runtime::MemoryLogLevel::Program,
-      "Device memory state before submit");
+  debug::logDeviceMemoryState(deviceHandle,
+                              "Device memory state before submit");
 
   std::unique_ptr<ProgramExecutor> executor = std::make_unique<ProgramExecutor>(
       deviceHandle, executableHandle, programIndex, inputs);
@@ -1713,10 +1755,7 @@ submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
 
   executor.reset();
 
-  ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(deviceHandle),
-      ::tt::runtime::MemoryLogLevel::Program,
-      "Device memory state after submit");
+  debug::logDeviceMemoryState(deviceHandle, "Device memory state after submit");
 
   return outputTensors;
 }

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -6,7 +6,6 @@
 
 #include "tt/runtime/detail/common/common.h"
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/types/program_desc_cache.h"
 #include "tt/runtime/detail/ttnn/types/trace_cache.h"
@@ -19,19 +18,6 @@
 namespace tt::runtime::ttnn::utils {
 
 using ::tt::runtime::DeviceRuntime;
-
-static tt::runtime::MemoryView
-createMemoryView(const tt::tt_metal::detail::MemoryView &memoryView) {
-  return tt::runtime::MemoryView{
-      .numBanks = memoryView.num_banks,
-      .totalBytesPerBank = memoryView.total_bytes_per_bank,
-      .totalBytesAllocatedPerBank = memoryView.total_bytes_allocated_per_bank,
-      .totalBytesFreePerBank = memoryView.total_bytes_free_per_bank,
-      .largestContiguousBytesFreePerBank =
-          memoryView.largest_contiguous_bytes_free_per_bank,
-      .blockTable = memoryView.block_table,
-  };
-}
 
 // TODO (bug #701)
 // Currently the memory layout/location in flatbuffer is incorrect
@@ -521,12 +507,6 @@ std::vector<const tt::target::ttnn::TensorRef *> convertFbTensorRefsToVector(
   return stdVector;
 }
 
-void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
-  ::tt::tt_metal::HostBuffer hostBuffer =
-      ::tt::tt_metal::host_buffer::get_host_buffer(tensor);
-  return static_cast<void *>(hostBuffer.view_bytes().data());
-}
-
 ::ttnn::TensorSpec createTensorSpec(const ::ttnn::Shape &shape,
                                     const ::ttnn::DataType &dataType,
                                     const ::ttnn::Layout &layout,
@@ -536,31 +516,10 @@ void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
   return tensorSpec;
 }
 
-std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device deviceHandle) {
-  std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-      memoryMap;
-  ::ttnn::MeshDevice &meshDevice =
-      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
-
-  auto dramMemoryView = ::tt::tt_metal::detail::GetMemoryView(
-      &meshDevice, ::ttnn::BufferType::DRAM);
-  auto l1MemoryView = ::tt::tt_metal::detail::GetMemoryView(
-      &meshDevice, ::ttnn::BufferType::L1);
-  auto l1SmallMemoryView = ::tt::tt_metal::detail::GetMemoryView(
-      &meshDevice, ::ttnn::BufferType::L1_SMALL);
-  auto traceMemoryView = ::tt::tt_metal::detail::GetMemoryView(
-      &meshDevice, ::ttnn::BufferType::TRACE);
-
-  memoryMap[tt::runtime::MemoryBufferType::DRAM] =
-      createMemoryView(dramMemoryView);
-  memoryMap[tt::runtime::MemoryBufferType::L1] = createMemoryView(l1MemoryView);
-  memoryMap[tt::runtime::MemoryBufferType::L1_SMALL] =
-      createMemoryView(l1SmallMemoryView);
-  memoryMap[tt::runtime::MemoryBufferType::TRACE] =
-      createMemoryView(traceMemoryView);
-
-  return memoryMap;
+void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
+  ::tt::tt_metal::HostBuffer hostBuffer =
+      ::tt::tt_metal::host_buffer::get_host_buffer(tensor);
+  return static_cast<void *>(hostBuffer.view_bytes().data());
 }
 
 } // namespace tt::runtime::ttnn::utils

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -292,18 +292,10 @@ void registerRuntimeBindings(nb::module_ &m) {
       .value("WORMHOLE_B0", ::tt::target::Arch::Wormhole_b0)
       .value("BLACKHOLE", ::tt::target::Arch::Blackhole);
 
-  nb::enum_<::tt::runtime::MemoryLogLevel>(m, "MemoryLogLevel", nb::is_flag())
-      .value("NONE", ::tt::runtime::MemoryLogLevel::NONE)
-      .value("PROGRAM", ::tt::runtime::MemoryLogLevel::Program)
-      .value("OPERATION", ::tt::runtime::MemoryLogLevel::Operation)
-      .value("ANY", ::tt::runtime::MemoryLogLevel::ANY);
-
   m.def("set_mlir_home", &tt::runtime::setMlirHome, nb::arg("mlir_home"),
         "Set the MLIR home directory");
   m.def("set_metal_home", &tt::runtime::setMetalHome, nb::arg("metal_home"),
         "Set the Metal home directory");
-  m.def("set_memory_log_level", &tt::runtime::setMemoryLogLevel,
-        nb::arg("log_level"), "Set the memory log level");
   m.def("get_current_device_runtime", &tt::runtime::getCurrentDeviceRuntime,
         "Get the backend device runtime type");
   m.def("get_available_device_runtimes",
@@ -650,5 +642,8 @@ void registerRuntimeBindings(nb::module_ &m) {
 
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
+
+  m.def("log_memory_state", &::tt::runtime::debug::logMemoryState,
+        nb::arg("memory_state"), nb::arg("prefix") = "");
 }
 } // namespace tt::runtime::python

--- a/runtime/test/ttnn/python/n150/test_runtime_api.py
+++ b/runtime/test/ttnn/python/n150/test_runtime_api.py
@@ -2,21 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import pytest
 import ttrt
 import ttrt.runtime
 import torch
 from ttrt.common.util import *
-from ..utils import (
-    TT_MLIR_HOME,
-    Helper,
-    DeviceContext,
-    ProgramTestConfig,
-    ProgramTestRunner,
-    assert_pcc,
-    get_runtime_tensor_from_torch,
-)
+from ..utils import Helper, DeviceContext, assert_pcc, get_runtime_tensor_from_torch
 
 
 @pytest.mark.parametrize("shape", [(64, 128)])
@@ -279,73 +270,3 @@ def test_unblocking_to_host(num_loops):
             )
 
             assert torch.allclose(torch_input_tensor, torch_output_tensor)
-
-
-@pytest.mark.parametrize(
-    "log_level",
-    [
-        ttrt.runtime.MemoryLogLevel.NONE,
-        ttrt.runtime.MemoryLogLevel.PROGRAM,
-        ttrt.runtime.MemoryLogLevel.OPERATION,
-        ttrt.runtime.MemoryLogLevel.PROGRAM | ttrt.runtime.MemoryLogLevel.OPERATION,
-    ],
-)
-def test_memory_logging(helper, request, capfd, log_level):
-    binary_path = os.path.join(
-        f"{TT_MLIR_HOME}/build/test/ttmlir/Runtime/TTNN/n150/consteval/Output",
-        "binary_ops.mlir.tmp.ttnn",
-    )
-    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
-    helper.initialize(request.node.name, binary_path)
-    helper.check_constraints()
-    ttrt.runtime.set_current_device_runtime(ttrt.runtime.DeviceRuntime.TTNN)
-    ttrt.runtime.set_memory_log_level(log_level)
-
-    test_config = ProgramTestConfig(
-        name="binary_ops_consteval",
-        expected_num_inputs=4,
-        compute_golden=lambda inputs: (inputs[0] + inputs[1])
-        * ((inputs[1] + inputs[2]) - (inputs[2] + inputs[3])),
-        description="Binary ops memory logging test",
-    )
-
-    test_runner = ProgramTestRunner(test_config, helper.binary, 0)
-
-    with DeviceContext(mesh_shape=[1, 1]) as device:
-        inputs_runtime_with_layout, _ = test_runner.get_inputs_and_golden(device)
-        test_runner.run_program(device, inputs_runtime_with_layout)
-
-    program_log_str = [
-        "Device memory state before submit",
-        "Device memory state after submit",
-    ]
-    operation_log_str = ["Device memory state before operation"]
-    captured = capfd.readouterr()
-
-    if log_level == ttrt.runtime.MemoryLogLevel.NONE:
-        for log_str in program_log_str + operation_log_str:
-            assert log_str not in captured.out
-
-    elif log_level == ttrt.runtime.MemoryLogLevel.PROGRAM:
-        for log_str in program_log_str:
-            assert log_str in captured.out
-        for log_str in operation_log_str:
-            assert log_str not in captured.out
-
-    elif log_level == ttrt.runtime.MemoryLogLevel.OPERATION:
-        for log_str in operation_log_str:
-            assert log_str in captured.out
-        for log_str in program_log_str:
-            assert log_str not in captured.out
-
-    elif (
-        log_level
-        == ttrt.runtime.MemoryLogLevel.PROGRAM | ttrt.runtime.MemoryLogLevel.OPERATION
-    ):
-        for log_str in program_log_str + operation_log_str:
-            assert log_str in captured.out
-
-    else:
-        raise ValueError(f"Invalid log level: {log_level}")
-
-    helper.teardown()

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -14,7 +14,6 @@ try:
         DeviceRuntime,
         HostRuntime,
         DispatchCoreType,
-        MemoryLogLevel,
         DebugEnv,
         PerfEnv,
         DebugHooks,
@@ -25,7 +24,6 @@ try:
         DistributedMode,
         set_mlir_home,
         set_metal_home,
-        set_memory_log_level,
         get_current_device_runtime,
         set_current_device_runtime,
         set_compatible_device_runtime,
@@ -62,6 +60,7 @@ try:
         WorkaroundEnv,
         get_op_loc_info,
         unregister_hooks,
+        log_memory_state,
         FabricConfig,
     )
 except ModuleNotFoundError:


### PR DESCRIPTION
This reverts commit 70efb12f5f75c7b1642542e7c3ce330c472ea038.

All models that we track perf for have regressed. More details here: https://github.com/tenstorrent/tt-forge/issues/691