### PR TITLE
[runtime] Exposed clear program cache in runtime

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -102,6 +102,7 @@ std::vector<uint32_t> getMeshShape(Device meshDevice);
 std::vector<int> getDeviceIds(Device meshDevice);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
 size_t getNumDramChannels(Device meshDevice);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -171,6 +171,7 @@ std::vector<uint32_t> getMeshOffset(Device meshDevice);
 std::vector<int> getDeviceIds(Device meshDevice);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
 size_t getNumDramChannels(Device meshDevice);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -150,6 +150,7 @@ std::vector<uint32_t> getMeshShape(Device meshDevice);
 std::vector<int> getDeviceIds(Device meshDevice);
 size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
+void clearProgramCache(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
 size_t getNumDramChannels(Device meshDevice);

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -675,6 +675,17 @@ bool isProgramCacheEnabled(Device meshDevice) {
       });
 }
 
+void clearProgramCache(Device meshDevice) {
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::clearProgramCache(meshDevice); },
+      [&]() { ::tt::runtime::ttmetal::clearProgramCache(meshDevice); },
+      [&]() {
+        detail::fatalNotImplemented("clearProgramCache",
+                                    HostRuntime::Distributed);
+      });
+}
+
 size_t getL1SmallSize(Device meshDevice) {
   using RetType = size_t;
   return DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -373,6 +373,13 @@ bool isProgramCacheEnabled(Device meshDevice) {
   return metalMeshDevice.get_program_cache().is_enabled();
 }
 
+void clearProgramCache(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.clear_program_cache();
+}
+
 size_t getL1SmallSize(Device meshDevice) {
   ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
       meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -597,6 +597,12 @@ bool isProgramCacheEnabled(Device meshDevice) {
   return ttnnMeshDevice.get_program_cache().is_enabled();
 }
 
+void clearProgramCache(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.clear_program_cache();
+}
+
 size_t getL1SmallSize(Device meshDevice) {
   ::ttnn::MeshDevice &ttnnMeshDevice =
       meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -33,6 +33,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def("get_device_ids", &tt::runtime::getDeviceIds)
       .def("get_num_hw_cqs", &tt::runtime::getNumHwCqs)
       .def("is_program_cache_enabled", &tt::runtime::isProgramCacheEnabled)
+      .def("clear_program_cache", &tt::runtime::clearProgramCache)
       .def("get_l1_small_size", &tt::runtime::getL1SmallSize)
       .def("get_trace_region_size", &tt::runtime::getTraceRegionSize)
       .def("get_num_dram_channels", &tt::runtime::getNumDramChannels)

--- a/runtime/python/runtime/stubs_macos.cpp
+++ b/runtime/python/runtime/stubs_macos.cpp
@@ -225,6 +225,7 @@ std::vector<std::uint32_t> getTensorStride(Tensor tensor) { __builtin_trap(); }
 std::uint32_t getTensorVolume(Tensor tensor) { __builtin_trap(); }
 size_t getTraceRegionSize(Device meshDevice) { __builtin_trap(); }
 bool isProgramCacheEnabled(Device meshDevice) { __builtin_trap(); }
+void clearProgramCache(Device meshDevice) { __builtin_trap(); }
 bool isTensorAllocated(Tensor tensor) { __builtin_trap(); }
 void launchDistributedRuntime(const DistributedOptions &options) {
   __builtin_trap();


### PR DESCRIPTION
Exposed clear device program cache call in runtime, so that frontends can use it to manually clear caches.

Issue: https://github.com/tenstorrent/tt-xla/issues/2227
