### PR TITLE
Log memory only in debug mode

### DIFF
--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -176,8 +176,10 @@ bool isSupportedDataType(::tt::target::DataType dataType);
 getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType);
 
 void logMemoryStateIfNeeded(
-    const std::unordered_map<tt::runtime::MemoryBufferType,
-                             tt::runtime::MemoryView> &memoryState,
+    const std::function<std::unordered_map<tt::runtime::MemoryBufferType,
+                                           tt::runtime::MemoryView>(
+        tt::runtime::Device)> &getMemoryView,
+    tt::runtime::Device device,
     ::tt::runtime::MemoryLogLevel level = ::tt::runtime::MemoryLogLevel::ANY,
     std::string_view prefix = "");
 

--- a/runtime/lib/common/utils.cpp
+++ b/runtime/lib/common/utils.cpp
@@ -311,9 +311,11 @@ void handleBufferCast(const void *oldBuffer, void *newBuffer,
 }
 
 void logMemoryStateIfNeeded(
-    const std::unordered_map<tt::runtime::MemoryBufferType,
-                             tt::runtime::MemoryView> &memoryState,
-    ::tt::runtime::MemoryLogLevel level, std::string_view prefix) {
+    const std::function<std::unordered_map<tt::runtime::MemoryBufferType,
+                                           tt::runtime::MemoryView>(
+        tt::runtime::Device)> &getMemoryView,
+    tt::runtime::Device device, ::tt::runtime::MemoryLogLevel level,
+    std::string_view prefix) {
   constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
       tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
       tt::runtime::MemoryBufferType::L1_SMALL,
@@ -325,6 +327,8 @@ void logMemoryStateIfNeeded(
   if (!(currentLogLevel & level)) {
     return;
   }
+
+  auto memoryState = getMemoryView(device);
 
   if (!prefix.empty()) {
     LOG_INFO(prefix);

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -166,11 +166,13 @@ std::vector<::tt::runtime::Tensor> ProgramExecutor::gatherOutputTensors() {
 
 void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(getContext().getDeviceHandle()),
+      ::tt::runtime::ttnn::utils::getMemoryView, getContext().getDeviceHandle(),
       ::tt::runtime::MemoryLogLevel::Operation,
       std::string("Device memory state before operation ") +
           ::tt::target::ttnn::EnumNameOpType(op->type_type()));
+#endif
 
   switch (op->type_type()) {
   case ::tt::target::ttnn::OpType::GetDeviceOp: {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1699,10 +1699,12 @@ std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs) {
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(deviceHandle),
+      ::tt::runtime::ttnn::utils::getMemoryView, deviceHandle,
       ::tt::runtime::MemoryLogLevel::Program,
       "Device memory state before submit");
+#endif
 
   std::unique_ptr<ProgramExecutor> executor = std::make_unique<ProgramExecutor>(
       deviceHandle, executableHandle, programIndex, inputs);
@@ -1713,10 +1715,12 @@ submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
 
   executor.reset();
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   ::tt::runtime::utils::logMemoryStateIfNeeded(
-      utils::getMemoryView(deviceHandle),
+      ::tt::runtime::ttnn::utils::getMemoryView, deviceHandle,
       ::tt::runtime::MemoryLogLevel::Program,
       "Device memory state after submit");
+#endif
 
   return outputTensors;
 }


### PR DESCRIPTION
### Ticket
#6057

### Problem description
Perf regression due to memory logging checks on the critical path.

### What's changed
Guard memory logging behind `-DTT_RUNTIME_DEBUG=ON`

To enable memory logging, build with `-DTT_RUNTIME_DEBUG=ON` and set the memory logging level via `tt::runtime::setMemoryLogLevel`. An example can be found in `runtime/test/ttnn/python/n150/test_runtime_api.py::test_memory_logging`

### Checklist
- [X] New/Existing tests provide coverage for changes
