### PR TITLE
[cmake] set metal build dir properly

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,6 +13,13 @@ else()
 endif()
 message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(TTMETAL_BUILD_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build)
+else()
+  set(TTMETAL_BUILD_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build_Debug)
+endif()
+set(TTMETAL_LIBRARY_DIR ${TTMETAL_BUILD_DIR}/lib)
+
 set(TRACY_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
 )
@@ -36,7 +43,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/include
+  ${TTMETAL_BUILD_DIR}/include
   ${CPM_SOURCE_CACHE}/reflect/f93e77475670eaeacf332927dfe8b50e3f3812e0
   ${CPM_SOURCE_CACHE}/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
   ${CPM_SOURCE_CACHE}/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include
@@ -50,9 +57,6 @@ set(TTMETAL_INCLUDE_DIRS
   ${CPM_SOURCE_CACHE}/xtensor-blas/0_22_0_patched/include
   PARENT_SCOPE
 )
-
-set(TTMETAL_BUILD_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build)
-set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/lib)
 
 set(TTNN_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnncpp.so)
 set(TTNN_PY_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
@@ -93,14 +97,13 @@ else()
   set(ENABLE_DISTRIBUTED OFF)
 endif()
 
-set(METAL_BUILD_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build)
-set(METAL_INSTALL_PREFIX "${METAL_BUILD_DIR}")
+set(METAL_INSTALL_PREFIX "${TTMETAL_BUILD_DIR}")
 ExternalProject_Add(
   tt-metal
   PREFIX ${TTMLIR_SOURCE_DIR}/third_party/tt-metal
-  BINARY_DIR ${METAL_BUILD_DIR}
+  BINARY_DIR ${TTMETAL_BUILD_DIR}
   # This patch command creates the build dir that otherwise doesn't get created
-  PATCH_COMMAND ${CMAKE_COMMAND} -E make_directory ${METAL_BUILD_DIR}
+  PATCH_COMMAND ${CMAKE_COMMAND} -E make_directory ${TTMETAL_BUILD_DIR}
   CMAKE_ARGS
     -DCMAKE_INSTALL_MESSAGE=NEVER
   CMAKE_GENERATOR Ninja

--- a/tools/ttrt/CMakeLists.txt
+++ b/tools/ttrt/CMakeLists.txt
@@ -24,6 +24,7 @@ add_custom_command(
           TTMLIR_VERSION_PATCH=${TTMLIR_VERSION_PATCH}
           CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}
           SOURCE_ROOT=${TTMLIR_SOURCE_DIR}
+          TTMETAL_BUILD_DIR=${TTMETAL_BUILD_DIR}
           python -m pip wheel . --wheel-dir build
   COMMAND python -m pip install build/*.whl --force-reinstall
   COMMAND touch ${CMAKE_CURRENT_BINARY_DIR}/build/.installed

--- a/tools/ttrt/setup.py
+++ b/tools/ttrt/setup.py
@@ -24,7 +24,10 @@ ttmlir_build_dir = os.environ.get(
     os.path.join(src_dir, "build"),
 )
 
-metaldir = f"{src_dir}/third_party/tt-metal/src/tt-metal/build"
+metaldir = os.environ.get(
+    "TTMETAL_BUILD_DIR",
+    f"{src_dir}/third_party/tt-metal/src/tt-metal/build",
+)
 ttmetalhome = os.environ.get("TT_METAL_RUNTIME_ROOT", "")
 
 os.environ["LDFLAGS"] = "-Wl,-rpath,'$ORIGIN'"


### PR DESCRIPTION
### Problem description
When switching from release build to debug build, I got the error that some variables are unused. It was because the compiler expanded the code to `(void) 0` when `SPDLOG_ACTIVE_LEVEL` is greater than DEBUG. The log level was controlled by the cmake variable `TT_METAL_ENABLE_LOGGING` which was set by the release build, and reused in the subsequent debug build. This fix uses different build directories for debug and release builds, so that debug builds won't reuse release builds' log level settings.

### Longer story
When switching from release build to debug build (without cleaning), I got the following error:
```
In file included from /localdev/gfeng/mlir/third_party/tt-metal/src/tt-metal/build/ttnn/CMakeFiles/ttnn.dir/Unity/unity_24_cxx.cxx:19:
/localdev/gfeng/mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn-pybind/pytensor.cpp:61:21: error: unused variable '[name, value]' [-Werror,-Wunused-variable]
   61 |         for (auto&& [name, value] : attributes) {
      |                     ^
/localdev/gfeng/mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn-pybind/pytensor.cpp:68:21: error: unused variable 'tensor' [-Werror,-Wunused-variable]
   68 |         const auto& tensor = input_tensors[index];
      |                     ^~~~~~
2 errors generated.
```

The code is like:
```
#ifdef DEBUG
        for (auto&& [name, value] : attributes) {
            log_debug(tt::LogOp, "\t{} = {}", name, value);
        }
```

The macro `log_debug()` expands to `(void) 0` when SPDLOG_ACTIVE_LEVEL is greater than SPDLOG_LEVEL_DEBUG (see https://github.com/tenstorrent/tt-logger/blob/8c0874ecc0dce030c60b8cbc88eb5d278c7eb7aa/include/tt-logger/tt-logger.hpp#L247), so the variables become unused.

Looking at tt-metal's CMakeLists.txt, it does set SPDLOG_ACTIVE_LEVEL to SPDLOG_LEVEL_TRACE for debug builds, but only if the cmake variable TT_METAL_ENABLE_LOGGING isn't already set. In this case, the release build set the TT_METAL_ENABLE_LOGGING to be false, which caused the log level to be its default value, INFO, and TT_METAL_ENABLE_LOGGING=false was reused by the debug build.

Therefore, the simple fix is to set TT_METAL_ENABLE_LOGGING when building tt-metal. Interestingly, tt-metal doesn't do that, and doesn't have this problem, because it uses different build dirs for release and debug builds. When tt-mlir builds tt-metal, it only uses one hardcoded build dir (`third_party/tt-metal/src/tt-metal/build`). 

### What's changed
- Introduced the cmake variable `TTMETAL_BUILD_DIR`.
- Set different value of `TTMETAL_BUILD_DIR` for release and debug builds.
- Pass `TTMETAL_BUILD_DIR` as an environment variable to ttrt builds.

### Checklist
- [X] Builds passed when switching from release to debug and vice versa.