### PR TITLE
Enabled linear opmodel tests.

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2195,10 +2195,8 @@ TEST_P(OpModelLinearParam, LinearParam) {
   }
 }
 
-// Disabled due to bias shape constraint failure in tt-metal matmul op,
-// see https://github.com/tenstorrent/tt-mlir/issues/5789
 INSTANTIATE_TEST_SUITE_P(
-    DISABLED_LinearInterleavedTests, OpModelLinearParam,
+    LinearInterleavedTests, OpModelLinearParam,
     ::testing::Values(
         std::make_tuple(
             detail::interleaved2048X2048Dram, detail::interleaved2048X2048Dram,
@@ -2233,11 +2231,8 @@ INSTANTIATE_TEST_SUITE_P(
             detail::interleaved2048X2048Dram, detail::inerleaved2048X2048L1,
             llvm::SmallVector<int64_t>{8, 8}, detail::ExpectedResult{true})));
 
-// Disabled due to bias shape incompatibility: padded second last dimension of
-// bias (1792 = 56*32) not equal to tile height (32)
-// See https://github.com/tenstorrent/tt-mlir/issues/5789
 INSTANTIATE_TEST_SUITE_P(
-    DISABLED_LinearShardedTests, OpModelLinearParam,
+    LinearShardedTests, OpModelLinearParam,
     ::testing::Values(
         std::make_tuple(detail::TestTensor{{56 * 32, 56 * 32},
                                            TensorMemoryLayout::BlockSharded,


### PR DESCRIPTION
### Ticket
#5789

### Problem description
Opmodel tests were disabled with [this commit](https://github.com/tenstorrent/tt-mlir/commit/877303b5b9b31e7e1679c54bafc6f9624a371a61) by @ctodTT Now that linear op workaround is changed from default to specific cases, the opmodel tests should be re-enabled.
Linear op is rewritten to matmul and add under these conditions, based on [this commit](https://github.com/tenstorrent/tt-mlir/commit/4937cb9e271ba2a07819c669a8cba40e1790d0ea) 
- input b is batched 
- bias is not 1d. (1d bias examples: <64>, <1x64>, <1x1x64>

The latter condition is added so that linear op is modelled after [PyTorch linear](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html). This is a more accurate modelling and overcomes tt-metal limitations.

### What's changed
Enabled linear opmodel tests. 
