### PR TITLE
Suppress getOpConstraint tt-metal logs in tt-mlir

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -37,6 +37,33 @@ namespace mlir::tt::ttnn::op_model {
 #ifdef TTMLIR_ENABLE_OPMODEL
 namespace operation {
 
+/// RAII helper to temporarily suppress tt-metal logs queries.
+struct MetalLogLevelGuard {
+  MetalLogLevelGuard(spdlog::level::level_enum logLevel,
+                     ::tt::LogType loggerType)
+      : loggerType_(loggerType) {
+    // Save current log level for given tt-metal logger type and set new log
+    // level
+    auto logger = ::tt::LoggerRegistry::instance().get(loggerType);
+    savedLevel_ = logger->level();
+    logger->set_level(logLevel);
+  }
+
+  ~MetalLogLevelGuard() {
+    // Restore original log level
+    ::tt::LoggerRegistry::instance().get(loggerType_)->set_level(savedLevel_);
+  }
+
+  MetalLogLevelGuard(const MetalLogLevelGuard &) = delete;
+  MetalLogLevelGuard &operator=(const MetalLogLevelGuard &) = delete;
+  MetalLogLevelGuard(MetalLogLevelGuard &&) = delete;
+  MetalLogLevelGuard &operator=(MetalLogLevelGuard &&) = delete;
+
+private:
+  spdlog::level::level_enum savedLevel_;
+  ::tt::LogType loggerType_;
+};
+
 /// RAII helper to preserve and restore the program cache state.
 struct ProgramCacheState {
   ::tt::tt_metal::distributed::MeshDevice *device_ = nullptr;
@@ -70,8 +97,9 @@ executeConstraintQuery(Callable &callable) {
   ::ttnn::graph::ConstraintQueryResponse query;
   try {
     auto *device = SingletonDeviceContext::getInstance().getDevice();
-    ::ttnn::graph::detail::LogLevelGuard log_guard(
-        spdlog::level::level_enum::off);
+    MetalLogLevelGuard logGuard(
+        spdlog::level::critical,
+        ::tt::LogMetal); // Suppress Metal logs during constraint query
     ProgramCacheState pcState(device);
     device->disable_and_clear_program_cache();
     query = callable();


### PR DESCRIPTION
### Ticket
Adresses #6058

### Problem description
Since #6094 we are using [LogLevelGuard from tt-metal](https://github.com/tenstorrent/tt-metal/blob/7c4c6782f3b73a01fe99b2dc93080fa7b240759b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp#L25-L39) (created [here](https://github.com/tenstorrent/tt-metal/pull/30746)) to suppress logs in tt-mlir that come from enabling/disabling program cache:

https://github.com/tenstorrent/tt-mlir/blob/6e0bace5a83ee45a654f560e96cc057a1c0a47ca/lib/OpModel/TTNN/TTNNOpModel.cpp#L67-L100

This way we suppress logging in tt-mlir, and then again in tt-metal.
Also, tt-metal LogLevelGuard returns all logger types to the saved level of `LogOp` logger, which is a bug.

We should consider migrating LogLevelGuard logic from tt-metal to tt-mlir, that way tt-mlir is responsible for suppressing redundant logs.