### PR TITLE
D2M: partially re-enable hanging matmul tests on BH

### DIFF
--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -104,30 +104,7 @@ def test_matmul_multi_core_8otpc(m: int, k: int, n: int, target: str, request, d
     )
 
 
-# Temporary testcase to verify larger testcases compile on p150 (execution hangs, but we want to cover non-square grid cases)
-@pytest.mark.only_config(["ttmetal", "p150"])
-@pytest.mark.parametrize("target", ["ttmetal"])
-def test_matmul_p150_grid_selection_compile_only(target: str, request, device):
-    from builder.base.builder_utils import compile_ttir_to_flatbuffer
-
-    lhs = (1024, 1024)
-    rhs = (1024, 1024)
-
-    options = [
-        f"num-stream-buffers=1",
-    ]
-
-    # Compile only - verify IR is well-formed with correct dim_alignments, etc.
-    mlir_path = compile_ttir_to_flatbuffer(
-        create_matmul_constrained_inputs(lhs, rhs),
-        [lhs, rhs],
-        target=target,
-        custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
-@pytest.mark.skip_config(["ttmetal", "p150"], reason="See issue #5341")
+@pytest.mark.skip_exec(["ttmetal", "p150"], reason="See issue #5341")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -176,10 +153,11 @@ def test_matmul_ttnn_shapes_single_buffered(
         print_ir=True,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
+        skip_exec=getattr(request.node, "skip_exec", False),
     )
 
 
-@pytest.mark.skip_config(["ttmetal", "p150"], reason="See issue #5341")
+@pytest.mark.skip_exec(["ttmetal", "p150"], reason="See issue #5341")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -225,4 +203,5 @@ def test_matmul_ttnn_shapes_double_buffered(
         print_ir=True,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
+        skip_exec=getattr(request.node, "skip_exec", False),
     )


### PR DESCRIPTION
### What's changed
Re-enable the compilation of the hanging matmul tests on BH using `skip_exec` from #5841.
Remove the temporary BH-only test.