### PR TITLE
Make conv2d config fallback for OOM issues

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TTNN/Analysis/Conv2dConfigSearchSpace.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -106,6 +108,13 @@ ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
 bool tryFallbacks(Operation *operation,
                   const std::vector<TTNNLayoutAttr> &originalInputLayouts,
                   const OpConfig &config);
+
+// Try config fallbacks for Conv2d-like operations
+bool tryConfigFallbacks(Operation *operation,
+                        const std::vector<TTNNLayoutAttr> &originalInputLayouts,
+                        const OpConfig &originalConfig);
+
+void applyConfigChange(Operation *operation, Conv2dConfigAttr newConfig);
 } // namespace fallbacks
 
 class TTNNOperationValidationAndFallback
@@ -207,7 +216,26 @@ public:
           }
         } else {
           // Try fallback configurations
-          if (fallbacks::tryFallbacks(operation, inputLayouts, config)) {
+          // For OOM errors, try config fallbacks first as they're cheaper (no
+          // ToLayout ops)
+          bool fixed = false;
+          if (originalResult.status ==
+              op_constraint_validation::ValidationStatus::OutOfMemoryError) {
+            TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+                         "OOM error detected, trying config fallbacks first "
+                         "for operation {} at {}",
+                         operation->getName(), operation->getLoc());
+            fixed =
+                fallbacks::tryConfigFallbacks(operation, inputLayouts, config);
+          }
+
+          // If config fallbacks didn't work or it wasn't an OOM error, try
+          // layout fallbacks
+          if (!fixed) {
+            fixed = fallbacks::tryFallbacks(operation, inputLayouts, config);
+          }
+
+          if (fixed) {
             operationsFixed++;
             TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
                          "Operation {} at {} fixed with fallback configuration",
@@ -685,6 +713,122 @@ ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
                                                 targetLayout.getBufferType()),
                             /*shardSpec=*/std::nullopt));
 }
+
+// Try config fallbacks for Conv2d-like operations
+bool tryConfigFallbacks(Operation *operation,
+                        const std::vector<TTNNLayoutAttr> &originalInputLayouts,
+                        const OpConfig &originalConfig) {
+  // Only applicable to operations with Conv2dAttrs
+  if (!std::holds_alternative<Conv2dAttrs>(originalConfig.opSpecificAttrs)) {
+    return false;
+  }
+
+  const auto &conv2dAttrs =
+      std::get<Conv2dAttrs>(originalConfig.opSpecificAttrs);
+  if (!conv2dAttrs.conv2dConfig.has_value()) {
+    return false;
+  }
+
+  Conv2dConfigAttr originalConfigAttr = conv2dAttrs.conv2dConfig.value();
+
+  // Create search space focused on act_block_h_override
+  // Try all multiples of 32 from 1024 down to 32
+  Conv2dConfigSearchSpace searchSpace;
+  searchSpace.actBlockHOverride.push_back(0);
+  for (uint32_t val = 1024; val >= 32; val -= 32) {
+    searchSpace.actBlockHOverride.push_back(val);
+  }
+
+  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+               "Trying config fallbacks for operation {} at {} with {} "
+               "act_block_h_override values",
+               operation->getName(), operation->getLoc(),
+               searchSpace.actBlockHOverride.size());
+
+  // Use Conv2dConfigParams to unset act_block_h_override so the generator
+  // will iterate through the search space values
+  Conv2dConfigParams configParams(originalConfigAttr);
+  configParams.actBlockHOverride = std::nullopt; // Unset this field
+  Conv2dConfigAttr baseConfig =
+      configParams.buildConv2dConfigAttr(operation->getContext());
+
+  // Use the Conv2dConfigGenerator to iterate through configs
+  auto filterOutFn = [](const Conv2dConfigAttr &) { return false; };
+
+  Conv2dConfigAttr workingConfig = nullptr;
+  op_constraint_validation::ValidationResult workingResult;
+
+  // Use TypeSwitch to handle both Conv2dOp and ConvTranspose2dOp
+  bool foundConfig =
+      llvm::TypeSwitch<Operation *, bool>(operation)
+          .Case<ttnn::Conv2dOp, ttnn::ConvTranspose2dOp>([&](auto convOp) {
+            Conv2dConfigGenerator configGenerator(&convOp, baseConfig,
+                                                  searchSpace, filterOutFn);
+
+            // Iterate through generated configs
+            while (Conv2dConfigAttr configAttr =
+                       configGenerator.getNextConfig()) {
+              // Test this config
+              OpConfig testConfig = originalConfig;
+              auto &testConv2dAttrs =
+                  std::get<Conv2dAttrs>(testConfig.opSpecificAttrs);
+              testConv2dAttrs.conv2dConfig = configAttr;
+
+              auto result = testFallbackCombination(operation, testConfig,
+                                                    originalInputLayouts);
+
+              if (result.isSuccess()) {
+                workingConfig = configAttr;
+                workingResult = result;
+                return true;
+              }
+
+              TTMLIR_TRACE(ttmlir::LogComponent::OpValidation,
+                           "Config fallback failed (status: {}): {}",
+                           static_cast<int>(result.status),
+                           result.errorMessage);
+            }
+            return false;
+          })
+          .Default([](Operation *) { return false; });
+
+  if (!foundConfig) {
+    return false;
+  }
+
+  if (workingConfig) {
+    // Found a working config, apply it
+    applyConfigChange(operation, workingConfig);
+
+    if (originalConfig.outputLayout &&
+        workingResult.actualOutputLayout != originalConfig.outputLayout) {
+      applyOutputLayoutRevert(operation, workingResult.actualOutputLayout,
+                              originalConfig.outputLayout);
+    }
+
+    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+                 "Found working config fallback for operation {} at {}",
+                 operation->getName(), operation->getLoc());
+    return true;
+  }
+
+  return false;
+}
+
+// Apply config change to the operation
+void applyConfigChange(Operation *operation, Conv2dConfigAttr newConfig) {
+  if (auto conv2dOp = mlir::dyn_cast<ttnn::Conv2dOp>(operation)) {
+    conv2dOp.setConv2dConfigAttr(newConfig);
+  } else if (auto convTranspose2dOp =
+                 mlir::dyn_cast<ttnn::ConvTranspose2dOp>(operation)) {
+    convTranspose2dOp.setConv2dConfigAttr(newConfig);
+  }
+
+  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+               "Applied config change to operation {} at {}: new config = {}",
+               operation->getName(), operation->getLoc(), newConfig);
+}
+
 } // namespace fallbacks
 
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/conv_transpose2d_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/op_layout_fallbacks/conv_transpose2d_validation.mlir
@@ -1,0 +1,60 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-operation-validation-and-fallback %s -o %t.mlir
+// RUN: FileCheck %s --input-file %t.mlir
+
+// Test that the post-optimizer validation analysis automatically detects
+// and handles conv_transpose2d operations that fail validation.
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout_input = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 16384 + d1 * 16384 + d2, d3), <1x1>, memref<8x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_weight = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 128 + d1 * 2 + d2, d3), <1x1>, memref<16384x2xbf16, #system_memory>>
+#ttnn_layout_bias = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 + d1 + d2, d3), <1x1>, memref<1x64xbf16, #system_memory>>
+#ttnn_layout_output = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 65536 + d1 * 65536 + d2, d3), <1x1>, memref<2048x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  func.func @conv_transpose2d_validation(%arg0: tensor<1x1x16384x128xbf16, #ttnn_layout_input>,
+                                         %arg1: tensor<128x64x2x2xbf16, #ttnn_layout_weight>,
+                                         %arg2: tensor<1x1x1x64xbf16, #ttnn_layout_bias>) -> tensor<1x1x65536x64xbf16, #ttnn_layout_output> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // The op validation pass should detect that conv_transpose2d may fail validation
+    // and insert appropriate fallback transformations if needed.
+
+    // CHECK: %[[RES:.*]] = "ttnn.conv_transpose2d"
+    // CHECK-SAME: batch_size = 1 : i32
+    // CHECK-SAME: conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, deallocate_activation = true, act_block_h_override = {{[1-9][0-9]*}}, enable_kernel_stride_folding = false>
+    // CHECK-SAME: dilation = array<i32: 1, 1>
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: groups = 1 : i32
+    // CHECK-SAME: in_channels = 128 : i32
+    // CHECK-SAME: input_height = 128 : i32
+    // CHECK-SAME: input_width = 128 : i32
+    // CHECK-SAME: kernel_size = array<i32: 2, 2>
+    // CHECK-SAME: out_channels = 64 : i32
+    // CHECK-SAME: output_padding = array<i32: 0, 0>
+    // CHECK-SAME: padding = array<i32: 0, 0>
+    // CHECK-SAME: stride = array<i32: 2, 2>
+
+    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0) <{
+      batch_size = 1 : i32,
+      conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, deallocate_activation = true, act_block_h_override = 0, enable_kernel_stride_folding = false>,
+      dilation = array<i32: 1, 1>,
+      dtype = #ttcore.supportedDataTypes<bf16>,
+      groups = 1 : i32,
+      in_channels = 128 : i32,
+      input_height = 128 : i32,
+      input_width = 128 : i32,
+      kernel_size = array<i32: 2, 2>,
+      out_channels = 64 : i32,
+      output_padding = array<i32: 0, 0>,
+      padding = array<i32: 0, 0>,
+      stride = array<i32: 2, 2>
+    }> : (tensor<1x1x16384x128xbf16, #ttnn_layout_input>,
+         tensor<128x64x2x2xbf16, #ttnn_layout_weight>,
+         tensor<1x1x1x64xbf16, #ttnn_layout_bias>,
+         !ttnn.device) -> tensor<1x1x65536x64xbf16, #ttnn_layout_output>
+
+    return %1 : tensor<1x1x65536x64xbf16, #ttnn_layout_output>
+  }
+}


### PR DESCRIPTION
Add config fallback mechanism to the validation fallback pass for
Conv2d and ConvTranspose2d operations that fail with OOM errors.

Problem:
Conv2d operations can fail validation with OutOfMemoryError when
act_block_h_override is set to 0 (default), causing L1 memory usage
to exceed available capacity.

Solution:
- Detect OOM errors during validation and try config fallbacks first
  before attempting more expensive layout transformations
- Use Conv2dConfigGenerator to iterate through act_block_h_override
  values (0, 1024, 992, ..., 64, 32) - all multiples of 32 from
  1024 down to 32
- Apply the first config that passes validation without modifying
  input layouts (no ToLayoutOp insertions needed)
