### PR TITLE
Fix deallocation pass to check ConvTranspose2d op

### DIFF
--- a/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_deallocate_use_after_free.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_deallocate_use_after_free.mlir
@@ -13,7 +13,7 @@ module {
 
     // This conv2d has deallocate_activation=true, which means it will deallocate %input
     // However, it's not the last user because the add operation also uses %input
-    // CHECK: error: use-after-free detected: conv2d op deallocates its input but is not the last user
+    // CHECK: error: use-after-free detected: op deallocates its input but is not the last user
     %conv_out = "ttnn.conv2d"(%input, %weight, %bias, %device) <{
       in_channels = 64: i32,
       out_channels = 64: i32,


### PR DESCRIPTION
Fixes problem where `ttrt perf` fails debug assert like
```
            RuntimeTTNN |    DEBUG | Executing operation: %86 = "ttnn.conv_transpose2d"(%85, %21, %7, %50) <{batch_size = 1 : i32, conv2d_config = #ttnn.conv2d_config<weights_dtype = bf16, deallocate_activation = true, act_block_h_override = 0, enable_kernel_stride_folding = false>, dilation = array<i32: 1, 1>, dtype = #ttcore.supportedDataTypes<bf16>, groups = 1 : i32, in_channels = 512 : i32, input_height = 16 : i32, input_width = 16 : i32, kernel_size = array<i32: 2, 2>, out_channels = 512 : i32, output_padding = array<i32: 0, 0>, padding = array<i32: 0, 0>, stride = array<i32: 2, 2>}> : (tensor<1x1x256x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 256 + d1 * 256 + d2, d3), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>>>, tensor<512x512x2x2xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 2 + d2, d3), <1x1>, memref<524288x2xbf16, #ttnn.buffer_type<system_memory>>>>, tensor<1x1x1x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 + d1 + d2, d3), <1x1>, memref<1x512xbf16, #ttnn.buffer_type<system_memory>>>>, !ttnn.device) -> tensor<1x1x1024x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 1024 + d2, d3), <8x8, (d0, d1) -> (0, d0, d1)>, memref<4x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>>> loc("xla-mlirs/unet.ttnn.mlir":1111:15)
   0.26 Mbps / 19.1% =   1.38 Mbps | Tx: 172.53 KB | 64.13 MB | 18.97 s            RuntimeTTNN |    DEBUG | Executing operation: "ttnn.deallocate"(%85) <{force = false}> : (tensor<1x1x256x512xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 256 + d1 * 256 + d2, d3), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x2x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<l1>>, <block_sharded>>>) -> () loc("xla-mlirs/unet.ttnn.mlir":1112:9)
                 Always |    FATAL | 
DEBUG_ASSERT @ /localdev/rpavlovic/tt-mlir-local/runtime/lib/ttnn/types/types.cpp:128: ttnnTensor.is_allocated()
backtrace:
 --- tt::runtime::ttnn::ProgramTensorPool::getRuntimeTensorAndValidate(tt::target::ttnn::TensorRef const*) const
 --- tt::runtime::ttnn::ProgramTensorPool::getTTNNTensorWrapperAndValidate(tt::target::ttnn::TensorRef const*) const
 --- tt::runtime::ttnn::ProgramTensorPool::getTTNNTensorWrapperAndValidate(tt::target::ttnn::TensorRef const*)
```