### PR TITLE
Fix double ceil_mode arg

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -656,12 +656,11 @@ public:
             rewriter.getI32ArrayAttr(padding)),
         emitter.template emit<std::vector<uint32_t>>(
             maxPool2dOp.getDilationAttr()),
-        emitter.emit(maxPool2dOp.getCeilMode()),
+        emitter.emit(maxPool2dOp.getCeilMode(), "ceil_mode"),
         emitter.emit(emitter.getMemoryConfig(maxPool2dOp.getResult()),
                      "memory_config"),
         emitter.emit(maxPool2dOp.getAppliedShardScheme(),
                      "applied_shard_scheme"),
-        emitter.emit(maxPool2dOp.getCeilMode(), "ceil_mode"),
         emitter.emit(maxPool2dOp.getReallocateHaloOutput(),
                      "reallocate_halo_output"),
     };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6148

### Problem description
Incorrect arguments passed to maxpool2d op when converting from TTNN to EmitPy dialect.

### What's changed
Removed duplicated `ceil_mode` arg.

### Checklist
- [ ] New/Existing tests provide coverage for changes
