### PR TITLE
[tt-lang] handle dma src as arg

### DIFF
--- a/lib/Dialect/D2M/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericLowerDMAs.cpp
@@ -525,8 +525,16 @@ public:
   static AffineMap getMemoryMap(ttcore::DeviceAttr device, Value input,
                                 bool isRemote) {
     if (isRemote) {
-      std::pair<MemRefType, AffineMap> srcUnderlyingMemrefAndView =
-          mlir::tt::d2m::applyViews(input.getDefiningOp());
+      std::pair<MemRefType, AffineMap> srcUnderlyingMemrefAndView;
+      if (Operation *defOp = input.getDefiningOp()) {
+        srcUnderlyingMemrefAndView = mlir::tt::d2m::applyViews(defOp);
+      } else {
+        // Block argument: use type directly with identity map
+        auto memrefType = mlir::cast<MemRefType>(input.getType());
+        srcUnderlyingMemrefAndView = std::make_pair(
+            memrefType, AffineMap::getMultiDimIdentityMap(memrefType.getRank(),
+                                                          input.getContext()));
+      }
       return device.getMemoryMap(srcUnderlyingMemrefAndView,
                                  0 /* use default page size*/);
     }


### PR DESCRIPTION
tt-lang sometimes dma's directly into an arg, which currently crashes because the defining op is null; tested in tt-lang implicitly. 

refs https://github.com/tenstorrent/tt-lang/pull/50