### PR TITLE
Fix linking error for MLIRD2MTransforms

### DIFF
--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -31,4 +31,5 @@ add_mlir_dialect_library(MLIRD2MTransforms
         LINK_LIBS PUBLIC
         MLIRD2MAnalysis
         MLIRD2MUtils
+        MLIRTTUtils
         )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
On Ubuntu 24.04, I see this error:

```
lib/libLLVMSupport.a  -lrt  -ldl  -lm  /usr/lib/x86_64-linux-gnu/libz.so  /opt/ttmlir-toolchain/lib/libLLVMDemangle.a && :
/usr/bin/ld: lib/libMLIRD2MTransforms.a(LowerToLayout.cpp.o): in function `mlir::tt::d2m::(anonymous namespace)::D2MLowerToLayoutRewriter::lowerMappingChange(mlir::PatternRewriter&, mlir::Value, mlir::Value, mlir::Location, llvm::ArrayRef<long>)':
LowerToLayout.cpp:(.text._ZN4mlir2tt3d2m12_GLOBAL__N_124D2MLowerToLayoutRewriter18lowerMappingChangeERNS_15PatternRewriterENS_5ValueES6_NS_8LocationEN4llvm8ArrayRefIlEE+0x2cd): undefined reference to `mlir::tt::ttcore::utils::buildLayoutTransformMap(mlir::tt::ttcore::MetalLayoutAttr, mlir::RankedTensorType, mlir::tt::ttcore::MetalLayoutAttr, mlir::RankedTensorType)'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

### What's changed
The function buildLayoutTransformMap is defined in the MLIRTTUtils library (built from lib/Dialect/TTCore/Utils/CMakeLists.txt), but the MLIRD2MTransforms library (in lib/Dialect/D2M/Transforms/CMakeLists.txt) doesn't link against it. The fix is to add MLIRTTUtils to the LINK_LIBS PUBLIC section in the D2M Transforms CMakeLists.txt

### Checklist
- [x] New/Existing tests provide coverage for changes
