### PR TITLE
Add explicit CSE pass

### DIFF
--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -80,6 +80,7 @@ void createStableHLOToTTIRPipeline(
   ttir::ConvertStableHLOToTTIROptions passOptions;
   passOptions.enablePartialConversion = options.enableCPUFallback;
   pm.addPass(createConvertStableHLOToTTIRPass(passOptions));
+  pm.addPass(mlir::createCSEPass());
 
   if (options.enableCPUFallback) {
     // Wrap all ops in DeviceModule.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There is no explicit CSE pass from stablehlo to ttir graph which redundant ops are left in the graph.

### What's changed
Run CSE after the StableHLO → TTIR conversion to produce cleaner TTIR and eliminate redundant ops generated during the lowering.

### Checklist
- [ ] New/Existing tests provide coverage for changes
