### PR TITLE
Fix number of sharded layouts to 8

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -204,7 +204,7 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, OptionNames::maxLegalLayouts,
       llvm::cl::desc("Override maximum number of sharded layouts for legal "
                      "layout analysis."),
-      llvm::cl::init(64)};
+      llvm::cl::init(8)};
 
   ListOption<int64_t> meshShape{
       *this, OptionNames::meshShape,


### PR DESCRIPTION
## Summary

This PR reduces the default maximum number of sharded layouts for legal layout analysis from 64 to 8 to improve compilation time.

## Changes

- Updated \`maxLegalLayouts\` default value from 64 to 8 in \`TTIRToTTNNBackendPipelineOptions\`

## Impact

Reducing the number of layouts considered during legal layout analysis significantly decreases compilation time by limiting the number of expensive \`getOpConstraints\` API calls. Each layout candidate requires constraint evaluation, so reducing from 64 to 8 layouts provides substantial performance improvement while maintaining reasonable layout exploration for most use cases.