### PR TITLE
Enable EIO for all models

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -132,7 +132,7 @@ def TTIREraseInverseOps: Pass<"ttir-erase-inverse-ops", "::mlir::ModuleOp">
     Option<"enableCommuteUpwards", "enable-commute-upwards", "bool", "true", "Enable commuting upwards. This should only be false for testing purposes (i.e you want to test a commute downwards pattern)">,
     Option<"enableCommuteDownwards", "enable-commute-downwards", "bool", "true", "Enable commuting downwards. This should only be false for testing purposes (i.e you want to test a commute upwards pattern)">,
     Option<"maxIterations", "max-iterations", "uint64_t", "100", "Maximum number of iterations to perform commuting. The number of TMs is expected to converge before this limit is reached.">,
-    Option<"force", "force", "bool", "false", "Force the pass to run even if we don't expect any inverse TMs (no operations have TTIR_FlattenedCompatInfoAttr). When false, the pass only runs on funcOps containing at least one operation with the flattened_compat_info attribute.">
+    Option<"force", "force", "bool", "true", "Force the pass to run even if we don't expect any inverse TMs (no operations have TTIR_FlattenedCompatInfoAttr). When false, the pass only runs on funcOps containing at least one operation with the flattened_compat_info attribute.">
   ];
 }
 

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/skip_without_flattened_attr.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/skip_without_flattened_attr.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-erase-inverse-ops -o %t %s
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // This test verifies that the EIO pass is skipped when no operations have


### PR DESCRIPTION
### Problem description
Previously EIO was disabled for models without pooling ops. But in some LLM we get there redundant reshaped in MLP:
```mlir
        %78 = "ttnn.reshape"(%77) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16, #ttnn_layout20>) -> tensor<32x2048xbf16, #ttnn_layout23>
        "ttnn.deallocate"(%77) <{force = false}> : (tensor<32x1x2048xbf16, #ttnn_layout20>) -> ()
        %79 = "ttnn.matmul"(%78, %12) <{transpose_a = false, transpose_b = true}> : (tensor<32x2048xbf16, #ttnn_layout23>, tensor<8192x2048x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout8>) -> tensor<32x8192xbf16, #ttnn_layout38>
        "ttnn.deallocate"(%12) <{force = false}> : (tensor<8192x2048x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout8>) -> ()
        %80 = "ttnn.reshape"(%79) <{shape = [32 : i32, 1 : i32, 8192 : i32]}> : (tensor<32x8192xbf16, #ttnn_layout38>) -> tensor<32x1x8192xbf16, #ttnn_layout39>
        "ttnn.deallocate"(%79) <{force = false}> : (tensor<32x8192xbf16, #ttnn_layout38>) -> ()
        %81 = "ttnn.silu"(%80) : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> tensor<32x1x8192xbf16, #ttnn_layout39>
        "ttnn.deallocate"(%80) <{force = false}> : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> ()
        %82 = "ttnn.matmul"(%78, %4) <{transpose_a = false, transpose_b = true}> : (tensor<32x2048xbf16, #ttnn_layout23>, tensor<8192x2048x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout8>) -> tensor<32x8192xbf16, #ttnn_layout38>
        "ttnn.deallocate"(%78) <{force = false}> : (tensor<32x2048xbf16, #ttnn_layout23>) -> ()
        "ttnn.deallocate"(%4) <{force = false}> : (tensor<8192x2048x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout8>) -> ()
        %83 = "ttnn.reshape"(%82) <{shape = [32 : i32, 1 : i32, 8192 : i32]}> : (tensor<32x8192xbf16, #ttnn_layout38>) -> tensor<32x1x8192xbf16, #ttnn_layout39>
        "ttnn.deallocate"(%82) <{force = false}> : (tensor<32x8192xbf16, #ttnn_layout38>) -> ()
        %84 = "ttnn.multiply"(%81, %83) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x1x8192xbf16, #ttnn_layout39>, tensor<32x1x8192xbf16, #ttnn_layout39>) -> tensor<32x1x8192xbf16, #ttnn_layout39>
        "ttnn.deallocate"(%83) <{force = false}> : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> ()
        "ttnn.deallocate"(%81) <{force = false}> : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> ()
        %85 = "ttnn.reshape"(%84) <{shape = [32 : i32, 8192 : i32]}> : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> tensor<32x8192xbf16, #ttnn_layout38>
        "ttnn.deallocate"(%84) <{force = false}> : (tensor<32x1x8192xbf16, #ttnn_layout39>) -> ()
        %86 = "ttnn.matmul"(%85, %5) <{transpose_a = false, transpose_b = true}> : (tensor<32x8192xbf16, #ttnn_layout38>, tensor<2048x8192x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout10>) -> tensor<32x2048xbf16, #ttnn_layout23>
        "ttnn.deallocate"(%85) <{force = false}> : (tensor<32x8192xbf16, #ttnn_layout38>) -> ()
        "ttnn.deallocate"(%5) <{force = false}> : (tensor<2048x8192x!ttcore.tile<32x32, bfp_bf8>, #ttnn_layout10>) -> ()
        %87 = "ttnn.reshape"(%86) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16, #ttnn_layout23>) -> tensor<32x1x2048xbf16, #ttnn_layout20>

```

### What's changed
Force enable EIO for all models
