### PR TITLE
[Explorer] Use Module.parsefile to keep loc data

### DIFF
--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -7,6 +7,7 @@ from . import runner, utils, mlir
 import dataclasses
 import logging
 import os
+import tempfile
 from ttmlir import optimizer_overrides
 
 OVERRIDE_PARAMETER_DISABLED_STR = "None"
@@ -187,8 +188,7 @@ class TTAdapter(model_explorer.Adapter):
             golden_results = self.model_runner.get_golden_results(model_path)
             cpp_code = self.model_runner.get_cpp_code(model_path)
 
-            with open(optimized_model_path, "r") as model_file:
-                module = utils.parse_mlir_str(model_file.read())
+            module = utils.parse_mlir_file(optimized_model_path)
 
             # Convert TTIR to Model Explorer Graphs and Display/Return
             graph_handler = mlir.GraphHandler()
@@ -217,12 +217,16 @@ class TTAdapter(model_explorer.Adapter):
                 )
 
                 if module_str:
-                    module = utils.parse_mlir_str(module_str)
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".mlir"
+                    ) as tmp_file:
+                        tmp_file.write(module_str)
+                        tmp_file.flush()
+                        module = utils.parse_mlir_file(tmp_file.name)
                 elif module_str is None:
                     raise Exception("Failed to parse flatbuffer")
             else:
-                with open(model_path, "r") as model_file:
-                    module = utils.parse_mlir_str(model_file.read())
+                module = utils.parse_mlir_file(model_path)
 
             # Convert TTIR to Model Explorer Graphs and Display/Return
             graph_handler = mlir.GraphHandler()

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -423,8 +423,7 @@ class ModelRunner:
                 )
 
             # Get module from file
-            with open(ttnn_ir_file, "r") as f:
-                ttnn_module = utils.parse_mlir_str(f.read())
+            ttnn_module = utils.parse_mlir_file(ttnn_ir_file)
 
             self.log("Running TTNN to Flatbuffer File")
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/utils.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/utils.py
@@ -12,6 +12,8 @@ import os
 import logging
 import torch
 
+from ttmlir.ir import Module
+
 from . import ttrt_loader
 
 
@@ -24,9 +26,10 @@ def get_resolved_ir_dumps_dir():
     return str(Path(IR_DUMPS_DIR).expanduser().resolve())
 
 
-def parse_mlir_str(module_str):
+def parse_mlir_file(file_path):
     with ttmlir.ir.Context() as ctx:
-        module = ttmlir.ir.Module.parse(module_str, ctx)
+        # Use parseFile to preserve file location information
+        module = Module.parseFile(file_path, ctx)
         return module
 
 


### PR DESCRIPTION
### Ticket
None

### Problem description
When `.mlir` are being loaded from file, `Module.Parse` completely ignores parsing location data, even when present in the .mlir, and generates it's own FileLineCol locations with `-` as the filename.

### What's changed
Use Module.parseFile instead, which preserves existing location.

### Checklist
- [ ] New/Existing tests provide coverage for changes
  - Tests are currently disabled. Will be addressed in separate PR. See https://github.com/tenstorrent/tt-mlir/issues/5470

TODO before merge: Override from explorer still doesn't work when NameLocs are not defined in the mlir content