### PR TITLE
Record program metadata in ttmetal runtime

### DIFF
--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -542,6 +542,8 @@ executeMeshDeviceProgram(distributed::MeshDevice *meshDevice,
     std::string zoneName =
         "executeCommandQueue_mcq_" + std::to_string(cq->queue_id());
     ZoneName(zoneName.c_str(), zoneName.size());
+    perf::Env::get().tracyLogProgramMetadata(
+        perf::Env::get().tracyProgramMetadata);
 
     executor.execute(cq);
 


### PR DESCRIPTION
This allows `ttrt perf` to not skip ttnn api duration and device kernel duration in ttmetal code path.
