### PR TITLE
Change shardy patch code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Misc
 /env/ @nsmithtt @vwellsTT
+/env/patches/shardy* @tenstorrent/forge-developers-mlir-stablehlo
 *.fbs @jnie-TT @nsmithtt
 /.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT @tt-mpantic
 LICENSE @nsmithtt


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently, any changes to shardy patches are bottlenecked by Nick and Vincent. It is better if stablehlo developers are added as codeowners to these files.

### What's changed
Codeowners