### PR TITLE
[tt-lang][ttnn-interop] Add DRAM Interleaved DMA lowering

### DIFF
--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1028,6 +1028,25 @@ static Value castCBTypeAsAddress(OpBuilder &rewriter, Location loc, Value cb) {
       ->getResult(0);
 }
 
+/// Check if a memref has DRAM interleaved layout
+static bool isDRAMInterleaved(MemRefType memref) {
+  auto layout = mlir::dyn_cast<ttcore::MetalLayoutAttr>(memref.getLayout());
+  if (!layout) {
+    return false;
+  }
+  return layout.getMemorySpace() == ttcore::MemorySpace::DeviceDRAM &&
+         layout.getMemoryLayout() == ttcore::TensorMemoryLayout::Interleaved;
+}
+
+/// Get page size in bytes for a memref element type
+static int64_t getPageSizeBytes(Type elementType) {
+  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
+    return tileType.getSizeBytes();
+  }
+  // For non-tile types, use element size
+  return ttcore::getElementSizeBytes(elementType);
+}
+
 static Value buildNocAddress(OpBuilder &rewriter, Location loc, Value cb,
                              ValueRange index, ttcore::ChipDescAttr chipDesc,
                              ttcore::MemorySpace memspace) {
@@ -1087,13 +1106,8 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
 
     auto chipDesc = ttcore::getOpChipDescAttr(op);
+    auto srcMemRefType = op.getSrcMemRefType();
 
-    // NOTE: All reads must be from remote locations in DMAReadOp
-    // local->local transfers are lowered as nocAsyncWrites, which require
-    // write barriers.
-    auto srcNocAddr =
-        buildNocAddress(rewriter, op.getLoc(), adaptor.getSrc(),
-                        op.getSrcIndices(), chipDesc, op.getSrcMemorySpace());
     auto dstCBMapping = cbProducerConsumer->get(op.getDst());
     TT_assertv((dstCBMapping == d2m::ThreadCBOrientation::Producer ||
                 dstCBMapping == d2m::ThreadCBOrientation::Default),
@@ -1102,9 +1116,36 @@ public:
     Value dstL1Addr = buildL1Address<ttkernel::GetWritePtrOp>(
         rewriter, op.getLoc(), adaptor.getDst(), op.getDstIndices());
 
-    auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
-    rewriter.create<ttkernel::NocAsyncReadOp>(op.getLoc(), srcNocAddr,
-                                              dstL1Addr, size);
+    if (isDRAMInterleaved(srcMemRefType)) {
+      auto baseAddr =
+          castCBTypeAsAddress(rewriter, op.getLoc(), adaptor.getSrc());
+      auto pageSize = i32(rewriter, op.getLoc(),
+                          getPageSizeBytes(srcMemRefType.getElementType()));
+      auto dataFormat = rewriter.create<ttkernel::GetDataFormatOp>(
+          op.getLoc(), adaptor.getDst());
+      auto isDRAM = rewriter.create<arith::ConstantOp>(
+          op.getLoc(), rewriter.getI1Type(), rewriter.getBoolAttr(true));
+
+      auto addrGen = rewriter.create<ttkernel::GetInterleavedAddrGenFastOp>(
+          op.getLoc(), isDRAM, baseAddr, pageSize, dataFormat);
+
+      // For interleaved, index[1] is the tile ID
+      auto tileId = rewriter.create<arith::IndexCastOp>(
+          op.getLoc(), rewriter.getI32Type(), op.getSrcIndices()[1]);
+
+      rewriter.create<ttkernel::NocAsyncReadTileOp>(op.getLoc(), tileId, addrGen,
+                                                    dstL1Addr);
+    } else {
+      // NOTE: All reads must be from remote locations in DMAReadOp
+      // local->local transfers are lowered as nocAsyncWrites, which require
+      // write barriers.
+      auto srcNocAddr =
+          buildNocAddress(rewriter, op.getLoc(), adaptor.getSrc(),
+                          op.getSrcIndices(), chipDesc, op.getSrcMemorySpace());
+      auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
+      rewriter.create<ttkernel::NocAsyncReadOp>(op.getLoc(), srcNocAddr,
+                                                dstL1Addr, size);
+    }
 
     // Add attribute marking whether the DMA wait is for a read or write
     // operation This will be used when loweing the wait ops because the current
@@ -1215,12 +1256,35 @@ public:
     } else if (op.isDstRemote()) {
       auto srcL1Addr = buildL1Address<ttkernel::GetReadPtrOp>(
           rewriter, op.getLoc(), adaptor.getSrc(), op.getSrcIndices());
-      auto dstNocAddr =
-          buildNocAddress(rewriter, op.getLoc(), adaptor.getDst(),
-                          op.getDstIndices(), chipDesc, op.getDstMemorySpace());
-      auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
-      rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Addr,
-                                                 dstNocAddr, size);
+      auto dstMemRefType = op.getDstMemRefType();
+
+      if (isDRAMInterleaved(dstMemRefType)) {
+        auto baseAddr =
+            castCBTypeAsAddress(rewriter, op.getLoc(), adaptor.getDst());
+        auto pageSize = i32(rewriter, op.getLoc(),
+                            getPageSizeBytes(dstMemRefType.getElementType()));
+        auto dataFormat = rewriter.create<ttkernel::GetDataFormatOp>(
+            op.getLoc(), adaptor.getSrc());
+        auto isDRAM = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getI1Type(), rewriter.getBoolAttr(true));
+
+        auto addrGen = rewriter.create<ttkernel::GetInterleavedAddrGenFastOp>(
+            op.getLoc(), isDRAM, baseAddr, pageSize, dataFormat);
+
+        // For interleaved, index[1] is the tile ID
+        auto tileId = rewriter.create<arith::IndexCastOp>(
+            op.getLoc(), rewriter.getI32Type(), op.getDstIndices()[1]);
+
+        rewriter.create<ttkernel::NocAsyncWriteTileOp>(op.getLoc(), tileId,
+                                                       addrGen, srcL1Addr);
+      } else {
+        auto dstNocAddr =
+            buildNocAddress(rewriter, op.getLoc(), adaptor.getDst(),
+                            op.getDstIndices(), chipDesc, op.getDstMemorySpace());
+        auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
+        rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Addr,
+                                                   dstNocAddr, size);
+      }
     }
 
     // Add attribute marking whether the DMA wait is for a read or write

--- a/test/ttmlir/Conversion/D2MToTTKernel/dram_interleaved_dma_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/dram_interleaved_dma_lowering.mlir
@@ -1,0 +1,36 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-generic-lower-dmas --d2m-generic-generate-loops --canonicalize --d2m-generic-regions-to-funcs --convert-d2m-to-ttkernel %s | FileCheck %s -dump-input=always
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// DRAM interleaved layout: tiles are striped round-robin across DRAM banks
+#dram_interleaved = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, dram, interleaved, index_map = map(0)>
+#l1_sharded = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded, index_map = map(0)>
+
+module {
+
+// Test: DRAM interleaved read should use InterleavedAddrGenFast + NocAsyncReadTile
+// CHECK-LABEL: func.func private @datamovement_kernel0
+func.func @test_dram_interleaved_read(%arg0: tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #dram_interleaved>) {
+
+  // Should generate interleaved address gen and tile read ops
+  //   CHECK: ttkernel.get_dataformat
+  //   CHECK: ttkernel.get_interleaved_addr_gen_fast
+  //   CHECK: ttkernel.noc_async_read_tile
+
+  %alloc_l1 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #l1_sharded>
+  %view = d2m.view_layout %arg0 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #dram_interleaved> -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #dram_interleaved>
+  d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<datamovement>]}
+      ins(%view : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #dram_interleaved>)
+      outs(%alloc_l1 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #l1_sharded>)  {
+  ^datamovement0(%cb0: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #dram>>, %cb1: !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>):
+    %buf = d2m.reserve %cb1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    %tx = d2m.dma %view<affine_map<(d0, d1) -> (d0, d1)>>, %buf : (tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #dram_interleaved>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+    d2m.dma_wait %tx
+  }
+  return
+}
+
+}


### PR DESCRIPTION
Enables DMA operations to read/write directly from DRAM interleaved tensors without requiring L1 intermediate storage. Update`D2MDMA(Read,Write)Rewriter` to generate `GetInterleavedAddrGenFastOp` with `NocAsyncReadTileOp`/`NocAsyncWriteTileOp` for DRAM interleaved sources and destinations.

Other half of: https://github.com/tenstorrent/tt-lang/pull/55