### PR TITLE
Fix `ttir.dot_general` for mixed type inputs

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1627,8 +1627,7 @@ struct DotGeneralToMatmulConversionPattern
     SmallVector<int64_t> rhsBatchDims(op.getBatchDimsRhs());
     SmallVector<int64_t> rhsContractDims(op.getContractDimsRhs());
 
-    Type elementType = lhsType.getElementType();
-    Attribute encoding = lhsType.getEncoding();
+    Type elementType = op.getType().getElementType();
 
     SmallVector<int64_t> lhsResultDims =
         getResultDims(lhsBatchDims, lhsContractDims, lhsRank);
@@ -1690,8 +1689,7 @@ struct DotGeneralToMatmulConversionPattern
 
     // Perform matmul operation.
     auto matmulOp = rewriter.create<ttir::MatmulOp>(
-        op.getLoc(),
-        RankedTensorType::get(matmulDestinationShape, elementType, encoding),
+        op.getLoc(), RankedTensorType::get(matmulDestinationShape, elementType),
         lhsMatmulInput, rhsMatmulInput);
 
     // Propagate the hoist attribute to the matmul op.
@@ -1717,7 +1715,7 @@ struct DotGeneralToMatmulConversionPattern
                                              resultShape.end());
 
     auto reshapeOutput = rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
-        op, RankedTensorType::get(resultShape, elementType, encoding), matmulOp,
+        op, RankedTensorType::get(resultShape, elementType), matmulOp,
         rewriter.getI32ArrayAttr(finalShapeI32));
 
     reshapeOutput->setLoc(ttmlir::utils::appendLocationSuffix(

--- a/test/ttmlir/Dialect/TTIR/Decomposition/dot_general/dot_general_matmul_mixed_types.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/dot_general/dot_general_matmul_mixed_types.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition -o %t %s
+
+// Regression test for failure when the inputs are mixed types
+// https://github.com/tenstorrent/tt-mlir/issues/6227
+
+func.func @main(%arg0: tensor<1x16x128x512x16xf32>, %arg1: tensor<1x16x128x1x512xbf16>) -> tensor<1x16x128x1x16xf32> {
+  %0 = "ttir.dot_general"(%arg1, %arg0) <{batch_dims_lhs = array<i64: 0, 1, 2>, batch_dims_rhs = array<i64: 0, 1, 2>, contract_dims_lhs = array<i64: 4>, contract_dims_rhs = array<i64: 3>}> : (tensor<1x16x128x1x512xbf16>, tensor<1x16x128x512x16xf32>) -> tensor<1x16x128x1x16xf32>
+  return %0 : tensor<1x16x128x1x16xf32>
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6227

### Problem description
TTIRToTTIRDecompostion failed on `ttir.dot_general` when inputs and output didn't have the same data type.

### What's changed
Change the output type of `matmul` (and subsequent `reshape` and `permute`) to the output type of `dot_general`.

### Checklist
- [x] New/Existing tests provide coverage for changes
