### PR TITLE
multiple output tensors (simple version)

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "93e6cd7c0d2dbde65698178c0ebcd50d0bc3f204")
+set(TT_METAL_VERSION "f4eac8cd73e4fed9fbc15e27a66b4c79d37d821e")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
### Ticket
#5558 

### Problem description
Allow multiple output tensors.

### What's changed
1. The output of an op will be a vector instead of a single object.
2. Awaiting metal change to query_op_constraints, which will return a vector output_tensor_specs.
3. Before changing all references to output_tensor_spec, we extract the first element in the vector as the workaround.

