### PR TITLE
[ttnn.jit] Dump kernel source to file

### DIFF
--- a/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
+++ b/include/ttmlir/Target/TTNN/TTNNToFlatbuffer.h
@@ -24,7 +24,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
     const std::unordered_map<std::string,
                              std::unordered_map<std::uint32_t, GoldenTensor>>
         &goldenMap = {},
-    const std::vector<std::pair<std::string, std::string>> &moduleCache = {});
+    const std::vector<std::pair<std::string, std::string>> &moduleCache = {},
+    const std::string &kernelDumpDir = "");
 
 // Convert a TTNNIR operation to a flatbuffer
 // This function signature is required in order to register the conversion in
@@ -41,7 +42,8 @@ LogicalResult translateTTNNToFlatbuffer(
         }
         */
         &goldenMap = {},
-    const std::vector<std::pair<std::string, std::string>> &moduleCache = {});
+    const std::vector<std::pair<std::string, std::string>> &moduleCache = {},
+    const std::string &kernelDumpDir = "");
 } // namespace mlir::tt::ttnn
 
 #endif

--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -58,7 +58,8 @@ inline Value getOperandThroughDPSOps(Value value) {
 template <typename OpT, typename FnT, typename TensorFnT>
 Program<OpT> funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry,
                              FnT fn, TensorFnT tensorValueToFlatbuffer,
-                             const llvm::StringMap<uint32_t> &programIndexMap) {
+                             const llvm::StringMap<uint32_t> &programIndexMap,
+                             const std::string &kernelDumpDir = "") {
   OpPrintingFlags printFlags;
   printFlags = printFlags.elideLargeElementsAttrs()
                    .elideLargeResourceString()
@@ -83,7 +84,8 @@ Program<OpT> funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry,
     } else {
       std::string debugStr = getOpDebugString(op, printState);
       std::string locInfo = getOpLocInfo(op);
-      program.ops.push_back(fn(cache, op, programIndexMap, debugStr, locInfo));
+      program.ops.push_back(
+          fn(cache, op, programIndexMap, debugStr, locInfo, kernelDumpDir));
     }
   });
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -41,6 +41,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir::tt::ttnn {
@@ -2474,7 +2476,8 @@ createKernelArgs(FlatbufferObjectCache &cache,
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::GenericOp>
-createOp(FlatbufferObjectCache &cache, GenericOp op) {
+createOp(FlatbufferObjectCache &cache, GenericOp op,
+         const std::string &kernelDumpDir = "") {
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ios;
   for (auto operand : op.getInputsAndOutputs()) {
     ios.push_back(cache.at<::tt::target::ttnn::TensorRef>(
@@ -2498,6 +2501,27 @@ createOp(FlatbufferObjectCache &cache, GenericOp op) {
         ttkernel::translateTopLevelKernelToCpp(moduleOp, stream, kernelSymbol);
     assert(result.succeeded());
     assert(source.size() > 0 && "empty kernel source");
+
+    // Dump kernel to file if requested
+    if (!kernelDumpDir.empty()) {
+      llvm::SmallString<256> dumpPath(kernelDumpDir);
+      std::error_code ec = llvm::sys::fs::create_directories(dumpPath);
+      if (ec) {
+        llvm::errs() << "Failed to create kernel dump directory " << dumpPath
+                     << ": " << ec.message() << "\n";
+      } else {
+        llvm::sys::path::append(dumpPath, kernelSymbol.str() + ".cpp");
+        std::error_code fileError;
+        llvm::raw_fd_ostream kernelFile(dumpPath, fileError);
+        if (fileError) {
+          llvm::errs() << "Failed to open kernel dump file " << dumpPath << ": "
+                       << fileError.message() << "\n";
+        } else {
+          kernelFile << source;
+          kernelFile.flush();
+        }
+      }
+    }
 
     ::tt::target::ttnn::KernelConfig configType =
         ::tt::target::ttnn::KernelConfig::NONE;
@@ -2706,7 +2730,8 @@ createOp(FlatbufferObjectCache &cache, LoadTensorOp op) {
 ::flatbuffers::Offset<::tt::target::ttnn::Operation>
 emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                   const llvm::StringMap<uint32_t> &programIndexMap,
-                  const std::string &debugString, const std::string &locInfo) {
+                  const std::string &debugString, const std::string &locInfo,
+                  const std::string &kernelDumpDir = "") {
   if (auto getDeviceOp = dyn_cast<GetDeviceOp>(op); getDeviceOp) {
     return createOperation(cache, createOp(cache, getDeviceOp), debugString,
                            locInfo);
@@ -3306,8 +3331,8 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                            debugString, locInfo);
   }
   if (auto genericOp = dyn_cast<GenericOp>(op); genericOp) {
-    return createOperation(cache, createOp(cache, genericOp), debugString,
-                           locInfo);
+    return createOperation(cache, createOp(cache, genericOp, kernelDumpDir),
+                           debugString, locInfo);
   }
   if (auto nlpConcatHeadsDecodeOp = dyn_cast<NLPConcatHeadsDecodeOp>(op);
       nlpConcatHeadsDecodeOp) {
@@ -3371,7 +3396,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
     const std::unordered_map<std::string,
                              std::unordered_map<std::uint32_t, GoldenTensor>>
         &goldenMap,
-    const std::vector<std::pair<std::string, std::string>> &moduleCache) {
+    const std::vector<std::pair<std::string, std::string>> &moduleCache,
+    const std::string &kernelDumpDir) {
   ModuleOp rootModule = dyn_cast<ModuleOp>(op);
   assert(rootModule && "Expected ModuleOp as top level operation");
 
@@ -3463,7 +3489,7 @@ std::shared_ptr<void> ttnnToFlatbuffer(
       Program<::tt::target::ttnn::Operation> program =
           funcOpToProgram<::tt::target::ttnn::Operation>(
               cache, func, emitTTNNOperation, tensorValueToFlatbuffer,
-              programIdxMap);
+              programIdxMap, kernelDumpDir);
 
       ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(func);
 
@@ -3514,8 +3540,10 @@ LogicalResult translateTTNNToFlatbuffer(
     const std::unordered_map<std::string,
                              std::unordered_map<std::uint32_t, GoldenTensor>>
         &goldenMap,
-    const std::vector<std::pair<std::string, std::string>> &moduleCache) {
-  std::shared_ptr<void> data = ttnnToFlatbuffer(op, goldenMap, moduleCache);
+    const std::vector<std::pair<std::string, std::string>> &moduleCache,
+    const std::string &kernelDumpDir) {
+  std::shared_ptr<void> data =
+      ttnnToFlatbuffer(op, goldenMap, moduleCache, kernelDumpDir);
   std::size_t size = ::flatbuffers::GetSizePrefixedBufferLength(
       static_cast<const uint8_t *>(data.get()));
   os.write(reinterpret_cast<const char *>(data.get()), size);

--- a/lib/Target/TTNN/TTNNToFlatbufferRegistration.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbufferRegistration.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
+#include "llvm/Support/CommandLine.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
@@ -19,11 +20,19 @@ using namespace mlir;
 
 namespace mlir::tt::ttnn {
 
+// Command line option for kernel dump directory
+static llvm::cl::opt<std::string>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    kernelDumpDir("kernel-dump-dir",
+                  llvm::cl::desc("Directory to dump translated kernel sources "
+                                 "during compilation (default: no dumping)"),
+                  llvm::cl::init(""));
+
 void registerTTNNToFlatbuffer() {
   TranslateFromMLIRRegistration reg(
       "ttnn-to-flatbuffer", "translate ttnn to flatbuffer",
       [](Operation *op, llvm::raw_ostream &os) -> LogicalResult {
-        return translateTTNNToFlatbuffer(op, os, {});
+        return translateTTNNToFlatbuffer(op, os, {}, {}, kernelDumpDir);
       },
       [](DialectRegistry &registry) {
         // clang-format off

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -208,40 +208,45 @@ void populatePassesModule(nb::module_ &m) {
       std::string, std::unordered_map<unsigned int, mlir::tt::GoldenTensor>>>(
       m, "GoldenMap");
 
-  m.def("ttnn_to_flatbuffer_file",
-        [](MlirModule module, std::string &filepath,
-           const std::unordered_map<
-               std::string,
-               std::unordered_map<std::uint32_t, mlir::tt::GoldenTensor>>
-               &goldenMap = {},
-           const std::vector<std::pair<std::string, std::string>> &moduleCache =
-               {}) {
-          mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+  m.def(
+      "ttnn_to_flatbuffer_file",
+      [](MlirModule module, std::string &filepath,
+         const std::unordered_map<
+             std::string,
+             std::unordered_map<std::uint32_t, mlir::tt::GoldenTensor>>
+             &goldenMap = {},
+         const std::vector<std::pair<std::string, std::string>> &moduleCache =
+             {},
+         const std::string &kernelDumpDir = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
 
-          // Create a dialect registry and register all necessary dialects and
-          // translations
-          mlir::DialectRegistry registry;
+        // Create a dialect registry and register all necessary dialects and
+        // translations
+        mlir::DialectRegistry registry;
 
-          // Register all LLVM IR translations
-          registerAllToLLVMIRTranslations(registry);
+        // Register all LLVM IR translations
+        registerAllToLLVMIRTranslations(registry);
 
-          // Apply the registry to the module's context
-          moduleOp->getContext()->appendDialectRegistry(registry);
+        // Apply the registry to the module's context
+        moduleOp->getContext()->appendDialectRegistry(registry);
 
-          std::error_code fileError;
-          llvm::raw_fd_ostream file(filepath, fileError);
+        std::error_code fileError;
+        llvm::raw_fd_ostream file(filepath, fileError);
 
-          if (fileError) {
-            throw std::runtime_error("Failed to open file: " + filepath +
-                                     ". Error: " + fileError.message());
-          }
+        if (fileError) {
+          throw std::runtime_error("Failed to open file: " + filepath +
+                                   ". Error: " + fileError.message());
+        }
 
-          if (mlir::failed(mlir::tt::ttnn::translateTTNNToFlatbuffer(
-                  moduleOp, file, goldenMap, moduleCache))) {
-            throw std::runtime_error("Failed to write flatbuffer to file: " +
-                                     filepath);
-          }
-        });
+        if (mlir::failed(mlir::tt::ttnn::translateTTNNToFlatbuffer(
+                moduleOp, file, goldenMap, moduleCache, kernelDumpDir))) {
+          throw std::runtime_error("Failed to write flatbuffer to file: " +
+                                   filepath);
+        }
+      },
+      nb::arg("module"), nb::arg("filepath"),
+      nb::arg("golden_map") = nb::dict(), nb::arg("module_cache") = nb::list(),
+      nb::arg("kernel_dump_dir") = "");
 
   m.def("ttmetal_to_flatbuffer_file",
         [](MlirModule module, std::string filepath,

--- a/tools/ttnn-jit/_src/jit.py
+++ b/tools/ttnn-jit/_src/jit.py
@@ -124,7 +124,9 @@ class JitFunction:
                 print("---- IR Dump after ttnn_to_ttmetal_pipeline ----")
                 print(ir)
             flatbuffer_bin = os.path.join(self.out_dir, self.func.__name__ + ".ttn")
-            ttnn_to_flatbuffer_file(ir, flatbuffer_bin, {}, [])
+            ttnn_to_flatbuffer_file(
+                ir, flatbuffer_bin, {}, [], kernel_dump_dir=self.out_dir
+            )
             return ir
 
         if self.cache:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We want to be able to dump the cpp kernels to a dedicated folder when running jit in `compile_only` mode. This is completely separate from ttrt

### What's changed
- modified `TTNNToFlatbuffer` to take a `kernelDumpDir` field which generic op translation will dump the kernel source to
- this will work for both the api and CLI
- for jit, `compile_only` mode will dump kernels to `generated/ttnn-jit/`

### Checklist
- [ ] New/Existing tests provide coverage for changes
