### PR TITLE
Fixing illegal folding during ETN

### DIFF
--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -234,10 +234,12 @@ struct ElementTypeNormalization
     }
 
     mlir::RewritePatternSet patterns(&getContext());
+    GreedyRewriteConfig config;
+    config.enableFolding(false);
     patterns.add<UniformTypeRewriter>(converter, &getContext());
     patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
-    if (failed(
-            mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    if (failed(mlir::applyPatternsGreedily(getOperation(), std::move(patterns),
+                                           config))) {
       signalPassFailure();
       return;
     }

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_folding_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_folding_test.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt --ttir-element-type-normalization -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+func.func @fold_broadcast(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
+  // CHECK-NOT: "ttir.broadcast"
+  // CHECK: -> tensor<1x256x1xf32>
+  %1 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
+  return %1 : tensor<1x256x1xf64>
+}

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -144,10 +144,3 @@ func.func @constant_bf16() -> tensor<32x32xbf16> {
   %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
   return %0 : tensor<32x32xbf16>
 }
-
-func.func @fold_broadcast(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
-  // CHECK-NOT: "ttir.broadcast"
-  // CHECK: -> tensor<1x256x1xf32>
-  %1 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
-  return %1 : tensor<1x256x1xf64>
-}


### PR DESCRIPTION
This fixes regression which was introduced (unintentionally) with #5714 .
Best description on the issue is here: #2932 

Proper solution again is described in #2932 but requires extensive work to have it working. 

