### PR TITLE
[ttnn.jit] Don't run nightly ttnn-jit tests on llmbox

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -33,7 +33,7 @@
   { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
   { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
-  { "runs-on": ["n150","llmbox"],   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
+  { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
   { "runs-on": ["n150","llmbox"],   "image": "tracy",  "script": "ttnn_jit.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
   { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}


### PR DESCRIPTION
### Problem description
ttnn-jit nightly tests were running in llmbox 
see https://github.com/tenstorrent/tt-mlir/actions/runs/20106543355/job/57693681303?pr=6234

### What's changed
fix the test matrix