### PR TITLE
Fix KV Cache operations to always use tiled layout

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -596,7 +596,9 @@ private:
 
   bool shouldForceInputRowMajor(BlockArgument arg) const {
     for (Operation *user : arg.getUsers()) {
-      if (mlir::isa<ttir::MeshShardOp>(user)) {
+      // MeshShardOp/UpdateCacheOp/PagedUpdateCacheOp inputs should be tiled.
+      if (mlir::isa<ttir::MeshShardOp, ttir::UpdateCacheOp,
+                    ttir::PagedUpdateCacheOp>(user)) {
         return false;
       }
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
KV Cache tensors need to be tiled, but were not excluded from the row-major forcing logic in `TTNNLayout.cpp`. This could cause incorrect layouts for KV cache tensors.

### What's changed
Added `UpdateCacheOp` and `PagedUpdateCacheOp` to the check in `shouldForceInputRowMajor()` so that inputs to these operations remain tiled instead of being forced to row-major layout. This is consistent with how `MeshShardOp` is handled.

### Checklist
- [ ] New/Existing tests provide coverage for changes