### PR TITLE
[ttnn.jit] Separate target for jit deps

### DIFF
--- a/tools/ttnn-jit/CMakeLists.txt
+++ b/tools/ttnn-jit/CMakeLists.txt
@@ -49,9 +49,14 @@ if (USE_TTNN_JIT_WHEEL)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build/.ttnn-jit-installed
   )
 
+  add_custom_target(ttnn-jit-deps
+    COMMENT "ttnn-jit dependencies"
+    DEPENDS _ttnn_jit _ttmlir_runtime TTMLIRPythonModules
+  )
+
   add_custom_target(ttnn-jit ALL
     COMMENT "ttnn-jit package"
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/build/.ttnn-jit-installed _ttnn_jit _ttmlir_runtime TTMLIRPythonModules)
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/build/.ttnn-jit-installed ttnn-jit-deps)
 
   set_target_properties(JITCPP PROPERTIES
     INSTALL_RPATH "${JIT_WHEEL_RPATHS}"

--- a/tools/ttnn-jit/setup.py
+++ b/tools/ttnn-jit/setup.py
@@ -125,12 +125,13 @@ class CMakeBuild(build_ext):
                 "-DTTMLIR_ENABLE_TTRT=OFF",
                 "-DTTMLIR_ENABLE_OPMODEL=OFF",
                 "-DTTMLIR_ENABLE_TESTS=OFF",
+                "-DTTMLIR_ENABLE_ALCHEMIST=OFF",
             ]
             cmake_args.extend(["-S", str(source_dir)])
             print(f"Running CMake configure: {' '.join(cmake_args)}")
             subprocess.check_call(cmake_args, env=build_env)
 
-            build_cmd = ["cmake", "--build", str(build_dir), "--", "ttnn-jit"]
+            build_cmd = ["cmake", "--build", str(build_dir), "--", "ttnn-jit-deps"]
             print(f"Running CMake build: {' '.join(build_cmd)}")
             subprocess.check_call(build_cmd, env=build_env)
             print("CMake build completed successfully")


### PR DESCRIPTION
### Problem description
If we try building wheel on it's own (outside of the cmake flow) w/ `python -m build --wheel` it will recurse and call the same wheel build command just with `TTMLIR_DEV_ENV=ON` in the cmake flow. 

While not functionally broken, this is just an unnecessary nested build

### What's changed
- added new target `ttnn-jit-deps` that depends on all the jit deps being built, but not the jit wheel itself
- jit wheel setup.py will build this new target to avoid the nested build

side note: turn alchemist off for jit wheel.. idk why this is even on.
