### PR TITLE
Add missing struct member initialization

### DIFF
--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -32,7 +32,8 @@ static ::tt::tt_metal::SemaphoreDescriptor createSemaphoreDescriptor(
   tt::tt_metal::CBFormatDescriptor cbFormatDescriptor = {
       .buffer_index = bufferIndex,
       .data_format = dataFormat,
-      .page_size = pageSize};
+      .page_size = pageSize,
+      .tile = std::nullopt};
   return cbFormatDescriptor;
 }
 
@@ -208,6 +209,7 @@ createKernelDescriptor(const ::tt::target::ttnn::KernelDescriptor &kernelDesc,
       .source_type = convertSourceType(kernelDesc.source_type()),
       .core_ranges = coreRanges,
       .compile_time_args = compileTimeArgs,
+      .named_compile_time_args = {},
       .defines = {},
       .runtime_args = runtimeArgs,
       .common_runtime_args = commonRuntimeArgs,


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/commit/2f70c56f7a5a6561d9a6968a973d356b664cbbf8 added new struct members to `tt_metal::CBFormatDescriptor` and `tt_metal::KernelDescriptor`. Newer compilers (clang-18 and gcc 13) seem to have more strict requirements for explicitly initializing struct members - possibly b/c of designated initializer support in c++20. Explicitly initializing resolves compiler errors using clang-18 and gcc 13. 