### PR TITLE
[ttnn.jit] Change device fixture to function scope

### DIFF
--- a/test/ttnn-jit/conftest.py
+++ b/test/ttnn-jit/conftest.py
@@ -8,7 +8,7 @@ import torch
 from loguru import logger
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def device():
     # Only care about single device, multi-device will use mesh_device fixture
     if ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.P150:


### PR DESCRIPTION
### Problem description
We want to match ttnn pytest fixture device setup.

### What's changed
- device fixture changed from `module` to `function` scope
