### PR TITLE
[fix] add "REQUIRES: stablehlo" in lit tests that fail when SHLO is disabled

### DIFF
--- a/test/ttmlir/Conversion/StableHLOToTTIR/fill_cache_batch32.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/fill_cache_batch32.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 module {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 

--- a/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
+++ b/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
 // RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir


### PR DESCRIPTION
### Problem description
When StableHLO support is disabled (`TTMLIR_ENABLE_STABLEHLO=OFF`), three tests that depend on StableHLO operations still run and fail:
- `test/ttmlir/Conversion/StableHLOToTTIR/fill_cache_batch32.mlir`
- `test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir`
- `test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir`

### What's changed
Added `// REQUIRES: stablehlo` directive to the three failing test files. This causes them to be skipped when StableHLO is disabled, consistent with all other StableHLO-dependent tests in the codebase. 

### Checklist
- [X] New/Existing tests provide coverage for changes
