### PR TITLE
Add `target-module` option for TTNN->EmitPy

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -429,9 +429,12 @@ struct TTNNBackendToEmitCPipelineOptions
 //
 struct TTNNBackendToEmitPyPipelineOptions
     : public PassPipelineOptions<TTNNBackendToEmitPyPipelineOptions> {
-  // TTNNToEmitC pipeline options contain "target-dylib" and
-  // "tuplify-input-if-empty" options. There's no dylib (or equivalent) path in
-  // EmitPy yet, so these options are removed.
+  Option<bool> targetModule{
+      *this, "target-module",
+      llvm::cl::desc("Tailor passes for Python module target. When enabled, "
+                     "the entry function is named 'forward' with tuple of "
+                     "tensors and device as inputs."),
+      llvm::cl::init(false)};
 
   Option<bool> loadInputTensorsFromDisk{
       *this, "load-input-tensors-from-disk",

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -179,6 +179,45 @@ def TTNNTuplifyTensors: Pass<"ttnn-tuplify-tensors", "::mlir::ModuleOp"> {
   ];
 }
 
+def TTNNPrepareModuleForExport : Pass<"ttnn-prepare-module-for-export", "::mlir::ModuleOp"> {
+  let summary = "Prepare module for Python module export.";
+  let description = [{
+    This pass prepares the module for export as a Python module by:
+    1. Renaming the first public (non-private, non-const-eval) function to "forward"
+    2. Adding a device argument to the function signature
+    3. Replacing all ttnn.get_device ops with the device function argument
+
+    Given a forward function like this:
+
+    ```mlir
+    func.func @add(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tuple<tensor<32x32xbf16>> {
+      %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
+      %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
+      %2 = "ttnn.get_device"() : () -> !ttnn.device
+      %3 = "ttnn.to_device"(%0, %2) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %4 = "ttnn.to_device"(%1, %2) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %5 = "ttnn.add"(%3, %4) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %6 = ttcore.tuple %5 : tuple<tensor<32x32xbf16>>
+      return %6 : tuple<tensor<32x32xbf16>>
+    }
+    ```
+
+    The pass will return:
+
+    ```mlir
+    func.func @forward(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>, %arg1: !ttnn.device) -> tuple<tensor<32x32xbf16>> {
+      %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
+      %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
+      %2 = "ttnn.to_device"(%0, %arg1) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %3 = "ttnn.to_device"(%1, %arg1) : (tensor<32x32xbf16, !ttnn.device) -> tensor<32x32xbf16>
+      %4 = "ttnn.add"(%2, %3) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %5 = ttcore.tuple %4 : tuple<tensor<32x32xbf16>>
+      return %5 : tuple<tensor<32x32xbf16>>
+    }
+    ```
+  }];
+}
+
 def TTNNPrepareConv2dWeightsAndBias : Pass<"ttnn-prepare-conv2d-weights-and-bias", "::mlir::ModuleOp"> {
   let summary = "Optimize Conv2d ops by inserting PrepareConv2dWeights and PrepareConv2dBias ops before them.";
   let description = [{

--- a/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
+++ b/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
@@ -81,9 +81,17 @@ public:
     // Handle func::FuncOp operations:
     module.walk([&](func::FuncOp funcOp) {
       for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
-        std::string argName = funcOp.getNumArguments() > 1
-                                  ? "input_" + std::to_string(i)
-                                  : "input";
+        std::string argName;
+
+        // Check if an emitpy.name attribute already exists for this argument.
+        // If so, use it instead of generating a new name.
+        if (auto existingNameAttr =
+                funcOp.getArgAttrOfType<StringAttr>(i, "emitpy.name")) {
+          argName = existingNameAttr.getValue().str();
+        } else {
+          argName = funcOp.getNumArguments() > 1 ? "input_" + std::to_string(i)
+                                                 : "input";
+        }
 
         // Check if parameter name collides with the function name
         if (reservedNames.contains(argName)) {

--- a/test/ttmlir/EmitPy/target_module.mlir
+++ b/test/ttmlir/EmitPy/target_module.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="target-module=true" -o %t.mlir %s
+// RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
+// RUN: FileCheck %s --input-file=%t.py
+
+// Verify that with target-module=true:
+// 1. The entry function is renamed to 'forward'
+// 2. The inputs are tuplified into a single argument
+// 3. A device argument is added as the second parameter
+// 4. No DeviceGetter.get_device call is present (device comes from argument)
+
+// CHECK: def forward(input, device):
+// CHECK-NOT: utils.DeviceGetter.get_device
+
+func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %1 = "ttir.add"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6218

### Problem description
We need a way to generate a uniform Python API for the `forward` function. This is linked to https://github.com/tenstorrent/tt-mlir/pull/6125, which should enable testing from the tt-xla.

### What's changed
Added a `target-module` option, which, when enabled:
- renames public function to `forward`
- changes signature to `(input: tuple<Tensor>, device: Device)`

### Checklist
- [x] New/Existing tests provide coverage for changes
