### PR TITLE
[docs][ttnn.jit] Clarify Layout Support

### DIFF
--- a/docs/src/ttnn-jit.md
+++ b/docs/src/ttnn-jit.md
@@ -110,7 +110,7 @@ Not every operation is supported within the above categories.
   - Height, width, and block sharded tensors in L1.
   - DRAM tensors are not supported.
 
-Note: Only tiled tensors with tile-aligned dimensions are currently supported. Padding and row-major layotus are not supported.
+Note: Only tiled tensors with tile-aligned dimensions are currently supported. Padding is not supported. Row-major layouts are not supported.
 
 ### Supported Datatypes
 | Operation Category | Supported Datatypes |


### PR DESCRIPTION
Previously, the docs did not call out that ttnn.jit does not support padding or row-major tensors. This has been fixed