### PR TITLE
Add folding for consecutive RepeatOp

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2954,6 +2954,8 @@ def TTIR_RepeatOp : TTIR_NamedOp<"repeat"> {
   let results = (outs AnyRankedTensor:$result);
 
   let hasVerifier = 1;
+
+  let hasFolder = 1;
 }
 
 def TTIR_RepeatInterleaveOp : TTIR_NamedOp<"repeat_interleave"> {

--- a/test/ttmlir/Dialect/TTIR/canonicalize/repeat_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/repeat_op_fold_tests.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @consecutive_repeat_fold(%arg0: tensor<1x128x128x96xbf16>) -> tensor<8x256x256x1536xbf16> {
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 8, 2, 2, 16>
+    // CHECK-NOT: "ttir.repeat"
+
+    %1 = "ttir.repeat"(%arg0) <{repeat_dimensions = array<i64: 1, 2, 2, 4>}> : (tensor<1x128x128x96xbf16>) -> tensor<1x256x256x384xbf16>
+    %2 = "ttir.repeat"(%1) <{repeat_dimensions = array<i64: 8, 1, 1, 4>}> : (tensor<1x256x256x384xbf16>) -> tensor<8x256x256x1536xbf16>
+    return %2 : tensor<8x256x256x1536xbf16>
+  }
+
+  func.func @consecutive_repeat_fold_no_fold_multiple_producer_uses(%arg0: tensor<1x128x128x96xbf16>) -> (tensor<8x256x256x384xbf16>, tensor<384x256x256x1xbf16>) {
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 2, 2, 4>
+    // CHECK: "ttir.repeat"
+    // CHECK-SAME: repeat_dimensions = array<i64: 8, 1, 1, 1>
+
+    %1 = "ttir.repeat"(%arg0) <{repeat_dimensions = array<i64: 1, 2, 2, 4>}> : (tensor<1x128x128x96xbf16>) -> tensor<1x256x256x384xbf16>
+    %2 = "ttir.repeat"(%1) <{repeat_dimensions = array<i64: 8, 1, 1, 1>}> : (tensor<1x256x256x384xbf16>) -> tensor<8x256x256x384xbf16>
+    %3 = "ttir.permute"(%1) <{permutation = array<i64: 3, 2, 1, 0>}> : (tensor<1x256x256x384xbf16>) -> tensor<384x256x256x1xbf16>
+    return %2, %3 : tensor<8x256x256x384xbf16>, tensor<384x256x256x1xbf16>
+  }
+}


### PR DESCRIPTION
### Problem description

Back to back Producer-Consumer RepeatOp
can be Folded by composing their repeat
dimensions into a single Op and rewiring
the consumer RepeatOp to repeat  directly
from the the original produce input.

We only fold if the producer has one use,
if not, we do not fold.

### Motivation

Reduces the number of Ops by folding away
the producer-consumer repeats.

### Testing

Added a test to validate consecutive
repeats are merged to single RepeatOp
given producer has only one use. Also
added a test case to validate no fold
occurs when there are multiple producer
ops.

```
pre-commit run --show-diff-on-failure --color=always --all-files

llvm-lit -sv test/ttmlir/Dialect/TTIR/canonicalize/repeat_op_fold_tests.mlir 

Testing Time: 0.39s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/6292)

Provide context for the problem.

### What's changed
Consecutive Producer-Consumer RepeatOp
will be Folded into single RepeatOp.

Used the [folding pattern](https://mlir.llvm.org/docs/Canonicalization/) do the Consecutive fold.
Updated Tablegen to indicate the RepeatOp has fold method by defining
hasFolder = 1.

### Example

```
        %74 = "ttnn.repeat"(%73) <{repeat_dims = #ttnn.shape<32x1x1x1>}> : (tensor<1x1x1x128xbf16, #ttnn_layout51>) -> tensor<32x1x1x128xbf16, #ttnn_layout52>
        %75 = "ttnn.repeat"(%74) <{repeat_dims = #ttnn.shape<1x1x32x1>}> : (tensor<32x1x1x128xbf16, #ttnn_layout52>) -> tensor<32x1x32x128xbf16, #ttnn_layout52>
```

If first repeat is not used again, and if

First repeat dims = ```<k1, ..., kn>``` and,

Second ```<m1, ..., mn>```

Folded repeat dims will be ```<k1*m1, ..., kn*mn>```


### Checklist
- [x] New/Existing tests provide coverage for changes
