### PR TITLE
Uplift third_party/tt-metal to f73be13bca1763be5e69d209e9d053fa7ec32abd 2025-12-15

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "9c763fa7a2ba5a8852ccd4f70bf1a935fb99276e")
+set(TT_METAL_VERSION "f73be13bca1763be5e69d209e9d053fa7ec32abd")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the f73be13bca1763be5e69d209e9d053fa7ec32abd

No patches needed.

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-fe/actions/runs/20250426973
  - [x] [tt-xla (basic + models)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/20250040008
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):