### PR TITLE
Arguments for embedding in emitPy

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2116,7 +2116,6 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(embeddingOp.getInput()),
         emitter.emit(embeddingOp.getWeight()),
-        emitter.emit(std::nullopt, "padding_idx"),
         emitter.emit(layoutAttr, "layout"),
     };
 


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/6333

### Problem description
EmitPy requires named arguments, but it was set as positional.

### What's changed
Added argument names for emitPy generation.

