### PR TITLE
Uplift third_party/tt-metal to d711ccab373610637d6de7dd35cb86d46f6cf68f 2025-12-16

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "b165c6a01d490fa8d6c1f112be5b8da80140e1b0")
+set(TT_METAL_VERSION "d711ccab373610637d6de7dd35cb86d46f6cf68f")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d711ccab373610637d6de7dd35cb86d46f6cf68f

No changes needed.

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-fe/actions/runs/20275359332 (some failures to be fixed, filed issue below)
  - [x] [tt-xla (basic + models)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/20275266660
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any):
      - tt-forge-fe CI failures: https://github.com/tenstorrent/tt-forge-fe/issues/3101
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):