### PR TITLE
Multiple func + runtime support in builder

### DIFF
--- a/test/python/golden/mlir_snippets/ttir/ttir_device_module_nested_func.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_device_module_nested_func.mlir
@@ -1,0 +1,19 @@
+module {
+  ttcore.device_module {
+    builtin.module {
+      func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        %1 = call @nested_func(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %1 : tensor<32x32xf32>
+      }
+      func.func nested @nested_func(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %0 : tensor<32x32xf32>
+      }
+      func.func @my_modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %0 : tensor<32x32xf32>
+      }
+    }
+  }
+}

--- a/test/python/golden/mlir_snippets/ttir/ttir_multiple_funcs.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_multiple_funcs.mlir
@@ -1,0 +1,10 @@
+module {
+  func.func @modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+  func.func @modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}

--- a/test/python/golden/mlir_snippets/ttir/ttir_nested_funcs.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_nested_funcs.mlir
@@ -1,0 +1,15 @@
+module {
+  func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = call @nested_func(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %1 : tensor<32x32xf32>
+  }
+  func.func @nested_func(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+  func.func @my_modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -1,5 +1,530 @@
 # `builder`
 
-`builder` contains `ttir-builder` and `stablehlo-builder` to create ttir or stablehlo graphs.
+`builder` contains `ttir-builder`, `stablehlo-builder` and `ttnn-builder` to create mlir graphs.
 
-To get started, refer to `builder` [documentation](../../docs/src/builder/).
+## Important relevant packages
+```python
+from builder.base.builder_apis import Operand
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.stablehlo.stablehlo_builder import StableHLOBuilder
+from builder.ttnn.ttnn_builder import TTNNBuilder
+from builder.base.builder_apis import *
+from builder.base.builder_runtime import *
+```
+
+## Build a ttir module
+Check each op's definition to see what parameters you can override. They are kept as close as possible to their MLIR definition.
+For example: tools/builder/ttir/ttir_builder.py see `@tag(ttir.SigmoidOp)`.
+Under the hood, random inputs are getting generated for in0, all intermediates are evaluated and output is calculated.
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Set inputs/outputs when building module
+You can use builder APIs to set the inputs which will be used for all subsequent intermediate + output golden evaluation.
+```python
+def module(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def test_with_mixed_init(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_goldens({in0: torch.zeros, in1: torch.ones})
+        add_result = builder.add(in0, in1)
+        return add_result
+
+module, builder = build_module(module, "ttir")
+print(module)
+```
+
+## Change output dtype for mixed precision
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0, output_type=torch.bfloat16)
+      return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xbf16> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xbf16>
+    return %0 : tensor<32x32xbf16>
+  }
+}
+```
+
+## Build a stablehlo/ttnn module
+```python
+def module0(builder: StableHLOBuilder):
+
+  @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+  def modela(in0: Operand, in1: Operand, builder: StableHLOBuilder):
+      add0 = builder.add(in0, in1)
+      return add0
+
+new_module, builder = build_module(module0, "stablehlo")
+print(new_module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=1, "y"=1]>
+  func.func @modela(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Build multiple functions
+All goldens are calculated for each function. Each root function will be executed as a separate program on device.
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modelb(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+  func.func @modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Build nested functions
+```python
+def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32)], [torch.float32])
+    def my_modela(in0: Operand, builder: TTIRBuilder):
+        def nested_func(in0: Operand, builder: TTIRBuilder):
+            sigmoid0 = builder.sigmoid(in0)
+            return sigmoid0
+
+        sigmoid0 = builder.sigmoid(in0)
+        ttir_builder0 = TTIRBuilder(builder.context, builder.location)
+        nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
+        return nested_func0
+
+    @builder.func([(32, 32)], [torch.float32])
+    def my_modelb(in0: Operand, builder: TTIRBuilder):
+        sigmoid0 = builder.sigmoid(in0)
+        return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = call @nested_func(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %1 : tensor<32x32xf32>
+  }
+  func.func private @nested_func(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+  func.func @my_modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Build device module graphs
+```python
+def module0(builder: TTIRBuilder):
+    @builder.device_module
+    def my_device_module(builder: TTIRBuilder):
+        @builder.func([(32, 32)], [torch.float32])
+        def my_modela(in0: Operand, builder: TTIRBuilder):
+            def nested_func(in0: Operand, builder: TTIRBuilder):
+                sigmoid0 = builder.sigmoid(in0)
+                return sigmoid0
+
+            sigmoid0 = builder.sigmoid(in0)
+            ttir_builder0 = TTIRBuilder(builder.context, builder.location)
+            nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
+            return nested_func0
+
+        @builder.func([(32, 32)], [torch.float32])
+        def my_modelb(in0: Operand, builder: TTIRBuilder):
+            sigmoid0 = builder.sigmoid(in0)
+            return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  ttcore.device_module {
+    builtin.module {
+      func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        %1 = call @nested_func(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %1 : tensor<32x32xf32>
+      }
+      func.func private @nested_func(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %0 : tensor<32x32xf32>
+      }
+      func.func @my_modelb(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %0 : tensor<32x32xf32>
+      }
+    }
+  }
+}
+```
+
+## Build cpu hoisted graphs
+```python
+def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32)], [torch.float32])
+    def softmax(in0: Operand, builder: TTIRBuilder):
+        return builder.softmax(
+            in0,
+            dimension=-1,
+            numeric_stable=False,
+            unit_attrs=["ttir.should_hoist"],
+        )
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @softmax(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.softmax"(%arg0) <{dimension = -1 : si32, numericStable = false}> {ttir.should_hoist} : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## You can run any mlir pass on any generated module
+See full list of passes supported at `python/Passes.cpp`.
+```python
+from ttmlir.passes import stablehlo_to_ttir_pipeline
+
+def module0(builder: StableHLOBuilder):
+
+  @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+  def modela(in0: Operand, in1: Operand, builder: StableHLOBuilder):
+      add0 = builder.add(in0, in1)
+      return add0
+
+new_module, builder = build_module(module0, "stablehlo")
+stablehlo_to_ttir_pipeline(new_module) # module is modified in-place!
+print(new_module)
+```
+
+```mlir
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+  ttcore.device_module {
+    builtin.module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+      func.func @modela(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+        %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+        return %0 : tensor<32x32xf32>
+      }
+    }
+  }
+}
+```
+
+## Compile a module to a flatbuffer
+This will return the builder instance, where the .mlir file was dumped, the input/output golden dictionary per root level function and the intermediate golden dictionary.
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modelb(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0)
+```
+
+## Interface with mlir runtime
+All mlir runtime C++ APIs are nanobinded. See full list here: `runtime/python/runtime/runtime.cpp`.
+You can also pass in `enable_intermediate_verification` in `compile_and_execute_ttir` to give you back a report of all intermediate golden results.
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+## Execute flatbuffer
+Each root level function will execute and evaluate its pcc.
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modelb(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+```
+Program level golden for output_0 matched. pcc=0.9999998360475333
+Program level golden for output_0 matched. pcc=0.9999998372226931
+```
+
+## Execute flatbuffer manually
+You can optionally call the APIs manually. You can also pass in `enable_intermediate_verification` in `execute_fb` to give you back a report of all intermediate golden results.
+```python
+module, builder = build_module(module0, "ttir")
+
+mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
+    module,
+    builder,
+    test_base="sample_test",
+)
+
+flatbuffer_path = os.path.join("ttir-builder-artifacts", "ttnn", f"sample_test_ttnn.mlir.ttnn")
+execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+```
+
+## Load mlir file
+All goldens are evaluated under the hood with random inputs.
+```python3
+mlir_file_path = "test.mlir"
+with open(mlir_file_path, 'r') as f:
+    mlir_ir_string = f.read()
+
+module, builder = load_mlir_file(mlir_ir_string, target="ttir")
+print(module)
+```
+
+```mlir
+module {
+  func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Load mlir file with custom inputs
+User can provide inputs per root level function to use in golden evaluation. All intermediate + output goldens are evaluated.
+```python3
+module, builder = load_mlir_file(mlir_ir_string, target="ttir", golden_inputs={"my_modela": [torch.randn(32, 32), torch.randn(32, 32)]})
+```
+
+## Execute loaded mlir file
+```python3
+module, builder = load_mlir_file(mlir_ir_string, target="ttir")
+
+mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
+    module,
+    builder,
+    test_base="sample_test",
+)
+
+flatbuffer_path = os.path.join("ttir-builder-artifacts", "ttnn", f"sample_test_ttnn.mlir.ttnn")
+execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+```
+
+```
+Program level golden for output_0 matched. pcc=0.9999998360475333
+```
+
+## Split mlir file
+Splitting a mlir module will convert each op into a standalone module + op. The goldens are reused. Each intermediate op will take it's original golden inputs and set that as the inputs to its new module. This applied to the output as well.
+```python3
+mlir_ir_string = '''module {
+  func.func @my_modela(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.sigmoid"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %1 : tensor<32x32xf32>
+  }
+}'''
+
+module, builder = load_mlir_file(mlir_ir_string, target="ttir")
+builder_module_list = split_mlir_file(module, builder)
+
+for module, builder in builder_module_list:
+    print(module)
+```
+
+```mlir
+module {
+  func.func @add_module(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+```mlir
+module {
+  func.func @sigmoid_module(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+}
+```
+
+## Build multi-device graphs
+```python
+def module(builder: TTIRBuilder):
+    @builder.func([(1, 1, 256, 512)], [torch.float32])
+    def all_gather(in0: Operand, builder: TTIRBuilder):
+        in_shard = builder.mesh_shard(
+            in0,
+            shard_direction="#ttcore.shard_direction<full_to_shard>",
+            shard_type="#ttcore.shard_type<devices>",
+            shard_shape=(1, 1, 8, 4),
+            shard_dims=(2, 3),
+        )
+
+        all_gather0 = builder.all_gather(
+            in_shard,
+            all_gather_dim=3,
+            cluster_axis=1,
+        )
+
+        return builder.mesh_shard(
+            all_gather0,
+            shard_direction="#ttcore.shard_direction<shard_to_full>",
+            shard_type="#ttcore.shard_type<devices>",
+            shard_shape=(1, 1, 8, 1),
+            shard_dims=(2, -1),
+        )
+
+module, builder = build_module(module, "ttir", mesh_dict=OrderedDict([("x", 8), ("y", 4)]))
+print(module)
+```
+
+```mlir
+module {
+  func.func @all_gather(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
+    %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: 2, 3>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1x1x256x512xf32>) -> tensor<1x1x32x128xf32>
+    %1 = "ttir.all_gather"(%0) <{all_gather_dim = 3 : si32, cluster_axis = 1 : ui32}> : (tensor<1x1x32x128xf32>) -> tensor<1x1x32x512xf32>
+    %2 = "ttir.mesh_shard"(%1) <{shard_dims = array<i64: 2, -1>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 1>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1x1x32x512xf32>) -> tensor<1x1x256x512xf32>
+    return %2 : tensor<1x1x256x512xf32>
+  }
+}
+```
+
+## Build shardy annotated graph
+```python
+def module(builder: StableHLOBuilder):
+    @builder.func([(2, 4, 8, 16), (2, 4, 8, 16)], [torch.float32, torch.float32])
+    def op_sharding_annotation(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+    ):
+        builder.set_graph_level_check(True)
+        sharding_attr = builder.create_sharding_attr_from_tuples("mesh", [("x", True), ("y", False), ("", False), ("", False)])
+        return builder.add(in0, in1, sharding_attr=sharding_attr)
+
+module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
+print(module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=2, "y"=4]>
+  func.func @op_sharding_annotation(%arg0: tensor<2x4x8x16xf32>, %arg1: tensor<2x4x8x16xf32>) -> tensor<2x4x8x16xf32> {
+    %0 = stablehlo.add %arg0, %arg1 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"x"}, {"y", ?}, {?}, {?}]>]>} : tensor<2x4x8x16xf32>
+    return %0 : tensor<2x4x8x16xf32>
+  }
+}
+```
+
+## Run pipelines on shardy annotated graph
+```python3
+module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
+stablehlo_pipeline(module)
+print(module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=2, "y"=4]>
+  func.func @op_sharding_annotation(%arg0: tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"x"}, {"y"}, {}, {}]>, <@mesh, [{"x"}, {"y"}, {}, {}]>] out_shardings=[<@mesh, [{"x"}, {"y"}, {}, {}]>] manual_axes={"x", "y"} (%arg2: tensor<1x1x8x16xf32>, %arg3: tensor<1x1x8x16xf32>) {
+      %1 = stablehlo.add %arg2, %arg3 : tensor<1x1x8x16xf32>
+      sdy.return %1 : tensor<1x1x8x16xf32>
+    } : (tensor<2x4x8x16xf32>, tensor<2x4x8x16xf32>) -> tensor<2x4x8x16xf32>
+    return %0 : tensor<2x4x8x16xf32>
+  }
+}
+```

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -51,8 +51,9 @@ class Builder(metaclass=BuilderMeta):
         self._force_graph_level_check = False
 
         # Keep a list of inputs and outputs in order so we know how to store them in golden map.
-        self._ordered_inputs: List[Operand] = []
-        self._ordered_outputs: List[Operand] = []
+        # ordered dict determines program order when comparing goldens during runtime
+        # func_op: [[ordered_inputs], [ordered_outputs]]
+        self._func_ops_generated: Dict[func.FuncOp, List[List[Operand]]] = {}
 
         # Explicity set goldens to store. If empty, store all goldens.
         self._goldens_to_store: List[Operand] = []
@@ -85,6 +86,13 @@ class Builder(metaclass=BuilderMeta):
             self._meshes[name] = mesh
 
         self._mesh_shape = tuple(mesh_dict[0].values())
+
+        # Internal values to keep track
+        self._root_module_insertion_point = None
+        self._current_module_insertion_point = None
+        self._hoisted_cpu_functions: List[str] = []
+        self._nested_funcs: List[str] = []
+        self._func_name_to_op: Dict[str, func.FuncOp] = {}
 
     # ----- Class helper methods -----
 
@@ -154,31 +162,57 @@ class Builder(metaclass=BuilderMeta):
         return self._mesh_shape
 
     @property
-    def golden_map(self) -> Dict[str, Dict[int, GoldenMapTensor]]:
-        golden_info: Dict[str, Dict[int, GoldenMapTensor]] = {}
+    def golden_map(
+        self,
+    ) -> Tuple[
+        Dict[int, Dict[str, Dict[int, GoldenMapTensor]]],
+        Dict[str, Dict[int, GoldenMapTensor]],
+    ]:
+        # { program_index: {loc: {device_id: GoldenMapTensor} } }
+        input_output_golden_info: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]] = {}
+        intermediate_golden_info: Dict[str, Dict[int, GoldenMapTensor]] = {}
 
         if self._disable_golden_check:
-            return golden_info
+            return input_output_golden_info, intermediate_golden_info
 
         # If no specific golden is marked to be stored, store all goldens.
         if len(self._goldens_to_store) == 0:
             self._goldens_to_store = list(self._goldens.keys())
 
-        # Always store inputs into golden map.
-        for index, input in enumerate(self._ordered_inputs):
-            loc = f"input_{index}"
-            golden_info[loc] = self._get_golden_tensor(input)
-
-        # Store outputs into golden map if they are marked to be stored.
-        for index, output in enumerate(self._ordered_outputs):
-            if output not in self._goldens_to_store:
+        # Iterate through all functions generated to collect their inputs and outputs.
+        programs = []
+        for func_op, ordered_values in self._func_ops_generated.items():
+            if (
+                func_op.name.value in self._hoisted_cpu_functions
+                or func_op.name.value in self._nested_funcs
+            ):
                 continue
 
-            loc = f"output_{index}"
-            golden_info[loc] = self._get_golden_tensor(output)
+            programs.append(ordered_values)
+
+        for program_index, ordered_values in enumerate(programs):
+            input_output_golden_info[program_index] = {}
+            ordered_inputs, ordered_outputs = ordered_values
+
+            # Always store inputs into golden map.
+            for index, input in enumerate(ordered_inputs):
+                loc = f"input_{index}"
+                input_output_golden_info[program_index][loc] = self._get_golden_tensor(
+                    input
+                )
+
+            # Store outputs into golden map if they are marked to be stored.
+            for index, output in enumerate(ordered_outputs):
+                if output not in self._goldens_to_store:
+                    continue
+
+                loc = f"output_{index}"
+                input_output_golden_info[program_index][loc] = self._get_golden_tensor(
+                    output
+                )
 
         if self._force_graph_level_check:
-            return golden_info
+            return input_output_golden_info, intermediate_golden_info
 
         # Store other operands into golden map if they are marked to be stored.
         for operand, golden_map_tensor in self._goldens.items():
@@ -190,9 +224,9 @@ class Builder(metaclass=BuilderMeta):
 
             loc = self._operand_to_loc.get(operand, None)
             self._loc_to_operand[loc] = operand
-            golden_info[loc] = golden_map_tensor
+            intermediate_golden_info[loc] = golden_map_tensor
 
-        return golden_info
+        return input_output_golden_info, intermediate_golden_info
 
     def get_shape(self, input: Operand) -> Shape:
         return self._get_type(input).shape
@@ -574,12 +608,6 @@ class Builder(metaclass=BuilderMeta):
     ) -> List[GoldenMapTensor]:
         return [self._goldens[operand] for operand in operands]
 
-    def _set_input_ordering(self, inputs: List[Operand]):
-        self._ordered_inputs = inputs
-
-    def _set_output_ordering(self, outputs: List[Operand]):
-        self._ordered_outputs = outputs
-
     # ----- Shared Empty Operations -----
 
     def _empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
@@ -641,13 +669,68 @@ class Builder(metaclass=BuilderMeta):
             memory_layout,
         )
 
+    # ----- Operations -----
+
+    def call(
+        self, nested_func: Callable, original_inputs: List[Operand], builder: Builder
+    ):
+        fn_input_types = []
+        for operand in original_inputs:
+            fn_input_types.append(operand.type)
+
+        ordered_inputs = []
+        ordered_outputs = []
+
+        with InsertionPoint(self._current_module_insertion_point):
+
+            @func.func(*fn_input_types, name=nested_func.__name__)
+            def decorated_func(*inputs):
+                input_goldens: Dict[Operand, GoldenMapTensor] = {}
+                for index, (new_operand, original_operand) in enumerate(
+                    zip(inputs, original_inputs)
+                ):
+                    input_goldens[new_operand] = self._get_golden_tensor(
+                        original_operand
+                    )
+
+                builder._set_goldens(input_goldens)
+                ordered_inputs.extend(inputs)
+
+                result = nested_func(*inputs, builder)
+
+                outputs = result if hasattr(result, "__iter__") else [result]
+                output_goldens: Dict[Operand, GoldenMapTensor] = {}
+                for op in outputs:
+                    output_goldens[op] = builder._get_golden_tensor(op)
+                builder._set_goldens(output_goldens)
+                ordered_outputs.extend(outputs)
+
+                return process_multi_return_result(result)
+
+        new_func_op = decorated_func.func_op
+        new_func_op.sym_visibility = StringAttr.get("private")
+        builder._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+
+        call_op = func.CallOp(new_func_op, original_inputs)
+        for index, output in enumerate(ordered_outputs):
+            self._set_golden_tensor(
+                call_op.results[index], builder._get_golden_tensor(output)
+            )
+
+        return (
+            call_op.results[0] if len(call_op.results) == 1 else tuple(call_op.results)
+        )
+
     # ----- Parse module ----
 
     def _build_op_from_parsed_op(
         self,
         parsed_op: Operation,
         global_dict: Dict[Operand, Operand],
-    ) -> Tuple[Operation, Dict[Operand, GoldenMapTensor]]:
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        if isinstance(parsed_op, func.CallOp):
+            return self.parse_call_op(parsed_op, global_dict)
+
         parsed_function = self.get_parser_from_opview(type(parsed_op))
         return parsed_function(self, parsed_op, global_dict)
 
@@ -671,9 +754,36 @@ class Builder(metaclass=BuilderMeta):
         ]
 
     def parse_root_module(
-        self, parsed_root_module: Module, golden_inputs: List[torch.tensor]
+        self, parsed_root_module: Module, golden_inputs: Dict[str, [List[torch.tensor]]]
     ):
+        for entry in parsed_root_module.body.operations:
+            if isinstance(entry, ttcore.CPUModuleOp):
+                builtin_module = entry.regions[0].blocks[0].operations[0]
+                for op in builtin_module.regions[0].blocks[0].operations:
+                    if isinstance(op, func.FuncOp):
+                        self._hoisted_cpu_functions.append(op.name.value)
+                        self._func_name_to_op[op.name.value] = op
+            elif isinstance(entry, ttcore.DeviceModuleOp):
+                builtin_module = entry.regions[0].blocks[0].operations[0]
+                for op in builtin_module.regions[0].blocks[0].operations:
+                    if isinstance(op, func.FuncOp):
+                        self._func_name_to_op[op.name.value] = op
+
+                        for block in op.body:
+                            for inner_op in block.operations:
+                                if isinstance(inner_op, func.CallOp):
+                                    self._nested_funcs.append(inner_op.callee.value)
+            elif isinstance(entry, func.FuncOp):
+                self._func_name_to_op[entry.name.value] = entry
+
+                for block in entry.body:
+                    for inner_op in block.operations:
+                        if isinstance(inner_op, func.CallOp):
+                            self._nested_funcs.append(inner_op.callee.value)
+
         new_root_module = Module.create()
+        self._root_module_insertion_point = new_root_module.body
+        self._current_module_insertion_point = new_root_module.body
 
         with InsertionPoint(new_root_module.body):
             for entry in parsed_root_module.body.operations:
@@ -688,27 +798,39 @@ class Builder(metaclass=BuilderMeta):
                         new_builtin_module.operation
                     )
                 elif isinstance(entry, func.FuncOp):
+                    if entry.name.value in self._nested_funcs:
+                        continue
                     self.parse_func(entry, golden_inputs)
 
         return new_root_module
 
     def parse_builtin_module(
-        self, parsed_builtin_module: Module, golden_inputs: List[torch.tensor]
+        self,
+        parsed_builtin_module: Module,
+        golden_inputs: Dict[str, [List[torch.tensor]]],
     ):
         new_builtin_module = Module.create()
         cloned_op = new_builtin_module.operation.clone()
+        self._current_module_insertion_point = cloned_op.regions[0].blocks[0]
 
-        for entry in parsed_builtin_module.regions[0].blocks[0].operations:
-            if isinstance(entry, func.FuncOp):
-                new_func = self.parse_func(entry, golden_inputs)
-                cloned_op.regions[0].blocks[0].append(new_func)
+        with InsertionPoint(cloned_op.regions[0].blocks[0]):
+            for entry in parsed_builtin_module.regions[0].blocks[0].operations:
+                if isinstance(entry, func.FuncOp):
+                    if entry.name.value in self._nested_funcs:
+                        continue
+                    new_func = self.parse_func(entry, golden_inputs)
 
         return cloned_op
 
-    def parse_func(self, parsed_func: func.FuncOp, golden_inputs: List[torch.tensor]):
+    def parse_func(
+        self, parsed_func: func.FuncOp, golden_inputs: Dict[str, [List[torch.tensor]]]
+    ):
         fn_input_types = self.get_input_types(parsed_func)
 
-        if len(golden_inputs) == 0:
+        parsed_func_golden_inputs = []
+        if parsed_func.name.value in golden_inputs.keys():
+            parsed_func_golden_inputs = golden_inputs[parsed_func.name.value]
+        else:
             for ttype in fn_input_types:
                 shape = ttype.shape
                 dtype = self._get_torch_dtype_from_type(ttype.element_type)
@@ -718,31 +840,34 @@ class Builder(metaclass=BuilderMeta):
                         golden_input = torch.randn(1, dtype=dtype).squeeze()
                     else:
                         golden_input = torch.randn(*shape, dtype=dtype)
-                    golden_inputs.append(golden_input)
+                    parsed_func_golden_inputs.append(golden_input)
                 elif dtype == torch.bool:
                     if len(shape) == 0:
                         golden_input = torch.randint(0, 2, (), dtype=dtype)
                     else:
                         golden_input = torch.randint(0, 2, shape, dtype=dtype)
-                    golden_inputs.append(golden_input)
+                    parsed_func_golden_inputs.append(golden_input)
                 else:
                     if len(shape) == 0:
                         golden_input = torch.randint(0, 256, (), dtype=dtype)
                     else:
                         golden_input = torch.randint(0, 256, shape, dtype=dtype)
-                    golden_inputs.append(golden_input)
+                    parsed_func_golden_inputs.append(golden_input)
+
+        ordered_inputs = []
+        ordered_outputs = []
 
         @func.func(*fn_input_types, name=parsed_func.name.value)
         def decorated_func(*inputs):
             golden_dict = {}
-            for operand, torch_golden in zip(inputs, golden_inputs):
+            for operand, torch_golden in zip(inputs, parsed_func_golden_inputs):
                 golden_dict[operand] = torch_golden
 
             input_goldens: Dict[
                 Operand, GoldenMapTensor
             ] = self._create_builder_golden_from_torch_tensor(golden_dict)
             self._set_goldens(input_goldens)
-            self._set_input_ordering(inputs)
+            ordered_inputs.extend(inputs)
 
             global_dict = {}
             for i, arg in enumerate(parsed_func.arguments):
@@ -771,11 +896,136 @@ class Builder(metaclass=BuilderMeta):
             for op in outputs:
                 output_goldens[op] = self._get_golden_tensor(op)
             self._set_goldens(output_goldens)
-            self._set_output_ordering(list(outputs))
+            ordered_outputs.extend(outputs)
 
             return process_multi_return_result(global_result)
 
-        return decorated_func.func_op
+        new_func_op = decorated_func.func_op
+        self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+        return new_func_op
+
+    def parse_nested_func(
+        self, parsed_func: func.FuncOp, golden_inputs: List[GoldenMapTensor]
+    ):
+        fn_input_types = self.get_input_types(parsed_func)
+
+        ordered_inputs = []
+        ordered_outputs = []
+
+        @func.func(*fn_input_types, name=parsed_func.name.value)
+        def decorated_func(*inputs):
+            input_goldens = {}
+            for operand, golden_map_tensor in zip(inputs, golden_inputs):
+                input_goldens[operand] = golden_map_tensor
+
+            self._set_goldens(input_goldens)
+            ordered_inputs.extend(inputs)
+
+            global_dict = {}
+            for i, arg in enumerate(parsed_func.arguments):
+                global_dict[arg] = inputs[i]
+
+            global_result = None
+            for block in parsed_func.body:
+                for op in block.operations:
+                    if isinstance(op, func.ReturnOp):
+                        global_result = tuple(
+                            global_dict[operand] for operand in op.operands
+                        )
+                    else:
+                        (
+                            parsed_op,
+                            op_golden_dictionary,
+                        ) = self._build_op_from_parsed_op(op, global_dict)
+                        global_dict.update(op_golden_dictionary)
+
+            outputs = (
+                global_result
+                if hasattr(global_result, "__iter__")
+                else (global_result,)
+            )
+            output_goldens: Dict[Operand, GoldenMapTensor] = {}
+            for op in outputs:
+                output_goldens[op] = self._get_golden_tensor(op)
+            self._set_goldens(output_goldens)
+            ordered_outputs.extend(outputs)
+
+            return process_multi_return_result(global_result)
+
+        new_func_op = decorated_func.func_op
+        new_func_op.sym_visibility = StringAttr.get("private")
+        self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+        return new_func_op
+
+    def parse_call_op(
+        self,
+        parsed_op: func.CallOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[Operand, GoldenMapTensor]]:
+        is_hoisted_cpu_call = False
+        for attr in parsed_op.attributes:
+            if attr.name == "ttir.cpu_hoisted_call":
+                is_hoisted_cpu_call = True
+                break
+
+        if is_hoisted_cpu_call:
+            raise NotImplementedError(
+                "Hoisted CPU calls are not supported in parsing yet."
+            )
+
+        nested_func_op = self._func_name_to_op[parsed_op.callee.value]
+        new_golden_inputs = []
+        for operand in parsed_op.operands:
+            owner0 = operand.owner
+            if isinstance(owner0, Block):
+                queried_operand = operand
+            else:
+                queried_operand = owner0.result
+
+            new_golden_inputs.append(
+                self._get_golden_tensor(global_dict[queried_operand])
+            )
+
+        with InsertionPoint(self._current_module_insertion_point):
+            new_func_op = self.parse_nested_func(nested_func_op, new_golden_inputs)
+
+        new_operands = [global_dict[operand] for operand in parsed_op.operands]
+        call_op = func.CallOp(new_func_op, new_operands)
+
+        ordered_inputs, ordered_outputs = self._func_ops_generated[new_func_op]
+        for index, output in enumerate(ordered_outputs):
+            self._set_golden_tensor(
+                call_op.results[index], self._get_golden_tensor(output)
+            )
+
+        op_map_dictionary = {}
+        for old_result, new_result in zip(parsed_op.results, call_op.results):
+            op_map_dictionary[old_result] = new_result
+
+        return call_op, op_map_dictionary
+
+    def split_call_op(
+        self,
+        old_op: func.CallOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        nested_func_op = self._func_name_to_op[old_op.callee.value]
+        sub_modules_and_builders = []
+
+        for block in nested_func_op.body:
+            for op in block.operations:
+                if isinstance(op, func.ReturnOp) or isinstance(
+                    op,
+                    ttir.EmptyOp,
+                ):
+                    continue
+                elif isinstance(op, func.CallOp):
+                    sub_op_module_builder = self.split_call_op(op)
+                    sub_modules_and_builders.append(sub_op_module_builder)
+                else:
+                    sub_op_module_builder = self.split_op(op)
+                    sub_modules_and_builders.append(sub_op_module_builder)
+
+        return sub_modules_and_builders
 
     # ----- Helper decorator functions ----
 
@@ -791,6 +1041,9 @@ class Builder(metaclass=BuilderMeta):
                 for shape, dtype in zip(input_shapes, input_types)
             ]
 
+            ordered_inputs = []
+            ordered_outputs = []
+
             @func.func(*fn_input_types, name=fn.__name__)
             def decorated_func(*inputs):
                 input_goldens: Dict[Operand, GoldenMapTensor] = {}
@@ -799,7 +1052,7 @@ class Builder(metaclass=BuilderMeta):
                         operand, dtype
                     )
                 self._set_goldens(input_goldens)
-                self._set_input_ordering(inputs)
+                ordered_inputs.extend(inputs)
 
                 result = fn(*inputs, self)
 
@@ -808,9 +1061,14 @@ class Builder(metaclass=BuilderMeta):
                 for op in outputs:
                     output_goldens[op] = self._get_golden_tensor(op)
                 self._set_goldens(output_goldens)
-                self._set_output_ordering(outputs)
+                ordered_outputs.extend(outputs)
 
                 return process_multi_return_result(result)
+
+            new_func_op = decorated_func.func_op
+            print(new_func_op.attributes["sym_name"])
+            self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+            return new_func_op
 
         return wrapper
 
@@ -820,11 +1078,12 @@ class Builder(metaclass=BuilderMeta):
             region = device_module_op.regions[0]
             block = Block.create_at_start(region)
             new_module = Module.create()
-
-            with InsertionPoint(new_module.body):
-                root_func(self)
-
             cloned_op = new_module.operation.clone()
+            self._current_module_insertion_point = cloned_op.regions[0].blocks[0]
+
+            with InsertionPoint(cloned_op.regions[0].blocks[0]):
+                new_func = root_func(self)
+
             device_module_op.regions[0].blocks[0].append(cloned_op.operation)
             return device_module_op
 
@@ -836,11 +1095,12 @@ class Builder(metaclass=BuilderMeta):
             region = cpu_module_op.regions[0]
             block = Block.create_at_start(region)
             new_module = Module.create()
-
-            with InsertionPoint(new_module.body):
-                root_func(self)
-
             cloned_op = new_module.operation.clone()
+            self._current_module_insertion_point = cloned_op.regions[0].blocks[0]
+
+            with InsertionPoint(cloned_op.regions[0].blocks[0]):
+                new_func = root_func(self)
+
             cpu_module_op.regions[0].blocks[0].append(cloned_op.operation)
             return cpu_module_op
 


### PR DESCRIPTION
This PR introduces multiple function support, as well as func.call op support. All supported with runtime integration as well in builder.

Users can now create such graphs

```
def module1(builder: TTIRBuilder):

  @builder.func([(32, 32)], [torch.float32])
  def modela(in0: Operand, builder: TTIRBuilder):
      sigmoid0 = builder.sigmoid(in0)
      return sigmoid0

  @builder.func([(32, 32)], [torch.float32])
  def modelb(in0: Operand, builder: TTIRBuilder):
      sigmoid0 = builder.sigmoid(in0)
      return sigmoid0


def module2(builder: TTIRBuilder):
    @builder.func([(32, 32)], [torch.float32])
    def my_modela(in0: Operand, builder: TTIRBuilder):
        def nested_func(in0: Operand, builder: TTIRBuilder):
            sigmoid0 = builder.sigmoid(in0)
            return sigmoid0

        sigmoid0 = builder.sigmoid(in0)
        ttir_builder0 = TTIRBuilder(builder.context, builder.location)
        nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
        return nested_func0

    @builder.func([(32, 32)], [torch.float32])
    def my_modelb(in0: Operand, builder: TTIRBuilder):
        sigmoid0 = builder.sigmoid(in0)
        return sigmoid0
```