### PR TITLE
Refactor TTNN pipelines to enable CPU hoisting across targets

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
+++ b/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
@@ -70,6 +70,11 @@ struct LinalgToLLVMPipelineOptions
       llvm::cl::init(true)};
 };
 
+// Options for the TTIR to LLVM CPU pipeline.
+// Inherits from LinalgToLLVMPipelineOptions to reuse the options.
+//
+struct TTIRToLLVMCPUPipelineOptions : public LinalgToLLVMPipelineOptions {};
+
 #ifdef TTMLIR_ENABLE_STABLEHLO
 void createStableHLOToTTIRPipeline(
     OpPassManager &pm, const StableHLOToTTIRPipelineOptions &options);
@@ -80,8 +85,9 @@ void createTTIRToNVVMPipeline(OpPassManager &manager,
 
 void createLinalgToLLVMPipeline(OpPassManager &pm,
                                 const LinalgToLLVMPipelineOptions &options);
-void createTTIRToCPUPipeline(OpPassManager &manager,
-                             const LinalgToLLVMPipelineOptions &options);
+
+void createTTIRToLLVMCPUPipeline(OpPassManager &manager,
+                                 const TTIRToLLVMCPUPipelineOptions &options);
 
 /// Registers all pipelines for the TTIR dialect.
 void registerTTIRPipelines();

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_PIPELINES_TTNNPIPELINES_H
 
 #include "ttmlir/Dialect/TTCore/Utils/PopulateArgumentTypes.h"
+#include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTNN/Utils/MemoryLayoutAnalysisParams.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 
@@ -17,10 +18,10 @@ class MeshDevice;
 } // namespace tt::tt_metal::distributed
 
 namespace mlir::tt::ttnn {
-// Options for the TTIR to TTNN backend pipeline.
+// TTIR to TTNN Device pipeline options.
 //
-struct TTIRToTTNNBackendPipelineOptions
-    : public PassPipelineOptions<TTIRToTTNNBackendPipelineOptions> {
+struct TTIRToTTNNDevicePipelineOptions
+    : public PassPipelineOptions<TTIRToTTNNDevicePipelineOptions> {
   // Optimization level controls multiple optimization passes.
   // Level 0 (default): All optimizer passes disabled.
   // Level 1: All optimizer passes enabled. Memory layout analysis is disabled.
@@ -394,10 +395,10 @@ struct TTIRToTTNNBackendPipelineOptions
   }
 };
 
-// TTNN Backend to EmitC PipelineOptions.
+// TTNN to EmitC Device pipeline options.
 //
-struct TTNNBackendToEmitCPipelineOptions
-    : public PassPipelineOptions<TTNNBackendToEmitCPipelineOptions> {
+struct TTNNToEmitCDevicePipelineOptions
+    : public PassPipelineOptions<TTNNToEmitCDevicePipelineOptions> {
   Option<bool> targetDylib{*this, "target-dylib",
                            llvm::cl::desc("Tailor passes for dylib target."),
                            llvm::cl::init(false)};
@@ -425,10 +426,10 @@ struct TTNNBackendToEmitCPipelineOptions
       llvm::cl::desc("Prefix for input tensor files"), llvm::cl::init("arg")};
 };
 
-// TTNN Backend to EmitPy PipelineOptions.
+// TTNN to EmitPy Device pipeline options.
 //
-struct TTNNBackendToEmitPyPipelineOptions
-    : public PassPipelineOptions<TTNNBackendToEmitPyPipelineOptions> {
+struct TTNNToEmitPyDevicePipelineOptions
+    : public PassPipelineOptions<TTNNToEmitPyDevicePipelineOptions> {
   Option<bool> targetModule{
       *this, "target-module",
       llvm::cl::desc("Tailor passes for Python module target. When enabled, "
@@ -452,48 +453,38 @@ struct TTNNBackendToEmitPyPipelineOptions
       llvm::cl::desc("Prefix for input tensor files"), llvm::cl::init("arg")};
 };
 
-// TTIR to EmitC pipeline options.
-// Inherit from TTIRToTTNNBackendPipelineOptions and
-// TTNNBackendToEmitCPipelineOptions to reuse the options.
+// TTIR to TTNN backend pipeline options.
 //
-struct TTIRToEmitCPipelineOptions : public TTIRToTTNNBackendPipelineOptions,
-                                    public TTNNBackendToEmitCPipelineOptions {};
+// Inherits from TTIRToTTNNDevicePipelineOptions and
+// TTIRToLLVMCPUPipelineOptions to reuse the options.
+//
+struct TTIRToTTNNBackendPipelineOptions
+    : public TTIRToTTNNDevicePipelineOptions,
+      public ttir::TTIRToLLVMCPUPipelineOptions {};
+
+// TTIR to EmitC end-to-end pipeline options.
+//
+// Inherits from TTIRToTTNNDevicePipelineOptions and
+// TTNNToEmitCDevicePipelineOptions to reuse the options.
+//
+struct TTIRToEmitCPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
+                                    public TTNNToEmitCDevicePipelineOptions {};
 
 // TTIR to EmitPy pipeline options.
-// Inherit from TTIRToTTNNBackendPipelineOptions and
-// TTNNBackendToEmitPyPipelineOptions to reuse the options.
 //
-struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNBackendPipelineOptions,
-                                     public TTNNBackendToEmitPyPipelineOptions {
+// Inherits from TTIRToTTNNDevicePipelineOptions and
+// TTNNToEmitPyDevicePipelineOptions to reuse the options.
+//
+struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
+                                     public TTNNToEmitPyDevicePipelineOptions {
 };
 
 //===----------------------------------------------------------------------===//
-// Passes and pipelines
+// End-to-end pipelines, which lower TTIR to various TTNN targets.
 //===----------------------------------------------------------------------===//
-
-void createTTNNPipelineTTIRPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTNNPipelineAnalysisPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTNNPipelineLoweringPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTNNPipelineLayoutDecompositionPass(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTNNPipelineDeallocPass(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTNNBackendToEmitCPipeline(
-    OpPassManager &pm, const TTNNBackendToEmitCPipelineOptions &options);
-
-void createTTNNBackendToEmitPyPipeline(
-    OpPassManager &pm, const TTNNBackendToEmitPyPipelineOptions &options);
 
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options);
@@ -501,8 +492,6 @@ void createTTIRToEmitCPipeline(OpPassManager &pm,
 void createTTIRToEmitPyPipeline(OpPassManager &pm,
                                 const TTIRToEmitPyPipelineOptions &options);
 
-/// Registers all pipelines for the `bufferization` dialect. Currently,
-/// this includes only the "ttir-to-ttnn-backend-pipeline".
 void registerTTNNPipelines();
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -15,7 +15,7 @@ class MeshDevice;
 
 namespace mlir::tt::ttnn {
 
-struct TTIRToTTNNBackendPipelineOptions;
+struct TTIRToTTNNDevicePipelineOptions;
 
 //===----------------------------------------------------------------------===//
 // TTNNOptimizer
@@ -41,7 +41,7 @@ struct TTNNOptimizerOptions {
   TTNNOptimizerOptions() = default;
 
   explicit TTNNOptimizerOptions(
-      const TTIRToTTNNBackendPipelineOptions &pipelineOptions);
+      const TTIRToTTNNDevicePipelineOptions &pipelineOptions);
 };
 
 std::unique_ptr<::mlir::Pass> createTTNNOptimizer();

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -62,11 +62,6 @@ struct ConvertTTNNToEmitCPass
           ConvertTTNNToEmitCPass> {
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
-    // Only run conversion on top-level moduleOp.
-    if (module->getParentOp() != nullptr) {
-      return;
-    }
-
     mlir::ConversionTarget target(getContext());
 
     // EmitC is legal, TTNN is illegal
@@ -98,17 +93,6 @@ struct ConvertTTNNToEmitCPass
       //
       builder.create<emitc::IncludeOp>(module.getLoc(), "ttnn-precompiled.hpp",
                                        /*isStandard=*/false);
-    }
-
-    // Unwrap device_module into top-level ModuleOp (if present)
-    {
-      OpPassManager pm(ModuleOp::getOperationName());
-      pm.addPass(mlir::tt::ttcore::createTTCoreUnwrapDeviceModulePass());
-
-      if (failed(runPipeline(pm, module))) {
-        signalPassFailure();
-        return;
-      }
     }
 
     // TTNN -> EmitC

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -265,8 +265,11 @@ void createLinalgToLLVMPipeline(OpPassManager &manager,
   }
 }
 
-void createTTIRToCPUPipeline(OpPassManager &cpuPm,
-                             const LinalgToLLVMPipelineOptions &options) {
+void createTTIRToLLVMCPUPipeline(OpPassManager &pm,
+                                 const TTIRToLLVMCPUPipelineOptions &options) {
+
+  auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
+
 #ifdef TTMLIR_ENABLE_STABLEHLO
   // Directly convert any hoisted SHLO ops into linalg ops.
   cpuPm.addPass(stablehlo::createStablehloLegalizeToLinalgPass());

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -235,11 +235,9 @@ void createTTIRToTTMetalPipeline(OpPassManager &pm,
   createTTIRToTTMetalMiddleendPipeline(devicePm, options);
   createTTIRToTTMetalBackendPipeline(devicePm, options);
 
-  // Run lowering to LLVM pass on hoisted funcs in CPUModule.
-  auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
-
-  ttir::LinalgToLLVMPipelineOptions linalgToLLVMOptions;
-  ttir::createTTIRToCPUPipeline(cpuPm, linalgToLLVMOptions);
+  // Run lowering to LLVM pass.
+  ttir::TTIRToLLVMCPUPipelineOptions ttirToCPUOptions;
+  ttir::createTTIRToLLVMCPUPipeline(pm, ttirToCPUOptions);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -23,11 +23,11 @@
 
 namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
-// Pipeline implementation.
+// Helper functions which combine multiple passes into logical groupings.
 //===----------------------------------------------------------------------===//
 
 void createTTNNPipelineTTIRPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
 
   ttcore::TTCoreRegisterDevicePassOptions registerDeviceOptions;
   {
@@ -80,7 +80,7 @@ void createTTNNPipelineTTIRPasses(
 }
 
 void createTTNNPipelineAnalysisPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
 
   // Add pass to check for unique operation locations if enabled
   if (options.checkUniqueLocations) {
@@ -120,7 +120,7 @@ void createTTNNPipelineAnalysisPasses(
 }
 
 void createTTNNPipelineLoweringPasses(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
   // Add pass to add layout information.
   pm.addPass(createTTNNLayout());
   // Add pass to convert TTIR to TTNN.
@@ -138,7 +138,7 @@ void createTTNNPipelineLoweringPasses(
 // If optimizer is not enabled we just add fusing pass directly and we don't
 // do op constraint validation.
 void createTTNNFusingPass(OpPassManager &pm,
-                          const TTIRToTTNNBackendPipelineOptions &options) {
+                          const TTIRToTTNNDevicePipelineOptions &options) {
   if (options.enableFusing) {
     if (options.optimizerPassEnabled) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -165,7 +165,7 @@ void createTTNNFusingPass(OpPassManager &pm,
 
 // Create a pass to workaround issues in the TTNN dialect.
 void createTTNNPipelineWorkaroundPass(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
 
   // If the workaround pass is disabled, skip adding it.
   if (options.disableWorkarounds) {
@@ -185,17 +185,32 @@ void createTTNNPipelineWorkaroundPass(
 }
 
 void createTTNNPipelineLayoutDecompositionPass(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
   pm.addPass(createTTNNDecomposeLayouts());
 }
 
 void createTTNNPipelineDeallocPass(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
   pm.addPass(createTTNNDeallocate());
 }
 
-void createTTIRToTTNNBackendPipeline(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+//===----------------------------------------------------------------------===//
+// Intermediate pipelines used to build end-to-end pipelines.
+// Each of these pipelines lowers either the Device or CPU module, which is
+// encoded in the pipeline name.
+//
+// The OpPassManager argument is expected to correspond to the top-level
+// (root) ModuleOp.
+//===----------------------------------------------------------------------===//
+
+// Pipeline which prepares the TTIR ops in the Device module for TTNN
+// lowering, and then lowers them to TTNN dialect.
+//
+// CPU module does get modified in this pipeline, but only by
+// adding more TTIR ops to it (CPUHoistTransform passes).
+//
+void createTTIRToTTNNDevicePipeline(
+    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
   // Resolve options controlled by optimization_level.
   options.resolveOptimizationLevelOptions();
 
@@ -280,33 +295,30 @@ void createTTIRToTTNNBackendPipeline(
     devicePm.addPass(ttcore::createTTCoreOptimizationBarrierFold());
 
     createTTNNPipelineDeallocPass(devicePm, options);
-  }
 
-  // Run lowering to LLVM pass on hoisted funcs.
-  {
-    auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
+    if (options.ttnnPerfMetricsEnabled) {
+      ttnn::TTNNCollectPerfMetricsOptions metricsOptions{
+          options.ttnnPerfMetricsOutputFile,
+          options.ttnnPerfMetricsVerboseOutputEnabled, options.enableTrace};
 
-    ttir::LinalgToLLVMPipelineOptions linalgToLLVMOptions;
-    ttir::createTTIRToCPUPipeline(cpuPm, linalgToLLVMOptions);
-  }
-
-  if (options.ttnnPerfMetricsEnabled) {
-    auto &devicePm = pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
-
-    ttnn::TTNNCollectPerfMetricsOptions metricsOptions{
-        options.ttnnPerfMetricsOutputFile,
-        options.ttnnPerfMetricsVerboseOutputEnabled, options.enableTrace};
-
-    devicePm.addPass(
-        mlir::tt::ttnn::createTTNNCollectPerfMetrics(metricsOptions));
+      devicePm.addPass(
+          mlir::tt::ttnn::createTTNNCollectPerfMetrics(metricsOptions));
+    }
   }
 }
 
-void createTTNNBackendToEmitCPipeline(
-    OpPassManager &pm, const TTNNBackendToEmitCPipelineOptions &options) {
-
+// Pipeline which lowers the Device module from TTNN to EmitC dialect.
+//
+void createTTNNToEmitCDevicePipeline(
+    OpPassManager &pm, const TTNNToEmitCDevicePipelineOptions &options) {
   pm.addPass(createTTNNAdjustDeallocs());
 
+  // Unwrapping the device module.
+  //
+  // TODO(dmilinkovic): Should be removed after support for generating
+  // a dynamic library from CPU module is implemented inside EmitC translation
+  // pipeline - issue #6100.
+  //
   pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
 
   if (options.targetDylib) {
@@ -337,11 +349,18 @@ void createTTNNBackendToEmitCPipeline(
   pm.addPass(createConvertTTNNToEmitCPass());
 }
 
-void createTTNNBackendToEmitPyPipeline(
-    OpPassManager &pm, const TTNNBackendToEmitPyPipelineOptions &options) {
-
+// Pipeline which lowers the Device module from TTNN to EmitPy dialect.
+//
+void createTTNNToEmitPyDevicePipeline(
+    OpPassManager &pm, const TTNNToEmitPyDevicePipelineOptions &options) {
   pm.addPass(createTTNNAdjustDeallocs());
 
+  // Unwrapping the device module.
+  //
+  // TODO(dmilinkovic): Should be replaced by merging device and CPU modules
+  // by linking CPU-hoisted function declarations in Device module
+  // with their definitions from CPU module - issue #6099.
+  //
   pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
 
   // Apply EmitPy-specific workarounds before conversion
@@ -377,6 +396,28 @@ void createTTNNBackendToEmitPyPipeline(
   pm.addPass(createEmitPyNameVarsPass());
 }
 
+//===----------------------------------------------------------------------===//
+// End-to-end pipelines.
+//===----------------------------------------------------------------------===//
+
+// Complete pipeline for lowering TTIR to TTNN backend.
+//
+// Device module: TTIR -> TTNN.
+// CPU module: TTIR (+ StableHLO) -> LLVM.
+//
+void createTTIRToTTNNBackendPipeline(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+
+  createTTIRToTTNNDevicePipeline(pm, options);
+
+  ttir::createTTIRToLLVMCPUPipeline(pm, options);
+}
+
+// Complete pipeline for lowering TTIR to EmitC.
+//
+// Device module: TTIR -> TTNN -> EmitC.
+// CPU module: TTIR (+ StableHLO) -> LLVM.
+//
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options) {
   if (options.enableTrace) {
@@ -384,12 +425,17 @@ void createTTIRToEmitCPipeline(OpPassManager &pm,
         "Trace currently not supported in createTTIRToEmitCPipeline");
   }
 
-  // TTIR -> TTNN Backend -> EmitC.
-  //
-  createTTIRToTTNNBackendPipeline(pm, options);
-  createTTNNBackendToEmitCPipeline(pm, options);
+  createTTIRToTTNNDevicePipeline(pm, options);
+  createTTNNToEmitCDevicePipeline(pm, options);
+
+  // TODO(dmilinkovic): Lower CPU module to LLVM - issue #6100.
 }
 
+// Complete pipeline for lowering TTIR to EmitPy.
+//
+// Device module: TTIR -> TTNN -> EmitPy.
+// CPU module: TTIR -> TTNN -> EmitPy (with golden functions).
+//
 void createTTIRToEmitPyPipeline(OpPassManager &pm,
                                 const TTIRToEmitPyPipelineOptions &options) {
   if (options.enableTrace) {
@@ -397,10 +443,14 @@ void createTTIRToEmitPyPipeline(OpPassManager &pm,
         "Trace currently not supported in createTTIRToEmitPyPipeline");
   }
 
-  // TTIR -> TTNN Backend -> EmitPy.
+  createTTIRToTTNNDevicePipeline(pm, options);
+  createTTNNToEmitPyDevicePipeline(pm, options);
+
+  // TODO(dmilinkovic): Lower CPU module to EmitPy using TTNN golden functions -
+  // issue #6099.
   //
-  createTTIRToTTNNBackendPipeline(pm, options);
-  createTTNNBackendToEmitPyPipeline(pm, options);
+
+  // TODO(dmilinkovic): Merge Device and CPU modules - issue #6099.
 }
 
 //===----------------------------------------------------------------------===//
@@ -416,36 +466,32 @@ void registerTTNNPipelines() {
       "Pipeline lowering TTIR to TTNN backend.",
       mlir::tt::ttnn::createTTIRToTTNNBackendPipeline);
 
-  // TTNN backend to EmitC pipeline.
+  // TTNN to EmitC Device pipeline.
   //
   mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTNNBackendToEmitCPipelineOptions>(
-      "ttnn-backend-to-emitc-pipeline",
-      "Pipeline lowering TTNN backend to EmitC.",
-      mlir::tt::ttnn::createTTNNBackendToEmitCPipeline);
+      mlir::tt::ttnn::TTNNToEmitCDevicePipelineOptions>(
+      "ttnn-to-emitc-device-pipeline",
+      "Pipeline lowering TTNN to EmitC in the Device module.",
+      mlir::tt::ttnn::createTTNNToEmitCDevicePipeline);
 
-  // TTNN backend to EmitPy pipeline.
+  // TTNN to EmitPy Device pipeline.
   //
   mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTNNBackendToEmitPyPipelineOptions>(
-      "ttnn-backend-to-emitpy-pipeline",
-      "Pipeline lowering TTNN backend to EmitPy.",
-      mlir::tt::ttnn::createTTNNBackendToEmitPyPipeline);
+      mlir::tt::ttnn::TTNNToEmitPyDevicePipelineOptions>(
+      "ttnn-to-emitpy-device-pipeline",
+      "Pipeline lowering TTNN to EmitPy in the Device module.",
+      mlir::tt::ttnn::createTTNNToEmitPyDevicePipeline);
 
   // TTIR to EmitC pipeline.
   //
   mlir::PassPipelineRegistration<mlir::tt::ttnn::TTIRToEmitCPipelineOptions>(
-      "ttir-to-emitc-pipeline",
-      "Pipeline lowering TTIR to EmitC. Under the hood, it runs "
-      "--ttir-to-ttnn-backend-pipeline and --ttnn-backend-to-emitc-pipeline.",
+      "ttir-to-emitc-pipeline", "Pipeline lowering TTIR to EmitC.",
       mlir::tt::ttnn::createTTIRToEmitCPipeline);
 
   // TTIR to EmitPy pipeline.
   //
   mlir::PassPipelineRegistration<mlir::tt::ttnn::TTIRToEmitPyPipelineOptions>(
-      "ttir-to-emitpy-pipeline",
-      "Pipeline lowering TTIR to EmitPy. Under the hood, it runs "
-      "--ttir-to-ttnn-backend-pipeline and --ttnn-backend-to-emitpy-pipeline.",
+      "ttir-to-emitpy-pipeline", "Pipeline lowering TTIR to EmitPy.",
       mlir::tt::ttnn::createTTIRToEmitPyPipeline);
 }
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -49,7 +49,7 @@
 namespace mlir::tt::ttnn {
 
 TTNNOptimizerOptions::TTNNOptimizerOptions(
-    const TTIRToTTNNBackendPipelineOptions &pipelineOptions)
+    const TTIRToTTNNDevicePipelineOptions &pipelineOptions)
     : insertMemReconfig(pipelineOptions.insertMemReconfig),
       overrideOutputLayout(pipelineOptions.overrideOutputLayout),
       overrideConv2dConfig(pipelineOptions.overrideConv2dConfig),

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-backend-to-emitc-pipeline -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-to-emitc-device-pipeline -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_target_dylib_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_target_dylib_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitc-pipeline="target-dylib=true system-desc-path=%system_desc_path%" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttcore-unwrap-device-module --ttnn-backend-to-emitc-pipeline="target-dylib=true" -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttcore-unwrap-device-module --ttnn-to-emitc-device-pipeline="target-dylib=true" -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 //

--- a/test/ttmlir/Dialect/EmitPy/TTNN/consteval/global.mlir
+++ b/test/ttmlir/Dialect/EmitPy/TTNN/consteval/global.mlir
@@ -1,6 +1,5 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
-// RUN: ttmlir-opt --ttnn-backend-to-emitpy-pipeline -o %t2.mlir %t.mlir
-// RUN: FileCheck %s --input-file=%t2.mlir
+// RUN: ttmlir-opt --ttir-to-emitpy-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
 
 // Verify that all 4 GlobalOp-related operations are generated correctly when
 // LoadCachedOp is converted from TTNN to EmitPy.

--- a/test/ttmlir/Dialect/EmitPy/ttir_to_emitpy_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitPy/ttir_to_emitpy_pipeline_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitpy-pipeline="system-desc-path=%system_desc_path%" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-backend-to-emitpy-pipeline -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-to-emitpy-device-pipeline --ttcore-unwrap-device-module -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 

--- a/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm_training.mlir
+++ b/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm_training.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_assymetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_assymetric_padding.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_bf16.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_bf16.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_f32.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_f32.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // TODO (#2507): conv2d currently fails when run in group. Merge this with

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_activation.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_activation.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights_and_prepare_conv2d_bias.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights_and_prepare_conv2d_bias.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/depthwise_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/depthwise_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/depthwise_separable_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/depthwise_separable_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/dilated_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/dilated_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/grouped_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/grouped_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/pointwise_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/pointwise_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias_asymmetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias_asymmetric_padding.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
+++ b/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // default

--- a/test/ttmlir/EmitC/TTNN/element_type_normalization/block_type_conversion.mlir
+++ b/test/ttmlir/EmitC/TTNN/element_type_normalization/block_type_conversion.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module  {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/add.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/add.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @atan2(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/bitwise.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/bitwise.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
   func.func @bitwise_and(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> tensor<64x128xi32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/compare.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/compare.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @lt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/divide.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/divide.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/gelu_bw.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/gelu_bw.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logical.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logical.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logical_and(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalleftshift.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalleftshift.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logicalleftshift(%arg0: tensor<5xui32>, %arg1: tensor<5xui32>) -> tensor<5xui32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalrightshift.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalrightshift.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logicalrightshift(%arg0: tensor<5xui32>, %arg1: tensor<5xui32>) -> tensor<5xui32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @minimum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/multiply.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/multiply.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/pow.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/pow.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @pow_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @remainder(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/subtract.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/subtract.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_where(%arg0: tensor<13x37xbf16>, %arg1: tensor<13x37xbf16>) -> tensor<13x37xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/abs.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/abs.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @abs(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/atan.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/atan.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @atan(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/bitwise_not.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/bitwise_not.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @bitwise_not(%arg0: tensor<64x128xi32>) -> tensor<64x128xi32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cbrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/ceil.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/ceil.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @ceil(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/cos.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/cos.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cos(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/erf.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/erf.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @erf(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/erfc.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/erfc.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @erfc(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/exp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/exp.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/expm1.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/expm1.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @expm1(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/floor.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/floor.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/gelu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/gelu.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @gelu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/isfinite.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/isfinite.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @isfinite(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/leaky_relu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/leaky_relu.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @leaky_relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/log.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/log.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @log(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/log1p.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/log1p.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @log1p(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/logical_not.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/logical_not.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logical_not(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/neg.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/neg.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @neg(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/reciprocal.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/reciprocal.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @reciprocal(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/relu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/relu.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/relu6.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/relu6.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @relu6(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/rsqrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/rsqrt.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @rsqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sigmoid.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sigmoid.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sigmoid(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sign.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sign.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sign(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/silu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/silu.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @silu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sin.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sin.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sin(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sqrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sqrt.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/tan.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/tan.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @tan(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/tanh.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/tanh.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @tanh(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/paged_update_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/paged_update_cache.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/update_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/update_cache.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @update_cache(%arg0: tensor<1x8x16x128xbf16>, %arg1: tensor<1x8x1x128xbf16>, %arg2: tensor<1xi32>) -> tensor<1x8x16x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/matmul/linear.mlir
+++ b/test/ttmlir/EmitC/TTNN/matmul/linear.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/matmul/matmul.mlir
+++ b/test/ttmlir/EmitC/TTNN/matmul/matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @matmul(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {

--- a/test/ttmlir/EmitC/TTNN/memory/multiple_ops.mlir
+++ b/test/ttmlir/EmitC/TTNN/memory/multiple_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 //
 // This test tests multiple ops. It runs a single "ttir.add" op but it is expected that several other memory-related ops will be generated in the TTNN dialect:

--- a/test/ttmlir/EmitC/TTNN/memory/typecast.mlir
+++ b/test/ttmlir/EmitC/TTNN/memory/typecast.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @typecast(%arg0: tensor<64x128xf32>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/models/llama_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/llama_attention.mlir
@@ -1,4 +1,4 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %models/llama_attention.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // https://huggingface.co/meta-llama/Llama-3.2-1B

--- a/test/ttmlir/EmitC/TTNN/models/mnist.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/mnist.mlir
@@ -1,4 +1,4 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %models/mnist.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" %s -o %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // Temporary workaround for running optimizer tests in CI is to run optimizer locally and run the rest of the pipeline on obtained IR:

--- a/test/ttmlir/EmitC/TTNN/models/resnet.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/resnet.mlir
@@ -1,4 +1,4 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %models/resnet_hf.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @embedding(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 

--- a/test/ttmlir/EmitC/TTNN/other/cumsum.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/cumsum.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cumsum(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/embedding.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/embedding.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @embedding(%arg0: tensor<32x32xbf16>, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/pad.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/pad.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 //
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/other/softmax.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/softmax.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @softmax(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {

--- a/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/global_avg_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/global_avg_pool2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/max_pool2d_with_indices.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/max_pool2d_with_indices.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/upsample.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/upsample.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/quantization/dequantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/dequantize.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/quantization/quantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/quantize.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/quantization/requantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/requantize.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/rand/rand.mlir
+++ b/test/ttmlir/EmitC/TTNN/rand/rand.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // https://github.com/tenstorrent/tt-mlir/issues/4383

--- a/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64xi32> {

--- a/test/ttmlir/EmitC/TTNN/reduction/max.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/max.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<32x32x64xbf16>) -> tensor<1x1x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/min.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/min.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xf32>) -> tensor<f32> {

--- a/test/ttmlir/EmitC/TTNN/reduction/prod.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/prod.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x1x32x4xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/sum.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/sum.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/sanity_add.mlir
+++ b/test/ttmlir/EmitC/TTNN/sanity_add.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {

--- a/test/ttmlir/EmitC/TTNN/sanity_two_fns.mlir
+++ b/test/ttmlir/EmitC/TTNN/sanity_two_fns.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {

--- a/test/ttmlir/EmitC/TTNN/sort/sort.mlir
+++ b/test/ttmlir/EmitC/TTNN/sort/sort.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_sort(%arg0: tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xi16>) {

--- a/test/ttmlir/EmitC/TTNN/tensor/concat.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/concat.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @concat(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/construct.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/construct.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --convert-ttir-to-ttnn -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/full.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/full.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @full_float() -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @ones() -> tensor<13x24x56x42xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/repeat.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/repeat.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-repeat-folding-workaround-pass=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @repeat_interleave(%arg0: tensor<4x6xf32>) -> tensor<4x24xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/reshape.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/reshape.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @slice(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/transpose.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/transpose.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @transpose(%arg0: tensor<64x128xbf16>) -> tensor<128x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @zeros() -> tensor<13x24x56x42xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #system_memory = #ttnn.buffer_type<system_memory>

--- a/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 func.func @concatenate_heads(%arg0: tensor<1x24x32x128xbf16>) -> tensor<1x32x3072xbf16> {

--- a/test/ttmlir/EmitC/TTNN/transformer/nlp_create_qkv_heads_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/nlp_create_qkv_heads_decode.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/transformer/paged_scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/paged_scaled_dot_product_attention_decode.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 module @sdpa {
     func.func public @sdpa_causal(%arg0: tensor<1x1x12x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x1x12x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 module {

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 module {

--- a/test/ttmlir/EmitC/TTNN/transformer/split_query_key_value_and_split_heads.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/split_query_key_value_and_split_heads.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-backend-to-emitc-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 func.func @split_qkv_and_split_heads(%arg0: tensor<2x32x3072xf32>) -> (tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>) {

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -361,7 +361,7 @@ class ModelRunner:
             )
             emitc_command = [
                 f"{self._build_dir}/bin/ttmlir-opt",
-                "--ttnn-backend-to-emitc-pipeline",
+                "--ttnn-to-emitc-device-pipeline",
                 ttnn_ir_file,
                 "-o",
                 emitc_ir_file,

--- a/tools/tt-alchemist/csrc/lib/utils.cpp
+++ b/tools/tt-alchemist/csrc/lib/utils.cpp
@@ -30,13 +30,13 @@ std::string getPipelineName(mlir::ModuleOp module,
   switch (target) {
   case CodeGenerationTarget::Cpp:
     if (isOnlyTTNN) {
-      return "ttnn-backend-to-emitc-pipeline";
+      return "ttnn-to-emitc-device-pipeline";
     } else {
       return "ttir-to-emitc-pipeline";
     }
   case CodeGenerationTarget::Python:
     if (isOnlyTTNN) {
-      return "ttnn-backend-to-emitpy-pipeline";
+      return "ttnn-to-emitpy-device-pipeline";
     } else {
       return "ttir-to-emitpy-pipeline";
     }


### PR DESCRIPTION
### Ticket
#6099 #6100 

### Problem description

Before enabling CPU-hoisting on EmitPy and EmitC targets, a few issues need to be addressed:
- EmitPy target doesn't require TTIR -> LLVM lowering for the CPU module; on the other hand, EmitC and Flatbuffers target require TTIR -> LLVM lowering. 
  - This means that `TTIRToTTNNBackendPipeline` should be aware of the downstream pipelines, which introduces tight coupling between pipelines.
- Some passes expect to run on either top-level module, or Device/CPU inner module. This tightly couples the passes with the CPU/Device module logic, negatively affecting separation of concerns, testability and modularity. This logic should, IMHO, be part of the pipeline implementations rather that pass implementations.

### Goals of the refactor
- There should be three **end-to-end** TTNN pipelines, for the three corresponding targets
- Only **end-to-end** pipelines should be exposed through `TTNNPipelines.h` to the outside world
- **Intermediate** pipelines should perform lowering on either the Device or the CPU module to avoid confusion
- End-to-end pipelines should be composed of intermediate pipelines (and possibly, some additional passes)
- Individual passes shouldn't care about whether they run on Device or on CPU module; rather, the Pipelines should be responsible for nesting the pass managers to achieve the same result

### New pipelines structure in `TTNNPipelines.cpp`

#### Intermediate pipelines
- `TTIRToTTNNDevicePipeline` (renamed from `TTIRToTTNNBackendPipeline`)
  - Runs on the `Device` module. Performs the necessary TTIR passes which prepare the TTIR for lowering to TTNN, after which it performs the actual lowering.
- `TTNNToEmitCDevicePipeline`
  - Runs on the `Device` module. 
- `TTNNToEmitPyDevicePipeline`
  - Runs on the `Device` module.
- `TTIRToLLVMCPUPipeline` (from `TTIRPipelines.h`)
  - Runs on the `CPU` module.

#### End-to-end pipelines
  - `TTIRToTTNNBackendPipeline` (flatbuffers)
     - Device module: TTIR -> TTNN
     - CPU module: TTIR (+ StabeHLO) + LLVM (compiled to dylib during translation)
  - `TTIRToEmitPyPipeline` (will be finished with #6099)
     - Device module: TTNN -> EmitPy
     - CPU module: TTIR -> TTNN -> EmitPy (through `golden_function` invocations)
   - `TTIRToEmitCPipeline` (will be finished with #6100)
     - Device module: TTIR -> TTNN -> EmitC
     - CPU module:  TTIR (+ StableHLO) -> LLVM (compiled to dylib during translation)

### Checklist
- [x] New/Existing tests provide coverage for changes
