### PR TITLE
fixing CMake warning

### DIFF
--- a/runtime/tools/chisel/CMakeLists.txt
+++ b/runtime/tools/chisel/CMakeLists.txt
@@ -2,7 +2,8 @@ add_custom_target(chisel
   COMMENT "python chisel package")
 
 add_custom_command(
-  COMMAND python -m pip install -e .
   TARGET chisel
+  POST_BUILD
+  COMMAND python -m pip install -e .
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )


### PR DESCRIPTION
### Problem description
Fixes warning:

`CMake Warning (dev) (add_custom_command): Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given. Assuming POST_BUILD to preserve backward compatibility. `
