### PR TITLE
Create matmul program config in optimizer and pass to OpModel

### DIFF
--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -143,6 +143,9 @@ getSDPAProgramConfig(
 std::optional<std::string> getScatterReductionType(
     const std::optional<ttcore::ReduceTypeAttr> &reduceTypeAttr);
 
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+getMatmulProgramConfig(mlir::Attribute programConfigAttr);
+
 } // namespace conversion
 } // namespace mlir::tt::ttnn::op_model
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -973,7 +973,8 @@ struct OpModel<LinearOp> {
       TTNNLayoutAttr inputLayoutB,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
-      bool transposeA, bool transposeB);
+      bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -993,7 +994,8 @@ struct OpModel<MatmulOp> {
       ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
       TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
       TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
-      bool transposeB);
+      bool transposeB, std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr = std::nullopt);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2880,10 +2880,15 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
+  // Convert activation attribute to optional StringRef
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<LinearOp>::getOpConstraints, *this, deviceGrid,
       inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
-      opConfig.outputLayout, getTransposeA(), getTransposeB());
+      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation);
 }
 
 llvm::Expected<size_t>
@@ -2945,10 +2950,15 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
+  // Convert activation attribute to optional StringRef
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<MatmulOp>::getOpConstraints, *this, deviceGrid,
       inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      getTransposeA(), getTransposeB());
+      getTransposeA(), getTransposeB(), activation, getMatmulProgramConfig());
 }
 
 llvm::Expected<size_t>

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -734,6 +734,98 @@ std::optional<std::string> getScatterReductionType(
   }
 }
 
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+getMatmulProgramConfig(mlir::Attribute programConfigAttr) {
+  if (!programConfigAttr) {
+    return std::nullopt;
+  }
+
+  if (auto config = mlir::dyn_cast<MatmulMultiCoreReuseProgramConfigAttr>(
+          programConfigAttr)) {
+    CoreCoordAttr gridSize = config.getComputeWithStorageGridSize();
+    return ::ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{
+        .compute_with_storage_grid_size =
+            ::tt::tt_metal::CoreCoord{gridSize.getX(), gridSize.getY()},
+        .in0_block_w = config.getIn0BlockW(),
+        .out_subblock_h = config.getOutSubblockH(),
+        .out_subblock_w = config.getOutSubblockW(),
+        .per_core_M = config.getPerCoreM(),
+        .per_core_N = config.getPerCoreN()};
+  }
+
+  if (auto config =
+          mlir::dyn_cast<MatmulMultiCoreReuseMultiCastProgramConfigAttr>(
+              programConfigAttr)) {
+    CoreCoordAttr gridSize = config.getComputeWithStorageGridSize();
+    std::optional<::ttnn::operations::unary::UnaryWithParam> fusedActivation =
+        std::nullopt;
+    if (auto actAttr = config.getFusedActivation()) {
+      fusedActivation = getUnaryWithParams(actAttr);
+    }
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastProgramConfig{
+            .compute_with_storage_grid_size =
+                ::tt::tt_metal::CoreCoord{gridSize.getX(), gridSize.getY()},
+            .in0_block_w = config.getIn0BlockW(),
+            .out_subblock_h = config.getOutSubblockH(),
+            .out_subblock_w = config.getOutSubblockW(),
+            .out_block_h = config.getOutBlockH(),
+            .out_block_w = config.getOutBlockW(),
+            .per_core_M = config.getPerCoreM(),
+            .per_core_N = config.getPerCoreN(),
+            .transpose_mcast = config.getTransposeMcast(),
+            .fused_activation = fusedActivation,
+            .fuse_batch = config.getFuseBatch()};
+  }
+
+  if (auto config =
+          mlir::dyn_cast<MatmulMultiCoreReuseMultiCast1DProgramConfigAttr>(
+              programConfigAttr)) {
+    CoreCoordAttr gridSize = config.getComputeWithStorageGridSize();
+    std::optional<::ttnn::operations::unary::UnaryWithParam> fusedActivation =
+        std::nullopt;
+    if (auto actAttr = config.getFusedActivation()) {
+      fusedActivation = getUnaryWithParams(actAttr);
+    }
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCast1DProgramConfig{
+            .compute_with_storage_grid_size =
+                ::tt::tt_metal::CoreCoord{gridSize.getX(), gridSize.getY()},
+            .in0_block_w = config.getIn0BlockW(),
+            .out_subblock_h = config.getOutSubblockH(),
+            .out_subblock_w = config.getOutSubblockW(),
+            .out_block_h = config.getOutBlockH(),
+            .out_block_w = config.getOutBlockW(),
+            .per_core_M = config.getPerCoreM(),
+            .per_core_N = config.getPerCoreN(),
+            .fuse_batch = config.getFuseBatch(),
+            .fused_activation = fusedActivation,
+            .mcast_in0 = config.getMcastIn0(),
+            .gather_in0 = config.getGatherIn0(),
+            .hop_cores = getCoreRangeSet(config.getHopCores()),
+            .num_global_cb_receivers = config.getNumGlobalCbReceivers(),
+            .untilize_out = config.getUntilizeOut()};
+  }
+
+  if (auto config = mlir::dyn_cast<
+          MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          programConfigAttr)) {
+    std::optional<::ttnn::operations::unary::UnaryWithParam> fusedActivation =
+        std::nullopt;
+    if (auto actAttr = config.getFusedActivation()) {
+      fusedActivation = getUnaryWithParams(actAttr);
+    }
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig{
+            .in0_block_w = config.getIn0BlockW(),
+            .per_core_M = config.getPerCoreM(),
+            .per_core_N = config.getPerCoreN(),
+            .fused_activation = fusedActivation};
+  }
+
+  return std::nullopt;
+}
+
 } // namespace conversion
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4070,7 +4070,8 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
-    bool transposeA, bool transposeB) {
+    bool transposeA, bool transposeB,
+    std::optional<llvm::StringRef> activation) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4101,11 +4102,16 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  // Convert activation to std::optional<std::string> for tt-metal API
+  std::optional<std::string> activationStr =
+      activation ? std::make_optional(activation->str()) : std::nullopt;
+
   // Create query closure
   auto linearOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
-        transposeB, outputMemoryConfig, outputDType);
+        transposeB, outputMemoryConfig, outputDType,
+        /*program_config=*/std::nullopt, activationStr);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,
@@ -4167,11 +4173,13 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
+
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
     TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
-    bool transposeB) {
+    bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4195,11 +4203,20 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  // Convert activation to std::optional<std::string> for tt-metal API
+  std::optional<std::string> activationStr =
+      activation ? std::make_optional(activation->str()) : std::nullopt;
+
+  // Use program config from IR if provided
+  std::optional<::ttnn::operations::matmul::MatmulProgramConfig> programConfig =
+      programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
+                        : std::nullopt;
+
   // Create query closure
   auto matmulOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
-        outputMemoryConfig, outputDType);
+        outputMemoryConfig, outputDType, programConfig, activationStr);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), deviceGrid,

--- a/lib/Scheduler/Scheduler.cpp
+++ b/lib/Scheduler/Scheduler.cpp
@@ -15,9 +15,10 @@
 
 namespace mlir::tt::scheduler {
 
-// TTNN op is scheduleable if it is not an EmptyOp and has at least one result.
+// TTNN op is scheduleable if it is not an EmptyOp or GetDeviceOp.
+// This includes in-place ops (like paged_update_cache) that have no results.
 static bool isTTNNScheduleableOp(mlir::Operation *op) {
-  return isa<ttnn::TTNNDialect>(op->getDialect()) && op->getNumResults() > 0 &&
+  return isa<ttnn::TTNNDialect>(op->getDialect()) &&
          !llvm::isa<ttnn::EmptyOp>(op) && !llvm::isa<ttnn::GetDeviceOp>(op);
 }
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2276,7 +2276,7 @@ TEST_P(OpModelLinearParam, LinearParam) {
 
   auto constraintsExp = OpModel<LinearOp>::getOpConstraints(
       CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      biasShape, biasLayout, outputLayout, false, false);
+      biasShape, biasLayout, outputLayout, false, false, std::nullopt);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
@@ -2497,7 +2497,7 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
 
   auto constraintsExp = OpModel<MatmulOp>::getOpConstraints(
       CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      outputLayout, false, false);
+      outputLayout, false, false, std::nullopt);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have

--- a/test/unittests/OpModel/TTNN/Op/TestMatmulBlockShardedConstraint.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestMatmulBlockShardedConstraint.cpp
@@ -76,7 +76,8 @@ TEST_F(OpModelTest, MatmulBlockShardedInputWithPadding) {
       {
         auto constraintsExp = op_model::OpModel<MatmulOp>::getOpConstraints(
             deviceGrid, inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-            nullptr, matmul.getTransposeA(), matmul.getTransposeB());
+            nullptr, matmul.getTransposeA(), matmul.getTransposeB(),
+            std::nullopt);
         // Don't check the error - this will crash if fix is not in place
         (void)constraintsExp;
       },


### PR DESCRIPTION
This change ensures the optimizer generates matmul program configs that are used consistently during both compile-time validation and runtime execution.

OpModel: Read program config from IR for matmul ops
- Added getMatmulProgramConfig conversion function (Conversion.cpp/h)
- Updated OpModel<MatmulOp>::getOpConstraints to accept optional program config
- Removed createMatmulProgramConfigForShardedActivation workaround
- Config from IR is now passed to query_op_constraints

Pass activation to OpModel constraints for matmul/linear ops:
- Pass activation parameter to query_op_constraints for MatmulOp/LinearOp

Scheduler: Include in-place ops (like paged_update_cache) in scheduling
- Removed op->getNumResults() > 0 check that caused dominance errors for ops with no results

