### PR TITLE
llvm uplift 2025 December

### DIFF
--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 project(ttmlir-toolchain LANGUAGES CXX C)
 
 set(FLATBUFFERS_VERSION "fb9afbafc7dfe226b9db54d4923bfb8839635274")
-set(LLVM_PROJECT_VERSION "4efe170d858eb54432f520abb4e7f0086236748b")
-set(STABLEHLO_VERSION "0a4440a5c8de45c4f9649bf3eb4913bf3f97da0d")
-set(SHARDY_VERSION "edfd6730ddfc39da5fbea8b6b202357fdf1cdb90")
+set(LLVM_PROJECT_VERSION "43bfec29cbecc1ff2e5aa6f8908c4d63e9c896c5")
+set(STABLEHLO_VERSION "1ef9e390b5295e676d2b864fe1924bc2f3f4cf0f")
+set(SHARDY_VERSION "f36aaacad42e307da330bace41c920bdf23f1869")
 set(LLVM_BUILD_TYPE MinSizeRel CACHE STRING "Build type for LLVM")
 
 include(ExternalProject)

--- a/env/patches/shardy.patch
+++ b/env/patches/shardy.patch
@@ -1,6 +1,6 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-new file mode 100755
-index 0000000..ec8d310
+new file mode 100644
+index 0000000..30904b5
 --- /dev/null
 +++ b/CMakeLists.txt
 @@ -0,0 +1,57 @@
@@ -61,7 +61,6 @@ index 0000000..ec8d310
 +add_subdirectory(shardy/dialect/sdy/transforms)
 +add_subdirectory(shardy/integrations/python/ir)
 +add_subdirectory(shardy/integrations/c)
-\ No newline at end of file
 diff --git a/shardy/common/CMakeLists.txt b/shardy/common/CMakeLists.txt
 new file mode 100644
 index 0000000..5ae192d
@@ -87,7 +86,7 @@ index 0000000..5ae192d
 +  SdyDialect
 +)
 diff --git a/shardy/dialect/sdy/ir/CMakeLists.txt b/shardy/dialect/sdy/ir/CMakeLists.txt
-new file mode 100755
+new file mode 100644
 index 0000000..b2c87de
 --- /dev/null
 +++ b/shardy/dialect/sdy/ir/CMakeLists.txt
@@ -199,7 +198,7 @@ index 0000000..b2c87de
 +  MLIRSupport
 +)
 diff --git a/shardy/dialect/sdy/transforms/CMakeLists.txt b/shardy/dialect/sdy/transforms/CMakeLists.txt
-new file mode 100755
+new file mode 100644
 index 0000000..90e2fc5
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/CMakeLists.txt
@@ -231,7 +230,7 @@ index 0000000..90e2fc5
 +  $<BUILD_INTERFACE:${SHARDY_BINARY_DIR}>
 +)
 diff --git a/shardy/dialect/sdy/transforms/common/CMakeLists.txt b/shardy/dialect/sdy/transforms/common/CMakeLists.txt
-new file mode 100755
+new file mode 100644
 index 0000000..3b414d1
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/common/CMakeLists.txt
@@ -266,8 +265,8 @@ index 0000000..3b414d1
 +  SdyDialect
 +)
 diff --git a/shardy/dialect/sdy/transforms/export/CMakeLists.txt b/shardy/dialect/sdy/transforms/export/CMakeLists.txt
-new file mode 100755
-index 0000000..60f1952
+new file mode 100644
+index 0000000..7670080
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/export/CMakeLists.txt
 @@ -0,0 +1,94 @@
@@ -357,17 +356,17 @@ index 0000000..60f1952
 +)
 +
 +target_include_directories(SdyTransformsExportPasses INTERFACE
-+  $<BUILD_INTERFACE:${SHARDY_SOURCE_DIR}>
-+  $<BUILD_INTERFACE:${SHARDY_BINARY_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_SOURCE_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_BINARY_DIR}>
 +)
 +
 +target_include_directories(SdyExplicitReshardsUtil INTERFACE
-+  $<BUILD_INTERFACE:${SHARDY_SOURCE_DIR}>
-+  $<BUILD_INTERFACE:${SHARDY_BINARY_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_SOURCE_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_BINARY_DIR}>
 +)
 diff --git a/shardy/dialect/sdy/transforms/import/CMakeLists.txt b/shardy/dialect/sdy/transforms/import/CMakeLists.txt
-new file mode 100755
-index 0000000..c302390
+new file mode 100644
+index 0000000..b478a8f
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/import/CMakeLists.txt
 @@ -0,0 +1,47 @@
@@ -415,12 +414,12 @@ index 0000000..c302390
 +)
 +
 +target_include_directories(SdyTransformsImportPasses INTERFACE
-+  $<BUILD_INTERFACE:${SHARDY_SOURCE_DIR}>
-+  $<BUILD_INTERFACE:${SHARDY_BINARY_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_SOURCE_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_BINARY_DIR}>
 +)
 diff --git a/shardy/dialect/sdy/transforms/propagation/CMakeLists.txt b/shardy/dialect/sdy/transforms/propagation/CMakeLists.txt
-new file mode 100755
-index 0000000..809f431
+new file mode 100644
+index 0000000..569cf02
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/propagation/CMakeLists.txt
 @@ -0,0 +1,188 @@
@@ -489,8 +488,8 @@ index 0000000..809f431
 +)
 +
 +target_include_directories(SdyTransformsPropagationPasses INTERFACE
-+  $<BUILD_INTERFACE:${SHARDY_SOURCE_DIR}>
-+  $<BUILD_INTERFACE:${SHARDY_BINARY_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_SOURCE_DIR}>
++  \$<BUILD_INTERFACE:\${SHARDY_BINARY_DIR}>
 +)
 +
 +add_mlir_library(SdyTransformsPropagationOpShardingRuleBuilder
@@ -636,10 +635,10 @@ index 0000000..dc33501
 +  SdyTransformsPropagationShardingProjection
 +)
 diff --git a/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc b/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
-index 86f16d1..8039a00 100644
+index a73917b..78cc827 100644
 --- a/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
 +++ b/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
-@@ -338,6 +338,7 @@ void saveShardingOriginsOnModule(
+@@ -346,6 +346,7 @@ void saveShardingOriginsOnModule(
  // the case for the target of the edge, because if the source appears multiple
  // times, then it's because it effects multiple other operands/results in the
  // op.
@@ -647,6 +646,48 @@ index 86f16d1..8039a00 100644
  bool insertSeenValue(Operation* op, const PropagationEdge& edge,
                       llvm::SmallDenseSet<Value>& seenValues) {
    EdgeNode target = edge.target;
+diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+index 12f8d12..79fe46a 100644
+--- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
++++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+@@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
+         }
+         return builder.build();
+       })
++      .Case<stablehlo::BatchNormInferenceOp>(
++        [conservativePropagation](stablehlo::BatchNormInferenceOp bn) {
++          auto inTy  = llvm::cast<mlir::RankedTensorType>(bn.getOperand().getType());
++          auto outTy = llvm::cast<mlir::RankedTensorType>(bn.getResult().getType());
++
++          OpShardingRuleBuilder builder(bn);
++
++          const int64_t numOperands = static_cast<int64_t>(bn->getNumOperands());
++          llvm::SmallVector<int64_t> opDims(numOperands, kNullDim);
++
++          for (auto [dU, dimSize] : llvm::enumerate(inTy.getShape())) {
++            const int64_t d = static_cast<int64_t>(dU);
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[0] = d;
++            builder.addFactor(opDims, d, dimSize);
++          }
++
++          const int64_t featAxis = static_cast<int64_t>(bn.getFeatureIndex());
++          const int64_t C = outTy.getDimSize(featAxis);
++
++          for (int64_t paramIdx : {1LL, 2LL, 3LL, 4LL}) {
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[paramIdx] = 0;
++            auto factorType = conservativePropagation ? FactorType::kNeedReplication
++                                                        : FactorType::kPassThrough;
++            builder.addFactor(opDims, kNullDim, C,
++                  factorType, true);
++          }
++
++          return builder.build();
++        })
+       .Case<stablehlo::BitcastConvertOp>(
+           [](stablehlo::BitcastConvertOp bitcastConvert) {
+             ArrayRef<int64_t> inShape =
 diff --git a/shardy/integrations/c/CMakeLists.txt b/shardy/integrations/c/CMakeLists.txt
 new file mode 100644
 index 0000000..fdd50c4
@@ -789,75 +830,3 @@ index 0000000..30a5cf9
 +include "shardy/dialect/sdy/ir/ops.td"
 +
 +#endif
-diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-index ab93067..283d6ad 100644
---- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-+++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-@@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-         }
-         return builder.build();
-       })
-+      .Case<stablehlo::BatchNormInferenceOp>(
-+        [conservativePropagation](stablehlo::BatchNormInferenceOp bn) {
-+          auto inTy  = llvm::cast<mlir::RankedTensorType>(bn.getOperand().getType());
-+          auto outTy = llvm::cast<mlir::RankedTensorType>(bn.getResult().getType());
-+
-+          OpShardingRuleBuilder builder(bn);
-+
-+          const int64_t numOperands = static_cast<int64_t>(bn->getNumOperands());
-+          llvm::SmallVector<int64_t> opDims(numOperands, kNullDim);
-+
-+          for (auto [dU, dimSize] : llvm::enumerate(inTy.getShape())) {
-+            const int64_t d = static_cast<int64_t>(dU);
-+            std::fill(opDims.begin(), opDims.end(), kNullDim);
-+            opDims[0] = d;
-+            builder.addFactor(opDims, d, dimSize);
-+          }
-+
-+          const int64_t featAxis = static_cast<int64_t>(bn.getFeatureIndex());
-+          const int64_t C = outTy.getDimSize(featAxis);
-+
-+          for (int64_t paramIdx : {1LL, 2LL, 3LL, 4LL}) {
-+            std::fill(opDims.begin(), opDims.end(), kNullDim);
-+            opDims[paramIdx] = 0;
-+            auto factorType = conservativePropagation ? FactorType::kNeedReplication
-+                                                        : FactorType::kPassThrough;
-+            builder.addFactor(opDims, kNullDim, C,
-+                  factorType, true);
-+          }
-+
-+          return builder.build();
-+        })
-       .Case<stablehlo::BitcastConvertOp>(
-           [](stablehlo::BitcastConvertOp bitcastConvert) {
-             ArrayRef<int64_t> inShape =
-@@ -685,6 +716,12 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-                   /*isBlocked=*/usedByRngBitGenerator)
-               .build();
-         }
-+        // Check if the custom call implements the ShardingRuleOpInterface.
-+        if (auto shardingRuleOp =
-+                  llvm::dyn_cast<ShardingRuleOpInterface>(customCall.getOperation())) {
-+          return shardingRuleOp.getShardingRule();
-+        }
-+
-         // TODO(b/327191011): output unregistered op stats instead.
-         static llvm::once_flag onceFlag;
-         emitOpWarningOnce(
-@@ -1093,6 +1130,16 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-             return builder.build();
-           })
-       .Case<stablehlo::ScatterOp>([](stablehlo::ScatterOp scatter) {
-+        // Check if the scatter op implements the ShardingRuleOpInterface.
-+        if (auto shardingRuleOp =
-+              llvm::dyn_cast<ShardingRuleOpInterface>(scatter.getOperation())) {
-+          // Try to get custom rule - if it returns non-null, use it.
-+          if (auto customRule = shardingRuleOp.getShardingRule()) {
-+            return customRule;
-+          }
-+          // If custom rule returns null, fall through to default.
-+        }
-+
-         OpShardingRuleBuilder builder(scatter);
-
-         // Since all inputs and results have compatible shapes, we can look at

--- a/include/ttmlir/AffineMapUtils.h
+++ b/include/ttmlir/AffineMapUtils.h
@@ -105,8 +105,8 @@ fullyApplyAffineMap(mlir::OpBuilder &builder, mlir::Location loc,
                     mlir::AffineMap map, mlir::ValueRange inputs) {
   llvm::SmallVector<mlir::Value> results;
   for (unsigned i = 0; i < map.getNumResults(); i++) {
-    results.push_back(builder.create<mlir::affine::AffineApplyOp>(
-        loc, affineMapSelectOneOutput(map, i), inputs));
+    results.push_back(mlir::affine::AffineApplyOp::create(
+        builder, loc, affineMapSelectOneOutput(map, i), inputs));
   }
   return results;
 }

--- a/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitPy/EmitPyConversion.h
@@ -1779,12 +1779,11 @@ private:
   }
 
   mlir::Value createList(ValueRange operands) {
-    return rewriter
-        .create<emitpy::CallOpaqueOp>(
-            op.getLoc(),
-            emitpy::OpaqueType::get(rewriter.getContext(),
-                                    TypeNameV<std::vector<::ttnn::Tensor>>),
-            kCreateListFunctionName, operands, nullptr, nullptr)
+    return emitpy::CallOpaqueOp::create(
+               rewriter, op.getLoc(),
+               emitpy::OpaqueType::get(rewriter.getContext(),
+                                       TypeNameV<std::vector<::ttnn::Tensor>>),
+               kCreateListFunctionName, operands, nullptr, nullptr)
         ->getResult(0);
   }
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1299,7 +1299,7 @@ class D2M_CBOp<string mnemonic, list<Trait> traits = []> : D2M_GenericRegionOp<m
         return this->emitOpError();
       });
       assert(succeeded(cbBufferType));
-      auto toBuffer = rewriter.create<bufferization::ToBufferOp>(
+      auto toBuffer = bufferization::ToBufferOp::create(rewriter,
           this->getLoc(), *cbBufferType, getCb());
       mlir::bufferization::replaceOpWithNewBufferizedOp<$cppClass>(
           rewriter, *this, toBuffer.getResult());

--- a/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
@@ -250,8 +250,8 @@ inline PermuteOp getInverseTM(PermuteOp permuteOp, Value input,
   SmallVector<int64_t> outputShape = ttmlir::utils::applyPermutation(
       inputType.getShape(), ArrayRef<int64_t>(inversePermutation));
   RankedTensorType resultType = inputType.clone(outputShape);
-  return rewriter.create<PermuteOp>(permuteOp->getLoc(), resultType, input,
-                                    inversePermutation);
+  return PermuteOp::create(rewriter, permuteOp->getLoc(), resultType, input,
+                           inversePermutation);
 }
 
 inline ReshapeOp getInverseTM(ReshapeOp reshapeOp, Value input,
@@ -264,8 +264,8 @@ inline ReshapeOp getInverseTM(ReshapeOp reshapeOp, Value input,
   auto outputShape = reshapeOp.getInput().getType().getShape();
   RankedTensorType resultType = inputType.clone(outputShape);
 
-  return rewriter.create<ReshapeOp>(
-      reshapeOp->getLoc(), resultType, input,
+  return ReshapeOp::create(
+      rewriter, reshapeOp->getLoc(), resultType, input,
       rewriter.getI32ArrayAttr(SmallVector<int32_t>(outputShape)));
 }
 

--- a/include/ttmlir/Dialect/TTIR/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/Utils.h
@@ -65,19 +65,19 @@ struct SplitCaller<OpTy, std::index_sequence<Is...>,
     // ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands,
     // ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {})`.
     if constexpr (sizeof...(Js) == 0) {
-      return builder.create<OpTy>(loc, output.getType(),
-                                  ttmlir::utils::flatten<mlir::Value>(
-                                      std::get<Is>(std::forward_as_tuple(
-                                          std::forward<ArgsTy>(args)...))...,
-                                      output));
+      return OpTy::create(builder, loc, output.getType(),
+                          ttmlir::utils::flatten<mlir::Value>(
+                              std::get<Is>(std::forward_as_tuple(
+                                  std::forward<ArgsTy>(args)...))...,
+                              output));
     } else if constexpr (sizeof...(Js) == 1 &&
                          std::is_convertible_v<
                              std::tuple_element_t<
                                  sizeof...(Is) + sizeof...(Js) - 1,
                                  std::tuple<llvm::remove_cvref_t<ArgsTy>...>>,
                              mlir::ArrayRef<mlir::NamedAttribute>>) {
-      return builder.create<OpTy>(
-          loc, output.getType(),
+      return OpTy::create(
+          builder, loc, output.getType(),
           ttmlir::utils::flatten<mlir::Value>(
               std::get<Is>(
                   std::forward_as_tuple(std::forward<ArgsTy>(args)...))...,
@@ -87,8 +87,8 @@ struct SplitCaller<OpTy, std::index_sequence<Is...>,
       // Otherwise, call the op specific builder that provides positional
       // `Attribute` arguments.
     } else {
-      return builder.create<OpTy>(
-          loc, output.getType(),
+      return OpTy::create(
+          builder, loc, output.getType(),
           std::get<Is>(std::forward_as_tuple(std::forward<ArgsTy>(args)...))...,
           output,
           std::get<sizeof...(Is) + Js>(
@@ -130,17 +130,17 @@ constexpr bool has_dps_trait_v =
 // createDPSOp<OpTy>(rewriter, loc,  outputType, operand1, operand2, ...,
 // operandN, attribute1, attribute2, ..., attributeM);
 // is equivalent to:
-// auto output = rewriter.create<ttir::EmptyOp>(loc, outputType.getShape(),
+// auto output = ttir::EmptyOp::create(rewriter, loc, outputType.getShape(),
 // outputType.getElementType(), outputType.getEncoding());
-// rewriter.create<OpTy>(loc, outputType, operand1, operand2, ..., operandN,
+// OpTy::create(rewriter, loc, outputType, operand1, operand2, ..., operandN,
 // output, attribute1, attribute2, ..., attributeM);
 template <typename OpTy, typename... ArgsTy>
 OpTy createDPSOp(mlir::OpBuilder &builder, mlir::Location loc,
                  mlir::RankedTensorType outputType, ArgsTy &&...args) {
   static_assert(has_dps_trait_v<OpTy>);
 
-  auto output = builder.create<mlir::tt::ttir::EmptyOp>(
-      loc, outputType.getShape(), outputType.getElementType(),
+  auto output = mlir::tt::ttir::EmptyOp::create(
+      builder, loc, outputType.getShape(), outputType.getElementType(),
       outputType.getEncoding());
 
   return detail::splitAndCall<OpTy>(builder, loc, output,
@@ -157,9 +157,9 @@ OpTy createDPSOp(mlir::OpBuilder &builder, mlir::Location loc,
 // is equivalent to:
 // auto outputType = mlir::RankedTensorType::get(outputShape, outputElementType,
 // outputEncoding);
-// auto output = rewriter.create<ttir::EmptyOp>(loc, outputShape,
+// auto output = ttir::EmptyOp::create(rewriter, loc, outputShape,
 // outputElementType, outputEncoding);
-// rewriter.create<OpTy>(loc, outputType, operand1, operand2, ..., operandN,
+// OpTy::create(rewriter, loc, outputType, operand1, operand2, ..., operandN,
 // output, attribute1, attribute2, ..., attributeM);
 template <typename OpTy, typename... ArgsTy>
 OpTy createDPSOp(mlir::OpBuilder &builder, mlir::Location loc,
@@ -181,7 +181,7 @@ OpTy createDPSOp(mlir::OpBuilder &builder, mlir::Location loc,
 // replaceOpWithNewDPSOp<OpTy>(rewriter, op, outputType, operand1, operand2,
 // ..., operandN, attribute1, attribute2, ..., attributeM);
 // is equivalent to:
-// auto output = rewriter.create<ttir::EmptyOp>(loc, outputType.getShape(),
+// auto output = ttir::EmptyOp::create(rewriter, loc, outputType.getShape(),
 // outputType.getElementType(), outputType.getEncoding());
 // rewriter.replaceOpWithNewOp<OpTy>(op, outputType, operand1, operand2, ...,
 // operandN, output, attribute1, attribute2, ..., attributeM);
@@ -208,7 +208,7 @@ OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
 // is equivalent to:
 // auto outputType = mlir::RankedTensorType::get(outputShape, outputElementType,
 // outputEncoding);
-// auto output = rewriter.create<ttir::EmptyOp>(loc, outputShape,
+// auto output = ttir::EmptyOp::create(rewriter, loc, outputShape,
 // outputElementType, outputEncoding);
 // rewriter.replaceOpWithNewOp<OpTy>(op, outputType, operand1, operand2, ...,
 // operandN, output, attribute1, attribute2, ..., attributeM);
@@ -294,8 +294,8 @@ inline ttir::ReshapeOp createReshapeOp(PatternRewriter &rewriter, Location loc,
   auto shapeAttr =
       rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(targetShape));
 
-  return rewriter.create<ttir::ReshapeOp>(
-      loc,
+  return ttir::ReshapeOp::create(
+      rewriter, loc,
       RankedTensorType::get(targetShape, inputType.getElementType(),
                             inputType.getEncoding()),
       input, shapeAttr);

--- a/lib/Conversion/ArithToD2MTileOps/ArithToD2MTileOps.cpp
+++ b/lib/Conversion/ArithToD2MTileOps/ArithToD2MTileOps.cpp
@@ -81,8 +81,8 @@ public:
     auto tileType = operands[0].getType();
 
     // First, compute (lhs - rhs)
-    auto subOp = rewriter.create<d2m::TileSubOp>(loc, tileType, operands[0],
-                                                 operands[1]);
+    auto subOp = d2m::TileSubOp::create(rewriter, loc, tileType, operands[0],
+                                        operands[1]);
 
     auto operandTileType = mlir::cast<ttcore::TileType>(operands[0].getType());
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -31,16 +31,14 @@ namespace mlir::tt::ttkernel {
 namespace {
 
 static Value i32(OpBuilder &rewriter, Location loc, int32_t value) {
-  return rewriter
-      .create<arith::ConstantOp>(loc, rewriter.getI32Type(),
-                                 rewriter.getI32IntegerAttr(value))
+  return arith::ConstantOp::create(rewriter, loc, rewriter.getI32Type(),
+                                   rewriter.getI32IntegerAttr(value))
       .getResult();
 }
 
 static Value index(OpBuilder &rewriter, Location loc, int64_t value) {
-  return rewriter
-      .create<arith::ConstantOp>(loc, rewriter.getIndexType(),
-                                 rewriter.getIndexAttr(value))
+  return arith::ConstantOp::create(rewriter, loc, rewriter.getIndexType(),
+                                   rewriter.getIndexAttr(value))
       .getResult();
 }
 
@@ -50,30 +48,28 @@ getVirtualCoordsFromLogicalCoords(OpBuilder &rewriter, Location loc,
                                   ValueRange dstCoreIndex) {
   auto offset = chipDesc.getCoordTranslationOffsets();
 
-  return {rewriter
-              .create<arith::AddIOp>(dstCoreIndex[0].getLoc(), dstCoreIndex[0],
-                                     index(rewriter, loc, offset[0]))
-              .getResult(),
-          rewriter
-              .create<arith::AddIOp>(dstCoreIndex[1].getLoc(), dstCoreIndex[1],
-                                     index(rewriter, loc, offset[1]))
-              .getResult()};
+  return {
+      arith::AddIOp::create(rewriter, dstCoreIndex[0].getLoc(), dstCoreIndex[0],
+                            index(rewriter, loc, offset[0]))
+          .getResult(),
+      arith::AddIOp::create(rewriter, dstCoreIndex[1].getLoc(), dstCoreIndex[1],
+                            index(rewriter, loc, offset[1]))
+          .getResult()};
 }
 
 static std::pair<Value, Value> getMcastEndCoords(PatternRewriter &rewriter,
                                                  Location loc, Value &nocStartY,
                                                  Value &nocStartX,
                                                  OperandRange mcastShape) {
-  return {rewriter.create<arith::SubIOp>(
-              nocStartY.getLoc(),
-              rewriter.create<arith::AddIOp>(nocStartY.getLoc(), nocStartY,
-                                             mcastShape[0]),
-              index(rewriter, loc, 1)),
-          rewriter.create<arith::SubIOp>(
-              nocStartX.getLoc(),
-              rewriter.create<arith::AddIOp>(nocStartX.getLoc(), nocStartX,
-                                             mcastShape[1]),
-              index(rewriter, loc, 1))};
+  return {
+      arith::SubIOp::create(rewriter, nocStartY.getLoc(),
+                            arith::AddIOp::create(rewriter, nocStartY.getLoc(),
+                                                  nocStartY, mcastShape[0]),
+                            index(rewriter, loc, 1)),
+      arith::SubIOp::create(rewriter, nocStartX.getLoc(),
+                            arith::AddIOp::create(rewriter, nocStartX.getLoc(),
+                                                  nocStartX, mcastShape[1]),
+                            index(rewriter, loc, 1))};
 }
 
 static Value getCB(ConversionPatternRewriter &rewriter, Value cb) {
@@ -219,13 +215,13 @@ public:
     Value rtIdx = index(rewriter, op.getLoc(), resultTy.getShape()[0]);
     Value ktIdx = index(rewriter, op.getLoc(), resultTy.getShape()[1]);
     Value tilesPerBlock =
-        rewriter.create<arith::MulIOp>(op.getLoc(), rtIdx, ktIdx);
+        arith::MulIOp::create(rewriter, op.getLoc(), rtIdx, ktIdx);
 
     // Convert the resolved source row offset to a block-row index.
     Value rowBlockIdx =
-        rewriter.create<arith::DivSIOp>(op.getLoc(), sourceIndices[0], rtIdx);
-    Value rowBase =
-        rewriter.create<arith::MulIOp>(op.getLoc(), rowBlockIdx, tilesPerBlock);
+        arith::DivSIOp::create(rewriter, op.getLoc(), sourceIndices[0], rtIdx);
+    Value rowBase = arith::MulIOp::create(rewriter, op.getLoc(), rowBlockIdx,
+                                          tilesPerBlock);
     rewriter.replaceOpWithNewOp<arith::AddIOp>(op, rowBase, sourceIndices[1]);
     return success();
   };
@@ -240,7 +236,7 @@ public:
   LogicalResult
   matchAndRewrite(d2m::AcquireDstOp op, d2m::AcquireDstOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewriter.create<ttkernel::TileRegsAcquireOp>(op.getLoc());
+    ttkernel::TileRegsAcquireOp::create(rewriter, op.getLoc());
     // Dst is an implicit resource in TTKernel, so we can just erase it.
     rewriter.eraseOp(op);
     return success();
@@ -276,7 +272,7 @@ public:
     auto cb = rewriter.getRemappedValue(load.getMemref());
     auto cbIndex = adaptor.getValue();
     auto dstIndex = adaptor.getIndices().front();
-    rewriter.create<ttkernel::CopyTileInitOp>(store.getLoc(), cb);
+    ttkernel::CopyTileInitOp::create(rewriter, store.getLoc(), cb);
     rewriter.replaceOpWithNewOp<ttkernel::CopyTileOp>(store, cb, cbIndex,
                                                       dstIndex);
     return success();
@@ -451,8 +447,8 @@ public:
       auto outCB = getOutCB(rewriter, op);
       setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
                                      /*allowHoisting*/ true);
-      rewriter.create<ttkernel::BinaryOpInitCommonOp>(op->getLoc(), cbA, cbB,
-                                                      outCB);
+      ttkernel::BinaryOpInitCommonOp::create(rewriter, op->getLoc(), cbA, cbB,
+                                             outCB);
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
     } else {
       static_assert(arity == 3 && !ttmlir::utils::always_false<ConcreteOp>(),
@@ -468,14 +464,14 @@ public:
       setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
                                      /*allowHoisting*/ true);
       auto transpose = i32(rewriter, op->getLoc(), 0);
-      rewriter.create<ttkernel::MatmulInitOp>(op->getLoc(), cbA, cbB, outCB,
-                                              transpose);
+      ttkernel::MatmulInitOp::create(rewriter, op->getLoc(), cbA, cbB, outCB,
+                                     transpose);
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-      rewriter.create<ttkernel::MatmulInitShortOp>(op->getLoc(), cbA, cbB,
-                                                   transpose);
-      rewriter.create<ttkernel::MatmulTilesOp>(op->getLoc(), cbA, cbB,
-                                               adaptor.getA(), adaptor.getB(),
-                                               adaptor.getC());
+      ttkernel::MatmulInitShortOp::create(rewriter, op->getLoc(), cbA, cbB,
+                                          transpose);
+      ttkernel::MatmulTilesOp::create(rewriter, op->getLoc(), cbA, cbB,
+                                      adaptor.getA(), adaptor.getB(),
+                                      adaptor.getC());
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileMatmulBlockOp>) {
       auto insertionPoint = rewriter.getInsertionPoint();
       auto cbA = getCB(rewriter, op.getA());
@@ -509,11 +505,12 @@ public:
 
       auto transpose = i32(rewriter, op->getLoc(), 0);
 
-      rewriter.create<ttkernel::MatmulBlockInitOp>(
-          op->getLoc(), cbA, cbB, outCB, transpose, ct_i32, rt_i32, kt_i32);
+      ttkernel::MatmulBlockInitOp::create(rewriter, op->getLoc(), cbA, cbB,
+                                          outCB, transpose, ct_i32, rt_i32,
+                                          kt_i32);
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-      rewriter.create<ttkernel::MatmulBlockInitShortOp>(
-          op->getLoc(), cbA, cbB, transpose, ct_i32, rt_i32, kt_i32);
+      ttkernel::MatmulBlockInitShortOp::create(
+          rewriter, op->getLoc(), cbA, cbB, transpose, ct_i32, rt_i32, kt_i32);
 
       // Get the tile index for each input in the global memref. This is done by
       // resolving tile (0,0) from the subview, representing a block, into the
@@ -533,9 +530,9 @@ public:
         bTileIndex = index(rewriter, op.getLoc(), 0);
       }
 
-      rewriter.create<ttkernel::ExperimentalMatmulBlockOp>(
-          op->getLoc(), cbA, cbB, aTileIndex, bTileIndex, destIndex, transpose,
-          ct_i32, rt_i32, kt_i32, nt_i32);
+      ttkernel::ExperimentalMatmulBlockOp::create(
+          rewriter, op->getLoc(), cbA, cbB, aTileIndex, bTileIndex, destIndex,
+          transpose, ct_i32, rt_i32, kt_i32, nt_i32);
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileReduceSumOp> ||
                          std::is_same_v<ConcreteOp, d2m::TileReduceMaxOp>) {
       ttkernel::ReduceType reduce_type;
@@ -564,13 +561,13 @@ public:
       auto outCB = getOutCB(rewriter, op);
       setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
                                      /*allowHoisting*/ true);
-      rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), cbA,
-                                                          cbB, outCB);
+      ttkernel::ComputeKernelHWStartupOp::create(rewriter, op->getLoc(), cbA,
+                                                 cbB, outCB);
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-      rewriter.create<ttkernel::ReduceInitOp>(op->getLoc(), cbA, cbB, outCB,
-                                              reduce_type, kernel_reduce_dim);
-      rewriter.create<ttkernel::ReduceTileOp>(
-          op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(),
+      ttkernel::ReduceInitOp::create(rewriter, op->getLoc(), cbA, cbB, outCB,
+                                     reduce_type, kernel_reduce_dim);
+      ttkernel::ReduceTileOp::create(
+          rewriter, op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(),
           adaptor.getC(), reduce_type, kernel_reduce_dim);
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileBcastOp>) {
       ttkernel::BcastType bcastType = ttkernel::BcastType::None;
@@ -590,17 +587,17 @@ public:
       }
       auto cb = getCB(rewriter, op.getInput());
       auto dstIdx = getDstIdxFromResult(op.getResult());
-      rewriter.create<ttkernel::UnaryBcastInitOp>(op->getLoc(), cb, cb,
-                                                  bcastType);
-      rewriter.create<ttkernel::UnaryBcastTileOp>(
-          op->getLoc(), cb, adaptor.getInput(), dstIdx, bcastType);
+      ttkernel::UnaryBcastInitOp::create(rewriter, op->getLoc(), cb, cb,
+                                         bcastType);
+      ttkernel::UnaryBcastTileOp::create(rewriter, op->getLoc(), cb,
+                                         adaptor.getInput(), dstIdx, bcastType);
     } else if constexpr (arity == 2) {
       auto dstIdx = getDstIdxFromResult(op.getResult());
-      rewriter.create<InitOp>(op->getLoc(), getCB(rewriter, op.getLhs()),
-                              getCB(rewriter, op.getRhs()));
-      rewriter.create<FPUOp>(op->getLoc(), getCB(rewriter, op.getLhs()),
-                             getCB(rewriter, op.getRhs()), adaptor.getLhs(),
-                             adaptor.getRhs(), dstIdx);
+      InitOp::create(rewriter, op->getLoc(), getCB(rewriter, op.getLhs()),
+                     getCB(rewriter, op.getRhs()));
+      FPUOp::create(rewriter, op->getLoc(), getCB(rewriter, op.getLhs()),
+                    getCB(rewriter, op.getRhs()), adaptor.getLhs(),
+                    adaptor.getRhs(), dstIdx);
     } else {
       return llvm::failure();
     }
@@ -636,7 +633,7 @@ public:
     rewriter.setInsertionPointToStart(rewriter.getInsertionBlock());
     setInsertionPointAfterOperands(rewriter, {inCB, outCB},
                                    /*allowHoisting*/ true);
-    rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), inCB, outCB);
+    ttkernel::InitSFPUOp::create(rewriter, op->getLoc(), inCB, outCB);
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
     // For binary ops (arity == 2), check if rhs is a scalar to create the right
@@ -648,15 +645,15 @@ public:
       if (isScalarRhs) {
         // Use scalar-specific init ops
         if constexpr (std::is_same_v<ConcreteOp, d2m::TilePowOp>) {
-          rewriter.create<ttkernel::PowerTileInitOp>(op->getLoc());
+          ttkernel::PowerTileInitOp::create(rewriter, op->getLoc());
         } else {
-          rewriter.create<ttkernel::BinopWithScalarTileInitOp>(op->getLoc());
+          ttkernel::BinopWithScalarTileInitOp::create(rewriter, op->getLoc());
         }
       } else {
-        rewriter.create<InitOp>(op->getLoc());
+        InitOp::create(rewriter, op->getLoc());
       }
     } else {
-      rewriter.create<InitOp>(op->getLoc());
+      InitOp::create(rewriter, op->getLoc());
     }
     if constexpr (std::is_same_v<SFPUOp, ttkernel::CeilTileOp> ||
                   std::is_same_v<SFPUOp, ttkernel::FloorTileOp>) {
@@ -666,14 +663,14 @@ public:
       const bool isCBF32 = llvm::isa<Float32Type>(elemType);
       if (isCBF32) {
         if (std::is_same_v<SFPUOp, ttkernel::CeilTileOp>) {
-          rewriter.create<ttkernel::CeilTileF32Op>(op->getLoc(),
-                                                   adaptor.getInput());
+          ttkernel::CeilTileF32Op::create(rewriter, op->getLoc(),
+                                          adaptor.getInput());
         } else {
-          rewriter.create<ttkernel::FloorTileF32Op>(op->getLoc(),
-                                                    adaptor.getInput());
+          ttkernel::FloorTileF32Op::create(rewriter, op->getLoc(),
+                                           adaptor.getInput());
         }
       } else {
-        rewriter.create<SFPUOp>(op->getLoc(), adaptor.getInput());
+        SFPUOp::create(rewriter, op->getLoc(), adaptor.getInput());
       }
     } else if constexpr (std::is_same_v<SFPUOp, ttkernel::AbsTileOp> ||
                          std::is_same_v<SFPUOp,
@@ -689,17 +686,17 @@ public:
       }
       if (isCBI32) {
         if (std::is_same_v<SFPUOp, ttkernel::AbsTileOp>) {
-          rewriter.create<ttkernel::AbsTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::AbsTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if (std::is_same_v<SFPUOp, ttkernel::LogicalNotUnaryTileOp>) {
-          rewriter.create<ttkernel::LogicalNotUnaryTileI32Op>(
-              op->getLoc(), adaptor.getInput());
+          ttkernel::LogicalNotUnaryTileI32Op::create(rewriter, op->getLoc(),
+                                                     adaptor.getInput());
         } else if (std::is_same_v<SFPUOp, ttkernel::ReluTileOp>) {
-          rewriter.create<ttkernel::ReluTileI32Op>(op->getLoc(),
-                                                   adaptor.getInput());
+          ttkernel::ReluTileI32Op::create(rewriter, op->getLoc(),
+                                          adaptor.getInput());
         }
       } else {
-        rewriter.create<SFPUOp>(op->getLoc(), adaptor.getInput());
+        SFPUOp::create(rewriter, op->getLoc(), adaptor.getInput());
       }
     } else if constexpr (std::is_same_v<SFPUOp, ttkernel::EqzTileOp> ||
                          std::is_same_v<SFPUOp, ttkernel::NezTileOp> ||
@@ -717,36 +714,36 @@ public:
       }
       if (isCBI32) {
         if constexpr (std::is_same_v<SFPUOp, ttkernel::EqzTileOp>) {
-          rewriter.create<ttkernel::EqzTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::EqzTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if constexpr (std::is_same_v<SFPUOp, ttkernel::NezTileOp>) {
-          rewriter.create<ttkernel::NezTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::NezTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if constexpr (std::is_same_v<SFPUOp, ttkernel::GtzTileOp>) {
-          rewriter.create<ttkernel::GtzTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::GtzTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if constexpr (std::is_same_v<SFPUOp, ttkernel::GezTileOp>) {
-          rewriter.create<ttkernel::GezTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::GezTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if constexpr (std::is_same_v<SFPUOp, ttkernel::LtzTileOp>) {
-          rewriter.create<ttkernel::LtzTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::LtzTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         } else if constexpr (std::is_same_v<SFPUOp, ttkernel::LezTileOp>) {
-          rewriter.create<ttkernel::LezTileI32Op>(op->getLoc(),
-                                                  adaptor.getInput());
+          ttkernel::LezTileI32Op::create(rewriter, op->getLoc(),
+                                         adaptor.getInput());
         }
       } else {
-        rewriter.create<SFPUOp>(op->getLoc(), adaptor.getInput());
+        SFPUOp::create(rewriter, op->getLoc(), adaptor.getInput());
       }
     } else if constexpr (std::is_same_v<SFPUOp, ttkernel::TypecastTileOp>) {
       const auto inDtype =
           mlir::cast<ttcore::TileType>(op.getInput().getType()).getDataType();
       const auto outDtype =
           mlir::cast<ttcore::TileType>(op.getResult().getType()).getDataType();
-      rewriter.create<ttkernel::TypecastTileOp>(
-          op->getLoc(), adaptor.getInput(), inDtype, outDtype);
+      ttkernel::TypecastTileOp::create(rewriter, op->getLoc(),
+                                       adaptor.getInput(), inDtype, outDtype);
     } else if constexpr (arity == 1) {
-      rewriter.create<SFPUOp>(op->getLoc(), adaptor.getInput());
+      SFPUOp::create(rewriter, op->getLoc(), adaptor.getInput());
     } else if constexpr (arity == 2) {
       // Check if rhs is a scalar (float or integer) at runtime
       auto rhsType = adaptor.getRhs().getType();
@@ -760,26 +757,26 @@ public:
         // Create the appropriate unary scalar op based on the D2M op type
         if constexpr (std::is_same_v<ConcreteOp, d2m::TileAddOp>) {
           // Bitcast the scalar value to i32 to pass as parameter
-          auto scalarParam = rewriter.create<arith::BitcastOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
-          rewriter.create<ttkernel::AddUnaryTileOp>(loc, dstIdx, scalarParam);
+          auto scalarParam = arith::BitcastOp::create(
+              rewriter, loc, rewriter.getI32Type(), adaptor.getRhs());
+          ttkernel::AddUnaryTileOp::create(rewriter, loc, dstIdx, scalarParam);
         } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileSubOp>) {
-          auto scalarParam = rewriter.create<arith::BitcastOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
-          rewriter.create<ttkernel::SubUnaryTileOp>(loc, dstIdx, scalarParam);
+          auto scalarParam = arith::BitcastOp::create(
+              rewriter, loc, rewriter.getI32Type(), adaptor.getRhs());
+          ttkernel::SubUnaryTileOp::create(rewriter, loc, dstIdx, scalarParam);
         } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileMulOp>) {
-          auto scalarParam = rewriter.create<arith::BitcastOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
-          rewriter.create<ttkernel::MulUnaryTileOp>(loc, dstIdx, scalarParam);
+          auto scalarParam = arith::BitcastOp::create(
+              rewriter, loc, rewriter.getI32Type(), adaptor.getRhs());
+          ttkernel::MulUnaryTileOp::create(rewriter, loc, dstIdx, scalarParam);
         } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileDivOp>) {
-          auto scalarParam = rewriter.create<arith::BitcastOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
-          rewriter.create<ttkernel::DivUnaryTileOp>(loc, dstIdx, scalarParam);
+          auto scalarParam = arith::BitcastOp::create(
+              rewriter, loc, rewriter.getI32Type(), adaptor.getRhs());
+          ttkernel::DivUnaryTileOp::create(rewriter, loc, dstIdx, scalarParam);
         } else if constexpr (std::is_same_v<ConcreteOp, d2m::TilePowOp>) {
           // For power, convert float value to integer (not bitcast)
-          auto scalarParam = rewriter.create<arith::FPToSIOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
-          rewriter.create<ttkernel::PowUnaryTileOp>(loc, dstIdx, scalarParam);
+          auto scalarParam = arith::FPToSIOp::create(
+              rewriter, loc, rewriter.getI32Type(), adaptor.getRhs());
+          ttkernel::PowUnaryTileOp::create(rewriter, loc, dstIdx, scalarParam);
         }
       } else {
         // Binary tile operation
@@ -788,8 +785,8 @@ public:
         setInsertionPointAfterOperands(
             rewriter, {adaptor.getLhs(), adaptor.getRhs(), dstIdx},
             /*allowHoisting*/ false);
-        rewriter.create<SFPUOp>(op->getLoc(), adaptor.getLhs(),
-                                adaptor.getRhs(), dstIdx);
+        SFPUOp::create(rewriter, op->getLoc(), adaptor.getLhs(),
+                       adaptor.getRhs(), dstIdx);
       }
     } else {
       // Ternary tile operation (arity == 3)
@@ -806,14 +803,13 @@ public:
       const bool isCBF32 = llvm::isa<Float32Type>(elemType);
       if (isCBF32) {
         if (std::is_same_v<ConcreteOp, d2m::TileWhereOp>) {
-          rewriter.create<ttkernel::WhereTileF32Op>(
-              op->getLoc(), adaptor.getCondition(), adaptor.getTrueValue(),
-              adaptor.getFalseValue(), dstIdx);
+          ttkernel::WhereTileF32Op::create(
+              rewriter, op->getLoc(), adaptor.getCondition(),
+              adaptor.getTrueValue(), adaptor.getFalseValue(), dstIdx);
         }
       } else {
-        rewriter.create<SFPUOp>(op->getLoc(), adaptor.getCondition(),
-                                adaptor.getTrueValue(), adaptor.getFalseValue(),
-                                dstIdx);
+        SFPUOp::create(rewriter, op->getLoc(), adaptor.getCondition(),
+                       adaptor.getTrueValue(), adaptor.getFalseValue(), dstIdx);
       }
     }
 
@@ -857,20 +853,20 @@ public:
 
     auto blockR = i32(rewriter, op->getLoc(), collapsed2DShape[0]);
     auto blockC = i32(rewriter, op->getLoc(), collapsed2DShape[1]);
-    rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), src,
-                                                        nullptr, dst);
+    ttkernel::ComputeKernelHWStartupOp::create(rewriter, op->getLoc(), src,
+                                               nullptr, dst);
 
     if constexpr (std::is_same_v<BlockOp,
                                  ttkernel::ExperimentalTilizeBlockOp>) {
-      rewriter.create<ttkernel::TilizeInitOp>(op->getLoc(), src, blockC, dst);
+      ttkernel::TilizeInitOp::create(rewriter, op->getLoc(), src, blockC, dst);
     } else if constexpr (std::is_same_v<
                              BlockOp, ttkernel::ExperimentalUntilizeBlockOp>) {
-      rewriter.create<ttkernel::UntilizeInitOp>(op->getLoc(), src);
+      ttkernel::UntilizeInitOp::create(rewriter, op->getLoc(), src);
     } else {
       llvm_unreachable("unsupported tilize/untilize op");
     }
 
-    rewriter.create<BlockOp>(op->getLoc(), src, dst, blockR, blockC);
+    BlockOp::create(rewriter, op->getLoc(), src, dst, blockR, blockC);
 
     rewriter.eraseOp(op);
 
@@ -898,7 +894,7 @@ public:
     auto insertionPoint = rewriter.getInsertionPoint();
     setInsertionPointAfterOperands(rewriter, {inCB, outCB},
                                    /*allowHoisting*/ true);
-    rewriter.create<ttkernel::TransposeInitOp>(op->getLoc(), inCB, outCB);
+    ttkernel::TransposeInitOp::create(rewriter, op->getLoc(), inCB, outCB);
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
     // Get the tile index from the input operand.
@@ -907,8 +903,8 @@ public:
     // Get the destination index where the result will be stored.
     Value dstIdx = getDstIdxFromResult(op.getResult());
 
-    rewriter.create<ttkernel::TransposeTileOp>(op->getLoc(), inCB, tileIndex,
-                                               dstIdx);
+    ttkernel::TransposeTileOp::create(rewriter, op->getLoc(), inCB, tileIndex,
+                                      dstIdx);
 
     rewriter.eraseOp(op);
     return success();
@@ -990,13 +986,13 @@ public:
         op.getCb().getType().template getUnderlyingAs<MemRefType>());
     auto numPages = i32(rewriter, op->getLoc(), cbNumPages);
 
-    rewriter.create<TTKernelAcquireOp>(op.getLoc(), adaptor.getCb(), numPages);
+    TTKernelAcquireOp::create(rewriter, op.getLoc(), adaptor.getCb(), numPages);
 
     // Only insert automatic release if there's no explicit push/pop
     if (!hasExplicitRelease(op)) {
       Block *block = op->getBlock();
-      auto release = rewriter.create<TTKernelReleaseOp>(
-          op.getLoc(), adaptor.getCb(), numPages);
+      auto release = TTKernelReleaseOp::create(rewriter, op.getLoc(),
+                                               adaptor.getCb(), numPages);
       if (block->mightHaveTerminator()) {
         rewriter.moveOpBefore(release, block->getTerminator());
       } else {
@@ -1046,8 +1042,8 @@ static Value castCBTypeAsAddress(OpBuilder &rewriter, Location loc, Value cb) {
   // 2. It can represent remote data, which we need to lower to a compile time
   // address (I32 type)
   // More information on ticket #3172
-  return rewriter
-      .create<UnrealizedConversionCastOp>(loc, rewriter.getI32Type(), cb)
+  return UnrealizedConversionCastOp::create(rewriter, loc,
+                                            rewriter.getI32Type(), cb)
       ->getResult(0);
 }
 
@@ -1063,25 +1059,25 @@ static Value buildNocAddress(OpBuilder &rewriter, Location loc, Value cb,
     auto gridY = index[0];
     auto gridX = index[1];
     auto offset = index[2];
-    auto offsetInt =
-        rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), offset);
-    auto addr = rewriter.create<arith::AddIOp>(loc, baseAddr, offsetInt);
+    auto offsetInt = arith::IndexCastOp::create(rewriter, loc,
+                                                rewriter.getI32Type(), offset);
+    auto addr = arith::AddIOp::create(rewriter, loc, baseAddr, offsetInt);
     // Translate the src coordinates to virtual coordinates.
     auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
         rewriter, loc, chipDesc, ValueRange{gridY, gridX});
     noc_addr_op =
-        rewriter.create<ttkernel::GetNocAddrOp>(loc, virtX, virtY, addr);
+        ttkernel::GetNocAddrOp::create(rewriter, loc, virtX, virtY, addr);
   } else {
     auto bankID = index[1];
-    auto bankIDInt =
-        rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), bankID);
+    auto bankIDInt = arith::IndexCastOp::create(rewriter, loc,
+                                                rewriter.getI32Type(), bankID);
     auto offset = index[2];
-    auto offsetInt =
-        rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), offset);
-    auto addr = rewriter.create<arith::AddIOp>(loc, baseAddr, offsetInt);
+    auto offsetInt = arith::IndexCastOp::create(rewriter, loc,
+                                                rewriter.getI32Type(), offset);
+    auto addr = arith::AddIOp::create(rewriter, loc, baseAddr, offsetInt);
 
-    return rewriter.create<ttkernel::GetNocAddrFromBankIDOp>(loc, bankIDInt,
-                                                             addr);
+    return ttkernel::GetNocAddrFromBankIDOp::create(rewriter, loc, bankIDInt,
+                                                    addr);
   }
   return noc_addr_op;
 }
@@ -1090,10 +1086,10 @@ template <typename ReadWritePtrOp>
 static Value buildL1Address(OpBuilder &rewriter, Location loc, Value cb,
                             ValueRange index) {
   // Use the cb addr as the write address since it is local.
-  Value baseAddr = rewriter.create<ReadWritePtrOp>(loc, cb);
-  auto offset =
-      rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), index[0]);
-  return rewriter.create<arith::AddIOp>(loc, baseAddr, offset);
+  Value baseAddr = ReadWritePtrOp::create(rewriter, loc, cb);
+  auto offset = arith::IndexCastOp::create(rewriter, loc, rewriter.getI32Type(),
+                                           index[0]);
+  return arith::AddIOp::create(rewriter, loc, baseAddr, offset);
 }
 
 class D2MDMAReadRewriter : public OpConversionPattern<d2m::DMAReadOp> {
@@ -1126,8 +1122,8 @@ public:
         rewriter, op.getLoc(), adaptor.getDst(), op.getDstIndices());
 
     auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
-    rewriter.create<ttkernel::NocAsyncReadOp>(op.getLoc(), srcNocAddr,
-                                              dstL1Addr, size);
+    ttkernel::NocAsyncReadOp::create(rewriter, op.getLoc(), srcNocAddr,
+                                     dstL1Addr, size);
 
     // Add attribute marking whether the DMA wait is for a read or write
     // operation This will be used when loweing the wait ops because the current
@@ -1173,11 +1169,11 @@ public:
       Value srcL1Start;
       auto srcCBMapping = cbProducerConsumer->get(op.getSrc());
       if (srcCBMapping == d2m::ThreadCBOrientation::Producer) {
-        srcL1Start = rewriter.create<ttkernel::GetWritePtrOp>(op.getLoc(),
-                                                              adaptor.getSrc());
+        srcL1Start = ttkernel::GetWritePtrOp::create(rewriter, op.getLoc(),
+                                                     adaptor.getSrc());
       } else {
-        srcL1Start = rewriter.create<ttkernel::GetReadPtrOp>(op.getLoc(),
-                                                             adaptor.getSrc());
+        srcL1Start = ttkernel::GetReadPtrOp::create(rewriter, op.getLoc(),
+                                                    adaptor.getSrc());
       }
       auto dstCBMapping = cbProducerConsumer->get(op.getDst());
       TT_assertv((dstCBMapping == d2m::ThreadCBOrientation::Producer ||
@@ -1185,8 +1181,8 @@ public:
                   dstCBMapping == d2m::ThreadCBOrientation::Default),
                  "Expected dst cb of a write op to have a producer, "
                  "producer-consumer or default orientation, failing.");
-      Value dstL1Start = rewriter.create<ttkernel::GetWritePtrOp>(
-          op.getLoc(), adaptor.getDst());
+      Value dstL1Start = ttkernel::GetWritePtrOp::create(rewriter, op.getLoc(),
+                                                         adaptor.getDst());
 
       Value transferSize = i32(rewriter, op->getLoc(), op.getSizeBytes());
       if (op.isMcast()) {
@@ -1198,42 +1194,42 @@ public:
         // and mcast shape
         auto [mcastEndY, mcastEndX] = getMcastEndCoords(
             rewriter, op.getLoc(), virtY, virtX, op.getMcastShape());
-        auto numDestsIdx = rewriter.create<arith::MulIOp>(
-            op.getLoc(), op.getMcastShape()[0], op.getMcastShape()[1]);
-        auto numDests = rewriter.create<arith::IndexCastOp>(
-            op.getLoc(), rewriter.getI32Type(), numDestsIdx);
-        auto mcastAddr =
-            rewriter.create<ttkernel::ExperimentalGetNocMulticastAddrOp>(
-                op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, dstL1Start,
-                nullptr);
+        auto numDestsIdx =
+            arith::MulIOp::create(rewriter, op.getLoc(), op.getMcastShape()[0],
+                                  op.getMcastShape()[1]);
+        auto numDests = arith::IndexCastOp::create(
+            rewriter, op.getLoc(), rewriter.getI32Type(), numDestsIdx);
+        auto mcastAddr = ttkernel::ExperimentalGetNocMulticastAddrOp::create(
+            rewriter, op.getLoc(), virtX, virtY, mcastEndX, mcastEndY,
+            dstL1Start, nullptr);
         if (adaptor.getSrc() == adaptor.getDst()) {
           // If src and dst refer to the same memref, we do not loopback mcast
           // Dests are one less because the sender core is not included
-          rewriter.create<ttkernel::NocAsyncWriteMulticastOp>(
-              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDests,
-              nullptr, nullptr, nullptr);
+          ttkernel::NocAsyncWriteMulticastOp::create(
+              rewriter, op.getLoc(), srcL1Start, mcastAddr, transferSize,
+              numDests, nullptr, nullptr, nullptr);
         } else {
           // If src != dst, we loopback mcast
-          rewriter.create<ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>(
-              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDests,
-              nullptr, nullptr, nullptr);
+          ttkernel::NocAsyncWriteMulticastLoopbackSrcOp::create(
+              rewriter, op.getLoc(), srcL1Start, mcastAddr, transferSize,
+              numDests, nullptr, nullptr, nullptr);
         }
       } else {
         // Local L1 to Local L1 local data movement lowering
         // Get local coordinates using myY and myX ops
-        auto myY = rewriter.create<d2m::CoreIndexOp>(
-            op.getLoc(), rewriter.getIndexType(),
-            rewriter.getI64IntegerAttr(0));
-        auto myX = rewriter.create<d2m::CoreIndexOp>(
-            op.getLoc(), rewriter.getIndexType(),
-            rewriter.getI64IntegerAttr(1));
+        auto myY = d2m::CoreIndexOp::create(rewriter, op.getLoc(),
+                                            rewriter.getIndexType(),
+                                            rewriter.getI64IntegerAttr(0));
+        auto myX = d2m::CoreIndexOp::create(rewriter, op.getLoc(),
+                                            rewriter.getIndexType(),
+                                            rewriter.getI64IntegerAttr(1));
         // Convert local coordinates to virtual coordinates
         auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
             rewriter, op.getLoc(), chipDesc, ValueRange{myY, myX});
-        auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-            op.getLoc(), virtX, virtY, dstL1Start);
-        rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Start,
-                                                   nocAddr, transferSize);
+        auto nocAddr = ttkernel::GetNocAddrOp::create(rewriter, op.getLoc(),
+                                                      virtX, virtY, dstL1Start);
+        ttkernel::NocAsyncWriteOp::create(rewriter, op.getLoc(), srcL1Start,
+                                          nocAddr, transferSize);
       }
     } else if (op.isDstRemote()) {
       auto srcL1Addr = buildL1Address<ttkernel::GetReadPtrOp>(
@@ -1242,8 +1238,8 @@ public:
           buildNocAddress(rewriter, op.getLoc(), adaptor.getDst(),
                           op.getDstIndices(), chipDesc, op.getDstMemorySpace());
       auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
-      rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Addr,
-                                                 dstNocAddr, size);
+      ttkernel::NocAsyncWriteOp::create(rewriter, op.getLoc(), srcL1Addr,
+                                        dstNocAddr, size);
     }
 
     // Add attribute marking whether the DMA wait is for a read or write
@@ -1282,16 +1278,16 @@ public:
            op.getDim() == 1 &&
                "Expected core index dim to be in range 0-1, failing.");
     if (op.getDim()) {
-      auto coreIndex = rewriter.create<ttkernel::MyXOp>(op.getLoc(), nullptr);
-      auto normalizedCoreIndex = rewriter.create<arith::SubIOp>(
-          op.getLoc(), coreIndex,
+      auto coreIndex = ttkernel::MyXOp::create(rewriter, op.getLoc(), nullptr);
+      auto normalizedCoreIndex = arith::SubIOp::create(
+          rewriter, op.getLoc(), coreIndex,
           index(rewriter, op->getLoc(),
                 chipDesc.getCoordTranslationOffsets()[1]));
       rewriter.replaceOp(op, normalizedCoreIndex);
     } else {
-      auto coreIndex = rewriter.create<ttkernel::MyYOp>(op.getLoc(), nullptr);
-      auto normalizedCoreIndex = rewriter.create<arith::SubIOp>(
-          op.getLoc(), coreIndex,
+      auto coreIndex = ttkernel::MyYOp::create(rewriter, op.getLoc(), nullptr);
+      auto normalizedCoreIndex = arith::SubIOp::create(
+          rewriter, op.getLoc(), coreIndex,
           index(rewriter, op->getLoc(),
                 chipDesc.getCoordTranslationOffsets()[0]));
       rewriter.replaceOp(op, normalizedCoreIndex);
@@ -1316,11 +1312,11 @@ public:
     assert(isRead || isWrite);
 
     if (isRead) {
-      rewriter.create<ttkernel::NocAsyncReadBarrierOp>(op.getLoc());
+      ttkernel::NocAsyncReadBarrierOp::create(rewriter, op.getLoc());
     }
 
     if (isWrite) {
-      rewriter.create<ttkernel::NocAsyncWriteBarrierOp>(op.getLoc());
+      ttkernel::NocAsyncWriteBarrierOp::create(rewriter, op.getLoc());
     }
 
     rewriter.eraseOp(op);
@@ -1466,8 +1462,8 @@ public:
     for (auto arg : blockArgs) {
       Type argType = getTypeConverter()->convertType(arg.getType());
       if (mlir::isa<CBType>(argType)) {
-        auto cb = rewriter.create<GetCompileArgValOp>(
-            op.getLoc(), argType,
+        auto cb = GetCompileArgValOp::create(
+            rewriter, op.getLoc(), argType,
             rewriter.getI32IntegerAttr(arg.getArgNumber()));
         signatureConverter.remapInput(arg.getArgNumber(), {cb});
         ctArgSpecVector.push_back(
@@ -1477,11 +1473,11 @@ public:
           continue;
         }
         size_t ctArgIndex = ctArgSpecVector.size();
-        auto semaphoreIndex = rewriter.create<GetCompileArgValOp>(
-            op.getLoc(), rewriter.getI32Type(),
+        auto semaphoreIndex = GetCompileArgValOp::create(
+            rewriter, op.getLoc(), rewriter.getI32Type(),
             rewriter.getI32IntegerAttr(ctArgIndex));
         auto semaphore =
-            rewriter.create<GetSemaphoreOp>(op.getLoc(), semaphoreIndex);
+            GetSemaphoreOp::create(rewriter, op.getLoc(), semaphoreIndex);
         signatureConverter.remapInput(arg.getArgNumber(),
                                       semaphore.getResult());
         ctArgSpecVector.push_back(rewriter.getAttr<ArgAttr>(
@@ -1528,7 +1524,7 @@ public:
 
       // Local semaphore set
       auto semaphorePtr =
-          rewriter.create<ttkernel::CastToL1PtrOp>(op.getLoc(), semaphoreAddr);
+          ttkernel::CastToL1PtrOp::create(rewriter, op.getLoc(), semaphoreAddr);
 
       rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreSetOp>(op, semaphorePtr,
                                                                value);
@@ -1537,8 +1533,8 @@ public:
              "d2m.semaphore_set to single remote core is illegal.");
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
           rewriter, op.getLoc(), chipDesc, op.getDstCoreIndex());
-      auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, semaphoreAddr);
+      auto nocAddr = ttkernel::GetNocAddrOp::create(
+          rewriter, op.getLoc(), virtX, virtY, semaphoreAddr);
       rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(op, nocAddr,
                                                                value, nullptr);
     } else {
@@ -1549,19 +1545,18 @@ public:
           rewriter, op.getLoc(), chipDesc, op.getDstCoreIndex());
       auto [mcastEndY, mcastEndX] = getMcastEndCoords(
           rewriter, op.getLoc(), virtY, virtX, op.getMcastShape());
-      Value numDestsIdx = rewriter.create<arith::MulIOp>(
-          op.getLoc(), op.getMcastShape()[0], op.getMcastShape()[1]);
-      Value numDests = rewriter.create<arith::IndexCastOp>(
-          op.getLoc(), rewriter.getI32Type(), numDestsIdx);
-      auto mcastAddr =
-          rewriter.create<ttkernel::ExperimentalGetNocMulticastAddrOp>(
-              op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, semaphoreAddr,
-              nullptr);
+      Value numDestsIdx = arith::MulIOp::create(
+          rewriter, op.getLoc(), op.getMcastShape()[0], op.getMcastShape()[1]);
+      Value numDests = arith::IndexCastOp::create(
+          rewriter, op.getLoc(), rewriter.getI32Type(), numDestsIdx);
+      auto mcastAddr = ttkernel::ExperimentalGetNocMulticastAddrOp::create(
+          rewriter, op.getLoc(), virtX, virtY, mcastEndX, mcastEndY,
+          semaphoreAddr, nullptr);
 
       auto semaphorePtr =
-          rewriter.create<ttkernel::CastToL1PtrOp>(op.getLoc(), semaphoreAddr);
-      rewriter.create<ttkernel::NocSemaphoreSetOp>(op.getLoc(), semaphorePtr,
-                                                   value);
+          ttkernel::CastToL1PtrOp::create(rewriter, op.getLoc(), semaphoreAddr);
+      ttkernel::NocSemaphoreSetOp::create(rewriter, op.getLoc(), semaphorePtr,
+                                          value);
       rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreSetMulticastOp>(
           op, semaphoreAddr, mcastAddr, numDests, nullptr, nullptr);
     }
@@ -1583,13 +1578,13 @@ public:
 
     Value semaphoreAddr = adaptor.getSemaphore();
     auto semaphorePtr =
-        rewriter.create<ttkernel::CastToL1PtrOp>(op.getLoc(), semaphoreAddr);
+        ttkernel::CastToL1PtrOp::create(rewriter, op.getLoc(), semaphoreAddr);
 
     rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreWaitOp>(op, semaphorePtr,
                                                               op.getValue());
     if (op.getResetValue()) {
-      rewriter.create<ttkernel::NocSemaphoreSetOp>(op.getLoc(), semaphorePtr,
-                                                   op.getResetValue());
+      ttkernel::NocSemaphoreSetOp::create(rewriter, op.getLoc(), semaphorePtr,
+                                          op.getResetValue());
     }
 
     return success();

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -259,7 +259,7 @@ public:
                                                               output);
     // Insert global barrier to ensure the read completes before subsequent
     // ops use it.
-    rewriter.create<ttmetal::FinishOp>(op->getLoc());
+    ttmetal::FinishOp::create(rewriter, op->getLoc());
     return success();
   }
 };

--- a/lib/Conversion/SFPIToEmitC/SFPIToEmitC.cpp
+++ b/lib/Conversion/SFPIToEmitC/SFPIToEmitC.cpp
@@ -58,7 +58,8 @@ public:
       if (inputs.size() != 1) {
         return nullptr;
       }
-      return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+      return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                inputs)
           .getResult(0);
     });
 
@@ -67,7 +68,8 @@ public:
       if (inputs.size() != 1) {
         return nullptr;
       }
-      return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+      return UnrealizedConversionCastOp::create(builder, loc, resultType,
+                                                inputs)
           .getResult(0);
     });
   }
@@ -110,8 +112,8 @@ protected:
         operands.push_back(*maybeValue);
       } else if (auto *maybeStr = std::get_if<std::string>(&valueOrStr);
                  maybeStr) {
-        auto literalAttribute = rewriter.create<emitc::LiteralOp>(
-            op.getLoc(), rewriter.getI32Type(), *maybeStr);
+        auto literalAttribute = emitc::LiteralOp::create(
+            rewriter, op.getLoc(), rewriter.getI32Type(), *maybeStr);
         operands.push_back(literalAttribute->getResult(0));
       } else {
         llvm_unreachable("Unsupported builtin operand variant");

--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -196,8 +196,9 @@ public:
       // Create a new mesh shard op.
       auto outputType = mlir::cast<mlir::RankedTensorType>(
           getTypeConverter()->convertType(localArgType));
-      auto meshShardOp = rewriter.create<mlir::tt::ttir::MeshShardOp>(
-          loc, outputType, globalOperand, shardyMeshSharding->getShardType(),
+      auto meshShardOp = mlir::tt::ttir::MeshShardOp::create(
+          rewriter, loc, outputType, globalOperand,
+          shardyMeshSharding->getShardType(),
           shardyMeshSharding->getShardDirection(),
           shardyMeshSharding->getShardShape(),
           shardyMeshSharding->getShardDims());
@@ -228,8 +229,8 @@ public:
       // Create a new mesh shard op.
       auto outputType = mlir::cast<mlir::RankedTensorType>(
           getTypeConverter()->convertType(opResult.getType()));
-      auto meshShardOp = rewriter.create<mlir::tt::ttir::MeshShardOp>(
-          loc, outputType, returnOperand.get(),
+      auto meshShardOp = mlir::tt::ttir::MeshShardOp::create(
+          rewriter, loc, outputType, returnOperand.get(),
           shardyMeshSharding->getShardType(),
           shardyMeshSharding->getShardDirection(),
           shardyMeshSharding->getShardShape(),

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -67,8 +67,8 @@ struct IndexToSliceConversionPattern
       }
     }
 
-    auto newOp = rewriter.create<ttir::SliceStaticOp>(
-        op.getLoc(), getTypeConverter()->convertType(op.getType()),
+    auto newOp = ttir::SliceStaticOp::create(
+        rewriter, op.getLoc(), getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), rewriter.getArrayAttr(begins),
         rewriter.getArrayAttr(ends), rewriter.getArrayAttr(steps));
 
@@ -233,8 +233,8 @@ sliceForBatchGroups(ConversionPatternRewriter &rewriter, Location loc,
                                                inputShape.end());
     inputSliceShape[groupDimensionIndex] = inputSliceSize;
 
-    auto inputSlice = rewriter.create<ttir::SliceStaticOp>(
-        ttmlir::utils::appendLocationSuffix(loc, "_inputSlice"),
+    auto inputSlice = ttir::SliceStaticOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_inputSlice"),
         RankedTensorType::get(inputSliceShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, rewriter.getI32ArrayAttr(inputBegins),
@@ -254,8 +254,8 @@ sliceForBatchGroups(ConversionPatternRewriter &rewriter, Location loc,
                                                 weightShape.end());
     weightSliceShape[kernelOutputFeatureDim] = weightSliceSize;
 
-    auto weightSlice = rewriter.create<ttir::SliceStaticOp>(
-        ttmlir::utils::appendLocationSuffix(loc, "_weightSlice"),
+    auto weightSlice = ttir::SliceStaticOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_weightSlice"),
         RankedTensorType::get(weightSliceShape, weightType.getElementType(),
                               weightType.getEncoding()),
         weight, rewriter.getI32ArrayAttr(weightBegins),
@@ -342,8 +342,8 @@ public:
 
     if (batchGroupCount > 1) {
       int64_t outputFeatureDim = convolutionLayout.getOutputFeatureDimension();
-      auto concatOp = rewriter.create<ttir::ConcatOp>(
-          op.getLoc(), outputType, results, outputFeatureDim);
+      auto concatOp = ttir::ConcatOp::create(rewriter, op.getLoc(), outputType,
+                                             results, outputFeatureDim);
       rewriter.replaceOp(op, concatOp);
     } else {
       rewriter.replaceOp(op, results[0]);
@@ -413,8 +413,8 @@ private:
         convolutionLayout.getOutputSpatialDimensions());
     conv2dOutputSpatialDimensions.push_back(3);
 
-    auto new2dConvolutionOp = rewriter.create<ttir::ConvolutionOp>(
-        loc,
+    auto new2dConvolutionOp = ttir::ConvolutionOp::create(
+        rewriter, loc,
         RankedTensorType::get(conv2dOutputShape, outputElementType,
                               outputEncoding),
         reshapeInput, reshapeWeight, Value(), conv2dOpWindowsStridesAttr,
@@ -446,8 +446,8 @@ private:
     auto shapeAttr =
         rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(targetShape));
 
-    return rewriter.create<ttir::ReshapeOp>(
-        loc,
+    return ttir::ReshapeOp::create(
+        rewriter, loc,
         RankedTensorType::get(targetShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, shapeAttr);
@@ -591,8 +591,8 @@ public:
       int64_t concatDim = std::find(conv2dLayout.begin(), conv2dLayout.end(),
                                     ConvolutionDimension::FEATURE) -
                           conv2dLayout.begin();
-      finalResult = rewriter.create<ttir::ConcatOp>(
-          op.getLoc(), concatOutputType, results, concatDim);
+      finalResult = ttir::ConcatOp::create(
+          rewriter, op.getLoc(), concatOutputType, results, concatDim);
     } else {
       finalResult = results[0];
     }
@@ -664,8 +664,8 @@ private:
     auto permutation = generateConvPermutation(op, conv2dLayout);
     auto permuteOutputShape =
         ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
-    auto permutedInput = rewriter.create<ttir::PermuteOp>(
-        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_input"),
+    auto permutedInput = ttir::PermuteOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(op.getLoc(), "_input"),
         RankedTensorType::get(permuteOutputShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, permutation);
@@ -683,8 +683,8 @@ private:
         op, isTransposed ? conv2dTransposeKernelLayout : conv2dKernelLayout);
     auto weightOutputShape = ::ttmlir::utils::applyPermutation(
         weightType.getShape(), kernelPermutation);
-    permutedWeight = rewriter.create<ttir::PermuteOp>(
-        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_weight"),
+    permutedWeight = ttir::PermuteOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(op.getLoc(), "_weight"),
         RankedTensorType::get(weightOutputShape, weightType.getElementType(),
                               weightType.getEncoding()),
         permutedWeight, kernelPermutation);
@@ -699,8 +699,8 @@ private:
           biasType.getShape(), biasPermutation);
       SmallVector<int32_t> biasOutputShapeI32(biasOutputShape.begin(),
                                               biasOutputShape.end());
-      biasValue = rewriter.create<ttir::ReshapeOp>(
-          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_bias"),
+      biasValue = ttir::ReshapeOp::create(
+          rewriter, ttmlir::utils::appendLocationSuffix(op.getLoc(), "_bias"),
           RankedTensorType::get(biasOutputShape, biasType.getElementType(),
                                 biasType.getEncoding()),
           biasValue, rewriter.getI32ArrayAttr(biasOutputShapeI32));
@@ -746,14 +746,15 @@ private:
           static_cast<int32_t>(adaptor.getInputDilation()[SPATIAL_DIM_HEIGHT]),
           static_cast<int32_t>(adaptor.getInputDilation()[SPATIAL_DIM_WIDTH]),
       });
-      newConv = rewriter.create<ttir::ConvTranspose2dOp>(
-          op.getLoc(), outputType, Value(permutedInput), Value(permutedWeight),
-          biasValue, inputDilationAttr, paddingAttr, outputPaddingAttr,
-          dilationAttr, groupsAttr);
+      newConv = ttir::ConvTranspose2dOp::create(
+          rewriter, op.getLoc(), outputType, Value(permutedInput),
+          Value(permutedWeight), biasValue, inputDilationAttr, paddingAttr,
+          outputPaddingAttr, dilationAttr, groupsAttr);
     } else {
-      newConv = rewriter.create<ttir::Conv2dOp>(
-          op.getLoc(), outputType, Value(permutedInput), Value(permutedWeight),
-          biasValue, strideAttr, paddingAttr, dilationAttr, groupsAttr,
+      newConv = ttir::Conv2dOp::create(
+          rewriter, op.getLoc(), outputType, Value(permutedInput),
+          Value(permutedWeight), biasValue, strideAttr, paddingAttr,
+          dilationAttr, groupsAttr,
           /*flattenedCompatInfo=*/nullptr);
     }
 
@@ -838,8 +839,8 @@ public:
     auto inputPermutation = generateConvPermutation(op, conv3dLayout);
     auto permutedInputShape =
         ttmlir::utils::applyPermutation(inputType.getShape(), inputPermutation);
-    Value permutedInput = rewriter.create<ttir::PermuteOp>(
-        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_input"),
+    Value permutedInput = ttir::PermuteOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(op.getLoc(), "_input"),
         RankedTensorType::get(permutedInputShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, inputPermutation);
@@ -922,8 +923,8 @@ private:
         generateConvKernelPermutation(op, conv3dKernelLayout);
     auto weightOutputShape = ::ttmlir::utils::applyPermutation(
         weightType.getShape(), kernelPermutation);
-    permutedWeight = rewriter.create<ttir::PermuteOp>(
-        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_weight"),
+    permutedWeight = ttir::PermuteOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(op.getLoc(), "_weight"),
         RankedTensorType::get(weightOutputShape, weightType.getElementType(),
                               weightType.getEncoding()),
         permutedWeight, kernelPermutation);
@@ -961,7 +962,8 @@ private:
         llvm::SmallVector<int64_t> permutedBiasShape =
             ttmlir::utils::applyPermutation(biasType.getShape(),
                                             biasPermutation);
-        biasValue = rewriter.create<ttir::PermuteOp>(
+        biasValue = ttir::PermuteOp::create(
+            rewriter,
             ttmlir::utils::appendLocationSuffix(op.getLoc(), "_bias_permute"),
             RankedTensorType::get(permutedBiasShape, biasType.getElementType(),
                                   biasType.getEncoding()),
@@ -970,9 +972,9 @@ private:
       // Bias is now in NDHWC format (1,1,1,1,C_out) as required by Conv3dOp
     }
 
-    mlir::Value newConv = rewriter.create<ttir::Conv3dOp>(
-        op.getLoc(), outputType, Value(permutedInput), Value(permutedWeight),
-        biasValue, strideAttr, paddingAttr, groupsAttr,
+    mlir::Value newConv = ttir::Conv3dOp::create(
+        rewriter, op.getLoc(), outputType, Value(permutedInput),
+        Value(permutedWeight), biasValue, strideAttr, paddingAttr, groupsAttr,
         /*padding_mode=*/nullptr);
 
     return newConv;
@@ -1010,8 +1012,8 @@ struct ReverseOpConversionPattern
 
       auto denseAttr = DenseIntElementsAttr::get(tensorType, indices);
 
-      Value reversedIndices =
-          rewriter.create<ttir::ConstantOp>(op.getLoc(), tensorType, denseAttr);
+      Value reversedIndices = ttir::ConstantOp::create(rewriter, op.getLoc(),
+                                                       tensorType, denseAttr);
 
       SmallVector<int64_t> offsetDims;
       for (int64_t i = 0; i < static_cast<int64_t>(shape.size()); i++) {
@@ -1023,8 +1025,8 @@ struct ReverseOpConversionPattern
       SmallVector<int64_t> sliceSizes(shape.begin(), shape.end());
       sliceSizes[dim] = 1;
 
-      currentInput = rewriter.create<ttir::GatherOp>(
-          op.getLoc(), getTypeConverter()->convertType(op.getType()),
+      currentInput = ttir::GatherOp::create(
+          rewriter, op.getLoc(), getTypeConverter()->convertType(op.getType()),
           /*input=*/currentInput,
           /*start_indices=*/reversedIndices,
           /*offset_dims=*/offsetDims,
@@ -1287,8 +1289,8 @@ struct GatherToEmbeddingConversionPattern
     auto embeddingOutputType = mlir::RankedTensorType::get(
         newOutputShape, input.getType().getElementType(),
         input.getType().getEncoding());
-    ttir::EmbeddingOp embeddingOp = rewriter.create<ttir::EmbeddingOp>(
-        op.getLoc(), embeddingOutputType, startIndices, input);
+    ttir::EmbeddingOp embeddingOp = ttir::EmbeddingOp::create(
+        rewriter, op.getLoc(), embeddingOutputType, startIndices, input);
 
     rewriter.replaceOp(op, reshapeAndPermuteOutput(rewriter, embeddingOp,
                                                    startIndexMap[0], op));
@@ -1315,8 +1317,8 @@ private:
         }));
     auto permutedInputShape =
         ttmlir::utils::applyPermutation(inputType.getShape(), inputPermutation);
-    return rewriter.create<ttir::PermuteOp>(
-        loc,
+    return ttir::PermuteOp::create(
+        rewriter, loc,
         RankedTensorType::get(permutedInputShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, inputPermutation);
@@ -1368,20 +1370,21 @@ private:
     auto permutedStartIndicesShape = ttmlir::utils::applyPermutation(
         startIndicesType.getShape(), startIndicesPermutation);
     auto startIndicesPermuted =
-        rewriter
-            .create<ttir::PermuteOp>(
-                ttmlir::utils::appendLocationSuffix(op.getLoc(),
-                                                    "_permuteStartIndices"),
-                RankedTensorType::get(permutedStartIndicesShape,
-                                      startIndicesType.getElementType(),
-                                      startIndicesType.getEncoding()),
-                startIndices, startIndicesPermutation)
+        ttir::PermuteOp::create(
+            rewriter,
+            ttmlir::utils::appendLocationSuffix(op.getLoc(),
+                                                "_permuteStartIndices"),
+            RankedTensorType::get(permutedStartIndicesShape,
+                                  startIndicesType.getElementType(),
+                                  startIndicesType.getEncoding()),
+            startIndices, startIndicesPermutation)
             .getResult();
 
     // Typecast op because matmul needs float operands.
     auto typecastResultType = startIndicesPermuted.getType().clone(
         mlir::Float32Type::get(op.getContext()));
-    ttir::TypecastOp typecastOp = rewriter.create<ttir::TypecastOp>(
+    ttir::TypecastOp typecastOp = ttir::TypecastOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(op->getLoc(), "_typecast"),
         typecastResultType, startIndicesPermuted);
 
@@ -1397,7 +1400,8 @@ private:
                                     mlir::Float32Type::get(op.getContext()));
     auto denseAttr =
         mlir::DenseElementsAttr::get(tensorType, llvm::ArrayRef(strides));
-    ttir::ConstantOp constantOp = rewriter.create<ttir::ConstantOp>(
+    ttir::ConstantOp constantOp = ttir::ConstantOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(op->getLoc(), "_constant"),
         tensorType, denseAttr);
 
@@ -1407,8 +1411,8 @@ private:
     auto matmulResultType = mlir::RankedTensorType::get(
         matmulResultShape, Float32Type::get(op.getContext()));
 
-    return rewriter.create<ttir::MatmulOp>(op.getLoc(), matmulResultType,
-                                           typecastOp.getResult(), constantOp);
+    return ttir::MatmulOp::create(rewriter, op.getLoc(), matmulResultType,
+                                  typecastOp.getResult(), constantOp);
   }
 
   // If startIndicesShape[indexVectorDim] > 1, but we are actually slicing only
@@ -1437,8 +1441,8 @@ private:
     llvm::SmallVector<int64_t> resultShape(startIndicesShape);
     resultShape[indexVectorDim] = 1;
 
-    return rewriter.create<ttir::SliceStaticOp>(
-        loc,
+    return ttir::SliceStaticOp::create(
+        rewriter, loc,
         RankedTensorType::get(resultShape, startIndicesType.getElementType(),
                               startIndicesType.getEncoding()),
         startIndices, rewriter.getI32ArrayAttr(begins),
@@ -1489,21 +1493,23 @@ private:
         startIndicesType.getEncoding());
     auto offsetAttr =
         mlir::DenseElementsAttr::get(expandedType, llvm::ArrayRef(matrixData));
-    auto offsetConstant = rewriter.create<ttir::ConstantOp>(
-        ttmlir::utils::appendLocationSuffix(loc, "_offsetConstant"),
+    auto offsetConstant = ttir::ConstantOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_offsetConstant"),
         expandedType, offsetAttr);
     // Create broadcast dimensions - all dimensions map directly except the
     // expanded one.
     llvm::SmallVector<int64_t> broadcastDimensions = {sliceSize, 1};
 
     // Broadcast the original startIndices to the expanded shape.
-    auto broadcastedStartIndices = rewriter.create<ttir::BroadcastOp>(
+    auto broadcastedStartIndices = ttir::BroadcastOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(loc, "_broadcastStartIndices"),
         expandedType, startIndices,
         rewriter.getDenseI64ArrayAttr(broadcastDimensions));
 
     // Add the broadcasted tensors to get the final expanded indices.
-    return rewriter.create<ttir::AddOp>(
+    return ttir::AddOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(loc, "_expandedStartIndices"),
         expandedType, broadcastedStartIndices, offsetConstant);
   }
@@ -1566,7 +1572,8 @@ private:
         ttmlir::utils::appendLocationSuffix(op->getLoc(), "_reshapeOutput"),
         output, permutedOutputShape);
 
-    return rewriter.create<ttir::PermuteOp>(
+    return ttir::PermuteOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(op->getLoc(), "_permuteOutput"),
         RankedTensorType::get(expectedOutputShape,
                               expectedOutputType.getElementType(),
@@ -1581,9 +1588,10 @@ private:
     auto shapeAttr =
         rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(targetShape));
 
-    return rewriter.create<ttir::ReshapeOp>(
-        loc, inputType.cloneWith(targetShape, inputType.getElementType()),
-        input, shapeAttr);
+    return ttir::ReshapeOp::create(
+        rewriter, loc,
+        inputType.cloneWith(targetShape, inputType.getElementType()), input,
+        shapeAttr);
   }
 };
 } // namespace
@@ -1688,8 +1696,9 @@ struct DotGeneralToMatmulConversionPattern
         computeProductOfDims(rhsType.getShape(), rhsResultDims));
 
     // Perform matmul operation.
-    auto matmulOp = rewriter.create<ttir::MatmulOp>(
-        op.getLoc(), RankedTensorType::get(matmulDestinationShape, elementType),
+    auto matmulOp = ttir::MatmulOp::create(
+        rewriter, op.getLoc(),
+        RankedTensorType::get(matmulDestinationShape, elementType),
         lhsMatmulInput, rhsMatmulInput);
 
     // Propagate the hoist attribute to the matmul op.
@@ -1781,8 +1790,8 @@ private:
     SmallVector<int64_t> destinationShape =
         ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
 
-    auto permuteOp = rewriter.create<ttir::PermuteOp>(
-        loc,
+    auto permuteOp = ttir::PermuteOp::create(
+        rewriter, loc,
         RankedTensorType::get(destinationShape, inputType.getElementType(),
                               inputType.getEncoding()),
         input, permutation);
@@ -1825,8 +1834,8 @@ private:
     llvm::SmallVector<int32_t> finalShapeI32(finalShape.begin(),
                                              finalShape.end());
 
-    auto reshapeOp = rewriter.create<ttir::ReshapeOp>(
-        loc,
+    auto reshapeOp = ttir::ReshapeOp::create(
+        rewriter, loc,
         RankedTensorType::get(finalShape, type.getElementType(),
                               type.getEncoding()),
         input, rewriter.getI32ArrayAttr(finalShapeI32));
@@ -2054,7 +2063,8 @@ private:
       RankedTensorType inputTy = mlir::cast<RankedTensorType>(input.getType());
       auto inputPermuteShape =
           ::ttmlir::utils::applyPermutation(inputTy.getShape(), permutation);
-      input = rewriter.create<ttir::PermuteOp>(
+      input = ttir::PermuteOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_permuteInput"),
           RankedTensorType::get(inputPermuteShape, inputTy.getElementType(),
                                 inputTy.getEncoding()),
@@ -2065,16 +2075,16 @@ private:
           originalOutputTy.getShape(), permutation);
       PoolOpType newPool;
       if constexpr (std::is_same_v<PoolOpType, ttir::AvgPool2dOp>) {
-        newPool = rewriter.create<PoolOpType>(
-            op.getLoc(),
+        newPool = PoolOpType::create(
+            rewriter, op.getLoc(),
             RankedTensorType::get(resultPermuteShape,
                                   originalOutputTy.getElementType(),
                                   originalOutputTy.getEncoding()),
             input, kernelAttr, strideAttr, dilationAttr, paddingAttr,
             ceilModeAttr, /*count_include_pad=*/rewriter.getBoolAttr(true));
       } else if constexpr (std::is_same_v<PoolOpType, ttir::MaxPool2dOp>) {
-        newPool = rewriter.create<PoolOpType>(
-            op.getLoc(),
+        newPool = PoolOpType::create(
+            rewriter, op.getLoc(),
             RankedTensorType::get(resultPermuteShape,
                                   originalOutputTy.getElementType(),
                                   originalOutputTy.getEncoding()),
@@ -2085,7 +2095,8 @@ private:
       }
       // Applying the inverse of permutation to the output will restore the
       // tensor to the original layout.
-      auto output = rewriter.create<ttir::PermuteOp>(
+      auto output = ttir::PermuteOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_permuteOutput"),
           originalOutputTy, newPool, inverseOfPermutation);
       outputs.push_back(output);
@@ -2125,14 +2136,16 @@ private:
 
     mlir::DenseElementsAttr constantValueAttr =
         mlir::SplatElementsAttr::get(outputType, constantValue);
-    auto constantOp = rewriter.create<ttir::ConstantOp>(
+    auto constantOp = ttir::ConstantOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(op->getLoc(), "_constant"),
         outputType, constantValueAttr);
 
     llvm::SmallVector<Value> sumPoolOutputs;
     // Multiply each average pooling op with kernel size.
     for (Value inputOp : avgPoolOutputs) {
-      auto outputOp = rewriter.create<ttir::MultiplyOp>(
+      auto outputOp = ttir::MultiplyOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op->getLoc(), "_multiply"),
           outputType, inputOp, constantOp);
       sumPoolOutputs.push_back(outputOp);
@@ -2202,8 +2215,8 @@ public:
                     FloatAttr::get(Float32Type::get(rewriter.getContext()),
                                    std::get<float>(newConstValue)));
 
-      newConstant = rewriter.create<ttir::FullOp>(
-          op.getLoc(), op.getResult(i).getType(), newConstValueAttr);
+      newConstant = ttir::FullOp::create(
+          rewriter, op.getLoc(), op.getResult(i).getType(), newConstValueAttr);
       newResults.push_back(newConstant);
     }
 
@@ -2300,8 +2313,8 @@ public:
       begins[dim] = newBegin;
       ends[dim] = newEnd;
 
-      auto newOp = rewriter.create<ttir::SliceStaticOp>(
-          op.getLoc(),
+      auto newOp = ttir::SliceStaticOp::create(
+          rewriter, op.getLoc(),
           RankedTensorType::get(resultShape, inputType.getElementType(),
                                 inputType.getEncoding()),
           adaptor.getInput(), rewriter.getI32ArrayAttr(begins),
@@ -2311,8 +2324,8 @@ public:
 
     assert(!slices.empty());
     if (slices.size() > 1) {
-      auto concatOp =
-          rewriter.create<ttir::ConcatOp>(op.getLoc(), outputType, slices, dim);
+      auto concatOp = ttir::ConcatOp::create(rewriter, op.getLoc(), outputType,
+                                             slices, dim);
       rewriter.replaceOp(op, concatOp);
     } else {
       rewriter.replaceOp(op, slices[0]);
@@ -2363,12 +2376,11 @@ public:
     RankedTensorType arangeOutputType = RankedTensorType::get(
         requiredShape, outputType.getElementType(), outputType.getEncoding());
 
-    Value output =
-        rewriter
-            .create<ttir::ArangeOp>( // perform arange on the last dimension to
-                                     // match how ttnn behaves
-                op.getLoc(), arangeOutputType, start, end, step, 0)
-            .getResult();
+    Value output = ttir::ArangeOp::create(
+                       rewriter, // perform arange on the last dimension to
+                                 // match how ttnn behaves
+                       op.getLoc(), arangeOutputType, start, end, step, 0)
+                       .getResult();
 
     std::vector<int64_t> outputShape = arangeOutputType.getShape().vec();
 
@@ -2382,7 +2394,8 @@ public:
                              : reshapeShape.push_back(1);
       }
 
-      output = rewriter.create<ttir::ReshapeOp>(
+      output = ttir::ReshapeOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshapeOutput"),
           RankedTensorType::get(reshapeShape, outputType.getElementType(),
                                 outputType.getEncoding()),
@@ -2412,7 +2425,8 @@ public:
           ttmlir::utils::getBroadcastDimensions<int64_t>(inputShape,
                                                          outputShape);
 
-      output = rewriter.create<ttir::BroadcastOp>(
+      output = ttir::BroadcastOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_broadcastOutput"),
           broadcastType, output, broadcastShape);
 
@@ -2500,8 +2514,9 @@ normalizeToNCHW(mlir::Value input, uint64_t featureIndex,
     llvm::SmallVector<int64_t> permutedShape = ttmlir::utils::applyPermutation(
         llvm::ArrayRef(currentShape), llvm::ArrayRef(permutation));
 
-    newInput = rewriter.create<mlir::tt::ttir::PermuteOp>(
-        loc, RankedTensorType::get(permutedShape, inputType.getElementType()),
+    newInput = mlir::tt::ttir::PermuteOp::create(
+        rewriter, loc,
+        RankedTensorType::get(permutedShape, inputType.getElementType()),
         newInput, rewriter.getDenseI64ArrayAttr(permutation));
     currentShape = permutedShape;
   }
@@ -2516,8 +2531,8 @@ normalizeToNCHW(mlir::Value input, uint64_t featureIndex,
         currentShape[3] * currentShape[4]};
     llvm::SmallVector<int32_t> reshapedShapeI32(reshapedShape.begin(),
                                                 reshapedShape.end());
-    newInput = rewriter.create<mlir::tt::ttir::ReshapeOp>(
-        loc,
+    newInput = mlir::tt::ttir::ReshapeOp::create(
+        rewriter, loc,
         RankedTensorType::get(reshapedShape, inputType.getElementType(),
                               inputType.getEncoding()),
         newInput, rewriter.getI32ArrayAttr(reshapedShapeI32));
@@ -2528,8 +2543,8 @@ normalizeToNCHW(mlir::Value input, uint64_t featureIndex,
     reshapedShape.append(4 - rank, 1);
     llvm::SmallVector<int32_t> reshapedShapeI32(reshapedShape.begin(),
                                                 reshapedShape.end());
-    newInput = rewriter.create<mlir::tt::ttir::ReshapeOp>(
-        loc,
+    newInput = mlir::tt::ttir::ReshapeOp::create(
+        rewriter, loc,
         RankedTensorType::get(reshapedShape, inputType.getElementType(),
                               inputType.getEncoding()),
         newInput, rewriter.getI32ArrayAttr(reshapedShapeI32));
@@ -2565,8 +2580,8 @@ static mlir::Value denormalizeFromNCHW(mlir::Value output,
 
     llvm::SmallVector<int32_t> shapeAfterPermuteI32(shapeAfterPermute.begin(),
                                                     shapeAfterPermute.end());
-    result = rewriter.create<mlir::tt::ttir::ReshapeOp>(
-        loc,
+    result = mlir::tt::ttir::ReshapeOp::create(
+        rewriter, loc,
         RankedTensorType::get(shapeAfterPermute, outputType.getElementType(),
                               outputType.getEncoding()),
         result, rewriter.getI32ArrayAttr(shapeAfterPermuteI32));
@@ -2580,8 +2595,8 @@ static mlir::Value denormalizeFromNCHW(mlir::Value output,
     std::iota(permutation.begin(), permutation.end(), 0);
     std::swap(permutation[1], permutation[originalFeatureIndex]);
 
-    result = rewriter.create<mlir::tt::ttir::PermuteOp>(
-        loc,
+    result = mlir::tt::ttir::PermuteOp::create(
+        rewriter, loc,
         RankedTensorType::get(originalShape, outputType.getElementType(),
                               outputType.getEncoding()),
         result, rewriter.getDenseI64ArrayAttr(permutation));
@@ -2616,8 +2631,8 @@ static mlir::Value getBatchNorm4DTensor(PatternRewriter &rewriter, Location loc,
   llvm::SmallVector<int32_t> shape32(newShape.begin(), newShape.end());
   auto shapeAttr = rewriter.getI32ArrayAttr(shape32);
 
-  return rewriter.create<ttir::ReshapeOp>(
-      loc,
+  return ttir::ReshapeOp::create(
+      rewriter, loc,
       RankedTensorType::get(newShape, inputType.getElementType(),
                             inputType.getEncoding()),
       batchNormInput, shapeAttr);
@@ -2639,8 +2654,8 @@ static mlir::Value reshapeBatchNorm4DTo1D(PatternRewriter &rewriter,
   llvm::SmallVector<int32_t> shape1D = {
       static_cast<int32_t>(target1DType.getDimSize(0))};
 
-  return rewriter.create<ttir::ReshapeOp>(
-      loc,
+  return ttir::ReshapeOp::create(
+      rewriter, loc,
       RankedTensorType::get(target1DType.getShape(),
                             target1DType.getElementType(),
                             target1DType.getEncoding()),
@@ -2723,10 +2738,9 @@ public:
     IntegerAttr dimensionAttr = mlir::IntegerAttr::get(integerType, 1);
 
     // Create the BatchNorm op with normalized input and 4D weight tensors
-    auto batchNormInferenceOp =
-        rewriter.create<mlir::tt::ttir::BatchNormInferenceOp>(
-            loc, normalizedOutputType, normalizedInput, scale4D, offset4D,
-            mean4D, variance4D, adaptor.getEpsilonAttr(), dimensionAttr);
+    auto batchNormInferenceOp = mlir::tt::ttir::BatchNormInferenceOp::create(
+        rewriter, loc, normalizedOutputType, normalizedInput, scale4D, offset4D,
+        mean4D, variance4D, adaptor.getEpsilonAttr(), dimensionAttr);
 
     // Denormalize output back to original layout
     mlir::Value result =
@@ -2816,8 +2830,9 @@ public:
 
     // Create new BatchNormTrainingOp with normalized input and all 4D weight
     // tensors
-    auto batchNormTrainingOp = rewriter.create<ttir::BatchNormTrainingOp>(
-        loc, TypeRange{normalizedOutputType, mean4DType, variance4DType},
+    auto batchNormTrainingOp = ttir::BatchNormTrainingOp::create(
+        rewriter, loc,
+        TypeRange{normalizedOutputType, mean4DType, variance4DType},
         normalizedInput, scale4D, offset4D, mean4D, variance4D,
         adaptor.getEpsilonAttr(), dimensionAttr, adaptor.getMomentumAttr());
 
@@ -2861,7 +2876,7 @@ getScaleAndZeroPoint(mlir::quant::QuantizedType elementType,
     mlir::DenseFPElementsAttr scaleDenseAttr =
         mlir::DenseFPElementsAttr::get(scaleType, scaleValue);
     ttir::ConstantOp scaleConstant =
-        rewriter.create<ttir::ConstantOp>(loc, scaleType, scaleDenseAttr);
+        ttir::ConstantOp::create(rewriter, loc, scaleType, scaleDenseAttr);
 
     // Create ttir::ConstantOp for zero point.
     int32_t zeroPoint = static_cast<int32_t>(quantPerTensorType.getZeroPoint());
@@ -2869,8 +2884,8 @@ getScaleAndZeroPoint(mlir::quant::QuantizedType elementType,
         {1}, IntegerType::get(rewriter.getContext(), 32, IntegerType::Signed));
     mlir::DenseIntElementsAttr zeroPointDenseAttr =
         mlir::DenseIntElementsAttr::get(zeroPointType, zeroPoint);
-    ttir::ConstantOp zeroPointConstant = rewriter.create<ttir::ConstantOp>(
-        loc, zeroPointType, zeroPointDenseAttr);
+    ttir::ConstantOp zeroPointConstant = ttir::ConstantOp::create(
+        rewriter, loc, zeroPointType, zeroPointDenseAttr);
     return {scaleConstant.getResult(), zeroPointConstant.getResult()};
   }
 
@@ -2886,7 +2901,7 @@ getScaleAndZeroPoint(mlir::quant::QuantizedType elementType,
     mlir::DenseFPElementsAttr scaleDenseAttr =
         mlir::DenseFPElementsAttr::get(scaleType, scales);
     ttir::ConstantOp scaleConstant =
-        rewriter.create<ttir::ConstantOp>(loc, scaleType, scaleDenseAttr);
+        ttir::ConstantOp::create(rewriter, loc, scaleType, scaleDenseAttr);
 
     // Create ttir::ConstantOp for zero point.
     SmallVector<int32_t> zeroPoints(
@@ -2896,8 +2911,8 @@ getScaleAndZeroPoint(mlir::quant::QuantizedType elementType,
         IntegerType::get(rewriter.getContext(), 32, IntegerType::Signed));
     mlir::DenseIntElementsAttr zeroPointDenseAttr =
         mlir::DenseIntElementsAttr::get(zeroPointType, zeroPoints);
-    ttir::ConstantOp zeroPointConstant = rewriter.create<ttir::ConstantOp>(
-        loc, zeroPointType, zeroPointDenseAttr);
+    ttir::ConstantOp zeroPointConstant = ttir::ConstantOp::create(
+        rewriter, loc, zeroPointType, zeroPointDenseAttr);
     return {scaleConstant.getResult(), zeroPointConstant.getResult()};
   }
 
@@ -3081,8 +3096,9 @@ public:
       }
 
       RankedTensorType outputType = RankedTensorType::get(shape, elementType);
-      runningProdOp = rewriter.create<ttir::ProdOp>(
-          op.getLoc(), outputType, runningProdOp, op.getKeepDimAttr(), dimArg);
+      runningProdOp =
+          ttir::ProdOp::create(rewriter, op.getLoc(), outputType, runningProdOp,
+                               op.getKeepDimAttr(), dimArg);
     }
 
     rewriter.replaceOp(op, runningProdOp);

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -26,9 +26,9 @@ ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
       ttnn::utils::RankedTensorTypeFactory::create(inputType, newShape);
 
   llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
-  return rewriter.create<ttnn::ReshapeOp>(newLoc, outputType, input,
-                                          rewriter.getI32ArrayAttr(newShapeI32),
-                                          /* memory_config */ nullptr);
+  return ttnn::ReshapeOp::create(rewriter, newLoc, outputType, input,
+                                 rewriter.getI32ArrayAttr(newShapeI32),
+                                 /* memory_config */ nullptr);
 }
 
 ttnn::ReshapeOp
@@ -53,9 +53,10 @@ ttnn::PermuteOp generatePermute(mlir::TypedValue<mlir::RankedTensorType> input,
   RankedTensorType outputType =
       ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
 
-  return rewriter.create<ttnn::PermuteOp>(
-      newLoc, outputType, input, rewriter.getDenseI64ArrayAttr(permutation),
-      /* memory_config */ nullptr, /* pad_value */ mlir::FloatAttr());
+  return ttnn::PermuteOp::create(rewriter, newLoc, outputType, input,
+                                 rewriter.getDenseI64ArrayAttr(permutation),
+                                 /* memory_config */ nullptr,
+                                 /* pad_value */ mlir::FloatAttr());
 }
 
 ttnn::PadOp generatePad(mlir::TypedValue<mlir::RankedTensorType> input,
@@ -75,10 +76,11 @@ ttnn::PadOp generatePad(mlir::TypedValue<mlir::RankedTensorType> input,
   RankedTensorType outputType =
       ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
 
-  return rewriter.create<ttnn::PadOp>(
-      newLoc, outputType, input, rewriter.getDenseI32ArrayAttr(padding),
-      rewriter.getF32FloatAttr(0.0f), rewriter.getBoolAttr(true),
-      /*memory_config=*/nullptr);
+  return ttnn::PadOp::create(rewriter, newLoc, outputType, input,
+                             rewriter.getDenseI32ArrayAttr(padding),
+                             rewriter.getF32FloatAttr(0.0f),
+                             rewriter.getBoolAttr(true),
+                             /*memory_config=*/nullptr);
 }
 } // namespace ttir_to_ttnn::utils
 } // namespace tt

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -898,8 +898,8 @@ public:
 
     using ReturnTy = std::vector<::ttnn::Tensor>;
 
-    auto maxPool2dWithIndicesOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto maxPool2dWithIndicesOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         rewriter.getType<emitc::OpaqueType>(ttnn_to_emitc::TypeNameV<ReturnTy>),
         convertOpName(srcOp), rewriter.getArrayAttr(args),
         /*template_args=*/nullptr, adaptor.getOperands());
@@ -908,8 +908,8 @@ public:
     for (unsigned i = 0; i < srcOp.getNumResults(); ++i) {
       // Create index to access i-th element.
       auto indexType = rewriter.getIndexType();
-      auto indexOp = rewriter.create<emitc::LiteralOp>(
-          srcOp.getLoc(), indexType, std::to_string(i));
+      auto indexOp = emitc::LiteralOp::create(rewriter, srcOp.getLoc(),
+                                              indexType, std::to_string(i));
       Value indexVal = indexOp.getResult();
 
       // Create LValue type for the tensor reference.
@@ -918,13 +918,13 @@ public:
           ttnn_to_emitc::TypeNameV<ReturnTy::value_type>));
 
       // Get reference to the i-th element in the result vector.
-      auto subscriptOp = rewriter.create<emitc::SubscriptOp>(
-          srcOp.getLoc(), lvalueType, maxPool2dWithIndicesOp.getResult(0),
-          indexVal);
+      auto subscriptOp = emitc::SubscriptOp::create(
+          rewriter, srcOp.getLoc(), lvalueType,
+          maxPool2dWithIndicesOp.getResult(0), indexVal);
 
       // Load the actual tensor value from the reference.
-      auto loadOp = rewriter.create<emitc::LoadOp>(
-          srcOp.getLoc(),
+      auto loadOp = emitc::LoadOp::create(
+          rewriter, srcOp.getLoc(),
           emitc::OpaqueType::get(
               rewriter.getContext(),
               ttnn_to_emitc::TypeNameV<ReturnTy::value_type>),
@@ -2248,8 +2248,8 @@ public:
     // SubscriptOp requires a Value object as index, which is created by
     // invoking the emitc::LiteralOp.
     //
-    Value indexAsVal = rewriter.create<emitc::LiteralOp>(
-        getTupleElementOp->getLoc(), rewriter.getIndexType(),
+    Value indexAsVal = emitc::LiteralOp::create(
+        rewriter, getTupleElementOp->getLoc(), rewriter.getIndexType(),
         std::to_string(adaptor.getIndex()));
 
     // SubscriptOp also returns an emitc::LValueType, so we wrap the
@@ -2258,9 +2258,9 @@ public:
     emitc::LValueType lvalueReturnType =
         emitc::LValueType::get(emitc::OpaqueType::get(
             rewriter.getContext(), ttnn_to_emitc::TypeNameV<::ttnn::Tensor>));
-    Value subscript = rewriter.create<emitc::SubscriptOp>(
-        getTupleElementOp->getLoc(), lvalueReturnType, adaptor.getOperand(),
-        indexAsVal);
+    Value subscript = emitc::SubscriptOp::create(
+        rewriter, getTupleElementOp->getLoc(), lvalueReturnType,
+        adaptor.getOperand(), indexAsVal);
 
     // As SubscriptOp returns an LValueType, we need to convert it to an
     // OpaqueType - this is done by invoking the emitc::LoadOp.
@@ -2341,8 +2341,9 @@ public:
     rewriter.setInsertionPoint(funcOp);
 
     // Create the global variable using EmitC's GlobalOp
-    rewriter.create<emitc::GlobalOp>(
-        srcOp.getLoc(), StringAttr::get(rewriter.getContext(), globalVarName),
+    emitc::GlobalOp::create(
+        rewriter, srcOp.getLoc(),
+        StringAttr::get(rewriter.getContext(), globalVarName),
         TypeAttr::get(tupleType),
         /*initialValue=*/nullptr,
         /*extern_specifier=*/UnitAttr(),
@@ -2365,40 +2366,41 @@ public:
                   ":std::vector<::ttnn::Tensor>)>");
     auto addressAttr =
         emitc::OpaqueAttr::get(rewriter.getContext(), "&" + callee.str());
-    auto funcPtrValue = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(), funcPtrType, addressAttr);
+    auto funcPtrValue = emitc::ConstantOp::create(rewriter, srcOp.getLoc(),
+                                                  funcPtrType, addressAttr);
 
-    auto tupleOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(), tupleType,
+    auto tupleOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), tupleType,
         mlir::tt::ttnn_to_emitc::kCreateVectorFunctionName, nullptr, nullptr,
         adaptor.getInputs());
     Value tupleValue = tupleOp.getResult(0);
 
     // Get a reference to the global variable using GetGlobalOp
-    auto globalVar = rewriter.create<emitc::GetGlobalOp>(
-        srcOp.getLoc(), emitc::LValueType::get(tupleType), globalSym);
+    auto globalVar = emitc::GetGlobalOp::create(
+        rewriter, srcOp.getLoc(), emitc::LValueType::get(tupleType), globalSym);
 
     // Create a pointer type for the output parameter
     auto ptrType = emitc::PointerType::get(rewriter.getContext(), tupleType);
 
     // Get the address of the global variable
-    auto addressOfOp = rewriter.create<emitc::ApplyOp>(srcOp.getLoc(), ptrType,
-                                                       "&", globalVar);
+    auto addressOfOp = emitc::ApplyOp::create(rewriter, srcOp.getLoc(), ptrType,
+                                              "&", globalVar);
 
     // Call the wrapper function with the pointer
     if (isZeroArgWrapper) {
-      rewriter.create<emitc::CallOpaqueOp>(
-          srcOp.getLoc(), TypeRange{}, "ttnn::constEvalFuncWrapperZeroArg",
-          ValueRange{funcPtrValue, addressOfOp}, ArrayAttr{});
+      emitc::CallOpaqueOp::create(rewriter, srcOp.getLoc(), TypeRange{},
+                                  "ttnn::constEvalFuncWrapperZeroArg",
+                                  ValueRange{funcPtrValue, addressOfOp},
+                                  ArrayAttr{});
     } else {
-      rewriter.create<emitc::CallOpaqueOp>(
-          srcOp.getLoc(), TypeRange{}, "ttnn::constEvalFuncWrapper",
+      emitc::CallOpaqueOp::create(
+          rewriter, srcOp.getLoc(), TypeRange{}, "ttnn::constEvalFuncWrapper",
           ValueRange{funcPtrValue, tupleValue, addressOfOp}, ArrayAttr{});
     }
 
     // Load the value from the global variable
     auto resultVar =
-        rewriter.create<emitc::LoadOp>(srcOp.getLoc(), tupleType, globalVar);
+        emitc::LoadOp::create(rewriter, srcOp.getLoc(), tupleType, globalVar);
 
     // Unpack the tuple result - extract each element from the tuple
     SmallVector<Value> results;
@@ -2406,8 +2408,8 @@ public:
     for (unsigned i = 0; i < srcOp.getNumResults(); ++i) {
       // Create index value
       auto indexType = rewriter.getIndexType();
-      auto indexOp = rewriter.create<emitc::LiteralOp>(
-          srcOp.getLoc(), indexType, std::to_string(i));
+      auto indexOp = emitc::LiteralOp::create(rewriter, srcOp.getLoc(),
+                                              indexType, std::to_string(i));
       Value indexVal = indexOp.getResult();
 
       // Create LValue type for the tensor reference
@@ -2416,12 +2418,13 @@ public:
 
       // Get reference to the i-th element in the static cache result
       // Use the variable that references our global result
-      auto subscriptOp = rewriter.create<emitc::SubscriptOp>(
-          srcOp.getLoc(), lvalueType, resultVar.getResult(), indexVal);
+      auto subscriptOp =
+          emitc::SubscriptOp::create(rewriter, srcOp.getLoc(), lvalueType,
+                                     resultVar.getResult(), indexVal);
 
       // Load the actual tensor value from the reference
-      auto loadOp = rewriter.create<emitc::LoadOp>(
-          srcOp.getLoc(),
+      auto loadOp = emitc::LoadOp::create(
+          rewriter, srcOp.getLoc(),
           emitc::OpaqueType::get(rewriter.getContext(), "::ttnn::Tensor"),
           subscriptOp.getResult());
       results.push_back(loadOp.getResult());
@@ -2503,8 +2506,8 @@ public:
                   mlir::tt::ttnn::MeshShardOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.create<emitc::VerbatimOp>(
-        srcOp.getLoc(),
+    emitc::VerbatimOp::create(
+        rewriter, srcOp.getLoc(),
         "assert(0 && \"Mesh shard operation is "
         "not supported in emitc yet.\"); // ::ttnn::mesh_shard");
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::MeshShardOp> emitter(
@@ -2582,8 +2585,8 @@ public:
         rewriter.getContext(), kDistributedNs + "MeshMapperConfig");
     auto mapperConfigOpaqueAttr =
         rewriter.getAttr<emitc::OpaqueAttr>(configCode);
-    auto mapperConfigOp = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(), mapperConfigType, mapperConfigOpaqueAttr);
+    auto mapperConfigOp = emitc::ConstantOp::create(
+        rewriter, srcOp.getLoc(), mapperConfigType, mapperConfigOpaqueAttr);
 
     auto meshDeviceRef = emitter.dereferenceToRef(
         adaptor.getMeshDevice(), kDistributedNs + "MeshDevice&");
@@ -2591,8 +2594,8 @@ public:
     auto meshMapperType = emitc::OpaqueType::get(
         rewriter.getContext(),
         "::std::unique_ptr<" + kDistributedNs + "TensorToMesh>");
-    auto createMapperOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(), meshMapperType,
+    auto createMapperOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), meshMapperType,
         rewriter.getStringAttr(kDistributedNs + "create_mesh_mapper"), nullptr,
         nullptr,
         llvm::SmallVector<mlir::Value>{meshDeviceRef,
@@ -2664,8 +2667,8 @@ public:
         rewriter.getContext(), kDistributedNs + "MeshComposerConfig");
     auto composerConfigOpaqueAttr =
         rewriter.getAttr<emitc::OpaqueAttr>(configCode);
-    auto composerConfigOp = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(), composerConfigType, composerConfigOpaqueAttr);
+    auto composerConfigOp = emitc::ConstantOp::create(
+        rewriter, srcOp.getLoc(), composerConfigType, composerConfigOpaqueAttr);
 
     auto meshDeviceRef = emitter.dereferenceToRef(
         adaptor.getMeshDevice(), kDistributedNs + "MeshDevice&");
@@ -2673,8 +2676,8 @@ public:
     auto meshComposerType = emitc::OpaqueType::get(
         rewriter.getContext(),
         "::std::unique_ptr<" + kDistributedNs + "MeshToTensor>");
-    auto createComposerOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(), meshComposerType,
+    auto createComposerOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), meshComposerType,
         rewriter.getStringAttr(kDistributedNs + "create_mesh_composer"),
         nullptr, nullptr,
         llvm::SmallVector<mlir::Value>{meshDeviceRef,
@@ -2831,8 +2834,8 @@ public:
                   mlir::tt::ttnn::CollectivePermuteOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.create<emitc::VerbatimOp>(
-        srcOp.getLoc(),
+    emitc::VerbatimOp::create(
+        rewriter, srcOp.getLoc(),
         "assert(0 && \"Collective permute operation is "
         "not supported in emitc yet.\"); // ::ttnn::collective_permute");
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::CollectivePermuteOp>
@@ -2871,15 +2874,15 @@ public:
     // Create SmallVector variable for begins
     auto beginsAttr =
         emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getBegins());
-    auto beginsVar = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(),
+    auto beginsVar = emitc::ConstantOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::SmallVector<int32_t>"),
         beginsAttr);
 
     // Create span from SmallVector variable using CallOpaqueOp
-    auto beginsSpanVar = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto beginsSpanVar = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::Span<const int32_t>"),
         "ttsl::make_const_span", mlir::ArrayAttr{}, nullptr,
@@ -2887,15 +2890,15 @@ public:
 
     // Create SmallVector variable for ends
     auto endsAttr = emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getEnds());
-    auto endsVar = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(),
+    auto endsVar = emitc::ConstantOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::SmallVector<int32_t>"),
         endsAttr);
 
     // Create span from SmallVector variable using CallOpaqueOp
-    auto endsSpanVar = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto endsSpanVar = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::Span<const int32_t>"),
         "ttsl::make_const_span", mlir::ArrayAttr{}, nullptr,
@@ -2903,15 +2906,15 @@ public:
 
     // Create SmallVector variable for step
     auto stepAttr = emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep());
-    auto stepVar = rewriter.create<emitc::ConstantOp>(
-        srcOp.getLoc(),
+    auto stepVar = emitc::ConstantOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::SmallVector<int32_t>"),
         stepAttr);
 
     // Create span from SmallVector variable using CallOpaqueOp
-    auto stepSpanVar = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto stepSpanVar = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         emitc::OpaqueType::get(rewriter.getContext(),
                                "::ttsl::Span<const int32_t>"),
         "ttsl::make_const_span", mlir::ArrayAttr{}, nullptr,
@@ -3106,8 +3109,8 @@ public:
     auto resultType =
         this->getTypeConverter()->convertType(srcOp.getResult().getType());
 
-    auto callOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(), resultType, "ttnn::batch_norm",
+    auto callOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), resultType, "ttnn::batch_norm",
         rewriter.getArrayAttr(args), /*template_args=*/nullptr,
         adaptor.getOperands());
 
@@ -3362,8 +3365,8 @@ public:
                   mlir::tt::ttnn::PointToPointOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.create<emitc::VerbatimOp>(
-        srcOp.getLoc(),
+    emitc::VerbatimOp::create(
+        rewriter, srcOp.getLoc(),
         "assert(0 && \"PointToPoint  operation is "
         "not supported in emitc yet.\"); // ::ttnn::PointToPoint");
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::PointToPointOp> emitter(
@@ -3631,8 +3634,8 @@ public:
       operands.push_back(adaptor.getBatchOffset());
     }
 
-    auto nlpCreateQKVHeadsDecodeOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto nlpCreateQKVHeadsDecodeOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         rewriter.getType<emitc::OpaqueType>(
             ttnn_to_emitc::TypeNameV<OpReturnType>),
         convertOpName(srcOp), rewriter.getArrayAttr(args),
@@ -3640,8 +3643,8 @@ public:
 
     llvm::SmallVector<mlir::Value, 3> results;
     for (std::size_t i = 0; i < srcOp.getNumResults(); ++i) {
-      auto tupleGetResult = rewriter.create<emitc::CallOpaqueOp>(
-          srcOp.getLoc(),
+      auto tupleGetResult = emitc::CallOpaqueOp::create(
+          rewriter, srcOp.getLoc(),
           rewriter.getType<emitc::OpaqueType>(
               ttnn_to_emitc::TypeNameV<::ttnn::Tensor>),
           "::std::get", /*args=*/nullptr,
@@ -3697,18 +3700,17 @@ public:
     using OpReturnType =
         std::tuple<::ttnn::Tensor, ::ttnn::Tensor, ::ttnn::Tensor>;
 
-    auto splitQueryKeyValueAndSplitHeadsOp =
-        rewriter.create<emitc::CallOpaqueOp>(
-            srcOp.getLoc(),
-            rewriter.getType<emitc::OpaqueType>(
-                ttnn_to_emitc::TypeNameV<OpReturnType>),
-            convertOpName(srcOp), rewriter.getArrayAttr(args),
-            /*template_args=*/nullptr, adaptor.getOperands());
+    auto splitQueryKeyValueAndSplitHeadsOp = emitc::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
+        rewriter.getType<emitc::OpaqueType>(
+            ttnn_to_emitc::TypeNameV<OpReturnType>),
+        convertOpName(srcOp), rewriter.getArrayAttr(args),
+        /*template_args=*/nullptr, adaptor.getOperands());
 
     llvm::SmallVector<mlir::Value, 3> results;
     for (std::size_t i = 0; i < srcOp.getNumResults(); ++i) {
-      auto tupleGetResult = rewriter.create<emitc::CallOpaqueOp>(
-          srcOp.getLoc(),
+      auto tupleGetResult = emitc::CallOpaqueOp::create(
+          rewriter, srcOp.getLoc(),
           rewriter.getType<emitc::OpaqueType>(
               ttnn_to_emitc::TypeNameV<::ttnn::Tensor>),
           "::std::get", /*args=*/nullptr,
@@ -3890,13 +3892,13 @@ public:
     rewriter.setInsertionPoint(&*insertionPointOp);
 
     // Define global variable to track if this is the first call.
-    auto isFirstCall = rewriter.create<emitc::GlobalOp>(
-        loc, /*sym_name=*/"is_first_call", rewriter.getI1Type(),
+    auto isFirstCall = emitc::GlobalOp::create(
+        rewriter, loc, /*sym_name=*/"is_first_call", rewriter.getI1Type(),
         rewriter.getBoolAttr(true));
 
     // Define global variable to track the trace id.
-    auto traceId = rewriter.create<emitc::GlobalOp>(
-        loc, /*sym_name=*/"trace_id",
+    auto traceId = emitc::GlobalOp::create(
+        rewriter, loc, /*sym_name=*/"trace_id",
         getTypeConverter()->convertType(
             mlir::tt::ttnn::utils::getTraceIdType(srcOp.getContext())),
         /*initial_value=*/nullptr);
@@ -3904,8 +3906,8 @@ public:
     // Define global variables to track the inputs.
     llvm::SmallVector<emitc::GlobalOp> traceInputVariable;
     for (auto [i, input] : llvm::enumerate(adaptor.getInputs())) {
-      traceInputVariable.emplace_back(rewriter.create<emitc::GlobalOp>(
-          loc, /*sym_name=*/"input_" + std::to_string(i),
+      traceInputVariable.emplace_back(emitc::GlobalOp::create(
+          rewriter, loc, /*sym_name=*/"input_" + std::to_string(i),
           getTypeConverter()->convertType(input.getType()),
           /*initial_value=*/nullptr));
     }
@@ -3913,8 +3915,8 @@ public:
     // Define global variables to track the outputs.
     llvm::SmallVector<emitc::GlobalOp> traceOutputVariable;
     for (auto [i, output] : llvm::enumerate(srcOp.getResults())) {
-      traceOutputVariable.emplace_back(rewriter.create<emitc::GlobalOp>(
-          loc, /*sym_name=*/"output_" + std::to_string(i),
+      traceOutputVariable.emplace_back(emitc::GlobalOp::create(
+          rewriter, loc, /*sym_name=*/"output_" + std::to_string(i),
           getTypeConverter()->convertType(output.getType()),
           /*initial_value=*/nullptr));
     }
@@ -3933,7 +3935,7 @@ public:
     auto funcType = rewriter.getFunctionType(inputTypes, resultTypes);
 
     rewriter.setInsertionPoint(srcOp->getParentOfType<func::FuncOp>());
-    auto funcOp = rewriter.create<emitc::FuncOp>(loc, funcName, funcType);
+    auto funcOp = emitc::FuncOp::create(rewriter, loc, funcName, funcType);
 
     auto *block = funcOp.addEntryBlock();
 
@@ -3942,15 +3944,16 @@ public:
     // Define local variables that represent the return values.
     llvm::SmallVector<emitc::VariableOp> returnVariable =
         llvm::map_to_vector(resultTypes, [&](auto resultType) {
-          return rewriter.create<emitc::VariableOp>(
-              loc, emitc::LValueType::get(ttnnTensorType),
+          return emitc::VariableOp::create(
+              rewriter, loc, emitc::LValueType::get(ttnnTensorType),
               emitc::OpaqueAttr::get(rewriter.getContext(),
                                      "::ttnn::Tensor()"));
         });
 
     // Create if statement with then/else blocks
-    auto ifOp = rewriter.create<emitc::IfOp>(
-        loc, loadGlobalVariable(rewriter, srcOp.getLoc(), isFirstCall),
+    auto ifOp = emitc::IfOp::create(
+        rewriter, loc,
+        loadGlobalVariable(rewriter, srcOp.getLoc(), isFirstCall),
         /*add_then_block=*/true,
         /*add_else_block=*/true);
 
@@ -3960,25 +3963,25 @@ public:
       rewriter.setInsertionPointToStart(&thenBlock);
 
       // is_first_call = false;
-      auto falseC = rewriter.create<mlir::arith::ConstantOp>(
-          loc, rewriter.getI1Type(), rewriter.getBoolAttr(false));
-      rewriter.create<emitc::AssignOp>(
-          loc, getGlobalVariable(rewriter, loc, isFirstCall), falseC);
+      auto falseC = mlir::arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI1Type(), rewriter.getBoolAttr(false));
+      emitc::AssignOp::create(
+          rewriter, loc, getGlobalVariable(rewriter, loc, isFirstCall), falseC);
 
       // v = capture_callee(args...)
       // First block argument is the device, so we drop it.
       auto autoTy = emitc::OpaqueType::get(ctx, "auto");
-      auto captureTuple = rewriter.create<emitc::CallOpaqueOp>(
-          loc, autoTy, srcOp.getCaptureCallee(), nullptr, nullptr,
+      auto captureTuple = emitc::CallOpaqueOp::create(
+          rewriter, loc, autoTy, srcOp.getCaptureCallee(), nullptr, nullptr,
           block->getArguments().drop_front());
 
       // trace_id = std::get<0>(v);
-      auto getTraceId = rewriter.create<emitc::CallOpaqueOp>(
-          loc, traceId.getType(), "::std::get<0>", nullptr, nullptr,
+      auto getTraceId = emitc::CallOpaqueOp::create(
+          rewriter, loc, traceId.getType(), "::std::get<0>", nullptr, nullptr,
           captureTuple.getResult(0));
-      rewriter.create<emitc::AssignOp>(
-          loc, getGlobalVariable(rewriter, loc, traceId),
-          getTraceId.getResult(0));
+      emitc::AssignOp::create(rewriter, loc,
+                              getGlobalVariable(rewriter, loc, traceId),
+                              getTraceId.getResult(0));
 
       // local_output_0 = std::get<outputBaseIndex + i>(v);
       // ...
@@ -3987,11 +3990,11 @@ public:
       for (size_t i = 0; i < returnVariable.size(); ++i) {
         std::string getName =
             "::std::get<" + std::to_string(outputBaseIndex + i) + ">";
-        auto getResult = rewriter.create<emitc::CallOpaqueOp>(
-            loc, ttnnTensorType, getName, nullptr, nullptr,
+        auto getResult = emitc::CallOpaqueOp::create(
+            rewriter, loc, ttnnTensorType, getName, nullptr, nullptr,
             captureTuple.getResult(0));
-        rewriter.create<emitc::AssignOp>(loc, returnVariable[i].getResult(),
-                                         getResult.getResult(0));
+        emitc::AssignOp::create(rewriter, loc, returnVariable[i].getResult(),
+                                getResult.getResult(0));
       }
 
       // input_i = std::get<inputBaseIndex + i>(v)
@@ -3999,11 +4002,12 @@ public:
       for (size_t i = 0; i < traceInputVariable.size(); ++i) {
         std::string getName =
             "::std::get<" + std::to_string(inputBaseIndex + i) + ">";
-        auto getResult = rewriter.create<emitc::CallOpaqueOp>(
-            loc, traceInputVariable[i].getType(), getName, nullptr, nullptr,
-            ValueRange{captureTuple.getResult(0)});
-        rewriter.create<emitc::AssignOp>(
-            loc, getGlobalVariable(rewriter, loc, traceInputVariable[i]),
+        auto getResult = emitc::CallOpaqueOp::create(
+            rewriter, loc, traceInputVariable[i].getType(), getName, nullptr,
+            nullptr, ValueRange{captureTuple.getResult(0)});
+        emitc::AssignOp::create(
+            rewriter, loc,
+            getGlobalVariable(rewriter, loc, traceInputVariable[i]),
             getResult.getResult(0));
       }
 
@@ -4012,15 +4016,16 @@ public:
       for (size_t i = 0; i < traceOutputVariable.size(); ++i) {
         std::string getName =
             "::std::get<" + std::to_string(traceOutputBaseIndex + i) + ">";
-        auto getResult = rewriter.create<emitc::CallOpaqueOp>(
-            loc, traceOutputVariable[i].getType(), getName, nullptr, nullptr,
-            captureTuple.getResult(0));
-        rewriter.create<emitc::AssignOp>(
-            loc, getGlobalVariable(rewriter, loc, traceOutputVariable[i]),
+        auto getResult = emitc::CallOpaqueOp::create(
+            rewriter, loc, traceOutputVariable[i].getType(), getName, nullptr,
+            nullptr, captureTuple.getResult(0));
+        emitc::AssignOp::create(
+            rewriter, loc,
+            getGlobalVariable(rewriter, loc, traceOutputVariable[i]),
             getResult.getResult(0));
       }
 
-      rewriter.create<emitc::YieldOp>(loc);
+      emitc::YieldOp::create(rewriter, loc);
     }
 
     // ELSE: execute path
@@ -4029,17 +4034,17 @@ public:
       rewriter.setInsertionPointToStart(&elseBlock);
 
       // execute_callee(trace_id);
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, srcOp.getExecuteCallee(), nullptr, nullptr,
-          loadGlobalVariable(rewriter, loc, traceId));
+      emitc::CallOpaqueOp::create(rewriter, loc, TypeRange{},
+                                  srcOp.getExecuteCallee(), nullptr, nullptr,
+                                  loadGlobalVariable(rewriter, loc, traceId));
 
       // Load the result to the return variable.
       assert(returnVariable.size() == 1 && "expected one return variable");
-      rewriter.create<emitc::AssignOp>(
-          loc, returnVariable[0],
+      emitc::AssignOp::create(
+          rewriter, loc, returnVariable[0],
           loadGlobalVariable(rewriter, loc, traceOutputVariable[0]));
 
-      rewriter.create<emitc::YieldOp>(loc);
+      emitc::YieldOp::create(rewriter, loc);
     }
 
     // After the if-then-else, load the result and return it from the function.
@@ -4047,8 +4052,8 @@ public:
 
     assert(returnVariable.size() == 1 && "expected one return variable");
     auto result =
-        rewriter.create<emitc::LoadOp>(loc, ttnnTensorType, returnVariable[0]);
-    rewriter.create<emitc::ReturnOp>(loc, result.getResult());
+        emitc::LoadOp::create(rewriter, loc, ttnnTensorType, returnVariable[0]);
+    emitc::ReturnOp::create(rewriter, loc, result.getResult());
 
     // Replace the original operation with a call to our new function.
     auto resultType =
@@ -4066,8 +4071,8 @@ private:
   mlir::Value getGlobalVariable(mlir::PatternRewriter &rewriter,
                                 mlir::Location loc,
                                 emitc::GlobalOp globalOp) const {
-    return rewriter.create<emitc::GetGlobalOp>(
-        loc, emitc::LValueType::get(globalOp.getType()),
+    return emitc::GetGlobalOp::create(
+        rewriter, loc, emitc::LValueType::get(globalOp.getType()),
         globalOp.getSymNameAttr());
   }
 
@@ -4075,7 +4080,8 @@ private:
                                  mlir::Location loc,
                                  emitc::GlobalOp globalOp) const {
     auto getGlobalOp = getGlobalVariable(rewriter, loc, globalOp);
-    return rewriter.create<emitc::LoadOp>(loc, globalOp.getType(), getGlobalOp);
+    return emitc::LoadOp::create(rewriter, loc, globalOp.getType(),
+                                 getGlobalOp);
   }
 };
 } // namespace
@@ -4130,12 +4136,11 @@ public:
     // The `update_index` is modeled as a tensor in the IR, but the
     // `ttnn::update_cache` expects a `uint32_t` scalar.
     mlir::Value updateIndex =
-        rewriter
-            .create<emitc::CallOpaqueOp>(
-                srcOp.getLoc(), rewriter.getI32Type(),
-                ttnn_to_emitc::kGetScalarFromTensorFunctionName,
-                /*args=*/nullptr,
-                /*template_args=*/nullptr, adaptor.getUpdateIndex())
+        emitc::CallOpaqueOp::create(
+            rewriter, srcOp.getLoc(), rewriter.getI32Type(),
+            ttnn_to_emitc::kGetScalarFromTensorFunctionName,
+            /*args=*/nullptr,
+            /*template_args=*/nullptr, adaptor.getUpdateIndex())
             .getResult(0);
 
     llvm::SmallVector<mlir::Attribute> args{

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -96,8 +96,8 @@ struct ConvertTTNNToEmitCPass
 
       // Include headers
       //
-      builder.create<emitc::IncludeOp>(module.getLoc(), "ttnn-precompiled.hpp",
-                                       /*isStandard=*/false);
+      emitc::IncludeOp::create(builder, module.getLoc(), "ttnn-precompiled.hpp",
+                               /*isStandard=*/false);
     }
 
     // Unwrap device_module into top-level ModuleOp (if present)

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2309,13 +2309,12 @@ public:
 
     // The `update_index` is modeled as a tensor in the IR, but the
     // `ttnn.update_cache` expects a `int` scalar.
-    auto updateIndex = rewriter
-                           .create<emitpy::CallOpaqueOp>(
-                               srcOp.getLoc(), rewriter.getI32Type(),
-                               ttnn_to_emitpy::kGetScalarFromTensorFunctionName,
-                               adaptor.getUpdateIndex(),
-                               /*args=*/nullptr,
-                               /*keyword_args=*/nullptr)
+    auto updateIndex = emitpy::CallOpaqueOp::create(
+                           rewriter, srcOp.getLoc(), rewriter.getI32Type(),
+                           ttnn_to_emitpy::kGetScalarFromTensorFunctionName,
+                           adaptor.getUpdateIndex(),
+                           /*args=*/nullptr,
+                           /*keyword_args=*/nullptr)
                            .getResult(0);
 
     llvm::SmallVector<mlir::Attribute> args{
@@ -2346,8 +2345,8 @@ public:
     // SubscriptOp requires a Value object as index, which is created by
     // invoking the emitpy::LiteralOp.
     //
-    Value indexAsVal = rewriter.create<emitpy::LiteralOp>(
-        getTupleElementOp->getLoc(), rewriter.getIndexType(),
+    Value indexAsVal = emitpy::LiteralOp::create(
+        rewriter, getTupleElementOp->getLoc(), rewriter.getIndexType(),
         std::to_string(adaptor.getIndex()));
 
     rewriter.replaceOpWithNewOp<emitpy::SubscriptOp>(
@@ -2404,8 +2403,8 @@ public:
     // Create a global variable for caching.
     //
     std::string globalVarName = "CACHED_" + calleeName.str();
-    rewriter.create<emitpy::GlobalOp>(
-        loadCachedOp.getLoc(),
+    emitpy::GlobalOp::create(
+        rewriter, loadCachedOp.getLoc(),
         StringAttr::get(rewriter.getContext(), globalVarName),
         emitpy::OpaqueAttr::get(rewriter.getContext(), "None"));
     rewriter.restoreInsertionPoint(currentInsertionPoint);
@@ -2420,10 +2419,9 @@ public:
             : emitpy::OpaqueType::get(rewriter.getContext(),
                                       "([ttnn.Tensor]) -> [ttnn.Tensor]");
     mlir::Value callee =
-        rewriter
-            .create<emitpy::ConstantOp>(
-                loadCachedOp.getLoc(), calleeType,
-                emitpy::OpaqueAttr::get(rewriter.getContext(), calleeName))
+        emitpy::ConstantOp::create(
+            rewriter, loadCachedOp.getLoc(), calleeType,
+            emitpy::OpaqueAttr::get(rewriter.getContext(), calleeName))
             ->getResult(0);
 
     llvm::SmallVector<Value> operands;
@@ -2433,13 +2431,11 @@ public:
     //
     if (loadCachedOp.getInputs().size() > 0) {
       mlir::Value tensorsInList =
-          rewriter
-              .create<emitpy::CallOpaqueOp>(
-                  loadCachedOp.getLoc(),
-                  emitpy::OpaqueType::get(rewriter.getContext(),
-                                          "[ttnn.Tensor]"),
-                  ttnn_to_emitpy::kCreateListFunctionName,
-                  adaptor.getOperands(), nullptr)
+          emitpy::CallOpaqueOp::create(
+              rewriter, loadCachedOp.getLoc(),
+              emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]"),
+              ttnn_to_emitpy::kCreateListFunctionName, adaptor.getOperands(),
+              nullptr)
               ->getResult(0);
       operands.push_back(tensorsInList);
     }
@@ -2453,16 +2449,15 @@ public:
     //
     currentInsertionPoint = rewriter.saveInsertionPoint();
     rewriter.setInsertionPointToStart(&funcOp.getBody().front());
-    rewriter.create<emitpy::GlobalStatementOp>(loadCachedOp.getLoc(),
-                                               tensorListType, globalSymbol);
+    emitpy::GlobalStatementOp::create(rewriter, loadCachedOp.getLoc(),
+                                      tensorListType, globalSymbol);
     rewriter.restoreInsertionPoint(currentInsertionPoint);
 
     // Retrieve a global variable.
     //
     mlir::Value globalVar =
-        rewriter
-            .create<emitpy::GetGlobalOp>(loadCachedOp.getLoc(), tensorListType,
-                                         globalSymbol)
+        emitpy::GetGlobalOp::create(rewriter, loadCachedOp.getLoc(),
+                                    tensorListType, globalSymbol)
             ->getResult(0);
     operands.push_back(globalVar);
 
@@ -2475,11 +2470,12 @@ public:
     llvm::StringRef wrapperFuncName =
         isZeroArgWrapper ? constEvalFuncWrapperZeroArg : constEvalFuncWrapper;
 
-    auto cacheOp = rewriter.create<emitpy::CallOpaqueOp>(
-        loadCachedOp.getLoc(), tensorListType, wrapperFuncName, operands);
+    auto cacheOp =
+        emitpy::CallOpaqueOp::create(rewriter, loadCachedOp.getLoc(),
+                                     tensorListType, wrapperFuncName, operands);
     mlir::Value cacheResult = cacheOp->getResult(0);
-    rewriter.create<emitpy::AssignGlobalOp>(loadCachedOp.getLoc(), globalSymbol,
-                                            cacheResult);
+    emitpy::AssignGlobalOp::create(rewriter, loadCachedOp.getLoc(),
+                                   globalSymbol, cacheResult);
 
     // Unpack list of tensors.
     //
@@ -2488,14 +2484,14 @@ public:
       // Create index value.
       //
       auto indexType = rewriter.getIndexType();
-      auto indexOp = rewriter.create<emitpy::LiteralOp>(
-          loadCachedOp.getLoc(), indexType, std::to_string(i));
+      auto indexOp = emitpy::LiteralOp::create(rewriter, loadCachedOp.getLoc(),
+                                               indexType, std::to_string(i));
       Value indexVal = indexOp.getResult();
 
       // Get reference to the i-th element in the result.
       //
-      auto subscriptOp = rewriter.create<emitpy::SubscriptOp>(
-          loadCachedOp.getLoc(),
+      auto subscriptOp = emitpy::SubscriptOp::create(
+          rewriter, loadCachedOp.getLoc(),
           emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.Tensor"),
           cacheResult, indexVal);
 
@@ -2884,8 +2880,8 @@ public:
       configKeywordArgs.push_back(rewriter.getStringAttr(""));
     }
 
-    auto mapperConfigOp = rewriter.create<emitpy::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto mapperConfigOp = emitpy::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.MeshMapperConfig"),
         "ttnn.MeshMapperConfig", llvm::SmallVector<mlir::Value>{},
         rewriter.getArrayAttr(configArgs),
@@ -2893,8 +2889,8 @@ public:
 
     auto meshMapperType =
         emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.TensorToMesh");
-    auto createMapperOp = rewriter.create<emitpy::CallOpaqueOp>(
-        srcOp.getLoc(), meshMapperType, "ttnn.create_mesh_mapper",
+    auto createMapperOp = emitpy::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), meshMapperType, "ttnn.create_mesh_mapper",
         llvm::SmallVector<mlir::Value>{adaptor.getMeshDevice(),
                                        mapperConfigOp.getResult(0)});
 
@@ -2951,8 +2947,8 @@ public:
       configKeywordArgs.push_back(rewriter.getStringAttr(""));
     }
 
-    auto composerConfigOp = rewriter.create<emitpy::CallOpaqueOp>(
-        srcOp.getLoc(),
+    auto composerConfigOp = emitpy::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(),
         emitpy::OpaqueType::get(rewriter.getContext(),
                                 "ttnn.MeshComposerConfig"),
         "ttnn.MeshComposerConfig", llvm::SmallVector<mlir::Value>{},
@@ -2961,8 +2957,8 @@ public:
 
     auto meshComposerType =
         emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.MeshToTensor");
-    auto createComposerOp = rewriter.create<emitpy::CallOpaqueOp>(
-        srcOp.getLoc(), meshComposerType, "ttnn.create_mesh_composer",
+    auto createComposerOp = emitpy::CallOpaqueOp::create(
+        rewriter, srcOp.getLoc(), meshComposerType, "ttnn.create_mesh_composer",
         llvm::SmallVector<mlir::Value>{adaptor.getMeshDevice(),
                                        composerConfigOp.getResult(0)});
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPyPass.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPyPass.cpp
@@ -70,10 +70,10 @@ struct ConvertTTNNToEmitPyPass
 
     // Include headers
     //
-    builder.create<emitpy::ImportOp>(module->getLoc(), "ttnn", nullptr, nullptr,
-                                     nullptr, nullptr);
-    builder.create<emitpy::ImportOp>(module->getLoc(), "utils", nullptr,
-                                     nullptr, nullptr, nullptr);
+    emitpy::ImportOp::create(builder, module->getLoc(), "ttnn", nullptr,
+                             nullptr, nullptr, nullptr);
+    emitpy::ImportOp::create(builder, module->getLoc(), "utils", nullptr,
+                             nullptr, nullptr, nullptr);
 
     // Unwrap device_module into top-level ModuleOp (if present)
     {

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -31,8 +31,8 @@ bufferizeCBOp(OpTy op, mlir::RewriterBase &rewriter,
       mlir::cast<bufferization::TensorLikeType>(op.getCbType())
           .getBufferType(options, [&]() { return op.emitOpError(); });
   assert(succeeded(cbBufferType));
-  auto toBuffer = rewriter.create<bufferization::ToBufferOp>(
-      op.getLoc(), *cbBufferType, op.getCb());
+  auto toBuffer = bufferization::ToBufferOp::create(rewriter, op.getLoc(),
+                                                    *cbBufferType, op.getCb());
   mlir::bufferization::replaceOpWithNewBufferizedOp<OpTy>(rewriter, op,
                                                           toBuffer.getResult());
   return mlir::success();
@@ -423,8 +423,8 @@ mlir::LogicalResult TileTilizeBlockOp::bufferize(
   }
 
   mlir::Operation *old = getOperation();
-  auto newOp =
-      rewriter.create<mlir::tt::d2m::TileTilizeBlockOp>(old->getLoc(), in, out);
+  auto newOp = mlir::tt::d2m::TileTilizeBlockOp::create(rewriter, old->getLoc(),
+                                                        in, out);
   rewriter.replaceOp(old, newOp->getResults());
   return mlir::success();
 }
@@ -506,8 +506,8 @@ mlir::LogicalResult TileUntilizeBlockOp::bufferize(
   }
 
   mlir::Operation *old = getOperation();
-  auto newOp = rewriter.create<mlir::tt::d2m::TileUntilizeBlockOp>(
-      old->getLoc(), in, out);
+  auto newOp = mlir::tt::d2m::TileUntilizeBlockOp::create(
+      rewriter, old->getLoc(), in, out);
   rewriter.replaceOp(old, newOp->getResults());
   return mlir::success();
 }

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1198,7 +1198,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     rewriter.setInsertionPoint(op);
 
     auto bufferAllocOp =
-        rewriter.create<memref::AllocOp>(op.getLoc(), bufferType);
+        memref::AllocOp::create(rewriter, op.getLoc(), bufferType);
 
     assignAddressAndAlignment(rewriter, bufferAllocOp, req.offset, info);
     insertDealloc(rewriter, bufferAllocOp, req.last, sequencing);
@@ -1212,9 +1212,10 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         getStreamType(bufferType.getShape(), reblockingMap,
                       oldOperandType.getElementType(), remappedMemspace);
 
-    auto streamOp = rewriter.create<d2m::StreamLayoutOp>(
-        op.getLoc(), /* result */ streamType, /* input */ operand.get(),
-        /* storage */ bufferAllocOp);
+    auto streamOp = d2m::StreamLayoutOp::create(rewriter, op.getLoc(),
+                                                /* result */ streamType,
+                                                /* input */ operand.get(),
+                                                /* storage */ bufferAllocOp);
 
     rewriter.startOpModification(op);
     {
@@ -1251,8 +1252,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       OpBuilder::InsertionGuard guard(rewriter);
       {
         rewriter.setInsertionPointAfter(lastOp);
-        rewriter.create<memref::DeallocOp>(lastOp->getLoc(),
-                                           allocOp.getResult());
+        memref::DeallocOp::create(rewriter, lastOp->getLoc(),
+                                  allocOp.getResult());
       }
     }
   }

--- a/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
+++ b/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
@@ -233,8 +233,8 @@ static GenericOp createFusedGeneric(OpOperand *fusedOperand, GenericOp producer,
   /////////////////////////////////////////////////////////////////////////////
   auto fusedResultTypes = TypeRange(fusedOutputs);
 
-  auto fusedOp = rewriter.create<GenericOp>(
-      consumer.getLoc(), fusedResultTypes, fusedInputs, fusedOutputs,
+  auto fusedOp = GenericOp::create(
+      rewriter, consumer.getLoc(), fusedResultTypes, fusedInputs, fusedOutputs,
       consumer.getGrid(), consumer.getBlockFactors(),
       rewriter.getAffineMapArrayAttr(fusedMaps), consumer.getIteratorTypes(),
       consumer.getThreads(), /*regions=*/1);
@@ -463,7 +463,7 @@ static GenericOp createFusedGeneric(OpOperand *fusedOperand, GenericOp producer,
     fusedYields.push_back(irMap.lookupOrDefault(y));
   }
   rewriter.setInsertionPointToEnd(&fusedBlock);
-  rewriter.create<YieldOp>(fusedOp.getLoc(), fusedYields);
+  YieldOp::create(rewriter, fusedOp.getLoc(), fusedYields);
 
   return fusedOp;
 }

--- a/lib/Dialect/D2M/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericGenerateDatamovement.cpp
@@ -115,10 +115,9 @@ public:
           mlir::cast<ShapedType>(dst.getType()).getNumElements());
     }
 
-    return builder
-        .create<d2m::DMAOp>(loc, src, srcIndexingMapAttr, ValueRange(), dst,
-                            dstIndexingMapAttr, ValueRange(), numElemsAttr,
-                            coreIndex, mcastShape)
+    return d2m::DMAOp::create(builder, loc, src, srcIndexingMapAttr,
+                              ValueRange(), dst, dstIndexingMapAttr,
+                              ValueRange(), numElemsAttr, coreIndex, mcastShape)
         .getResult();
   }
 
@@ -134,10 +133,10 @@ public:
   calculateGatherMcastArguments(PatternRewriter &rewriter, Location loc,
                                 ttcore::GridAttr grid,
                                 ArrayRef<ttcore::IteratorType> mcastIterators) {
-    Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
-    Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
-                                                   rewriter.getIndexAttr(1));
+    Value zero = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
+    Value one = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexType(), rewriter.getIndexAttr(1));
 
     McastArguments args;
     args.senderCoreIndex.reserve(grid.getShape().size());
@@ -145,25 +144,26 @@ public:
     args.mcastShape.reserve(grid.getShape().size());
 
     for (auto [dim, iteratorType] : llvm::enumerate(mcastIterators)) {
-      Value core = rewriter.create<CoreIndexOp>(
-          loc, rewriter.getIndexType(), rewriter.getI64IntegerAttr(dim));
+      Value core = CoreIndexOp::create(rewriter, loc, rewriter.getIndexType(),
+                                       rewriter.getI64IntegerAttr(dim));
       if (iteratorType == ttcore::IteratorType::Parallel) {
         args.senderCoreIndex.push_back(Value(core));
         args.mcastCoreIndex.push_back(Value(core));
         args.mcastShape.push_back(Value(one));
       } else {
         int64_t numDests = grid.getShape()[dim] - 1;
-        Value gridDimMinusOne = rewriter.create<arith::ConstantOp>(
-            loc, rewriter.getIndexType(), rewriter.getIndexAttr(numDests));
+        Value gridDimMinusOne =
+            arith::ConstantOp::create(rewriter, loc, rewriter.getIndexType(),
+                                      rewriter.getIndexAttr(numDests));
         assert(iteratorType == ttcore::IteratorType::Reduction);
         args.senderCoreIndex.push_back(zero);
         args.mcastCoreIndex.push_back(one);
         args.mcastShape.push_back(gridDimMinusOne);
         args.mcastVolume *= numDests;
 
-        Value condition = rewriter.create<arith::CmpIOp>(
-            loc, rewriter.getI1Type(), mlir::arith::CmpIPredicate::eq, core,
-            zero);
+        Value condition =
+            arith::CmpIOp::create(rewriter, loc, rewriter.getI1Type(),
+                                  mlir::arith::CmpIPredicate::eq, core, zero);
         args.conditions.push_back(condition);
       }
     }
@@ -182,43 +182,43 @@ public:
                        MutableArrayRef<Region> regions) {
     McastArguments mcastArgs =
         calculateGatherMcastArguments(builder, loc, grid, mcastIterators);
-    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                   builder.getIndexAttr(0));
-    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                  builder.getIndexAttr(1));
+    Value zero = arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                           builder.getIndexAttr(0));
+    Value one = arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                          builder.getIndexAttr(1));
     assert(mcastArgs.mcastVolume > 0);
-    Value mcastVolumeVal = builder.create<arith::ConstantOp>(
-        loc, builder.getIndexType(),
-        builder.getIndexAttr(mcastArgs.mcastVolume));
+    Value mcastVolumeVal =
+        arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                  builder.getIndexAttr(mcastArgs.mcastVolume));
     Value receiversReadySemaphore = createSemaphore(builder, loc, regions);
     Value senderFinishedSemaphore = createSemaphore(builder, loc, regions);
     assert(mcastArgs.mcastCoreIndex.size() == mcastArgs.mcastShape.size());
     assert(mcastArgs.conditions.size() == 1 &&
            "Exactly one condition supported");
-    builder.create<scf::IfOp>(
-        loc, mcastArgs.conditions[0],
+    scf::IfOp::create(
+        builder, loc, mcastArgs.conditions[0],
         [&](OpBuilder &builder, Location loc) {
           bool isOutput = false;
           Value gatherMemTx =
               createDMA(builder, loc, src, dst, operandIndexingMap, isOutput);
-          builder.create<d2m::DMAWaitOp>(loc, gatherMemTx);
-          builder.create<d2m::SemaphoreWaitOp>(loc, receiversReadySemaphore,
-                                               mcastVolumeVal, zero);
+          d2m::DMAWaitOp::create(builder, loc, gatherMemTx);
+          d2m::SemaphoreWaitOp::create(builder, loc, receiversReadySemaphore,
+                                       mcastVolumeVal, zero);
           Value mcastMemTx =
               createDMA(builder, loc, dst, dst, std::nullopt, isOutput,
                         mcastArgs.mcastCoreIndex, mcastArgs.mcastShape);
-          builder.create<d2m::DMAWaitOp>(loc, mcastMemTx);
-          builder.create<d2m::SemaphoreSetOp>(loc, senderFinishedSemaphore, one,
-                                              mcastArgs.mcastCoreIndex,
-                                              mcastArgs.mcastShape);
-          builder.create<scf::YieldOp>(loc);
+          d2m::DMAWaitOp::create(builder, loc, mcastMemTx);
+          d2m::SemaphoreSetOp::create(builder, loc, senderFinishedSemaphore,
+                                      one, mcastArgs.mcastCoreIndex,
+                                      mcastArgs.mcastShape);
+          scf::YieldOp::create(builder, loc);
         },
         [&](OpBuilder &builder, Location loc) {
-          builder.create<d2m::SemaphoreIncOp>(loc, receiversReadySemaphore, one,
-                                              mcastArgs.senderCoreIndex);
-          builder.create<d2m::SemaphoreWaitOp>(loc, senderFinishedSemaphore,
-                                               one, zero);
-          builder.create<scf::YieldOp>(loc);
+          d2m::SemaphoreIncOp::create(builder, loc, receiversReadySemaphore,
+                                      one, mcastArgs.senderCoreIndex);
+          d2m::SemaphoreWaitOp::create(builder, loc, senderFinishedSemaphore,
+                                       one, zero);
+          scf::YieldOp::create(builder, loc);
         });
   }
 
@@ -230,8 +230,8 @@ public:
                          bool isOutput, MutableArrayRef<Region> regions) {
     Value cb =
         isOutput
-            ? builder.create<d2m::WaitOp>(loc, blockOperand).getResult()
-            : builder.create<d2m::ReserveOp>(loc, blockOperand).getResult();
+            ? d2m::WaitOp::create(builder, loc, blockOperand).getResult()
+            : d2m::ReserveOp::create(builder, loc, blockOperand).getResult();
 
     if (isStream(genericOperand)) {
       Value src = isOutput ? cb : genericOperand;
@@ -246,7 +246,7 @@ public:
       } else {
         Value memTx =
             createDMA(builder, loc, src, dst, operandIndexingMap, isOutput);
-        builder.create<d2m::DMAWaitOp>(loc, memTx);
+        d2m::DMAWaitOp::create(builder, loc, memTx);
       }
     }
 
@@ -267,11 +267,12 @@ public:
         numDataMovementRegions,
         rewriter.getAttr<ThreadAttr>(ThreadType::Datamovement));
     threads.append(generic.getThreads().begin(), generic.getThreads().end());
-    auto newGeneric = rewriter.create<GenericOp>(
-        generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
-        generic.getOutputs(), generic.getGrid(), generic.getBlockFactors(),
-        generic.getIndexingMaps(), generic.getIteratorTypes(),
-        rewriter.getArrayAttr(threads), numTotalRegions);
+    auto newGeneric =
+        GenericOp::create(rewriter, generic->getLoc(), generic.getResultTypes(),
+                          generic.getInputs(), generic.getOutputs(),
+                          generic.getGrid(), generic.getBlockFactors(),
+                          generic.getIndexingMaps(), generic.getIteratorTypes(),
+                          rewriter.getArrayAttr(threads), numTotalRegions);
 
     // Preinitialize all regions so that we can modify their signatures on the
     // fly. i.e. adding semaphore arguments.

--- a/lib/Dialect/D2M/Transforms/GenericGenerateLoops.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericGenerateLoops.cpp
@@ -20,14 +20,14 @@ public:
   static std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
   buildLoopBounds(OpBuilder &builder, Location loc,
                   ArrayRef<int64_t> loopBounds) {
-    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                   builder.getIndexAttr(0));
-    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                  builder.getIndexAttr(1));
+    Value zero = arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                           builder.getIndexAttr(0));
+    Value one = arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                          builder.getIndexAttr(1));
     SmallVector<Value> lbs(loopBounds.size(), zero);
     SmallVector<Value> ubs(llvm::map_range(loopBounds, [&](int64_t dim) {
-      return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                               builder.getIndexAttr(dim));
+      return arith::ConstantOp::create(builder, loc, builder.getIndexType(),
+                                       builder.getIndexAttr(dim));
     }));
     SmallVector<Value> step(loopBounds.size(), one);
     return std::make_tuple(lbs, ubs, step);
@@ -64,9 +64,9 @@ public:
       return failure();
     }
 
-    auto loopedGeneric = rewriter.create<GenericOp>(
-        generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
-        generic.getOutputs(), generic.getGrid(),
+    auto loopedGeneric = GenericOp::create(
+        rewriter, generic->getLoc(), generic.getResultTypes(),
+        generic.getInputs(), generic.getOutputs(), generic.getGrid(),
         /* block_factors */ rewriter.getArrayAttr({}),
         /* indexing_maps */ rewriter.getArrayAttr({}),
         /* iterator_types */ rewriter.getArrayAttr({}), generic.getThreads(),

--- a/lib/Dialect/D2M/Transforms/GenericLinearizeMemref.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericLinearizeMemref.cpp
@@ -68,8 +68,8 @@ public:
                                                               collapsedDims) &&
              "linearizeAffineMap assumes that the shape is collapsible aka "
              "has contiguous memory layout");
-      linearizedArg = rewriter.create<memref::CollapseShapeOp>(op.getLoc(), val,
-                                                               collapsedDims);
+      linearizedArg = memref::CollapseShapeOp::create(rewriter, op.getLoc(),
+                                                      val, collapsedDims);
       collapseOps->insert({val, linearizedArg});
     }
 
@@ -78,8 +78,8 @@ public:
 
     rewriter.setInsertionPoint(op);
 
-    Value linearIndex =
-        rewriter.create<affine::AffineApplyOp>(op.getLoc(), linearMap, indices);
+    Value linearIndex = affine::AffineApplyOp::create(rewriter, op.getLoc(),
+                                                      linearMap, indices);
 
     // Create new load/store with linearized access
     if constexpr (std::is_same_v<LoadStoreOp, memref::LoadOp>) {

--- a/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
@@ -37,7 +37,7 @@ static void rewriteOperand(OpBuilder &builder, DMAOpInterface dma,
         applyViews(dmaOperand.get().getDefiningOp());
   }
   Operation *globalOperand =
-      builder.create<GetGlobalOperandOp>(dma.getLoc(), memref, operandIndex);
+      GetGlobalOperandOp::create(builder, dma.getLoc(), memref, operandIndex);
   dmaOperand.set(globalOperand->getResult(0));
 }
 
@@ -90,24 +90,24 @@ public:
         Location loc = region.getNumArguments() > 0
                            ? region.getArgument(0).getLoc()
                            : generic.getLoc();
-        auto func = builder.create<func::FuncOp>(
-            loc, symbolName,
+        auto func = func::FuncOp::create(
+            builder, loc, symbolName,
             FunctionType::get(builder.getContext(), region.getArgumentTypes(),
                               {}));
         func.setPrivate();
         func->setAttr(d2m::ThreadAttr::name, threadAttrWithoutSym);
         func.getBody().takeBody(region);
         builder.setInsertionPointToEnd(&func.getBody().front());
-        builder.create<func::ReturnOp>(generic.getLoc());
+        func::ReturnOp::create(builder, generic.getLoc());
         threads.push_back(threadAttrWithSym);
       }
 
       builder.setInsertionPoint(generic);
-      auto symbolicGeneric = builder.create<GenericOp>(
-          generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
-          generic.getOutputs(), generic.getGrid(), generic.getBlockFactors(),
-          generic.getIndexingMaps(), generic.getIteratorTypes(),
-          builder.getArrayAttr(threads),
+      auto symbolicGeneric = GenericOp::create(
+          builder, generic->getLoc(), generic.getResultTypes(),
+          generic.getInputs(), generic.getOutputs(), generic.getGrid(),
+          generic.getBlockFactors(), generic.getIndexingMaps(),
+          generic.getIteratorTypes(), builder.getArrayAttr(threads),
           /*numRegions*/ 0);
 
       generic.replaceAllUsesWith(symbolicGeneric);

--- a/lib/Dialect/D2M/Transforms/GlobalDataFormatConversion.cpp
+++ b/lib/Dialect/D2M/Transforms/GlobalDataFormatConversion.cpp
@@ -52,7 +52,7 @@ struct GlobalDataFormatBodyConverter : mlir::TypeConverter {
                               mlir::Location loc) -> mlir::Value {
       mlir::RankedTensorType rankedType =
           mlir::cast<mlir::RankedTensorType>(type);
-      return builder.create<ttir::TypecastOp>(loc, rankedType, inputs);
+      return ttir::TypecastOp::create(builder, loc, rankedType, inputs);
     };
 
     addSourceMaterialization(materializeFunc); // Input conversions

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -390,17 +390,17 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
                             optimalGrid, isVirtualGrid, builder);
   builder.setInsertionPoint(emptyOp);
   auto newEmptyOp =
-      builder.create<d2m::EmptyOp>(emptyOp.getLoc(), newTensorType);
+      d2m::EmptyOp::create(builder, emptyOp.getLoc(), newTensorType);
 
   builder.setInsertionPoint(toLayoutOp);
-  auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
-      toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
+  auto newToLayoutOp = d2m::ToLayoutOp::create(
+      builder, toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
 
   // Reblock it back to original shape to preserve IR correctness.
   auto viewOutputType =
       utils::reblockTensor(newTensorType, oldLayout.getGridShape(outputType));
-  auto view = builder.create<d2m::ViewLayoutOp>(
-      toLayoutOp.getLoc(), viewOutputType, newToLayoutOp.getResult(0));
+  auto view = d2m::ViewLayoutOp::create(
+      builder, toLayoutOp.getLoc(), viewOutputType, newToLayoutOp.getResult(0));
 
   // We expect the ToLayout to be used only by the GenericOp we're optimizing.
   // Assert this assumption to catch unexpected sharing.
@@ -573,8 +573,9 @@ updateStreamLayoutOps(ArrayRef<StreamLayoutUpdateInfo> streamLayoutsToUpdate,
                            ? storageType.getElementType()
                            : ttcore::TileType::get(storageType.getElementType(),
                                                    llvm::ArrayRef(tileShape));
-    auto newStorageEmpty = builder.create<d2m::EmptyOp>(
-        storageEmpty.getLoc(), newStorageShape, elementType, newStorageLayout);
+    auto newStorageEmpty =
+        d2m::EmptyOp::create(builder, storageEmpty.getLoc(), newStorageShape,
+                             elementType, newStorageLayout);
 
     auto outputStreamType =
         mlir::cast<RankedTensorType>(streamLayout.getResult().getType());
@@ -594,9 +595,9 @@ updateStreamLayoutOps(ArrayRef<StreamLayoutUpdateInfo> streamLayoutsToUpdate,
         newStorageShape, outputStreamType.getElementType(), newOutputLayout);
 
     builder.setInsertionPoint(streamLayout);
-    auto newStreamLayout = builder.create<d2m::StreamLayoutOp>(
-        streamLayout.getLoc(), newStreamOutputType, streamLayout.getInput(),
-        newStorageEmpty);
+    auto newStreamLayout = d2m::StreamLayoutOp::create(
+        builder, streamLayout.getLoc(), newStreamOutputType,
+        streamLayout.getInput(), newStorageEmpty);
 
     // We expect the StreamLayout to be used only by the GenericOp we're
     // optimizing. Check that all uses are either the GenericOp itself or
@@ -634,7 +635,7 @@ static void updateEmptyOps(ArrayRef<EmptyUpdateInfo> emptyOpsToUpdate,
                               info.grid, info.isVirtualGrid, builder);
     builder.setInsertionPoint(info.op);
     auto newEmptyOp =
-        builder.create<d2m::EmptyOp>(emptyOp.getLoc(), newTensorType);
+        d2m::EmptyOp::create(builder, emptyOp.getLoc(), newTensorType);
     emptyOp.getResult().replaceAllUsesWith(newEmptyOp.getResult());
     emptyOp.erase();
   }
@@ -681,8 +682,8 @@ recreateGenericOp(d2m::GenericOp genericOp,
     auto tensorType =
         mlir::cast<mlir::RankedTensorType>(operand.get().getType());
     auto viewTensorType = utils::reblockTensor(tensorType, optimalGrid);
-    auto view = builder.create<d2m::ViewLayoutOp>(
-        genericOp.getLoc(), viewTensorType, operand.get());
+    auto view = d2m::ViewLayoutOp::create(builder, genericOp.getLoc(),
+                                          viewTensorType, operand.get());
     newOperands.push_back(view.getResult());
   }
 
@@ -696,9 +697,9 @@ recreateGenericOp(d2m::GenericOp genericOp,
 
     Region &oldRegion = genericOp.getRegion(0);
 
-    auto newGenericOp = builder.create<d2m::GenericOp>(
-        genericOp.getLoc(), newInputs, newOutputs, genericOp.getIndexingMaps(),
-        genericOp.getIteratorTypes(),
+    auto newGenericOp = d2m::GenericOp::create(
+        builder, genericOp.getLoc(), newInputs, newOutputs,
+        genericOp.getIndexingMaps(), genericOp.getIteratorTypes(),
         [&](OpBuilder &b, Location loc, ValueRange blockArgs) {
           IRMapping mapping;
           Block &oldBlock = oldRegion.front();
@@ -922,9 +923,10 @@ insertTTNNDRAMStreams(d2m::GenericOp genericOp,
 
     builder.setInsertionPointAfter(castOp);
     auto storageOp =
-        builder.create<d2m::EmptyOp>(castOp.getLoc(), storageTensor);
-    auto streamOp = builder.create<d2m::StreamLayoutOp>(
-        castOp.getLoc(), streamOutputTensor, castOp.getResult(), storageOp);
+        d2m::EmptyOp::create(builder, castOp.getLoc(), storageTensor);
+    auto streamOp = d2m::StreamLayoutOp::create(builder, castOp.getLoc(),
+                                                streamOutputTensor,
+                                                castOp.getResult(), storageOp);
     castOp.getResult().replaceAllUsesExcept(streamOp.getResult(), streamOp);
   }
 

--- a/lib/Dialect/D2M/Transforms/InsertStreams.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertStreams.cpp
@@ -70,9 +70,10 @@ public:
         MemRefType::get(memref.getShape(), memref.getElementType(), storageAttr,
                         rewriter.getAttr<ttcore::MemorySpaceAttr>(
                             ttcore::MemorySpace::DeviceL1));
-    auto storage = rewriter.create<memref::AllocOp>(op.getLoc(), storageMemref);
-    auto streamLayout = rewriter.create<d2m::StreamLayoutOp>(
-        op.getLoc(), streamMemref, operand.get(), storage);
+    auto storage =
+        memref::AllocOp::create(rewriter, op.getLoc(), storageMemref);
+    auto streamLayout = d2m::StreamLayoutOp::create(
+        rewriter, op.getLoc(), streamMemref, operand.get(), storage);
     rewriter.modifyOpInPlace(
         op, [&]() { operand.assign(streamLayout.getResult()); });
   }

--- a/lib/Dialect/D2M/Transforms/ScalarizeConstTensors.cpp
+++ b/lib/Dialect/D2M/Transforms/ScalarizeConstTensors.cpp
@@ -170,8 +170,8 @@ static linalg::GenericOp rebuildLinalgGenericWithoutScalarizedInputs(
   }
 
   rewriter.setInsertionPoint(linalgOp);
-  auto newLinalgOp = rewriter.create<linalg::GenericOp>(
-      linalgOp.getLoc(), linalgOp.getResultTypes(), newInputs,
+  auto newLinalgOp = linalg::GenericOp::create(
+      rewriter, linalgOp.getLoc(), linalgOp.getResultTypes(), newInputs,
       linalgOp.getOutputs(), newIndexingMaps, linalgOp.getIteratorTypesArray());
 
   Block *linalgBlock = linalgOp.getBody();
@@ -219,11 +219,11 @@ static GenericOp rebuildD2MGenericWithoutScalarizedInputs(
   }
 
   rewriter.setInsertionPoint(genericOp);
-  auto newGenericOp = rewriter.create<GenericOp>(
-      genericOp.getLoc(), genericOp.getResultTypes(), newGenericInputs,
-      genericOp.getOutputs(), genericOp.getGrid(), genericOp.getBlockFactors(),
-      rewriter.getArrayAttr(newIndexingMaps), genericOp.getIteratorTypes(),
-      genericOp.getThreads(),
+  auto newGenericOp = GenericOp::create(
+      rewriter, genericOp.getLoc(), genericOp.getResultTypes(),
+      newGenericInputs, genericOp.getOutputs(), genericOp.getGrid(),
+      genericOp.getBlockFactors(), rewriter.getArrayAttr(newIndexingMaps),
+      genericOp.getIteratorTypes(), genericOp.getThreads(),
       /*regions=*/1);
 
   for (auto [oldRegion, newRegion] :
@@ -305,10 +305,10 @@ public:
         Value scalarConst;
         if (auto floatAttr = dyn_cast<FloatAttr>(splatValue)) {
           scalarConst =
-              rewriter.create<arith::ConstantOp>(fullOp.getLoc(), floatAttr);
+              arith::ConstantOp::create(rewriter, fullOp.getLoc(), floatAttr);
         } else if (auto intAttr = dyn_cast<IntegerAttr>(splatValue)) {
           scalarConst =
-              rewriter.create<arith::ConstantOp>(fullOp.getLoc(), intAttr);
+              arith::ConstantOp::create(rewriter, fullOp.getLoc(), intAttr);
         }
 
         if (!scalarConst) {

--- a/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
@@ -181,7 +181,7 @@ static mlir::func::FuncOp outlineToFunc(
     mlir::Value escVal = mapping.lookupOrNull(esc);
     retVals.push_back(escVal);
   }
-  internalBuilder.create<mlir::func::ReturnOp>(func.getLoc(), retVals);
+  mlir::func::ReturnOp::create(internalBuilder, func.getLoc(), retVals);
 
   return func;
 }

--- a/lib/Dialect/StableHLO/Transforms/WrapUnderManualComputation.cpp
+++ b/lib/Dialect/StableHLO/Transforms/WrapUnderManualComputation.cpp
@@ -32,9 +32,10 @@ static mlir::LogicalResult wrapFunctionBodyInManualComputationOp(
   mlir::Block &entryBlock = funcOp.getBody().front();
   builder.setInsertionPointToStart(&entryBlock);
   mlir::sdy::ManualComputationOp manualComputationOp =
-      builder.create<mlir::sdy::ManualComputationOp>(
-          builder.getUnknownLoc(), funcType.getResults(), funcOp.getArguments(),
-          inShardings, outShardings, llvm::SmallVector<mlir::StringAttr>());
+      mlir::sdy::ManualComputationOp::create(
+          builder, builder.getUnknownLoc(), funcType.getResults(),
+          funcOp.getArguments(), inShardings, outShardings,
+          llvm::SmallVector<mlir::StringAttr>());
 
   // Determine the argumentTypes and argumentLocations that need to get
   // added to the new region in manualComputationOp.
@@ -70,8 +71,8 @@ static mlir::LogicalResult wrapFunctionBodyInManualComputationOp(
   // Create a new func.ReturnOp in the original func.funcOp that takes the
   // manualComputationOp as it's operand.
   builder.setInsertionPointAfter(manualComputationOp);
-  builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
-                                       manualComputationOp->getResults());
+  mlir::func::ReturnOp::create(builder, builder.getUnknownLoc(),
+                               manualComputationOp->getResults());
 
   // Update old arguments with new arguments inside of the
   // manualComputationBlock.
@@ -98,8 +99,8 @@ static mlir::LogicalResult wrapFunctionBodyInManualComputationOp(
 
     mlir::func::ReturnOp returnOp = mlir::cast<mlir::func::ReturnOp>(op);
     builder.setInsertionPoint(returnOp);
-    builder.create<mlir::sdy::ReturnOp>(builder.getUnknownLoc(),
-                                        returnOp->getOperands());
+    mlir::sdy::ReturnOp::create(builder, builder.getUnknownLoc(),
+                                returnOp->getOperands());
     returnOp->erase();
   }
 

--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -92,8 +92,8 @@ void addMeshToModule(mlir::ModuleOp &module, std::string meshName,
   mlir::sdy::MeshAttr sdyMeshAttr =
       shardy_utils::createMeshAttrFromMeshMap(context, meshMap);
   builder.setInsertionPoint(&(module.getBody()->front()));
-  builder.create<mlir::sdy::MeshOp>(
-      builder.getUnknownLoc(), builder.getStringAttr(meshName), sdyMeshAttr);
+  mlir::sdy::MeshOp::create(builder, builder.getUnknownLoc(),
+                            builder.getStringAttr(meshName), sdyMeshAttr);
 }
 
 // Create a TTMeshAttr from a sdy::meshOp.
@@ -865,8 +865,8 @@ convertCustomCallToShardingConstraint(mlir::ModuleOp &rootModule,
     // Create sdy.sharding_constraint op and replace it in place of custom
     // call
     builder.setInsertionPointAfter(customCallOp);
-    auto shardingConstraintOp = builder.create<mlir::sdy::ShardingConstraintOp>(
-        customCallOp->getLoc(), customCallOp.getResult(0).getType(),
+    auto shardingConstraintOp = mlir::sdy::ShardingConstraintOp::create(
+        builder, customCallOp->getLoc(), customCallOp.getResult(0).getType(),
         customCallOp.getOperand(0), tensorShardingAttr);
     customCallOp.getResult(0).replaceAllUsesWith(
         shardingConstraintOp.getResult());

--- a/lib/Dialect/TTCore/IR/Utils.cpp
+++ b/lib/Dialect/TTCore/IR/Utils.cpp
@@ -94,8 +94,8 @@ mlir::memref::GlobalOp createGlobal(ModuleOp moduleOp, StringRef name,
   auto symbolName = getUniqueSymbolName();
 
   OpBuilder builder(moduleOp.getRegion());
-  auto global = builder.create<memref::GlobalOp>(
-      moduleOp->getLoc(), symbolName,
+  auto global = memref::GlobalOp::create(
+      builder, moduleOp->getLoc(), symbolName,
       /*sym_visibility*/
       builder.getStringAttr(privateVisibility ? "private" : "public"), type,
       value, constant,

--- a/lib/Dialect/TTCore/Transforms/TTCoreModuleWrap.cpp
+++ b/lib/Dialect/TTCore/Transforms/TTCoreModuleWrap.cpp
@@ -42,7 +42,7 @@ public:
     innerModule.getBodyRegion().takeBody(rootModule.getBodyRegion());
     rootModule.getRegion().emplaceBlock();
     builder.setInsertionPointToStart(&rootModule.getBodyRegion().front());
-    auto deviceModule = builder.create<DeviceModuleOp>(rootModule.getLoc());
+    auto deviceModule = DeviceModuleOp::create(builder, rootModule.getLoc());
     builder.setInsertionPointToStart(&deviceModule.getBodyRegion().front());
     builder.clone(*innerModule);
     innerModule->erase();

--- a/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
+++ b/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
@@ -34,8 +34,8 @@ static LogicalResult registerDeviceInSymbolTable(ModuleOp moduleOp,
       return failure();
     }
     OpBuilder builder(moduleOp.getBodyRegion());
-    symbolTable.insert(builder.create<DeviceOp>(
-        moduleOp.getLoc(), getDefaultDeviceName(),
+    symbolTable.insert(DeviceOp::create(
+        builder, moduleOp.getLoc(), getDefaultDeviceName(),
         DeviceAttr::get(context, systemDesc, *finalMeshShape)));
   }
   return success();

--- a/lib/Dialect/TTIR/IR/TTIRDialect.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRDialect.cpp
@@ -122,7 +122,7 @@ void TTIRDialect::initialize() {
                                                     Attribute value, Type type,
                                                     Location loc) {
   if (auto elementsAttr = mlir::dyn_cast<mlir::ElementsAttr>(value)) {
-    return builder.create<ttir::ConstantOp>(loc, type, elementsAttr);
+    return ttir::ConstantOp::create(builder, loc, type, elementsAttr);
   }
   return {};
 }

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -70,8 +70,8 @@ public:
     rewriter.setInsertionPointAfter(op);
     auto broadcastDimensions = ttmlir::utils::getBroadcastDimensions<int64_t>(
         implicitBroadcastedShape, resultShape);
-    auto broadcastOp = rewriter.create<ttir::BroadcastOp>(
-        op->getLoc(),
+    auto broadcastOp = ttir::BroadcastOp::create(
+        rewriter, op->getLoc(),
         RankedTensorType::get(resultShape, newResultType.getElementType(),
                               newResultType.getEncoding()),
         op->getResult(0), broadcastDimensions);

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -210,7 +210,7 @@ public:
                                 mlir::Location loc) -> mlir::Value {
         mlir::RankedTensorType rankedType =
             mlir::cast<mlir::RankedTensorType>(type);
-        return builder.create<ttir::TypecastOp>(loc, rankedType, inputs);
+        return ttir::TypecastOp::create(builder, loc, rankedType, inputs);
       };
 
       addSourceMaterialization(materializeFunc);

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
@@ -221,15 +221,16 @@ public:
         RankedTensorType::get(newReshapeShape, tmResultType.getElementType(),
                               tmResultType.getEncoding());
 
-    auto newReshape = rewriter.create<ttir::ReshapeOp>(
-        reshapeUser.getLoc(), newTMResultType, op.getInput(),
+    auto newReshape = ttir::ReshapeOp::create(
+        rewriter, reshapeUser.getLoc(), newTMResultType, op.getInput(),
         rewriter.getI32ArrayAttr(SmallVector<int32_t>(newReshapeShape.begin(),
                                                       newReshapeShape.end())));
 
     assert(newBroadcastDimensions.size() ==
            static_cast<size_t>(tmResultType.getRank()));
-    auto newBroadcast = rewriter.create<ttir::BroadcastOp>(
-        op->getLoc(), tmResultType, newReshape, newBroadcastDimensions);
+    auto newBroadcast =
+        ttir::BroadcastOp::create(rewriter, op->getLoc(), tmResultType,
+                                  newReshape, newBroadcastDimensions);
 
     // All users must be identical TMs.
     // We must not reference `reshapeUser` during/after replacements, as it will
@@ -330,16 +331,17 @@ public:
         ttmlir::utils::applyPermutation(op.getBroadcastDimensions(),
                                         permutation);
 
-    auto newPermute = rewriter.create<ttir::PermuteOp>(
-        permuteUser->getLoc(),
+    auto newPermute = ttir::PermuteOp::create(
+        rewriter, permuteUser->getLoc(),
         RankedTensorType::get(newShape, tmResultType.getElementType(),
                               tmResultType.getEncoding()),
         operand, permutation);
 
     assert(newBroadcastDimensions.size() ==
            static_cast<size_t>(tmResultType.getRank()));
-    auto newBroadcast = rewriter.create<ttir::BroadcastOp>(
-        op->getLoc(), tmResultType, newPermute, newBroadcastDimensions);
+    auto newBroadcast =
+        ttir::BroadcastOp::create(rewriter, op->getLoc(), tmResultType,
+                                  newPermute, newBroadcastDimensions);
 
     // All users must be identical TMs.
     // We must not reference `permuteUser` during/after replacements, as it will

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConcatCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ConcatCommutePatterns.cpp
@@ -60,9 +60,8 @@ public:
           operandType.getElementType());
 
       newConcatOperands.push_back(
-          rewriter
-              .create<PermuteOp>(op->getLoc(), permuteOperandType, operand,
-                                 permuteUser.getPermutation())
+          PermuteOp::create(rewriter, op->getLoc(), permuteOperandType, operand,
+                            permuteUser.getPermutation())
               ->getResult(0));
     }
 
@@ -70,8 +69,8 @@ public:
         ttmlir::utils::applyPermutation(op.getType().getShape(),
                                         permuteUser.getPermutation()),
         op.getType().getElementType());
-    ConcatOp newConcat = rewriter.create<ConcatOp>(
-        op->getLoc(), newConcatType, newConcatOperands, newConcatDim);
+    ConcatOp newConcat = ConcatOp::create(rewriter, op->getLoc(), newConcatType,
+                                          newConcatOperands, newConcatDim);
 
     // All users must be identical TMs.
     // We must not reference `permuteUser` during/after replacements, as it will
@@ -131,16 +130,16 @@ public:
             ttmlir::utils::inversePermutation(permuteOperand.getPermutation())),
         op.getType().getElementType());
     int64_t newConcatDim = permuteOperand.getPermutation()[currentConcatDim];
-    ConcatOp newConcat = rewriter.create<ConcatOp>(
-        op->getLoc(), newConcatType, newConcatOperands, newConcatDim);
+    ConcatOp newConcat = ConcatOp::create(rewriter, op->getLoc(), newConcatType,
+                                          newConcatOperands, newConcatDim);
 
     RankedTensorType newPermuteType = RankedTensorType::get(
         ttmlir::utils::applyPermutation(newConcatType.getShape(),
                                         permuteOperand.getPermutation()),
         newConcatType.getElementType());
     PermuteOp newPerm =
-        rewriter.create<PermuteOp>(op->getLoc(), newPermuteType, newConcat,
-                                   permuteOperand.getPermutation());
+        PermuteOp::create(rewriter, op->getLoc(), newPermuteType, newConcat,
+                          permuteOperand.getPermutation());
 
     rewriter.replaceOp(op, newPerm);
   }
@@ -229,15 +228,15 @@ public:
       RankedTensorType newOperandType = RankedTensorType::get(
           SmallVector<int64_t>(newOperandShape.begin(), newOperandShape.end()),
           operandType.getElementType());
-      newConcatOperands.push_back(rewriter.create<ReshapeOp>(
-          op->getLoc(), newOperandType, operand,
-          rewriter.getI32ArrayAttr(newOperandShape)));
+      newConcatOperands.push_back(
+          ReshapeOp::create(rewriter, op->getLoc(), newOperandType, operand,
+                            rewriter.getI32ArrayAttr(newOperandShape)));
     }
 
     RankedTensorType newConcatType =
         RankedTensorType::get(newConcatShape, op.getType().getElementType());
-    ConcatOp newConcat = rewriter.create<ConcatOp>(
-        op->getLoc(), newConcatType, newConcatOperands, newConcatDim);
+    ConcatOp newConcat = ConcatOp::create(rewriter, op->getLoc(), newConcatType,
+                                          newConcatOperands, newConcatDim);
 
     // All users must be identical TMs.
     // We must not reference `reshapeUser` during/after replacements, as it will

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
@@ -50,9 +50,9 @@ public:
 
       mlir::Location newLoc = ttmlir::utils::appendLocationSuffix(
           tmUser->getLoc(), "_tm" + std::to_string(operandIdx));
-      auto newTM = rewriter.create<TMOpType>(
-          newLoc, newTMResultTypes[operandIdx], op->getOperand(operandIdx),
-          tmUser->getAttrs());
+      auto newTM =
+          TMOpType::create(rewriter, newLoc, newTMResultTypes[operandIdx],
+                           op->getOperand(operandIdx), tmUser->getAttrs());
 
       newEltwiseOperands.push_back(newTM);
     }
@@ -103,9 +103,9 @@ public:
     RankedTensorType newTMType =
         cast<RankedTensorType>(op->getResult(0).getType())
             .clone(tmOperand.getType().getShape());
-    TMOpType newUserTM = rewriter.create<TMOpType>(op->getLoc(), newTMType,
-                                                   newEltwise->getResult(0),
-                                                   tmOperand->getAttrs());
+    TMOpType newUserTM =
+        TMOpType::create(rewriter, op->getLoc(), newTMType,
+                         newEltwise->getResult(0), tmOperand->getAttrs());
 
     rewriter.replaceOp(op, newUserTM);
   }

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
@@ -97,7 +97,7 @@ private:
         outputShape, inputType.getElementType(), inputType.getEncoding());
 
     // Create and return the new PermuteOp
-    return rewriter.create<PermuteOp>(loc, outputType, input, permutation);
+    return PermuteOp::create(rewriter, loc, outputType, input, permutation);
   }
 
   ArrayAttr permuteDims(ArrayAttr dimArg, ArrayRef<int64_t> permutation,
@@ -134,8 +134,8 @@ private:
         RankedTensorType::get(newReduceShape, op.getType().getElementType(),
                               op.getType().getEncoding());
 
-    return rewriter.create<ReduceOpType>(op->getLoc(), newReduceType, newInput,
-                                         op.getKeepDimAttr(), newDimArgAttrs);
+    return ReduceOpType::create(rewriter, op->getLoc(), newReduceType, newInput,
+                                op.getKeepDimAttr(), newDimArgAttrs);
   }
 
   bool isCommuteUpwardsViable(ReduceOpType op, PermuteOp) const override {

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/SliceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/SliceCommutePatterns.cpp
@@ -44,8 +44,8 @@ public:
         sliceOperandType.getElementType(), sliceOperandType.getEncoding());
 
     PermuteOp newPerm =
-        rewriter.create<PermuteOp>(permuteUser->getLoc(), newPermuteType,
-                                   op.getInput(), permuteUser.getPermutation());
+        PermuteOp::create(rewriter, permuteUser->getLoc(), newPermuteType,
+                          op.getInput(), permuteUser.getPermutation());
 
     SmallVector<Attribute> newSliceStarts = ttmlir::utils::applyPermutation(
         op.getBegins().getValue(), permuteUser.getPermutation());
@@ -60,10 +60,10 @@ public:
         op.getType().getElementType(), op.getType().getEncoding());
 
     SliceStaticOp newSlice =
-        rewriter.create<SliceStaticOp>(op->getLoc(), newSliceType, newPerm,
-                                       rewriter.getArrayAttr(newSliceStarts),
-                                       rewriter.getArrayAttr(newSliceEnds),
-                                       rewriter.getArrayAttr(newSliceSteps));
+        SliceStaticOp::create(rewriter, op->getLoc(), newSliceType, newPerm,
+                              rewriter.getArrayAttr(newSliceStarts),
+                              rewriter.getArrayAttr(newSliceEnds),
+                              rewriter.getArrayAttr(newSliceSteps));
 
     // All users must be identical TMs.
     // We must not reference `permuteUser` during/after replacements, as it will
@@ -111,8 +111,8 @@ public:
     SmallVector<Attribute> newSliceSteps = ttmlir::utils::applyPermutation(
         op.getStep().getValue(), inversePermutation);
 
-    SliceStaticOp newSlice = rewriter.create<SliceStaticOp>(
-        op->getLoc(), newSliceType, permuteOperand.getInput(),
+    SliceStaticOp newSlice = SliceStaticOp::create(
+        rewriter, op->getLoc(), newSliceType, permuteOperand.getInput(),
         rewriter.getArrayAttr(newSliceStarts),
         rewriter.getArrayAttr(newSliceEnds),
         rewriter.getArrayAttr(newSliceSteps));
@@ -121,8 +121,8 @@ public:
         op.getType().getShape(), newSlice.getType().getElementType(),
         newSlice.getType().getEncoding());
     PermuteOp newPerm =
-        rewriter.create<PermuteOp>(permuteOperand->getLoc(), newPermuteType,
-                                   newSlice, permuteOperand.getPermutation());
+        PermuteOp::create(rewriter, permuteOperand->getLoc(), newPermuteType,
+                          newSlice, permuteOperand.getPermutation());
 
     rewriter.replaceOp(op, newPerm);
   }
@@ -220,8 +220,8 @@ public:
 
     // The reshape should produce the same output type as the original slice
     SmallVector<int32_t> reshapeTargetShape(op.getType().getShape());
-    ReshapeOp newReshape = rewriter.create<ReshapeOp>(
-        reshapeOperand->getLoc(), op.getType(), newSlice,
+    ReshapeOp newReshape = ReshapeOp::create(
+        rewriter, reshapeOperand->getLoc(), op.getType(), newSlice,
         rewriter.getI32ArrayAttr(reshapeTargetShape));
     rewriter.replaceOp(op, newReshape);
   }
@@ -336,9 +336,10 @@ private:
         RankedTensorType::get(newOutputShape, op.getType().getElementType(),
                               op.getType().getEncoding());
 
-    SliceStaticOp newSlice = rewriter.create<SliceStaticOp>(
-        op->getLoc(), newSliceType, input, rewriter.getArrayAttr(newBegins),
-        rewriter.getArrayAttr(newEnds), rewriter.getArrayAttr(newSteps));
+    SliceStaticOp newSlice = SliceStaticOp::create(
+        rewriter, op->getLoc(), newSliceType, input,
+        rewriter.getArrayAttr(newBegins), rewriter.getArrayAttr(newEnds),
+        rewriter.getArrayAttr(newSteps));
 
     return newSlice;
   }
@@ -374,9 +375,9 @@ private:
         op.getInput().getType().getEncoding());
     SmallVector<int32_t> targetShapeInt32(targetShape.begin(),
                                           targetShape.end());
-    return rewriter.create<ReshapeOp>(
-        reshapeUser->getLoc(), targetType, op.getInput(),
-        rewriter.getI32ArrayAttr(targetShapeInt32));
+    return ReshapeOp::create(rewriter, reshapeUser->getLoc(), targetType,
+                             op.getInput(),
+                             rewriter.getI32ArrayAttr(targetShapeInt32));
   }
 
   bool isCommuteUpwardsViable(SliceStaticOp op,

--- a/lib/Dialect/TTIR/Transforms/ExplicateTMs.cpp
+++ b/lib/Dialect/TTIR/Transforms/ExplicateTMs.cpp
@@ -43,7 +43,8 @@ public:
                       operandType.getShape().end());
 
       // Create a new reshape operation.
-      auto reshapeOp = rewriter.create<ttir::ReshapeOp>(
+      auto reshapeOp = ttir::ReshapeOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape"),
           RankedTensorType::get(newShape, operandType.getElementType(),
                                 operandType.getEncoding()),
@@ -104,7 +105,8 @@ public:
       }
 
       // Create a new broadcast operation.
-      auto broadcastOp = rewriter.create<ttir::BroadcastOp>(
+      auto broadcastOp = ttir::BroadcastOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(op.getLoc(), "_broadcast"),
           RankedTensorType::get(broadcastedShape, operandType.getElementType(),
                                 operandType.getEncoding()),

--- a/lib/Dialect/TTIR/Transforms/QuantDequantConversion.cpp
+++ b/lib/Dialect/TTIR/Transforms/QuantDequantConversion.cpp
@@ -102,8 +102,8 @@ private:
         if (mlir::dyn_cast<mlir::quant::QuantizedType>(
                 newResultType.getElementType())) {
           // It's quantized, so insert a DequantizeOp.
-          auto newDequant = rewriter.create<mlir::tt::ttir::DequantizeOp>(
-              op->getLoc(), oldType, newResult);
+          auto newDequant = mlir::tt::ttir::DequantizeOp::create(
+              rewriter, op->getLoc(), oldType, newResult);
           newResults.push_back(newDequant);
         } else {
           // It's already floating-point or non-quantized.
@@ -130,12 +130,12 @@ private:
             originalType.getShape(), quantType, originalType.getEncoding());
         // Create quantize op.
         mlir::tt::ttir::QuantizeOp quantize =
-            rewriter.create<mlir::tt::ttir::QuantizeOp>(op->getLoc(),
-                                                        quantizeType, result);
+            mlir::tt::ttir::QuantizeOp::create(rewriter, op->getLoc(),
+                                               quantizeType, result);
         // Now dequantize op, effectively commuting the original dequantize.
         mlir::tt::ttir::DequantizeOp dequantize =
-            rewriter.create<mlir::tt::ttir::DequantizeOp>(
-                op->getLoc(), originalType, quantize);
+            mlir::tt::ttir::DequantizeOp::create(rewriter, op->getLoc(),
+                                                 originalType, quantize);
         newResults.push_back(dequantize);
       }
     }
@@ -157,9 +157,8 @@ struct RewriteDQToRequantize
     auto dequantizeOp = mlir::dyn_cast<mlir::tt::ttir::DequantizeOp>(
         op.getInput().getDefiningOp());
     if (dequantizeOp) {
-      ttir::RequantizeOp requantize =
-          rewriter.create<mlir::tt::ttir::RequantizeOp>(
-              op->getLoc(), op.getType(), dequantizeOp.getInput());
+      ttir::RequantizeOp requantize = mlir::tt::ttir::RequantizeOp::create(
+          rewriter, op->getLoc(), op.getType(), dequantizeOp.getInput());
       rewriter.replaceOp(op, requantize);
       return mlir::success();
     }

--- a/lib/Dialect/TTIR/Utils/Utils.cpp
+++ b/lib/Dialect/TTIR/Utils/Utils.cpp
@@ -22,8 +22,8 @@ llvm::SmallVector<int64_t> unsqueezeValue(mlir::PatternRewriter &rewriter,
                                         unsqueezeShape.end());
 
   auto reshapeDimAttr = rewriter.getI32ArrayAttr(reshapeDim);
-  input = rewriter.create<ttir::ReshapeOp>(
-      loc,
+  input = ttir::ReshapeOp::create(
+      rewriter, loc,
       RankedTensorType::get(unsqueezeShape, desiredType.getElementType(),
                             desiredType.getEncoding()),
       input, reshapeDimAttr);
@@ -57,8 +57,8 @@ mlir::LogicalResult broadcastValue(mlir::PatternRewriter &rewriter,
       ttmlir::utils::getBroadcastDimensions<int64_t>(inputShape,
                                                      desiredType.getShape());
 
-  output = rewriter.create<ttir::BroadcastOp>(loc, desiredType, input,
-                                              broadcastDims);
+  output = ttir::BroadcastOp::create(rewriter, loc, desiredType, input,
+                                     broadcastDims);
   return mlir::success();
 }
 

--- a/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
+++ b/lib/Dialect/TTKernel/Transforms/ControlDstSection.cpp
@@ -30,10 +30,10 @@ public:
 
     Operation *parent = parentOpAtBlock(op, acquireBlock);
     rewriter.setInsertionPoint(parent);
-    rewriter.create<ttkernel::TileRegsCommitOp>(op->getLoc());
-    rewriter.create<ttkernel::TileRegsWaitOp>(op->getLoc());
+    ttkernel::TileRegsCommitOp::create(rewriter, op->getLoc());
+    ttkernel::TileRegsWaitOp::create(rewriter, op->getLoc());
     rewriter.setInsertionPointAfter(parent);
-    rewriter.create<ttkernel::TileRegsReleaseOp>(op->getLoc());
+    ttkernel::TileRegsReleaseOp::create(rewriter, op->getLoc());
 
     return success();
   };

--- a/lib/Dialect/TTKernel/Transforms/InsertDeviceZoneScopes.cpp
+++ b/lib/Dialect/TTKernel/Transforms/InsertDeviceZoneScopes.cpp
@@ -29,15 +29,15 @@ public:
         return;
       }
       OpBuilder builder(op);
-      builder.create<emitc::VerbatimOp>(op->getLoc(), "{");
+      emitc::VerbatimOp::create(builder, op->getLoc(), "{");
       auto name = op->getName().getStringRef();
       if (name.starts_with("ttkernel.")) {
         name = name.drop_front(9);
       }
-      builder.create<emitc::VerbatimOp>(op->getLoc(), "DeviceZoneScopedN(\"" +
-                                                          name.str() + "\");");
+      emitc::VerbatimOp::create(builder, op->getLoc(),
+                                "DeviceZoneScopedN(\"" + name.str() + "\");");
       builder.setInsertionPointAfter(op);
-      builder.create<emitc::VerbatimOp>(op->getLoc(), "}");
+      emitc::VerbatimOp::create(builder, op->getLoc(), "}");
     });
   }
 };

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -704,8 +704,8 @@ ToLayoutOp createToLayoutOp(OpBuilder &builder, Location loc,
   RankedTensorType resultType = RankedTensorType::get(
       currentResultType.getShape(), scalarElementType, targetLayout);
 
-  return builder.create<ToLayoutOp>(
-      loc, resultType, inputValue,
+  return ToLayoutOp::create(
+      builder, loc, resultType, inputValue,
       LayoutAttr::get(builder.getContext(), targetLayout.getLayout()),
       ttcore::DataTypeAttr::get(builder.getContext(),
                                 targetLayout.getDataType()),

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -764,8 +764,8 @@ private:
         OpBuilder builder(consumerOp);
         Location loc = ttmlir::utils::appendLocationSuffix(consumerOp->getLoc(),
                                                            "_mem_reconfig");
-        ToLayoutOp memoryReconfigOp = builder.create<ToLayoutOp>(
-            loc,
+        ToLayoutOp memoryReconfigOp = ToLayoutOp::create(
+            builder, loc,
             newTensorType,                             // output type
             consumerOp->getOperand(edge.operandIndex), // input value
             LayoutAttr::get(consumerOp->getContext(),
@@ -841,9 +841,9 @@ private:
       }
 
       // Step 2: Insert spilling to DRAM.
-      Operation *spillToDRAMOp = builder.create<ToLayoutOp>(
-          loc, newTensorType, spilledOp->getResult(0), newLayout, dataType,
-          memConfigAttr);
+      Operation *spillToDRAMOp = ToLayoutOp::create(
+          builder, loc, newTensorType, spilledOp->getResult(0), newLayout,
+          dataType, memConfigAttr);
 
       // Step 3: Reconnect uses.
       for (auto &use : uses) {

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv2dWeightsAndBias.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNPrepareConv2dWeightsAndBias.cpp
@@ -173,7 +173,8 @@ private:
                                mlir::tt::ttcore::DataTypeAttr outputDtypeAttr,
                                ttnn::Conv2dConfigAttr conv2dConfig) {
     if constexpr (std::is_same_v<ConvOp, ttnn::Conv2dOp>) {
-      return rewriter.create<PrepareWeightsOp>(
+      return PrepareWeightsOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(convOp.getLoc(),
                                               "_prepare_conv2d_weight"),
           getPreparedWeightsType(convOp, conv2dConfig), convOp.getWeight(),
@@ -190,7 +191,8 @@ private:
           outputDtypeAttr, conv2dConfig, /*compute_config=*/nullptr,
           convOp.getConv2dSliceConfigAttr());
     } else {
-      return rewriter.create<PrepareWeightsOp>(
+      return PrepareWeightsOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(
               convOp.getLoc(), "_prepare_conv_transpose2d_weight"),
           getPreparedWeightsType(convOp, conv2dConfig), convOp.getWeight(),
@@ -218,7 +220,8 @@ private:
                             mlir::tt::ttcore::DataTypeAttr outputDtypeAttr,
                             ttnn::Conv2dConfigAttr conv2dConfig) {
     if constexpr (std::is_same_v<ConvOp, ttnn::Conv2dOp>) {
-      return rewriter.create<PrepareBiasOp>(
+      return PrepareBiasOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(convOp.getLoc(),
                                               "_prepare_conv2d_bias"),
           getPreparedBiasType(convOp.getBias(), inputElementType),
@@ -232,7 +235,8 @@ private:
           inputDtypeAttr, outputDtypeAttr, conv2dConfig,
           /*compute_config=*/nullptr, convOp.getConv2dSliceConfigAttr());
     } else {
-      return rewriter.create<PrepareBiasOp>(
+      return PrepareBiasOp::create(
+          rewriter,
           ttmlir::utils::appendLocationSuffix(convOp.getLoc(),
                                               "_prepare_conv_transpose2d_bias"),
           getPreparedBiasType(convOp.getBias(), inputElementType),

--- a/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNConstEvalInputsToSystemMemory.cpp
@@ -176,8 +176,8 @@ static void convertArgumentOfConstEvalFunc(func::FuncOp constEvalFuncOp,
     auto originalDataTypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
         constEvalFuncOp.getContext(), deviceTensorLayout.getDataType());
 
-    auto toLayoutOp = builder.create<ttnn::ToLayoutOp>(
-        blockArgument.getLoc(), deviceTensorType, blockArgument,
+    auto toLayoutOp = ttnn::ToLayoutOp::create(
+        builder, blockArgument.getLoc(), deviceTensorType, blockArgument,
         deviceTensorLayout.getLayout(), originalDataTypeAttr,
         MemoryConfigAttr::get(deviceTensorLayout, deviceGrid));
 

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -269,8 +269,8 @@ private:
                        mlir::Value currentInput, Args &&...args) const {
 
     rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), op.getType(), currentInput,
-                                   std::forward<Args>(args)...);
+    return OpType::create(rewriter, op.getLoc(), op.getType(), currentInput,
+                          std::forward<Args>(args)...);
   }
 
   template <typename OpType, typename... Args>
@@ -278,8 +278,8 @@ private:
                        RankedTensorType newResultType, mlir::Value currentInput,
                        Args &&...args) const {
     rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), newResultType, currentInput,
-                                   std::forward<Args>(args)...);
+    return OpType::create(rewriter, op.getLoc(), newResultType, currentInput,
+                          std::forward<Args>(args)...);
   }
 
   mlir::Value createToDeviceOpIfNeeded(ttnn::ToLayoutOp op,

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -281,8 +281,8 @@ private:
 
     // Create rotary_embedding op
     auto resultType = srcOp.getType();
-    auto ropeOp = rewriter.create<RotaryEmbeddingOp>(
-        srcOp.getLoc(), resultType, xUnrotated, cos, sin,
+    auto ropeOp = RotaryEmbeddingOp::create(
+        rewriter, srcOp.getLoc(), resultType, xUnrotated, cos, sin,
         /*token_index=*/nullptr,
         /*memory_config=*/nullptr, /*compute_config=*/nullptr);
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -324,9 +324,9 @@ public:
     func::FuncOp funcOp = dyn_cast<func::FuncOp>(
         SymbolTable::lookupNearestSymbolFrom(callOp, callOp.getCalleeAttr()));
     // Create the original CallOp with the new inputs on host.
-    auto newCallOp = rewriter.create<func::CallOp>(
-        callOp.getLoc(), callOp.getCallee(), funcOp.getResultTypes(),
-        fromDeviceOperands);
+    auto newCallOp =
+        func::CallOp::create(rewriter, callOp.getLoc(), callOp.getCallee(),
+                             funcOp.getResultTypes(), fromDeviceOperands);
 
     newCallOp->setAttr(ttmlir::utils::g_cpuHoistFuncCallAttrName,
                        mlir::UnitAttr::get(rewriter.getContext()));

--- a/lib/Dialect/TTNN/Transforms/TTNNWeightBFP8Conversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNWeightBFP8Conversion.cpp
@@ -63,8 +63,8 @@ public:
         ttnn::utils::RankedTensorTypeFactory::create(weightType, bfp8DataType);
 
     // Insert typecast operation to convert weight to BFP8.
-    auto typecastOp = rewriter.create<TypecastOp>(
-        op.getLoc(), bfp8WeightType, weight,
+    auto typecastOp = TypecastOp::create(
+        rewriter, op.getLoc(), bfp8WeightType, weight,
         ttcore::DataTypeAttr::get(rewriter.getContext(), bfp8DataType));
 
     // Update op to use the typecast result.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
@@ -49,7 +49,8 @@ TTNNAllGatherWorkarounds::matchAndRewrite(ttnn::AllGatherOp op,
                                       paddedInputShape.end());
   RankedTensorType reshapeInputType =
       ttnn::utils::RankedTensorTypeFactory::create(inputType, paddedInputShape);
-  auto reshapeInput = rewriter.create<ttnn::ReshapeOp>(
+  auto reshapeInput = ttnn::ReshapeOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape_to_4d"),
       reshapeInputType, op.getInput(), rewriter.getI32ArrayAttr(paddedShapeI32),
       ttnn::MemoryConfigAttr());
@@ -61,7 +62,8 @@ TTNNAllGatherWorkarounds::matchAndRewrite(ttnn::AllGatherOp op,
 
   // Create the reduce gather operation on 4D tensors with adjusted
   // all_gather_dim
-  auto allGather4D = rewriter.create<ttnn::AllGatherOp>(
+  auto allGather4D = ttnn::AllGatherOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(op.getLoc(), "_all_gather_4d"),
       paddedOutputType, reshapeInput.getResult(), adjustedGatherDim,
       op.getClusterAxis(),

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
@@ -62,8 +62,9 @@ ArgMaxOpRewritePattern::matchAndRewrite(ttnn::ArgMaxOp srcOp,
         mlir::IntegerAttr::get(mlir::IntegerType::get(getContext(), 32), dim);
   }
   // Create new ttnn.argmax op with updated input tensor, dimension, etc.
-  ArgMaxOp argMaxOp = rewriter.create<mlir::tt::ttnn::ArgMaxOp>(
-      srcOp->getLoc(), newOutputType, preReshapeOp, dimAttr, srcOp.getKeepDim(),
+  ArgMaxOp argMaxOp = mlir::tt::ttnn::ArgMaxOp::create(
+      rewriter, srcOp->getLoc(), newOutputType, preReshapeOp, dimAttr,
+      srcOp.getKeepDim(),
       /*use_multicore=*/false, /*memoryConfig=*/nullptr);
 
   // Create ttnn.reshape op after performing ttnn.argmax op.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpDecompositionRewritePattern.cpp
@@ -54,8 +54,8 @@ LogicalResult ConcatOpDecompositionRewritePattern::matchAndRewrite(
     subInputs.append(subRange.begin(), subRange.end());
 
     runningConcatOp =
-        rewriter.create<ttnn::ConcatOp>(srcOp->getLoc(), outputType, subInputs,
-                                        dim, srcOp.getMemoryConfigAttr());
+        ttnn::ConcatOp::create(rewriter, srcOp->getLoc(), outputType, subInputs,
+                               dim, srcOp.getMemoryConfigAttr());
 
     start = end;
     end = std::min(end + kMaxAllowedInputs - 1, numInputs);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
@@ -44,9 +44,9 @@ LogicalResult ConcatOpReshapeRewritePattern::matchAndRewrite(
       utils::RankedTensorTypeFactory::create(outputType, newOutputShape);
 
   // Create new concat op with reshaped inputs and new output type.
-  auto newConcatOp = rewriter.create<ttnn::ConcatOp>(
-      srcOp->getLoc(), newOutputType, reshapedInputs, dim,
-      /*memory_config=*/nullptr);
+  auto newConcatOp = ttnn::ConcatOp::create(rewriter, srcOp->getLoc(),
+                                            newOutputType, reshapedInputs, dim,
+                                            /*memory_config=*/nullptr);
 
   // Reshape back to the original output shape.
   auto result = ttir_to_ttnn::utils::generateReshape(

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
@@ -44,7 +44,8 @@ LogicalResult ConcatenateHeadsOpRewritePattern::matchAndRewrite(
       utils::RankedTensorTypeFactory::create(outputType, permutedShape);
   auto input = srcOp.getInput();
 
-  PermuteOp permuteOp = rewriter.create<ttnn::PermuteOp>(
+  PermuteOp permuteOp = ttnn::PermuteOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_concat_heads"),
       permutedType, input, permutationAttr, ttnn::MemoryConfigAttr(),
       mlir::FloatAttr());

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
@@ -36,8 +36,8 @@ CumSumOpDimRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
       ttmlir::utils::applyPermutation(originalShape, permutation);
   RankedTensorType adaptedInputType =
       utils::RankedTensorTypeFactory::create(inputType, adaptedShape);
-  auto adaptedInput = rewriter.create<ttnn::PermuteOp>(
-      ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_permute"),
+  auto adaptedInput = ttnn::PermuteOp::create(
+      rewriter, ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_permute"),
       adaptedInputType, srcOp.getInput(),
       rewriter.getDenseI64ArrayAttr(permutation),
       /*memory_config=*/ttnn::MemoryConfigAttr(),
@@ -46,8 +46,8 @@ CumSumOpDimRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
   mlir::RankedTensorType outputType = srcOp.getResult().getType();
   RankedTensorType adaptedOutputType =
       utils::RankedTensorTypeFactory::create(outputType, adaptedShape);
-  auto adaptedCumSumOp = rewriter.create<mlir::tt::ttnn::MorehCumSumOp>(
-      srcOp->getLoc(), adaptedOutputType, adaptedInput, /*dim=*/0,
+  auto adaptedCumSumOp = mlir::tt::ttnn::MorehCumSumOp::create(
+      rewriter, srcOp->getLoc(), adaptedOutputType, adaptedInput, /*dim=*/0,
       /*memory_config=*/nullptr);
 
   auto permute = rewriter.replaceOpWithNewOp<ttnn::PermuteOp>(

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
@@ -39,10 +39,10 @@ CumSumOpRankRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
   RankedTensorType outputType = srcOp.getResult().getType();
   RankedTensorType adaptedOutputType =
       utils::RankedTensorTypeFactory::create(outputType, adaptedShape);
-  MorehCumSumOp adaptedCumSumOp =
-      rewriter.create<mlir::tt::ttnn::MorehCumSumOp>(
-          srcOp->getLoc(), adaptedOutputType, adaptedInput, srcOp.getDim(),
-          /*memory_config=*/nullptr);
+  MorehCumSumOp adaptedCumSumOp = mlir::tt::ttnn::MorehCumSumOp::create(
+      rewriter, srcOp->getLoc(), adaptedOutputType, adaptedInput,
+      srcOp.getDim(),
+      /*memory_config=*/nullptr);
 
   ReshapeOp cumsumOutput = ttir_to_ttnn::utils::generateReshape(
       adaptedCumSumOp, srcOp.getResult().getType().getShape(), rewriter,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ExplicateOperandBroadcastsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ExplicateOperandBroadcastsRewritePattern.cpp
@@ -32,8 +32,8 @@ LogicalResult ExplicateOperandBroadcastsRewritePattern::matchAndRewrite(
     auto broadcastDims = ttmlir::utils::getBroadcastDimensions<int64_t>(
         operandShape, resultShape);
     auto shapeAttr = ttnn::ShapeAttr::get(rewriter.getContext(), broadcastDims);
-    auto repeatOp = rewriter.create<ttnn::RepeatOp>(
-        srcOp->getLoc(), newOutputType, operand, shapeAttr);
+    auto repeatOp = ttnn::RepeatOp::create(rewriter, srcOp->getLoc(),
+                                           newOutputType, operand, shapeAttr);
 
     rewriter.modifyOpInPlace(srcOp, [&]() { srcOp->setOperand(i, repeatOp); });
     hasChanged = true;

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
@@ -149,7 +149,8 @@ LinearOpRewritePattern::matchAndRewrite(ttnn::LinearOp srcOp,
 
   // Step 1: Create MatMul operation.
 
-  MatmulOp matmulOp = rewriter.create<ttnn::MatmulOp>(
+  MatmulOp matmulOp = ttnn::MatmulOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_decomp_matmul"),
       matmulOutputType, srcOp.getA(), srcOp.getB(), srcOp.getTransposeA(),
       srcOp.getTransposeB(),
@@ -157,7 +158,8 @@ LinearOpRewritePattern::matchAndRewrite(ttnn::LinearOp srcOp,
       /*activation=*/nullptr);
 
   // Step 2: Create Add operation with bias.
-  AddOp addOp = rewriter.create<ttnn::AddOp>(
+  AddOp addOp = ttnn::AddOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_decomp_add"),
       outputType, matmulOp.getResult(), srcOp.getBias(),
       /*dtype=*/dataTypeAttr,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.cpp
@@ -57,9 +57,10 @@ LogicalResult MultiplyOpDecompositionRewritePattern::matchAndRewrite(
   RankedTensorType lhsPermutedType =
       utils::RankedTensorTypeFactory::create(lhsType, lhsPermutedShape);
 
-  PermuteOp lhsPermuted = rewriter.create<ttnn::PermuteOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_lhs_permute"), lhsPermutedType,
-      lhs, permutationAttr, ttnn::MemoryConfigAttr(), mlir::FloatAttr());
+  PermuteOp lhsPermuted = ttnn::PermuteOp::create(
+      rewriter, ttmlir::utils::appendLocationSuffix(loc, "_lhs_permute"),
+      lhsPermutedType, lhs, permutationAttr, ttnn::MemoryConfigAttr(),
+      mlir::FloatAttr());
 
   // Apply permutation to rhs input
   llvm::SmallVector<int64_t> rhsPermutedShape =
@@ -67,9 +68,10 @@ LogicalResult MultiplyOpDecompositionRewritePattern::matchAndRewrite(
   RankedTensorType rhsPermutedType =
       utils::RankedTensorTypeFactory::create(rhsType, rhsPermutedShape);
 
-  PermuteOp rhsPermuted = rewriter.create<ttnn::PermuteOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_rhs_permute"), rhsPermutedType,
-      rhs, permutationAttr, ttnn::MemoryConfigAttr(), mlir::FloatAttr());
+  PermuteOp rhsPermuted = ttnn::PermuteOp::create(
+      rewriter, ttmlir::utils::appendLocationSuffix(loc, "_rhs_permute"),
+      rhsPermutedType, rhs, permutationAttr, ttnn::MemoryConfigAttr(),
+      mlir::FloatAttr());
 
   // Create the multiply operation on permuted inputs
   llvm::SmallVector<int64_t> permutedOutputShape =
@@ -77,8 +79,8 @@ LogicalResult MultiplyOpDecompositionRewritePattern::matchAndRewrite(
   RankedTensorType permutedOutputType =
       utils::RankedTensorTypeFactory::create(outputType, permutedOutputShape);
 
-  MultiplyOp permutedMultiply = rewriter.create<ttnn::MultiplyOp>(
-      loc, permutedOutputType, lhsPermuted.getResult(),
+  MultiplyOp permutedMultiply = ttnn::MultiplyOp::create(
+      rewriter, loc, permutedOutputType, lhsPermuted.getResult(),
       rhsPermuted.getResult());
 
   // Apply reverse permutation to output (which is the same as forward: (2, 3,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
@@ -71,8 +71,8 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
       ttnn::MemoryConfigAttr::get(desiredInputLayout, grid);
   RankedTensorType memoryConfigedInputType =
       inputType.cloneWithEncoding(desiredInputLayout);
-  auto toLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
-      op.getLoc(), memoryConfigedInputType, op.getInput(),
+  auto toLayoutOp = ttnn::ToLayoutOp::create(
+      rewriter, op.getLoc(), memoryConfigedInputType, op.getInput(),
       tt::ttnn::Layout::Tile,
       ttcore::DataTypeAttr::get(
           rewriter.getContext(),
@@ -81,9 +81,9 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
 
   // Replace the original PagedUpdateCacheOp with one which takes our properly
   // configured input tensor.
-  auto pagedUpdateCacheOp = rewriter.create<ttnn::PagedUpdateCacheOp>(
-      op.getLoc(), op.getCache(), toLayoutOp.getResult(), op.getUpdateIndex(),
-      op.getShareCache(), op.getPageTable());
+  auto pagedUpdateCacheOp = ttnn::PagedUpdateCacheOp::create(
+      rewriter, op.getLoc(), op.getCache(), toLayoutOp.getResult(),
+      op.getUpdateIndex(), op.getShareCache(), op.getPageTable());
 
   rewriter.replaceOp(op, pagedUpdateCacheOp);
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
@@ -49,7 +49,8 @@ TTNNReduceScatterWorkarounds::matchAndRewrite(ttnn::ReduceScatterOp op,
                                       paddedInputShape.end());
   RankedTensorType reshapeInputType =
       ttnn::utils::RankedTensorTypeFactory::create(inputType, paddedInputShape);
-  auto reshapeInput = rewriter.create<ttnn::ReshapeOp>(
+  auto reshapeInput = ttnn::ReshapeOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape_to_4d"),
       reshapeInputType, op.getInput(), rewriter.getI32ArrayAttr(paddedShapeI32),
       ttnn::MemoryConfigAttr());
@@ -61,7 +62,8 @@ TTNNReduceScatterWorkarounds::matchAndRewrite(ttnn::ReduceScatterOp op,
 
   // Create the reduce scatter operation on 4D tensors with adjusted
   // scatter_dim
-  auto reduceScatter4D = rewriter.create<ttnn::ReduceScatterOp>(
+  auto reduceScatter4D = ttnn::ReduceScatterOp::create(
+      rewriter,
       ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reduce_scatter_4d"),
       paddedOutputType, reshapeInput.getResult(), op.getReduceType(),
       adjustedScatterDim, op.getClusterAxis(),

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RotaryEmbeddingOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RotaryEmbeddingOpRewritePattern.cpp
@@ -31,9 +31,9 @@ LogicalResult RotaryEmbeddingOpRewritePattern::matchAndRewrite(
   auto paddedType =
       utils::RankedTensorTypeFactory::create(resultType, paddedResultShape);
 
-  auto rope = rewriter.create<RotaryEmbeddingOp>(
-      srcOp.getLoc(), paddedType, srcOp.getInput(), srcOp.getCosCache(),
-      srcOp.getSinCache(), srcOp.getTokenIndexAttr(),
+  auto rope = RotaryEmbeddingOp::create(
+      rewriter, srcOp.getLoc(), paddedType, srcOp.getInput(),
+      srcOp.getCosCache(), srcOp.getSinCache(), srcOp.getTokenIndexAttr(),
       srcOp.getMemoryConfigAttr(), srcOp.getComputeConfigAttr());
 
   // Slice to original shape
@@ -42,8 +42,8 @@ LogicalResult RotaryEmbeddingOpRewritePattern::matchAndRewrite(
   SmallVector<int32_t> steps(resultShape.size(), 1);
   ends[ends.size() - 2] = originalSeqLen;
 
-  auto sliced = rewriter.create<ttnn::SliceStaticOp>(
-      srcOp.getLoc(), resultType, rope.getResult(),
+  auto sliced = ttnn::SliceStaticOp::create(
+      rewriter, srcOp.getLoc(), resultType, rope.getResult(),
       rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
       rewriter.getI32ArrayAttr(steps));
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeConfigRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeConfigRewritePattern.cpp
@@ -39,8 +39,8 @@ ScaledDotProductAttentionDecodeConfigRewritePattern::matchAndRewrite(
       /*max_cores_per_head_batch=*/std::nullopt);
 
   // Create a new operation with the program config set
-  auto newOp = rewriter.create<ScaledDotProductAttentionDecodeOp>(
-      srcOp.getLoc(), srcOp.getResult().getType(), srcOp.getQuery(),
+  auto newOp = ScaledDotProductAttentionDecodeOp::create(
+      rewriter, srcOp.getLoc(), srcOp.getResult().getType(), srcOp.getQuery(),
       srcOp.getKey(), srcOp.getValue(), srcOp.getIsCausal(),
       srcOp.getAttentionMask(), srcOp.getCurPosTensor(),
       srcOp.getAttentionSink(), srcOp.getScaleAttr(),

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadSequenceDimRewriterPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadSequenceDimRewriterPattern.cpp
@@ -32,12 +32,11 @@ Value padDimension(Value tensor, int64_t targetLen, int64_t dim,
   auto paddedType =
       utils::RankedTensorTypeFactory::create(tensorType, paddedShape);
 
-  return rewriter
-      .create<PadOp>(loc, paddedType, tensor,
-                     rewriter.getDenseI32ArrayAttr(padding),
-                     rewriter.getF32FloatAttr(padValue),
-                     /*use_multicore=*/rewriter.getBoolAttr(true),
-                     /*memory_config=*/nullptr)
+  return PadOp::create(rewriter, loc, paddedType, tensor,
+                       rewriter.getDenseI32ArrayAttr(padding),
+                       rewriter.getF32FloatAttr(padValue),
+                       /*use_multicore=*/rewriter.getBoolAttr(true),
+                       /*memory_config=*/nullptr)
       .getResult();
 }
 
@@ -62,10 +61,10 @@ Value sliceDimension(Value tensor, int64_t originalLen, int64_t dim,
   auto slicedType =
       utils::RankedTensorTypeFactory::create(tensorType, slicedShape);
 
-  return rewriter
-      .create<SliceStaticOp>(
-          loc, slicedType, tensor, rewriter.getI32ArrayAttr(begins),
-          rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps))
+  return SliceStaticOp::create(rewriter, loc, slicedType, tensor,
+                               rewriter.getI32ArrayAttr(begins),
+                               rewriter.getI32ArrayAttr(ends),
+                               rewriter.getI32ArrayAttr(steps))
       .getResult();
 }
 
@@ -156,8 +155,8 @@ ScaledDotProductAttentionPadTileDimsRewritePattern::matchAndRewrite(
   }
 
   auto resultType = paddedQuery.getType();
-  auto sdpaOp = rewriter.create<ScaledDotProductAttentionOp>(
-      srcOp.getLoc(), resultType, paddedQuery, paddedKey, paddedValue,
+  auto sdpaOp = ScaledDotProductAttentionOp::create(
+      rewriter, srcOp.getLoc(), resultType, paddedQuery, paddedKey, paddedValue,
       paddedMask, srcOp.getIsCausal(), srcOp.getScaleAttr(),
       srcOp.getSlidingWindowSizeAttr(), srcOp.getMemoryConfigAttr());
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScatterOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScatterOpRewritePattern.cpp
@@ -82,7 +82,8 @@ TTNNScatterWorkarounds::matchAndRewrite(ttnn::ScatterOp op,
     // Slice index tensor for this chunk.
     RankedTensorType chunkIndexType =
         ttnn::utils::RankedTensorTypeFactory::create(indexType, chunkShape);
-    auto chunkIndex = rewriter.create<ttnn::SliceStaticOp>(
+    auto chunkIndex = ttnn::SliceStaticOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(
             op.getLoc(), "_chunk_" + std::to_string(chunkIdx) + "_index"),
         chunkIndexType, op.getIndex(), rewriter.getI32ArrayAttr(begins),
@@ -96,14 +97,16 @@ TTNNScatterWorkarounds::matchAndRewrite(ttnn::ScatterOp op,
     RankedTensorType chunkSourceType =
         ttnn::utils::RankedTensorTypeFactory::create(sourceType,
                                                      chunkSourceShape);
-    auto chunkSource = rewriter.create<ttnn::SliceStaticOp>(
+    auto chunkSource = ttnn::SliceStaticOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(
             op.getLoc(), "_chunk_" + std::to_string(chunkIdx) + "_source"),
         chunkSourceType, op.getSource(), rewriter.getI32ArrayAttr(begins),
         rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
 
     // Perform scatter operation for this chunk.
-    auto chunkScatter = rewriter.create<ttnn::ScatterOp>(
+    auto chunkScatter = ttnn::ScatterOp::create(
+        rewriter,
         ttmlir::utils::appendLocationSuffix(
             op.getLoc(), "_chunk_" + std::to_string(chunkIdx) + "_scatter"),
         currentResult.getType(), currentResult, chunkIndex.getResult(),

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SubtractOpImplicitBroadcastRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SubtractOpImplicitBroadcastRewritePattern.cpp
@@ -17,9 +17,9 @@ LogicalResult SubtractOpImplicitBroadcastRewritePattern::matchAndRewrite(
     return failure();
   }
 
-  ttnn::NegOp negOp = rewriter.create<ttnn::NegOp>(
-      ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_neg"), rhsType,
-      srcOp.getRhs());
+  ttnn::NegOp negOp = ttnn::NegOp::create(
+      rewriter, ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_neg"),
+      rhsType, srcOp.getRhs());
   rewriter.replaceOpWithNewOp<ttnn::AddOp>(srcOp, srcOp.getResult().getType(),
                                            srcOp.getLhs(), negOp);
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -420,11 +420,10 @@ public:
         ttnn::utils::RankedTensorTypeFactory::create(inputType, inputTypeShape);
 
     // Create a new reducer scatter op.
-    ttnn::ReduceScatterOp reduceScatterOp =
-        rewriter.create<ttnn::ReduceScatterOp>(
-            ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
-            scatteredInputType, op.getInput(), op.getReduceType(), dimension,
-            clusterAxis, nullptr, nullptr, nullptr, nullptr);
+    ttnn::ReduceScatterOp reduceScatterOp = ttnn::ReduceScatterOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_reduceScatter"),
+        scatteredInputType, op.getInput(), op.getReduceType(), dimension,
+        clusterAxis, nullptr, nullptr, nullptr, nullptr);
 
     // Replace all_reduce op with all_gather op.
     rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
@@ -455,9 +454,9 @@ private:
         ttnn::utils::RankedTensorTypeFactory::create(inputType,
                                                      expandedInputShape);
 
-    ttnn::ReshapeOp leadingReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-        ttmlir::utils::appendLocationSuffix(loc, "_reshape"), reshapedInputType,
-        op.getInput(), reshapedInputShapeAttr,
+    ttnn::ReshapeOp leadingReshapeOp = ttnn::ReshapeOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_reshape"),
+        reshapedInputType, op.getInput(), reshapedInputShapeAttr,
         /* memory_config */ nullptr);
 
     // Create a new all gather op.
@@ -465,8 +464,8 @@ private:
     RankedTensorType allGatherOutputType =
         ttnn::utils::RankedTensorTypeFactory::create(reshapedInputType,
                                                      expandedInputShape);
-    ttnn::AllGatherOp allGatherOp = rewriter.create<ttnn::AllGatherOp>(
-        ttmlir::utils::appendLocationSuffix(loc, "_allGather"),
+    ttnn::AllGatherOp allGatherOp = ttnn::AllGatherOp::create(
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_allGather"),
         allGatherOutputType, leadingReshapeOp.getResult(), 0, clusterAxis,
         nullptr /*sub_device_id*/, nullptr /*memory_config*/,
         nullptr /*num_links*/, nullptr /*topology*/);

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -21,8 +21,8 @@ static GetDeviceOp insertGetDeviceOp(RewriterBase &rewriter,
   // TODO (jnie): Currently hardcoding the mesh offset to 0x0
   // Need a proper plan to dynamically determine this.
   llvm::SmallVector<int64_t, 2> meshOffset{0, 0};
-  return rewriter.create<ttnn::GetDeviceOp>(
-      loc, rewriter.getType<DeviceType>(),
+  return ttnn::GetDeviceOp::create(
+      rewriter, loc, rewriter.getType<DeviceType>(),
       ttnn::MeshShapeAttr::get(rewriter.getContext(), meshShape[0],
                                meshShape[1]),
       ttnn::MeshOffsetAttr::get(rewriter.getContext(), meshOffset[0],
@@ -111,8 +111,8 @@ ToLayoutOp createToLayoutOp(Operation *op,
   Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
   // Create a ToLayoutOp to convert the input operand to the desired
   // tensor layout, buffer type and memory layout.
-  return rewriter.create<ttnn::ToLayoutOp>(
-      loc, toLayoutOpResultType, inputValue,
+  return ttnn::ToLayoutOp::create(
+      rewriter, loc, toLayoutOpResultType, inputValue,
       LayoutAttr::get(rewriter.getContext(), targetTensorLayout),
       ttcore::DataTypeAttr::get(rewriter.getContext(), targetTensorDataType),
       outputMemConfigAttr);

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -37,139 +37,141 @@ public:
     if (!originalSymbolName.empty()) {
       emitComment(originalSymbolName);
     }
-    builder->create<emitc::IncludeOp>(loc, "cstdint",
-                                      /*isStandard=*/true);
+    emitc::IncludeOp::create(*builder, loc, "cstdint",
+                             /*isStandard=*/true);
 
-    builder->create<emitc::IncludeOp>(loc, "tools/profiler/kernel_profiler.hpp",
-                                      /*isStandard=*/false);
+    emitc::IncludeOp::create(*builder, loc,
+                             "tools/profiler/kernel_profiler.hpp",
+                             /*isStandard=*/false);
 
     if (threadType == ThreadType::Noc) {
 
-      builder->create<emitc::IncludeOp>(loc, "dataflow_api.h",
-                                        /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "dataflow_api.h",
+                               /*isStandard=*/false);
       emitExperimentalLLKs();
       emitDebugPrint(threadType);
     }
     if (threadType == ThreadType::Compute) {
-      builder->create<emitc::IncludeOp>(loc, "llk_defs.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc,
-                                        "compute_kernel_api/binary_max_min.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/common.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/matmul.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/bcast.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/tilize.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/untilize.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc,
-                                        "compute_kernel_api/transpose_wh.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc,
-                                        "compute_kernel_api/eltwise_binary.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_binary_sfpu.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api.h", // max ops
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(loc,
-                                        "compute_kernel_api/tile_move_copy.h",
-                                        /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/activations.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/eltwise_unary.h",
+      emitc::IncludeOp::create(*builder, loc, "llk_defs.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/binary_max_min.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/common.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/matmul.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/bcast.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/tilize.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/untilize.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/transpose_wh.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_binary.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_binary_sfpu.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api.h", // max ops
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/tile_move_copy.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/activations.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(
+          *builder, loc, "compute_kernel_api/eltwise_unary/eltwise_unary.h",
           /*isStandard=*/false);
       // TODO (kmitrovic) exp.h is an ExpOp-specific include. Every op has one,
       // should be handled in general, not like this.
       // Issue: https://github.com/tenstorrent/tt-mlir/issues/772
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/exp.h",
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/exp.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(
+          *builder, loc,
+          "compute_kernel_api/eltwise_unary/sfpu_split_includes.h",
           /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/sfpu_split_includes.h",
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/recip.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/fill.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/negative.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/sqrt.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/rounding.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(
+          *builder, loc, "compute_kernel_api/eltwise_unary/trigonometry.h",
           /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/recip.h",
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/gelu.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/erf_erfc.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(
+          *builder, loc, "compute_kernel_api/eltwise_unary/logical_not_noti.h",
           /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/fill.h",
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/comp.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/rsqrt.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/typecast.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/binary_bitwise_sfpu.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/bitwise_not.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/relu.h",
+                               /*isStandard=*/false);
+      emitc::IncludeOp::create(
+          *builder, loc, "compute_kernel_api/eltwise_unary/binop_with_scalar.h",
           /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/negative.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/sqrt.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/rounding.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/trigonometry.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/gelu.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/erf_erfc.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/logical_not_noti.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/comp.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/rsqrt.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/typecast.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/binary_bitwise_sfpu.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/bitwise_not.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/relu.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/binop_with_scalar.h",
-          /*isStandard=*/false);
-      builder->create<emitc::IncludeOp>(
-          loc, "compute_kernel_api/eltwise_unary/where.h",
-          /*isStandard=*/false);
+      emitc::IncludeOp::create(*builder, loc,
+                               "compute_kernel_api/eltwise_unary/where.h",
+                               /*isStandard=*/false);
       // Must define macros REDUCE_OP and REDUCE_DIM before including reduce.h
       // because they are default template parameters values in reduce api.
-      builder->create<emitc::VerbatimOp>(loc,
-                                         "#define REDUCE_OP PoolType::SUM");
-      builder->create<emitc::VerbatimOp>(
-          loc, "#define REDUCE_DIM ReduceDim::REDUCE_COL");
-      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/reduce.h",
-                                        /*isStandard=*/false);
+      emitc::VerbatimOp::create(*builder, loc,
+                                "#define REDUCE_OP PoolType::SUM");
+      emitc::VerbatimOp::create(*builder, loc,
+                                "#define REDUCE_DIM ReduceDim::REDUCE_COL");
+      emitc::IncludeOp::create(*builder, loc, "compute_kernel_api/reduce.h",
+                               /*isStandard=*/false);
       emitExperimentalLLKs();
       emitDebugPrint(threadType);
-      builder->create<emitc::VerbatimOp>(loc, "namespace NAMESPACE {");
+      emitc::VerbatimOp::create(*builder, loc, "namespace NAMESPACE {");
     }
   }
 
   ~ScopedModuleHelper() {
     if (threadType == ThreadType::Compute) {
-      builder->create<emitc::VerbatimOp>(loc, "void MAIN { kernel_main(); }");
-      builder->create<emitc::VerbatimOp>(loc,
-                                         "}"); // close namespace NAMESPACE
+      emitc::VerbatimOp::create(*builder, loc, "void MAIN { kernel_main(); }");
+      emitc::VerbatimOp::create(*builder, loc,
+                                "}"); // close namespace NAMESPACE
     }
   }
 
   void emitComment(StringRef str) {
-    builder->create<emitc::VerbatimOp>(loc, (Twine("// ") + str).str());
+    emitc::VerbatimOp::create(*builder, loc, (Twine("// ") + str).str());
   }
 
   void emitDebugPrint(ThreadType threadType) {
@@ -179,10 +181,10 @@ public:
       return;
     }
 
-    builder->create<emitc::IncludeOp>(loc, "debug/dprint.h",
-                                      /*isStandard=*/false);
+    emitc::IncludeOp::create(*builder, loc, "debug/dprint.h",
+                             /*isStandard=*/false);
 
-    builder->create<emitc::VerbatimOp>(loc, R""""(
+    emitc::VerbatimOp::create(*builder, loc, R""""(
 namespace ttmlir {
 template<typename Arg>
 void dprint(Arg &&arg) {
@@ -199,7 +201,7 @@ void dprint(Arg &&arg, ArgV&&... argv) {
 )"""");
 
     if (threadType == ThreadType::Compute) {
-      builder->create<emitc::VerbatimOp>(loc, R""""(
+      emitc::VerbatimOp::create(*builder, loc, R""""(
     namespace ttmlir {
       inline void print_cb_details_(DebugPrinter dp, uint32_t cb_id) {
       dp << "cb_id " << cb_id << ": { ";
@@ -235,34 +237,35 @@ void dprint(Arg &&arg, ArgV&&... argv) {
       auto experimentalTilizeLLKs =
           StringRef(experimental_tilize_llks_generated,
                     experimental_tilize_llks_generated_len);
-      builder->create<emitc::VerbatimOp>(loc, experimentalTilizeLLKs);
+      emitc::VerbatimOp::create(*builder, loc, experimentalTilizeLLKs);
     }
 
     if (hasCall("experimental::untilize")) {
       auto experimentalUntilizeLLKs =
           StringRef(experimental_untilize_llks_generated,
                     experimental_untilize_llks_generated_len);
-      builder->create<emitc::VerbatimOp>(loc, experimentalUntilizeLLKs);
+      emitc::VerbatimOp::create(*builder, loc, experimentalUntilizeLLKs);
     }
 
     if (hasCall("experimental::get_noc_multicast_addr")) {
       auto experimentalDataflowLLKs =
           StringRef(experimental_dataflow_api_generated,
                     experimental_dataflow_api_generated_len);
-      builder->create<emitc::VerbatimOp>(loc, experimentalDataflowLLKs);
+      emitc::VerbatimOp::create(*builder, loc, experimentalDataflowLLKs);
     }
 
     if (hasCall("experimental::matmul_block")) {
       auto experimentalMatmulLLKs =
           StringRef(experimental_matmul_llks_generated,
                     experimental_matmul_llks_generated_len);
-      builder->create<emitc::VerbatimOp>(loc, experimentalMatmulLLKs);
+      emitc::VerbatimOp::create(*builder, loc, experimentalMatmulLLKs);
     }
 
     if (hasVerbatim("experimental::invoke_sfpi")) {
-      builder->create<emitc::VerbatimOp>(
-          loc, StringRef(experimental_invoke_sfpi_llks_generated,
-                         experimental_invoke_sfpi_llks_generated_len));
+      emitc::VerbatimOp::create(
+          *builder, loc,
+          StringRef(experimental_invoke_sfpi_llks_generated,
+                    experimental_invoke_sfpi_llks_generated_len));
     }
   }
 
@@ -310,7 +313,7 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
 
   // We will wrap everything in a standalone module op so that we can run the
   // translation.
-  auto moduleWrapper = builder.create<mlir::ModuleOp>(loc, "module_wrapper");
+  auto moduleWrapper = mlir::ModuleOp::create(builder, loc, "module_wrapper");
   builder.setInsertionPointToStart(moduleWrapper.getBody());
 
   Region *kernelMainRegion;
@@ -319,8 +322,8 @@ cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
                                           origEntry.getName());
 
     // Clone 'region' into a new func op nested inside 'moduleWrapper':
-    auto kernelMain = builder.create<func::FuncOp>(
-        loc, "kernel_main",
+    auto kernelMain = func::FuncOp::create(
+        builder, loc, "kernel_main",
         builder.getType<FunctionType>(region->getArgumentTypes(), TypeRange()));
     kernelMainRegion = &kernelMain.getBody();
   }

--- a/lib/Transforms/CollapseParallelLoops.cpp
+++ b/lib/Transforms/CollapseParallelLoops.cpp
@@ -45,10 +45,10 @@ private:
 
     SmallVector<Value> newLowerBounds, newUpperBounds, newSteps;
 
-    newLowerBounds.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 0));
+    newLowerBounds.push_back(arith::ConstantIndexOp::create(rewriter, loc, 0));
     newUpperBounds.push_back(
-        rewriter.create<arith::ConstantIndexOp>(loc, collapsedSize));
-    newSteps.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 1));
+        arith::ConstantIndexOp::create(rewriter, loc, collapsedSize));
+    newSteps.push_back(arith::ConstantIndexOp::create(rewriter, loc, 1));
 
     newLowerBounds.push_back(lowerBounds[1]);
     newUpperBounds.push_back(upperBounds[1]);
@@ -58,8 +58,8 @@ private:
     newUpperBounds.push_back(upperBounds[0]);
     newSteps.push_back(steps[0]);
 
-    auto newParallelOp = rewriter.create<scf::ParallelOp>(
-        loc, newLowerBounds, newUpperBounds, newSteps, initVals);
+    auto newParallelOp = scf::ParallelOp::create(
+        rewriter, loc, newLowerBounds, newUpperBounds, newSteps, initVals);
 
     return newParallelOp;
   }
@@ -147,12 +147,13 @@ public:
       int64_t productOfRemainingDims =
           calculateProductOfRemainingDims(i + 1, endIdx, dimSizes);
       Value divisor =
-          rewriter.create<arith::ConstantIndexOp>(loc, productOfRemainingDims);
-      Value quotient = rewriter.create<arith::DivUIOp>(loc, remaining, divisor);
+          arith::ConstantIndexOp::create(rewriter, loc, productOfRemainingDims);
+      Value quotient =
+          arith::DivUIOp::create(rewriter, loc, remaining, divisor);
       decomposedVars.push_back(quotient);
 
-      Value product = rewriter.create<arith::MulIOp>(loc, quotient, divisor);
-      remaining = rewriter.create<arith::SubIOp>(loc, remaining, product);
+      Value product = arith::MulIOp::create(rewriter, loc, quotient, divisor);
+      remaining = arith::SubIOp::create(rewriter, loc, remaining, product);
     }
     decomposedVars.push_back(remaining);
 

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -653,8 +653,8 @@ private:
     // Create the const-eval function before the parent function
     // This ensures proper ordering in the generated EmitC code.
     builder.setInsertionPoint(originalFunc);
-    auto newFuncOp = builder.create<func::FuncOp>(originalFunc.getLoc(),
-                                                  newFuncName, funcType);
+    auto newFuncOp = func::FuncOp::create(builder, originalFunc.getLoc(),
+                                          newFuncName, funcType);
     // Mark the new function as const-eval and private.
     newFuncOp->setAttr(ttmlir::utils::g_constEvalAttrName,
                        builder.getUnitAttr());
@@ -710,7 +710,7 @@ private:
       returnValues.push_back(it->second);
     }
 
-    builder.create<func::ReturnOp>(originalFunc.getLoc(), returnValues);
+    func::ReturnOp::create(builder, originalFunc.getLoc(), returnValues);
 
     auto &originalEntryBlock = originalFunc.getBody().front();
     // Manually order LoadCachedOp as first n ops in original func--we may
@@ -724,8 +724,9 @@ private:
         mlir::SymbolRefAttr::get(builder.getContext(), newFuncName);
 
     // Create the LoadCachedOp with the correct argument order
-    auto callOp = builder.create<ttcore::LoadCachedOp>(
-        originalFunc.getLoc(), outputTypes, calleeAttr, ValueRange(inputs));
+    auto callOp = ttcore::LoadCachedOp::create(builder, originalFunc.getLoc(),
+                                               outputTypes, calleeAttr,
+                                               ValueRange(inputs));
 
     // Replace uses of original outputs with call results.
     for (size_t i = 0; i < outputs.size(); ++i) {

--- a/lib/Transforms/ConvertCPUHoistedFunctionsToDPS.cpp
+++ b/lib/Transforms/ConvertCPUHoistedFunctionsToDPS.cpp
@@ -128,12 +128,12 @@ private:
       for (auto [index, returnValue] : llvm::enumerate(returnedValues)) {
         auto outputArgument = funcOp.getArgument(funcOp.getNumArguments() -
                                                  returnTypes.size() + index);
-        builder.create<linalg::CopyOp>(returnOp.getLoc(), returnValue,
-                                       outputArgument);
+        linalg::CopyOp::create(builder, returnOp.getLoc(), returnValue,
+                               outputArgument);
       }
 
       // Insert void return op.
-      builder.create<func::ReturnOp>(returnOp.getLoc());
+      func::ReturnOp::create(builder, returnOp.getLoc());
       returnOp.erase();
     }
   }
@@ -180,13 +180,13 @@ private:
 
         for (auto returnType : returnTypes) {
           auto outputTensor =
-              builder.create<ttir::EmptyOp>(callOp.getLoc(), returnType);
+              ttir::EmptyOp::create(builder, callOp.getLoc(), returnType);
 
           callOperands.push_back(outputTensor);
         }
 
-        auto newCallOp =
-            builder.create<func::CallOp>(callOp.getLoc(), funcOp, callOperands);
+        auto newCallOp = func::CallOp::create(builder, callOp.getLoc(), funcOp,
+                                              callOperands);
 
         // Copy attributes from old call op to new call op.
         newCallOp->setAttrs(callOp->getAttrs());


### PR DESCRIPTION
### Problem description
TT-MLIR compiler references the following external projects:
- LLVM
- StableHLO
- Shardy

Last successful uplift was:
https://github.com/tenstorrent/tt-mlir/pull/5282

### What's changed
Integrating the fresh LLVM, StableHLO, and Shardy versions in the tt-mlir compiler.

Shardy:
f36aaacad42e307da330bace41c920bdf23f1869
StableHLO:
1ef9e390b5295e676d2b864fe1924bc2f3f4cf0f
LLVM:
43bfec29cbecc1ff2e5aa6f8908c4d63e9c896c5