### PR TITLE
pytest support for simulator environment

### DIFF
--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -8,6 +8,7 @@ import re
 import platform
 from functools import reduce
 import operator
+import os
 import torch
 import subprocess
 from typing import Any, Dict, List, Tuple, Optional
@@ -15,6 +16,8 @@ import math
 
 ALL_BACKENDS = set(["ttnn", "ttmetal", "emitc", "emitpy"])
 ALL_SYSTEMS = set(["n150", "n300", "llmbox", "tg", "p150", "p300"])
+ALL_ENVIRONMENTS = set(["silicon", "sim"])
+ALL_CONFIGS = ALL_BACKENDS | ALL_SYSTEMS | ALL_ENVIRONMENTS
 
 
 _current_device = None
@@ -105,6 +108,13 @@ def _get_device_for_target(target: str, mesh_shape: Tuple[int, int], pytestconfi
     _current_device_target = target
     _current_device_mesh_shape = mesh_shape
     return _current_device
+
+
+def _get_current_environment():
+    if "TT_METAL_SIMULATOR" in os.environ:
+        return "sim"
+
+    return "silicon"
 
 
 def is_x86_machine():
@@ -486,6 +496,42 @@ def pytest_runtest_call(item: pytest.Item):
         _safe_add_property(item, "failure_stage", failure_stage)
 
 
+def _mark_item_for_skip(
+    item,
+    current_target,
+    board_id,
+    current_environment,
+    marker_name,
+    skip_handler_fn,
+    negate_check=False,
+):
+    for marker in item.iter_markers(name=marker_name):
+        for platform_config in marker.args:
+
+            # All of the operations we need to do on these are set membership based
+            platform_config = set(platform_config)
+
+            reason = marker.kwargs.get("reason", "")
+
+            # Verify this is a valid configuration
+            if not platform_config <= ALL_CONFIGS:
+                outliers = platform_config - ALL_CONFIGS
+                raise ValueError(
+                    f"Invalid {marker_name}: {platform_config}, invalid entries: {outliers}. Please ensure that all entries in the config are members of {ALL_CONFIGS}"
+                )
+
+            should_skip = platform_config <= set(
+                [current_target, board_id, current_environment]
+            )
+
+            # For only_config we want to skip if config is NOT in the allowed list
+            if negate_check:
+                should_skip = not should_skip
+
+            if should_skip:
+                skip_handler_fn(item, platform_config, reason)
+
+
 def pytest_collection_modifyitems(config, items):
     valid_items = []
     deselected = []
@@ -521,82 +567,56 @@ def pytest_collection_modifyitems(config, items):
                 current_target = param[1]
                 break
 
-        for marker in item.iter_markers(name="skip_config"):
-            for platform_config in marker.args:
+        current_environment = _get_current_environment()
+        board_id = get_board_id(system_desc)
 
-                # All of the operations we need to do on these are set membership based
-                platform_config = set(platform_config)
+        def skip_config_handler(item, platform_config, reason):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=f"Operation not supported on following platform/target combination: {platform_config}. {reason}"
+                )
+            )
 
-                reason = marker.kwargs.get("reason", "")
+        def only_config_handler(item, platform_config, reason):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=f"Test only runs on following platform/target combination: {platform_config}. {reason}"
+                )
+            )
 
-                # Verify this is a valid configuration
-                if not platform_config <= ALL_BACKENDS.union(ALL_SYSTEMS):
-                    outliers = platform_config - ALL_BACKENDS.union(ALL_SYSTEMS)
-                    raise ValueError(
-                        f"Invalid skip config: {platform_config}, invalid entries: {outliers}. Please ensure that all entries in the config are members of {ALL_SYSTEMS} or {ALL_BACKENDS}"
-                    )
+        def skip_exec_handler(item, platform_config, reason):
+            # Set skip_exec attribute on the item instead of marking as skipped
+            item.skip_exec = True
+            xfail_reason = f"Execution skipped for platform/target combination: {platform_config}. {reason}"
+            item.skip_exec_reason = xfail_reason
+            # Mark test as xfail so it's expected to fail
+            item.add_marker(pytest.mark.xfail(reason=xfail_reason, strict=False))
 
-                board_id = get_board_id(system_desc)
-
-                if platform_config <= set([current_target, board_id]):
-                    item.add_marker(
-                        pytest.mark.skip(
-                            reason=f"Operation not supported on following platform/target combination: {platform_config}. {reason}"
-                        )
-                    )
-
-        for marker in item.iter_markers(name="only_config"):
-            for platform_config in marker.args:
-
-                # All of the operations we need to do on these are set membership based
-                platform_config = set(platform_config)
-
-                reason = marker.kwargs.get("reason", "")
-
-                # Verify this is a valid configuration
-                if not platform_config <= ALL_BACKENDS.union(ALL_SYSTEMS):
-                    outliers = platform_config - ALL_BACKENDS.union(ALL_SYSTEMS)
-                    raise ValueError(
-                        f"Invalid only_config: {platform_config}, invalid entries: {outliers}. Please ensure that all entries in the config are members of {ALL_SYSTEMS} or {ALL_BACKENDS}"
-                    )
-
-                board_id = get_board_id(system_desc)
-
-                # Skip if the current config is NOT in the allowed list
-                if not platform_config <= set([current_target, board_id]):
-                    item.add_marker(
-                        pytest.mark.skip(
-                            reason=f"Test only runs on following platform/target combination: {platform_config}. {reason}"
-                        )
-                    )
-
-        # Mark tests with skip_exec to skip execution but allow compilation
-        for marker in item.iter_markers(name="skip_exec"):
-            for platform_config in marker.args:
-
-                # All of the operations we need to do on these are set membership based
-                platform_config = set(platform_config)
-
-                reason = marker.kwargs.get("reason", "")
-
-                # Verify this is a valid configuration
-                if not platform_config <= ALL_BACKENDS.union(ALL_SYSTEMS):
-                    outliers = platform_config - ALL_BACKENDS.union(ALL_SYSTEMS)
-                    raise ValueError(
-                        f"Invalid skip_exec config: {platform_config}, invalid entries: {outliers}. Please ensure that all entries in the config are members of {ALL_SYSTEMS} or {ALL_BACKENDS}"
-                    )
-
-                board_id = get_board_id(system_desc)
-
-                if platform_config <= set([current_target, board_id]):
-                    # Set skip_exec attribute on the item instead of marking as skipped
-                    item.skip_exec = True
-                    xfail_reason = f"Execution skipped for platform/target combination: {platform_config}. {reason}"
-                    item.skip_exec_reason = xfail_reason
-                    # Mark test as xfail so it's expected to fail
-                    item.add_marker(
-                        pytest.mark.xfail(reason=xfail_reason, strict=False)
-                    )
+        _mark_item_for_skip(
+            item,
+            current_target,
+            board_id,
+            current_environment,
+            "skip_config",
+            skip_config_handler,
+        )
+        _mark_item_for_skip(
+            item,
+            current_target,
+            board_id,
+            current_environment,
+            "only_config",
+            only_config_handler,
+            negate_check=True,
+        )
+        _mark_item_for_skip(
+            item,
+            current_target,
+            board_id,
+            current_environment,
+            "skip_exec",
+            skip_exec_handler,
+        )
 
     # Update the items list (collected tests)
     items[:] = valid_items

--- a/test/python/golden/test_utils.py
+++ b/test/python/golden/test_utils.py
@@ -53,6 +53,47 @@ class Marks:
         return pytest.param(*lhs, marks=self.marks)
 
 
+class SkipIf:
+    """
+    Convenience class for adding pytest skip_config.
+
+    Example
+    -------
+    # Marks ttmetal target as skip OR (ttnn AND sim) as skip
+    >>> test_case | SkipConfig("ttmetal", ["ttnn", "sim"])
+    """
+
+    def __init__(self, *marks_groups, mark_fn=pytest.mark.skip_config):
+        self.marks_groups = [g if isinstance(g, list) else [g] for g in marks_groups]
+        self.mark_fn = mark_fn
+
+    def __ror__(self, lhs):
+        """
+        Apply marks to a test parameter.
+
+        Parameters
+        ----------
+        lhs : Any
+            Test parameter to mark
+
+        Returns
+        -------
+        pytest.param
+            Marked test parameter
+        """
+        return pytest.param(lhs, marks=[self.mark_fn(g) for g in self.marks_groups])
+
+
+class OnlyIf(SkipIf):
+    def __init__(self, *marks_groups):
+        super().__init__(*marks_groups, mark_fn=pytest.mark.only_config)
+
+
+class SkipExecIf(SkipIf):
+    def __init__(self, *marks_groups):
+        super().__init__(*marks_groups, mark_fn=pytest.mark.skip_exec)
+
+
 def shape_str(shape):
     """
     Converts shape tuple to string.

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
@@ -13,6 +13,7 @@ from builder.base.builder_apis import (
 )
 from test_utils import (
     Marks,
+    SkipIf,
     shape_str,
 )
 
@@ -337,12 +338,14 @@ def leaky_relu(
     return builder.leaky_relu(in0, parameter, unit_attrs=unit_attrs)
 
 
-unary_ops_with_float_param = [leaky_relu | Marks(pytest.mark.skip_config(["ttmetal"]))]
+unary_ops_with_float_param = [leaky_relu | SkipIf("ttmetal")]
 
 
 @pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
-@pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitc", "emitpy"])
+@pytest.mark.parametrize(
+    "target", ["ttnn" | SkipIf("sim"), "ttmetal", "emitc", "emitpy"]
+)
 @pytest.mark.parametrize("test_fn", unary_ops_with_float_param)
 @pytest.mark.parametrize("parameter", [0.01, 0.1, 0.2])
 def test_unary_ops_with_float_param(

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -2,6 +2,7 @@ lit
 pydantic
 pytest
 pytest-json-report
+pytest-forked
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.0
 einops


### PR DESCRIPTION
- Adds environment concept to distinguish silicon vs simulator
- SkipIf and friends convenience markers for marking test params for skip

Example test run:
```bash
export TT_METAL_SIMULATOR=/path/to/sim/libttsim.so
export TT_METAL_SLOW_DISPATCH_MODE=1
pytest --forked -svvv test/python/golden/ttir_ops/eltwise/test_ttir_unary.py::test_unary_ops_with_float_param --sys-desc=${SYSTEM_DESC_PATH}
```