### PR TITLE
[ttrt] enable prog cache by default

### DIFF
--- a/runtime/test/ttnn/python/utils.py
+++ b/runtime/test/ttnn/python/utils.py
@@ -129,7 +129,7 @@ class DeviceContext:
         self,
         mesh_shape=None,
         mesh_offset=None,
-        enable_program_cache=False,
+        enable_program_cache=True,
         trace_region_size=0,
         num_hw_cqs=1,
     ):

--- a/tools/ttrt/common/emitc.py
+++ b/tools/ttrt/common/emitc.py
@@ -100,7 +100,7 @@ class EmitC:
         EmitC.register_arg(
             name="--enable-program-cache",
             type=bool,
-            default=False,
+            default=True,
             choices=[True, False],
             help="enable program cache in ttnn runtime",
         )

--- a/tools/ttrt/common/emitpy.py
+++ b/tools/ttrt/common/emitpy.py
@@ -107,7 +107,7 @@ class EmitPy:
         EmitPy.register_arg(
             name="--enable-program-cache",
             type=bool,
-            default=False,
+            default=True,
             choices=[True, False],
             help="enable program cache in ttnn runtime",
         )

--- a/tools/ttrt/common/perf.py
+++ b/tools/ttrt/common/perf.py
@@ -115,7 +115,7 @@ class Perf:
         Perf.register_arg(
             name="--enable-program-cache",
             type=bool,
-            default=False,
+            default=True,
             choices=[True, False],
             help="enable program cache in ttnn runtime",
         )

--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -277,7 +277,7 @@ class Run:
         Run.register_arg(
             name="--enable-program-cache",
             type=bool,
-            default=False,
+            default=True,
             choices=[True, False],
             help="enable program cache in ttnn runtime",
         )


### PR DESCRIPTION
Enabling program cache in `ttrt` by default to align with the runtime defaults.