### PR TITLE
Expose ComputeKernelConfig for several TTNN ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -853,9 +853,18 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
 
   let arguments = (ins AnyRankedTensor:$input,
                        BoolAttr:$keep_dim,
-                       OptionalAttr<I32ArrayAttr>:$dim_arg);
-
+                       OptionalAttr<I32ArrayAttr>:$dim_arg,
+                       OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
   let results = (outs AnyRankedTensor:$result);
+
+  let builders = [
+    OpBuilder<(ins "Type":$result, "Value":$input,
+                   "bool":$keep_dim, "ArrayAttr":$dim_arg),
+    [{
+      build($_builder, $_state, result, input, keep_dim, dim_arg,
+            /*compute_config=*/nullptr);
+    }]>
+  ];
 
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
@@ -1208,9 +1217,25 @@ def TTNN_SoftmaxOp : TTNN_Op<"softmax"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          SI32Attr: $dimension,
-                         DefaultValuedAttr<BoolAttr, "false">:$numericStable);
+                         DefaultValuedAttr<BoolAttr, "false">:$numericStable,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$input,
+                     "int32_t":$dimension, "bool":$numericStable),
+      [{
+        build($_builder, $_state, result, input, dimension, numericStable,
+              /*compute_config=*/nullptr);
+      }]>,
+      OpBuilder<(ins "Type":$result, "Value":$input,
+                     "int32_t":$dimension),
+      [{
+        build($_builder, $_state, result, input, dimension, /*numericStable=*/false,
+              /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }
@@ -1461,9 +1486,20 @@ def TTNN_LinearOp : TTNN_Op<"linear"> {
                          Optional<AnyRankedTensor>:$bias,
                          DefaultValuedAttr<BoolAttr, "false">:$transpose_a,
                          DefaultValuedAttr<BoolAttr, "false">:$transpose_b,
-                         OptionalAttr<StrAttr>:$activation);
+                         OptionalAttr<StrAttr>:$activation,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$a, "Value":$b,
+                     "Value":$bias, "bool":$transpose_a, "bool":$transpose_b,
+                     "StringAttr":$activation),
+      [{
+        build($_builder, $_state, result, a, b, bias, transpose_a, transpose_b,
+              activation, /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }
@@ -1481,9 +1517,21 @@ def TTNN_MatmulOp : TTNN_Op<"matmul"> {
                             TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
                             TTNN_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
                          ]>>:$matmul_program_config,
-                         OptionalAttr<StrAttr>:$activation);
+                         OptionalAttr<StrAttr>:$activation,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$a, "Value":$b,
+                     "bool":$transpose_a, "bool":$transpose_b,
+                     "Attribute":$matmul_program_config,
+                     "StringAttr":$activation),
+      [{
+        build($_builder, $_state, result, a, b, transpose_a, transpose_b,
+              matmul_program_config, activation, /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }
@@ -1996,9 +2044,22 @@ def TTNN_BatchNormInferenceOp : TTNN_Op<"batch_norm_inference", [AttrSizedOperan
                          DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
                          Optional<AnyRankedTensor>:$weight,
                          Optional<AnyRankedTensor>:$bias,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$input,
+                     "Value":$running_mean, "Value":$running_var,
+                     "llvm::APFloat":$epsilon,
+                     "Value":$weight, "Value":$bias,
+                     "MemoryConfigAttr":$memory_config),
+      [{
+        build($_builder, $_state, result, input, running_mean, running_var,
+              epsilon, weight, bias, memory_config, /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }
@@ -2017,9 +2078,22 @@ def TTNN_BatchNormTrainingOp : TTNN_Op<"batch_norm_training", [AttrSizedOperandS
                          DefaultValuedAttr<F32Attr, "0.1">:$momentum,
                          Optional<AnyRankedTensor>:$weight,
                          Optional<AnyRankedTensor>:$bias,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$input,
+                     "Value":$running_mean, "Value":$running_var,
+                     "llvm::APFloat":$epsilon, "llvm::APFloat":$momentum,
+                     "Value":$weight, "Value":$bias,
+                     "MemoryConfigAttr":$memory_config),
+      [{
+        build($_builder, $_state, result, input, running_mean, running_var,
+              epsilon, momentum, weight, bias, memory_config, /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }
@@ -2039,9 +2113,21 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_MemoryC
                          Optional<AnyRankedTensor>:$weight,
                          Optional<AnyRankedTensor>:$bias,
                          DefaultValuedAttr<F32Attr, "1e-12">:$epsilon,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders = [
+      OpBuilder<(ins "Type":$result, "Value":$input,
+                     "Value":$weight, "Value":$bias,
+                     "llvm::APFloat":$epsilon,
+                     "MemoryConfigAttr":$memory_config),
+      [{
+        build($_builder, $_state, result, input, weight, bias,
+              epsilon, memory_config, /*compute_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Target/TTNN/operations/matmul.fbs
+++ b/include/ttmlir/Target/TTNN/operations/matmul.fbs
@@ -1,5 +1,6 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
+include "ttmlir/Target/TTNN/operations/configs.fbs";
 include "ttmlir/Target/TTNN/operations/eltwise.fbs";
 
 namespace tt.target.ttnn;
@@ -68,6 +69,7 @@ table MatmulOp {
   transpose_b: bool;
   matmul_program_config: tt.target.ttnn.MatmulProgramConfig;
   activation: string;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 // ANCHOR_END: adding_an_op_matmul_fbs
 
@@ -79,4 +81,5 @@ table LinearOp {
   transpose_a: bool;
   transpose_b: bool;
   activation: string;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -1,5 +1,6 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
+include "ttmlir/Target/TTNN/operations/configs.fbs";
 
 namespace tt.target.ttnn;
 
@@ -8,6 +9,7 @@ table SoftmaxOp {
   out: tt.target.ttnn.TensorRef;
   dimension: int32;
   numeric_stable: bool = false;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table BatchNormInferenceOp {
@@ -19,6 +21,7 @@ table BatchNormInferenceOp {
   bias: tt.target.ttnn.TensorRef;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table BatchNormTrainingOp {
@@ -31,6 +34,7 @@ table BatchNormTrainingOp {
   bias: tt.target.ttnn.TensorRef;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table RMSNormOp {
@@ -40,4 +44,5 @@ table RMSNormOp {
   epsilon: float;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }

--- a/include/ttmlir/Target/TTNN/operations/reduction.fbs
+++ b/include/ttmlir/Target/TTNN/operations/reduction.fbs
@@ -1,4 +1,5 @@
 include "ttmlir/Target/TTNN/types.fbs";
+include "ttmlir/Target/TTNN/operations/configs.fbs";
 
 namespace tt.target.ttnn;
 
@@ -15,6 +16,7 @@ table ReductionOp {
   out: tt.target.ttnn.TensorRef;
   dim_arg: [int32];
   keep_dim: bool;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table ReductionArgMaxOp {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -479,9 +479,14 @@ createOp(FlatbufferObjectCache &cache, MatmulOp op) {
 
   auto activation = toFlatbuffer(cache, op.getActivation()).value_or(0);
 
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateMatmulOp(
       *cache.fbb, a, b, output, op.getTransposeA(), op.getTransposeB(),
-      matmulProgramConfigType, matmulProgramConfigDesc, activation);
+      matmulProgramConfigType, matmulProgramConfigDesc, activation,
+      computeConfig.value_or(0));
 }
 // ANCHOR_END: adding_an_op_matmul_serialize_to_binary
 
@@ -1053,10 +1058,15 @@ createOp(FlatbufferObjectCache &cache, BatchNormInferenceOp op) {
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       op.getMemoryConfig() ? toFlatbuffer(cache, *op.getMemoryConfig()) : 0;
 
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   // For inference BatchNormInferenceOp: no momentum, no batch stats
   return ::tt::target::ttnn::CreateBatchNormInferenceOp(
       *cache.fbb, input, runningMean, runningVar,
-      op.getEpsilon().convertToFloat(), weight, bias, memoryConfig, output);
+      op.getEpsilon().convertToFloat(), weight, bias, memoryConfig, output,
+      computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::BatchNormTrainingOp>
@@ -1084,11 +1094,15 @@ createOp(FlatbufferObjectCache &cache, BatchNormTrainingOp op) {
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       op.getMemoryConfig() ? toFlatbuffer(cache, *op.getMemoryConfig()) : 0;
 
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   // For training BatchNormTrainingOp with momentum
   return ::tt::target::ttnn::CreateBatchNormTrainingOp(
       *cache.fbb, input, runningMean, runningVar,
       op.getEpsilon().convertToFloat(), op.getMomentum().convertToFloat(),
-      weight, bias, memoryConfig, output);
+      weight, bias, memoryConfig, output, computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::RMSNormOp>
@@ -1116,9 +1130,13 @@ createOp(FlatbufferObjectCache &cache, RMSNormOp op) {
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       getMemoryConfigIfNeeded(cache, op);
 
-  return ::tt::target::ttnn::CreateRMSNormOp(*cache.fbb, input, weight, bias,
-                                             op.getEpsilon().convertToFloat(),
-                                             memoryConfig, output);
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
+  return ::tt::target::ttnn::CreateRMSNormOp(
+      *cache.fbb, input, weight, bias, op.getEpsilon().convertToFloat(),
+      memoryConfig, output, computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::UpsampleOp>
@@ -1828,8 +1846,13 @@ createReductionOp(FlatbufferObjectCache &cache, ReductionOp op) {
   auto dimArg =
       arrayAttrToFlatbuffer<mlir::IntegerAttr, int>(cache, op.getDimArg());
 
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateReductionOp(*cache.fbb, type, in, output,
-                                               dimArg, op.getKeepDim());
+                                               dimArg, op.getKeepDim(),
+                                               computeConfig.value_or(0));
 }
 
 template <typename ReductionOp>
@@ -2172,9 +2195,12 @@ createSoftmaxOp(FlatbufferObjectCache &cache, SoftmaxOp op) {
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer);
   int32_t dimension = op.getDimension();
   bool numericStable = op.getNumericStable();
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
 
-  return ::tt::target::ttnn::CreateSoftmaxOp(*cache.fbb, in, out, dimension,
-                                             numericStable);
+  return ::tt::target::ttnn::CreateSoftmaxOp(
+      *cache.fbb, in, out, dimension, numericStable, computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::DeallocateOp>

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -36,10 +36,16 @@ void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
       op->activation() ? std::make_optional(op->activation()->str())
                        : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor output = ::ttnn::matmul(
       lhs, rhs, op->transpose_a(), op->transpose_b(), outputMemoryConfig,
       outputDataType, matmulProgramConfig,
-      /*activation=*/activation, /*compute_kernel_config=*/std::nullopt,
+      /*activation=*/activation, /*compute_kernel_config=*/computeConfig,
       /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
       /* optional_output_tensor=*/std::nullopt);
 
@@ -69,10 +75,16 @@ void run(const ::tt::target::ttnn::LinearOp *op, ProgramContext &context) {
       op->activation() ? std::make_optional(op->activation()->str())
                        : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor output = ::ttnn::linear(
       lhs, rhs, bias, op->transpose_a(), op->transpose_b(), outputMemoryConfig,
       outputDataType, /*program_config=*/std::nullopt,
-      /*activation=*/activation, /*compute_kernel_config=*/std::nullopt,
+      /*activation=*/activation, /*compute_kernel_config=*/computeConfig,
       /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
       /* optional_output_tensor=*/std::nullopt);
 

--- a/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/normalization/rms_norm.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::rms_norm {
@@ -29,13 +30,19 @@ void run(const ::tt::target::ttnn::RMSNormOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           op->memory_config());
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   // Call TTNN RMS norm operation
   ::ttnn::Tensor output = ::ttnn::rms_norm(
       input, epsilon, weight, bias,
       /*residual_input_tensor=*/std::nullopt, // Not used in our implementation
       memoryConfig,
-      /*program_config=*/std::nullopt,       // Use default
-      /*compute_kernel_config=*/std::nullopt // Use default
+      /*program_config=*/std::nullopt,        // Use default
+      /*compute_kernel_config=*/computeConfig // Use default
   );
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);

--- a/runtime/lib/ttnn/operations/normalization/softmax.cpp
+++ b/runtime/lib/ttnn/operations/normalization/softmax.cpp
@@ -23,8 +23,14 @@ void run(const ::tt::target::ttnn::SoftmaxOp *op, ProgramContext &context) {
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out = ::ttnn::softmax(in, dimension, outputMemoryConfig,
-                                       std::nullopt, numericStable);
+                                       computeConfig, numericStable);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -34,9 +34,15 @@ static void runReductionOp(
                                                              fbDimArg->end()))
                : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out = ttnnOp(
       in, dimArg, op->keep_dim(), outputMemoryConfig /* memory_config_arg */,
-      std::nullopt /* compute_kernel_config */, 1.0f /* scalar */);
+      computeConfig /* compute_kernel_config */, 1.0f /* scalar */);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/6349

### Problem description
There are several operations in TTNN dialect that don't expose ComputeKernelConfig from ttnn library.

### What's changed
Added attribute ComputeKernelConfig for following ops:
TTNN_MeanOp, TTNN_MinOp, TTNN_MaxOp, TTNN_SumOp, TTNN_RMSNormOp, TTNN_BatchNormInferenceOp, TTNN_BatchNormTrainingOp, TTNN_SoftmaxOp, TTNN_MatmulOp, TTNN_LinearOp

Updated tableGen to support old signatures.
