### PR TITLE
[CI] Build all dockers on push

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -19,6 +19,8 @@ jobs:
   build-image:
     uses: ./.github/workflows/call-build-docker.yml
     secrets: inherit
+    with:
+      dockbuild: "all"
   prepare-run:
     uses: ./.github/workflows/call-prepare-run.yml
     with:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/922

### Problem description
Need cibuildwheel docker image for tt-xla multi linux build

### What's changed
Build cibuildwheel docker on every push

### Checklist
- [ ] New/Existing tests provide coverage for changes
