### PR TITLE
Modularize `ci_compile_dylib.py`

### DIFF
--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -32,6 +32,7 @@ install(
     workarounds.hpp
     compile_so.hpp
     compile_so.cpp
+    emitc_compiler.py
   DESTINATION tools/ttnn-standalone
   COMPONENT TTNNStandalone
 )

--- a/tools/ttnn-standalone/ci_compile_dylib.py
+++ b/tools/ttnn-standalone/ci_compile_dylib.py
@@ -5,185 +5,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+CLI wrapper for EmitC compiler.
+
+This script compiles EmitC-generated C++ files to shared objects (.so) or
+standalone executables.
+
+Usage:
+    python ci_compile_dylib.py --file path/to/file.cpp
+    python ci_compile_dylib.py --dir path/to/cpp/files
+    python ci_compile_dylib.py --build-dir path/to/build
+"""
 
 import sys
 import os
-import subprocess
-import shutil
 import argparse
 
-
-# Returns the path where EmitC TTNN tests live
-#
-def get_emitc_tests_path(build_dir):
-    if get_emitc_tests_path.path:
-        return get_emitc_tests_path.path
-
-    get_emitc_tests_path.path = os.path.join(build_dir, "test/ttmlir/EmitC/TTNN")
-
-    return get_emitc_tests_path.path
-
-
-# Returns ttnn-standalone dir
-#
-def get_standalone_dir():
-    # Calculate standalone dir path by using this script's location
-    #
-    return os.path.dirname(os.path.abspath(__file__))
-
-
-# Runs cmake setup for .so compilation
-# Runs only once per script
-#
-def run_cmake_setup(args):
-    if run_cmake_setup.already_created:
-        return
-
-    standalone_source_dir = get_standalone_dir()
-    standalone_build_dir = os.path.join(standalone_source_dir, "build")
-    cmake_command = [
-        "cmake",
-        "-G",
-        "Ninja",
-        "-B",
-        standalone_build_dir,
-        "-S",
-        standalone_source_dir,
-        f"-DCMAKE_BUILD_TYPE={args.build_type}",
-        f"-DCMAKE_C_COMPILER={os.environ.get('CC', 'clang')}",
-        f"-DCMAKE_CXX_COMPILER={os.environ.get('CXX', 'clang++')}",
-    ]
-
-    if args.metal_src_dir:
-        cmake_command.append(f"-DMETAL_SRC_DIR={args.metal_src_dir}")
-
-    if args.metal_lib_dir:
-        cmake_command.append(f"-DMETAL_LIB_DIR={args.metal_lib_dir}")
-
-    try:
-        result = subprocess.run(
-            cmake_command,
-            check=True,
-            cwd=standalone_source_dir,
-            capture_output=True,
-            text=True,
-        )
-    except Exception as e:
-        print(f"Error setting up cmake environment: {e}")
-        print(e.stderr)
-        print(e.stdout)
-        sys.exit(1)
-
-    run_cmake_setup.already_created = True
-
-
-# Init fn variables
-#
-get_emitc_tests_path.path = None
-run_cmake_setup.already_created = None
-
-
-# Check if the modification time of file1 is lesser than file2 (i.e. if file1 is older than file2)
-#
-def is_file_older(f1_path, f2_path):
-    f1_mtime = os.path.getmtime(f1_path)
-    f2_mtime = os.path.getmtime(f2_path)
-    return f1_mtime < f2_mtime
-
-
-# Compile shared object, given source cpp and dest dir
-#
-def compile_shared_object(cpp_file_path, output_dir, args):
-    # Base name of the provided cpp file
-    #
-    cpp_base_name = os.path.basename(cpp_file_path).rsplit(".", 1)[0]
-
-    # Various dirs
-    #
-    standalone_source_dir = get_standalone_dir()
-    standalone_build_dir = os.path.join(standalone_source_dir, "build")
-    source_cpp_path = os.path.join(standalone_source_dir, f"ttnn-{args.mode}.cpp")
-    ttnn_precompiled_header_path = os.path.join(
-        standalone_source_dir, "ttnn-precompiled.hpp"
-    )
-    compiled_bin_path = os.path.join(
-        standalone_build_dir,
-        {
-            "dylib": "libttnn-dylib.so",
-            "standalone": "ttnn-standalone",
-        }[args.mode],
-    )
-
-    extension = {
-        "dylib": ".so",
-        "standalone": ".exe",
-    }[args.mode]
-
-    # Determine output .so path
-    output_file_name = cpp_base_name + extension
-    destination_path = os.path.join(output_dir, output_file_name)
-
-    # If the build is run in incremental mode, check if rebuild is needed by comparing modification times
-    if args.incremental and os.path.exists(destination_path):
-        if is_file_older(cpp_file_path, destination_path) and is_file_older(
-            ttnn_precompiled_header_path, destination_path
-        ):
-            print(
-                f"\nSkipping build for {cpp_base_name} - {output_file_name} file is up to date"
-            )
-            return
-
-    try:
-        # Copy provided cpp file to source dir
-        #
-        shutil.copy(cpp_file_path, source_cpp_path)
-
-        # Run cmake setup command first
-        #
-        run_cmake_setup(args)
-
-        # Remove previous .so if exists
-        if os.path.exists(compiled_bin_path):
-            os.remove(compiled_bin_path)
-
-        # Run build
-        #
-        print(f"\nBuilding: {cpp_base_name}")
-        build_command = [
-            "cmake",
-            "--build",
-            standalone_build_dir,
-            "--",
-            f"ttnn-{args.mode}",
-        ]
-        subprocess.run(
-            build_command,
-            check=True,
-            cwd=standalone_source_dir,
-            capture_output=True,
-            text=True,
-        )
-        print(f"  Build finished successfully!")
-
-        # Confirm .so exists
-        if not os.path.isfile(compiled_bin_path):
-            print(f"Error: Compiled file '{compiled_bin_path}' not found.")
-            sys.exit(1)
-
-        # Copy the compiled .so
-        #
-        shutil.copy2(compiled_bin_path, destination_path)
-        print(f"  Successfully copied compiled file to {destination_path}.")
-    except subprocess.CalledProcessError as e:
-        print(f"  Error during build process: {e}")
-        print(e.stderr)
-        print(e.stdout)
-        sys.exit(1)
-    except Exception as e:
-        print(f"  Error during file operations: {e}")
-        print(e.stderr)
-        print(e.stdout)
-        sys.exit(1)
+from emitc_compiler import EmitCCompiler, EmitCCompileError
 
 
 def parse_arguments():
@@ -238,7 +76,6 @@ def parse_arguments():
     )
 
     # Add option to override metal-src-dir and metal-lib-dir
-    #
     group = parser.add_argument_group(
         "dirs", description="Overrides for metal-src-dir and metal-lib-dir"
     )
@@ -256,58 +93,51 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
-    build_dir = args.build_dir if args.build_dir is not None else args.dir
-    needs_test_path = args.dir is None
-    file = args.file
 
-    # Enumerate files for compilation
-    cpp_files = []
+    # Create compiler instance
+    compiler = EmitCCompiler(
+        build_type=args.build_type,
+        mode=args.mode,
+        incremental=args.incremental,
+        metal_src_dir=args.metal_src_dir,
+        metal_lib_dir=args.metal_lib_dir,
+        verbose=True,
+    )
 
-    if file:
-        print(f"Using custom file for compilation: {file}")
+    try:
+        if args.file:
+            # Single file mode
+            print(f"Using custom file for compilation: {args.file}")
+            compiler.compile(args.file)
 
-        if not os.path.isfile(file) or not file.endswith(".cpp"):
-            print(f"Error: File '{file}' does not exist or is not a .cpp file.")
-            sys.exit(1)
+        else:
+            # Directory mode
+            build_dir = args.build_dir if args.build_dir is not None else args.dir
+            needs_test_path = args.dir is None
 
-        cpp_files.append(file)
-    else:
-        # If not even build_dir is provided, use default test path in tt-mlir
-        if not build_dir:
-            if not "TT_MLIR_HOME" in os.environ:
-                print(
-                    "Tried building tests from default path - TT_MLIR_HOME env not found, exiting!"
-                )
-                sys.exit(1)
-            build_dir = os.path.join(os.environ["TT_MLIR_HOME"], "build")
-            print(f"Building tt-mlir tests in {build_dir}")
+            if not build_dir:
+                if "TT_MLIR_HOME" not in os.environ:
+                    print(
+                        "Tried building tests from default path - TT_MLIR_HOME env not found, exiting!"
+                    )
+                    sys.exit(1)
+                build_dir = os.path.join(os.environ["TT_MLIR_HOME"], "build")
+                print(f"Building tt-mlir tests in {build_dir}")
 
-        test_path = get_emitc_tests_path(build_dir) if needs_test_path else build_dir
+            test_path = (
+                EmitCCompiler.get_emitc_tests_path(build_dir)
+                if needs_test_path
+                else build_dir
+            )
 
-        if not os.path.isdir(test_path):
-            print(f"Error: Test path directory '{test_path}' does not exist.")
-            sys.exit(1)
+            print(f"Using test path for compilation: {test_path}")
+            compiler.compile_directory(test_path)
 
-        print(f"Using test path for compilation: {test_path}")
+        print("Compilation completed successfully!")
 
-        for dir_path, _, files in os.walk(test_path):
-            for file in files:
-                if file.endswith(".cpp"):
-                    cpp_file_path = os.path.join(dir_path, file)
-                    cpp_files.append(cpp_file_path)
-
-    if not cpp_files:
-        print("Error: No .cpp files found for compilation.")
+    except (EmitCCompileError, FileNotFoundError, NotADirectoryError) as e:
+        print(f"Error: {e}")
         sys.exit(1)
-
-    for cpp_file in cpp_files:
-        compile_shared_object(
-            cpp_file_path=cpp_file,
-            output_dir=os.path.dirname(cpp_file),
-            args=args,
-        )
-
-    print("Compilation completed successfully!")
 
 
 if __name__ == "__main__":

--- a/tools/ttnn-standalone/emitc_compiler.py
+++ b/tools/ttnn-standalone/emitc_compiler.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+EmitC Compiler Module
+
+This module provides functionality to compile EmitC-generated C++ files to shared
+objects (.so) or standalone executables.
+
+Usage:
+    from emitc_compiler import EmitCCompiler, compile_emitc_to_so
+
+    # Simple usage
+    so_path = compile_emitc_to_so("/path/to/emitc.cpp")
+
+    # Advanced usage with compiler instance
+    compiler = EmitCCompiler(build_type="Release", mode="dylib")
+    so_path = compiler.compile(cpp_file_path)
+"""
+
+import os
+import subprocess
+import shutil
+from dataclasses import dataclass, field
+from typing import Optional, List, Literal
+
+
+class EmitCCompileError(Exception):
+    """Raised when EmitC compilation fails."""
+
+    pass
+
+
+@dataclass
+class EmitCCompiler:
+    """
+    Compiler for EmitC-generated C++ files.
+
+    This class manages the compilation of EmitC C++ files to shared objects (.so)
+    or standalone executables using CMake and Ninja.
+
+    Attributes:
+        build_type: CMake build type (Release, Debug, RelWithDebInfo, MinSizeRel)
+        mode: Compilation mode - "dylib" for shared objects, "standalone" for executables
+        incremental: If True, skip recompilation when output is newer than source
+        metal_src_dir: Optional override for tt-metal source directory
+        metal_lib_dir: Optional override for tt-metal library directory
+        verbose: If True, print build progress messages
+
+    Example:
+        >>> compiler = EmitCCompiler(build_type="Release", mode="dylib")
+        >>> so_path = compiler.compile("/path/to/emitc_output.cpp")
+        >>> print(f"Compiled to: {so_path}")
+    """
+
+    build_type: str = "Release"
+    mode: Literal["dylib", "standalone"] = "dylib"
+    incremental: bool = False
+    metal_src_dir: Optional[str] = None
+    metal_lib_dir: Optional[str] = None
+    verbose: bool = True
+
+    # Internal state
+    _cmake_configured: bool = field(default=False, init=False, repr=False)
+
+    @staticmethod
+    def get_standalone_dir() -> str:
+        """Returns the ttnn-standalone directory path."""
+        return os.path.dirname(os.path.abspath(__file__))
+
+    @staticmethod
+    def get_emitc_tests_path(build_dir: str) -> str:
+        """Returns the path where EmitC TTNN tests live."""
+        return os.path.join(build_dir, "test/ttmlir/EmitC/TTNN")
+
+    @staticmethod
+    def _is_file_older(f1_path: str, f2_path: str) -> bool:
+        """Check if f1 is older than f2 based on modification time."""
+        return os.path.getmtime(f1_path) < os.path.getmtime(f2_path)
+
+    def _log(self, message: str) -> None:
+        """Print message if verbose mode is enabled."""
+        if self.verbose:
+            print(message)
+
+    def _run_cmake_setup(self) -> None:
+        """
+        Run CMake configuration for the ttnn-standalone project.
+
+        This is called automatically before the first build and sets up
+        the Ninja build system.
+
+        Raises:
+            EmitCCompileError: If CMake configuration fails
+        """
+        if self._cmake_configured:
+            return
+
+        standalone_source_dir = self.get_standalone_dir()
+        standalone_build_dir = os.path.join(standalone_source_dir, "build")
+
+        cmake_command = [
+            "cmake",
+            "-G",
+            "Ninja",
+            "-B",
+            standalone_build_dir,
+            "-S",
+            standalone_source_dir,
+            f"-DCMAKE_BUILD_TYPE={self.build_type}",
+            f"-DCMAKE_C_COMPILER={os.environ.get('CC', 'clang')}",
+            f"-DCMAKE_CXX_COMPILER={os.environ.get('CXX', 'clang++')}",
+        ]
+
+        if self.metal_src_dir:
+            cmake_command.append(f"-DMETAL_SRC_DIR={self.metal_src_dir}")
+
+        if self.metal_lib_dir:
+            cmake_command.append(f"-DMETAL_LIB_DIR={self.metal_lib_dir}")
+
+        try:
+            subprocess.run(
+                cmake_command,
+                check=True,
+                cwd=standalone_source_dir,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise EmitCCompileError(
+                f"CMake configuration failed:\nstdout: {e.stdout}\nstderr: {e.stderr}"
+            )
+
+        self._cmake_configured = True
+
+    def compile(
+        self,
+        cpp_file_path: str,
+        output_dir: Optional[str] = None,
+    ) -> str:
+        """
+        Compile a single C++ file to a shared object or executable.
+
+        Args:
+            cpp_file_path: Path to the .cpp file to compile
+            output_dir: Directory for output file. If None, uses the same
+                       directory as the input file.
+
+        Returns:
+            Path to the compiled output file (.so or .exe)
+
+        Raises:
+            EmitCCompileError: If compilation fails
+            FileNotFoundError: If the input file doesn't exist
+            ValueError: If the input file is not a .cpp file
+        """
+        # Validate input
+        if not os.path.isfile(cpp_file_path):
+            raise FileNotFoundError(f"Input file not found: {cpp_file_path}")
+
+        if not cpp_file_path.endswith(".cpp"):
+            raise ValueError(f"Input file must be a .cpp file: {cpp_file_path}")
+
+        # Determine paths
+        cpp_base_name = os.path.basename(cpp_file_path).rsplit(".", 1)[0]
+        if output_dir is None:
+            output_dir = os.path.dirname(cpp_file_path)
+
+        standalone_source_dir = self.get_standalone_dir()
+        standalone_build_dir = os.path.join(standalone_source_dir, "build")
+        source_cpp_path = os.path.join(standalone_source_dir, f"ttnn-{self.mode}.cpp")
+        ttnn_precompiled_header_path = os.path.join(
+            standalone_source_dir, "ttnn-precompiled.hpp"
+        )
+
+        compiled_bin_path = os.path.join(
+            standalone_build_dir,
+            {"dylib": "libttnn-dylib.so", "standalone": "ttnn-standalone"}[self.mode],
+        )
+
+        extension = {"dylib": ".so", "standalone": ".exe"}[self.mode]
+        output_file_name = cpp_base_name + extension
+        destination_path = os.path.join(output_dir, output_file_name)
+
+        # Check if rebuild is needed (incremental mode)
+        if self.incremental and os.path.exists(destination_path):
+            if self._is_file_older(
+                cpp_file_path, destination_path
+            ) and self._is_file_older(ttnn_precompiled_header_path, destination_path):
+                self._log(
+                    f"\nSkipping build for {cpp_base_name} - {output_file_name} is up to date"
+                )
+                return destination_path
+
+        # Copy source file
+        shutil.copy(cpp_file_path, source_cpp_path)
+
+        # Configure CMake if needed
+        self._run_cmake_setup()
+
+        # Remove previous output if exists
+        if os.path.exists(compiled_bin_path):
+            os.remove(compiled_bin_path)
+
+        # Build
+        self._log(f"\nBuilding: {cpp_base_name}")
+        build_command = [
+            "cmake",
+            "--build",
+            standalone_build_dir,
+            "--",
+            f"ttnn-{self.mode}",
+        ]
+
+        try:
+            subprocess.run(
+                build_command,
+                check=True,
+                cwd=standalone_source_dir,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise EmitCCompileError(
+                f"Build failed for {cpp_base_name}:\nstdout: {e.stdout}\nstderr: {e.stderr}"
+            )
+
+        self._log("  Build finished successfully!")
+
+        # Verify output exists
+        if not os.path.isfile(compiled_bin_path):
+            raise EmitCCompileError(
+                f"Build succeeded but output not found: {compiled_bin_path}"
+            )
+
+        # Copy to destination
+        shutil.copy2(compiled_bin_path, destination_path)
+        self._log(f"  Successfully copied compiled file to {destination_path}")
+
+        return destination_path
+
+    def compile_directory(
+        self,
+        directory: str,
+        recursive: bool = True,
+    ) -> List[str]:
+        """
+        Compile all .cpp files in a directory.
+
+        Args:
+            directory: Path to directory containing .cpp files
+            recursive: If True, search subdirectories recursively
+
+        Returns:
+            List of paths to compiled output files
+
+        Raises:
+            EmitCCompileError: If any compilation fails
+            NotADirectoryError: If the directory doesn't exist
+        """
+        if not os.path.isdir(directory):
+            raise NotADirectoryError(f"Directory not found: {directory}")
+
+        cpp_files = []
+        if recursive:
+            for dir_path, _, files in os.walk(directory):
+                for file in files:
+                    if file.endswith(".cpp"):
+                        cpp_files.append(os.path.join(dir_path, file))
+        else:
+            for file in os.listdir(directory):
+                if file.endswith(".cpp"):
+                    cpp_files.append(os.path.join(directory, file))
+
+        if not cpp_files:
+            raise EmitCCompileError(f"No .cpp files found in: {directory}")
+
+        output_paths = []
+        for cpp_file in cpp_files:
+            output_path = self.compile(cpp_file, output_dir=os.path.dirname(cpp_file))
+            output_paths.append(output_path)
+
+        return output_paths
+
+
+def compile_emitc_to_so(
+    cpp_file_path: str,
+    output_dir: Optional[str] = None,
+    build_type: str = "Release",
+    incremental: bool = True,
+    verbose: bool = True,
+) -> str:
+    """
+    Compile an EmitC .cpp file to a shared object (.so).
+
+    This is a convenience function that creates an EmitCCompiler instance
+    and compiles a single file.
+
+    Args:
+        cpp_file_path: Path to the .cpp file to compile
+        output_dir: Directory for output .so file. If None, uses same directory as input.
+        build_type: CMake build type (Release, Debug, etc.)
+        incremental: If True, skip recompilation when .so is newer than .cpp
+        verbose: If True, print progress messages
+
+    Returns:
+        Path to the compiled .so file
+
+    Raises:
+        EmitCCompileError: If compilation fails
+
+    Example:
+        >>> so_path = compile_emitc_to_so("/path/to/emitc.cpp")
+        >>> print(f"Compiled: {so_path}")
+    """
+    compiler = EmitCCompiler(
+        build_type=build_type,
+        mode="dylib",
+        incremental=incremental,
+        verbose=verbose,
+    )
+    return compiler.compile(cpp_file_path, output_dir=output_dir)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6381

### Problem description

The `ci_compile_dylib.py` script compiles EmitC-generated C++ files to shared objects (.so), but it was designed only as a CLI tool. This made it difficult to integrate EmitC compilation into the builder system programmatically, as the script used `sys.exit()` for error handling and stored state in function attributes.

To enable builder integration, we need a clean Python API that can be imported and used directly without subprocess calls.

### What's changed

Refactored `ci_compile_dylib.py` into two files:

**New `emitc_compiler.py`** - Core library module containing:
- `EmitCCompiler` dataclass - Main compiler with configurable options (build_type, mode, incremental, etc.)
- `compile_emitc_to_so()` - Convenience function for simple use cases
- `EmitCCompileError` - Custom exception for proper error handling (replaces `sys.exit()`)
- Instance-based state management instead of function attributes

**Updated `ci_compile_dylib.py`** - Now a thin CLI wrapper that:
- Parses command-line arguments
- Creates an `EmitCCompiler` instance
- Delegates to the library methods

