### PR TITLE
Fix StableHLO conversion of dynamic_slice

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3206,8 +3206,8 @@ public:
                               startIndicesTensorType.getEncoding()),
         startIndicesTensor, sliceSizesConstant);
 
-    rewriter.create<mlir::tt::ttir::SliceDynamicOp>(
-        srcOp.getLoc(), outputType, adaptor.getOperand(), startIndicesTensor,
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::SliceDynamicOp>(
+        srcOp, outputType, adaptor.getOperand(), startIndicesTensor,
         endIndicesTensor, ArrayAttr());
 
     return success();


### PR DESCRIPTION
### Ticket
/

### Problem description
Conversion for StableHLO dynamic_slice op doesn't replace it with the TTIR equivalent, but leaves both ops in graph:
```
module @jit_dynamic_slice {
  ttcore.device_module {
    builtin.module @jit_dynamic_slice {
      func.func @dynamic_slice(%arg0: tensor<32x64xf32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> (tensor<8x8xf32> {jax.result_info = "result"}) {
        %0 = "ttir.reshape"(%arg1) <{shape = [1 : i32]}> : (tensor<i32>) -> tensor<1xi32>
        %1 = "ttir.reshape"(%arg2) <{shape = [1 : i32]}> : (tensor<i32>) -> tensor<1xi32>
        %2 = "ttir.concat"(%0, %1) <{dim = 0 : si32}> : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
        %3 = "ttir.constant"() <{value = dense<8> : tensor<2xi32>}> : () -> tensor<2xi32>
        %4 = "ttir.add"(%2, %3) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
        %5 = "ttir.reshape"(%arg1) <{shape = [1 : i32]}> : (tensor<i32>) -> tensor<1xi32>
        %6 = "ttir.reshape"(%arg2) <{shape = [1 : i32]}> : (tensor<i32>) -> tensor<1xi32>
        %7 = "ttir.concat"(%5, %6) <{dim = 0 : si32}> : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
        %8 = "ttir.constant"() <{value = dense<8> : tensor<2xi32>}> : () -> tensor<2xi32>
        %9 = "ttir.add"(%7, %8) : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
        %10 = "ttir.slice_dynamic"(%arg0, %7, %9) : (tensor<32x64xf32>, tensor<2xi32>, tensor<2xi32>) -> tensor<8x8xf32>
        %11 = stablehlo.dynamic_slice %arg0, %arg1, %arg2, sizes = [8, 8] : (tensor<32x64xf32>, tensor<i32>, tensor<i32>) -> tensor<8x8xf32>
        return %11 : tensor<8x8xf32>
      }
    }
  }
}
```

### What's changed
Replaced StableHLO op with TTIR op.

### Checklist
- [ ] New/Existing tests provide coverage for changes
