### PR TITLE
Add StableHLO RNG op support to Python builder

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -216,6 +216,14 @@ def module_select(builder: StableHLOBuilder):
         return builder.select(pred, on_true, on_false, unit_attrs=unit_attrs)
 
 
+# --- Moved from file top ---
+def module_rng(builder: StableHLOBuilder):
+    @builder.func([], [])
+    def rng(builder: StableHLOBuilder):
+        builder.set_graph_level_check(True)
+        return builder.rng([128, 128], torch.float32, low=0.0, high=1.0)
+
+
 def module_log(builder: StableHLOBuilder):
     @builder.func([(128, 128)], [torch.float32])
     def log(
@@ -1142,6 +1150,17 @@ def test_reverse(shapes, dtype, dimensions, target: str, request, device):
 def test_select(target: str, request, device):
     compile_and_execute_shlo(
         module_select,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+        device=device,
+    )
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_rng(target: str, request, device):
+    compile_and_execute_shlo(
+        module_rng,
         test_base=request.node.name,
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),


### PR DESCRIPTION
### Ticket
Closes #4887

### Problem description
The StableHLO Python builder did not expose support for the RngOp, even though the operation is already handled in the StableHLO → TTIR lowering. This made it impossible to construct StableHLO graphs with RNG operations directly from the builder.

### What's changed
- Added a StableHLO RngOp builder API to generate RNG operations from Python
- Added a golden mapping for stablehlo.RngOp using torch.rand
- Added a golden test to validate StableHLO RNG graph generation and execution

This aligns the StableHLO builder with existing lowering support and enables native RNG usage in StableHLO graphs.

### Checklist
- [x] New/Existing tests provide coverage for changes
