### PR TITLE
[d2m] Make D2MAllocate pass deterministic by using MapVector instead of DensseMap

### DIFF
--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1061,7 +1061,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       }
 
       for (const OperandContext &operandCtx : genericCtx.operands) {
-        auto memrefIt = analysis.memrefs.find(operandCtx.root);
+        const auto *memrefIt = analysis.memrefs.find(operandCtx.root);
         TT_debug(memrefIt != analysis.memrefs.end());
         const MemrefValueContext &memrefCtx = memrefIt->second;
 


### PR DESCRIPTION
### Problem
The D2MAllocate pass was producing different address assignments between runs due to iterating over DenseMap containers. DenseMap iteration order depends on pointer hash values, which change between process invocations which hampers reproducibility.

### What's changed
Replace `DenseMap` with `MapVector` for the memrefs and generics maps in `FuncAnalysisData`. `MapVector` preserves insertion order, ensuring deterministic iteration and consistent address assignments across runs.

### Checklist
- [X] Existing tests provide coverage for changes
