### PR TITLE
[CI] Limit number of cores in build to 32

### DIFF
--- a/.github/workflows/call-build-release.yml
+++ b/.github/workflows/call-build-release.yml
@@ -104,6 +104,8 @@ jobs:
       shell: bash
       run: |
         source env/activate
+        # Build causes the OOM error if parallel level is not limited
+        export CMAKE_BUILD_PARALLEL_LEVEL=32
         cmake -G Ninja \
           -B ${{ steps.strings.outputs.build-output-dir }} \
           -DCMAKE_CXX_COMPILER=clang++-17 \


### PR DESCRIPTION
### Ticket
slack

### Problem description
Sometimes build failes with exit code 137 (OOM).

### What's changed
We have 64 core builder machines. Ninja build utilize all cores but it is too much for available RAM

### Checklist
- [ ] New/Existing tests provide coverage for changes
