### PR TITLE
[Shardy] Bugfix for SliceOp start indices

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -96,12 +96,23 @@ static FailureOr<mlir::OperationState> createNewOperationState(
 
               if (failed(updatedLimitDim)) {
                 sliceOp->emitError(
-                    "Could not apply propagated tensor shardings "
-                    "to attribute dictionary for slice op");
+                    "Could not apply propagated tensor shardings for limit "
+                    "indices of attribute dictionary for slice op");
                 return mlir::failure();
               }
 
               limitIndices[i] = *updatedLimitDim;
+
+              FailureOr<int64_t> updatedStartDim =
+                  shardy_utils::calculateUpdatedDim(
+                      globalMeshOp.getMesh(), shardings[0], startIndices[i]);
+              if (failed(updatedStartDim)) {
+                sliceOp->emitError(
+                    "Could not apply propagated tensor shardings for start "
+                    "indices of attribute dictionary for slice op");
+                return mlir::failure();
+              }
+              startIndices[i] = *updatedStartDim;
             }
 
             // 4. Update start and limit indices in op named attributes.

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
@@ -55,3 +55,29 @@ func.func @partial_arg(%arg0: tensor<4x128x16384xbf16> {sdy.sharding = #sdy.shar
 // CHECK: stablehlo.all_gather
 // CHECK: stablehlo.slice %1 [0:4, 0:128, 1:16384:2]
 // CHECK: sdy.return %2 : tensor<4x128x8192xbf16>
+
+func.func @multiple_slice_unique_operand(%arg0: tensor<2560x9728xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22batch\22}]>"}, mhlo.sharding = "{devices=[1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg1: tensor<19456x2560xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22batch\22}, {}]>"}, mhlo.sharding = "{devices=[2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<2560xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<1x32x2560xbf16> {
+  // CHECK-LABEL: func.func @multiple_slice_unique_operand(
+  // CHECK: sdy.manual_computation(%arg0, %arg1, %arg2) in_shardings=[<@mesh, [{}, {"batch"}]>, <@mesh, [{"batch"}, {}]>, <@mesh, [{}]>] out_shardings=[<@mesh, [{}, {}, {}]>] manual_axes={"model", "batch"} (%arg3: tensor<2560x4864xbf16>, %arg4: tensor<9728x2560xbf16>, %arg5: tensor<2560xbf16>)
+  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 0:4864] : (tensor<1x32x9728xbf16>) -> tensor<1x32x4864xbf16>
+  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 4864:9728] : (tensor<1x32x9728xbf16>) -> tensor<1x32x4864xbf16>
+  // CHECK: stablehlo.all_reduce
+  // CHECK: sdy.return %{{.*}} : tensor<1x32x2560xbf16>
+  %0 = stablehlo.reshape %arg2 : (tensor<2560xbf16>) -> tensor<1x1x2560xbf16>
+  %1 = stablehlo.reshape %0 : (tensor<1x1x2560xbf16>) -> tensor<2560xbf16>
+  %2 = stablehlo.broadcast_in_dim %1, dims = [2] : (tensor<2560xbf16>) -> tensor<1x32x2560xbf16>
+  %3 = stablehlo.reshape %2 : (tensor<1x32x2560xbf16>) -> tensor<32x2560xbf16>
+  %4 = stablehlo.reshape %arg1 : (tensor<19456x2560xbf16>) -> tensor<1x19456x2560xbf16>
+  %5 = stablehlo.reshape %4 : (tensor<1x19456x2560xbf16>) -> tensor<19456x2560xbf16>
+  %6 = stablehlo.transpose %5, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "bf16[2560,19456]{0,1}"} : (tensor<19456x2560xbf16>) -> tensor<2560x19456xbf16>
+  %7 = stablehlo.dot_general %3, %6, contracting_dims = [1] x [0] : (tensor<32x2560xbf16>, tensor<2560x19456xbf16>) -> tensor<32x19456xbf16>
+  %8 = stablehlo.reshape %7 : (tensor<32x19456xbf16>) -> tensor<1x32x19456xbf16>
+  %9 = stablehlo.slice %8 [0:1, 0:32, 0:9728] : (tensor<1x32x19456xbf16>) -> tensor<1x32x9728xbf16>
+  %10 = stablehlo.slice %8 [0:1, 0:32, 9728:19456] : (tensor<1x32x19456xbf16>) -> tensor<1x32x9728xbf16>
+  %11 = stablehlo.multiply %9, %10 : tensor<1x32x9728xbf16>
+  %12 = stablehlo.reshape %11 : (tensor<1x32x9728xbf16>) -> tensor<32x9728xbf16>
+  %13 = stablehlo.transpose %arg0, dims = [1, 0] {result_layout = dense<[0, 1]> : tensor<2xindex>, xla_shape = "bf16[9728,2560]{0,1}"} : (tensor<2560x9728xbf16>) -> tensor<9728x2560xbf16>
+  %14 = stablehlo.dot_general %12, %13, contracting_dims = [1] x [0] : (tensor<32x9728xbf16>, tensor<9728x2560xbf16>) -> tensor<32x2560xbf16>
+  %15 = stablehlo.reshape %14 : (tensor<32x2560xbf16>) -> tensor<1x32x2560xbf16>
+  return %15 : tensor<1x32x2560xbf16>
+}


### PR DESCRIPTION
### Ticket
closes #6425 

### Problem description
Global to local shape updates for shardy op does not properly generate start indices for slice op

### What's changed
Generate correct start indices for slice op

### Checklist
- [X] New/Existing tests provide coverage for changes
