### PR TITLE
Skip flaky TTIR builder tests

### DIFF
--- a/test/python/golden/test_parse_split_ops.py
+++ b/test/python/golden/test_parse_split_ops.py
@@ -30,6 +30,8 @@ skip_split_ttir_tests = [
     "ttir_all_reduce.mlir",
     "ttir_collective_broadcast.mlir",
     "ttir_mesh_shard.mlir",
+    "ttir_device_module_nested_func.mlir",
+    "ttir_nested_funcs.mlir",
 ]
 ttir_snippets_dir_path = os.path.join(os.path.dirname(__file__), "mlir_snippets/ttir")
 for filename in os.listdir(ttir_snippets_dir_path):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some recently added TTIR builder tests are flaky. 

Example failures:
- https://github.com/tenstorrent/tt-mlir/actions/runs/20473700476/job/58834812899
- https://github.com/tenstorrent/tt-mlir/runs/58633546906

### Checklist
- [x] New/Existing tests provide coverage for changes
