### PR TITLE
Add fusion pattern for MishOp

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -571,6 +571,97 @@ public:
   }
 };
 
+std::optional<mlir::Value> matchNumericallyStableSoftplus(mlir::Value op) {
+  // common utility to match the numerically stable softplus
+  // NumericallyStableSoftplus = where[cond, x, ln(1 + e^x)]
+  WhereOp whereOp = op.getDefiningOp<WhereOp>();
+  if (!whereOp || !whereOp->hasOneUse()) {
+    return std::nullopt;
+  }
+  auto softplusInput = whereOp.getSecond();
+
+  // [cond, x, ln(1 + e^x)]
+  Log1pOp log1pOp = whereOp.getThird().getDefiningOp<Log1pOp>();
+  if (!log1pOp || !log1pOp->hasOneUse()) {
+    return std::nullopt;
+  }
+
+  GreaterThanOp gtOp = whereOp.getFirst().getDefiningOp<GreaterThanOp>();
+  if (!gtOp) {
+    return std::nullopt;
+  }
+
+  if (gtOp.getLhs() != softplusInput) {
+    return std::nullopt;
+  }
+
+  ExpOp expOp = log1pOp.getInput().getDefiningOp<ExpOp>();
+  if (!expOp || !expOp->hasOneUse()) {
+    return std::nullopt;
+  }
+
+  if (softplusInput != expOp.getInput()) {
+    return std::nullopt;
+  }
+
+  return softplusInput;
+}
+
+// Mish Fusion Pattern
+class MishFusingPattern : public mlir::OpRewritePattern<MultiplyOp> {
+  using mlir::OpRewritePattern<MultiplyOp>::OpRewritePattern;
+
+public:
+  // Match Pattern -  mish(x) = x * tanh(Softplus(x))
+  // where, Softplus(x) = x > C? x : ln(1 + e^x) (numerically stable variant of
+  // softplus(x)) Because for very large x, (1 + e^x) ~ e^x ln(e^x) = x
+  mlir::LogicalResult
+  matchAndRewrite(MultiplyOp multiplyOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    mlir::Value lhs = utils::lookThrough<TypecastOp>(multiplyOp.getLhs());
+    mlir::Value rhs = utils::lookThrough<TypecastOp>(multiplyOp.getRhs());
+
+    // Match multiply(x, tanh(softplus(x))) and
+    // multiply(tanh(softplus(x)), x)
+    mlir::Value originalInput;
+    TanhOp tanhOp = nullptr;
+    if (auto lhsTanhOp = lhs.getDefiningOp<TanhOp>()) {
+      tanhOp = lhsTanhOp;
+      originalInput = rhs;
+    } else if (auto rhsTanhOp = rhs.getDefiningOp<TanhOp>()) {
+      tanhOp = rhsTanhOp;
+      originalInput = lhs;
+    }
+
+    if (!tanhOp || !tanhOp->hasOneUse()) {
+      return mlir::failure();
+    }
+
+    // Check if tanh's input is softplus
+    auto softplusInput = matchNumericallyStableSoftplus(tanhOp.getInput());
+    if (!softplusInput || *softplusInput != originalInput) {
+      return mlir::failure();
+    }
+
+    auto inputType = originalInput.getType();
+    auto outputType = multiplyOp.getResult().getType();
+    auto mishOp =
+        rewriter.create<MishOp>(multiplyOp.getLoc(), inputType, originalInput);
+
+    // If multiply inputs and output are typecasted, we need to add a typecast
+    // after mish to convert it back to the original multiply Op's output type.
+    if (inputType != outputType) {
+      auto typecastOp = rewriter.create<TypecastOp>(
+          multiplyOp->getLoc(), outputType, mishOp.getResult());
+      rewriter.replaceOp(multiplyOp, typecastOp.getResult());
+    } else {
+      rewriter.replaceOp(multiplyOp, mishOp.getResult());
+    }
+
+    return mlir::success();
+  }
+};
+
 template <typename ConvOpType>
 class ConvWithMultiply : public mlir::OpRewritePattern<MultiplyOp> {
   using mlir::OpRewritePattern<MultiplyOp>::OpRewritePattern;
@@ -3574,6 +3665,7 @@ public:
       patterns.add<Relu6FusionPattern>(&getContext());
       patterns.add<SiluFusionPattern>(&getContext());
       patterns.add<HardsigmoidFusionPattern>(&getContext());
+      patterns.add<MishFusingPattern>(&getContext());
 
       GreedyRewriteConfig config;
       config.setUseTopDownTraversal(true);

--- a/test/python/golden/ttir_ops/fusing/test_mish_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_mish_fusing.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import torch
+import torch.nn.functional as F
+from typing import List, Optional
+
+from builder.base.builder_utils import Operand, Shape, get_artifact_dir
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+def check_op(mlir_file: str, op_name: str, dialect: str = "ttnn") -> bool:
+    """Check if an op exists in the MLIR file."""
+    op_pattern = f"{dialect}.{op_name}"
+    with open(mlir_file, "r") as f:
+        for line in f:
+            if op_pattern in line:
+                return True
+    return False
+
+
+def build_ttir(
+    input: Operand,
+    scalar_constant_value_for_threshold: float,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
+    # constant for numerically stable softplus
+    shape = builder.get_shape(input)
+    c = builder.constant(
+        torch.full(shape, scalar_constant_value_for_threshold, dtype=torch.float32)
+    )
+
+    # Check if input is greater than constant
+    gt = builder.gt(input, c, unit_attrs=unit_attrs)
+
+    # Exponentiate the input
+    exp = builder.exp(input, unit_attrs=unit_attrs)
+
+    log1p = builder.log1p(exp, unit_attrs=unit_attrs)
+
+    where = builder.where(gt, input, log1p, unit_attrs=unit_attrs)
+
+    tanh = builder.tanh(where, unit_attrs=unit_attrs)
+
+    return builder.multiply(input, tanh, unit_attrs=unit_attrs)
+
+
+def build_torch_golden(input, scalar_constant_value_for_threshold) -> torch.Tensor:
+    c = torch.full_like(input, scalar_constant_value_for_threshold)
+    stable_softplus = torch.where(input > c, input, F.softplus(input))
+    golden_output = input * torch.tanh(stable_softplus)
+    return golden_output
+
+
+@pytest.mark.parametrize("shape", [(1, 64, 64)])  # input
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_mish_fusion(shape: Shape, dtype: torch.dtype, target: str, request, device):
+    """
+    This test verifies the Mish fusion pattern.
+
+    The Mish operation is currently represented as the following sequence of ops:
+        mish(x) = x * tanh(numerically_stable_softplus(x)) where,
+    numerically_stable_softplus(x) is implemented as:
+        where(x > C, x, log1p(exp(x)))
+
+    Specifically, the unfused form performs:
+    - A comparison of the input tensor `x` against a constant `C`
+    - If `x > C`, the value `x` is selected directly
+        - Otherwise: - `exp(x)` is computed
+        - Followed by `log1p(exp(x))`
+    - The selected value is passed through `tanh`
+    - The result is multiplied elementwise with the original input `x`
+
+    This test checks that the above sequence is correctly recognized and fused into a single `mish` operation.
+    """
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def mish_fusing(
+            input: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+        ):
+            # Build input tensor
+            constant_scalar = 20.0
+            input_data = torch.randn(shape, dtype=dtype)
+            golden_output = build_torch_golden(input_data, constant_scalar)
+
+            result = build_ttir(input, constant_scalar, builder, unit_attrs=unit_attrs)
+
+            builder.set_goldens(
+                {input: input_data},
+                {result: golden_output},
+            )
+
+            return result
+
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        device=device,
+        save_artifacts=True,
+    )
+    output_path = os.path.join(
+        get_artifact_dir(
+            request.config.getoption("--path"), "TTIRBuilder", request.node.name
+        ),
+        "ttnn_compiled.mlir",
+    )
+
+    assert not check_op(output_path, "multiply")
+    assert not check_op(output_path, "tanh")
+    assert not check_op(output_path, "where")
+    assert check_op(
+        output_path, "mish"
+    ), "Sequence of exp, log1p, where, tanh and multiply should be fused to mish op"

--- a/test/ttmlir/Dialect/TTIR/fusing/mish_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/mish_fusing.mlir
@@ -1,0 +1,35 @@
+// RUN: ttmlir-opt --ttir-fusing %s -o %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module {
+    // CHECK-LABEL: func.func @mish_fusing
+    func.func @mish_fusing(%arg0:tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16> {
+        %1 = "ttir.constant"() <{value = dense<2.000000e+01> : tensor<1x32x480x640xbf16>}> : () -> tensor<1x32x480x640xbf16>
+        %2 = "ttir.gt"(%arg0, %1) : (tensor<1x32x480x640xbf16>, tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xi1>
+        %3 = "ttir.exp"(%arg0) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %4 = "ttir.log1p"(%3) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %5 = "ttir.where"(%2, %arg0, %4) : (tensor<1x32x480x640xi1>, tensor<1x32x480x640xbf16>, tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %6 = "ttir.tanh"(%5) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        // CHECK-NOT: "ttir.multiply"
+        %7 = "ttir.multiply"(%arg0, %6) : (tensor<1x32x480x640xbf16>, tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        // CHECK: "ttir.mish"
+        return %7:  tensor<1x32x480x640xbf16>
+    }
+
+    // CHECK-LABEL: func.func @mish_fusing_with_typecast
+    func.func @mish_fusing_with_typecast(%arg0:tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xf32> {
+        %1 = "ttir.constant"() <{value = dense<2.000000e+01> : tensor<1x32x480x640xbf16>}> : () -> tensor<1x32x480x640xbf16>
+        %2 = "ttir.gt"(%arg0, %1) : (tensor<1x32x480x640xbf16>, tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xi1>
+        %3 = "ttir.exp"(%arg0) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %4 = "ttir.log1p"(%3) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %5 = "ttir.where"(%2, %arg0, %4) : (tensor<1x32x480x640xi1>, tensor<1x32x480x640xbf16>, tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %6 = "ttir.tanh"(%5) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xbf16>
+        %7 = "ttir.typecast"(%arg0) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xf32>
+        %8 = "ttir.typecast"(%6) : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xf32>
+        // CHECK-NOT: "ttir.multiply"
+        %9 = "ttir.multiply"(%7, %8) : (tensor<1x32x480x640xf32>, tensor<1x32x480x640xf32>) -> tensor<1x32x480x640xf32>
+        // CHECK: "ttir.mish"
+        // CHECK: "ttir.typecast"({{.*}}){{.*}} : (tensor<1x32x480x640xbf16>) -> tensor<1x32x480x640xf32>
+        return %9:  tensor<1x32x480x640xf32>
+    }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/5247)

### Problem description

Yolo4 uses mish activation function that is lowered through torch-xla as
```x * tanh(where(x > C, x, log1p(e^x)))```
here, input to the tanh op is a numerically
stable variant of Softplus function

### Motivation

IR has a list of Ops like log1p, tanh, multiply
which is basically a Mish Activation function
for which the Op has already been added.
We can fuse these different ops into a single
mish op.

### What's changed

- Added a fusing pattern for mish activation function

### Testing

Added a test to verify the changes, both with and
without typecasting for multiple operands.

#### Before
<img width="570" height="833" alt="before_mish" src="https://github.com/user-attachments/assets/9a123b87-5197-4818-8932-639a6621ea5c" />

#### After
<img width="361" height="536" alt="after_mish_fusion_pattern" src="https://github.com/user-attachments/assets/6c5f587f-a62e-433c-ad69-26dd91a5d1ac" />

```
llvm-lit -sv ./test/ttmlir/Dialect/TTIR/fusing/mish_fusing.mlir 

Testing Time: 0.05s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

### Checklist
- [x] New/Existing tests provide coverage for changes
