### PR TITLE
Add SpillLocation enum and L1 interleaved spilling infrastructure

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
@@ -57,17 +57,21 @@ struct MemoryLayoutAnalysisResult {
   llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   llvm::DenseMap<Edge, MemReconfigEntry> memReconfigEntryMap;
   std::vector<Operation *> spillToDramOps;
+  std::vector<Operation *> spillToL1InterleavedOps;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
 
   MemoryLayoutAnalysisResult()
-      : legalConfigs(), memReconfigEntryMap(), spillToDramOps(), schedule() {}
+      : legalConfigs(), memReconfigEntryMap(), spillToDramOps(),
+        spillToL1InterleavedOps(), schedule() {}
 
   MemoryLayoutAnalysisResult(
       const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       const llvm::DenseMap<Edge, MemReconfigEntry> &memReconfigEntryMap,
-      const std::vector<Operation *> &spillToDramOps)
+      const std::vector<Operation *> &spillToDramOps,
+      const std::vector<Operation *> &spillToL1InterleavedOps)
       : legalConfigs(legalConfigs), memReconfigEntryMap(memReconfigEntryMap),
-        spillToDramOps(spillToDramOps) {}
+        spillToDramOps(spillToDramOps),
+        spillToL1InterleavedOps(spillToL1InterleavedOps) {}
 };
 
 // Analyze and determine which parts of the model graph can be pushed to L1

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -11,7 +11,7 @@
 #include "mlir/IR/Attributes.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/Support/FormatVariadicDetails.h"
+#include "llvm/Support/FormatVariadic.h"
 
 #include <variant>
 
@@ -170,6 +170,18 @@ struct format_provider<mlir::tt::ttnn::OpConfig::OpSpecificAttrs> {
     std::visit([&os](const auto &attr) { os << attr.toString(); }, variant);
   }
 };
+
+template <>
+struct format_provider<mlir::tt::ttnn::OpConfig> {
+  static void format(const mlir::tt::ttnn::OpConfig &config, raw_ostream &os,
+                     StringRef options) {
+    os << "OutputLayout: ";
+    os << config.outputLayout;
+    os << ", OpSpecificAttrs: ";
+    os << llvm::formatv("{0}", config.opSpecificAttrs);
+  }
+};
+
 } // namespace llvm
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIG_H

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -35,18 +35,25 @@ struct ValidationResult {
   // What the backend actually returned (only valid if status == Success).
   TTNNLayoutAttr actualOutputLayout;
 
+  // L1 memory usage for the output tensor in bytes (only valid if status ==
+  // Success). This is the per-core L1 footprint of the output tensor.
+  uint64_t outputL1Usage = 0;
+
   // Error message if status != Success.
   std::string errorMessage;
 
   ValidationResult() = default;
 
   explicit ValidationResult(size_t configIndex,
-                            TTNNLayoutAttr actualOutputLayout)
-      : configIndex(configIndex), actualOutputLayout(actualOutputLayout) {}
+                            TTNNLayoutAttr actualOutputLayout,
+                            uint64_t outputL1Usage = 0)
+      : configIndex(configIndex), actualOutputLayout(actualOutputLayout),
+        outputL1Usage(outputL1Usage) {}
 
   static ValidationResult success(size_t configIndex,
-                                  TTNNLayoutAttr actualOutputLayout) {
-    return ValidationResult(configIndex, actualOutputLayout);
+                                  TTNNLayoutAttr actualOutputLayout,
+                                  uint64_t outputL1Usage = 0) {
+    return ValidationResult(configIndex, actualOutputLayout, outputL1Usage);
   }
 
   static ValidationResult error(ValidationStatus status, std::string message) {
@@ -84,6 +91,11 @@ struct ValidationResult {
 // op: Operation to validate.
 // inputLayouts: Input tensor layouts for the operation.
 // config: Operation configuration to test.
+// additionalL1Usage: Additional L1 memory usage (in bytes) that must be
+//                    accounted for during validation. This is used when
+//                    validating ops that execute while other tensors occupy L1
+//                    (e.g., during chain merging where Chain A's output stays
+//                    in L1 while Chain B executes).
 // Returns: ValidationResult where status indicates the outcome:
 //   - status == Success: Operation validated successfully
 //   - status == NotSupported: Operation not supported for validation (expected
@@ -94,7 +106,8 @@ struct ValidationResult {
 // "NotSupported" is not an error - it indicates expected limitations.
 ValidationResult validateOperation(Operation *op,
                                    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                                   const OpConfig &config);
+                                   const OpConfig &config,
+                                   uint64_t additionalL1Usage = 0);
 
 // Test multiple attributes with all layouts.
 // op: Operation to validate.

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -187,7 +187,7 @@ void DFShardingPolicy::run() {
     // TODO(odjuricic): Add constraint check if op can write to dram.
     if (!resolvedShardSolution.selectedOpConfig[l1ChainConfig.getLastOp()]
              .outputLayout.hasDRAMBufferType()) {
-      l1ChainConfig.spillEndToDRAM = true;
+      l1ChainConfig.spillLocation = SpillLocation::DRAM;
     }
 
     TTMLIR_DEBUG(ttmlir::LogComponent::DFShardingPolicy,

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
@@ -108,8 +108,18 @@ void MemoryLayoutAnalysis::analysisImplementation() {
         l1ChainConfig.getMemReconfigEntryMap().begin(),
         l1ChainConfig.getMemReconfigEntryMap().end());
 
-    if (l1ChainConfig.spillEndToDRAM) {
+    // Handle spill location for chain output
+    switch (l1ChainConfig.spillLocation) {
+    case SpillLocation::DRAM:
       analysisResult.spillToDramOps.push_back(l1ChainConfig.getLastOp());
+      break;
+    case SpillLocation::L1Interleaved:
+      analysisResult.spillToL1InterleavedOps.push_back(
+          l1ChainConfig.getLastOp());
+      break;
+    case SpillLocation::None:
+      // No spill needed - chain output consumed directly by next chain
+      break;
     }
   }
 }

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -23,14 +23,15 @@ namespace op_constraint_validation {
 
 static ValidationResult
 validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config);
+                    const OpConfig &config, uint64_t additionalL1Usage);
 
 //----------- Public API implementations ----------
 
 ValidationResult validateOperation(Operation *op,
                                    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                                   const OpConfig &config) {
-  return validateConstraints(op, inputLayouts, config);
+                                   const OpConfig &config,
+                                   uint64_t additionalL1Usage) {
+  return validateConstraints(op, inputLayouts, config, additionalL1Usage);
 }
 
 std::vector<ValidationResult>
@@ -42,8 +43,8 @@ validateWithMultipleAttributes(Operation *op,
   std::vector<ValidationResult> results;
   for (const auto &testConfig : opConfigs) {
     // 1. Call core constraint checking.
-    ValidationResult constraintResult =
-        validateConstraints(op, inputLayouts, testConfig);
+    ValidationResult constraintResult = validateConstraints(
+        op, inputLayouts, testConfig, /*additionalL1Usage=*/0);
 
     // If not supported, backend error, or validation error - add to results
     // and continue (don't fail early, collect all results)
@@ -83,7 +84,7 @@ validateWithMultipleAttributes(Operation *op,
 
 static ValidationResult
 validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config) {
+                    const OpConfig &config, uint64_t additionalL1Usage) {
 
   // Get tensorL1UsageCap from module attribute
   const float tensorL1UsageCap = utils::getTensorL1UsageCap(op);
@@ -105,8 +106,8 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   }
 
   TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
-               "About to call getOpConstraints with {} input layouts",
-               inputLayouts.size());
+               "About to call getOpConstraints for {} with {} input layouts",
+               ttmlir::opToString(op), inputLayouts.size());
 
   for (size_t i = 0; i < inputLayouts.size(); ++i) {
     TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
@@ -114,6 +115,7 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                  inputLayouts[i], static_cast<int>(inputLayouts[i].getLayout()),
                  static_cast<int>(inputLayouts[i].getDataType()));
   }
+  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation, "Output config {}", config);
 
   llvm::Expected<ttnn::op_model::OpConstraints> l1UsageExp =
       backend.getOpConstraints(inputLayouts, config);
@@ -155,15 +157,18 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
   uint64_t usableL1CacheSize = chipDesc.getUsableL1Size();
 
-  if (overallPeakL1Usage > tensorL1UsageCap * usableL1CacheSize) {
+  uint64_t effectiveL1Limit =
+      static_cast<uint64_t>(tensorL1UsageCap * usableL1CacheSize);
+  uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
+
+  if (totalL1Usage > effectiveL1Limit) {
     TTMLIR_DEBUG(
         ttmlir::LogComponent::OpValidation,
-        "Not enough L1 memory. OpModel constraints failed for op {} \n"
-        "overallPeakL1Usage: {} [cbPeakUsage={}, l1BuffersPeakUsage={}] "
-        "limit: {}",
-        ttmlir::opToString(op), overallPeakL1Usage, cbPeakUsage,
-        l1BuffersPeakUsage,
-        static_cast<uint64_t>(tensorL1UsageCap * usableL1CacheSize));
+        "Not enough L1 memory. OpModel constraints failed for op {}\n"
+        "totalL1Usage: {} [overallPeakL1Usage={}, additionalL1Usage={}]"
+        " [cbPeakUsage={}, l1BuffersPeakUsage={}] limit: {}",
+        ttmlir::opToString(op), totalL1Usage, overallPeakL1Usage,
+        additionalL1Usage, cbPeakUsage, l1BuffersPeakUsage, effectiveL1Limit);
     return ValidationResult::outOfMemoryError("Not enough L1 memory");
   }
 
@@ -174,7 +179,7 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                ttmlir::opToString(op), outputLayout, overallPeakL1Usage,
                cbPeakUsage, l1BuffersPeakUsage, outputTensorUsagePerCore);
 
-  return ValidationResult::success(0, outputLayout);
+  return ValidationResult::success(0, outputLayout, outputTensorUsagePerCore);
 }
 
 } // namespace op_constraint_validation


### PR DESCRIPTION
## Summary
- Add `SpillLocation` enum to specify chain output spill destination (None, L1Interleaved, DRAM)
- Add `additionalL1Usage` parameter to `validateOperation` for L1 reservations during chain merging
- Add `outputL1Usage` field to `ValidationResult` for tracking output tensor L1 footprint
- Add `spillToL1InterleavedOps` vector to track ops needing L1 interleaved spilling
- Add `processSpillToL1InterleavedOps` in Optimizer to insert ToLayoutOp for L1 sharded → L1 interleaved conversion
- Add `fail()` method to L1ChainConfig for marking failed chains

This is foundational infrastructure for upcoming chain merging and L1 reservation features.