### PR TITLE
Misc fixes: permute fold, SDPA verification, scheduler, slice memory config

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4275,16 +4275,8 @@ mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
 
   RankedTensorType queryType = getQuery().getType();
   RankedTensorType keyType = getKey().getType();
-  RankedTensorType valueType = getValue().getType();
   RankedTensorType resultType = getResult().getType();
 
-  if (queryType != resultType) {
-    return emitOpError("Query and result must have the same type");
-  }
-
-  if (keyType != valueType) {
-    return emitOpError("Key and value must have the same type");
-  }
   if (queryType.getShape().size() != 4) {
     return emitOpError("Query must be a 4D tensor");
   }

--- a/lib/Scheduler/Scheduler.cpp
+++ b/lib/Scheduler/Scheduler.cpp
@@ -15,9 +15,10 @@
 
 namespace mlir::tt::scheduler {
 
-// TTNN op is scheduleable if it is not an EmptyOp and has at least one result.
+// TTNN op is scheduleable if it is not an EmptyOp or GetDeviceOp.
+// This includes in-place ops (like paged_update_cache) that have no results.
 static bool isTTNNScheduleableOp(mlir::Operation *op) {
-  return isa<ttnn::TTNNDialect>(op->getDialect()) && op->getNumResults() > 0 &&
+  return isa<ttnn::TTNNDialect>(op->getDialect()) &&
          !llvm::isa<ttnn::EmptyOp>(op) && !llvm::isa<ttnn::GetDeviceOp>(op);
 }
 

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/slice.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
+#include "tt/runtime/detail/ttnn/utils.h"
 
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
@@ -27,7 +28,12 @@ static void runSliceStaticOp(const ::tt::target::ttnn::SliceOp *op,
   ttsl::Span<const int32_t> endsSpan(ends.data(), ends.size());
   ttsl::Span<const int32_t> stepSpan(step.data(), step.size());
 
-  ::ttnn::Tensor out = ::ttnn::slice(in, beginsSpan, endsSpan, stepSpan);
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+
+  ::ttnn::Tensor out =
+      ::ttnn::slice(in, beginsSpan, endsSpan, stepSpan, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
@@ -49,7 +55,11 @@ static void runSliceDynamicOp(const ::tt::target::ttnn::SliceOp *op,
                    [](int32_t v) { return static_cast<uint32_t>(v); });
   }
 
-  ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+
+  ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_permute_broadcast.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_permute_broadcast.mlir
@@ -2,9 +2,12 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
+    // After commuting permute upwards through broadcast, the permute becomes
+    // permute(2048x1x1, [0,2,1]) which swaps dims 1 and 2 (both size 1).
+    // This is an identity permute and gets folded away, leaving just broadcast.
     func.func @test_permute_broadcast_commute_upwards(%arg0: tensor<2048x1x1xbf16>) -> tensor<2048x1x2048xbf16> {
-        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.permute"(%arg0
-        // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE]]
+        // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 1, 2048>}>
+        // CHECK-NEXT: return %[[BROADCAST]]
         %1 = "ttir.broadcast"(%arg0) <{broadcast_dimensions = array<i64: 1, 2048, 1>}> : (tensor<2048x1x1xbf16>) -> tensor<2048x2048x1xbf16>
         %3 = "ttir.permute"(%1) <{permutation = array<i64: 0, 2, 1>}> : (tensor<2048x2048x1xbf16>) -> tensor<2048x1x2048xbf16>
         return %3: tensor<2048x1x2048xbf16>


### PR DESCRIPTION
## Summary
- PermuteOp fold: handle permutations where all swapped dimensions have size 1 (e.g., [2, 0, 1, 3] on shape 1x1x1x64 is a no-op)
- Remove overly strict SDPA type verification constraints (query/result type, key/value type matching)
- Include in-place ops with no results (like paged_update_cache) as scheduleable
- Pass memory config to slice op for proper output placement