### PR TITLE
Mismatch in dimensions for embeddingbw

### DIFF
--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op_to_embedding_bw.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op_to_embedding_bw.mlir
@@ -24,4 +24,16 @@ module {
     return %result : tensor<2x128xf32>
   }
 
+  func.func @test_flattened_indices(%arg0: tensor<50257x768xf32>, %arg1: tensor<256x1xi64>, %arg2: tensor<256x768xf32>) -> tensor<50257x768xf32> {
+  // CHECK: "ttir.reshape"
+  // CHECK: (tensor<256x1xi64>) -> tensor<1x256x1xi64>
+  // CHECK: "ttir.embedding_backward"
+  // CHECK: (tensor<1x256x1xi64>, tensor<50257x768xf32>, tensor<256x768xf32>) -> tensor<50257x768xf32>
+  %result = "stablehlo.scatter"(%arg0, %arg1, %arg2) <{scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
+      ^bb0(%argL: tensor<f32>, %argR: tensor<f32>):
+        %sum = stablehlo.add %argL, %argR : tensor<f32>
+        stablehlo.return %sum : tensor<f32>
+      }) : (tensor<50257x768xf32>, tensor<256x1xi64>, tensor<256x768xf32>) -> tensor<50257x768xf32>
+    return %result : tensor<50257x768xf32>
+  }
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/6446

### Problem description
Conversion from stableHLO.scatterOp to ttnn.embeddingBW op requires padding if shape is not aligned with tile width. However, scatter can be mapped even if dimensions are 2D. Because stableHLO represents indices with vector of size 1, embeddingBW incorrectly deciphers what is the dimension that should be padded and results in a crash.

### What's changed
Added a reshape to conversion if it is necessary. 
### Checklist
- [x] New/Existing tests provide coverage for changes
