### PR TITLE
Fix arguments mismatch issue in CPU-hoisted operations

### DIFF
--- a/test/ttmlir/Dialect/StableHLO/cpu_hoisting/allowlisited_shlo_op.mlir
+++ b/test/ttmlir/Dialect/StableHLO/cpu_hoisting/allowlisited_shlo_op.mlir
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
-  func.func @dynamic_update_slice_example() -> tensor<4xi32> {
+  func.func @dynamic_update_slice_example() -> (tensor<4xi32>, tensor<4x4xi32>) {
     %base = stablehlo.constant dense<[0, 0, 0, 0]> : tensor<4xi32>
     %update = stablehlo.constant dense<[9, 9]> : tensor<2xi32>
     %start = stablehlo.constant dense<1> : tensor<i32>
@@ -11,10 +11,20 @@ module {
     %result = stablehlo.dynamic_update_slice %base, %update, %start
       : (tensor<4xi32>, tensor<2xi32>, tensor<i32>) -> tensor<4xi32>
 
-    return %result : tensor<4xi32>
+    %base_2d = stablehlo.constant dense<[[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>
+    %update_2d = stablehlo.constant dense<[[9, 9], [9, 9]]> : tensor<2x2xi32>
+    %start_2d = stablehlo.constant dense<1> : tensor<i32>
+
+    %result_2d = stablehlo.dynamic_update_slice %base_2d, %update_2d, %start_2d, %start_2d
+      : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i32>, tensor<i32>) -> tensor<4x4xi32>
+
+    return %result, %result_2d : tensor<4xi32>, tensor<4x4xi32>
   }
   // CHECK: ttcore.device_module
   // CHECK-NOT: stablehlo.dynamic_update_slice
   // CHECK: ttcore.cpu_module
+  // CHECK-LABEL: func.func @hoisted_stablehlo_dynamic_update_slice_4xi32_2xi32_i32_func
+  // CHECK: stablehlo.dynamic_update_slice
+  // CHECK-LABEL: func.func @hoisted_stablehlo_dynamic_update_slice_4x4xi32_2x2xi32_i32_i32_func
   // CHECK: stablehlo.dynamic_update_slice
 }

--- a/test/ttmlir/Dialect/TTIR/hoist/simple_add.mlir
+++ b/test/ttmlir/Dialect/TTIR/hoist/simple_add.mlir
@@ -8,7 +8,7 @@
 func.func @add1(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
-  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32_32x32_func_decl
+  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32xbf16_32x32xbf16_func_decl
   %1 = "ttir.add"(%arg0, %arg1) {ttir.should_hoist} : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
   return %1 : tensor<32x32xbf16>
@@ -16,14 +16,14 @@ func.func @add1(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<
 
 // CHECK: func.func @add2
 func.func @add2(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32_32x32_func_decl
+  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32xf32_32x32xf32_func_decl
   %1 = "ttir.add"(%arg0, %arg1) {ttir.should_hoist} : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
   return %1 : tensor<32x32xf32>
 }
 
 // CHECK: func.func @add3
 func.func @add3(%arg0: tensor<32x3xf32>, %arg1: tensor<32x3xf32>) -> tensor<32x3xf32> {
-  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x3_32x3_func_decl
+  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x3xf32_32x3xf32_func_decl
   %1 = "ttir.add"(%arg0, %arg1) {ttir.should_hoist} : (tensor<32x3xf32>, tensor<32x3xf32>) -> tensor<32x3xf32>
   return %1 : tensor<32x3xf32>
 }
@@ -32,15 +32,15 @@ func.func @add3(%arg0: tensor<32x3xf32>, %arg1: tensor<32x3xf32>) -> tensor<32x3
 func.func @add4(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
-  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32_32x32_func_decl
+  // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32xbf16_32x32xbf16_func_decl
   %1 = "ttir.add"(%arg0, %arg1) {ttir.should_hoist} : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: %{{.*}} = ttir.to_layout %{{.*}}, %{{.*}}
   return %1 : tensor<32x32xbf16>
 }
-// CHECK: func.func private @hoisted_ttir_add_32x32_32x32_func_decl
-// CHECK: func.func private @hoisted_ttir_add_32x3_32x3_func_decl
+// CHECK: func.func private @hoisted_ttir_add_32x32xbf16_32x32xbf16_func_decl
+// CHECK: func.func private @hoisted_ttir_add_32x3xf32_32x3xf32_func_decl
 
 // CHECK: ttcore.cpu_module {
 // CHECK: builtin.module {
-// CHECK: func.func @hoisted_ttir_add_32x32_32x32_func
-// CHECK: func.func @hoisted_ttir_add_32x3_32x3_func
+// CHECK: func.func @hoisted_ttir_add_32x32xbf16_32x32xbf16_func
+// CHECK: func.func @hoisted_ttir_add_32x3xf32_32x3xf32_func

--- a/test/ttmlir/Dialect/TTNN/construct_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/construct_tensor.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t
 module attributes {} {
   func.func @add(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32_32x32_func_decl
+    // CHECK: %{{.*}} = call @hoisted_ttir_add_32x32xf32_32x32xf32_func_decl
     %1 = "ttir.add"(%arg0, %arg1) {ttir.should_hoist} : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
     return %1 : tensor<32x32xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
@@ -11,9 +11,9 @@ module {
     // CHECK: %{{.*}} = "ttnn.multiply"(%{{.*}}, %{{.*}})
     %1 = "ttir.multiply"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.from_device"(%{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_func_decl(%{{.*}}, %{{.*}})
+    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128xf32_64x128xf32_func_decl(%{{.*}}, %{{.*}})
     %3 = "ttir.add"(%arg0, %1) {ttir.should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_func_decl(%{{.*}}, %{{.*}})
+    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128xf32_64x128xf32_func_decl(%{{.*}}, %{{.*}})
     %5 = "ttir.add"(%arg0, %3) {ttir.should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.to_device"(%{{.*}}, %{{.*}}) <{memory_config = {{.*}}}> : (tensor<[[DIMS:.*]], #{{.*}}>, !ttnn.device) -> tensor<[[DIMS]], #{{.*}}>
     // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
@@ -23,9 +23,9 @@ module {
     %7 = "ttir.multiply"(%3, %5) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     return %7 : tensor<64x128xf32>
   }
-  // CHECK: func.func private @hoisted_ttir_add_64x128_64x128_func_decl
+  // CHECK: func.func private @hoisted_ttir_add_64x128xf32_64x128xf32_func_decl
   // CHECK: ttcore.cpu_module {
   // CHECK: builtin.module {
-  // CHECK: llvm.func @hoisted_ttir_add_64x128_64x128_func
-  // CHECK: llvm.func @hoisted_ttir_add_64x128_64x128_func_helper(%arg0: !llvm.ptr)
+  // CHECK: llvm.func @hoisted_ttir_add_64x128xf32_64x128xf32_func
+  // CHECK: llvm.func @hoisted_ttir_add_64x128xf32_64x128xf32_func_helper(%arg0: !llvm.ptr)
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/fallback/unsupported.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/fallback/unsupported.mlir
@@ -19,7 +19,7 @@ module {
         %scale = stablehlo.constant dense<2.0> : tensor<32x64xf32>
         %1 = stablehlo.multiply %0, %scale : tensor<32x64xf32>
 
-        // CHECK: %[[EINSUM:.*]] = call @hoisted_stablehlo_einsum_32x64_64x48_func_decl
+        // CHECK: %[[EINSUM:.*]] = call @hoisted_stablehlo_einsum_32x64xf32_64x48xf32_func_decl
         %2 = "stablehlo.einsum"(%1, %arg2) {
         einsum_config = "ij,jk->ik"
         } : (tensor<32x64xf32>, tensor<64x48xf32>) -> tensor<32x48xf32>
@@ -34,7 +34,7 @@ module {
         %start = stablehlo.constant dense<1> : tensor<i32>
 
 
-        // CHECK: %[[DYNAMIC_UPDATE_SLICE:.*]] = call @hoisted_stablehlo_dynamic_update_slice_4_2__func_decl
+        // CHECK: %[[DYNAMIC_UPDATE_SLICE:.*]] = call @hoisted_stablehlo_dynamic_update_slice_4xi32_2xi32_i32_func_decl
         %result = stablehlo.dynamic_update_slice %base, %update, %start
             : (tensor<4xi32>, tensor<2xi32>, tensor<i32>) -> tensor<4xi32>
 
@@ -42,11 +42,11 @@ module {
     }
 
 
-    // CHECK: func.func private @hoisted_stablehlo_einsum_32x64_64x48_func_decl
-    // CHECK: func.func private @hoisted_stablehlo_dynamic_update_slice_4_2__func_decl
+    // CHECK: func.func private @hoisted_stablehlo_einsum_32x64xf32_64x48xf32_func_decl
+    // CHECK: func.func private @hoisted_stablehlo_dynamic_update_slice_4xi32_2xi32_i32_func_decl
 
     // CHECK: ttcore.cpu_module {
     // CHECK: builtin.module {
-    // CHECK: func.func @hoisted_stablehlo_einsum_32x64_64x48_func
-    // CHECK: func.func @hoisted_stablehlo_dynamic_update_slice_4_2__func
+    // CHECK: func.func @hoisted_stablehlo_einsum_32x64xf32_64x48xf32_func
+    // CHECK: func.func @hoisted_stablehlo_dynamic_update_slice_4xi32_2xi32_i32_func
 }


### PR DESCRIPTION
### Ticket
#6448

**Note: this PR is a somewhat-dirty hotfix. A proper fix should be delivered as part of #6465.**

### Problem description
During CPU hoisting, when the same value is used multiple times as an argument of an op, current implementation will skip it, because deduplication of the input arguments is being performed. This issue has been introduced as part of #6041. 

Deduplication makes sense when hoisting multiple ops at the same time (e.g. for const-eval CPU-hoisting), but it shouldn't be performed during single-op hoisting.

Additionally (but unrelated to the issue), element types and 0D-tensor input aren't encoded in the CPU-hoisted function names, which makes the IR hard to follow and debug.

### Example

📝 **Given**: For the `dynamic_update_slice` op in the following snippet:
```
%base_2d = stablehlo.constant dense<[[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>
%update_2d = stablehlo.constant dense<[[9, 9], [9, 9]]> : tensor<2x2xi32>
%start_2d = stablehlo.constant dense<1> : tensor<i32>
    
    
%result_2d = stablehlo.dynamic_update_slice %base_2d, %update_2d, %start_2d, %start_2d
      : (tensor<4x4xi32>, tensor<2x2xi32>, tensor<i32>, tensor<i32>) -> tensor<4x4xi32>
```

✅ **Expected behavior**: The following signature for the CPU-hoisted function is used:
```
func.func @hoisted...(tensor<4xi32>, tensor<2xi32>, tensor<i32>, tensor<i32>) -> tensor<4xi32>
--------------------------------------------------- ^^^^^^^^^^^^^^^^^^^^^^^^ -----------------
```

❌ **Actual behavior**: `%start_2d` argument gets deduplicated, and the following signature is used:
```
func.func private @hoisted...(tensor<4xi32>, tensor<2xi32>, tensor<i32>) -> tensor<4xi32>
----------------------------------------------------------- ^^^^^^^^^^^ -----------------
```

### What's changed
- Made the input arguments deduplication optional.
- Improved hoisted functions naming.

### Checklist
- [x] New/Existing tests provide coverage for changes
