### PR TITLE
Added support for sdy manual computation op in builder + shlo collective all_gather 

### DIFF
--- a/env/patches/shardy.patch
+++ b/env/patches/shardy.patch
@@ -267,7 +267,7 @@ index 0000000..3b414d1
 +)
 diff --git a/shardy/dialect/sdy/transforms/export/CMakeLists.txt b/shardy/dialect/sdy/transforms/export/CMakeLists.txt
 new file mode 100755
-index 0000000..60f1952
+index 0000000..f23330d
 --- /dev/null
 +++ b/shardy/dialect/sdy/transforms/export/CMakeLists.txt
 @@ -0,0 +1,94 @@
@@ -636,10 +636,10 @@ index 0000000..dc33501
 +  SdyTransformsPropagationShardingProjection
 +)
 diff --git a/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc b/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
-index 86f16d1..8039a00 100644
+index a73917b..78cc827 100644
 --- a/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
 +++ b/shardy/dialect/sdy/transforms/propagation/debugging/source_sharding.cc
-@@ -338,6 +338,7 @@ void saveShardingOriginsOnModule(
+@@ -346,6 +346,7 @@ void saveShardingOriginsOnModule(
  // the case for the target of the edge, because if the source appears multiple
  // times, then it's because it effects multiple other operands/results in the
  // op.
@@ -647,6 +647,78 @@ index 86f16d1..8039a00 100644
  bool insertSeenValue(Operation* op, const PropagationEdge& edge,
                       llvm::SmallDenseSet<Value>& seenValues) {
    EdgeNode target = edge.target;
+diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+index ab93067..283d6ad 100644
+--- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
++++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+@@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
+         }
+         return builder.build();
+       })
++      .Case<stablehlo::BatchNormInferenceOp>(
++        [conservativePropagation](stablehlo::BatchNormInferenceOp bn) {
++          auto inTy  = llvm::cast<mlir::RankedTensorType>(bn.getOperand().getType());
++          auto outTy = llvm::cast<mlir::RankedTensorType>(bn.getResult().getType());
++
++          OpShardingRuleBuilder builder(bn);
++
++          const int64_t numOperands = static_cast<int64_t>(bn->getNumOperands());
++          llvm::SmallVector<int64_t> opDims(numOperands, kNullDim);
++
++          for (auto [dU, dimSize] : llvm::enumerate(inTy.getShape())) {
++            const int64_t d = static_cast<int64_t>(dU);
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[0] = d;
++            builder.addFactor(opDims, d, dimSize);
++          }
++
++          const int64_t featAxis = static_cast<int64_t>(bn.getFeatureIndex());
++          const int64_t C = outTy.getDimSize(featAxis);
++
++          for (int64_t paramIdx : {1LL, 2LL, 3LL, 4LL}) {
++            std::fill(opDims.begin(), opDims.end(), kNullDim);
++            opDims[paramIdx] = 0;
++            auto factorType = conservativePropagation ? FactorType::kNeedReplication
++                                                        : FactorType::kPassThrough;
++            builder.addFactor(opDims, kNullDim, C,
++                  factorType, true);
++          }
++
++          return builder.build();
++        })
+       .Case<stablehlo::BitcastConvertOp>(
+           [](stablehlo::BitcastConvertOp bitcastConvert) {
+             ArrayRef<int64_t> inShape =
+@@ -685,6 +716,12 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
+                   /*isBlocked=*/usedByRngBitGenerator)
+               .build();
+         }
++        // Check if the custom call implements the ShardingRuleOpInterface.
++        if (auto shardingRuleOp =
++                  llvm::dyn_cast<ShardingRuleOpInterface>(customCall.getOperation())) {
++          return shardingRuleOp.getShardingRule();
++        }
++
+         // TODO(b/327191011): output unregistered op stats instead.
+         static llvm::once_flag onceFlag;
+         emitOpWarningOnce(
+@@ -1093,6 +1130,16 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
+             return builder.build();
+           })
+       .Case<stablehlo::ScatterOp>([](stablehlo::ScatterOp scatter) {
++        // Check if the scatter op implements the ShardingRuleOpInterface.
++        if (auto shardingRuleOp =
++              llvm::dyn_cast<ShardingRuleOpInterface>(scatter.getOperation())) {
++          // Try to get custom rule - if it returns non-null, use it.
++          if (auto customRule = shardingRuleOp.getShardingRule()) {
++            return customRule;
++          }
++          // If custom rule returns null, fall through to default.
++        }
++
+         OpShardingRuleBuilder builder(scatter);
+
+         // Since all inputs and results have compatible shapes, we can look at
 diff --git a/shardy/integrations/c/CMakeLists.txt b/shardy/integrations/c/CMakeLists.txt
 new file mode 100644
 index 0000000..fdd50c4
@@ -673,6 +745,243 @@ index 0000000..fdd50c4
 +  StablehloOps
 +  StablehloTypeInference
 +)
+diff --git a/shardy/integrations/c/attributes.cc b/shardy/integrations/c/attributes.cc
+index b683d09..05d5c93 100644
+--- a/shardy/integrations/c/attributes.cc
++++ b/shardy/integrations/c/attributes.cc
+@@ -66,6 +66,10 @@ int64_t sdyMeshAxisAttrGetSize(MlirAttribute attr) {
+   return unwrapAttr<sdy::MeshAxisAttr>(attr).getSize();
+ }
+
++MlirAttribute sdyMeshAxisAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::MeshAxisAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // MeshAttr
+ //===----------------------------------------------------------------------===//
+@@ -98,6 +102,10 @@ MlirAttribute sdyMeshAttrGetAxesElem(MlirAttribute attr, intptr_t pos) {
+   return wrap(unwrapAttr<sdy::MeshAttr>(attr).getAxes()[pos]);
+ }
+
++MlirAttribute sdyMeshAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::MeshAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // SubAxisInfoAttr
+ //===----------------------------------------------------------------------===//
+@@ -119,6 +127,10 @@ int64_t sdySubAxisInfoAttrGetSize(MlirAttribute attr) {
+   return unwrapAttr<sdy::SubAxisInfoAttr>(attr).getSize();
+ }
+
++MlirAttribute sdySubAxisInfoAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::SubAxisInfoAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // AxisRefAttr
+ //===----------------------------------------------------------------------===//
+@@ -146,6 +158,10 @@ MlirAttribute sdyAxisRefAttrGetSubAxisInfo(MlirAttribute attr) {
+   return subAsisInfo ? wrap(subAsisInfo) : MlirAttribute();
+ }
+
++MlirAttribute sdyAxisRefAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::AxisRefAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // DimensionShardingAttr
+ //===----------------------------------------------------------------------===//
+@@ -182,6 +198,10 @@ int64_t sdyDimensionShardingAttrGetPriority(MlirAttribute attr) {
+   return priority.has_value() ? *priority : -1;
+ }
+
++MlirAttribute sdyDimensionShardingAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::DimensionShardingAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // TensorShardingAttr
+ //===----------------------------------------------------------------------===//
+@@ -238,6 +258,10 @@ MlirAttribute sdyTensorShardingAttrGetUnreducedAxesElem(MlirAttribute attr,
+       unwrapAttr<sdy::TensorShardingAttr>(attr).getUnreducedAxes()[pos]);
+ }
+
++MlirAttribute sdyTensorShardingAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::TensorShardingAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // TensorShardingPerValueAttr
+ //===----------------------------------------------------------------------===//
+@@ -266,6 +290,10 @@ MlirAttribute sdyTensorShardingPerValueAttrGetShardingsElem(MlirAttribute attr,
+       unwrapAttr<sdy::TensorShardingPerValueAttr>(attr).getShardings()[pos]);
+ }
+
++MlirAttribute sdyTensorShardingPerValueAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::TensorShardingPerValueAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // DimMappingAttr
+ //===----------------------------------------------------------------------===//
+@@ -289,6 +317,10 @@ int64_t sdyDimMappingAttrGetFactorIndicesElem(MlirAttribute attr,
+   return unwrapAttr<sdy::DimMappingAttr>(attr).getFactorIndices()[pos];
+ }
+
++MlirAttribute sdyDimMappingAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::DimMappingAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // TensorMappingAttr
+ //===----------------------------------------------------------------------===//
+@@ -316,6 +348,10 @@ MlirAttribute sdyTensorMappingAttrGetDimMappingsElem(MlirAttribute attr,
+   return wrap(unwrapAttr<sdy::TensorMappingAttr>(attr).getDimMappings()[pos]);
+ }
+
++MlirAttribute sdyTensorMappingAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::TensorMappingAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // OpShardingRuleAttr
+ //===----------------------------------------------------------------------===//
+@@ -423,6 +459,10 @@ int64_t sdyOpShardingRuleAttrGetBlockedPropagationFactorsElem(
+       .getBlockedPropagationFactors()[pos];
+ }
+
++MlirAttribute sdyOpShardingRuleAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::OpShardingRuleAttr>(unwrap(attr)));
++}
++
+ //===----------------------------------------------------------------------===//
+ // ManualAxesAttr
+ //===----------------------------------------------------------------------===//
+@@ -446,4 +486,8 @@ MlirStringRef sdyManualAxesAttrGetAxesElem(
+   return wrap(unwrapAttr<sdy::ManualAxesAttr>(attr)[pos].getValue());
+ }
+
++MlirAttribute sdyManualAxesAttrMaybeDowncast(MlirAttribute attr) {
++  return wrap(mlir::cast<sdy::ManualAxesAttr>(unwrap(attr)));
++}
++
+ }  // extern "C"
+diff --git a/shardy/integrations/c/attributes.h b/shardy/integrations/c/attributes.h
+index b6e77c9..f36f004 100644
+--- a/shardy/integrations/c/attributes.h
++++ b/shardy/integrations/c/attributes.h
+@@ -40,6 +40,9 @@ MLIR_CAPI_EXPORTED MlirStringRef sdyMeshAxisAttrGetName(MlirAttribute attr);
+
+ MLIR_CAPI_EXPORTED int64_t sdyMeshAxisAttrGetSize(MlirAttribute attr);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyMeshAxisAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // MeshAttr
+ //===----------------------------------------------------------------------===//
+@@ -61,6 +64,9 @@ MLIR_CAPI_EXPORTED intptr_t sdyMeshAttrGetAxesSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirAttribute sdyMeshAttrGetAxesElem(MlirAttribute attr,
+                                                         intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyMeshAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // SubAxisInfoAttr
+ //===----------------------------------------------------------------------===//
+@@ -75,6 +81,9 @@ MLIR_CAPI_EXPORTED int64_t sdySubAxisInfoAttrGetPreSize(MlirAttribute attr);
+
+ MLIR_CAPI_EXPORTED int64_t sdySubAxisInfoAttrGetSize(MlirAttribute attr);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdySubAxisInfoAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // AxisRefAttr
+ //===----------------------------------------------------------------------===//
+@@ -92,6 +101,9 @@ MLIR_CAPI_EXPORTED MlirStringRef sdyAxisRefAttrGetName(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirAttribute
+ sdyAxisRefAttrGetSubAxisInfo(MlirAttribute attr);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyAxisRefAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // DimensionShardingAttr
+ //===----------------------------------------------------------------------===//
+@@ -116,6 +128,9 @@ MLIR_CAPI_EXPORTED bool sdyDimensionShardingAttrGetIsClosed(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED int64_t
+ sdyDimensionShardingAttrGetPriority(MlirAttribute attr);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyDimensionShardingAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // TensorShardingAttr
+ //===----------------------------------------------------------------------===//
+@@ -149,6 +164,9 @@ sdyTensorShardingAttrGetUnreducedAxesSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirAttribute
+ sdyTensorShardingAttrGetUnreducedAxesElem(MlirAttribute attr, intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyTensorShardingAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // TensorShardingPerValueAttr
+ //===----------------------------------------------------------------------===//
+@@ -165,6 +183,9 @@ sdyTensorShardingPerValueAttrGetShardingsSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirAttribute
+ sdyTensorShardingPerValueAttrGetShardingsElem(MlirAttribute attr, intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyTensorShardingPerValueAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // DimMappingAttr
+ //===----------------------------------------------------------------------===//
+@@ -180,6 +201,9 @@ sdyDimMappingAttrGetFactorIndicesSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED int64_t
+ sdyDimMappingAttrGetFactorIndicesElem(MlirAttribute attr, intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyDimMappingAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // TensorMappingAttr
+ //===----------------------------------------------------------------------===//
+@@ -197,6 +221,9 @@ sdyTensorMappingAttrGetDimMappingsSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirAttribute
+ sdyTensorMappingAttrGetDimMappingsElem(MlirAttribute attr, intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyTensorMappingAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // OpShardingRuleAttr
+ //===----------------------------------------------------------------------===//
+@@ -258,6 +285,9 @@ MLIR_CAPI_EXPORTED int64_t
+ sdyOpShardingRuleAttrGetBlockedPropagationFactorsElem(MlirAttribute attr,
+                                                       intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyOpShardingRuleAttrMaybeDowncast(MlirAttribute attr);
++
+ //===----------------------------------------------------------------------===//
+ // ManualAxesAttr
+ //===----------------------------------------------------------------------===//
+@@ -272,6 +302,9 @@ MLIR_CAPI_EXPORTED intptr_t sdyManualAxesAttrGetAxesSize(MlirAttribute attr);
+ MLIR_CAPI_EXPORTED MlirStringRef sdyManualAxesAttrGetAxesElem(
+   MlirAttribute attr, intptr_t pos);
+
++MLIR_CAPI_EXPORTED MlirAttribute
++sdyManualAxesAttrMaybeDowncast(MlirAttribute attr);
++
+ #ifdef __cplusplus
+ }
+ #endif
 diff --git a/shardy/integrations/python/ir/CMakeLists.txt b/shardy/integrations/python/ir/CMakeLists.txt
 new file mode 100644
 index 0000000..cbb4d66
@@ -789,75 +1098,192 @@ index 0000000..30a5cf9
 +include "shardy/dialect/sdy/ir/ops.td"
 +
 +#endif
-diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-index ab93067..283d6ad 100644
---- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-+++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-@@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-         }
-         return builder.build();
-       })
-+      .Case<stablehlo::BatchNormInferenceOp>(
-+        [conservativePropagation](stablehlo::BatchNormInferenceOp bn) {
-+          auto inTy  = llvm::cast<mlir::RankedTensorType>(bn.getOperand().getType());
-+          auto outTy = llvm::cast<mlir::RankedTensorType>(bn.getResult().getType());
-+
-+          OpShardingRuleBuilder builder(bn);
-+
-+          const int64_t numOperands = static_cast<int64_t>(bn->getNumOperands());
-+          llvm::SmallVector<int64_t> opDims(numOperands, kNullDim);
-+
-+          for (auto [dU, dimSize] : llvm::enumerate(inTy.getShape())) {
-+            const int64_t d = static_cast<int64_t>(dU);
-+            std::fill(opDims.begin(), opDims.end(), kNullDim);
-+            opDims[0] = d;
-+            builder.addFactor(opDims, d, dimSize);
-+          }
-+
-+          const int64_t featAxis = static_cast<int64_t>(bn.getFeatureIndex());
-+          const int64_t C = outTy.getDimSize(featAxis);
-+
-+          for (int64_t paramIdx : {1LL, 2LL, 3LL, 4LL}) {
-+            std::fill(opDims.begin(), opDims.end(), kNullDim);
-+            opDims[paramIdx] = 0;
-+            auto factorType = conservativePropagation ? FactorType::kNeedReplication
-+                                                        : FactorType::kPassThrough;
-+            builder.addFactor(opDims, kNullDim, C,
-+                  factorType, true);
-+          }
-+
-+          return builder.build();
-+        })
-       .Case<stablehlo::BitcastConvertOp>(
-           [](stablehlo::BitcastConvertOp bitcastConvert) {
-             ArrayRef<int64_t> inShape =
-@@ -685,6 +716,12 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-                   /*isBlocked=*/usedByRngBitGenerator)
-               .build();
-         }
-+        // Check if the custom call implements the ShardingRuleOpInterface.
-+        if (auto shardingRuleOp =
-+                  llvm::dyn_cast<ShardingRuleOpInterface>(customCall.getOperation())) {
-+          return shardingRuleOp.getShardingRule();
-+        }
-+
-         // TODO(b/327191011): output unregistered op stats instead.
-         static llvm::once_flag onceFlag;
-         emitOpWarningOnce(
-@@ -1093,6 +1130,16 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
-             return builder.build();
-           })
-       .Case<stablehlo::ScatterOp>([](stablehlo::ScatterOp scatter) {
-+        // Check if the scatter op implements the ShardingRuleOpInterface.
-+        if (auto shardingRuleOp =
-+              llvm::dyn_cast<ShardingRuleOpInterface>(scatter.getOperation())) {
-+          // Try to get custom rule - if it returns non-null, use it.
-+          if (auto customRule = shardingRuleOp.getShardingRule()) {
-+            return customRule;
-+          }
-+          // If custom rule returns null, fall through to default.
-+        }
-+
-         OpShardingRuleBuilder builder(scatter);
+diff --git a/shardy/integrations/python/ir/sdy_module.cc b/shardy/integrations/python/ir/sdy_module.cc
+index da451fa..3401ca9 100644
+--- a/shardy/integrations/python/ir/sdy_module.cc
++++ b/shardy/integrations/python/ir/sdy_module.cc
+@@ -109,7 +109,15 @@ NB_MODULE(_sdy, m) {
+                              })
+       .def_property_readonly("size", [](MlirAttribute self) {
+         return sdyMeshAxisAttrGetSize(self);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsAMeshAxisAttr(attr)) {
++              return cls(sdyMeshAxisAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
 
-         // Since all inputs and results have compatible shapes, we can look at
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "MeshAttr", sdyAttributeIsAMeshAttr)
+@@ -133,7 +141,15 @@ NB_MODULE(_sdy, m) {
+       .def_property_readonly("axes", [](MlirAttribute self) {
+         return propertyVector<MlirAttribute>(self, sdyMeshAttrGetAxesSize,
+                                              sdyMeshAttrGetAxesElem);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsAMeshAttr(attr)) {
++              return cls(sdyMeshAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "SubAxisInfoAttr", sdyAttributeIsASubAxisInfoAttr)
+@@ -150,7 +166,15 @@ NB_MODULE(_sdy, m) {
+           [](MlirAttribute self) { return sdySubAxisInfoAttrGetPreSize(self); })
+       .def_property_readonly("size", [](MlirAttribute self) {
+         return sdySubAxisInfoAttrGetSize(self);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsASubAxisInfoAttr(attr)) {
++              return cls(sdySubAxisInfoAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "AxisRefAttr", sdyAttributeIsAnAxisRefAttr)
+@@ -175,7 +199,15 @@ NB_MODULE(_sdy, m) {
+         MlirAttribute subAxisInfo = sdyAxisRefAttrGetSubAxisInfo(self);
+         return subAxisInfo.ptr == nullptr ? std::nullopt
+                                           : std::optional(subAxisInfo);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsAnAxisRefAttr(attr)) {
++              return cls(sdyAxisRefAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "DimensionShardingAttr", sdyAttributeIsADimensionShardingAttr)
+@@ -205,7 +237,15 @@ NB_MODULE(_sdy, m) {
+       .def_property_readonly("priority", [](MlirAttribute self) {
+         int64_t priority = sdyDimensionShardingAttrGetPriority(self);
+         return priority == -1 ? std::nullopt : std::optional(priority);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsADimensionShardingAttr(attr)) {
++              return cls(sdyDimensionShardingAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "TensorShardingAttr", sdyAttributeIsATensorShardingAttr)
+@@ -251,7 +291,15 @@ NB_MODULE(_sdy, m) {
+         return propertyVector<MlirAttribute>(
+             self, sdyTensorShardingAttrGetUnreducedAxesSize,
+             sdyTensorShardingAttrGetUnreducedAxesElem);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsATensorShardingAttr(attr)) {
++              return cls(sdyTensorShardingAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "TensorShardingPerValueAttr",
+@@ -270,7 +318,15 @@ NB_MODULE(_sdy, m) {
+         return propertyVector<MlirAttribute>(
+             self, sdyTensorShardingPerValueAttrGetShardingsSize,
+             sdyTensorShardingPerValueAttrGetShardingsElem);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsATensorShardingPerValueAttr(attr)) {
++              return cls(sdyTensorShardingPerValueAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "DimMappingAttr", sdyAttributeIsADimMappingAttr)
+@@ -288,7 +344,15 @@ NB_MODULE(_sdy, m) {
+         return propertyVector<intptr_t>(self,
+                                         sdyDimMappingAttrGetFactorIndicesSize,
+                                         sdyDimMappingAttrGetFactorIndicesElem);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsADimMappingAttr(attr)) {
++              return cls(sdyDimMappingAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "TensorMappingAttr", sdyAttributeIsATensorMappingAttr)
+@@ -310,7 +374,15 @@ NB_MODULE(_sdy, m) {
+                              })
+       .def_property_readonly("rank", [](MlirAttribute self) {
+         return sdyTensorMappingAttrGetRank(self);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsATensorMappingAttr(attr)) {
++              return cls(sdyTensorMappingAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+       m, "OpShardingRuleAttr", sdyAttributeIsAOpShardingRuleAttr)
+@@ -394,6 +466,14 @@ NB_MODULE(_sdy, m) {
+             return propertyVector<intptr_t>(
+                 self, sdyOpShardingRuleAttrGetBlockedPropagationFactorsSize,
+                 sdyOpShardingRuleAttrGetBlockedPropagationFactorsElem);
++          })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsAOpShardingRuleAttr(attr)) {
++              return cls(sdyOpShardingRuleAttrMaybeDowncast(attr));
++            }
++            return nb::none();
+           });
+
+   mlir::python::nanobind_adaptors::mlir_attribute_subclass(
+@@ -417,7 +497,15 @@ NB_MODULE(_sdy, m) {
+            })
+       .def("__len__", [](MlirAttribute& self) {
+         return sdyManualAxesAttrGetAxesSize(self);
+-      });
++      })
++      .def_classmethod(
++          "maybe_downcast",
++          [](nb::object cls, MlirAttribute attr) -> std::variant<MlirAttribute, nb::object> {
++            if (sdyAttributeIsAManualAxesAttr(attr)) {
++              return cls(sdyManualAxesAttrMaybeDowncast(attr));
++            }
++            return nb::none();
++          });
+ }
+
+ }  // namespace

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -3413,8 +3413,7 @@ def test_nested_function_calls(target, request, device):
                     return relu0
 
                 sigmoid0 = builder.sigmoid(in0)
-                ttir_builder0 = TTIRBuilder(builder.context, builder.location)
-                nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
+                nested_func0 = builder.call(nested_func, [sigmoid0])
                 return nested_func0
 
             @builder.func([(32, 32)], [torch.float32])

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -281,6 +281,25 @@ class Builder(metaclass=BuilderMeta):
         loc = str(operand.owner.location)
         self._bypass_ops.append(loc)
 
+    def set_arg_attribute(
+        self, operand: Operand, new_attr_name: str, new_attr: Attribute
+    ):
+        func_op = operand.owner.owner
+
+        arg_attr_list = func_op.arg_attrs
+        new_arg_attr_list = []
+        for arg_number, arg_attrs in enumerate(arg_attr_list):
+            if arg_number == operand.arg_number:
+                new_arg_attr = {}
+                for attr in arg_attrs:
+                    new_arg_attr[attr.name.value] = attr
+                new_arg_attr[new_attr_name] = new_attr
+                new_arg_attr_list.append(DictAttr.get(new_arg_attr))
+            else:
+                new_arg_attr_list.append(arg_attrs)
+
+        func_op.arg_attrs = ArrayAttr.get(new_arg_attr_list)
+
     # ----- Private methods -----
 
     def _get_output_shape_and_type(
@@ -609,6 +628,13 @@ class Builder(metaclass=BuilderMeta):
     ) -> List[GoldenMapTensor]:
         return [self._goldens[operand] for operand in operands]
 
+    def _get_location(self) -> Location:
+        stack = inspect.stack()
+        caller_frame = stack[2]
+        filename = caller_frame.filename
+        lineno = caller_frame.lineno
+        return Location.name(f"{filename}:{lineno}")
+
     # ----- Shared Empty Operations -----
 
     def _empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
@@ -675,7 +701,10 @@ class Builder(metaclass=BuilderMeta):
     # ----- Operations -----
 
     def call(
-        self, nested_func: Callable, original_inputs: List[Operand], builder: Builder
+        self,
+        nested_func: Callable,
+        original_inputs: List[Operand],
+        loc: Optional[str] = None,
     ):
         fn_input_types = []
         for operand in original_inputs:
@@ -696,28 +725,33 @@ class Builder(metaclass=BuilderMeta):
                         original_operand
                     )
 
-                builder._set_goldens(input_goldens)
+                self._set_goldens(input_goldens)
                 ordered_inputs.extend(inputs)
 
-                result = nested_func(*inputs, builder)
+                result = nested_func(*inputs, self)
 
                 outputs = result if hasattr(result, "__iter__") else [result]
                 output_goldens: Dict[Operand, GoldenMapTensor] = {}
                 for op in outputs:
-                    output_goldens[op] = builder._get_golden_tensor(op)
-                builder._set_goldens(output_goldens)
+                    output_goldens[op] = self._get_golden_tensor(op)
+                self._set_goldens(output_goldens)
                 ordered_outputs.extend(outputs)
 
                 return process_multi_return_result(result)
 
         new_func_op = decorated_func.func_op
         new_func_op.sym_visibility = StringAttr.get("private")
-        builder._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+        self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
 
-        call_op = func.CallOp(new_func_op, original_inputs)
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        call_op = func.CallOp(new_func_op, original_inputs, loc=loc)
         for index, output in enumerate(ordered_outputs):
             self._set_golden_tensor(
-                call_op.results[index], builder._get_golden_tensor(output)
+                call_op.results[index], self._get_golden_tensor(output)
             )
 
         return (
@@ -1122,21 +1156,24 @@ class Builder(metaclass=BuilderMeta):
 
             @func.func(*fn_input_types, name=fn.__name__)
             def decorated_func(*inputs):
-                input_goldens: Dict[Operand, GoldenMapTensor] = {}
-                for index, (operand, dtype) in enumerate(zip(inputs, input_types)):
-                    input_goldens[operand] = self._generate_golden_tensor(
-                        operand, dtype
-                    )
-                self._set_goldens(input_goldens)
+                if not self._disable_golden_check:
+                    input_goldens: Dict[Operand, GoldenMapTensor] = {}
+                    for index, (operand, dtype) in enumerate(zip(inputs, input_types)):
+                        input_goldens[operand] = self._generate_golden_tensor(
+                            operand, dtype
+                        )
+                    self._set_goldens(input_goldens)
                 ordered_inputs.extend(inputs)
 
                 result = fn(*inputs, self)
 
                 outputs = result if hasattr(result, "__iter__") else [result]
-                output_goldens: Dict[Operand, GoldenMapTensor] = {}
-                for op in outputs:
-                    output_goldens[op] = self._get_golden_tensor(op)
-                self._set_goldens(output_goldens)
+
+                if not self._disable_golden_check:
+                    output_goldens: Dict[Operand, GoldenMapTensor] = {}
+                    for op in outputs:
+                        output_goldens[op] = self._get_golden_tensor(op)
+                    self._set_goldens(output_goldens)
                 ordered_outputs.extend(outputs)
 
                 return process_multi_return_result(result)

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -194,7 +194,7 @@ def build_module(
     elif builder_type == "stablehlo":
         builder = StableHLOBuilder(ctx, loc, mesh_name, mesh_dict)
     elif builder_type == "ttnn":
-        builder = TTNNBuilder(ctx, loc)
+        builder = TTNNBuilder(ctx, loc, mesh_name, mesh_dict)
     elif builder_type == "d2m":
         builder = D2MBuilder(ctx, loc, mesh_name, mesh_dict)
     dir_name = builder_type + "-builder-artifacts"

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -20,7 +20,7 @@ from ttmlir.dialects import stablehlo, sdy, mpmd, func
 from builder.base.builder import *
 from builder.base.builder_utils import *
 
-from golden import *
+from golden import get_golden_function, apply_sharding, apply_unsharding
 
 
 class StableHLOBuilder(Builder):
@@ -39,8 +39,6 @@ class StableHLOBuilder(Builder):
     ):
         super().__init__(ctx, location, mesh_name, mesh_dict, disable_golden_check)
 
-        self._arg_attrs: Dict[Operand, Dict[str, Attribute]] = {}
-
     # ----- Class helper methods -----
 
     @classmethod
@@ -53,10 +51,6 @@ class StableHLOBuilder(Builder):
                     cls.opname_to_opview_map[op_name] = obj
 
     # ----- Public methods -----
-
-    @property
-    def arg_attrs(self) -> Dict[Operand, Dict[str, Attribute]]:
-        return self._arg_attrs
 
     def create_sharding_attr_from_tuples(
         self,
@@ -273,6 +267,493 @@ class StableHLOBuilder(Builder):
         return Location.name(f"{filename}:{lineno}")
 
     # ----- Public StableHLO Op Generators ----
+
+    ############### stablehlo.ReduceScatterOp ###############
+
+    @tag(stablehlo.ReduceScatterOp)
+    def reduce_scatter(
+        self,
+        input: Operand,
+        scatter_dimensions: int,
+        replica_groups: List[List[int]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.reduce_scatter)
+
+        scatter_dimensions_attr = IntegerAttr.get(
+            IntegerType.get_signless(64), scatter_dimensions
+        )
+        replica_groups_attr = DenseElementsAttr.get(np.array(replica_groups))
+        input0 = self._get_golden_tensor(input)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input0, scatter_dimensions_attr, replica_groups_attr
+        )
+        result = self._create_ranked_tensor_type(
+            golden_output.shape, self.get_type(input)
+        )
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            result,
+            input,
+            scatter_dimensions_attr,
+            replica_groups_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.ReduceScatterOp)
+    def reduce_scatter_parser(
+        self,
+        old_op: stablehlo.ReduceScatterOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(
+            StableHLOBuilder.reduce_scatter_parser
+        )
+
+        input = global_dict[old_op.operand]
+        scatter_dimensions_attr = old_op.scatter_dimensions
+        replica_groups_attr = old_op.replica_groups
+
+        new_op = stablehlo_op(
+            old_op.result.type,
+            input,
+            scatter_dimensions_attr,
+            replica_groups_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(
+                input0, scatter_dimensions_attr, replica_groups_attr
+            )
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    ############### stablehlo.CollectivePermuteOp ###############
+
+    @tag(stablehlo.CollectivePermuteOp)
+    def collective_permute(
+        self,
+        input: Operand,
+        source_target_pairs: List[Tuple[int, int]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.collective_permute)
+
+        source_target_pairs_attr = DenseElementsAttr.get(np.array(source_target_pairs))
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            input,
+            source_target_pairs_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, source_target_pairs_attr)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.CollectivePermuteOp)
+    def collective_permute_parser(
+        self,
+        old_op: stablehlo.CollectivePermuteOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(
+            StableHLOBuilder.collective_permute_parser
+        )
+
+        input = global_dict[old_op.operand]
+        source_target_pairs_attr = old_op.source_target_pairs
+
+        new_op = stablehlo_op(
+            old_op.result.type,
+            input,
+            source_target_pairs_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, source_target_pairs_attr)
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    ############### stablehlo.CollectiveBroadcastOp ###############
+
+    @tag(stablehlo.CollectiveBroadcastOp)
+    def collective_broadcast(
+        self,
+        input: Operand,
+        replica_groups: List[List[int]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(
+            StableHLOBuilder.collective_broadcast
+        )
+
+        replica_groups_attr = DenseElementsAttr.get(np.array(replica_groups))
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            input,
+            replica_groups_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, replica_groups_attr)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.CollectiveBroadcastOp)
+    def collective_broadcast_parser(
+        self,
+        old_op: stablehlo.CollectiveBroadcastOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(
+            StableHLOBuilder.collective_broadcast_parser
+        )
+
+        input = global_dict[old_op.operand]
+        replica_groups_attr = old_op.replica_groups
+
+        new_op = stablehlo_op(
+            old_op.result.type,
+            input,
+            replica_groups_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, replica_groups_attr)
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    ############### stablehlo.AllToAllOp ###############
+
+    @tag(stablehlo.AllToAllOp)
+    def all_to_all(
+        self,
+        input: Operand,
+        split_dim: int,
+        concat_dim: int,
+        split_count: int,
+        replica_groups: List[List[int]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.all_to_all)
+
+        split_dim_attr = IntegerAttr.get(IntegerType.get_signless(64), split_dim)
+        concat_dim_attr = IntegerAttr.get(IntegerType.get_signless(64), concat_dim)
+        split_count_attr = IntegerAttr.get(IntegerType.get_signless(64), split_count)
+        replica_groups_attr = DenseElementsAttr.get(np.array(replica_groups))
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            input,
+            split_dim_attr,
+            concat_dim_attr,
+            split_count_attr,
+            replica_groups_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(
+                input0,
+                split_dim_attr,
+                concat_dim_attr,
+                split_count_attr,
+                replica_groups_attr,
+            )
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.AllToAllOp)
+    def all_to_all_parser(
+        self,
+        old_op: stablehlo.AllToAllOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.all_to_all_parser)
+
+        input = global_dict[old_op.operand]
+        split_dim_attr = old_op.split_dim
+        concat_dim_attr = old_op.concat_dim
+        split_count_attr = old_op.split_count
+        replica_groups_attr = old_op.replica_groups
+
+        new_op = stablehlo_op(
+            input,
+            split_dim_attr,
+            concat_dim_attr,
+            split_count_attr,
+            replica_groups_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(
+                input0,
+                split_dim_attr,
+                concat_dim_attr,
+                split_count_attr,
+                replica_groups_attr,
+            )
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    ############### stablehlo.AllReduceOp ###############
+
+    @tag(stablehlo.AllReduceOp)
+    def all_reduce(
+        input: Operand,
+        replica_groups: Optional[List[List[int]]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.all_reduce)
+
+        replica_groups_attr = DenseElementsAttr.get(np.array(replica_groups))
+        input0 = self._get_golden_tensor(input)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(input0, replica_groups_attr)
+        result = self._create_ranked_tensor_type(
+            golden_output.shape, self.get_type(input)
+        )
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            result,
+            input,
+            replica_groups_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.AllReduceOp)
+    def all_reduce_parser(
+        self,
+        old_op: stablehlo.AllReduceOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.all_reduce_parser)
+
+        input = global_dict[old_op.operand]
+        replica_groups_attr = old_op.replica_groups
+
+        new_op = stablehlo_op(
+            old_op.result.type,
+            input,
+            replica_groups_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, replica_groups_attr)
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    ############### stablehlo.AllGatherOp ###############
+
+    def infer_all_gather_output_shape(
+        self,
+        input: Operand,
+        all_gather_dim: int,
+        replica_groups: Optional[List[List[int]]],
+    ) -> List[int]:
+        input_type = input.type
+        input_shape = input_type.shape
+
+        if replica_groups is None:
+            return input_shape
+
+        group_size = len(replica_groups[0])
+        output_shape = list(input_shape)
+        output_shape[all_gather_dim] = input_shape[all_gather_dim] * group_size
+        return output_shape
+
+    @tag(stablehlo.AllGatherOp)
+    def all_gather(
+        self,
+        input: Operand,
+        all_gather_dim: int,
+        replica_groups: Optional[List[List[int]]],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.all_gather)
+
+        all_gather_dim_attr = IntegerAttr.get(
+            IntegerType.get_signless(64), all_gather_dim
+        )
+        replica_groups_attr = DenseElementsAttr.get(np.array(replica_groups))
+        output_shape = self.infer_all_gather_output_shape(
+            input, all_gather_dim, replica_groups
+        )
+        result = self._create_ranked_tensor_type(output_shape, self.get_type(input))
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            [result],
+            [input],
+            all_gather_dim_attr,
+            replica_groups_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(
+                input0, all_gather_dim_attr, replica_groups_attr
+            )
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.AllGatherOp)
+    def all_gather_parser(
+        self,
+        old_op: stablehlo.AllGatherOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.all_gather_parser)
+
+        input = global_dict[old_op.operand]
+        all_gather_dim_attr = old_op.all_gather_dim
+        replica_groups_attr = old_op.replica_groups
+
+        new_op = stablehlo_op(
+            [old_op.result.type],
+            [input],
+            all_gather_dim_attr,
+            replica_groups_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(input)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(
+                input0, all_gather_dim_attr, replica_groups_attr
+            )
+            self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
 
     ############### stablehlo.DynamicUpdateSliceOp ###############
 
@@ -1710,10 +2191,6 @@ class StableHLOBuilder(Builder):
         else:
             mlir_output_type = self._get_type_from_torch_dtype(output_type)
 
-        input0 = self._get_golden_tensor(in0)
-        op_golden_function = get_golden_function(stablehlo_op)
-        golden_output = op_golden_function(input0, mlir_output_type)
-
         if loc is None:
             loc = self._get_location()
         else:
@@ -1733,6 +2210,9 @@ class StableHLOBuilder(Builder):
                 op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
         if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(in0)
+            op_golden_function = get_golden_function(stablehlo_op)
+            golden_output = op_golden_function(input0, mlir_output_type)
             self._set_golden_tensor(op_result, golden_output)
 
         return op_result
@@ -5564,7 +6044,6 @@ class StableHLOBuilder(Builder):
         )
 
     def _get_zero_attr(self, element_type: Type) -> Attribute:
-        """Create a zero constant attribute for the given element type."""
         if IntegerType.isinstance(element_type):
             return DenseElementsAttr.get_splat(
                 RankedTensorType.get([], element_type), IntegerAttr.get(element_type, 0)
@@ -5575,7 +6054,6 @@ class StableHLOBuilder(Builder):
             )
 
     def _get_one_attr(self, element_type: Type) -> Attribute:
-        """Create a one constant attribute for the given element type."""
         if IntegerType.isinstance(element_type):
             return DenseElementsAttr.get_splat(
                 RankedTensorType.get([], element_type), IntegerAttr.get(element_type, 1)
@@ -5586,7 +6064,6 @@ class StableHLOBuilder(Builder):
             )
 
     def _get_neg_inf_attr(self, element_type: Type) -> Attribute:
-        """Create a negative infinity constant attribute for the given element type."""
         if IntegerType.isinstance(element_type):
             int_type = IntegerType(element_type)
             width = int_type.width
@@ -5602,7 +6079,6 @@ class StableHLOBuilder(Builder):
             )
 
     def _get_pos_inf_attr(self, element_type: Type) -> Attribute:
-        """Create a positive infinity constant attribute for the given element type."""
         if IntegerType.isinstance(element_type):
             int_type = IntegerType(element_type)
             width = int_type.width
@@ -5617,6 +6093,131 @@ class StableHLOBuilder(Builder):
                 FloatAttr.get(element_type, math.inf),
             )
 
+    def _apply_sharding_to_shape(
+        self, shape: List[int], sharding: sdy.TensorShardingAttr
+    ) -> List[int]:
+        new_shape = list(shape)
+
+        for i in range(len(new_shape)):
+            dim_sharding_attr = sharding.dimension_shardings[i]
+            dim_sharding = sdy.DimensionShardingAttr.maybe_downcast(dim_sharding_attr)
+
+            # Mesh encoding in sdy.TensorShardingAttr starts with @ (ex. @mesh).
+            mesh_name = str(sharding.mesh_or_ref)[1:]
+            mesh_dict = self._meshes[mesh_name]
+
+            for axis_ref_attr in dim_sharding.axes:
+                axis_ref = sdy.AxisRefAttr.maybe_downcast(axis_ref_attr)
+                axis_name = axis_ref.name
+                new_shape[i] = new_shape[i] // mesh_dict[axis_name]
+
+        return new_shape
+
+    def _apply_sharding_to_type(
+        self, tensor_type: RankedTensorType, sharding: sdy.TensorShardingAttr
+    ) -> RankedTensorType:
+        new_shape = self._apply_sharding_to_shape(list(tensor_type.shape), sharding)
+        return RankedTensorType.get(new_shape, tensor_type.element_type)
+
+    def _apply_sharding_to_golden(
+        self,
+        golden_tensor: GoldenMapTensor,
+        sharding: sdy.TensorShardingAttr,
+        is_shard: bool,
+    ) -> GoldenMapTensor:
+        all_replicated = True
+        for dim_sharding_attr in sharding.dimension_shardings:
+            dim_sharding = sdy.DimensionShardingAttr.maybe_downcast(dim_sharding_attr)
+            if len(dim_sharding.axes) != 0:
+                all_replicated = False
+                break
+
+        # Mesh encoding in sdy.TensorShardingAttr starts with @ (ex. @mesh).
+        mesh_name = str(sharding.mesh_or_ref)[1:]
+        mesh_dict = self._meshes[mesh_name]
+        mesh_shape = []
+        for some_length in mesh_dict.values():
+            mesh_shape.append(some_length)
+
+        shard_dims = []
+        if not all_replicated:
+            for dim_num, dim_sharding_attr in enumerate(sharding.dimension_shardings):
+                dim_sharding = sdy.DimensionShardingAttr.maybe_downcast(
+                    dim_sharding_attr
+                )
+                if len(dim_sharding.axes) != 0:
+                    shard_dims.append(dim_num)
+        elif all_replicated:
+            shard_dims = [None] * len(mesh_shape)
+
+        if is_shard:
+            return apply_sharding(golden_tensor, mesh_shape, shard_dims)
+        return apply_unsharding(golden_tensor, mesh_shape, shard_dims)
+
+    def _run_dummy_func(
+        self,
+        nested_func: Callable,
+        original_inputs: List[Operand],
+        in_shardings: List[sdy.TensorShardingAttr],
+        out_shardings: List[sdy.TensorShardingAttr],
+    ) -> List[RankedTensorType]:
+        new_ctx = Context()
+        new_loc = Location.unknown(new_ctx)
+        dumy_output_types = []
+
+        with new_ctx, new_loc:
+            new_module = Module.create()
+            dummy_builder = StableHLOBuilder(
+                new_ctx, new_loc, disable_golden_check=True
+            )
+            dummy_builder._root_module_insertion_point = new_module.body
+            dummy_builder._current_module_insertion_point = new_module.body
+            new_module.body.append(dummy_builder._get_mesh())
+
+            with InsertionPoint(new_module.body):
+
+                dummy_input_shapes = []
+                dummy_input_types = []
+                for index, inp in enumerate(original_inputs):
+                    inp_type = inp.type
+                    new_shape = dummy_builder._apply_sharding_to_shape(
+                        list(inp_type.shape), in_shardings[index]
+                    )
+                    dummy_input_shapes.append(new_shape)
+                    dummy_input_types.append(
+                        self._get_torch_dtype_from_type(inp_type.element_type)
+                    )
+
+                new_func_op = dummy_builder.func(dummy_input_shapes, dummy_input_types)(
+                    nested_func
+                )
+
+                for block in new_func_op.body:
+                    for op in block.operations:
+                        if isinstance(op, func.ReturnOp):
+                            for result in op.operands:
+                                result_type = result.type
+                                result_shape = list(result_type.shape)
+                                result_torch_element_type = (
+                                    dummy_builder._get_torch_dtype_from_type(
+                                        result_type.element_type
+                                    )
+                                )
+                                dumy_output_types.append(
+                                    (result_shape, result_torch_element_type)
+                                )
+                            break
+
+        output_types_in_self_ctx = []
+        for shape, torch_element_type in dumy_output_types:
+            new_result = self._create_ranked_tensor_type(
+                shape,
+                self._get_type_from_torch_dtype(torch_element_type),
+            )
+            output_types_in_self_ctx.append(new_result)
+
+        return output_types_in_self_ctx
+
     # ----- Public Shardy Attribute Generators ----
 
     def mesh_axis_attr(
@@ -5624,43 +6225,12 @@ class StableHLOBuilder(Builder):
         name: str,
         size: int,
     ) -> sdy.MeshAxisAttr:
-        """
-        Creates a mesh axis attribute.
-        This attribute represents a single axis in a mesh, defined by its name and size.
-
-        Parameters
-        ----------
-        name : str
-            The name of the mesh axis
-        size : int
-            The size of the mesh axis, indicating how many elements are along this axis
-
-        Returns
-        -------
-        (*sdy.MeshAxisAttr*)
-            A mesh axis attribute representing the specified axis with its name and size
-        """
         return sdy.MeshAxisAttr.get(name, size)
 
     def mesh_attr(
         self,
         axes: List[sdy.MeshAxisAttr],
     ) -> MeshAttr:
-        """
-        Creates a mesh attribute from a list of mesh axis attributes.
-        This attribute represents a mesh, which is a collection of axes that can be used
-        to define the layout of tensors across multiple devices or processing units.
-
-        Parameters
-        ----------
-        axes : List[sdy.MeshAxisAttr]
-            A list of mesh axis attributes that define the axes of the mesh
-
-        Returns
-        -------
-        (*sdy.MeshAttr*)
-            A mesh attribute representing the collection of axes in the mesh
-        """
         return sdy.MeshAttr.get(axes)
 
     def axis_ref_attr(
@@ -5668,23 +6238,6 @@ class StableHLOBuilder(Builder):
         name: str,
         sub_axis_info_attr: Optional[sdy.AxisRefAttr] = None,
     ) -> sdy.AxisRefAttr:
-        """
-        Creates an axis reference attribute.
-        This attribute is used to reference a specific axis in a mesh, optionally with additional
-        sub-axis information.
-
-        Parameters
-        ----------
-        name : str
-            The name of the axis reference
-        sub_axis_info_attr : *Optional[sdy.AxisRefAttr]*
-            An optional sub-axis reference attribute that provides additional information about the axis
-
-        Returns
-        -------
-        (*sdy.AxisRefAttr*)
-            An axis reference attribute that can be used to refer to a specific axis in a mesh
-        """
         return sdy.AxisRefAttr.get(name, sub_axis_info_attr)
 
     def dimension_sharding_attr(
@@ -5693,25 +6246,6 @@ class StableHLOBuilder(Builder):
         is_closed: bool,
         priority: Optional[int] = None,
     ) -> sdy.DimensionShardingAttr:
-        """
-        Creates a dimension sharding attribute.
-        This attribute defines how a tensor is sharded across multiple devices or processing units
-        based on the specified axes. It can also indicate whether the sharding is closed and an optional priority for the sharding.
-
-        Parameters
-        ----------
-        axes : List[sdy.AxisRefAttr]
-            A list of axis reference attributes that define how the tensor is sharded across the mesh
-        is_closed : bool
-            A boolean indicating whether the sharding is closed
-        priority : *Optional[int]*
-            An optional integer that specifies the priority of the sharding. If not provided, defaults to None.
-
-        Returns
-        -------
-        (*sdy.DimensionShardingAttr*)
-            A dimension sharding attribute that describes how a tensor is distributed across the mesh
-        """
         return sdy.DimensionShardingAttr.get(axes, is_closed, priority)
 
     def tensor_sharding_attr(
@@ -5721,27 +6255,6 @@ class StableHLOBuilder(Builder):
         replicated_axes: List[sdy.AxisRefAttr] = [],
         unreduced_axes: List[sdy.AxisRefAttr] = [],
     ) -> sdy.TensorShardingAttr:
-        """
-        Creates a tensor sharding attribute.
-        This attribute describes how a tensor is sharded across a mesh, including the mesh name,
-        the dimension shardings, and any replicated or unreduced axes.
-
-        Parameters
-        ----------
-        mesh_name : str
-            The name of the mesh to which the tensor sharding applies
-        dimension_shardings : List[sdy.DimensionShardingAttr]
-            A list of dimension sharding attributes that define how the tensor is sharded across the mesh
-        replicated_axes : List[sdy.AxisRefAttr]
-            A list of axis reference attributes that are replicated across the mesh. Defaults to an empty list
-        unreduced_axes : List[sdy.AxisRefAttr]
-            A list of axis reference attributes that are not reduced in the sharding. Defaults to an empty list
-
-        Returns
-        -------
-        (*sdy.TensorShardingAttr*)
-            A tensor sharding attribute that describes how a tensor is distributed across the mesh
-        """
         return sdy.TensorShardingAttr.get(
             mesh_name,
             dimension_shardings,
@@ -5753,45 +6266,25 @@ class StableHLOBuilder(Builder):
         self,
         shardings: List[sdy.TensorShardingAttr],
     ) -> sdy.TensorShardingPerValueAttr:
-        """
-        Creates a tensor sharding per value attribute from a list of tensor sharding attributes.
-        This attribute allows for specifying different sharding strategies for different tensors.
-
-        Parameters
-        ----------
-        shardings : List[sdy.TensorShardingAttr]
-            A list of tensor sharding attributes, each defining a sharding strategy for a tensor
-
-        Returns
-        -------
-        (*sdy.TensorShardingPerValueAttr*)
-            A tensor sharding per value attribute that describes how multiple tensors are distributed across the mesh
-        """
         return sdy.TensorShardingPerValueAttr.get(
             shardings,
+        )
+
+    def manual_axes_attr(
+        self,
+        manual_axes: List[str],
+    ) -> sdy.ManualAxesAttr:
+        manual_axes_attr = []
+        for axis in manual_axes:
+            manual_axes_attr.append(StringAttr.get(axis))
+
+        return sdy.ManualAxesAttr.get(
+            manual_axes_attr,
         )
 
     # ----- Public Shardy Op Generators ----
 
     def mesh(self, mesh_name: str, mesh_attr: sdy.MeshAttr) -> sdy.MeshOp:
-        """
-        Creates a mesh operation.
-        This operation defines a mesh in the system, which can be used to distribute tensors
-        across multiple devices or processing units. The mesh is identified by its name and
-        defined by the provided mesh attribute.
-
-        Parameters
-        ----------
-        mesh_name : str
-            The name of the mesh to be created
-        mesh_attr : sdy.MeshAttr
-            The mesh attribute that defines the axes and properties of the mesh
-
-        Returns
-        -------
-        (*sdy.MeshOp*)
-            A mesh operation that represents the defined mesh in the system
-        """
         return sdy.MeshOp(sym_name=mesh_name, mesh=mesh_attr)
 
     def sharding_constraint(
@@ -5799,24 +6292,83 @@ class StableHLOBuilder(Builder):
         in0: Operand,
         tensor_sharding_attr: sdy.TensorShardingAttr,
     ) -> sdy.ShardingConstraintOp:
-        """
-        Creates a sharding constraint operation.
-        This operation applies a sharding constraint to a tensor, specifying how the tensor should be distributed
-        across a mesh based on the provided tensor sharding attribute.
-
-        Parameters
-        ----------
-        in0 : Operand
-            The input tensor to which the sharding constraint will be applied
-        tensor_sharding_attr : sdy.TensorShardingAttr
-            The tensor sharding attribute that defines how the tensor should be sharded across the mesh
-
-        Returns
-        -------
-        (*sdy.ShardingConstraintOp*)
-            A sharding constraint operation that applies the specified sharding to the input tensor
-        """
         return sdy.ShardingConstraintOp(in0, tensor_sharding_attr)
+
+    ################ sdy.ManualComputationOp ###############
+
+    @tag(sdy.ManualComputationOp)
+    def manual_computation(
+        self,
+        nested_func: Callable,
+        original_inputs: List[Operand],
+        in_shardings: List[sdy.TensorShardingAttr],
+        out_shardings: List[sdy.TensorShardingAttr],
+        manual_axes: List[str],
+        loc: Optional[str] = None,
+    ) -> sdy.ManualComputationOp:
+        sdy_op = self.get_opview_from_method(StableHLOBuilder.manual_computation)
+
+        original_input_goldens = [
+            self._get_golden_tensor(inp) for inp in original_inputs
+        ]
+        original_input_types = [inp.type for inp in original_inputs]
+        original_output_types = self._run_dummy_func(
+            nested_func, original_inputs, in_shardings, out_shardings
+        )
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        new_manual_computation_op = sdy_op(
+            original_output_types,
+            original_inputs,
+            self.tensor_sharding_per_value_attr(in_shardings),
+            self.tensor_sharding_per_value_attr(out_shardings),
+            self.manual_axes_attr(manual_axes),
+            loc=loc,
+        )
+        new_manual_computation_op_results = new_manual_computation_op.results
+
+        region = new_manual_computation_op.body
+        block = Block.create_at_start(region)
+
+        for inp_type, inp_golden, in_sharding in zip(
+            original_input_types, original_input_goldens, in_shardings
+        ):
+            new_inp_type = self._apply_sharding_to_type(inp_type, in_sharding)
+            new_arg = block.add_argument(new_inp_type, loc=Location.unknown(self._ctx))
+            new_inp_golden = self._apply_sharding_to_golden(
+                inp_golden, in_sharding, is_shard=True
+            )
+            self._set_golden_tensor(new_arg, new_inp_golden)
+
+        output_goldens = []
+        with InsertionPoint(block):
+            result = nested_func(*block.arguments, self)
+            outputs = result if hasattr(result, "__iter__") else [result]
+            sdy_return0 = sdy.ReturnOp(outputs)
+
+            for i, output in enumerate(outputs):
+                output_golden = self._get_golden_tensor(output)
+                output_goldens.append(output_golden)
+
+        for i, (out_sharding, output_golden) in enumerate(
+            zip(out_shardings, output_goldens)
+        ):
+            new_output_golden = self._apply_sharding_to_golden(
+                output_golden, out_sharding, is_shard=False
+            )
+            self._set_golden_tensor(
+                new_manual_computation_op_results[i], new_output_golden
+            )
+
+        return (
+            new_manual_computation_op_results[0]
+            if len(new_manual_computation_op_results) == 1
+            else tuple(new_manual_computation_op_results)
+        )
 
     # ----- Experimental Mpmd Attribute Generators ----
 


### PR DESCRIPTION
This PR adds support for creating manual computation ops in builder ecosystem.

```
def module(builder: StableHLOBuilder):

    @builder.func([(1, 1, 32, 32), (1, 1, 32, 32)], [torch.float32, torch.float32])
    def my_modela(in0: Operand, in1: Operand, builder: StableHLOBuilder):
        def single_device_func(in0: Operand, in1: Operand, builder: StableHLOBuilder):
            add0 = builder.add(in0, in1)
            add1 = builder.add(add0, in1)
            cosine0 = builder.cosine(add1)
            return cosine0, cosine0

        tensor_sharding_attr = builder.tensor_sharding_attr(
            mesh_name="mesh",
            dimension_shardings=[
                builder.dimension_sharding_attr(
                    axes=[],
                    is_closed=True,
                ),
                builder.dimension_sharding_attr(
                    axes=[],
                    is_closed=True,
                ),
                builder.dimension_sharding_attr(
                    axes=[builder.axis_ref_attr(name="x")],
                    is_closed=True,
                ),
                builder.dimension_sharding_attr(
                    axes=[builder.axis_ref_attr(name="y")],
                    is_closed=True,
                ),
            ],
        )

        manual_computation_op0, manual_computation_op1 = builder.manual_computation(single_device_func, [in0, in1], in_shardings=[tensor_sharding_attr, tensor_sharding_attr], out_shardings=[tensor_sharding_attr, tensor_sharding_attr], manual_axes=["x", "y"])
        return manual_computation_op0, manual_computation_op1

new_module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 1), ("y", 2)]))
```

```
module {
  sdy.mesh @mesh = <["x"=1, "y"=2]>
  func.func @my_modela(%arg0: tensor<1x1x32x32xf32>, %arg1: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) {
    %0:2 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>, <@mesh, [{}, {}, {"x"}, {"y"}]>] out_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>, <@mesh, [{}, {}, {"x"}, {"y"}]>] manual_axes={"x", "y"} (%arg2: tensor<1x1x32x16xf32>, %arg3: tensor<1x1x32x16xf32>) {
      %1 = stablehlo.add %arg2, %arg3 : tensor<1x1x32x16xf32>
      %2 = stablehlo.add %1, %arg3 : tensor<1x1x32x16xf32>
      %3 = stablehlo.cosine %2 : tensor<1x1x32x16xf32>
      sdy.return %3, %3 : tensor<1x1x32x16xf32>, tensor<1x1x32x16xf32>
    } : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>)
    return %0#0, %0#1 : tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>
  }
}
```

As well, it implements stablehlo collective all_gather. Multi-device goldens are being generated and compared against device. 


This PR also adds support in shardy patch for down casting an Attribute type into it's type aware object, which is a lacking feature in shardy and is required when trying to load a mlir file that has sdy attributes in it (eg meshattr).