### PR TITLE
Migrate profiler into standalone package

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(ttmlir-lsp-server)
 if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
   add_subdirectory(builder)
   add_subdirectory(golden)
+  add_subdirectory(profiler)
 
   if (TTMLIR_ENABLE_PYKERNEL)
     add_subdirectory(pykernel)

--- a/tools/profiler/CMakeLists.txt
+++ b/tools/profiler/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(AddMLIRPython)
+
+declare_mlir_python_sources(ProfilerSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  SOURCES
+    __init__.py
+    profiler.py
+)
+
+add_mlir_python_modules(ProfilerPythonModules
+  ROOT_PREFIX "${TTMLIR_PYTHON_PACKAGES_DIR}/profiler"
+  INSTALL_PREFIX "python_packages/profiler"
+  DECLARED_SOURCES ProfilerSources
+)

--- a/tools/profiler/__init__.py
+++ b/tools/profiler/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .profiler import *

--- a/tools/profiler/profiler.py
+++ b/tools/profiler/profiler.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+import os
+import sys
+import signal
+import subprocess
+import shutil
+
+from tracy.process_ops_logs import process_ops
+
+
+@contextmanager
+def trace(log_dir: str, port: int):
+    os.makedirs(log_dir, exist_ok=True)
+
+    TT_METAL_RUNTIME_ROOT = os.environ.get(
+        "TT_METAL_RUNTIME_ROOT", "third_party/tt-metal/src/tt-metal"
+    )
+    tracy_capture_tool_path = os.path.join(TT_METAL_RUNTIME_ROOT, "capture-release")
+    tracy_csvexport_tool_path = os.path.join(TT_METAL_RUNTIME_ROOT, "csvexport-release")
+    tracy_file_path = log_dir + "/tracy_profile_log_host.tracy"
+    tracy_ops_times_file_path = log_dir + "/tracy_ops_times.csv"
+    tracy_ops_data_file_path = log_dir + "/tracy_ops_data.csv"
+    profiler_logs_dir = TT_METAL_RUNTIME_ROOT + "/generated/profiler/.logs/"
+    profiler_csv_file_path = (
+        TT_METAL_RUNTIME_ROOT + "/generated/profiler/reports/ops_perf_results.csv"
+    )
+
+    shutil.rmtree(profiler_logs_dir)
+    os.makedirs(profiler_logs_dir)
+
+    tracy_capture_tool_command = (
+        f"{tracy_capture_tool_path} -o {tracy_file_path} -f -p {port}"
+    )
+    tracy_capture_tool_process = subprocess.Popen(
+        tracy_capture_tool_command, shell=True, start_new_session=True
+    )
+
+    def signal_handler(sig, frame):
+        os.killpg(os.getpgid(testProcess.pid), signal.SIGTERM)
+        tracy_capture_tool_process.terminate()
+        tracy_capture_tool_process.communicate()
+        sys.exit(3)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        yield
+    finally:
+        # Need to send kill signal to tracy server to flush the .tracy file.
+        os.killpg(tracy_capture_tool_process.pid, signal.SIGINT)
+        tracy_capture_tool_process.communicate(timeout=15)
+
+        with open(tracy_ops_times_file_path, "w") as csv_file:
+            child_calls = ["CompileProgram", "HWCommandQueue_write_buffer"]
+            child_calls_str = f"-x {','.join(child_calls)}"
+            subprocess.run(
+                f"{tracy_csvexport_tool_path} -u -p TT_DNN {child_calls_str} {tracy_file_path}",
+                shell=True,
+                check=True,
+                stdout=csv_file,
+                stderr=subprocess.DEVNULL,
+            )
+
+        with open(tracy_ops_data_file_path, "w") as csv_file:
+            subprocess.run(
+                f'{tracy_csvexport_tool_path} -m -s ";" {tracy_file_path}',
+                shell=True,
+                check=True,
+                stdout=csv_file,
+                stderr=subprocess.DEVNULL,
+            )
+
+        shutil.copy(tracy_file_path, profiler_logs_dir)
+        shutil.copy(tracy_ops_times_file_path, profiler_logs_dir)
+        shutil.copy(tracy_ops_data_file_path, profiler_logs_dir)
+        process_ops(None, None, False)
+
+        if os.path.exists(profiler_csv_file_path):
+            shutil.copy(profiler_csv_file_path, log_dir)


### PR DESCRIPTION
This PR introduces an independent profiler package outside of TTRT. The underlying applications can be profiled as follows with a context manager `with trace("/code/dec-22/tt-mlir/profiler", 8086):`

```
with trace("/code/dec-22/tt-mlir/profiler", 8086):
    def module3(builder: TTIRBuilder):
        @builder.device_module
        def module(builder: TTIRBuilder):
            @builder.func([(32, 32), (32, 32), (32, 32)], [torch.float32, torch.float32, torch.float32])
            def model(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
                add = builder.add(in0, in1)
                exp = builder.exp(in2)
                return builder.multiply(add, exp)


    new_module, builder = build_module(module3, "ttir")
    print(new_module)

    import _ttmlir_runtime as tt_runtime

    tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
    mesh_options = tt_runtime.runtime.MeshDeviceOptions()
    mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
    mesh_options.mesh_shape = (1, 1)
    device = tt_runtime.runtime.open_mesh_device(mesh_options)

    mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
        new_module,
        builder,
        test_base="taps_module2",
    )

    flatbuffer_path = "ttir-builder-artifacts/ttnn/taps_module2_ttnn.mlir.ttnn"
    golden_report = execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)

    tt_runtime.runtime.close_mesh_device(device)
```