### PR TITLE
D2M: fix incorrect placement of copy loop guards

### DIFF
--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_implicit_bcast.mlir
@@ -28,11 +28,11 @@ module {
           %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_1 = memref.subview %1[%arg2, 0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
-          // CHECK: affine.for
-          // CHECK: affine.for
           // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
           // CHECK-NEXT: %[[GUARD:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
           // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: affine.for
+          // CHECK-NEXT: affine.for
           // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
           // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type col>}>
           // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
@@ -78,11 +78,11 @@ module {
           %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_1 = memref.subview %1[0, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
-          // CHECK: affine.for
-          // CHECK: affine.for
           // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
           // CHECK-NEXT: %[[GUARD:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
           // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: affine.for
+          // CHECK-NEXT: affine.for
           // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
           // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type row>}>
           // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
@@ -127,14 +127,14 @@ module {
         scf.for %arg3 = %c0_11 to %c1_12 step %c1_13 {
           %subview = memref.subview %0[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_1 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
-          // CHECK: affine.for
-          // CHECK: affine.for
           // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
           // CHECK-NEXT: %[[GUARD0:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
           // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
           // CHECK-NEXT: %[[GUARD1:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
           // CHECK-NEXT: %[[GUARD:.*]] = arith.andi %[[GUARD0]], %[[GUARD1]] : i1
           // CHECK-NEXT: scf.if %[[GUARD]]
+          // CHECK-NEXT: affine.for
+          // CHECK-NEXT: affine.for
           // CHECK-NEXT: %[[L1_TILE:.*]] = affine.load
           // CHECK-NEXT: %[[DST_TILE:.*]] = "d2m.tile_bcast"(%[[L1_TILE]]) <{bcast_type = #d2m<tile_bcast_type scalar>}>
           // CHECK-NEXT: affine.store %[[DST_TILE]], %dst
@@ -182,12 +182,11 @@ module {
           %subview = memref.subview %0[%arg2, 0] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_1 = memref.subview %1[0, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
           %subview_2 = memref.subview %2[%arg2, %arg3] [1, 1] [1, 1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_> to memref<1x1x!ttcore.tile<32x32, f32>, strided<[1, 1], offset: ?>, #l1_>
-          // CHECK: affine.for
-          // CHECK: affine.for
-
           // CHECK: %[[DIM1:.*]] = d2m.iter_index(1) : index
           // CHECK-NEXT: %[[GUARD1:.*]] = arith.cmpi eq, %[[DIM1]], %{{.*}} : index
           // CHECK-NEXT: scf.if %[[GUARD1]]
+          // CHECK-NEXT: affine.for
+          // CHECK-NEXT: affine.for
           // CHECK-NEXT: %[[L1_TILE1:.*]] = affine.load
           // CHECK-NEXT: %[[DST_TILE1:.*]] = "d2m.tile_bcast"(%[[L1_TILE1]]) <{bcast_type = #d2m<tile_bcast_type col>}>
           // CHECK-NEXT: affine.store %[[DST_TILE1]], %dst
@@ -195,6 +194,8 @@ module {
           // CHECK: %[[DIM0:.*]] = d2m.iter_index(0) : index
           // CHECK-NEXT: %[[GUARD0:.*]] = arith.cmpi eq, %[[DIM0]], %{{.*}} : index
           // CHECK-NEXT: scf.if %[[GUARD0]]
+          // CHECK-NEXT: affine.for
+          // CHECK-NEXT: affine.for
           // CHECK-NEXT: %[[L1_TILE0:.*]] = affine.load
           // CHECK-NEXT: %[[DST_TILE0:.*]] = "d2m.tile_bcast"(%[[L1_TILE0]]) <{bcast_type = #d2m<tile_bcast_type row>}>
           // CHECK-NEXT: affine.store %[[DST_TILE0]], %dst

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block.mlir
@@ -57,14 +57,14 @@ module {
       // CHECK: %[[blockOut:.*]] = memref.cast {{%.*}} : memref<3x2x!ttcore.tile<32x32, f16>, #l1> to memref<3x2x!ttcore.tile<32x32, f16>, strided<[2, 1], offset: ?>, #l1>
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f16>, #dst>
 
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
-
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
+
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f16>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_block_large_dst.mlir
@@ -57,14 +57,14 @@ module {
       // CHECK: %[[blockOut:.*]] = memref.cast {{%.*}} : memref<3x2x!ttcore.tile<32x32, f32>, #l1> to memref<3x2x!ttcore.tile<32x32, f32>, strided<[2, 1], offset: ?>, #l1>
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f32>, #dst>
 
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
-
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
+
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f32>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile.mlir
@@ -58,14 +58,14 @@ module {
       // CHECK: %[[C0:.*]] = arith.constant 0 : index
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f16>, #dst>
 
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
-
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
+
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f16>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_matmul_tile_large_dst.mlir
@@ -58,14 +58,14 @@ module {
       // CHECK: %[[C0:.*]] = arith.constant 0 : index
       // CHECK: %[[DST:.*]] = d2m.acquire_dst() : memref<1x3x2x!ttcore.tile<32x32, f32>, #dst>
 
-      // Check conditional initialization loop structure (2D loop for initialization)
-      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
-      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
-
       // Check for iteration index and conditional initialization
       // CHECK: %[[ITER2:.*]] = d2m.iter_index(2) : index
       // CHECK: %[[CMP:.*]] = arith.cmpi ne, %[[ITER2]], %[[C0]] : index
       // CHECK: scf.if %[[CMP]] {
+
+      // Check conditional initialization loop structure (2D loop for initialization)
+      // CHECK: affine.for %[[INIT_I:.*]] = 0 to 3 {
+      // CHECK-NEXT: affine.for %[[INIT_J:.*]] = 0 to 2 {
 
       // Check initialization: load from l1, store to dst
       // CHECK: %[[INIT_VAL:.*]] = affine.load {{%.*}}[%[[INIT_I]], %[[INIT_J]]] : memref<3x2x!ttcore.tile<32x32, f32>, #l1>


### PR DESCRIPTION
### Problem description
After #5961, the load guards are moved to the inside of the cloned affine loops, in the hope that all the guarded and normal loads can share the same affine loop nest.

Unfortunately, the init hoisting pass hoists the `copy_tile_init` call to the outside of the guard, so it's invoked unconditionally, causing performance regression in matmul tests.

### What's changed
- The load guard now dominates the cloned affine loop nest.
- As a result, each guarded load now lives in its own loop nest.
- Bcast loop nests are inserted to the top of the compute tiling loops #6516.
- All normal loads still share the same loop nest.