### PR TITLE
Assert that system desc attr exists before querying for it

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3629,6 +3629,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   flatbuffers::Offset<::tt::target::MLIR> binaryMLIR =
       toMLIR(fbb, "ttnn", rootModule);
 
+  assert(moduleOp->hasAttr(ttcore::SystemDescAttr::name) &&
+         "ttcore::SystemDescAttr attribute missing on ModuleOp");
   auto systemDesc =
       toFlatbuffer(cache, mlir::cast<ttcore::SystemDescAttr>(
                               moduleOp->getAttr(ttcore::SystemDescAttr::name)));


### PR DESCRIPTION
Small change which makes it easier to debug issues translating hand crafted ops to flatbuffers. Because `getAttr` returns null the `cast<>` results in a segfault hiding the underlying problem. 