### PR TITLE
Adding ttnn.silu rewrite case

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.cpp
@@ -177,6 +177,8 @@ LinearOpRewritePattern::matchAndRewrite(ttnn::LinearOp srcOp,
       opName = StringAttr::get(rewriter.getContext(), "ttnn.gelu");
     } else if (activationStr == "tanh") {
       opName = StringAttr::get(rewriter.getContext(), "ttnn.tanh");
+    } else if (activationStr == "silu") {
+      opName = StringAttr::get(rewriter.getContext(), "ttnn.silu");
     } else {
       matmulOp.emitError()
           << "Unsupported activation type in LinearOp decomposition: "


### PR DESCRIPTION
### Ticket
Solves https://github.com/tenstorrent/tt-xla/issues/2608

### Problem description
Recently, the SDXL ops have started decomposing in the LinearOpRewritePattern TTNN Workaround and there was no case that handles matmul + silu activation combination. 

### What's changed
Rewrite to ttnn.silu has been added. With this change, the SDXL model passes again.