### PR TITLE
Bootstrap debug dialect, ops, builder and runtime support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,10 @@ LICENSE @nsmithtt
 /lib/CAPI/ @tapspatel
 /python/ @tapspatel
 
+# Debug Dialect
+include/ttmlir/Dialect/Debug @tapspatel
+lib/Dialect/Debug @tapspatel
+
 # StableHLO Dialect
 include/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 lib/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo

--- a/cmake/modules/TTMLIRInstall.cmake
+++ b/cmake/modules/TTMLIRInstall.cmake
@@ -37,6 +37,7 @@ set(ttmlir_export_targets
   MLIRTTKernelTransforms
 
   # Other dialects
+  MLIRDebugDialect
   MLIRSFPIDialect
   MLIRLLVMTransforms
   MLIREmitPyDialect

--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -62,6 +62,7 @@ void populateTTIRModule(nb::module_ &m);
 void populateD2MModule(nb::module_ &m);
 void populateTTKernelModule(nb::module_ &m);
 void populateTTNNModule(nb::module_ &m);
+void populateDebugModule(nb::module_ &m);
 void populateOverridesModule(nb::module_ &m);
 void populateOptimizerOverridesModule(nb::module_ &m);
 void populatePassesModule(nb::module_ &m);

--- a/include/ttmlir/Dialect/CMakeLists.txt
+++ b/include/ttmlir/Dialect/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(SFPI)
 add_subdirectory(LLVM)
 add_subdirectory(EmitPy)
 add_subdirectory(D2M)
+add_subdirectory(Debug)
 
 if (TTMLIR_ENABLE_STABLEHLO)
   add_subdirectory(StableHLO)

--- a/include/ttmlir/Dialect/Debug/CMakeLists.txt
+++ b/include/ttmlir/Dialect/Debug/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/include/ttmlir/Dialect/Debug/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/Debug/IR/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS DebugOps.td)
+mlir_tablegen(DebugOps.h.inc -gen-op-decls)
+mlir_tablegen(DebugOps.cpp.inc -gen-op-defs)
+mlir_tablegen(DebugOpsDialect.h.inc -gen-dialect-decls -dialect=debug)
+mlir_tablegen(DebugOpsDialect.cpp.inc -gen-dialect-defs -dialect=debug)
+add_public_tablegen_target(MLIRDebugOpsIncGen)
+add_dependencies(mlir-headers MLIRDebugOpsIncGen)

--- a/include/ttmlir/Dialect/Debug/IR/Debug.h
+++ b/include/ttmlir/Dialect/Debug/IR/Debug.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_DEBUG_IR_DEBUG_H
+#define TTMLIR_DIALECT_DEBUG_IR_DEBUG_H
+
+#include "mlir/IR/Dialect.h"
+
+#include "ttmlir/Dialect/Debug/IR/DebugOpsDialect.h.inc"
+
+#endif

--- a/include/ttmlir/Dialect/Debug/IR/DebugBase.td
+++ b/include/ttmlir/Dialect/Debug/IR/DebugBase.td
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_DEBUG_DEBUGDIALECT_TD
+#define TTMLIR_TTMLIR_DIALECT_DEBUG_DEBUGDIALECT_TD
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+//===----------------------------------------------------------------------===//
+// Debug dialect definition.
+//===----------------------------------------------------------------------===//
+
+def Debug_Dialect : Dialect {
+    let name = "debug";
+    let summary = "Debug dialect allows inserting debugging information into the IR, that can be used to analyze the IR at different lowering stages or captured by runtime.";
+    let description = [{
+        The purpose of the debug dialect is to be able to insert debugging information into the IR, that can be used to analyze the IR at different lowering stages or captured by runtime.
+        The debug dialect is a compiler API, it is and should be agnostic to the underlying IR it operates on.
+    }];
+    let cppNamespace = "::mlir::tt::debug";
+    let useDefaultTypePrinterParser = 1;
+    let useDefaultAttributePrinterParser = 1;
+    let dependentDialects = [
+      "::mlir::func::FuncDialect",
+      "::mlir::tensor::TensorDialect",
+    ];
+
+    let hasConstantMaterializer = 1;
+
+    let extraClassDeclaration = [{
+        void registerTypes();
+    }];
+}
+
+//===----------------------------------------------------------------------===//
+// Base Debug operation definition.
+//===----------------------------------------------------------------------===//
+
+class Debug_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Debug_Dialect, mnemonic, traits>;
+
+#endif

--- a/include/ttmlir/Dialect/Debug/IR/DebugOps.h
+++ b/include/ttmlir/Dialect/Debug/IR/DebugOps.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_DEBUG_IR_DEBUGOPS_H
+#define TTMLIR_DIALECT_DEBUG_IR_DEBUGOPS_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h.inc"
+
+#endif // TTMLIR_DIALECT_DEBUG_IR_DEBUGOPS_H

--- a/include/ttmlir/Dialect/Debug/IR/DebugOps.td
+++ b/include/ttmlir/Dialect/Debug/IR/DebugOps.td
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_DEBUG_DEBUGOPS_TD
+#define TTMLIR_TTMLIR_DIALECT_DEBUG_DEBUGOPS_TD
+
+include "ttmlir/Dialect/Debug/IR/DebugBase.td"
+include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td"
+include "mlir/Dialect/Linalg/IR/LinalgBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
+
+//===----------------------------------------------------------------------===//
+// Debug ops
+//===----------------------------------------------------------------------===//
+
+class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
+    Debug_Op<mnemonic, [Pure, SameOperandsAndResultType]> {
+
+    let summary = "Base class for debug op.";
+    let description = [{
+      Each debug op inherits from this base op.
+      Ensures that the operations that produce the `operand` are executed before any
+      operations that depend on the `result` and prevents compiler transformations
+      from moving operations across the barrier. Other than that, the operation is
+      an identity, i.e. `result` = `operand`.
+    }];
+}
+
+def Debug_AnnotateOp : Debug_BaseOp<"annotate", []> {
+  let summary = "Annotate operation";
+  let description = [{
+    Attaches a user-defined debug annotation to a value without changing its semantics or runtime behavior.
+
+    Example:
+    ```mlir
+    %1 = "debug.annotate"(%0) <{annotation = "This is from KV cache"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$annotation
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_BreakpointOp : Debug_BaseOp<"breakpoint", []> {
+  let summary = "Breakpoint operation";
+  let description = [{
+    Inserts a breakpoint in runtime execution.
+
+    Example:
+    ```mlir
+    %1 = "debug.breakpoint"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_PrintOp : Debug_BaseOp<"print", []> {
+  let summary = "Print operation";
+  let description = [{
+    Print a message during runtime.
+
+    Example:
+    ```mlir
+    %1 = "debug.print"(%0) <{message = "This is from KV cache"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$message
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_DumpOp : Debug_BaseOp<"dump", []> {
+  let summary = "Dump operation";
+  let description = [{
+    Save a tensor to disk.
+
+    Example:
+    ```mlir
+    %1 = "debug.dump"(%0) <{file_path = "system_tensor.tensorbin"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$file_path
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+}
+
+def Debug_OverwriteOp : Debug_BaseOp<"overwrite",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Overwrite operation";
+  let description = [{
+    Overwrite a tensor.
+
+    Example:
+    ```mlir
+    %1 = debug.overwrite %0 %cst : tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$dst,
+    AnyRankedTensor:$src
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_SnapshotOp : Debug_BaseOp<"snapshot",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Snapshot operation";
+  let description = [{
+    Snapshot device state.
+
+    Example:
+    ```mlir
+    %1 = "debug.snapshot"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_BeginTraceOp : Debug_Op<"begin_trace",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Begin trace operation";
+  let description = [{
+    Begin a graph trace.
+
+    Example:
+    ```mlir
+    %0 = debug.begin_trace %arg0 <{trace_id = "trace0"}> : tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$trace_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_EndTraceOp : Debug_Op<"end_trace",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "End trace operation";
+  let description = [{
+    End a graph trace.
+
+    Example:
+    ```mlir
+    %1 = debug.end_trace %0 <{trace_id = "trace0"}> : tensor<32x32xf32>, tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$trace_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_RegionStartOp : Debug_Op<"region_start",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Region start operation";
+  let description = [{
+    Mark the start of a region.
+
+    Example:
+    ```mlir
+    %0 = debug.region_start %arg0 <{region_id = "region0"}> : tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$region_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_RegionEndOp : Debug_Op<"region_end",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Region end operation";
+  let description = [{
+    Mark the end of a region.
+
+    Example:
+    ```mlir
+    %1 = debug.region_end %0 <{region_id = "region0"}> : tensor<32x32xf32>, tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$region_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_ProfilerStartOp : Debug_Op<"profiler_start",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Profiler start operation";
+  let description = [{
+    Start profiler.
+
+    Example:
+    ```mlir
+    %0 = debug.profiler_start %arg0 <{scope_id = "scope0"}> : tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$scope_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_ProfilerEndOp : Debug_Op<"profiler_end",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Profiler end operation";
+  let description = [{
+    End profiler.
+
+    Example:
+    ```mlir
+    %1 = debug.profiler_end %0 <{scope_id = "scope0"}> : tensor<32x32xf32>, tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$scope_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_MemorySnapshotOp : Debug_Op<"memory_snapshot",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Memory snapshot operation";
+  let description = [{
+    Capture memory state of device.
+
+    Example:
+    ```mlir
+    %1 = "debug.memory_snapshot"(%0) <{file_path = "/path/to/memory/file.json"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$file_path
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_TimestampOp : Debug_Op<"timestamp",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Timestamp operation";
+  let description = [{
+    Capture current clock time.
+
+    Example:
+    ```mlir
+    %1 = "debug.timestamp"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+def Debug_HookOp : Debug_Op<"hook",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Hook operation";
+  let description = [{
+    Insert runtime hook.
+
+    Example:
+    ```mlir
+    %1 = "debug.hook"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+}
+
+#endif

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(BuildFlatbuffers)
 
 set(TTNN_OPERATIONS_FBS_GEN_SOURCES
+  operations/debug.fbs
   operations/ccl.fbs
   operations/get_device.fbs
   operations/configs.fbs

--- a/include/ttmlir/Target/TTNN/operations/debug.fbs
+++ b/include/ttmlir/Target/TTNN/operations/debug.fbs
@@ -1,0 +1,21 @@
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
+
+namespace tt.target.ttnn;
+
+table AnnotateOp {
+  operand: tt.target.ttnn.TensorRef;
+  result: tt.target.ttnn.TensorRef;
+  annotation: string;
+}
+
+table BreakpointOp {
+  operand: tt.target.ttnn.TensorRef;
+  result: tt.target.ttnn.TensorRef;
+}
+
+table MemorySnapshotOp {
+  operand: tt.target.ttnn.TensorRef;
+  result: tt.target.ttnn.TensorRef;
+  file_path: string;
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -1,6 +1,7 @@
 include "ttmlir/Target/Common/types.fbs";
 include "ttmlir/Target/Common/debug_info.fbs";
 include "ttmlir/Target/TTNN/types.fbs";
+include "ttmlir/Target/TTNN/operations/debug.fbs";
 include "ttmlir/Target/TTNN/operations/ccl.fbs";
 include "ttmlir/Target/TTNN/operations/get_device.fbs";
 include "ttmlir/Target/TTNN/operations/conv.fbs";
@@ -120,6 +121,9 @@ union OpType {
   WriteTensorOp,
   DumpTensorOp,
   LoadTensorOp,
+  AnnotateOp,
+  BreakpointOp,
+  MemorySnapshotOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 
 #include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
@@ -41,6 +42,7 @@ struct ConvertTTIRToTTNNPass
     target.addLegalDialect<func::FuncDialect>();
     target.addLegalDialect<ttnn::TTNNDialect>();
     target.addLegalDialect<quant::QuantDialect>();
+    target.addLegalDialect<debug::DebugDialect>();
     target.addIllegalDialect<ttir::TTIRDialect>();
     target.addLegalOp<ttcore::DeviceOp>();
     target.addLegalOp<ttcore::OptimizationBarrierOp>();

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(SFPI)
 add_subdirectory(LLVM)
 add_subdirectory(EmitPy)
 add_subdirectory(D2M)
+add_subdirectory(Debug)
 
 if (TTMLIR_ENABLE_STABLEHLO)
   add_subdirectory(StableHLO)

--- a/lib/Dialect/Debug/CMakeLists.txt
+++ b/lib/Dialect/Debug/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/lib/Dialect/Debug/IR/CMakeLists.txt
+++ b/lib/Dialect/Debug/IR/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_dialect_library(MLIRDebugDialect
+  DebugDialect.cpp
+  DebugOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Dialect/Debug
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRSupport
+)

--- a/lib/Dialect/Debug/IR/DebugDialect.cpp
+++ b/lib/Dialect/Debug/IR/DebugDialect.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/FoldInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include "ttmlir/Dialect/Debug/IR/DebugOpsDialect.cpp.inc"
+
+namespace mlir::tt::debug {
+
+//===----------------------------------------------------------------------===//
+// Debug dialect.
+//===----------------------------------------------------------------------===//
+
+void DebugDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "ttmlir/Dialect/Debug/IR/DebugOps.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// Dialect parser/printer methods
+//===----------------------------------------------------------------------===//
+
+mlir::Type DebugDialect::parseType(mlir::DialectAsmParser &parser) const {
+  // For now, delegate to generated parser
+  StringRef typeTag;
+  if (parser.parseKeyword(&typeTag)) {
+    return {};
+  }
+
+  // Handle any Debug-specific types here
+  // Currently we don't have any custom types
+  parser.emitError(parser.getNameLoc(), "unknown Debug dialect type: ")
+      << typeTag;
+  return {};
+}
+
+void DebugDialect::printType(mlir::Type type,
+                             mlir::DialectAsmPrinter &os) const {
+  // Handle any Debug-specific types here
+  // Currently we don't have any custom types
+  os << "<<unknown Debug type>>";
+}
+
+mlir::Attribute DebugDialect::parseAttribute(mlir::DialectAsmParser &parser,
+                                             mlir::Type type) const {
+  // For now, delegate to generated parser
+  mlir::StringRef attrName;
+  if (parser.parseKeyword(&attrName)) {
+    return {};
+  }
+
+  // Handle any Debug-specific attributes here
+  // Currently we don't have any custom attributes
+  parser.emitError(parser.getNameLoc(), "unknown Debug dialect attribute: ")
+      << attrName;
+  return {};
+}
+
+void DebugDialect::printAttribute(mlir::Attribute attr,
+                                  mlir::DialectAsmPrinter &printer) const {
+  // Handle any Debug-specific attributes here
+  // Currently we don't have any custom attributes
+  printer << "<unknown debug attribute>";
+}
+
+mlir::Operation *DebugDialect::materializeConstant(mlir::OpBuilder &builder,
+                                                   mlir::Attribute value,
+                                                   mlir::Type type,
+                                                   mlir::Location loc) {
+  // For now, we cannot materialize any constants in the Debug dialect
+  return nullptr;
+}
+
+} // namespace mlir::tt::debug

--- a/lib/Dialect/Debug/IR/DebugOps.cpp
+++ b/lib/Dialect/Debug/IR/DebugOps.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpImplementation.h"
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
+
+#define GET_OP_CLASSES
+#include "ttmlir/Dialect/Debug/IR/DebugOps.cpp.inc"
+
+namespace mlir::tt::debug {
+
+// Custom verification logic for Debug operations can be added here
+
+} // namespace mlir::tt::debug

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/Passes.h"
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPy.h"
 #include "ttmlir/Dialect/LLVM/Transforms/Passes.h"
 #include "ttmlir/Dialect/SFPI/IR/SFPI.h"
@@ -92,7 +93,8 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
       mlir::tosa::TosaDialect, mlir::vector::VectorDialect,
       mlir::memref::MemRefDialect, mlir::emitc::EmitCDialect,
       mlir::bufferization::BufferizationDialect, mlir::LLVM::LLVMDialect,
-      mlir::quant::QuantDialect, mlir::tt::emitpy::EmitPyDialect>();
+      mlir::quant::QuantDialect, mlir::tt::emitpy::EmitPyDialect,
+      mlir::tt::debug::DebugDialect>();
 
 #if TTMLIR_ENABLE_STABLEHLO
   mlir::stablehlo::registerAllDialects(registry);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -71,6 +71,14 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME ttnn
 )
 
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT TTMLIRPythonSources.Dialects
+  ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
+  TD_FILE dialects/DebugBinding.td
+  SOURCES dialects/debug.py
+  DIALECT_NAME debug
+)
+
 declare_mlir_python_sources(TTMLIRPythonSources.OptimizerOverrides
   ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
   ADD_TO_PARENT TTMLIRPythonSources
@@ -112,6 +120,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     D2MModule.cpp
     TTKernelModule.cpp
     TTNNModule.cpp
+    DebugModule.cpp
     OptimizerOverrides.cpp
     Passes.cpp
     Util.cpp

--- a/python/DebugModule.cpp
+++ b/python/DebugModule.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Bindings/Python/TTMLIRModule.h"
+
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h"
+
+#include "mlir/CAPI/AffineMap.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/IR/AffineMap.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace mlir::ttmlir::python {
+void populateDebugModule(nb::module_ &m) {
+  // Populate Debug dialect bindings here when there are any.
+}
+} // namespace mlir::ttmlir::python

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -91,6 +91,8 @@ NB_MODULE(_ttmlir, m) {
   mlir::ttmlir::python::populateTTKernelModule(ttkernel_ir);
   auto ttnn_ir = m.def_submodule("ttnn_ir", "TTNN IR Bindings");
   mlir::ttmlir::python::populateTTNNModule(ttnn_ir);
+  auto debug_ir = m.def_submodule("debug_ir", "Debug IR Bindings");
+  mlir::ttmlir::python::populateDebugModule(debug_ir);
   auto passes =
       m.def_submodule("passes", "Python-Bound Passes & Transformations");
   mlir::ttmlir::python::populatePassesModule(passes);

--- a/python/ttmlir/dialects/DebugBinding.td
+++ b/python/ttmlir/dialects/DebugBinding.td
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PYTHON_BINDINGS_TTMLIR_DEBUGOPS
+#define PYTHON_BINDINGS_TTMLIR_DEBUGOPS
+
+include "ttmlir/Dialect/Debug/IR/DebugOps.td"
+
+#endif

--- a/python/ttmlir/dialects/debug.py
+++ b/python/ttmlir/dialects/debug.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ._debug_ops_gen import *
+from .._mlir_libs._ttmlir import debug_ir as ir

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -1,9 +1,12 @@
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
+
 if (NOT TTNN_RUNTIME_ENABLED)
   add_library(TTRuntimeTTNNOps INTERFACE)
   return()
 endif()
 
 set(TTNN_OPS_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/debug/debug.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cache/load_cached.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/aggregate_tensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/all_gather.cpp
@@ -112,7 +115,7 @@ target_include_directories(TTRuntimeTTNNOps PUBLIC
 
 target_include_directories(TTRuntimeTTNNOps SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 target_link_libraries(TTRuntimeTTNNOps PUBLIC TTNN_LIBRARY TTRuntimeTTNNDebug TTRuntimeTTNNTypes TTRuntimeTTNNUtils TRACY_LIBRARY)
-target_link_libraries(TTRuntimeTTNNOps PUBLIC coverage_config)
+target_link_libraries(TTRuntimeTTNNOps PUBLIC coverage_config Python::Python)
 
 
 add_dependencies(TTRuntimeTTNNOps TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNTypes TTRuntimeTTNNDebug RUNTIME_FBS_GENERATION)

--- a/runtime/lib/ttnn/operations/debug/debug.cpp
+++ b/runtime/lib/ttnn/operations/debug/debug.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/debug/debug.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+#include <Python.h>
+
+namespace tt::runtime::ttnn::operations::debug {
+
+void invoke_pdb() { PyRun_SimpleString("import pdb; pdb.set_trace()"); }
+
+void run(const ::tt::target::ttnn::AnnotateOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &operand =
+      tensorPool.getTTNNTensorAndValidate(op->operand());
+  tensorPool.insertTTNNTensorAndValidate(op->result(), operand);
+}
+
+void run(const ::tt::target::ttnn::BreakpointOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &operand =
+      tensorPool.getTTNNTensorAndValidate(op->operand());
+  tensorPool.insertTTNNTensorAndValidate(op->result(), operand);
+
+  invoke_pdb();
+}
+
+void run(const ::tt::target::ttnn::MemorySnapshotOp *op,
+         ProgramContext &context) {
+  constexpr std::array<tt::runtime::MemoryBufferType, 4> MEMORY_TYPES = {
+      tt::runtime::MemoryBufferType::DRAM, tt::runtime::MemoryBufferType::L1,
+      tt::runtime::MemoryBufferType::L1_SMALL,
+      tt::runtime::MemoryBufferType::TRACE};
+
+  std::string filePath = op->file_path()->str();
+  std::ofstream outFile(filePath, std::ios::out | std::ios::trunc);
+  if (!outFile.is_open()) {
+    throw std::runtime_error("Failed to open file: " + filePath);
+  }
+
+  auto memoryState =
+      ::tt::runtime::ttnn::utils::getMemoryView(context.getDeviceHandle());
+  for (const auto &memoryType : MEMORY_TYPES) {
+    outFile << "Device " << toString(memoryType)
+            << " memory state: " << memoryState.at(memoryType).toString()
+            << "\n";
+  }
+  outFile.close();
+
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &operand =
+      tensorPool.getTTNNTensorAndValidate(op->operand());
+  tensorPool.insertTTNNTensorAndValidate(op->result(), operand);
+}
+
+} // namespace tt::runtime::ttnn::operations::debug

--- a/runtime/lib/ttnn/operations/debug/debug.h
+++ b/runtime/lib/ttnn/operations/debug/debug.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_DEBUG_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_DEBUG_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::debug {
+
+void run(const ::tt::target::ttnn::AnnotateOp *op, ProgramContext &context);
+void run(const ::tt::target::ttnn::BreakpointOp *op, ProgramContext &context);
+void run(const ::tt::target::ttnn::MemorySnapshotOp *op,
+         ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::debug
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -38,6 +38,7 @@
 #include "operations/data_movement/sort.h"
 #include "operations/data_movement/transpose.h"
 #include "operations/data_movement/write_tensor.h"
+#include "operations/debug/debug.h"
 #include "operations/deletion/deallocate.h"
 #include "operations/eltwise/binary/binary.h"
 #include "operations/eltwise/binary/binary_composite.h"
@@ -489,6 +490,15 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::DistributeTensorOp: {
     return operations::ccl::run(op->type_as_DistributeTensorOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::AnnotateOp: {
+    return operations::debug::run(op->type_as_AnnotateOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::BreakpointOp: {
+    return operations::debug::run(op->type_as_BreakpointOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
+    return operations::debug::run(op->type_as_MemorySnapshotOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::NONE: {
     LOG_FATAL("Unsupported operation type: ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1279,6 +1279,18 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_DistributeTensorOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::AnnotateOp: {
+    tensorRef = opContext.type_as_AnnotateOp()->result();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::BreakpointOp: {
+    tensorRef = opContext.type_as_BreakpointOp()->result();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
+    tensorRef = opContext.type_as_MemorySnapshotOp()->result();
+    break;
+  }
   case ::tt::target::ttnn::OpType::NONE: {
     LOG_FATAL("Invalid op type");
     break;
@@ -1722,6 +1734,18 @@ getOpInputRefs(OpContext opContextHandle,
   }
   case ::tt::target::ttnn::OpType::DistributeTensorOp: {
     tensorRefs = {opContext.type_as_DistributeTensorOp()->in()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::AnnotateOp: {
+    tensorRefs = {opContext.type_as_AnnotateOp()->operand()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::BreakpointOp: {
+    tensorRefs = {opContext.type_as_BreakpointOp()->operand()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
+    tensorRefs = {opContext.type_as_MemorySnapshotOp()->operand()};
     break;
   }
   case ::tt::target::ttnn::OpType::NONE: {

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -2,20 +2,23 @@
 
 `builder` contains `ttir-builder`, `stablehlo-builder` and `ttnn-builder` to create mlir graphs.
 
-## Important relevant packages
+## import relevant packages
+
 ```python
-from builder.base.builder_apis import Operand
+from ttmlir.passes import ttir_to_ttnn_backend_pipeline
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 from builder.ttnn.ttnn_builder import TTNNBuilder
 from builder.base.builder_apis import *
 from builder.base.builder_runtime import *
+from builder.base.builder_enums import *
+
+import torch
 ```
 
-## Build a ttir module
-Check each op's definition to see what parameters you can override. They are kept as close as possible to their MLIR definition.
-For example: tools/builder/ttir/ttir_builder.py see `@tag(ttir.SigmoidOp)`.
-Under the hood, random inputs are getting generated for in0, all intermediates are evaluated and output is calculated.
+## build ttir module
+
+Check each op's definition to see what parameters you can override. They are kept as close as possible to their MLIR definition. For example: tools/builder/ttir/ttir_builder.py see @tag(ttir.SigmoidOp). Under the hood, random inputs are getting generated for in0, all intermediates are evaluated and output is calculated.
 
 ```python
 def module0(builder: TTIRBuilder):
@@ -26,20 +29,116 @@ def module0(builder: TTIRBuilder):
       return sigmoid0
 
 new_module, builder = build_module(module0, "ttir")
+print(new_module.operation.get_asm(enable_debug_info=True))
+```
+
+```mlir
+#loc = loc("/code/jan-2/tt-mlir/test.py":12:0)
+module {
+  func.func @modela(%arg0: tensor<32x32xf32> loc("/code/jan-2/tt-mlir/test.py":12:0)) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32> loc(#loc1)
+    return %0 : tensor<32x32xf32> loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc("/code/jan-2/tt-mlir/test.py:16")
+```
+
+## override location
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0, loc="tenstorrent://custom_location/sigmoid_op")
+      return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
+print(new_module.operation.get_asm(enable_debug_info=True))
+```
+
+```mlir
+#loc = loc("/code/jan-2/tt-mlir/test.py":12:0)
+module {
+  func.func @modela(%arg0: tensor<32x32xf32> loc("/code/jan-2/tt-mlir/test.py":12:0)) -> tensor<32x32xf32> {
+    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32> loc(#loc1)
+    return %0 : tensor<32x32xf32> loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc("tenstorrent://custom_location/sigmoid_op")
+```
+
+## add op attributes
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0, unit_attrs=["ttir.should_hoist"])
+      return sigmoid0
+
+new_module, builder = build_module(module0, "ttir")
 print(new_module)
 ```
 
 ```mlir
 module {
   func.func @modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = "ttir.sigmoid"(%arg0) {ttir.should_hoist} : (tensor<32x32xf32>) -> tensor<32x32xf32>
     return %0 : tensor<32x32xf32>
   }
 }
 ```
 
-## Set inputs/outputs when building module
+## multiple returns
+
+```python
+shapes = [(2, 16, 32, 32), (16,), (16,), (16,), (16,)]
+dtypes = [torch.float32, torch.float32, torch.float32, torch.float32, torch.float32]
+
+def module(builder: TTIRBuilder):
+    @builder.func(shapes, dtypes)
+    def batch_norm_training(
+        in0: Operand,
+        scale: Operand,
+        offset: Operand,
+        running_mean: Operand,
+        running_variance: Operand,
+        builder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+
+        result, batch_mean, batch_variance = builder.batch_norm_training(
+            in0,
+            scale,
+            offset,
+            running_mean,
+            running_variance,
+            epsilon=1e-5,
+            dimension=1,
+            momentum=0.1,
+        )
+
+        return result, batch_mean, batch_variance
+
+new_module, builder = build_module(module, "ttir")
+print(new_module)
+```
+
+```mlir
+module {
+  func.func @batch_norm_training(%arg0: tensor<2x16x32x32xf32>, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>, %arg3: tensor<16xf32>, %arg4: tensor<16xf32>) -> (tensor<2x16x32x32xf32>, tensor<16xf32>, tensor<16xf32>) {
+    %result, %batch_mean, %batch_variance = "ttir.batch_norm_training"(%arg0, %arg1, %arg2, %arg3, %arg4) <{dimension = 1 : i32, epsilon = 9.99999974E-6 : f32, momentum = 1.000000e-01 : f32}> : (tensor<2x16x32x32xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>) -> (tensor<2x16x32x32xf32>, tensor<16xf32>, tensor<16xf32>)
+    return %result, %batch_mean, %batch_variance : tensor<2x16x32x32xf32>, tensor<16xf32>, tensor<16xf32>
+  }
+}
+```
+
+## set inputs/outputs
+
 You can use builder APIs to set the inputs which will be used for all subsequent intermediate + output golden evaluation.
+
 ```python
 def module(builder: TTIRBuilder):
     @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
@@ -54,10 +153,54 @@ def module(builder: TTIRBuilder):
         return add_result
 
 module, builder = build_module(module, "ttir")
-print(module)
+print(new_module)
 ```
 
-## Change output dtype for mixed precision
+## set inputs/outputs with torch tensors
+
+```python
+def module(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def test_with_mixed_init(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        input0 = torch.randn(32, 32)
+        input1 = torch.randn(32, 32)
+        builder.set_goldens({in0: input0, in1: input1})
+        add_result = builder.add(in0, in1)
+        return add_result
+
+module, builder = build_module(module, "ttir")
+print(new_module)
+```
+
+## set inputs/outputs with custom goldens
+
+```python
+def module(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def test_with_mixed_init(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        input0 = torch.randn(32, 32)
+        input1 = torch.randn(32, 32)
+        builder.set_goldens({in0: input0, in1: input1})
+        add_result = builder.add(in0, in1)
+        builder.set_operand_goldens({add_result: torch.add(input0, input1)})
+        return add_result
+
+module, builder = build_module(module, "ttir")
+print(new_module)
+```
+
+## change output dtype for mixed precision
+
 ```python
 def module0(builder: TTIRBuilder):
 
@@ -79,7 +222,8 @@ module {
 }
 ```
 
-## Build a stablehlo/ttnn module
+## build stablehlo module
+
 ```python
 def module0(builder: StableHLOBuilder):
 
@@ -102,8 +246,39 @@ module {
 }
 ```
 
-## Build multiple functions
+## build ttnn module
+
+```python
+def module0(builder: TTNNBuilder):
+
+  @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+  def modela(in0: Operand, in1: Operand, builder: TTNNBuilder):
+      add0 = builder.add(in0, in1)
+      return add0
+
+new_module, builder = build_module(module0, "ttnn")
+print(new_module)
+```
+
+```mlir
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @modela(%arg0: tensor<32x32xf32, #ttnn_layout>, %arg1: tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout> {
+    %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<32x32xf32, #ttnn_layout>, tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout>
+    return %0 : tensor<32x32xf32, #ttnn_layout>
+  }
+}
+```
+
+## golden library
+
+See `golden/mapping.py`.
+
+## build multiple functions
+
 All goldens are calculated for each function. Each root function will be executed as a separate program on device.
+
 ```python
 def module0(builder: TTIRBuilder):
 
@@ -134,7 +309,8 @@ module {
 }
 ```
 
-## Build nested functions
+## build nested functions
+
 ```python
 def module0(builder: TTIRBuilder):
     @builder.func([(32, 32)], [torch.float32])
@@ -144,8 +320,7 @@ def module0(builder: TTIRBuilder):
             return sigmoid0
 
         sigmoid0 = builder.sigmoid(in0)
-        ttir_builder0 = TTIRBuilder(builder.context, builder.location)
-        nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
+        nested_func0 = builder.call(nested_func, [sigmoid0])
         return nested_func0
 
     @builder.func([(32, 32)], [torch.float32])
@@ -175,7 +350,8 @@ module {
 }
 ```
 
-## Build device module graphs
+## build device module graph
+
 ```python
 def module0(builder: TTIRBuilder):
     @builder.device_module
@@ -187,8 +363,7 @@ def module0(builder: TTIRBuilder):
                 return sigmoid0
 
             sigmoid0 = builder.sigmoid(in0)
-            ttir_builder0 = TTIRBuilder(builder.context, builder.location)
-            nested_func0 = builder.call(nested_func, [sigmoid0], ttir_builder0)
+            nested_func0 = builder.call(nested_func, [sigmoid0])
             return nested_func0
 
         @builder.func([(32, 32)], [torch.float32])
@@ -222,33 +397,10 @@ module {
 }
 ```
 
-## Build cpu hoisted graphs
-```python
-def module0(builder: TTIRBuilder):
-    @builder.func([(32, 32)], [torch.float32])
-    def softmax(in0: Operand, builder: TTIRBuilder):
-        return builder.softmax(
-            in0,
-            dimension=-1,
-            numeric_stable=False,
-            unit_attrs=["ttir.should_hoist"],
-        )
+## run any pass on any module
 
-new_module, builder = build_module(module0, "ttir")
-print(new_module)
-```
-
-```mlir
-module {
-  func.func @softmax(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.softmax"(%arg0) <{dimension = -1 : si32, numericStable = false}> {ttir.should_hoist} : (tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %0 : tensor<32x32xf32>
-  }
-}
-```
-
-## You can run any mlir pass on any generated module
 See full list of passes supported at `python/Passes.cpp`.
+
 ```python
 from ttmlir.passes import stablehlo_to_ttir_pipeline
 
@@ -277,8 +429,8 @@ module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
 }
 ```
 
-## Compile a module to a flatbuffer
-This will return the builder instance, where the .mlir file was dumped, the input/output golden dictionary per root level function and the intermediate golden dictionary.
+## compile a module to a flatbuffer
+
 ```python
 def module0(builder: TTIRBuilder):
 
@@ -295,9 +447,49 @@ def module0(builder: TTIRBuilder):
 builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0)
 ```
 
-## Interface with mlir runtime
-All mlir runtime C++ APIs are nanobinded. See full list here: `runtime/python/runtime/runtime.cpp`.
-You can also pass in `enable_intermediate_verification` in `compile_and_execute_ttir` to give you back a report of all intermediate golden results.
+## compile a module to ttmetal
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0, target="ttmetal")
+```
+
+## compile a module to a emitc
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0, target="emitc")
+```
+
+## compile a module to a emitpy
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0, target="emitpy")
+```
+
+## interface with mlir runtime
+
+All mlir runtime C++ APIs are nanobinded. See full list here: `runtime/python/runtime/runtime.cpp`. You can also pass in `enable_intermediate_verification` in `compile_and_execute_ttir` to give you back a report of all intermediate golden results.
+
 ```python
 import _ttmlir_runtime as tt_runtime
 
@@ -309,8 +501,17 @@ device = tt_runtime.runtime.open_mesh_device(mesh_options)
 tt_runtime.runtime.close_mesh_device(device)
 ```
 
-## Execute flatbuffer
+## nanobinds
+
+runtime: `runtime/python/runtime/runtime.cpp`
+ttcore, ttir, ttnn, d2m: `python/`
+shardy: https://github.com/openxla/shardy/tree/main/shardy/integrations/python/ir
+stablehlo: https://github.com/openxla/stablehlo/tree/main/stablehlo/integrations/python/mlir/dialects
+
+## execute flatbuffer
+
 Each root level function will execute and evaluate its pcc.
+
 ```python
 import _ttmlir_runtime as tt_runtime
 
@@ -340,14 +541,71 @@ compile_and_execute_ttir(
 tt_runtime.runtime.close_mesh_device(device)
 ```
 
-```
-Program level golden for output_0 matched. pcc=0.9999998360475333
-Program level golden for output_0 matched. pcc=0.9999998372226931
+## execute emitc
+
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0, target="emitc")
+emitted_cpp_file =  "./ttir-builder-artifacts/emitc/test_ttnn.mlir.cpp"
+
+execute_cpp(emitted_cpp_file, input_output_goldens, pcc=0.98, device=device)
+
+tt_runtime.runtime.close_mesh_device(device)
 ```
 
-## Execute flatbuffer manually
-You can optionally call the APIs manually. You can also pass in `enable_intermediate_verification` in `execute_fb` to give you back a report of all intermediate golden results.
+## execute emitpy
+
 ```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+builder, module_file_path, input_output_goldens, intermediate_goldens = compile_ttir_to_flatbuffer(module0, target="emitpy")
+emitted_py_file =  "./ttir-builder-artifacts/emitpy/test_ttnn.mlir.py"
+
+execute_py(emitted_py_file, input_output_goldens, pcc=0.98)
+```
+
+## execute flatbuffer manually
+
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modelb(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      return sigmoid0
+
 module, builder = build_module(module0, "ttir")
 
 mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
@@ -358,11 +616,42 @@ mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_f
 
 flatbuffer_path = os.path.join("ttir-builder-artifacts", "ttnn", f"sample_test_ttnn.mlir.ttnn")
 execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+
+tt_runtime.runtime.close_mesh_device(device)
 ```
 
-## Load mlir file
+## bypass op
+
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      builder.bypass(sigmoid0)
+      return sigmoid0
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+## load mlir file (useful for checking compiler pass goldens)
+
 All goldens are evaluated under the hood with random inputs.
-```python3
+
+```python
 mlir_file_path = "test.mlir"
 with open(mlir_file_path, 'r') as f:
     mlir_ir_string = f.read()
@@ -371,23 +660,34 @@ module, builder = load_mlir_file(mlir_ir_string, target="ttir")
 print(module)
 ```
 
-```mlir
-module {
-  func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %0 : tensor<32x32xf32>
-  }
-}
-```
+## load mlir file with custom inputs
 
-## Load mlir file with custom inputs
 User can provide inputs per root level function to use in golden evaluation. All intermediate + output goldens are evaluated.
-```python3
-module, builder = load_mlir_file(mlir_ir_string, target="ttir", golden_inputs={"my_modela": [torch.randn(32, 32), torch.randn(32, 32)]})
+
+```python
+mlir_file_path = "test.mlir"
+with open(mlir_file_path, 'r') as f:
+    mlir_ir_string = f.read()
+
+module, builder = load_mlir_file(mlir_ir_string, target="ttir", golden_inputs={"modela": [torch.randn(32, 32), torch.randn(32, 32)], "modelb": [torch.randn(32, 32), torch.randn(32, 32)]})
+print(module)
 ```
 
-## Execute loaded mlir file
-```python3
+## execute loaded mlir file
+
+```python
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+mlir_file_path = "test.mlir"
+with open(mlir_file_path, 'r') as f:
+    mlir_ir_string = f.read()
+
 module, builder = load_mlir_file(mlir_ir_string, target="ttir")
 
 mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
@@ -398,23 +698,15 @@ mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_f
 
 flatbuffer_path = os.path.join("ttir-builder-artifacts", "ttnn", f"sample_test_ttnn.mlir.ttnn")
 execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+
+tt_runtime.runtime.close_mesh_device(device)
 ```
 
-```
-Program level golden for output_0 matched. pcc=0.9999998360475333
-```
+## split mlir file
 
-## Split mlir file
 Splitting a mlir module will convert each op into a standalone module + op. The goldens are reused. Each intermediate op will take it's original golden inputs and set that as the inputs to its new module. This applied to the output as well.
-```python3
-mlir_ir_string = '''module {
-  func.func @my_modela(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
-    %1 = "ttir.sigmoid"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %1 : tensor<32x32xf32>
-  }
-}'''
 
+```python
 module, builder = load_mlir_file(mlir_ir_string, target="ttir")
 builder_module_list = split_mlir_file(module, builder)
 
@@ -422,33 +714,84 @@ for module, builder in builder_module_list:
     print(module)
 ```
 
-```mlir
-module {
-  func.func @add_module(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %0 : tensor<32x32xf32>
-  }
-}
+## load+split+execute mlir file
+
+```python
+module, builder = load_mlir_file(mlir_ir_string, target="ttir")
+builder_module_list = split_mlir_file(module, builder)
+
+for split_module, split_builder in builder_module_list:
+    print("-------------- Running test for split module: --------------")
+    print(split_module)
+    import _ttmlir_runtime as tt_runtime
+
+    tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+    mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+    mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+    mesh_options.mesh_shape = (1, 1)
+    device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+    mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
+        split_module,
+        split_builder,
+        test_base="sample_test",
+    )
+
+    flatbuffer_path = os.path.join("ttir-builder-artifacts", "ttnn", f"sample_test_ttnn.mlir.ttnn")
+    execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+
+    tt_runtime.runtime.close_mesh_device(device)
 ```
 
-```mlir
-module {
-  func.func @sigmoid_module(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %0 : tensor<32x32xf32>
-  }
-}
+## profiler
+
+```python
+from profiler import *
+
+with trace("/code/jan-2/tt-mlir/profiler", 8086):
+    def module3(builder: TTIRBuilder):
+        @builder.device_module
+        def module(builder: TTIRBuilder):
+            @builder.func([(32, 32), (32, 32), (32, 32)], [torch.float32, torch.float32, torch.float32])
+            def model(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
+                add = builder.add(in0, in1)
+                exp = builder.exp(in2)
+                return builder.multiply(add, exp)
+
+
+    new_module, builder = build_module(module3, "ttir")
+    print(new_module)
+
+    import _ttmlir_runtime as tt_runtime
+
+    tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+    mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+    mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+    mesh_options.mesh_shape = (1, 1)
+    device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+    mlir_path, input_output_goldens, intermediate_goldens = compile_ttir_module_to_flatbuffer(
+        new_module,
+        builder,
+        test_base="taps_module2",
+    )
+
+    flatbuffer_path = "ttir-builder-artifacts/ttnn/taps_module2_ttnn.mlir.ttnn"
+    golden_report = execute_fb(flatbuffer_path, input_output_goldens, intermediate_goldens, device=device)
+
+    tt_runtime.runtime.close_mesh_device(device)
 ```
 
-## Build multi-device graphs
+## build multi-device graphs
+
 ```python
 def module(builder: TTIRBuilder):
     @builder.func([(1, 1, 256, 512)], [torch.float32])
     def all_gather(in0: Operand, builder: TTIRBuilder):
         in_shard = builder.mesh_shard(
             in0,
-            shard_direction="#ttcore.shard_direction<full_to_shard>",
-            shard_type="#ttcore.shard_type<devices>",
+            shard_direction=MeshShardDirection.FullToShard.value,
+            shard_type=MeshShardType.Devices.value,
             shard_shape=(1, 1, 8, 4),
             shard_dims=(2, 3),
         )
@@ -461,8 +804,8 @@ def module(builder: TTIRBuilder):
 
         return builder.mesh_shard(
             all_gather0,
-            shard_direction="#ttcore.shard_direction<shard_to_full>",
-            shard_type="#ttcore.shard_type<devices>",
+            shard_direction=MeshShardDirection.ShardToFull.value,
+            shard_type=MeshShardType.Devices.value,
             shard_shape=(1, 1, 8, 1),
             shard_dims=(2, -1),
         )
@@ -482,7 +825,8 @@ module {
 }
 ```
 
-## Build shardy annotated graph
+## build shardy annotated graph
+
 ```python
 def module(builder: StableHLOBuilder):
     @builder.func([(2, 4, 8, 16), (2, 4, 8, 16)], [torch.float32, torch.float32])
@@ -490,10 +834,37 @@ def module(builder: StableHLOBuilder):
         in0: Operand,
         in1: Operand,
         builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         builder.set_graph_level_check(True)
-        sharding_attr = builder.create_sharding_attr_from_tuples("mesh", [("x", True), ("y", False), ("", False), ("", False)])
-        return builder.add(in0, in1, sharding_attr=sharding_attr)
+        sharding_attr = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="x")],
+                    is_closed=True,
+                    priority=10,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="y")],
+                    is_closed=False,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=False,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=False,
+                ),
+            ],
+        )
+
+        return builder.add(
+            in0,
+            in1,
+            sharding_attr=builder.tensor_sharding_per_value_attr([sharding_attr]),
+        )
 
 module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
 print(module)
@@ -503,14 +874,108 @@ print(module)
 module {
   sdy.mesh @mesh = <["x"=2, "y"=4]>
   func.func @op_sharding_annotation(%arg0: tensor<2x4x8x16xf32>, %arg1: tensor<2x4x8x16xf32>) -> tensor<2x4x8x16xf32> {
-    %0 = stablehlo.add %arg0, %arg1 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"x"}, {"y", ?}, {?}, {?}]>]>} : tensor<2x4x8x16xf32>
+    %0 = stablehlo.add %arg0, %arg1 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"x"}p10, {"y", ?}, {?}, {?}]>]>} : tensor<2x4x8x16xf32>
     return %0 : tensor<2x4x8x16xf32>
   }
 }
 ```
 
-## Run pipelines on shardy annotated graph
-```python3
+## build shardy annotated input graph
+
+```python
+def module(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def input_annotation(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        tensor_sharding_attr = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="x")],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="y")],
+                    is_closed=True,
+                ),
+            ],
+        )
+        builder.set_arg_attribute(in0, "sdy.sharding", tensor_sharding_attr)
+        return builder.add(in0, in1)
+
+module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
+print(module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=2, "y"=4]>
+  func.func @input_annotation(%arg0: tensor<128x128xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {"y"}]>}, %arg1: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<128x128xf32>
+    return %0 : tensor<128x128xf32>
+  }
+}
+```
+
+## run pipelines on shardy annotated graph
+
+```python
+module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
+stablehlo_pipeline(module)
+print(module)
+```
+
+## build manual computation op graph
+
+```python
+def module(builder: StableHLOBuilder):
+    @builder.func([(1, 1, 32, 32), (1, 1, 32, 32)], [torch.float32, torch.float32])
+    def my_modela(in0: Operand, in1: Operand, builder: StableHLOBuilder):
+        def single_device_func(
+            inner0: Operand, inner1: Operand, builder: StableHLOBuilder
+        ):
+            add0 = builder.add(inner0, inner1)
+            add1 = builder.add(add0, inner1)
+            cosine0 = builder.cosine(add1)
+            sin0 = builder.sine(add1)
+            return cosine0, sin0
+
+        tensor_sharding_attr = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="x")],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="y")],
+                    is_closed=True,
+                ),
+            ],
+        )
+
+        manual_computation_op0, manual_computation_op1 = builder.manual_computation(
+            single_device_func,
+            [in0, in1],
+            in_shardings=[tensor_sharding_attr, tensor_sharding_attr],
+            out_shardings=[tensor_sharding_attr, tensor_sharding_attr],
+            manual_axes=["x", "y"],
+        )
+        return manual_computation_op0, manual_computation_op1
+
 module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
 stablehlo_pipeline(module)
 print(module)
@@ -519,12 +984,245 @@ print(module)
 ```mlir
 module {
   sdy.mesh @mesh = <["x"=2, "y"=4]>
-  func.func @op_sharding_annotation(%arg0: tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<2x4x8x16xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
-    %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"x"}, {"y"}, {}, {}]>, <@mesh, [{"x"}, {"y"}, {}, {}]>] out_shardings=[<@mesh, [{"x"}, {"y"}, {}, {}]>] manual_axes={"x", "y"} (%arg2: tensor<1x1x8x16xf32>, %arg3: tensor<1x1x8x16xf32>) {
-      %1 = stablehlo.add %arg2, %arg3 : tensor<1x1x8x16xf32>
-      sdy.return %1 : tensor<1x1x8x16xf32>
-    } : (tensor<2x4x8x16xf32>, tensor<2x4x8x16xf32>) -> tensor<2x4x8x16xf32>
-    return %0 : tensor<2x4x8x16xf32>
+  func.func @my_modela(%arg0: tensor<1x1x32x32xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, %arg1: tensor<1x1x32x32xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) -> (tensor<1x1x32x32xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}, tensor<1x1x32x32xf32> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0:2 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>, <@mesh, [{}, {}, {"x"}, {"y"}]>] out_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>, <@mesh, [{}, {}, {"x"}, {"y"}]>] manual_axes={"x", "y"} (%arg2: tensor<1x1x16x8xf32>, %arg3: tensor<1x1x16x8xf32>) {
+      %1 = stablehlo.add %arg2, %arg3 : tensor<1x1x16x8xf32>
+      %2 = stablehlo.add %1, %arg3 : tensor<1x1x16x8xf32>
+      %3 = stablehlo.cosine %2 : tensor<1x1x16x8xf32>
+      %4 = stablehlo.sine %2 : tensor<1x1x16x8xf32>
+      sdy.return %3, %4 : tensor<1x1x16x8xf32>, tensor<1x1x16x8xf32>
+    } : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>)
+    return %0#0, %0#1 : tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>
   }
 }
+```
+
+## build manual computation op with ccl
+
+```python
+def module_all_gather(builder: StableHLOBuilder):
+    @builder.func([(1, 1, 32, 32)], [torch.float32])
+    def my_modela(in0: Operand, builder: StableHLOBuilder):
+        def single_device_func(in0: Operand, builder: StableHLOBuilder):
+            all_gather0 = builder.all_gather(in0, 3, [[0]])
+            return all_gather0
+
+        tensor_sharding_attr = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="x")],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="y")],
+                    is_closed=True,
+                ),
+            ],
+        )
+
+        manual_computation_op0 = builder.manual_computation(
+            single_device_func,
+            [in0],
+            in_shardings=[tensor_sharding_attr],
+            out_shardings=[tensor_sharding_attr],
+            manual_axes=["x", "y"],
+        )
+        return manual_computation_op0
+
+module, builder = build_module(module_all_gather, "stablehlo", mesh_dict=OrderedDict([("x", 1), ("y", 1)]))
+print(module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=1, "y"=1]>
+  func.func @my_modela(%arg0: tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32> {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>] out_shardings=[<@mesh, [{}, {}, {"x"}, {"y"}]>] manual_axes={"x", "y"} (%arg1: tensor<1x1x32x32xf32>) {
+      %1 = "stablehlo.all_gather"(%arg1) <{all_gather_dim = 3 : i64, replica_groups = dense<0> : tensor<1x1xi64>}> : (tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+      sdy.return %1 : tensor<1x1x32x32xf32>
+    } : (tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %0 : tensor<1x1x32x32xf32>
+  }
+}
+```
+
+## build sdy all gather op graph
+
+```python
+def module(builder: StableHLOBuilder):
+    @builder.func([(1, 1, 32, 32), (1, 1, 32, 32)], [torch.float32, torch.float32])
+    def my_modela(in0: Operand, in1: Operand, builder: StableHLOBuilder):
+        tensor_sharding_attr0 = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="x")],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[builder.axis_ref_attr(name="y")],
+                    is_closed=True,
+                ),
+            ],
+        )
+        add0 = builder.add(
+            in0,
+            in1,
+            sharding_attr=builder.tensor_sharding_per_value_attr(
+                [tensor_sharding_attr0]
+            ),
+        )
+
+        tensor_sharding_attr1 = builder.tensor_sharding_attr(
+            mesh_name="mesh",
+            dimension_shardings=[
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+                builder.dimension_sharding_attr(
+                    axes=[],
+                    is_closed=True,
+                ),
+            ],
+        )
+        axes_ref_list0 = builder.axes_ref_list_attr(axis_ref_list=[])
+        axes_ref_list1 = builder.axes_ref_list_attr(axis_ref_list=[])
+        axes_ref_list2 = builder.axes_ref_list_attr(
+            axis_ref_list=[builder.axis_ref_attr(name="x")]
+        )
+        axes_ref_list3 = builder.axes_ref_list_attr(
+            axis_ref_list=[builder.axis_ref_attr(name="y")]
+        )
+        gathering_axes = builder.list_of_axis_ref_lists_attr(
+            [axes_ref_list0, axes_ref_list1, axes_ref_list2, axes_ref_list3]
+        )
+        sdy_all_gather0 = builder.sdy_all_gather(
+            add0, gathering_axes, tensor_sharding_attr1
+        )
+        return sdy_all_gather0
+
+module, builder = build_module(module, "stablehlo", mesh_dict=OrderedDict([("x", 2), ("y", 4)]))
+print(module)
+```
+
+```mlir
+module {
+  sdy.mesh @mesh = <["x"=2, "y"=4]>
+  func.func @my_modela(%arg0: tensor<1x1x32x32xf32>, %arg1: tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32> {
+    %0 = stablehlo.add %arg0, %arg1 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"x"}, {"y"}]>]>} : tensor<1x1x32x32xf32>
+    %1 = sdy.all_gather [{}, {}, {"x"}, {"y"}] %0 out_sharding=<@mesh, [{}, {}, {}, {}]> : tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+```
+
+## load manual computation op graph
+
+```python
+mlir_file_path = "multidevice.mlir"
+with open(mlir_file_path, 'r') as f:
+    mlir_ir_string = f.read()
+
+module, builder = load_mlir_file(mlir_ir_string, target="stablehlo")
+print(module)
+```
+
+## automatic parallelization
+
+```python
+file_path = "permutation.mlir"
+with open(file_path, "r", encoding="utf-8") as f:
+    mlir_text = f.read()
+
+module_permutations = generate_all_module_permutations(mlir_text, num_devices = 2)
+
+for module_permutation in module_permutations:
+    print("----- Module Permutation -----")
+    print(module_permutation)
+
+optimal_modules = get_optimal_module_least_num_collectives(module_permutations)
+
+for optimal_module in optimal_modules:
+    print("----- Optimal Module -----")
+    print(optimal_module)
+```
+
+## debug dialect breakpoint
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      breakpoint0 = builder.breakpoint(sigmoid0)
+      return breakpoint0
+
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 2)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+## debug dialect memory
+
+```python
+def module0(builder: TTIRBuilder):
+
+  @builder.func([(32, 32)], [torch.float32])
+  def modela(in0: Operand, builder: TTIRBuilder):
+      sigmoid0 = builder.sigmoid(in0)
+      memory0 = builder.memory_snapshot(sigmoid0, "sigmoid_memory_snapshot.json")
+      return memory0
+
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 2)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
 ```

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -11,11 +11,17 @@ import re
 from collections import OrderedDict
 
 from ttmlir.ir import *
-from ttmlir.dialects import tensor, quant, func, ttir, ttcore, stablehlo, ttnn
+from ttmlir.dialects import tensor, quant, func, ttir, ttcore, stablehlo, ttnn, debug
 from ttmlir.passes import GoldenTensor, DataType
 from golden import GoldenMapTensor, get_golden_function
 
-from builder.base.builder_utils import process_multi_return_result, TypeInfo
+from builder.base.builder_utils import (
+    process_multi_return_result,
+    TypeInfo,
+    tag,
+    parse,
+    split,
+)
 
 
 class BuilderMeta(type):
@@ -1217,3 +1223,92 @@ class Builder(metaclass=BuilderMeta):
             return cpu_module_op
 
         return wrapper(self)
+
+    # ----- Debug dialect operations ----
+
+    @tag(debug.AnnotateOp)
+    def annotate(
+        self,
+        operand: Operand,
+        annotation: str,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        debug_op = self.get_opview_from_method(Builder.annotate)
+        annotation_attr = StringAttr.get(annotation)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = debug_op(
+            operand,
+            annotation=annotation_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(operand)
+            op_golden_function = get_golden_function(debug_op)
+            golden_output = op_golden_function(input0, annotation_attr)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @tag(debug.BreakpointOp)
+    def breakpoint(
+        self,
+        operand: Operand,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        debug_op = self.get_opview_from_method(Builder.breakpoint)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = debug_op(
+            operand,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(operand)
+            op_golden_function = get_golden_function(debug_op)
+            golden_output = op_golden_function(input0)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @tag(debug.MemorySnapshotOp)
+    def memory_snapshot(
+        self,
+        operand: Operand,
+        file_path: str,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        debug_op = self.get_opview_from_method(Builder.memory_snapshot)
+        file_path_attr = StringAttr.get(file_path)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = debug_op(
+            operand,
+            file_path=file_path_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(operand)
+            op_golden_function = get_golden_function(debug_op)
+            golden_output = op_golden_function(input0, file_path_attr)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -18,7 +18,7 @@ import operator
 import einops
 import torch
 import torch.nn.functional
-from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy
+from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy, debug
 from ttmlir.ir import *
 from ttmlir.passes import DataType
 
@@ -4826,6 +4826,29 @@ def ttnn_mish_golden(
     return torch.nn.functional.mish(input_tensor).to(output_dtype)
 
 
+################ Debug Op Golden Functions ###############
+
+
+def debug_annotate_golden(
+    input_tensor: GoldenMapTensor,
+    annotation_attr: StringAttr,
+) -> GoldenMapTensor:
+    return input_tensor.clone()
+
+
+def debug_breakpoint_golden(
+    input_tensor: GoldenMapTensor,
+) -> GoldenMapTensor:
+    return input_tensor.clone()
+
+
+def debug_memory_snapshot_golden(
+    input_tensor: GoldenMapTensor,
+    file_path_attr: StringAttr,
+) -> GoldenMapTensor:
+    return input_tensor.clone()
+
+
 GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # ----- TTIR OPS -----
     # Elementwise unary operations
@@ -5097,6 +5120,10 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.RepeatInterleaveOp: ttnn_repeat_interleave_golden,
     ttnn.ClampScalarOp: ttnn_clamp_scalar_golden,
     ttnn.ClampTensorOp: ttnn_clamp_tensor_golden,
+    # ----- DEBUG OPS -----
+    debug.AnnotateOp: debug_annotate_golden,
+    debug.BreakpointOp: debug_breakpoint_golden,
+    debug.MemorySnapshotOp: debug_memory_snapshot_golden,
 }
 
 


### PR DESCRIPTION
This PR introduces a debug dialect.

The goal of the debug dialect is to be able to instrument the IR at various levels of the compiler pipeline. Supported operations include
```
debug.annotate
debug.breakpoint
debug.print
debug.dump
debug.overwrite
debug.snapshot
debug.begin_trace
debug.end_trace
debug.region_start
debug.region_end
debug.profiler_start
debug.profiler_end
debug.memory_snapshot
debug.timestamp
debug.hook
```

This PR bootstraps these operations and provides implementations for debug.annotate, debug.breakpoint and debug.memory_snapshot.

Sample IR
```
module {
  func.func @my_modela(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
    %0 = "ttir.sigmoid"(%arg0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
    %1 = "debug.memory_snapshot"(%0) <{file_path = "/code/jan-2/tt-mlir/taps.txt"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
    return %1 : tensor<32x32xf32>
  }
}
```

Sample builder construction
```
def module(builder: TTIRBuilder):
    @builder.func([(32, 32)], [torch.float32])
    def my_modela(in0: Operand, builder: TTIRBuilder):
        sigmoid0 = builder.sigmoid(in0)
        memory0 = builder.memory_snapshot(sigmoid0, "/code/jan-2/tt-mlir/taps.txt")
        return memory0
```