### PR TITLE
Pass memory config to split QKV in runtime

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2827,9 +2827,10 @@ createOp(FlatbufferObjectCache &cache, SplitQueryKeyValueAndSplitHeadsOp op) {
       toFlatbuffer(cache, op.getNumKvHeads());
   bool transposeKey = op.getTransposeKey();
 
-  auto memoryConfig = op.getMemoryConfig()
-                          ? toFlatbuffer(cache, op.getMemoryConfig().value())
-                          : 0;
+  auto memoryConfig =
+      op.getMemoryConfig()
+          ? toFlatbuffer(cache, *op.getMemoryConfig())
+          : getMemoryConfigFromTensorTypeIfNeeded(cache, op.getQuery());
 
   return ::tt::target::ttnn::CreateSplitQueryKeyValueAndSplitHeadsOp(
       *cache.fbb, inputTensor, inputKVTensor, outQuery, outKey, outValue,

--- a/runtime/lib/ttnn/operations/transformer/split_query_key_value_and_split_heads.cpp
+++ b/runtime/lib/ttnn/operations/transformer/split_query_key_value_and_split_heads.cpp
@@ -15,6 +15,7 @@ static void runSplitQueryKeyValueAndSplitHeadsOp(
     ProgramTensorPool &tensorPool) {
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
   uint32_t numHeads = op->num_heads();
   std::optional<uint32_t> numKVHeads;
   if (op->num_kv_heads()) {


### PR DESCRIPTION
split_qkv op infers memory config from Q tensor if given output memory config is null.
