### PR TITLE
Allow const-evaluation of identity `MeshShard` ops

### DIFF
--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -169,10 +169,12 @@ private:
     if (op->hasTrait<mlir::OpTrait::IsTerminator>()) {
       return;
     }
-    // Skip mesh_shard ops. Identity mesh_shard ops are just forwarding their
-    // input, so they don't need to be included in const-eval subgraphs.
-    if (isa<mlir::tt::ttnn::MeshShardOp>(op)) {
-      return;
+
+    // Skip non-identity mesh shard ops.
+    if (auto meshShardOp = mlir::dyn_cast<mlir::tt::ttnn::MeshShardOp>(op)) {
+      if (meshShardOp.getShardType() != ttcore::MeshShardType::Identity) {
+        return;
+      }
     }
 
     // Handle shared ops separately as well.


### PR DESCRIPTION
### Ticket
#6524 

### Problem description
Identity `ttnn.mesh_shard` ops don't get picked up by const-eval, which blocks some following ops to be const-eval-ed.

### What's changed
- Disabled skipping identity `ttnn.mesh_shard` in `ConstEvalHoist` pass

### Checklist
- [x] New/Existing tests provide coverage for changes
