### PR TITLE
Setting fp32 accumulation pipeline option to false by default to unblock tt-mlir uplift

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -372,7 +372,7 @@ struct TTIRToTTNNDevicePipelineOptions
       *this, "compute-cfg-fp32-dest-acc-en",
       llvm::cl::desc("Set fp32 destination accumulation for all ttnn "
                      "operations exposing compute kernel config."),
-      llvm::cl::init(true)};
+      llvm::cl::init(false)};
 
   Option<bool> ttnnPerfMetricsEnabled{
       *this, "ttnn-perf-metrics-enabled",


### PR DESCRIPTION
### Ticket


### Problem description
fp32 accumulation on by default introduces PCC issues on some operations. Setting it to false by default to unblock tt-mlir uplift to tt-xla.

### What's changed
Setting fp32 accumulation pipeline option to false by default to unblock tt-mlir uplift.
