### PR TITLE
Adding tensor cloning to builder golden checks

### DIFF
--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -183,6 +183,9 @@ def mask_torch_inf_nan(tensor):
 
 
 def get_atol_rtol_pcc(golden, calculated, atol, rtol):
+    # Clone tensors to avoid modifying the originals
+    golden = golden.clone()
+    calculated = calculated.clone()
     if not torch.is_floating_point(golden):
         golden = golden.to(torch.float64)
     if not torch.is_floating_point(calculated):


### PR DESCRIPTION
### Ticket
Closes [#6485](https://github.com/tenstorrent/tt-mlir/issues/6485)

### Problem description
Running execute_fb with intermediate verification on modules whose output tensors have `inf` values causes a PCC fail. The intermediate/output golden are represented by the same `torch.tensor` instance, and it gets modified in place in `mask_torch_inf_nan` during the intermediate golden verification and the changed tensor fails the output pcc comparison. 

### What's changed
Added tensor cloning into `get_atol_rtol_pcc` so the changes made during golden verification don't affect the originals.

### Checklist
- [ ] New/Existing tests provide coverage for changes
