### PR TITLE
Add d2m-discover.py

### DIFF
--- a/tools/scripts/d2m-discover.py
+++ b/tools/scripts/d2m-discover.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+d2m-discover: Discover weakly connected components in MLIR modules.
+
+This script walks an MLIR file and finds weakly connected components (WCCs)
+of operations based on SSA value connectivity. It filters out components
+of size 1 and operations matching an ignore list.
+"""
+
+import argparse
+from collections import defaultdict
+
+import ttmlir
+import ttmlir.util
+from ttmlir.ir import Context, Module, Location, InsertionPoint, Block, Operation
+from ttmlir.dialects import func, ttir
+
+# Ignorelist of operation names to ignore when building the graph.
+# Operations matching these names will be excluded from analysis.
+OP_IGNORELIST = [
+    "func.return",
+]
+
+
+class UnionFind:
+    """Union-Find data structure for efficient connected component discovery."""
+
+    def __init__(self):
+        self.parent = {}
+        self.rank = {}
+
+    def find(self, x):
+        """Find the representative of the set containing x with path compression."""
+        if x not in self.parent:
+            self.parent[x] = x
+            self.rank[x] = 0
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+
+    def union(self, x, y):
+        """Union the sets containing x and y using union by rank."""
+        px, py = self.find(x), self.find(y)
+        if px == py:
+            return
+        if self.rank[px] < self.rank[py]:
+            px, py = py, px
+        self.parent[py] = px
+        if self.rank[px] == self.rank[py]:
+            self.rank[px] += 1
+
+
+def get_op_id(op):
+    """Get a unique identifier for an operation."""
+    return op.operation
+
+
+def get_location_str(location):
+    """Extract a human-readable location string from an MLIR location."""
+    loc_str = str(location)
+    # Location format is typically: loc("filename":line:col)
+    # Extract the relevant parts
+    if loc_str.startswith("loc("):
+        loc_str = loc_str[4:-1]  # Remove loc( and )
+    return loc_str
+
+
+def process_func_op(func_op, uf, op_map):
+    """Process a func.func operation and add its ops to the union-find structure."""
+    for region in func_op.regions:
+        for block in region:
+            for op in block.operations:
+                # Skip ignored operations
+                if op.name in OP_IGNORELIST:
+                    continue
+
+                op_id = get_op_id(op)
+                op_map[op_id] = op
+                uf.find(op_id)  # Ensure the operation is in the union-find
+
+                # Connect this operation to the operations that define its operands
+                for operand in op.operands:
+                    # Get the defining operation for this operand
+                    # operand.owner gives us the operation that defines this value
+                    defining_op = operand.owner
+                    if defining_op is None:
+                        # This is a block argument, not defined by an operation
+                        continue
+
+                    # owner can be a Block (for block arguments), skip those
+                    if not hasattr(defining_op, "name"):
+                        continue
+
+                    # Skip if the defining operation is in the ignorelist
+                    if defining_op.name in OP_IGNORELIST:
+                        continue
+
+                    defining_op_id = get_op_id(defining_op)
+
+                    # Only connect if the defining op is in our set
+                    # (it might be outside if we're not traversing into regions)
+                    if defining_op_id in op_map:
+                        uf.union(op_id, defining_op_id)
+
+
+def find_connected_components(module):
+    """
+    Find weakly connected components in the MLIR module.
+
+    Returns a list of components, where each component is a list of operations.
+    Only components with more than one operation are returned.
+    """
+    uf = UnionFind()
+    op_map = {}  # id -> operation
+
+    # Collect all operations and build the union-find structure
+    # Recurse into top-level func.func ops and func.func ops inside ttcore.device_module
+    for entry in module.body.operations:
+        op_name = entry.operation.name
+        if op_name == "func.func":
+            process_func_op(entry, uf, op_map)
+        elif op_name == "ttcore.device_module":
+            # Recurse into device_module to find nested func.func ops
+            for region in entry.regions:
+                for block in region:
+                    for nested_op in block.operations:
+                        assert nested_op.operation.name == "builtin.module"
+                        for region in nested_op.operation.regions:
+                            for block in region:
+                                for nested_op in block.operations:
+                                    if nested_op.operation.name == "func.func":
+                                        process_func_op(nested_op, uf, op_map)
+
+    # Group operations by their component representative
+    components = defaultdict(list)
+    for op_id, op in op_map.items():
+        root = uf.find(op_id)
+        components[root].append(op)
+
+    # Filter out components of size 1
+    return [ops for ops in components.values() if len(ops) > 1]
+
+
+def print_components(components):
+    """Print the discovered connected components."""
+    if not components:
+        print("No connected components of size > 1 found.")
+        return
+
+    print(f"Found {len(components)} connected component(s) of size > 1:\n")
+
+    for i, ops in enumerate(components, 1):
+        print(f"Component {i} ({len(ops)} operations):")
+        for op in ops:
+            loc_str = get_location_str(op.location)
+            print(f"  - {op.name} @ {loc_str}")
+        print()
+
+
+def topological_sort(ops):
+    """Sort operations in topological order based on SSA dependencies."""
+    op_set = set(get_op_id(op) for op in ops)
+    op_by_id = {get_op_id(op): op for op in ops}
+
+    # Build dependency graph within the component
+    in_degree = {get_op_id(op): 0 for op in ops}
+    dependents = defaultdict(list)
+
+    for op in ops:
+        op_id = get_op_id(op)
+        for operand in op.operands:
+            defining_op = operand.owner
+            if defining_op is None or not hasattr(defining_op, "name"):
+                continue
+            def_id = get_op_id(defining_op)
+            if def_id in op_set and def_id != op_id:
+                in_degree[op_id] += 1
+                dependents[def_id].append(op_id)
+
+    # Kahn's algorithm
+    queue = [op_id for op_id, deg in in_degree.items() if deg == 0]
+    sorted_ops = []
+
+    while queue:
+        op_id = queue.pop(0)
+        sorted_ops.append(op_by_id[op_id])
+        for dep_id in dependents[op_id]:
+            in_degree[dep_id] -= 1
+            if in_degree[dep_id] == 0:
+                queue.append(dep_id)
+
+    return sorted_ops
+
+
+def get_op_operands(op):
+    """Get input and output operands for an operation (handles DPS convention)."""
+    if "operandSegmentSizes" in op.attributes:
+        segments = op.attributes["operandSegmentSizes"]
+        assert len(segments) == 2
+        ins, outs = segments
+        assert ins + outs == len(op.operands)
+        return (list(op.operands[:ins]), list(op.operands[ins:]))
+    elif ttmlir.util.is_dps(op):
+        return (list(op.operands[:-1]), list(op.operands[-1:]))
+    return (list(op.operands), [])
+
+
+def emit_component_as_func(ops, func_name, ip, loc):
+    """Emit a connected component as a standalone func.func."""
+    sorted_ops = topological_sort(ops)
+    op_set = set(get_op_id(op) for op in ops)
+
+    # Find external inputs (operands defined outside the component)
+    external_inputs = []  # List of (value, type)
+    external_input_map = {}  # value -> index in external_inputs
+
+    for op in sorted_ops:
+        for operand in op.operands:
+            defining_op = operand.owner
+            # External if: no owner, owner is a Block, or owner not in component
+            is_external = (
+                defining_op is None
+                or not hasattr(defining_op, "name")
+                or get_op_id(defining_op) not in op_set
+            )
+            if is_external and operand not in external_input_map:
+                external_input_map[operand] = len(external_inputs)
+                external_inputs.append((operand, operand.type))
+
+    # Find outputs (results of the last operation in topological order)
+    # For simplicity, use all results of the final operation
+    final_op = sorted_ops[-1]
+    result_types = [result.type for result in final_op.results]
+
+    # Create the function
+    input_types = [t for _, t in external_inputs]
+    entry = func.FuncOp(func_name, (input_types, result_types), ip=ip, loc=loc)
+    entry_block = Block.create_at_start(entry.body, input_types)
+
+    with InsertionPoint(entry_block) as block_ip, Location.unknown() as block_loc:
+        # Map from original values to new values
+        value_map = {}
+
+        # Map external inputs to block arguments
+        for orig_value, idx in external_input_map.items():
+            value_map[orig_value] = entry_block.arguments[idx]
+
+        # Clone each operation in topological order
+        for op in sorted_ops:
+            op_inputs, op_outputs = get_op_operands(op)
+
+            # Remap input operands
+            new_operands = []
+            for operand in op_inputs:
+                if operand in value_map:
+                    new_operands.append(value_map[operand])
+                else:
+                    new_operands.append(operand)
+
+            # Create empty tensors for DPS outputs
+            for output in op_outputs:
+                output_type = output.type
+                empty_op = ttir.empty(
+                    output_type.shape,
+                    output_type.element_type,
+                    encoding=output_type.encoding,
+                    ip=block_ip,
+                    loc=block_loc,
+                )
+                new_operands.append(empty_op)
+
+            # Clone the operation
+            attrs = {attr.name: attr.attr for attr in op.attributes}
+            new_op = Operation.create(
+                name=op.name,
+                results=[r.type for r in op.results],
+                operands=new_operands,
+                attributes=attrs,
+                successors=op.successors,
+                regions=len(op.regions),
+                loc=block_loc,
+                ip=block_ip,
+            )
+
+            # Map results
+            for orig_result, new_result in zip(op.results, new_op.results):
+                value_map[orig_result] = new_result
+
+        # Create return with the final operation's results
+        final_results = [value_map[r] for r in final_op.results]
+        Operation.create(
+            name="func.return",
+            results=[],
+            operands=final_results,
+            loc=block_loc,
+            ip=block_ip,
+        )
+
+
+def emit_components_as_module(components, ctx):
+    """Emit all connected components as a new MLIR module with func.func ops."""
+    out_module = Module.create(Location.unknown(ctx))
+    with InsertionPoint(out_module.body) as ip, Location.unknown() as loc:
+        for i, ops in enumerate(components, 1):
+            func_name = f"component_{i}"
+            emit_component_as_func(ops, func_name, ip, loc)
+    return out_module
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="d2m-discover: Discover weakly connected components in MLIR modules"
+    )
+    parser.add_argument("mlir", type=str, help="Path to the MLIR file")
+    parser.add_argument(
+        "--emit-funcs",
+        action="store_true",
+        help="Emit components as standalone func.func ops (outputs MLIR)",
+    )
+    args = parser.parse_args()
+
+    with Context() as ctx, open(args.mlir, "r") as mlir_fd:
+        ctx.allow_unregistered_dialects = True
+        module = Module.parse(mlir_fd.read())
+        components = find_connected_components(module)
+
+        if args.emit_funcs:
+            out_module = emit_components_as_module(components, ctx)
+            print(out_module)
+        else:
+            print_components(components)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script can be used to discover weakly connected subgraphs that do not contain ops in the OP_IGNORELIST (defined at the top of the script).

Usage (python enabled mlir build):

    # Pretty print the subgraphs
    python tools/scripts/d2m-discover.py test/ttmlir/models/llama_attention.mlir

    # Print the subgraphs as standalone mlir funcs for unit test generation
    python tools/scripts/d2m-discover.py --emit-funcs test/ttmlir/models/llama_attention.mlir