### PR TITLE
Fix LinearOp parameter order to match MatmulOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1486,13 +1486,13 @@ def TTNN_LinearOp : TTNN_Op<"linear", [TTNN_ComputeKernelConfigOpInterface]> {
                          Optional<AnyRankedTensor>:$bias,
                          DefaultValuedAttr<BoolAttr, "false">:$transpose_a,
                          DefaultValuedAttr<BoolAttr, "false">:$transpose_b,
-                         OptionalAttr<StrAttr>:$activation,
                          OptionalAttr<AnyAttrOf<[
                             TTNN_MatmulMultiCoreReuseProgramConfigAttr,
                             TTNN_MatmulMultiCoreReuseMultiCastProgramConfigAttr,
                             TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
                             TTNN_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
                          ]>>:$matmul_program_config,
+                         OptionalAttr<StrAttr>:$activation,
                          OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
@@ -1503,7 +1503,7 @@ def TTNN_LinearOp : TTNN_Op<"linear", [TTNN_ComputeKernelConfigOpInterface]> {
                      "StringAttr":$activation),
       [{
         build($_builder, $_state, result, a, b, bias, transpose_a, transpose_b,
-              activation, /*matmul_program_config=*/nullptr, /*compute_config=*/nullptr);
+              /*matmul_program_config=*/nullptr, activation, /*compute_config=*/nullptr);
       }]>
     ];
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1143,8 +1143,8 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::LinearOp>(
         op, this->getTypeConverter()->convertType(op.getType()), adaptor.getA(),
         adaptor.getB(), adaptor.getBias(), adaptor.getTransposeA(),
-        adaptor.getTransposeB(), /*activation=*/nullptr,
-        /*matmul_program_config=*/nullptr, /*compute_config=*/nullptr);
+        adaptor.getTransposeB(), /*matmul_program_config=*/nullptr,
+        /*activation=*/nullptr, /*compute_config=*/nullptr);
     return success();
   }
 };


### PR DESCRIPTION
LinearOp had matmul_program_config after activation in the TableGen definition, which was inconsistent with MatmulOp (which has matmul_program_config before activation) and the TTNN API.

Fixes #6552

