### PR TITLE
Stablehlo Fusing 

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -108,6 +108,38 @@ def ConvertXlaSdyToSdyPass : Pass<"convert-xla-sdy-to-sdy", "::mlir::ModuleOp">
   ];
 }
 
+def StableHLOFusingPass : Pass<"stablehlo-fusing", "::mlir::ModuleOp">
+{
+  let summary = "StableHLO fusing pass for shardy passes optimization.";
+  let description = [{
+    This pass tries to fuse stablehlo operations together with the goal of optimizing shardy passes.
+    If proposed fusion is not optimizing shardy passes, it should be implemented in lower level passes. i.e. in TTIR/ TTNN fusion passes.
+
+    For example, it implements `ConcatenateToBroadcastInDimFusionPattern` pattern which fuses stablehlo.concatenate
+    and stablehlo.reshape into stablehlo.broadcast_in_dim. This is due to the fact that
+    stablehlo.broadcast_in_dim propagates shardings better during UserPriorityPropagationPass and InsertExplicitReshardsPass.
+    See https://github.com/openxla/shardy/issues/945 for more details.
+
+    Example, this pass will convert the following code:
+    ```mlir
+      %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 :
+            (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) ->
+            tensor<6x4xbf16>
+      %1 = stablehlo.reshape %0 : (tensor<6x4xbf16>) -> tensor<3x2x4xbf16>
+    ```
+
+    Into:
+    ```mlir
+      %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 2] :
+            (tensor<2x4xbf16>) -> tensor<3x2x4xbf16>
+    ```
+  }];
+
+  let dependentDialects = [
+    "::mlir::stablehlo::StablehloDialect"
+  ];
+}
+
 def PartiallyConvertSdyToStableHLOPass : Pass<"partially-convert-sdy-to-stablehlo", "::mlir::ModuleOp">
 {
   let summary = "Partially convert Shardy operations to StableHLO operations.";
@@ -140,7 +172,6 @@ def PartiallyConvertSdyToStableHLOPass : Pass<"partially-convert-sdy-to-stablehl
     "::mlir::sdy::SdyDialect"
   ];
 }
-
 
 def AnalyzeMeshPass : Pass<"analyze-mesh", "::mlir::ModuleOp">
 {

--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h
@@ -193,6 +193,9 @@ std::optional<mlir::DenseElementsAttr> tryGetPeriodicShardSlice(
     mlir::DenseElementsAttr globalAttr, mlir::RankedTensorType localType,
     mlir::sdy::TensorShardingAttr sharding, mlir::sdy::MeshOp meshOp);
 
+// Check if the operation has Shardy-sharded inputs or outputs.
+bool opHasShardySharding(mlir::Operation *op);
+
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 
 } // namespace mlir::tt::shardy_utils

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -76,8 +76,8 @@ def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::M
 {
   let summary = "Normalize element types into list of supported types.";
   let description = [{
-    "This pass walks through the graph and normalizes the element types into a list of supported types. This is useful for lowering
-        to a target that only supports a subset of the element types.
+    This pass walks through the graph and normalizes the element types into a list of supported types. This is useful for lowering
+    to a target that only supports a subset of the element types.
   }];
 
   list<Option> options = [

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -25,6 +25,9 @@ void createStableHLOPipeline(OpPassManager &pm,
   // Convert any xla.sdy ops to sdy ops.
   pm.addPass(createConvertXlaSdyToSdyPass());
 
+  // Apply StableHLO fusing pass.
+  pm.addPass(mlir::tt::stablehlo::createStableHLOFusingPass());
+
   // Partially convert sdy ops to stablehlo.
   pm.addPass(createPartiallyConvertSdyToStableHLOPass());
 

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   ReoutlineComposite.cpp
   ShardyCCLCanonicalization.cpp
   ShardyCCLToStableHLOCCLPatterns.cpp
+  StableHLOFusing.cpp
   UnsolvedGraphPasses.cpp
   UpdateGlobalToLocalShapes.cpp
   WrapUnderManualComputation.cpp

--- a/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
+++ b/lib/Dialect/StableHLO/Transforms/StableHLOFusing.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+#include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_STABLEHLOFUSINGPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+// Fuses concatenate + reshape patterns into broadcast_in_dim operations.
+//
+// Example transformation:
+//   Input:
+//     %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 :
+//            (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) ->
+//            tensor<6x4xbf16>
+//     %1 = stablehlo.reshape %0 : (tensor<6x4xbf16>) -> tensor<3x2x4xbf16>
+//
+//   Output:
+//     %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 2] :
+//            (tensor<2x4xbf16>) -> tensor<3x2x4xbf16>
+//
+// The concatenate -> reshape fusion pattern is valid when the number of repeats
+// (3 in this example) appears in the reshape output shape before the
+// concatenate dimension. Here, the repeat count 3 appears at dimension 0 in the
+// output shape <3x2x4xbf16>, which comes just before the original concatenate
+// dimension 0 (now dimension 1 in the output: <3x2x4xbf16>). The broadcast
+// dims [1, 2] correspond to the original tensor dimensions, while dimension 0
+// handles the repeat.
+//
+// Fusion is skipped if any of the operations involved have sharded inputs or
+// outputs, as sharding adds complexity that requires separate handling.
+//
+// TODO(@ddilbazTT): Add support for reshape -> concat fusion.
+class ConcatenateToBroadcastInDimFusionPattern
+    : public OpRewritePattern<::mlir::stablehlo::ConcatenateOp> {
+  using OpRewritePattern<::mlir::stablehlo::ConcatenateOp>::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(::mlir::stablehlo::ConcatenateOp concatOp,
+                                ::mlir::PatternRewriter &rewriter) const final {
+    // Check if fusable.
+    if (!isFusable(concatOp)) {
+      return failure();
+    }
+    // Fuse concat -> reshape.
+    // To find broadcast dims, remove the concat dim from reshape output shape.
+    ::mlir::stablehlo::ReshapeOp reshapeOp =
+        mlir::dyn_cast<::mlir::stablehlo::ReshapeOp>(
+            *concatOp.getResult().getUsers().begin());
+    if (!reshapeOp) {
+      return failure();
+    }
+    ArrayRef<int64_t> reshapeOutputShape =
+        reshapeOp.getResult().getType().getShape();
+    uint64_t dim = concatOp.getDimension();
+    SmallVector<int64_t> broadcastDims;
+    for (size_t i = 0; i < reshapeOutputShape.size(); i++) {
+      if (i != dim) {
+        broadcastDims.push_back(i);
+      }
+    }
+    // Create broadcast_in_dim op with concatenate input and broadcast dims.
+    // Replace reshape op with broadcast_in_dim op.
+    ::mlir::stablehlo::BroadcastInDimOp broadcastInDimOp =
+        rewriter.create<::mlir::stablehlo::BroadcastInDimOp>(
+            concatOp.getLoc(), reshapeOp.getResult().getType(),
+            concatOp.getInputs()[0], broadcastDims);
+    rewriter.replaceOp(reshapeOp, broadcastInDimOp.getResult());
+    return success();
+  }
+
+private:
+  bool isFusable(::mlir::stablehlo::ConcatenateOp concatOp) const {
+    // Check all arguments of concat are the same.
+    if (!::llvm::all_equal(concatOp.getInputs())) {
+      return false;
+    }
+
+    // Case 1: concat -> reshape.
+    // Check concat has one user and that user is a reshape op.
+    if (concatOp.getResult().hasOneUse()) {
+      if (auto reshapeOp = mlir::dyn_cast<::mlir::stablehlo::ReshapeOp>(
+              *concatOp.getResult().getUsers().begin())) {
+        if (!checkConcatThenReshape(concatOp, reshapeOp)) {
+          return false;
+        }
+        // Do not fuse if either concatenate or reshape op inputs or outputs are
+        // sharded. Otherwise, would need to accommodate for sharding attributes
+        // which is out of scope for this fusion pass.
+        if (shardy_utils::opHasShardySharding(reshapeOp.getOperation()) ||
+            shardy_utils::opHasShardySharding(concatOp.getOperation())) {
+          return false;
+        }
+        return true;
+      }
+    }
+
+    // Note: Not yet added support for reshape -> concat fusion.
+    return false;
+  }
+
+  bool checkConcatThenReshape(::mlir::stablehlo::ConcatenateOp concatOp,
+                              ::mlir::stablehlo::ReshapeOp reshapeOp) const {
+    auto concatInput =
+        mlir::cast<TypedValue<RankedTensorType>>(concatOp.getInputs()[0]);
+    ArrayRef<int64_t> concatInputShape = concatInput.getType().getShape();
+    ArrayRef<int64_t> reshapeOutputShape =
+        reshapeOp.getResult().getType().getShape();
+    // Number of dimensions of concat should be -1 number of dimensions of
+    // reshape.
+    if (concatInputShape.size() !=
+        static_cast<size_t>(reshapeOutputShape.size() - 1)) {
+      return false;
+    }
+    // If concat dim is i, reshape_output[i] = repeat_dim, reshape_output[i+1] =
+    // concat_input[i]
+    uint64_t dim = concatOp.getDimension();
+    // num repeats is the number of concat inputs.
+    int64_t numRepeats = static_cast<int64_t>(concatOp.getInputs().size());
+    if (reshapeOutputShape[dim] != numRepeats) {
+      return false;
+    }
+    if (reshapeOutputShape[dim + 1] != concatInputShape[dim]) {
+      return false;
+    }
+    return true;
+  }
+};
+
+struct StableHLOFusingPass
+    : public impl::StableHLOFusingPassBase<StableHLOFusingPass> {
+public:
+  using impl::StableHLOFusingPassBase<
+      StableHLOFusingPass>::StableHLOFusingPassBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ConcatenateToBroadcastInDimFusionPattern>(&getContext());
+
+    GreedyRewriteConfig config;
+    config.setUseTopDownTraversal(true);
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
+  }
+};
+} // namespace mlir::tt::stablehlo

--- a/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/broadcast_in_dim.mlir
+++ b/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/broadcast_in_dim.mlir
@@ -1,0 +1,89 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline --split-input-file  -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module {
+  sdy.mesh @mesh = <["_axis_0"=8]>
+  func.func @concatenate_reshape_test(%arg0: tensor<128x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, %arg1: tensor<32x2880x5760xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}, {}]>}) -> tensor<32x128x5760xbf16> {
+    %0 = stablehlo.concatenate
+        %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0,
+        %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0,
+        %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0,
+        %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0, %arg0,
+        dim = 0 : (
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>,
+          tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>
+        ) -> tensor<4096x2880xbf16>
+
+    %1 = stablehlo.reshape %0 : (tensor<4096x2880xbf16>) -> tensor<32x128x2880xbf16>
+    %2 = stablehlo.dot_general %1, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1] : (tensor<32x128x2880xbf16>, tensor<32x2880x5760xbf16>) -> tensor<32x128x5760xbf16>
+    // CHECK: stablehlo.broadcast_in_dim
+    // CHECK-SAME: dims = [1, 2]
+    return %2 : tensor<32x128x5760xbf16>
+  }
+  // Test that fusion does NOT occur when input is sharded.
+  func.func @concatenate_reshape_sharded_input(%arg0: tensor<128x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>}) -> tensor<3x128x2880xbf16> {
+    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 : (tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>) -> tensor<384x2880xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<384x2880xbf16>) -> tensor<3x128x2880xbf16>
+    // CHECK-NOT: stablehlo.broadcast_in_dim
+    return %1 : tensor<3x128x2880xbf16>
+  }
+
+  // Test that fusion does NOT occur when concatenate output is sharded.
+  func.func @concatenate_reshape_sharded_output(%arg0: tensor<128x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<3x128x2880xbf16> {
+    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"_axis_0"}, {}]>]>} : (tensor<128x2880xbf16>, tensor<128x2880xbf16>, tensor<128x2880xbf16>) -> tensor<384x2880xbf16>
+    %1 = stablehlo.reshape %0 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"_axis_0"}, {}]>]>} : (tensor<384x2880xbf16>) -> tensor<3x128x2880xbf16>
+    // CHECK-NOT: stablehlo.broadcast_in_dim
+    return %1 : tensor<3x128x2880xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @concatenate_reshape(%arg0: tensor<2x4xbf16>) -> tensor<2x3x4xbf16> {
+    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 : (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) -> tensor<6x4xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<6x4xbf16>) -> tensor<2x3x4xbf16>
+    // CHECK-NOT: stablehlo.broadcast_in_dim
+    return %1 : tensor<2x3x4xbf16>
+    // not a broadcast operation
+  }
+  func.func @concatenate_reshape_2(%arg0: tensor<2x4xbf16>) -> tensor<3x2x4xbf16> {
+    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 : (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) -> tensor<6x4xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<6x4xbf16>) -> tensor<3x2x4xbf16>
+    // CHECK: stablehlo.broadcast_in_dim
+    // CHECK-SAME: dims = [1, 2]
+    return %1 : tensor<3x2x4xbf16>
+    // broadcast dims [1, 2]
+  }
+  func.func @concatenate_reshape_3(%arg0: tensor<2x4xbf16>) -> tensor<2x3x4xbf16> {
+    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 1 : (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) -> tensor<2x12xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<2x12xbf16>) -> tensor<2x3x4xbf16>
+    // CHECK: stablehlo.broadcast_in_dim
+    // CHECK-SAME: dims = [0, 2]
+    return %1 : tensor<2x3x4xbf16>
+    // broadcast dims [0, 2]
+  }
+  func.func @concatenate_reshape_4(%arg0: tensor<2x4xbf16>) -> tensor<3x2x4xbf16> {
+    %0 = stablehlo.reshape %arg0 : (tensor<2x4xbf16>) -> tensor<1x2x4xbf16>
+    %1 = stablehlo.concatenate %0, %0, %0, dim = 0 : (tensor<1x2x4xbf16>, tensor<1x2x4xbf16>, tensor<1x2x4xbf16>) -> tensor<3x2x4xbf16>
+    // not yet added support for reshape -> concat fusion
+    // CHECK-NOT: stablehlo.broadcast_in_dim
+    return %1 : tensor<3x2x4xbf16>
+    // broadcast dims [1, 2]
+  }
+  func.func @concatenate_reshape_5(%arg0: tensor<2x4xbf16>) -> tensor<2x3x4xbf16> {
+    %0 = stablehlo.reshape %arg0 : (tensor<2x4xbf16>) -> tensor<2x1x4xbf16>
+    %1 = stablehlo.concatenate %0, %0, %0, dim = 1 : (tensor<2x1x4xbf16>, tensor<2x1x4xbf16>, tensor<2x1x4xbf16>) -> tensor<2x3x4xbf16>
+    // not yet added support for reshape -> concat fusion
+    // CHECK-NOT: stablehlo.broadcast_in_dim
+    return %1 : tensor<2x3x4xbf16>
+    // broadcast dims [0, 2]
+  }
+}


### PR DESCRIPTION
### Ticket
None

### Problem description
It would be preferable to have a stablehlo fusion pass before sharding passes to optimize sharding pass behaviour. One example of this is concatenate + reshape, which can be fused into broadcast in certain situations. Broadcast sharding is implemented better compared to concatenate + reshape. Support for this has been added in tt-xla as a pytorch decomposition: https://github.com/tenstorrent/tt-xla/commit/4711f260529df63d403aec5debafe548633d0e7e However, there will be sharding related errors in concatenate op if running in eager mode.

Example concatenate + reshape:
```
    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 0 : (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) -> tensor<6x4xbf16>
    %1 = stablehlo.reshape %0 : (tensor<6x4xbf16>) -> tensor<3x2x4xbf16>
```
We need to check that the repeat nums is before the dim concatenated along. In this example, `%arg0` is concatenated three times. Therefore repeat nums = 3. Concatenation is along dim 0. So 3 needs to come before concatenate dim. 
input: `<2x4xbf16>` -> output: `<3x2x4xbf16>` --> 3 (repeat nums) is before concatenate dim. 

This is equivalent to broadcasting `%arg0` with broadcast dims `[1, 2]`. `0` now corresponds to the repeat. 

However if the reshape output was `<2x3x4xbf16`, it wouldn't be a valid `broadcast_in_dim`. 

Another concatenate + reshape example:
```
    %0 = stablehlo.concatenate %arg0, %arg0, %arg0, dim = 1 : (tensor<2x4xbf16>, tensor<2x4xbf16>, tensor<2x4xbf16>) -> tensor<2x12xbf16>
    %1 = stablehlo.reshape %0 : (tensor<2x12xbf16>) -> tensor<2x3x4xbf16>
```
repeat nums = 3. Concatenate dim is 1. So repeat nums needs to come before concatenate dim.
input: `<2x4xbf16>` -> output: `<2x3x4xbf16>` -> 3 (repeat nums) is before concatenate dim.

This is equivalent to broadcasting `%arg0` with broadcast dims `[0, 2]`. `1` now corresponds to the repeat.

### What's changed
Created stablehlo fusing pass and added a `broadcast_in_dim` fusion pass which determines a valid concatenate -> reshape chain. reshape -> concatenate would also yield valid broadcast_in_dim pattern but currently not added yet. This is a proof of concept for stablehlo fusion pass. 

### Checklist
- [X] Created `test/ttmlir/Dialect/StableHLO/stablehlo_fusing` folder and added `test/ttmlir/Dialect/StableHLO/stablehlo_fusing/broadcast_in_dim.mlir` with expected or not supported fusions. 
- [X] ran with tt-xla uplift qualifications test: https://github.com/tenstorrent/tt-xla/actions/runs/21832117293 
    - previous failures are due to github outage
