### PR TITLE
Fusing linear with GELU

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -962,7 +962,9 @@ public:
         TTNNMatmulAndLinearWithActivation<MatmulOp, SigmoidOp>,
         TTNNMatmulAndLinearWithActivation<LinearOp, SigmoidOp>,
         TTNNMatmulAndLinearWithActivation<MatmulOp, SiluOp>,
-        TTNNMatmulAndLinearWithActivation<LinearOp, SiluOp>>(&getContext());
+        TTNNMatmulAndLinearWithActivation<LinearOp, SiluOp>,
+        TTNNMatmulAndLinearWithActivation<MatmulOp, GeluOp>,
+        TTNNMatmulAndLinearWithActivation<LinearOp, GeluOp>>(&getContext());
 
 #ifdef TTMLIR_ENABLE_OPMODEL
     if (enableOpConstraints) {

--- a/test/ttmlir/Dialect/TTNN/Transforms/Fusing/matmul_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Fusing/matmul_fusing.mlir
@@ -27,6 +27,19 @@ module {
     }
 }
 
+// Test fusing gelu activation into matmul operation
+module {
+    func.func @matmul_gelu(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x256xbf16>) -> tensor<64x256xbf16> {
+        // CHECK: %[[MATMUL:[0-9]+]] = "ttnn.matmul"(%arg0, %arg1)
+        // CHECK-SAME: activation = "gelu"
+        // CHECK-NOT: ttnn.gelu
+        // CHECK: return %[[MATMUL]]
+        %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<64x128xbf16>, tensor<128x256xbf16>) -> tensor<64x256xbf16>
+        %1 = "ttnn.gelu"(%0) : (tensor<64x256xbf16>) -> tensor<64x256xbf16>
+        return %1 : tensor<64x256xbf16>
+    }
+}
+
 // Test matmul without activation (should not be modified)
 module {
     func.func @matmul_no_activation(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x256xbf16>) -> tensor<64x256xbf16> {


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/5954

### Problem description
LinearOp can be fused with GELU activation function.

### What's changed
Added GeluOp as a valid activation function for fusing with MatmulOp and LinearOp.

### Checklist
- [x] New/Existing tests provide coverage for changes
