### PR TITLE
Simplify const-evaluation of MeshShardOp

### DIFF
--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -170,13 +170,6 @@ private:
       return;
     }
 
-    // Skip non-identity mesh shard ops.
-    if (auto meshShardOp = mlir::dyn_cast<mlir::tt::ttnn::MeshShardOp>(op)) {
-      if (meshShardOp.getShardType() != ttcore::MeshShardType::Identity) {
-        return;
-      }
-    }
-
     // Handle shared ops separately as well.
     if (isSharedOp(op)) {
       sharedOps.push_back(op);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Since `ttnn::MeshShardOp` is always an identity-sharding operation, `ConstEvalHoist` pass can be simplified by removing the check altogether.

### Checklist
- [ ] New/Existing tests provide coverage for changes
