### PR TITLE
Restructured mlir python bindings to fit CAPI pattern

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -12,18 +12,117 @@
 extern "C" {
 #endif
 
-MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTGridAttrGet(MlirContext ctx,
-                                                     int64_t *shape,
-                                                     size_t shapeSize);
+//===----------------------------------------------------------------------===//
+// TileType
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool ttmlirIsTileType(MlirType type);
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTileTypeGet(MlirContext ctx, int64_t height,
+                                              int64_t width,
+                                              MlirAttribute dataType);
+
+MLIR_CAPI_EXPORTED int64_t ttmlirTileTypeGetHeight(MlirType type);
+
+MLIR_CAPI_EXPORTED int64_t ttmlirTileTypeGetWidth(MlirType type);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTileTypeGetDataType(MlirType type);
+
+//===----------------------------------------------------------------------===//
+// GridAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool ttmlirIsGridAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirGridAttrGet(MlirContext ctx,
+                                                   intptr_t nShape,
+                                                   const int64_t *shape);
+
+MLIR_CAPI_EXPORTED intptr_t ttmlirGridAttrGetShapeSize(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED int64_t ttmlirGridAttrGetShapeElem(MlirAttribute attr,
+                                                      intptr_t pos);
+
+//===----------------------------------------------------------------------===//
+// ReduceTypeAttr
+//===----------------------------------------------------------------------===//
+
+enum MlirReduceTypeEnum {
+  MlirReduceTypeSum,
+  MlirReduceTypeMean,
+  MlirReduceTypeMax,
+  MlirReduceTypeMin,
+  MlirReduceTypeStd,
+  MlirReduceTypeVar,
+  MlirReduceTypeProd,
+  MlirReduceTypeInvalid,
+};
+typedef enum MlirReduceTypeEnum MlirReduceTypeEnum;
+
+MLIR_CAPI_EXPORTED bool ttmlirIsReduceTypeAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirReduceTypeAttrGet(MlirContext ctx, MlirReduceTypeEnum reduceType);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirReduceTypeAttrFromStringGet(MlirContext ctx, MlirStringRef value);
+
+MLIR_CAPI_EXPORTED MlirReduceTypeEnum
+ttmlirReduceTypeAttrGetValue(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// DataTypeAttr
+//===----------------------------------------------------------------------===//
+
+enum MlirDataTypeEnum {
+  MlirDataTypeFloat32,
+  MlirDataTypeFloat16,
+  MlirDataTypeBFloat16,
+  MlirDataTypeBFP_Float8,
+  MlirDataTypeBFP_BFloat8,
+  MlirDataTypeBFP_Float4,
+  MlirDataTypeBFP_BFloat4,
+  MlirDataTypeBFP_Float2,
+  MlirDataTypeBFP_BFloat2,
+  MlirDataTypeUInt32,
+  MlirDataTypeUInt16,
+  MlirDataTypeUInt8,
+  MlirDataTypeInt32,
+  MlirDataTypeBool
+};
+typedef enum MlirDataTypeEnum MlirDataTypeEnum;
+
+MLIR_CAPI_EXPORTED bool ttmlirIsDataTypeAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirDataTypeAttrGet(MlirContext ctx, MlirDataTypeEnum dataType);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirDataTypeAttrFromStringGet(MlirContext ctx, MlirStringRef value);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirDataTypeAttrFromIntGet(MlirContext ctx,
+                                                              uint32_t value);
+
+MLIR_CAPI_EXPORTED MlirDataTypeEnum
+ttmlirDataTypeAttrGetValue(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
+// ChipCapabilityAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTChipCapabilityAttrGet(MlirContext ctx, uint32_t chipCapability);
 
+//===----------------------------------------------------------------------===//
+// ArchAttr
+//===----------------------------------------------------------------------===//
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTArchAttrGet(MlirContext ctx,
                                                      uint32_t arch);
 
-MLIR_CAPI_EXPORTED MlirAttribute
-ttmlirTTDataTypeAttrGet(MlirContext ctx, uint16_t *supportedDataTypes);
+//===----------------------------------------------------------------------===//
+// ChipDescAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
@@ -37,13 +136,25 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipDescAttrGet(
     unsigned numCBs, unsigned numComputeThreads,
     unsigned numDatamovementThreads);
 
+//===----------------------------------------------------------------------===//
+// ChipCoordAttr
+//===----------------------------------------------------------------------===//
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipCoordAttrGet(
     MlirContext ctx, unsigned rack, unsigned shelf, unsigned y, unsigned x);
+
+//===----------------------------------------------------------------------===//
+// ChipChannelAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipChannelAttrGet(
     MlirContext ctx, unsigned deviceId0, int64_t *ethernetCoreCoord0,
     size_t ethernetCoreCoord0Size, unsigned deviceId1,
     int64_t *ethernetCoreCoord1, size_t ethernetCoreCoord1Size);
+
+//===----------------------------------------------------------------------===//
+// SystemDescAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTSystemDescAttrGet(
     MlirContext ctx, MlirAttribute *cpuDescs, size_t cpuDescsSize,
@@ -53,26 +164,52 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTSystemDescAttrGet(
     size_t chipCoordsSize, MlirAttribute *chipChannels,
     size_t chipChannelsSize);
 
-MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTMetalLayoutAttrGet(
-    MlirContext ctx, intptr_t logicalRank, const int64_t *logicalShape,
-    intptr_t gridRank, const int64_t *gridShape, MlirType elementType,
-    intptr_t tileRank, const int64_t *tileShape, unsigned oobVal,
-    unsigned memorySpace);
+//===----------------------------------------------------------------------===//
+// MetalLayoutAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirMetalLayoutAttrGet(
+    MlirContext ctx, intptr_t nLogicalShape, const int64_t *logicalShape,
+    uint32_t oobValValue, uint32_t memorySpaceValue);
+
+//===----------------------------------------------------------------------===//
+// MemorySpaceAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTMemorySpaceAttrGet(MlirContext ctx, uint32_t memorySpace);
 
+//===----------------------------------------------------------------------===//
+// OOBValAttr
+//===----------------------------------------------------------------------===//
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTOOBValAttrGet(MlirContext ctx,
                                                        uint32_t oobVal);
+
+//===----------------------------------------------------------------------===//
+// IteratorTypeAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTIteratorTypeAttrGet(MlirContext ctx, uint32_t iteratorType);
 
+//===----------------------------------------------------------------------===//
+// IteratorTypeArrayAttr
+//===----------------------------------------------------------------------===//
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTIteratorTypeArrayAttrGet(
     MlirContext ctx, uint32_t *iteratorTypes, size_t iteratorTypesSize);
 
+//===----------------------------------------------------------------------===//
+// TileSizeAttr
+//===----------------------------------------------------------------------===//
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx,
                                                          int64_t y, int64_t x);
+
+//===----------------------------------------------------------------------===//
+// CoreCoordAttr
+//===----------------------------------------------------------------------===//
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx,
                                                           int64_t y, int64_t x);

--- a/lib/CAPI/TTCoreAttrs.cpp
+++ b/lib/CAPI/TTCoreAttrs.cpp
@@ -2,18 +2,284 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 #include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
 #include "ttmlir-c/TTAttrs.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
 using namespace mlir::tt::ttcore;
 
-MlirAttribute ttmlirTTGridAttrGet(MlirContext ctx, int64_t *shape,
-                                  int shapeSize) {
-  return wrap(GridAttr::get(unwrap(ctx), {shape, shape + shapeSize},
-                            mlir::AffineMap::get(unwrap(ctx))));
+//===----------------------------------------------------------------------===//
+// TileType
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool ttmlirIsTileType(MlirType type) {
+  return mlir::isa<TileType>(unwrap(type));
 }
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTileTypeGet(MlirContext ctx, int64_t height,
+                                              int64_t width,
+                                              MlirAttribute dataType) {
+  return wrap(
+      TileType::get(unwrap(ctx), llvm::SmallVector<std::int64_t>{height, width},
+                    mlir::cast<DataTypeAttr>(unwrap(dataType)).getValue()));
+}
+
+MLIR_CAPI_EXPORTED int64_t ttmlirTileTypeGetHeight(MlirType type) {
+  return mlir::cast<TileType>(unwrap(type)).getHeight();
+}
+
+MLIR_CAPI_EXPORTED int64_t ttmlirTileTypeGetWidth(MlirType type) {
+  return mlir::cast<TileType>(unwrap(type)).getWidth();
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTileTypeGetDataType(MlirType type) {
+  TileType tileType = mlir::cast<TileType>(unwrap(type));
+  mlir::MLIRContext *ctx = tileType.getContext();
+  return wrap(DataTypeAttr::get(ctx, tileType.getDataType()));
+}
+
+//===----------------------------------------------------------------------===//
+// GridAttr
+//===----------------------------------------------------------------------===//
+
+bool ttmlirIsGridAttr(MlirAttribute attr) {
+  return mlir::isa<GridAttr>(unwrap(attr));
+}
+
+MlirAttribute ttmlirGridAttrGet(MlirContext ctx, intptr_t nShape,
+                                const int64_t *shape) {
+  return wrap(
+      GridAttr::get(unwrap(ctx), llvm::ArrayRef<int64_t>(shape, nShape)));
+}
+
+intptr_t ttmlirGridAttrGetShapeSize(MlirAttribute attr) {
+  return mlir::cast<GridAttr>(unwrap(attr)).getShape().size();
+}
+
+int64_t ttmlirGridAttrGetShapeElem(MlirAttribute attr, intptr_t pos) {
+  return mlir::cast<GridAttr>(unwrap(attr)).getShape()[pos];
+}
+
+//===----------------------------------------------------------------------===//
+// ReduceTypeAttr
+//===----------------------------------------------------------------------===//
+
+std::optional<ReduceType>
+enumTypeToReduceType(MlirReduceTypeEnum reduceTypeEnum) {
+  switch (reduceTypeEnum) {
+  case MlirReduceTypeSum:
+    return ReduceType::Sum;
+  case MlirReduceTypeMean:
+    return ReduceType::Mean;
+  case MlirReduceTypeMax:
+    return ReduceType::Max;
+  case MlirReduceTypeMin:
+    return ReduceType::Min;
+  case MlirReduceTypeStd:
+    return ReduceType::Std;
+  case MlirReduceTypeVar:
+    return ReduceType::Var;
+  case MlirReduceTypeProd:
+    return ReduceType::Prod;
+  case MlirReduceTypeInvalid:
+    return ReduceType::Invalid;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<MlirReduceTypeEnum> reduceTypeToEnumType(ReduceType reduceType) {
+  switch (reduceType) {
+  case ReduceType::Sum:
+    return MlirReduceTypeSum;
+  case ReduceType::Mean:
+    return MlirReduceTypeMean;
+  case ReduceType::Max:
+    return MlirReduceTypeMax;
+  case ReduceType::Min:
+    return MlirReduceTypeMin;
+  case ReduceType::Std:
+    return MlirReduceTypeStd;
+  case ReduceType::Var:
+    return MlirReduceTypeVar;
+  case ReduceType::Prod:
+    return MlirReduceTypeProd;
+  case ReduceType::Invalid:
+    return MlirReduceTypeInvalid;
+  }
+
+  return std::nullopt;
+}
+
+MLIR_CAPI_EXPORTED bool ttmlirIsReduceTypeAttr(MlirAttribute attr) {
+  return mlir::isa<ReduceTypeAttr>(unwrap(attr));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirReduceTypeAttrGet(MlirContext ctx, MlirReduceTypeEnum reduceType) {
+  std::optional<ReduceType> rt = enumTypeToReduceType(reduceType);
+
+  if (!rt) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return wrap(ReduceTypeAttr::get(unwrap(ctx), rt.value()));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirReduceTypeAttrFromStringGet(MlirContext ctx, MlirStringRef value) {
+  std::optional<ReduceType> reduceType = symbolizeReduceType(unwrap(value));
+
+  if (!reduceType) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return wrap(ReduceTypeAttr::get(unwrap(ctx), reduceType.value()));
+}
+
+MLIR_CAPI_EXPORTED MlirReduceTypeEnum
+ttmlirReduceTypeAttrGetValue(MlirAttribute attr) {
+  ReduceType reduceType = mlir::cast<ReduceTypeAttr>(unwrap(attr)).getValue();
+  std::optional<MlirReduceTypeEnum> reduceTypeEnum =
+      reduceTypeToEnumType(reduceType);
+
+  if (!reduceTypeEnum) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return reduceTypeEnum.value();
+}
+
+//===----------------------------------------------------------------------===//
+// DataTypeAttr
+//===----------------------------------------------------------------------===//
+
+std::optional<DataType> enumTypeToDataType(MlirDataTypeEnum dataTypeEnum) {
+  switch (dataTypeEnum) {
+  case MlirDataTypeFloat32:
+    return DataType::Float32;
+  case MlirDataTypeFloat16:
+    return DataType::Float16;
+  case MlirDataTypeBFloat16:
+    return DataType::BFloat16;
+  case MlirDataTypeBFP_Float8:
+    return DataType::BFP_Float8;
+  case MlirDataTypeBFP_BFloat8:
+    return DataType::BFP_BFloat8;
+  case MlirDataTypeBFP_Float4:
+    return DataType::BFP_Float4;
+  case MlirDataTypeBFP_BFloat4:
+    return DataType::BFP_BFloat4;
+  case MlirDataTypeBFP_Float2:
+    return DataType::BFP_Float2;
+  case MlirDataTypeBFP_BFloat2:
+    return DataType::BFP_BFloat2;
+  case MlirDataTypeUInt32:
+    return DataType::UInt32;
+  case MlirDataTypeUInt16:
+    return DataType::UInt16;
+  case MlirDataTypeUInt8:
+    return DataType::UInt8;
+  case MlirDataTypeInt32:
+    return DataType::Int32;
+  case MlirDataTypeBool:
+    return DataType::Bool;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<MlirDataTypeEnum> dataTypeToEnumType(DataType dataType) {
+  switch (dataType) {
+  case DataType::Float32:
+    return MlirDataTypeFloat32;
+  case DataType::Float16:
+    return MlirDataTypeFloat16;
+  case DataType::BFloat16:
+    return MlirDataTypeBFloat16;
+  case DataType::BFP_Float8:
+    return MlirDataTypeBFP_Float8;
+  case DataType::BFP_BFloat8:
+    return MlirDataTypeBFP_BFloat8;
+  case DataType::BFP_Float4:
+    return MlirDataTypeBFP_Float4;
+  case DataType::BFP_BFloat4:
+    return MlirDataTypeBFP_BFloat4;
+  case DataType::BFP_Float2:
+    return MlirDataTypeBFP_Float2;
+  case DataType::BFP_BFloat2:
+    return MlirDataTypeBFP_BFloat2;
+  case DataType::UInt32:
+    return MlirDataTypeUInt32;
+  case DataType::UInt16:
+    return MlirDataTypeUInt16;
+  case DataType::UInt8:
+    return MlirDataTypeUInt8;
+  case DataType::Int32:
+    return MlirDataTypeInt32;
+  case DataType::Bool:
+    return MlirDataTypeBool;
+  }
+
+  return std::nullopt;
+}
+
+MLIR_CAPI_EXPORTED bool ttmlirIsDataTypeAttr(MlirAttribute attr) {
+  return mlir::isa<DataTypeAttr>(unwrap(attr));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirDataTypeAttrGet(MlirContext ctx, MlirDataTypeEnum dataTypeEnum) {
+  std::optional<DataType> dataType = enumTypeToDataType(dataTypeEnum);
+
+  if (!dataType) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return wrap(DataTypeAttr::get(unwrap(ctx), dataType.value()));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirDataTypeAttrFromStringGet(MlirContext ctx, MlirStringRef value) {
+  std::optional<DataType> dataType = DataTypeStringToEnum(unwrap(value));
+
+  if (!dataType) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return wrap(DataTypeAttr::get(unwrap(ctx), dataType.value()));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirDataTypeAttrFromIntGet(MlirContext ctx,
+                                                              uint32_t value) {
+  std::optional<DataType> dataType = symbolizeDataType(value);
+
+  if (!dataType) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return wrap(DataTypeAttr::get(unwrap(ctx), dataType.value()));
+}
+
+MLIR_CAPI_EXPORTED MlirDataTypeEnum
+ttmlirDataTypeAttrGetValue(MlirAttribute attr) {
+  DataType dataType = mlir::cast<DataTypeAttr>(unwrap(attr)).getValue();
+  std::optional<MlirDataTypeEnum> dataTypeEnum = dataTypeToEnumType(dataType);
+
+  if (!dataTypeEnum) {
+    llvm::report_fatal_error("Invalid value.");
+  }
+
+  return dataTypeEnum.value();
+}
+
+//===----------------------------------------------------------------------===//
+// ChipCapabilityAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTChipCapabilityAttrGet(MlirContext ctx,
                                             uint32_t chipCapability) {
@@ -21,15 +287,17 @@ MlirAttribute ttmlirTTChipCapabilityAttrGet(MlirContext ctx,
       unwrap(ctx), static_cast<ChipCapability>(chipCapability)));
 }
 
+//===----------------------------------------------------------------------===//
+// ArchAttr
+//===----------------------------------------------------------------------===//
+
 MlirAttribute ttmlirTTArchAttrGet(MlirContext ctx, uint32_t arch) {
   return wrap(ArchAttr::get(unwrap(ctx), static_cast<Arch>(arch)));
 }
 
-MlirAttribute ttmlirTTDataTypeAttrGet(MlirContext ctx,
-                                      uint16_t *supportedDataTypes) {
-  return wrap(DataTypeAttr::get(unwrap(ctx),
-                                static_cast<DataType>(*supportedDataTypes)));
-}
+//===----------------------------------------------------------------------===//
+// ChipDescAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
@@ -57,10 +325,18 @@ MlirAttribute ttmlirTTChipDescAttrGet(
       dstPhysicalSizeTiles, numCBs, numComputeThreads, numDatamovementThreads));
 }
 
+//===----------------------------------------------------------------------===//
+// ChipCoordAttr
+//===----------------------------------------------------------------------===//
+
 MlirAttribute ttmlirTTChipCoordAttrGet(MlirContext ctx, unsigned rack,
                                        unsigned shelf, unsigned y, unsigned x) {
   return wrap(ChipCoordAttr::get(unwrap(ctx), rack, shelf, y, x));
 }
+
+//===----------------------------------------------------------------------===//
+// ChipChannelAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTChipChannelAttrGet(MlirContext ctx, unsigned deviceId0,
                                          int64_t *ethernetCoreCoord0,
@@ -75,6 +351,10 @@ MlirAttribute ttmlirTTChipChannelAttrGet(MlirContext ctx, unsigned deviceId0,
   return wrap(ChipChannelAttr::get(unwrap(ctx), deviceId0, ethCoord0Vec,
                                    deviceId1, ethCoord1Vec));
 }
+
+//===----------------------------------------------------------------------===//
+// SystemDescAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTSystemDescAttrGet(
     MlirContext ctx, MlirAttribute *cpuDescs, size_t cpuDescsSize,
@@ -124,17 +404,28 @@ MlirAttribute ttmlirTTSystemDescAttrGet(
       chipCapabilitiesUnwrapped, chipCoordsUnwrapped, chipChannelsUnwrapped));
 }
 
-MlirAttribute ttmlirTTMetalLayoutAttrGet(MlirContext ctx, intptr_t logicalRank,
-                                         const int64_t *logicalShape,
-                                         intptr_t gridRank, unsigned oobVal,
-                                         unsigned memorySpace) {
+//===----------------------------------------------------------------------===//
+// MetalLayoutAttr
+//===----------------------------------------------------------------------===//
 
-  llvm::ArrayRef<int64_t> logicalShapeRef(logicalShape, logicalRank);
-
-  return wrap(MetalLayoutAttr::get(
-      unwrap(ctx), logicalShapeRef, static_cast<OOBVal>(oobVal),
-      static_cast<MemorySpace>(memorySpace), TensorMemoryLayout::Sharded));
+bool ttmlirIsMetalLayoutAttr(MlirAttribute attr) {
+  return mlir::isa<MetalLayoutAttr>(unwrap(attr));
 }
+
+MlirAttribute ttmlirMetalLayoutAttrGet(MlirContext ctx, intptr_t nLogicalShape,
+                                       const int64_t *logicalShape,
+                                       uint32_t oobValValue,
+                                       uint32_t memorySpaceValue) {
+  return wrap(mlir::tt::ttcore::MetalLayoutAttr::get(
+      unwrap(ctx), mlir::ArrayRef(logicalShape, nLogicalShape),
+      static_cast<mlir::tt::ttcore::OOBVal>(oobValValue),
+      static_cast<mlir::tt::ttcore::MemorySpace>(memorySpaceValue),
+      mlir::tt::ttcore::TensorMemoryLayout::Sharded));
+}
+
+//===----------------------------------------------------------------------===//
+// MemorySpaceAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,
                                          uint32_t memorySpace) {
@@ -142,15 +433,27 @@ MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,
       MemorySpaceAttr::get(unwrap(ctx), static_cast<MemorySpace>(memorySpace)));
 }
 
+//===----------------------------------------------------------------------===//
+// OOBValAttr
+//===----------------------------------------------------------------------===//
+
 MlirAttribute ttmlirTTOOBValAttrGet(MlirContext ctx, uint32_t oobVal) {
   return wrap(OOBValAttr::get(unwrap(ctx), static_cast<OOBVal>(oobVal)));
 }
+
+//===----------------------------------------------------------------------===//
+// IteratorTypeAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTIteratorTypeAttrGet(MlirContext ctx,
                                           uint32_t iteratorType) {
   return wrap(IteratorTypeAttr::get(unwrap(ctx),
                                     static_cast<IteratorType>(iteratorType)));
 }
+
+//===----------------------------------------------------------------------===//
+// IteratorTypeArrayAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTIteratorTypeArrayAttrGet(MlirContext ctx,
                                                uint32_t *iteratorTypes,
@@ -167,9 +470,17 @@ MlirAttribute ttmlirTTIteratorTypeArrayAttrGet(MlirContext ctx,
   return wrap(mlir::ArrayAttr::get(unwrap(ctx), iteratorTypesArray));
 }
 
+//===----------------------------------------------------------------------===//
+// TileSizeAttr
+//===----------------------------------------------------------------------===//
+
 MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx, int64_t y, int64_t x) {
   return wrap(TileSizeAttr::get(unwrap(ctx), y, x));
 }
+
+//===----------------------------------------------------------------------===//
+// CoreCoordAttr
+//===----------------------------------------------------------------------===//
 
 MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx, int64_t y, int64_t x) {
   return wrap(CoreCoordAttr::get(unwrap(ctx), y, x));

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -79,6 +79,12 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME debug
 )
 
+declare_mlir_python_sources(TTMLIRPythonSources.Init
+  ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
+  ADD_TO_PARENT TTMLIRPythonSources
+  SOURCES __init__.py
+)
+
 declare_mlir_python_sources(TTMLIRPythonSources.OptimizerOverrides
   ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
   ADD_TO_PARENT TTMLIRPythonSources

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -81,6 +81,14 @@ NB_MODULE(_ttmlir, m) {
       },
       nb::arg("context"), nb::arg("load") = true);
 
+  m.def(
+      "context_init_hook",
+      [](MlirContext context) {
+        mlir::MLIRContext *mlirContext = unwrap(context);
+        mlirContext->loadAllAvailableDialects();
+      },
+      nb::arg("context"));
+
   auto tt_ir = m.def_submodule("tt_ir", "TT IR Bindings");
   mlir::ttmlir::python::populateTTModule(tt_ir);
   auto ttir_ir = m.def_submodule("ttir_ir", "TTIR IR Bindings");

--- a/python/ttmlir/__init__.py
+++ b/python/ttmlir/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ._mlir_libs._ttmlir import register_dialect
+from ._mlir_libs._mlir.ir import Context

--- a/python/ttmlir/_mlir_libs/_site_initialize_0.py
+++ b/python/ttmlir/_mlir_libs/_site_initialize_0.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .._mlir_libs._ttmlir import register_dialects
+from .._mlir_libs._ttmlir import register_dialects, context_init_hook

--- a/test/python/capi/test_ttcore.py
+++ b/test/python/capi/test_ttcore.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from typing import Callable, List, Optional, Tuple, Union
+
+import ttmlir
+from ttmlir.dialects import ttcore
+from ttmlir.ir import *
+
+
+def test_grid_attr():
+    ctx = ttmlir.Context()
+    shape = [1, 2, 3]
+    grid_attr = ttcore.ir.GridAttr.get(ctx, shape)
+
+    assert isinstance(grid_attr, ttcore.ir.GridAttr)
+    assert list(grid_attr.shape) == shape
+
+
+@pytest.mark.parametrize(
+    "reduce_type",
+    [
+        ttcore.ir.ReduceType.Sum,
+        ttcore.ir.ReduceType.Mean,
+        ttcore.ir.ReduceType.Max,
+        ttcore.ir.ReduceType.Min,
+        ttcore.ir.ReduceType.Std,
+        ttcore.ir.ReduceType.Var,
+        ttcore.ir.ReduceType.Prod,
+        ttcore.ir.ReduceType.Invalid,
+    ],
+)
+def test_reduce_type_attr(reduce_type):
+    ctx = ttmlir.Context()
+    reduce_attr = ttcore.ir.ReduceTypeAttr.get(ctx, reduce_type)
+
+    assert isinstance(reduce_attr, ttcore.ir.ReduceTypeAttr)
+    assert reduce_attr.value == reduce_type
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        ttcore.ir.DataType.Float32,
+        ttcore.ir.DataType.Float16,
+        ttcore.ir.DataType.BFloat16,
+        ttcore.ir.DataType.BFP_Float8,
+        ttcore.ir.DataType.BFP_BFloat8,
+        ttcore.ir.DataType.BFP_Float4,
+        ttcore.ir.DataType.BFP_BFloat4,
+        ttcore.ir.DataType.BFP_Float2,
+        ttcore.ir.DataType.BFP_BFloat2,
+        ttcore.ir.DataType.UInt32,
+        ttcore.ir.DataType.UInt16,
+        ttcore.ir.DataType.UInt8,
+        ttcore.ir.DataType.Int32,
+        ttcore.ir.DataType.Bool,
+    ],
+)
+def test_data_type_attr(data_type):
+    ctx = ttmlir.Context()
+    data_type_attr = ttcore.ir.DataTypeAttr.get(ctx, data_type)
+
+    assert isinstance(data_type_attr, ttcore.ir.DataTypeAttr)
+    assert data_type_attr.value == data_type
+
+
+def test_tile_type():
+    ctx = ttmlir.Context()
+    height = 4
+    width = 8
+    data_type = ttcore.ir.DataTypeAttr.get(ctx, ttcore.ir.DataType.Float32)
+    tile_type = ttcore.ir.TileType.get(ctx, height, width, data_type)
+
+    assert isinstance(tile_type, ttcore.ir.TileType)
+    assert tile_type.height == height
+    assert tile_type.width == width
+
+    downcasted_datatype = ttcore.ir.DataTypeAttr.from_attribute(tile_type.datatype)
+    assert downcasted_datatype.value == ttcore.ir.DataType.Float32

--- a/test/python/device_attr.py
+++ b/test/python/device_attr.py
@@ -4,10 +4,11 @@
 
 # RUN: %python %s | FileCheck %s
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import ttcore
+from ttmlir.ir import *
 
-ctx = Context()
+ctx = ttmlir.Context()
 
 
 def updiv(n, d):

--- a/test/python/golden/test_composite_functions.py
+++ b/test/python/golden/test_composite_functions.py
@@ -6,8 +6,6 @@ import pytest
 import torch
 from typing import List
 
-from ttmlir.ir import *
-
 from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import (

--- a/test/python/golden/test_metal_bfp8_typecast.py
+++ b/test/python/golden/test_metal_bfp8_typecast.py
@@ -6,10 +6,6 @@ import pytest
 import torch
 from typing import List, Callable, Sequence, Optional
 
-from ttmlir.ir import *
-from ttmlir.passes import ttir_to_ttmetal_backend_pipeline
-from ttmlir.dialects import ttir
-
 from builder.base.builder_utils import Operand, Shape, TypeInfo
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir

--- a/test/python/golden/test_metal_dma.py
+++ b/test/python/golden/test_metal_dma.py
@@ -6,8 +6,8 @@ import pytest
 import torch
 from typing import Callable, List
 
-from ttmlir.dialects import ttir, ttcore
-from ttmlir.ir import *
+import ttmlir
+from ttmlir.dialects import ttcore
 
 from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder

--- a/test/python/golden/test_metal_layout.py
+++ b/test/python/golden/test_metal_layout.py
@@ -6,9 +6,6 @@ import pytest
 import torch
 from typing import List
 
-from ttmlir.dialects import ttcore
-from ttmlir.ir import *
-
 from builder.base.builder_utils import Operand
 from builder.d2m.d2m_builder import D2MBuilder
 from builder.base.builder_apis import compile_and_execute_d2m

--- a/test/python/golden/test_metal_masking.py
+++ b/test/python/golden/test_metal_masking.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 from typing import List
 
+import ttmlir
 from ttmlir.dialects import ttcore
 from ttmlir.ir import *
 

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -6,8 +6,6 @@ import pytest
 import torch
 from typing import List
 
-from ttmlir.ir import *
-
 from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir

--- a/test/python/golden/test_metal_tilize.py
+++ b/test/python/golden/test_metal_tilize.py
@@ -6,9 +6,6 @@ import pytest
 import torch
 from typing import Callable, List
 
-from ttmlir.dialects import ttcore
-from ttmlir.ir import *
-
 from builder.base.builder_utils import Operand, Shape
 from golden import get_golden_function
 from builder.d2m.d2m_builder import D2MBuilder

--- a/test/python/golden/test_rearrange.py
+++ b/test/python/golden/test_rearrange.py
@@ -8,9 +8,6 @@ import einops
 import itertools
 from typing import Callable, List
 
-from ttmlir.dialects import ttir, ttcore
-from ttmlir.ir import *
-
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
 from test_utils import Marks

--- a/test/python/golden/test_ttir_eltwise_fusion.py
+++ b/test/python/golden/test_ttir_eltwise_fusion.py
@@ -6,10 +6,6 @@ import pytest
 import torch
 from typing import List, Callable, Sequence, Optional
 
-from ttmlir.ir import *
-from ttmlir.passes import ttir_to_ttmetal_backend_pipeline
-from ttmlir.dialects import ttir
-
 from builder.base.builder_utils import Operand, Shape, TypeInfo
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir

--- a/test/python/golden/test_ttir_models_llama_tp.py
+++ b/test/python/golden/test_ttir_models_llama_tp.py
@@ -5,6 +5,9 @@
 import torch
 import pytest
 
+import ttmlir
+from ttmlir.dialects import ttcore
+
 from typing import List, Tuple
 from collections import OrderedDict
 
@@ -222,7 +225,7 @@ def test_llama_attention_1xn_tp(
             arg11_mesh_shard = full_to_shard_device(arg11, builder, 0)
             output3 = builder.matmul(output1, arg11_mesh_shard)
             output3 = builder.all_reduce(
-                output3, reduce_type=ReduceType.Sum.value, cluster_axis=1
+                output3, reduce_type=ttcore.ir.ReduceType.Sum, cluster_axis=1
             )
             output5 = builder.reshape(output3, (1, 128, 32, 128))
             output7 = builder.transpose(output5, -3, -2)
@@ -249,7 +252,7 @@ def test_llama_attention_1xn_tp(
             output25 = builder.matmul(arg4_mesh_shard, output23)
             output25 = builder.reduce_scatter(
                 output25,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 scatter_dim=3,
                 cluster_axis=1,
             )
@@ -261,7 +264,7 @@ def test_llama_attention_1xn_tp(
             output33 = builder.matmul(arg6_mesh_shard, output31)
             output33 = builder.reduce_scatter(
                 output33,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 scatter_dim=3,
                 cluster_axis=1,
             )
@@ -279,7 +282,7 @@ def test_llama_attention_1xn_tp(
             arg12_mesh_shard = full_to_shard_device(arg12, builder, 0)
             output49 = builder.matmul(output1, arg12_mesh_shard)
             output49 = builder.all_reduce(
-                output49, reduce_type=ReduceType.Sum.value, cluster_axis=1
+                output49, reduce_type=ttcore.ir.ReduceType.Sum, cluster_axis=1
             )
             output51 = builder.reshape(output49, (1, 128, 32, 128))
             output53 = builder.transpose(output51, -3, -2)
@@ -291,7 +294,7 @@ def test_llama_attention_1xn_tp(
             output59 = builder.matmul(arg7_mesh_shard, output57)
             output59 = builder.reduce_scatter(
                 output59,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 scatter_dim=3,
                 cluster_axis=1,
             )
@@ -303,7 +306,7 @@ def test_llama_attention_1xn_tp(
             output67 = builder.matmul(arg9_mesh_shard, output65)
             output67 = builder.reduce_scatter(
                 output67,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 scatter_dim=3,
                 cluster_axis=1,
             )
@@ -341,7 +344,7 @@ def test_llama_attention_1xn_tp(
             arg13_mesh_shard = full_to_shard_device(arg13, builder, 0)
             output93 = builder.matmul(output1, arg13_mesh_shard)
             output93 = builder.all_reduce(
-                output93, reduce_type=ReduceType.Sum.value, cluster_axis=1
+                output93, reduce_type=ttcore.ir.ReduceType.Sum, cluster_axis=1
             )
             output95 = builder.reshape(output93, (1, 128, 32, 128))
             output95 = shard_to_full_replicate(output95, builder)
@@ -352,7 +355,7 @@ def test_llama_attention_1xn_tp(
             output103 = builder.transpose(output101, -2, -1)
             output105 = builder.matmul(output91, output103)
             output105 = builder.all_reduce(
-                output105, reduce_type=ReduceType.Sum.value, cluster_axis=1
+                output105, reduce_type=ttcore.ir.ReduceType.Sum, cluster_axis=1
             )
             output107 = builder.unsqueeze(output105, 0)
             output109 = builder.transpose(output107, -3, -2)

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -10,6 +10,9 @@ from functools import reduce
 import operator
 from conftest import x86_only
 
+import ttmlir
+from ttmlir.dialects import ttcore
+
 from builder.base.builder_utils import Operand, Shape, TypeInfo
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir, build_module
@@ -2735,7 +2738,7 @@ def test_all_reduce(
 
             all_reduce0 = builder.all_reduce(
                 in_shard,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 cluster_axis=cluster_axis,
             )
 
@@ -2829,7 +2832,7 @@ def test_reduce_scatter(
 
             reduce_scatter0 = builder.reduce_scatter(
                 in_shard,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 scatter_dim=scatter_dim,
                 cluster_axis=cluster_axis,
             )

--- a/test/python/golden/test_ttir_parallels.py
+++ b/test/python/golden/test_ttir_parallels.py
@@ -7,6 +7,9 @@ import pytest
 from typing import List, Tuple
 from collections import OrderedDict
 
+import ttmlir
+from ttmlir.dialects import ttcore
+
 from builder.base.builder_utils import Operand, Shape
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
@@ -66,7 +69,7 @@ def _build_matmul_parallel(
     partial_matmul = builder.matmul(mesh_shard_in, mesh_shard_wt)
     reduced = builder.reduce_scatter(
         partial_matmul,
-        reduce_type=ReduceType.Sum.value,
+        reduce_type=ttcore.ir.ReduceType.Sum,
         scatter_dim=1,
         cluster_axis=parallelize_axis,
     )
@@ -608,7 +611,7 @@ def test_jit_tensor_parallel(mesh_shape: Tuple[int, int], request, device):
             reduce_scatter = builder.reduce_scatter(
                 permute,
                 scatter_dim=2,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 cluster_axis=1,
             )
             mesh_shard_out = builder.mesh_shard(
@@ -730,7 +733,7 @@ def test_jit_data_tensor_parallel(mesh_shape: Tuple[int, int], request, device):
             reduce_scatter = builder.reduce_scatter(
                 permute,
                 scatter_dim=2,
-                reduce_type=ReduceType.Sum.value,
+                reduce_type=ttcore.ir.ReduceType.Sum,
                 cluster_axis=1,
             )
             shard_dims_out = [0, 2]

--- a/test/python/lit.local.cfg
+++ b/test/python/lit.local.cfg
@@ -1,5 +1,6 @@
 config.suffixes.add(".py")
 
+config.excludes.add("capi")
 config.excludes.add("golden")
 config.excludes.add("op_by_op")
 

--- a/test/python/smoketest.py
+++ b/test/python/smoketest.py
@@ -4,10 +4,11 @@
 
 # RUN: %python %s | FileCheck %s
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import ttcore, ttir
+from ttmlir.ir import *
 
-with Context() as ctx:
+with ttmlir.Context() as ctx:
 
     module = Module.parse(
         """

--- a/test/python/test_d2m_cbtype.py
+++ b/test/python/test_d2m_cbtype.py
@@ -6,10 +6,11 @@
 
 # Tests for the d2m::CBType Python bindings
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import d2m, ttcore
+from ttmlir.ir import *
 
-with Context() as ctx, Location.unknown():
+with ttmlir.Context() as ctx, Location.unknown():
     # Test CBType.get() with a tensor type
     f32 = F32Type.get()
     tensor_type = RankedTensorType.get([32, 64], f32)
@@ -33,7 +34,9 @@ with Context() as ctx, Location.unknown():
     print(cb_memref)
 
     # TileType test
-    tile_type = ttcore.ir.TileType.get(ctx, 32, 32, 2)  # 2 = BFloat16
+    tile_type = ttcore.ir.TileType.get(
+        ctx, 32, 32, ttcore.ir.DataTypeAttr.get(ctx, ttcore.ir.DataType.BFloat16)
+    )
     tile_tensor = RankedTensorType.get([2, 4], tile_type)
     cb_tile = d2m.ir.CBType.get(ctx, tile_tensor)
 

--- a/test/python/test_ttkernel_argspec.py
+++ b/test/python/test_ttkernel_argspec.py
@@ -6,10 +6,11 @@
 
 # Tests for the ttkernel::ArgSpecAttr Python bindings
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import ttkernel
+from ttmlir.ir import *
 
-with Context() as ctx, Location.unknown():
+with ttmlir.Context() as ctx, Location.unknown():
     # Create ArgAttr instances for rt_args and ct_args.
     # ArgAttr.get() returns MlirAttribute for MLIR interop.
     rt_arg1_attr = ttkernel.ir.ArgAttr.get(ctx._CAPIPtr, 0, 0, True)

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -10,8 +10,9 @@ from enum import Enum, auto
 import re
 from collections import OrderedDict
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import tensor, quant, func, ttir, ttcore, stablehlo, ttnn, debug
+from ttmlir.ir import *
 from ttmlir.passes import GoldenTensor, DataType
 from golden import GoldenMapTensor, get_golden_function
 

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -14,8 +14,9 @@ from typing import Callable, List, Optional, Tuple, Union, Literal, Dict
 from collections import OrderedDict
 import json
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import func, ttcore, ttnn, ttir, sdy
+from ttmlir.ir import *
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
@@ -173,7 +174,7 @@ def build_module(
     Tuple[Module, Union[TTIRBuilder, StableHLOBuilder, TTNNBuilder, D2MBuilder]]
         The constructed MLIR module and the corresponding builder instance.
     """
-    ctx = Context()
+    ctx = ttmlir.Context()
 
     try:
         fname = inspect.getfile(mod)
@@ -1287,7 +1288,7 @@ def load_mlir_file(
     Tuple[Module, Builder]
         Parsed MLIR module and a builder instance initialized from it.
     """
-    ctx = Context()
+    ctx = ttmlir.Context()
 
     if target == "ttir":
         module, builder = TTIRBuilder.from_module(ctx, mlir_text, golden_inputs)
@@ -1355,7 +1356,7 @@ def generate_all_module_permutations(mlir_text: str, num_devices: int) -> List[M
     List[Module]
         All discovered module permutations suitable for the given device count.
     """
-    ctx = Context()
+    ctx = ttmlir.Context()
     loc = Location.unknown(ctx)
 
     with ctx, loc:
@@ -1400,7 +1401,7 @@ def experimental_build_stablehlo_module(
     base: Optional[str] = None,
     output_root: str = ".",
 ) -> Tuple[Module, StableHLOBuilder]:
-    ctx = Context()
+    ctx = ttmlir.Context()
 
     # Grab the location of the test function in python for later debugging
     try:

--- a/tools/builder/base/builder_enums.py
+++ b/tools/builder/base/builder_enums.py
@@ -6,17 +6,6 @@ from enum import Enum
 from ttmlir.dialects import ttir, ttcore, tensor, quant, func
 
 
-class ReduceType(Enum):
-    Sum = ttcore.ir.ReduceType.Sum
-    Mean = ttcore.ir.ReduceType.Mean
-    Max = ttcore.ir.ReduceType.Max
-    Min = ttcore.ir.ReduceType.Min
-    Std = ttcore.ir.ReduceType.Std
-    Var = ttcore.ir.ReduceType.Var
-    Prod = ttcore.ir.ReduceType.Prod
-    Invalid = ttcore.ir.ReduceType.Invalid
-
-
 class MeshShardType(Enum):
     Identity = ttcore.ir.MeshShardType.Identity
     Replicate = ttcore.ir.MeshShardType.Replicate

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -14,8 +14,9 @@ from collections import OrderedDict
 import json
 from dataclasses import dataclass
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import func, ttcore, ttnn, ttir
+from ttmlir.ir import *
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
@@ -288,7 +289,9 @@ def get_metal_tensor_layout(
 
     # For tiled layouts, ensure the device shape accounts for tiles.
     if tiled:
-        elemType = ttcore.ir.TileType.get(ctx, 32, 32, ttcore.DataType.Float32)
+        elemType = ttcore.ir.TileType.get(
+            ctx, 32, 32, ttcore.ir.DataTypeAttr.get(ctx, ttcore.ir.DataType.Float32)
+        )
         if grid is None or grid == (1, 1):
             # For default 1x1 grid, use tile count based on aligned shape.
             # If dim_alignments is specified, use that; otherwise use logical_shape.

--- a/tools/builder/d2m/d2m_builder.py
+++ b/tools/builder/d2m/d2m_builder.py
@@ -11,8 +11,9 @@ from enum import Enum, auto
 import re
 from collections import OrderedDict
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import d2m, ttcore, tensor, quant
+from ttmlir.ir import *
 from ttmlir.passes import GoldenTensor, DataType
 
 from builder.base.builder import *

--- a/tools/builder/stablehlo/shardy_parallelization_utils.py
+++ b/tools/builder/stablehlo/shardy_parallelization_utils.py
@@ -6,8 +6,9 @@ import itertools
 from typing import Callable, List, Optional, Tuple, Union, Literal, Dict
 from collections import OrderedDict
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import func, ttcore, ttnn, ttir, sdy
+from ttmlir.ir import *
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     stablehlo_pipeline,

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -14,8 +14,9 @@ import re
 from collections import OrderedDict
 import math
 
-from ttmlir.ir import *
+import ttmlir
 from ttmlir.dialects import stablehlo, sdy, mpmd, func
+from ttmlir.ir import *
 
 from builder.base.builder import *
 from builder.base.builder_utils import *

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 from typing import List, Callable, Any
 import torch
 
+import ttmlir
+from ttmlir.dialects import ttnn, ttcore, func
 from ttmlir.ir import *
 from ttmlir import util
-from ttmlir.dialects import ttnn, ttcore, func
 
 from builder.base.builder import *
 from builder.base.builder_utils import *
@@ -156,7 +157,9 @@ class TTNNBuilder(Builder):
             element_type = self._get_type_from_torch_dtype(element_type)
         with self._ctx, self._loc:
             data_type = util.element_type_to_data_type(element_type)
-            tile_element_type = ttcore.ir.TileType.get(self._ctx, 32, 32, data_type)
+            tile_element_type = ttcore.ir.TileType.get(
+                self._ctx, 32, 32, ttcore.ir.DataTypeAttr.get(self._ctx, data_type)
+            )
             buffer_type = ttnn.BufferType.DRAM
             grid_attr = ttcore.ir.GridAttr.get(self._ctx, [1, 1])
             ttnn_layout_attr = ttnn.ir.TTNNLayoutAttr.get(
@@ -184,7 +187,9 @@ class TTNNBuilder(Builder):
     ) -> ttnn.ir.TTNNLayoutAttr:
         with self._ctx, self._loc:
             data_type = util.element_type_to_data_type(element_type)
-            tile_element_type = ttcore.ir.TileType.get(self._ctx, 32, 32, data_type)
+            tile_element_type = ttcore.ir.TileType.get(
+                self._ctx, 32, 32, ttcore.ir.DataTypeAttr.get(self._ctx, data_type)
+            )
             buffer_type = ttnn.BufferType.L1
             grid_attr = ttcore.ir.GridAttr.get(self._ctx, [1, 1])
             return ttnn.ir.TTNNLayoutAttr.get(

--- a/tools/pykernel/_src/kernel_ast.py
+++ b/tools/pykernel/_src/kernel_ast.py
@@ -6,6 +6,7 @@ import ast
 import inspect
 import functools
 
+import ttmlir
 from ttmlir.ir import *
 from ttmlir.dialects import ttcore, ttkernel, func, scf, arith, memref, emitc
 from ttmlir.dialects._ods_common import get_default_loc_context
@@ -89,7 +90,7 @@ class TTCompilerBase(PyKernelAstBase):
             default_context = get_default_loc_context()
         except ValueError:
             default_context = None
-        self.ctx = default_context if default_context is not None else Context()
+        self.ctx = default_context if default_context is not None else ttmlir.Context()
         self.cursor = Location.unknown(self.ctx)
         self.module = Module.create(self.cursor)
         self.insert_point = self.module.body
@@ -945,7 +946,10 @@ class TTKernelCompiler(TTCompilerBase):
             operand_idx += 1
 
             tile_type = ttcore.ir.TileType.get(
-                self.ctx, 32, 32, getattr(ttcore.DataType, self.args[i].dtype)
+                self.ctx,
+                32,
+                32,
+                ttcore.ir.DataTypeAttr.get(self.ctx, self.args[i].dtype),
             )
 
         self.func_entry = func.FuncOp(name=node.name, type=([], []))
@@ -972,7 +976,10 @@ class TTKernelCompiler(TTCompilerBase):
             # Get all of the CBs using the arg_spec attr
             for indexIndex, i in enumerate(cb_idx):
                 tile_type = ttcore.ir.TileType.get(
-                    self.ctx, 32, 32, getattr(ttcore.DataType, self.args[i].dtype)
+                    self.ctx,
+                    32,
+                    32,
+                    ttcore.ir.DataTypeAttr.get(self.ctx, self.args[i].dtype),
                 )
                 cb_type = ttkernel.ir.CBType.get(
                     self.ctx, MemRefType.get(self.args[i].tilized_shape, tile_type)

--- a/tools/pykernel/_src/kernel_types.py
+++ b/tools/pykernel/_src/kernel_types.py
@@ -5,11 +5,14 @@
 import os
 from enum import Enum
 
-from ttmlir.dialects import ttkernel
+import ttmlir
+from ttmlir.dialects import ttkernel, ttcore
 
 
 class CircularBuffer:
-    def __init__(self, cb_id, tensor_shape=(8, 128, 128), dtype="Float32"):
+    def __init__(
+        self, cb_id, tensor_shape=(8, 128, 128), dtype=ttcore.ir.DataType.Float32
+    ):
         self.cb_id = cb_id
         self.tensor_shape = tensor_shape
         self.tile_shape = 32  # default to 32x32 tile shape


### PR DESCRIPTION
This PR restructures MLIR bindings to better fit CAPI pattern. This also supports working with native python types, instead of having to downcast in order to access object members and attributes, which is not pythonic. 

It introduces the following structure:

Attributes:
- all attributes are to inherit from `mlir::python::nanobind_adaptors::mlir_attribute_subclass`
- associated `isSomeAttr` must be implemented 
- associated `.def_classmethod("get",` must be implemented
- associated `.def_classmethod("from_attribute",` must be implemented

See `GridAttr` for an example.

Types:
- all types are to inherit from `mlir::python::nanobind_adaptors::mlir_type_subclass`
- associated `isSomeType` must be implemented 
- associated `.def_classmethod("get",` must be implemented
- associated `.def_classmethod("from_attribute",` must be implemented

See `TileType` for an example.

Enums:
- enums are to be binded as a separate class in their respective source file

See `MlirDataTypeEnum` for an example

Other:
- CAPI headers must be defined in respective header file eg. `include/ttmlir-c/TTAttrs.h`
- Function implementations must be defined in respective source file eg. `lib/CAPI/TTCoreAttrs.cpp`
- unwrap/wrap logic should only happen in source file, NOT python module file