### PR TITLE
[conv3d] Setting conv3dConfig

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1907,6 +1907,13 @@ public:
       if (conv3dConfig->getCInBlock()) {
         rso << "config.C_in_block = " << *conv3dConfig->getCInBlock() << "; ";
       }
+      if (conv3dConfig->getComputeWithStorageGridSize()) {
+        auto gridAttr = *conv3dConfig->getComputeWithStorageGridSize();
+        rso << "config.compute_with_storage_grid_size = "
+               "tt::tt_metal::CoreCoord{"
+            << gridAttr.getShape()[0] << ", " << gridAttr.getShape()[1]
+            << "}; ";
+      }
     }
 
     rso << "return config; }()";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -745,7 +745,7 @@ def TTNN_Conv3dConfigAttr : TTNN_Attr<"Conv3dConfig", "conv3d_config"> {
   let summary = "TTNN Conv3dConfig attribute";
   let description = [{
     Configuration parameters for TTNN conv3d operations.
-    Controls performance tuning parameters like block sizes and data formats.
+    Controls performance tuning parameters like block sizes, data formats, and grid configuration.
   }];
 
   let parameters = (ins
@@ -754,7 +754,8 @@ def TTNN_Conv3dConfigAttr : TTNN_Attr<"Conv3dConfig", "conv3d_config"> {
     OptionalParameter<"std::optional<uint32_t>">:$w_out_block,
     OptionalParameter<"std::optional<uint32_t>">:$h_out_block,
     OptionalParameter<"std::optional<uint32_t>">:$c_out_block,
-    OptionalParameter<"std::optional<uint32_t>">:$c_in_block
+    OptionalParameter<"std::optional<uint32_t>">:$c_in_block,
+    OptionalParameter<"std::optional<ttcore::GridAttr>">:$compute_with_storage_grid_size
   );
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dBlockingRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dBlockingRewritePattern.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV3DBLOCKINGREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV3DBLOCKINGREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Conv3d configuration workaround for hardware requirements.
+//
+// Problem: L1 Memory Overflow
+// (https://github.com/tenstorrent/tt-metal/issues/35436)
+//
+// Conv3d operations can overflow L1 cache so we set blocking
+// parameters that tell hardware to process data in smaller chunks.
+//
+// Only applies config when user hasn't provided it.
+class Conv3dBlockingRewritePattern : public mlir::OpRewritePattern<Conv3dOp> {
+public:
+  using mlir::OpRewritePattern<Conv3dOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(Conv3dOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto conv3dConfig = srcOp.getConv3dConfig();
+
+    // Only apply workaround if config is completely missing
+    if (conv3dConfig && *conv3dConfig) {
+      return failure();
+    }
+
+    uint32_t in_channels = srcOp.getInChannels();
+    uint32_t c_in_block = calculateOptimalCInBlock(in_channels);
+    conv3dConfig = createConv3dConfig(rewriter, c_in_block);
+
+    rewriter.modifyOpInPlace(
+        srcOp, [&]() { srcOp.setConv3dConfigAttr(*conv3dConfig); });
+
+    return success();
+  }
+
+private:
+  // Calculate optimal C_in_block based on channel count:
+  // - Not divisible by 16 → 0 (bypass validation, TT-Metal uses full size)
+  // - Divisible by 16 and ≤128 → use as-is
+  // - > 128 → cap at 128 (max efficient blocking)
+  uint32_t calculateOptimalCInBlock(uint32_t in_channels) const {
+    if (in_channels % 16 != 0) {
+      return 0; // Bypass validation
+    }
+    return std::min(in_channels, 128u);
+  }
+
+  std::optional<Conv3dConfigAttr>
+  createConv3dConfig(mlir::PatternRewriter &rewriter,
+                     uint32_t c_in_block) const {
+    return Conv3dConfigAttr::get(rewriter.getContext(),
+                                 ttcore::DataType::BFloat16, 1, 1, 1,
+                                 32, // TILE_WIDTH
+                                 c_in_block, std::nullopt);
+  }
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONV3DBLOCKINGREWRITEPATTERN_H

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -42,6 +42,7 @@ table Conv3dConfig {
   h_out_block: uint32 = null;
   c_out_block: uint32 = null;
   c_in_block: uint32 = null;
+  compute_with_storage_grid_size: CoreCoord;
 }
 
 table PrepareConv2dWeightsOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1467,8 +1467,8 @@ public:
         adaptor.getInput(), reshapedWeight, reshapedBias, device,
         inChannelsAttr, outChannelsAttr, batchSizeAttr, inputDepthAttr,
         inputHeightAttr, inputWidthAttr, kernelSizeAttr, *strideAttr,
-        *paddingAttr, paddingModeAttr, groupsAttr, outputDtypeAttr,
-        /*conv3d_config=*/nullptr, /*compute_config=*/nullptr);
+        *paddingAttr, paddingModeAttr, groupsAttr, outputDtypeAttr, nullptr,
+        nullptr);
 
     return success();
   }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dEnableKernelStrideFoldingRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dBlockingRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv3dRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.h"
@@ -585,6 +586,7 @@ public:
           workarounds::decomposition::
               Conv2dEnableKernelStrideFoldingRewritePattern<ConvTranspose2dOp>,
           workarounds::decomposition::Conv3dRewritePattern,
+          workarounds::decomposition::Conv3dBlockingRewritePattern,
           workarounds::decomposition::ConcatenateHeadsOpRewritePattern,
           workarounds::decomposition::
               SplitQueryKeyValueAndSplitHeadsOpRewritePattern,

--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -40,10 +40,6 @@ createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg);
 ::ttnn::operations::conv::conv2d::Conv2dSliceConfig
 createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfig *config);
 
-::ttnn::operations::experimental::conv3d::Conv3dConfig
-createConv3dConfig(const ::tt::target::ttnn::Conv3dConfig *config,
-                   ::ttnn::MeshDevice &targetDevice);
-
 ::ttnn::operations::transformer::SDPAProgramConfig
 createSDPAProgramConfig(const ::tt::target::ttnn::SDPAConfig *config);
 

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -432,41 +432,6 @@ createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfig *config) {
   return sliceConfig;
 }
 
-::ttnn::operations::experimental::conv3d::Conv3dConfig
-createConv3dConfig(const ::tt::target::ttnn::Conv3dConfig *config,
-                   ::ttnn::MeshDevice &targetDevice) {
-
-  ::ttnn::operations::experimental::conv3d::Conv3dConfig conv3dConfig;
-
-  conv3dConfig.compute_with_storage_grid_size =
-      targetDevice.compute_with_storage_grid_size();
-
-  // Apply config overrides from flatbuffer if provided
-  if (config) {
-    if (config->weights_dtype()) {
-      conv3dConfig.weights_dtype =
-          ::tt::runtime::ttnn::utils::toTTNNDataType(*config->weights_dtype());
-    }
-    if (config->t_out_block()) {
-      conv3dConfig.T_out_block = *config->t_out_block();
-    }
-    if (config->w_out_block()) {
-      conv3dConfig.W_out_block = *config->w_out_block();
-    }
-    if (config->h_out_block()) {
-      conv3dConfig.H_out_block = *config->h_out_block();
-    }
-    if (config->c_out_block()) {
-      conv3dConfig.C_out_block = *config->c_out_block();
-    }
-    if (config->c_in_block()) {
-      conv3dConfig.C_in_block = *config->c_in_block();
-    }
-  }
-
-  return conv3dConfig;
-}
-
 ::ttnn::DeviceComputeKernelConfig createDeviceComputeKernelConfig(
     const ::tt::target::ttnn::DeviceComputeKernelConfig *config) {
   ::ttnn::WormholeComputeKernelConfig computeKernelConfig;

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
@@ -18,7 +18,8 @@
   w_out_block = 1,
   h_out_block = 1,
   c_out_block = 32,
-  c_in_block = 32
+  c_in_block = 32,
+  compute_with_storage_grid_size = #ttcore.grid<8x8>
 >
 
 func.func @conv3d_with_config(%arg0: tensor<1x8x28x28x32xbf16, #ttnn_layout>, %arg1: tensor<32x32x3x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x1x32xbf16, #ttnn_layout2>) -> tensor<1x6x26x26x32xbf16, #ttnn_layout3> {


### PR DESCRIPTION
### Problem description
Not passing `Conv3dConfig` caused `conv3d` op to fail with OOM L1 exception due to insufficient blocking.

### What's changed
Passed `Conv3dConfig` in workarounds so that issues has been solved.

***Note**: `Conv3dConfig` was created in a way that calculates feasible blocking configuration (not the optimal one) until metal makes support for automatically picking optimal configuration.