### PR TITLE
Enabling running execute_fb without goldens

### DIFF
--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -565,8 +565,8 @@ def convert_golden_input_output_to_torch(
 
 def execute_fb(
     compiled_bin,
-    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]],
-    intermediate_goldens: Dict[str, Dict[int, GoldenMapTensor]],
+    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]] = {},
+    intermediate_goldens: Dict[str, Dict[int, GoldenMapTensor]] = {},
     pcc: float = 0.99,
     atol: float = 1e-08,
     rtol: float = 1e-05,
@@ -633,6 +633,8 @@ def execute_fb(
     golden_report = {}
     if bypass_ops is None:
         bypass_ops = []
+    if len(golden_input_output_tensors) == 0:
+        disable_golden = True
 
     callback_runtime_config = CallbackRuntimeConfig(
         device=device,


### PR DESCRIPTION
### Ticket
Closes [#6626](https://github.com/tenstorrent/tt-mlir/issues/6626)

### Problem description
Builder's `execute_fb` requires golden mappings

### What's changed
Made goldens optional

### Checklist
- [ ] New/Existing tests provide coverage for changes
