### PR TITLE
docs: Add comprehensive docstrings to builder files

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -2,6 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+TTIR Operations Golden Tests.
+
+This module contains pytest test cases for verifying TTIR (Tenstorrent IR)
+operations using golden tensor verification. Each test builds an MLIR module
+using TTIRBuilder, compiles it, executes it, and compares the results against
+pre-computed golden (reference) values computed using PyTorch.
+
+The tests cover a wide range of operations including:
+- Element-wise operations (logical_not, clamp, div, etc.)
+- Reduction operations (sum, mean, max, etc.)
+- Matrix operations (matmul, conv2d, etc.)
+- Data movement operations (reshape, transpose, concat, etc.)
+- Collective operations (all_reduce, all_gather, etc.)
+
+Tests are parameterized by shape, dtype, and target backend (ttnn, ttmetal)
+to provide comprehensive coverage across different configurations.
+"""
+
 import pytest
 import torch
 from typing import Callable, List, Optional, Tuple, Union
@@ -33,6 +52,31 @@ def logical_not(
     dtype: torch.dtype,
     unit_attrs: Optional[List[str]] = None,
 ):
+    """
+    Build a logical NOT operation with custom golden tensor setup.
+
+    This helper function creates a logical NOT operation and sets up
+    custom golden tensors for verification. The input tensor is generated
+    with values that include zeros and non-zeros to test both cases.
+
+    Parameters
+    ----------
+    in0 : Operand
+        Input operand from the function signature.
+    builder : TTIRBuilder
+        The TTIR builder instance.
+    shape : Shape
+        Shape of the input tensor.
+    dtype : torch.dtype
+        Data type of the input tensor.
+    unit_attrs : List[str], optional
+        Unit attributes to set on the operation.
+
+    Returns
+    -------
+    OpResult
+        The result of the logical NOT operation.
+    """
     randn_tensor = torch.randn(shape, dtype=torch.float32)
     input_tensor = randn_tensor.uniform_(-10.0, 10.0)
     input_tensor[torch.abs(input_tensor) < 4.0] = 0.0
@@ -51,6 +95,13 @@ def logical_not(
 def test_hoisted_logical_not(
     shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
+    """
+    Test logical NOT operation with CPU hoisting enabled.
+
+    This test verifies that logical NOT operations marked with the
+    'ttir.should_hoist' attribute are correctly hoisted to CPU execution
+    while maintaining correct golden tensor verification.
+    """
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def hoisted_logical_not_wrapper(

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -25,7 +25,40 @@ from builder.base.builder_utils import (
 
 
 class BuilderMeta(type):
+    """
+    Metaclass for Builder that automatically registers operation builders.
+
+    This metaclass is responsible for building lookup maps that connect MLIR
+    operation views (OpView) to their corresponding builder, parser, and split
+    methods. When a Builder subclass is created, the metaclass scans all methods
+    for special decorators (@tag, @parse, @split) and populates the appropriate
+    dictionaries.
+
+    The maps enable dynamic dispatch from MLIR operations to their handler
+    methods, which is essential for both constructing new operations and
+    parsing existing MLIR modules.
+    """
+
     def __new__(mcls, name, bases, namespace):
+        """
+        Create a new Builder class and register its operation handlers.
+
+        Parameters
+        ----------
+        mcls : type
+            The metaclass (BuilderMeta).
+        name : str
+            Name of the class being created.
+        bases : tuple
+            Base classes of the new class.
+        namespace : dict
+            Class namespace containing methods and attributes.
+
+        Returns
+        -------
+        type
+            The newly created Builder subclass with populated operation maps.
+        """
         cls = super().__new__(mcls, name, bases, namespace)
         cls.build_opview_to_builder_map()
         cls.build_opview_to_parser_map()
@@ -34,6 +67,38 @@ class BuilderMeta(type):
 
 
 class Builder(metaclass=BuilderMeta):
+    """
+    Base class for constructing MLIR modules with golden tensor verification.
+
+    The Builder class provides infrastructure for programmatically constructing
+    MLIR operations while simultaneously computing and tracking golden (reference)
+    tensors for verification. It manages the mapping between MLIR operands and
+    their corresponding PyTorch tensors, enabling end-to-end correctness checking.
+
+    This class serves as the foundation for dialect-specific builders (e.g.,
+    TTIRBuilder, TTNNBuilder) that implement the actual operation construction
+    methods.
+
+    Attributes
+    ----------
+    opview_to_builder_map : Dict[OpView, Callable]
+        Maps MLIR operation views to their builder methods.
+    opview_to_parser_map : Dict[OpView, Callable]
+        Maps MLIR operation views to their parser methods.
+    opview_to_split_map : Dict[OpView, Callable]
+        Maps MLIR operation views to their split methods.
+
+    Examples
+    --------
+    Subclasses should implement dialect-specific operations::
+
+        class TTIRBuilder(Builder):
+            @tag(ttir.AddOp)
+            def add(self, lhs: Operand, rhs: Operand) -> OpResult:
+                # Implementation here
+                pass
+    """
+
     opview_to_builder_map: Dict[OpView, Callable] = {}
     opview_to_parser_map: Dict[OpView, Callable] = {}
     opview_to_split_map: Dict[OpView, Callable] = {}
@@ -50,6 +115,29 @@ class Builder(metaclass=BuilderMeta):
         ] = OrderedDict([("x", 1), ("y", 1)]),
         disable_golden_check: bool = False,
     ):
+        """
+        Initialize a new Builder instance.
+
+        Parameters
+        ----------
+        ctx : Context
+            MLIR context for creating operations and types.
+        location : Location
+            Default MLIR location for operations created by this builder.
+        mesh_name : Union[List[str], str], optional
+            Name(s) of the device mesh(es). Defaults to "mesh".
+        mesh_dict : Union[List[OrderedDict[str, int]], OrderedDict[str, int]], optional
+            Dictionary specifying mesh dimensions. Keys are dimension names
+            (e.g., "x", "y") and values are sizes. Defaults to a 1x1 mesh.
+        disable_golden_check : bool, optional
+            If True, skip golden tensor computation and verification.
+            Defaults to False.
+
+        Raises
+        ------
+        ValueError
+            If mesh_name and mesh_dict have different lengths when both are lists.
+        """
         self._ctx = ctx
         self._loc = location
         self._global_id = -1
@@ -105,6 +193,13 @@ class Builder(metaclass=BuilderMeta):
 
     @classmethod
     def build_opview_to_builder_map(cls):
+        """
+        Scan class methods and register those decorated with @tag.
+
+        This method populates the opview_to_builder_map dictionary by finding
+        all methods that have been decorated with the @tag decorator, which
+        associates them with specific MLIR operation views.
+        """
         for attr_name in dir(cls):
             attr = getattr(cls, attr_name)
             func = attr
@@ -114,6 +209,13 @@ class Builder(metaclass=BuilderMeta):
 
     @classmethod
     def build_opview_to_parser_map(cls):
+        """
+        Scan class methods and register those decorated with @parse.
+
+        This method populates the opview_to_parser_map dictionary by finding
+        all methods that have been decorated with the @parse decorator, which
+        associates them with specific MLIR operation views for parsing.
+        """
         for attr_name in dir(cls):
             attr = getattr(cls, attr_name)
             func = attr
@@ -123,6 +225,13 @@ class Builder(metaclass=BuilderMeta):
 
     @classmethod
     def build_opview_to_split(cls, map):
+        """
+        Scan class methods and register those decorated with @split.
+
+        This method populates the opview_to_split_map dictionary by finding
+        all methods that have been decorated with the @split decorator, which
+        associates them with specific MLIR operation views for splitting.
+        """
         for attr_name in dir(cls):
             attr = getattr(cls, attr_name)
             func = attr
@@ -131,25 +240,121 @@ class Builder(metaclass=BuilderMeta):
                 cls.opview_to_split_map[func._split] = attr
 
     def get_opview_from_method(self, method: func) -> OpView:
+        """
+        Extract the OpView type from a method decorated with @tag.
+
+        Parameters
+        ----------
+        method : Callable
+            A method that was decorated with @tag.
+
+        Returns
+        -------
+        OpView or None
+            The MLIR operation view type associated with the method,
+            or None if the method was not decorated.
+        """
         return getattr(method, "_tag", None)
 
     def get_opview_from_parser(self, parser: func) -> OpView:
+        """
+        Extract the OpView type from a method decorated with @parse.
+
+        Parameters
+        ----------
+        parser : Callable
+            A method that was decorated with @parse.
+
+        Returns
+        -------
+        OpView or None
+            The MLIR operation view type associated with the parser,
+            or None if the method was not decorated.
+        """
         return getattr(parser, "_parse", None)
 
     def get_opview_from_split(self, split: func) -> OpView:
+        """
+        Extract the OpView type from a method decorated with @split.
+
+        Parameters
+        ----------
+        split : Callable
+            A method that was decorated with @split.
+
+        Returns
+        -------
+        OpView or None
+            The MLIR operation view type associated with the split method,
+            or None if the method was not decorated.
+        """
         return getattr(split, "_split", None)
 
     def get_builder_from_opview(self, opview: OpView) -> Callable:
+        """
+        Look up the builder method for a given MLIR operation view.
+
+        Parameters
+        ----------
+        opview : OpView
+            The MLIR operation view type to look up.
+
+        Returns
+        -------
+        Callable
+            The builder method that can construct this operation type.
+
+        Raises
+        ------
+        AssertionError
+            If no builder is registered for the given opview.
+        """
         if opview not in self.opview_to_builder_map:
             assert False, f"No builder found for opview {opview}"
         return self.opview_to_builder_map.get(opview)
 
     def get_parser_from_opview(self, opview: OpView) -> Callable:
+        """
+        Look up the parser method for a given MLIR operation view.
+
+        Parameters
+        ----------
+        opview : OpView
+            The MLIR operation view type to look up.
+
+        Returns
+        -------
+        Callable
+            The parser method that can reconstruct this operation type.
+
+        Raises
+        ------
+        AssertionError
+            If no parser is registered for the given opview.
+        """
         if opview not in self.opview_to_parser_map:
             assert False, f"No parser found for opview {opview}"
         return self.opview_to_parser_map.get(opview)
 
     def get_split_from_opview(self, opview: OpView) -> Callable:
+        """
+        Look up the split method for a given MLIR operation view.
+
+        Parameters
+        ----------
+        opview : OpView
+            The MLIR operation view type to look up.
+
+        Returns
+        -------
+        Callable
+            The split method for this operation type.
+
+        Raises
+        ------
+        AssertionError
+            If no split function is registered for the given opview.
+        """
         if opview not in self.opview_to_split_map:
             assert False, f"No split function found for opview {opview}"
         return self.opview_to_split_map.get(opview)
@@ -158,14 +363,38 @@ class Builder(metaclass=BuilderMeta):
 
     @property
     def context(self) -> Context:
+        """
+        Get the MLIR context associated with this builder.
+
+        Returns
+        -------
+        Context
+            The MLIR context used for creating operations and types.
+        """
         return self._ctx
 
     @property
     def location(self) -> Location:
+        """
+        Get the default MLIR location for this builder.
+
+        Returns
+        -------
+        Location
+            The default location used for operations created by this builder.
+        """
         return self._loc
 
     @property
     def mesh_shape(self) -> Tuple[int, int]:
+        """
+        Get the device mesh shape.
+
+        Returns
+        -------
+        Tuple[int, int]
+            The shape of the device mesh as (x, y) dimensions.
+        """
         return self._mesh_shape
 
     @property
@@ -175,6 +404,28 @@ class Builder(metaclass=BuilderMeta):
         Dict[int, Dict[str, Dict[int, GoldenMapTensor]]],
         Dict[str, Dict[int, GoldenMapTensor]],
     ]:
+        """
+        Get the golden tensor map for verification.
+
+        This property compiles and returns the golden (reference) tensors
+        that have been computed during module construction. The returned
+        maps can be used to verify correctness of the compiled program
+        against expected outputs.
+
+        Returns
+        -------
+        Tuple[Dict, Dict]
+            A tuple containing:
+            - input_output_golden_info: Nested dict mapping program index to
+              location to device_id to GoldenMapTensor for inputs/outputs.
+            - intermediate_golden_info: Dict mapping location string to
+              device_id to GoldenMapTensor for intermediate values.
+
+        Notes
+        -----
+        If golden checking is disabled or no goldens are marked for storage,
+        empty dictionaries are returned.
+        """
         # { program_index: {loc: {device_id: GoldenMapTensor} } }
         input_output_golden_info: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]] = {}
         intermediate_golden_info: Dict[str, Dict[int, GoldenMapTensor]] = {}
@@ -236,9 +487,35 @@ class Builder(metaclass=BuilderMeta):
         return input_output_golden_info, intermediate_golden_info
 
     def get_shape(self, input: Operand) -> Shape:
+        """
+        Get the shape of an operand's tensor type.
+
+        Parameters
+        ----------
+        input : Operand
+            The MLIR operand (BlockArgument or OpResult) to query.
+
+        Returns
+        -------
+        Shape
+            The shape of the operand's tensor type as a list or tuple of ints.
+        """
         return self._get_type(input).shape
 
     def get_type(self, input: Operand) -> Type:
+        """
+        Get the element type of an operand's tensor type.
+
+        Parameters
+        ----------
+        input : Operand
+            The MLIR operand (BlockArgument or OpResult) to query.
+
+        Returns
+        -------
+        Type
+            The MLIR element type (e.g., F32Type, BF16Type) of the tensor.
+        """
         return self._get_type(input).element_type
 
     def set_goldens(
@@ -247,6 +524,25 @@ class Builder(metaclass=BuilderMeta):
         outputs: Dict[Operand, Union[torch.tensor, Dict[int : torch.tensor]]] = None,
         set_all_outputs: bool = True,
     ):
+        """
+        Set golden (reference) tensors for input and output operands.
+
+        This method associates PyTorch tensors with MLIR operands for later
+        verification. The tensors can be provided directly, as callables that
+        generate tensors, or as device-sharded dictionaries.
+
+        Parameters
+        ----------
+        inputs : Dict[Operand, Union[Callable, torch.tensor, Dict[int, torch.tensor]]]
+            Mapping from input operands to their golden tensors. Values can be:
+            - torch.Tensor: Used directly
+            - Callable: Called with operand shape to generate tensor
+            - Dict[int, torch.Tensor]: Device ID to tensor mapping for sharded data
+        outputs : Dict[Operand, Union[torch.tensor, Dict[int, torch.tensor]]], optional
+            Mapping from output operands to their expected golden tensors.
+        set_all_outputs : bool, optional
+            If True, mark all provided outputs for verification. Defaults to True.
+        """
         self._set_goldens(self._create_builder_golden_from_torch_tensor(inputs))
 
         if outputs != None:
@@ -259,6 +555,19 @@ class Builder(metaclass=BuilderMeta):
         inputs: Dict[Operand, GoldenMapTensor],
         outputs: Dict[Operand, GoldenMapTensor] = None,
     ):
+        """
+        Set golden tensors using pre-constructed GoldenMapTensor objects.
+
+        This is an alternative to set_goldens() when you already have
+        GoldenMapTensor instances rather than raw PyTorch tensors.
+
+        Parameters
+        ----------
+        inputs : Dict[Operand, GoldenMapTensor]
+            Mapping from input operands to their GoldenMapTensor objects.
+        outputs : Dict[Operand, GoldenMapTensor], optional
+            Mapping from output operands to their expected GoldenMapTensor objects.
+        """
         self._set_goldens(inputs)
 
         if outputs != None:
@@ -268,19 +577,68 @@ class Builder(metaclass=BuilderMeta):
     def set_operand_goldens(
         self, operands: Dict[Operand, Union[torch.tensor, Dict[int : torch.tensor]]]
     ):
+        """
+        Set golden tensors for operands and mark them for verification.
+
+        This is a convenience method that combines setting goldens and marking
+        them for verification in a single call.
+
+        Parameters
+        ----------
+        operands : Dict[Operand, Union[torch.tensor, Dict[int, torch.tensor]]]
+            Mapping from operands to their golden tensors or device shard maps.
+        """
         self._set_goldens(self._create_builder_golden_from_torch_tensor(operands))
         self.set_goldens_to_check(operands.keys())
 
     def set_goldens_to_check(self, operands: List[Operand], override: bool = False):
+        """
+        Mark operands for golden verification.
+
+        Parameters
+        ----------
+        operands : List[Operand]
+            List of operands whose golden values should be verified.
+        override : bool, optional
+            If True, replace the existing list. If False, append to it.
+            Defaults to False.
+        """
         if override:
             self._goldens_to_store = operands
         else:
             self._goldens_to_store.extend(operands)
 
     def set_graph_level_check(self, check: bool):
+        """
+        Enable or disable graph-level golden checking.
+
+        When enabled, only input/output goldens are verified, skipping
+        intermediate value verification.
+
+        Parameters
+        ----------
+        check : bool
+            True to enable graph-level checking only, False for full checking.
+        """
         self._force_graph_level_check = check
 
     def bypass(self, operand: Operand):
+        """
+        Mark an operation to be bypassed during golden comparison.
+
+        This is useful for operations whose outputs cannot be meaningfully
+        compared (e.g., random number generation).
+
+        Parameters
+        ----------
+        operand : Operand
+            The operand whose defining operation should be bypassed.
+
+        Raises
+        ------
+        TypeError
+            If the operand is a BlockArgument (function inputs cannot be bypassed).
+        """
         if isinstance(operand, BlockArgument):
             raise TypeError("Cannot bypass BlockArgument")
 
@@ -290,6 +648,22 @@ class Builder(metaclass=BuilderMeta):
     def set_arg_attribute(
         self, operand: Operand, new_attr_name: str, new_attr: Attribute
     ):
+        """
+        Add or update an attribute on a function argument.
+
+        Parameters
+        ----------
+        operand : Operand
+            A BlockArgument representing a function parameter.
+        new_attr_name : str
+            Name of the attribute to set.
+        new_attr : Attribute
+            The MLIR attribute value to assign.
+
+        Notes
+        -----
+        This modifies the arg_attrs of the containing FuncOp in place.
+        """
         func_op = operand.owner.owner
 
         arg_attr_list = func_op.arg_attrs
@@ -315,6 +689,30 @@ class Builder(metaclass=BuilderMeta):
         op_function: Callable,
         golden_kwargs: dict = {},
     ):
+        """
+        Compute the output shape and type by running the golden function.
+
+        This method executes the golden (reference) implementation of an
+        operation to determine what shape and dtype the output should have.
+        This is necessary because TTIR operations do not have MLIR shape
+        inference traits.
+
+        Parameters
+        ----------
+        organize_golden_args : Callable
+            Function to transform input operands into golden function arguments.
+        inputs : List[Operand]
+            List of input operands to the operation.
+        op_function : Callable
+            The MLIR operation function being built.
+        golden_kwargs : dict, optional
+            Additional keyword arguments to pass to the golden function.
+
+        Returns
+        -------
+        Tuple[Shape, torch.dtype] or None
+            The output shape and dtype, or None if no golden function exists.
+        """
         op_golden_function = get_golden_function(op_function, **golden_kwargs)
         if op_golden_function is None:
             return
@@ -330,6 +728,19 @@ class Builder(metaclass=BuilderMeta):
         return golden_output.shape, golden_output.dtype
 
     def _get_datatype_from_torch_dtype(self, dtype: torch.dtype) -> DataType:
+        """
+        Convert a PyTorch dtype to a tt-mlir DataType enum value.
+
+        Parameters
+        ----------
+        dtype : torch.dtype
+            The PyTorch data type to convert.
+
+        Returns
+        -------
+        DataType
+            The corresponding tt-mlir DataType enum value.
+        """
         match dtype:
             case torch.float16:
                 return DataType.Float16
@@ -349,6 +760,19 @@ class Builder(metaclass=BuilderMeta):
                 return DataType.Float32
 
     def _get_type(self, input: Operand) -> RankedTensorType:
+        """
+        Get the MLIR type of an operand.
+
+        Parameters
+        ----------
+        input : Operand
+            The operand to query.
+
+        Returns
+        -------
+        RankedTensorType
+            The MLIR RankedTensorType of the operand.
+        """
         return input.type
 
     def _get_type_from_torch_dtype(
@@ -357,6 +781,34 @@ class Builder(metaclass=BuilderMeta):
         scale: Optional[float] = None,
         zero_point: Optional[float] = None,
     ) -> Type:
+        """
+        Convert a PyTorch dtype to an MLIR Type.
+
+        Supports standard floating-point, integer, and quantized types.
+        For quantized types, a TypeInfo object with scale and zero_point
+        must be provided.
+
+        Parameters
+        ----------
+        dtype : Union[torch.dtype, TypeInfo]
+            The PyTorch dtype or TypeInfo for quantized types.
+        scale : float, optional
+            Quantization scale (used with dtype if TypeInfo not provided).
+        zero_point : float, optional
+            Quantization zero point (used with dtype if TypeInfo not provided).
+
+        Returns
+        -------
+        Type
+            The corresponding MLIR type.
+
+        Raises
+        ------
+        ValueError
+            If quantized type is requested without proper TypeInfo.
+        TypeError
+            If the dtype is not supported.
+        """
         if scale is not None and zero_point is not None:
             dtype = TypeInfo(dtype=dtype, scale=scale, zero_point=zero_point)
         base_dtype = dtype.dtype if isinstance(dtype, TypeInfo) else dtype
@@ -487,10 +939,40 @@ class Builder(metaclass=BuilderMeta):
             raise TypeError(f"Unsupported MLIR type: {mlir_type}")
 
     def _get_next_global_id(self) -> int:
+        """
+        Generate the next unique global identifier.
+
+        Returns
+        -------
+        int
+            A monotonically increasing integer ID.
+        """
         self._global_id += 1
         return self._global_id
 
     def _get_loc_of_extra_file_callee(self, id: int = 0) -> Location:
+        """
+        Create an MLIR Location from the external call site.
+
+        This method walks up the call stack to find the first frame that
+        is outside the current file, and creates a location string from
+        that frame's filename and line number.
+
+        Parameters
+        ----------
+        id : int, optional
+            An additional identifier to include in the location string.
+
+        Returns
+        -------
+        Location
+            An MLIR named location with format "filename:lineno:id(N)".
+
+        Raises
+        ------
+        RuntimeError
+            If the entire call stack is within the same file.
+        """
         stack = inspect.stack()
         caller_filename = stack[1].filename
 
@@ -507,6 +989,19 @@ class Builder(metaclass=BuilderMeta):
         )
 
     def _get_loc_from_str(self, loc: Union[str, Location]) -> Location:
+        """
+        Convert a string or Location to an MLIR Location.
+
+        Parameters
+        ----------
+        loc : Union[str, Location]
+            Either a string to convert or an existing Location.
+
+        Returns
+        -------
+        Location
+            An MLIR Location object.
+        """
         if isinstance(loc, str):
             return Location.name(loc)
         else:
@@ -518,6 +1013,24 @@ class Builder(metaclass=BuilderMeta):
         data_type: Optional[Union[Type, torch.dtype]] = None,
         encoding: Optional[Attribute] = None,
     ) -> RankedTensorType:
+        """
+        Create an MLIR RankedTensorType.
+
+        Parameters
+        ----------
+        shape : Shape
+            The shape of the tensor.
+        data_type : Union[Type, torch.dtype], optional
+            The element type. Can be an MLIR Type or torch.dtype.
+            Defaults to F32Type.
+        encoding : Attribute, optional
+            Optional tensor encoding attribute (e.g., for layout info).
+
+        Returns
+        -------
+        RankedTensorType
+            The constructed MLIR tensor type.
+        """
         with self._ctx, self._loc:
             if isinstance(data_type, torch.dtype):
                 dtype = self._get_type_from_torch_dtype(data_type)
@@ -526,11 +1039,43 @@ class Builder(metaclass=BuilderMeta):
             return RankedTensorType.get(shape, dtype, encoding)
 
     def _organize_eltwise_golden(self, inputs: List[Operand]) -> List[GoldenMapTensor]:
+        """
+        Retrieve golden tensors for element-wise operation inputs.
+
+        Parameters
+        ----------
+        inputs : List[Operand]
+            List of input operands.
+
+        Returns
+        -------
+        List[GoldenMapTensor]
+            List of corresponding golden tensors.
+        """
         return [self._goldens[inp] for inp in inputs]
 
     def _generate_random_tensor(
         self, shape: Shape, dtype: Union[torch.dtype, TypeInfo]
     ) -> torch.Tensor:
+        """
+        Generate a random PyTorch tensor with the specified shape and dtype.
+
+        For floating-point types, generates values from a standard normal
+        distribution. For integer types, generates values across the full
+        range. For quantized types, generates and quantizes random floats.
+
+        Parameters
+        ----------
+        shape : Shape
+            The shape of the tensor to generate.
+        dtype : Union[torch.dtype, TypeInfo]
+            The data type, or TypeInfo for quantized types.
+
+        Returns
+        -------
+        torch.Tensor
+            A randomly initialized tensor.
+        """
         if isinstance(dtype, TypeInfo):
             float_tensor = torch.randn(shape, dtype=torch.float32)
             return torch.quantize_per_tensor(
@@ -712,6 +1257,31 @@ class Builder(metaclass=BuilderMeta):
         original_inputs: List[Operand],
         loc: Optional[str] = None,
     ):
+        """
+        Create a function call operation with golden tensor propagation.
+
+        This method creates a new MLIR function from the provided Python
+        callable, wraps it in a FuncOp, and generates a CallOp to invoke it.
+        Golden tensors are automatically propagated from the original inputs
+        through the nested function to its outputs.
+
+        Parameters
+        ----------
+        nested_func : Callable
+            A Python function that takes operands and a builder, and returns
+            one or more output operands. The function will be converted to
+            an MLIR FuncOp.
+        original_inputs : List[Operand]
+            The input operands to pass to the function call.
+        loc : str, optional
+            Location string for the call operation. If None, auto-generated.
+
+        Returns
+        -------
+        Union[OpResult, Tuple[OpResult, ...]]
+            The result(s) of the call operation. Returns a single OpResult
+            if the function has one output, or a tuple for multiple outputs.
+        """
         fn_input_types = []
         for operand in original_inputs:
             fn_input_types.append(operand.type)
@@ -1148,6 +1718,34 @@ class Builder(metaclass=BuilderMeta):
     # ----- Helper decorator functions ----
 
     def func(self, input_shapes: List[List[int]], input_types: List[torch.dtype]):
+        """
+        Decorator for creating MLIR functions with automatic golden tensor generation.
+
+        This decorator transforms a Python function into an MLIR FuncOp. Input
+        tensors are automatically created with random golden values, and the
+        decorated function can use builder operations to construct the function
+        body.
+
+        Parameters
+        ----------
+        input_shapes : List[List[int]]
+            List of shapes for each input tensor argument.
+        input_types : List[torch.dtype]
+            List of PyTorch dtypes for each input tensor argument.
+
+        Returns
+        -------
+        Callable
+            A decorator that wraps a function and returns its FuncOp.
+
+        Examples
+        --------
+        ::
+
+            @builder.func([[64, 128], [64, 128]], [torch.float32, torch.float32])
+            def my_add(in0: Operand, in1: Operand, builder: TTIRBuilder):
+                return builder.add(in0, in1)
+        """
         def wrapper(fn):
             encoding_fn = self.create_tensor_encoding
             fn_input_types = [
@@ -1193,6 +1791,22 @@ class Builder(metaclass=BuilderMeta):
         return wrapper
 
     def device_module(self, root_func: Callable):
+        """
+        Create a device module containing the given function.
+
+        This method wraps a function in a DeviceModuleOp, which represents
+        code that will execute on Tenstorrent accelerator devices.
+
+        Parameters
+        ----------
+        root_func : Callable
+            A function that takes a builder and creates MLIR operations.
+
+        Returns
+        -------
+        ttcore.DeviceModuleOp
+            The device module operation containing the generated code.
+        """
         def wrapper(self):
             device_module_op = ttcore.DeviceModuleOp()
             region = device_module_op.regions[0]
@@ -1210,6 +1824,22 @@ class Builder(metaclass=BuilderMeta):
         return wrapper(self)
 
     def cpu_module(self, root_func: Callable):
+        """
+        Create a CPU module containing the given function.
+
+        This method wraps a function in a CPUModuleOp, which represents
+        code that will execute on the host CPU rather than accelerators.
+
+        Parameters
+        ----------
+        root_func : Callable
+            A function that takes a builder and creates MLIR operations.
+
+        Returns
+        -------
+        ttcore.CPUModuleOp
+            The CPU module operation containing the generated code.
+        """
         def wrapper(self):
             cpu_module_op = ttcore.CPUModuleOp()
             region = cpu_module_op.regions[0]
@@ -1235,6 +1865,26 @@ class Builder(metaclass=BuilderMeta):
         annotation: str,
         loc: Optional[str] = None,
     ) -> OpResult:
+        """
+        Add an annotation to an operand for debugging purposes.
+
+        The annotation is attached as metadata and passed through to the
+        output without modifying the tensor values.
+
+        Parameters
+        ----------
+        operand : Operand
+            The tensor operand to annotate.
+        annotation : str
+            The annotation string to attach.
+        loc : str, optional
+            Location string for the operation.
+
+        Returns
+        -------
+        OpResult
+            The annotated tensor (same values as input).
+        """
         debug_op = self.get_opview_from_method(Builder.annotate)
         annotation_attr = StringAttr.get(annotation)
 
@@ -1264,6 +1914,24 @@ class Builder(metaclass=BuilderMeta):
         operand: Operand,
         loc: Optional[str] = None,
     ) -> OpResult:
+        """
+        Insert a breakpoint operation for debugging.
+
+        This operation can be used to pause execution during debugging
+        and inspect tensor values. The tensor values pass through unchanged.
+
+        Parameters
+        ----------
+        operand : Operand
+            The tensor operand to inspect at the breakpoint.
+        loc : str, optional
+            Location string for the operation.
+
+        Returns
+        -------
+        OpResult
+            The tensor (same values as input).
+        """
         debug_op = self.get_opview_from_method(Builder.breakpoint)
 
         if loc is None:
@@ -1292,6 +1960,26 @@ class Builder(metaclass=BuilderMeta):
         file_path: str,
         loc: Optional[str] = None,
     ) -> OpResult:
+        """
+        Capture a memory snapshot to a file for debugging.
+
+        This operation dumps the tensor contents to a file at the specified
+        path during execution, useful for post-mortem debugging analysis.
+
+        Parameters
+        ----------
+        operand : Operand
+            The tensor operand to snapshot.
+        file_path : str
+            Path where the memory snapshot will be written.
+        loc : str, optional
+            Location string for the operation.
+
+        Returns
+        -------
+        OpResult
+            The tensor (same values as input).
+        """
         debug_op = self.get_opview_from_method(Builder.memory_snapshot)
         file_path_attr = StringAttr.get(file_path)
 


### PR DESCRIPTION
## Summary
- Add NumPy-style docstrings to `builder.py`, `ttir_builder.py`, and `test_ttir_ops.py`
- Document classes, methods, and key functions to improve code discoverability
- Docstrings are compatible with Sphinx autodoc for automatic documentation generation

## Changes
**tools/builder/base/builder.py** (688 lines added)
- `BuilderMeta` metaclass: Document purpose and `__new__` method
- `Builder` class: Add comprehensive class docstring with examples
- All public methods: `context`, `location`, `mesh_shape`, `golden_map`, `get_shape`, `get_type`, `set_goldens`, etc.
- Key private methods: `_get_output_shape_and_type`, `_get_type_from_torch_dtype`, `_create_ranked_tensor_type`, etc.
- Helper decorators: `func`, `device_module`, `cpu_module`
- Debug operations: `annotate`, `breakpoint`, `memory_snapshot`

**tools/builder/ttir/ttir_builder.py** (190 lines added)
- `TTIRBuilder` class docstring with examples
- `__init__` method documentation
- Core `_op_proxy` method documentation
- Representative operations: `add`, `abs`, `matmul`

**test/python/golden/test_ttir_ops.py** (51 lines added)
- Module-level docstring explaining test coverage
- Helper function `logical_not` docstring
- Representative test function docstring

## Test plan
- [ ] Docstrings follow NumPy style guide per coding-guidelines.md
- [ ] Syntax is valid Python (verified with py_compile on Python 3.10+)
- [ ] Sphinx autodoc will pick up docstrings when docs are rebuilt

Closes #4360