### PR TITLE
Read compute kernel config for matmul program config subblock size

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -687,8 +687,8 @@ def TTNN_DeviceComputeKernelConfig : TTNN_Attr<"DeviceComputeKernelConfig", "dev
       - `fp32_dest_acc_en`: Configures destination registers to use 32-bit floating-point precision instead of the default 16-bit mode. It provides higher precision at the cost of reducing available destination register count by half.
       - `packer_l1_acc`: When packing multiple tiles to the same address, subsequent packs perform accumulation (addition using FP16 or FP32 precision) rather than overwriting.
       - `dst_full_sync_en`: Configures destination register acquisition mode:
-        - Half mode (false): Acquires 8 tiles in destination registers
-        - Full mode (true): Acquires 16 tiles in destination registers, providing increased parallelism at the cost of higher resource usage
+        - Half mode (false): Acquires 8 tiles in destination registers, allowing pipelined execution
+        - Full mode (true): Acquires 16 tiles in destination registers, providing more register space at the cost of reduced parallelism due to full synchronization
 
     Example:
 


### PR DESCRIPTION
The max subblock size (out_subblock_w * out_subblock_h) depends on the compute kernel config settings:
- Base: 16 tiles (for standard 32x32 tiles)
- If dst_full_sync_en = false: divide by 2 -> 8 tiles
- If fp32_dest_acc_en = true: divide by 2 -> 4 tiles

Previously the code hardcoded 8, which doesn't account for fp32_dest_acc_en. Now we read the compute kernel config from the operation and calculate the correct max subblock size.

### Ticket
https://github.com/tenstorrent/tt-forge/issues/819

