### PR TITLE
Uplift third_party/tt-metal to 8af4bf7994a5ca9b3d453345d68f2705b2d0bf8f 2026-01-21

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=acd0707afc9ca0e276a3f1eafecccb534a0c7772
+ARG TT_METAL_DEPENDENCIES_COMMIT=8af4bf7994a5ca9b3d453345d68f2705b2d0bf8f
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "11436d5d672e00864de0388174047c526bd4535f")
+set(TT_METAL_VERSION "8af4bf7994a5ca9b3d453345d68f2705b2d0bf8f")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 8af4bf7994a5ca9b3d453345d68f2705b2d0bf8f

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-onnx/actions/runs/21198795129):
  - [x] [tt-xla (mlir-uplift-qualification)](https://github.com/tenstorrent/tt-xla/actions/runs/21198795848):
- **Follow-up Actions**
  - ~**Issues filed** to follow up on incomplete changes (if any):~
  - ~**Frontend fix PRs** ready (if needed by this uplift):~