### PR TITLE
Add optimizer refactoring proposal to spec document

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ LICENSE @nsmithtt
 # Docs
 *.md @nsmithtt @sdjordjevicTT
 /docs/ @nsmithtt @sdjordjevicTT
-/docs/src/specs/ttnn-optimizer.md @rpavlovicTT
+/docs/src/specs/ttnn-optimizer.md @rpavlovicTT @odjuricicTT
 
 # tt-mlir Bindings
 /include/ttmlir/Bindings/ @tapspatel


### PR DESCRIPTION
Merges the pass-based architecture proposal into the TTNN optimizer spec as Section 5. 

The proposal outlines replacing DFShardingPolicy, ShardSolver, and most analysis pipeline with a simpler greedy approach based on empirical analysis of 50+ models.

