### PR TITLE
[TTIRFusion] Update LinearOp fusion pattern

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -15,6 +15,7 @@
 #include "ttmlir/Dialect/TTIR/Utils/VerificationUtils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -3297,13 +3298,32 @@ bool mlir::tt::ttir::TTNNMetalLayoutCastOp::bufferizesToMemoryWrite(
 
     // Verify that the dimensions of the matmul of A and B are broadcast
     // compatible with input bias.
-    llvm::SmallVector<int64_t> matmulShape = expectedOutputShape;
-    if (!mlir::OpTrait::util::getBroadcastedShape(matmulShape, biasShape,
-                                                  expectedOutputShape)) {
+    llvm::SmallVector<int64_t> broadcastShape;
+    if (!mlir::OpTrait::util::getBroadcastedShape(expectedOutputShape,
+                                                  biasShape, broadcastShape)) {
       return emitOpError("Bias shape(")
              << ttmlir::utils::join(biasShape, ",")
              << ") is not broadcast compatible with the matmul output shape("
-             << ttmlir::utils::join(matmulShape, ",") << ")";
+             << ttmlir::utils::join(expectedOutputShape, ",") << ")";
+    }
+
+    // tt-metal uses a composite LinearOp where the bias is added after the
+    // matmul, and ttnn.add supports broadcasting of both operands. Otherwise,
+    // tt-metal lowers to a fused LinearOp, which uses the matmul result shape
+    // as the output shape. The composite LinearOp requires that the bias
+    // second-to-last dim (of padded shape) does not match the tile height.
+    // Update the expected output shape to the fully broadcasted shape when:
+    // 1) The matmul result is a scalar (vector x vector), so the inferred
+    //    output shape is empty and must be derived from the bias via
+    //    broadcasting, or
+    // 2) The bias second-to-last dim (of padded shape) does not match the
+    //    tile height, indicating the composite LinearOp is used.
+    llvm::SmallVector<int64_t> paddedBiasShape =
+        ttnn::utils::getTilePaddedShape(biasShape);
+    if (expectedOutputShape.empty() ||
+        (paddedBiasShape.size() > 1 &&
+         paddedBiasShape[paddedBiasShape.size() - 2] != ttnn::TILE_HEIGHT)) {
+      expectedOutputShape = broadcastShape;
     }
   }
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -6,6 +6,8 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -1327,59 +1329,67 @@ public:
   mlir::LogicalResult
   matchAndRewrite(AddOp addOp, mlir::PatternRewriter &rewriter) const final {
     // Matmul -> Add pattern.
-    if (MatmulOp matmulOp = getFusableMatmulOp(addOp); matmulOp) {
-      TypedValue<RankedTensorType> bias = addOp.getLhs() == matmulOp.getResult()
-                                              ? addOp.getRhs()
-                                              : addOp.getLhs();
-      Value matmulOpA = matmulOp.getA();
-      Value matmulOpB = matmulOp.getB();
-      LinearOp linearOp = rewriter.create<ttir::LinearOp>(
-          addOp.getLoc(), addOp.getResult().getType(), matmulOpA, matmulOpB,
-          bias, matmulOp.getTransposeA(), matmulOp.getTransposeB());
-
-      rewriter.replaceOp(addOp, linearOp);
-
-      return mlir::success();
-    }
-    // Matmul -> Reshape -> Add pattern.
-    if (MatmulOp matmulOp = getFusableReshapedMatmulOp(addOp); matmulOp) {
+    MatmulOp matmulOp = nullptr;
+    TypedValue<RankedTensorType> bias = nullptr;
+    if (matmulOp = getFusableMatmulOp(addOp); matmulOp) {
+      bias = addOp.getLhs() == matmulOp.getResult() ? addOp.getRhs()
+                                                    : addOp.getLhs();
+    } else if (matmulOp = getFusableReshapedMatmulOp(addOp); matmulOp) {
       ReshapeOp reshapeOp =
           mlir::dyn_cast<ReshapeOp>(*matmulOp.getResult().getUsers().begin());
-      TypedValue<RankedTensorType> bias =
-          (addOp.getLhs() == reshapeOp.getResult()) ? addOp.getRhs()
-                                                    : addOp.getLhs();
-      auto biasType = bias.getType();
-      llvm::ArrayRef<int64_t> addOpShape =
-          addOp.getResult().getType().getShape();
-      SmallVector<int32_t> addShapeI32(addOpShape.begin(), addOpShape.end());
-
-      llvm::SmallVector<int64_t> newLinearOutputShape;
-      OpTrait::util::getBroadcastedShape(matmulOp.getType().getShape(),
-                                         biasType.getShape(),
-                                         newLinearOutputShape);
-
-      auto matmulOutputType = matmulOp.getResult().getType();
-      auto newOutputType = RankedTensorType::get(
-          newLinearOutputShape, matmulOutputType.getElementType());
-      Value matmulOpA = matmulOp.getA();
-      Value matmulOpB = matmulOp.getB();
-
-      LinearOp linearOp = rewriter.create<ttir::LinearOp>(
-          addOp.getLoc(), newOutputType, matmulOpA, matmulOpB, bias,
-          matmulOp.getTransposeA(), matmulOp.getTransposeB());
-
-      RankedTensorType addOpType = addOp.getType();
-
-      Value finalReshape = rewriter.create<ttir::ReshapeOp>(
-          addOp.getLoc(),
-          RankedTensorType::get(addOpShape, addOpType.getElementType(),
-                                addOpType.getEncoding()),
-          linearOp.getResult(), rewriter.getI32ArrayAttr(addShapeI32));
-      rewriter.replaceOp(addOp, finalReshape);
-
-      return mlir::success();
+      bias = (addOp.getLhs() == reshapeOp.getResult()) ? addOp.getRhs()
+                                                       : addOp.getLhs();
+    } else {
+      return mlir::failure();
     }
-    return mlir::failure();
+
+    ReshapeOp biasReshapeOp = bias.getDefiningOp<ReshapeOp>();
+    llvm::SmallVector<int64_t> broadcastShape;
+    // Remove bias reshape op if the input can be broadcasted to matmul or add
+    // output shape.
+    if (biasReshapeOp &&
+        mlir::OpTrait::util::getBroadcastedShape(
+            matmulOp.getType().getShape(),
+            biasReshapeOp.getInput().getType().getShape(), broadcastShape) &&
+        (llvm::equal(broadcastShape, addOp.getType().getShape()) ||
+         llvm::equal(broadcastShape, matmulOp.getType().getShape()))) {
+      bias = biasReshapeOp.getInput();
+    }
+
+    Value matmulOpA = matmulOp.getA();
+    Value matmulOpB = matmulOp.getB();
+    RankedTensorType outputType = matmulOp.getResult().getType();
+    RankedTensorType biasType = bias.getType();
+    // tt-metal uses a composite LinearOp where the bias is added after the
+    // matmul, and ttnn.add supports broadcasting of both operands. Otherwise,
+    // tt-metal lowers to a fused LinearOp, which uses the matmul result shape
+    // as the output shape. The composite LinearOp requires that the bias
+    // second-to-last dim (of padded shape) does not match the tile height.
+    // Update the output type to match the broadcasted shape in this case.
+    llvm::SmallVector<int64_t> paddedBiasShape =
+        ttnn::utils::getTilePaddedShape(biasType.getShape());
+    if (paddedBiasShape.size() > 1 &&
+        paddedBiasShape[paddedBiasShape.size() - 2] != ttnn::TILE_HEIGHT) {
+      llvm::SmallVector<int64_t> broadcastOutputShape;
+      mlir::OpTrait::util::getBroadcastedShape(matmulOp.getType().getShape(),
+                                               bias.getType().getShape(),
+                                               broadcastOutputShape);
+      outputType = RankedTensorType::get(broadcastOutputShape,
+                                         outputType.getElementType(),
+                                         outputType.getEncoding());
+    }
+    LinearOp linearOp = rewriter.create<ttir::LinearOp>(
+        addOp.getLoc(), outputType, matmulOpA, matmulOpB, bias,
+        matmulOp.getTransposeA(), matmulOp.getTransposeB());
+
+    llvm::SmallVector<int32_t> addShapeI32(addOp.getType().getShape().begin(),
+                                           addOp.getType().getShape().end());
+    Value finalReshape = rewriter.create<ttir::ReshapeOp>(
+        addOp.getLoc(), addOp.getType(), linearOp.getResult(),
+        rewriter.getI32ArrayAttr(addShapeI32));
+    rewriter.replaceOp(addOp, finalReshape);
+
+    return mlir::success();
   }
 
 private:

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
@@ -7,7 +7,7 @@
 
 module {
   func.func @dot_general_with_bias_1(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<68x1024xf32> {
-    // CHECK: func.func @dot_general_with_bias_1
+    // CHECK-LABEL: func.func @dot_general_with_bias_1
     // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
@@ -21,7 +21,7 @@ module {
 module {
   // Replace order of operands for add op.
   func.func @dot_general_with_bias_2(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x16x64xf32> {
-    // CHECK: func.func @dot_general_with_bias_2
+    // CHECK-LABEL: func.func @dot_general_with_bias_2
     // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
@@ -36,7 +36,7 @@ module {
 module {
   // dot_general op followed by reshape op before add op.
   func.func @dot_general_with_bias_3(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
-    // CHECK: func.func @dot_general_with_bias_3
+    // CHECK-LABEL: func.func @dot_general_with_bias_3
     // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
@@ -52,12 +52,10 @@ module {
 
 module {
   func.func @dot_general_with_bias_4(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
-    // CHECK: func.func @dot_general_with_bias_4
-    // CHECK: "ttir.reshape"(%arg2
-    // CHECK-SAME: (tensor<1024xf32>) -> tensor<1x1x1024xf32>
-    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
-    // CHECK: "ttir.reshape"(%1)
-    // CHECK-SAME: (tensor<1x68x1024xf32>) -> tensor<2x34x1024xf32>
+    // CHECK-LABEL: func.func @dot_general_with_bias_4
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
+    // CHECK: "ttir.reshape"(%0)
+    // CHECK-SAME: (tensor<68x1024xf32>) -> tensor<2x34x1024xf32>
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
     // CHECK-NOT: "ttir.add"
@@ -72,7 +70,7 @@ module {
 
 module {
   func.func @dot_general_with_bias_5(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x68x1024xf32>) -> tensor<2x68x1024xf32> {
-    // CHECK: func.func @dot_general_with_bias_5
+    // CHECK-LABEL: func.func @dot_general_with_bias_5
     // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
@@ -85,7 +83,7 @@ module {
 
 module {
   func.func @dot_general_with_bias_6(%arg0: tensor<1576x2xf32>, %arg1: tensor<2x768xf32>, %bias: tensor<768xf32>) -> tensor<8x197x768xf32> {
-    // CHECK: func.func @dot_general_with_bias_6
+    // CHECK-LABEL: func.func @dot_general_with_bias_6
     // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
@@ -101,10 +99,10 @@ module {
 
 module {
   func.func @dot_general_with_bias_7(%arg0: tensor<256x1024xbf16>, %arg1: tensor<1024x1024xbf16>, %bias: tensor<1024xbf16>) -> tensor<1x256x1024xbf16> {
-    // CHECK: func.func @dot_general_with_bias_7
-    // CHECK: "ttir.reshape"(%arg2)
-    // CHECK-SAME: (tensor<1024xbf16>) -> tensor<1x1x1024xbf16>
-    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
+    // CHECK-LABEL: func.func @dot_general_with_bias_7
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
+    // CHECK: "ttir.reshape"(%0)
+    // CHECK-SAME: (tensor<256x1024xbf16>) -> tensor<1x256x1024xbf16>
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
     // CHECK-NOT: "ttir.add"
@@ -121,10 +119,10 @@ module {
 
 module {
   func.func @dot_general_with_bias_8(%arg0: tensor<16x256x64xbf16>, %arg1: tensor<16x64x256xbf16>, %bias: tensor<1x256xbf16>) -> tensor<1x16x256x256xbf16> {
-    // CHECK: func.func @dot_general_with_bias_8
-    // CHECK: "ttir.reshape"(%arg2)
-    // CHECK-SAME: (tensor<1x256xbf16>) -> tensor<1x1x1x256xbf16>
-    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
+    // CHECK-LABEL: func.func @dot_general_with_bias_8
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
+    // CHECK: "ttir.reshape"(%0)
+    // CHECK-SAME: (tensor<16x256x256xbf16>) -> tensor<1x16x256x256xbf16>
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
     // CHECK-NOT: "ttir.add"
@@ -141,10 +139,8 @@ module {
 
 module {
   func.func @dot_general_with_bias_9(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<68x1024xf32> {
-    // CHECK: func.func @dot_general_with_bias_9
-    // CHECK: "ttir.reshape"(%arg2)
-    // CHECK-SAME: (tensor<1024xf32>) -> tensor<1x1024xf32>
-    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
+    // CHECK-LABEL: func.func @dot_general_with_bias_9
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
     // CHECK-NOT: "ttir.dot_general"
     // CHECK-NOT: "ttir.matmul"
     // CHECK-NOT: "ttir.add"
@@ -153,5 +149,58 @@ module {
     %5 = "ttir.broadcast"(%3) <{broadcast_dimensions = array<i64: 68, 1>}> : (tensor<1x1024xf32>) -> tensor<68x1024xf32>
     %7 = "ttir.add"(%1, %5) : (tensor<68x1024xf32>, tensor<68x1024xf32>) -> tensor<68x1024xf32>
     return %7 : tensor<68x1024xf32>
+  }
+}
+
+module {
+  func.func @dot_general_with_bias_10(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<2x512xf32>) -> tensor<1x68x1024xf32> {
+    // CHECK-LABEL: func.func @dot_general_with_bias_10
+    // CHECK: "ttir.reshape"(%arg2)
+    // CHECK-SAME: (tensor<2x512xf32>) -> tensor<1024xf32>
+    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
+    // CHECK: "ttir.reshape"(%1)
+    // CHECK-SAME: (tensor<68x1024xf32>) -> tensor<1x68x1024xf32>
+    // CHECK-NOT: "ttir.dot_general"
+    // CHECK-NOT: "ttir.matmul"
+    // CHECK-NOT: "ttir.add"
+    %0 = "ttir.reshape"(%bias) <{shape = [1024 : i32]}> : (tensor<2x512xf32>) -> tensor<1024xf32>
+    %1 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<68x1024xf32>, tensor<1024x1024xf32>) -> (tensor<68x1024xf32>)
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 68 : i32, 1024 : i32]}> : (tensor<68x1024xf32>) -> tensor<1x68x1024xf32>
+
+    %3 = "ttir.add"(%2, %0) : (tensor<1x68x1024xf32>, tensor<1024xf32>) -> tensor<1x68x1024xf32>
+    return %3 : tensor<1x68x1024xf32>
+  }
+}
+
+module {
+  func.func @dot_general_with_bias_11(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048x51200xbf16>, %bias: tensor<32x1x51200xbf16>) -> tensor<32x1x51200xbf16> {
+    // CHECK-LABEL: func.func @dot_general_with_bias_11
+    // CHECK: "ttir.reshape"(%arg2)
+    // CHECK-SAME: (tensor<32x1x51200xbf16>) -> tensor<32x51200xbf16>
+    // CHECK: "ttir.linear"(%arg0, %arg1, %0)
+    // CHECK: "ttir.reshape"(%1)
+    // CHECK-SAME: (tensor<32x51200xbf16>) -> tensor<32x1x51200xbf16>
+    // CHECK-NOT: "ttir.dot_general"
+    // CHECK-NOT: "ttir.matmul"
+    // CHECK-NOT: "ttir.add"
+    %0 = "ttir.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<32x2048xbf16>, tensor<2048x51200xbf16>) -> tensor<32x51200xbf16>
+    %1 = "ttir.reshape"(%bias) <{shape = [32 : i32, 51200 : i32]}> : (tensor<32x1x51200xbf16>) -> tensor<32x51200xbf16>
+    %2 = "ttir.add"(%0, %1) : (tensor<32x51200xbf16>, tensor<32x51200xbf16>) -> tensor<32x51200xbf16>
+    %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 1 : i32, 51200 : i32]}> : (tensor<32x51200xbf16>) -> tensor<32x1x51200xbf16>
+    return %3 : tensor<32x1x51200xbf16>
+  }
+}
+
+module {
+  func.func @dot_general_with_bias_12(%arg0: tensor<1x1x68x2048xbf16>, %arg1: tensor<2048x51200xbf16>, %bias: tensor<1x68x51200xbf16>) -> tensor<1x1x68x51200xbf16> {
+    // CHECK-LABEL: func.func @dot_general_with_bias_12
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
+    // CHECK-SAME: (tensor<1x1x68x2048xbf16>, tensor<2048x51200xbf16>, tensor<1x68x51200xbf16>) -> tensor<1x1x68x51200xbf16>
+    // CHECK-NOT: "ttir.dot_general"
+    // CHECK-NOT: "ttir.matmul"
+    // CHECK-NOT: "ttir.add"
+    %0 = "ttir.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<1x1x68x2048xbf16>, tensor<2048x51200xbf16>) -> tensor<1x1x68x51200xbf16>
+    %1 = "ttir.add"(%0, %bias) : (tensor<1x1x68x51200xbf16>, tensor<1x68x51200xbf16>) -> tensor<1x1x68x51200xbf16>
+    return %1 : tensor<1x1x68x51200xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/split_query_key_values_and_split_heads_mha_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/split_query_key_values_and_split_heads_mha_positive.mlir
@@ -19,18 +19,18 @@ module {
 
     // Concatenate Q, K, V biases:
     // CHECK: "ttir.concat"
-    // CHECK-SAME: <{dim = 2 : si32}>
-    // CHECK-SAME: (tensor<1x1x1024xf32>, tensor<1x1x1024xf32>, tensor<1x1x1024xf32>) -> tensor<1x1x3072xf32>
+    // CHECK-SAME: <{dim = 0 : si32}>
+    // CHECK-SAME: (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) -> tensor<3072xf32>
 
     // Linear Q, K, V projections with concatenated bias:
     // CHECK: "ttir.linear"
     // CHECK-SAME:  <{transpose_a = false, transpose_b = true}>
-    // CHECK-SAME: (tensor<68x1024xf32>, tensor<3072x1024xf32>, tensor<1x1x3072xf32>) -> tensor<1x68x3072xf32>
+    // CHECK-SAME: (tensor<68x1024xf32>, tensor<3072x1024xf32>, tensor<3072xf32>) -> tensor<68x3072xf32>
 
     // Check that linear op is reshaped.
     // CHECK: "ttir.reshape"
     // CHECK-SAME: <{shape = [2 : i32, 34 : i32, 3072 : i32]}>
-    // CHECK-SAME: (tensor<1x68x3072xf32>) -> tensor<2x34x3072xf32>
+    // CHECK-SAME: (tensor<68x3072xf32>) -> tensor<2x34x3072xf32>
 
     // Split Q, K, V heads:
     // CHECK: "ttir.split_query_key_value_and_split_heads"
@@ -155,13 +155,18 @@ module {
 
     // Concatenate Q, K, V biases:
     // CHECK: "ttir.concat"
-    // CHECK-SAME: <{dim = 2 : si32}>
-    // CHECK-SAME: (tensor<1x1x768xbf16>, tensor<1x1x768xbf16>, tensor<1x1x768xbf16>) -> tensor<1x1x2304xbf16>
+    // CHECK-SAME: <{dim = 0 : si32}>
+    // CHECK-SAME: (tensor<768xbf16>, tensor<768xbf16>, tensor<768xbf16>) -> tensor<2304xbf16>
 
     // Linear Q, K, V projections with concatenated bias:
     // CHECK: "ttir.linear"
     // CHECK-SAME: <{transpose_a = false, transpose_b = true}>
-    // CHECK-SAME: (tensor<128x768xbf16>, tensor<2304x768xbf16>, tensor<1x1x2304xbf16>) -> tensor<1x128x2304xbf16>
+    // CHECK-SAME: (tensor<128x768xbf16>, tensor<2304x768xbf16>, tensor<2304xbf16>) -> tensor<128x2304xbf16>
+
+    // Check that linear op is reshaped.
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: <{shape = [1 : i32, 128 : i32, 2304 : i32]}>
+    // CHECK-SAME: (tensor<128x2304xbf16>) -> tensor<1x128x2304xbf16>
 
     // Split Q, K, V heads:
     // CHECK: "ttir.split_query_key_value_and_split_heads"


### PR DESCRIPTION
### Ticket
closes #6733

### Problem description
Fusion pattern always uses broadcasted shape (for reshaped matmul fusion) as output shape although tt-metal only uses broadcasted shape if padded H dim of bias does not match with the TILE_HEIGHT. 

### What's changed
- Generate LinearOp with broadcasted shape if H dims of bias does not match with TILE_HEIGHT; otherwise, use matmul shape as output shape.
- Update TTIR and TTNN LinearOp verification to match this behaviour.

### Checklist
- [X] Existing/New tests provide coverage for changes
