### PR TITLE
Revert `std::string` -> `llvm::SmallString` change in hashing implementation

### DIFF
--- a/include/ttmlir/Support/IRHasher.h
+++ b/include/ttmlir/Support/IRHasher.h
@@ -8,10 +8,11 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/SHA256.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <string>
 
 namespace mlir::tt {
 
@@ -25,7 +26,7 @@ namespace mlir::tt {
 // explicit form of all op attributes and types.
 //
 // SHA256 hex digest is 64 characters.
-inline llvm::SmallString<64> hashFuncOp(func::FuncOp func) {
+inline std::string hashFuncOp(func::FuncOp func) {
   auto originalSymName = func.getSymName();
 
   // RAII guard to undo the temporary changes made to the function
@@ -64,10 +65,7 @@ inline llvm::SmallString<64> hashFuncOp(func::FuncOp func) {
   auto digest = llvm::SHA256::hash(llvm::ArrayRef<uint8_t>(
       reinterpret_cast<const uint8_t *>(irBuffer.data()), irBuffer.size()));
 
-  llvm::SmallString<64> result;
-  llvm::raw_svector_ostream hexOs(result);
-  hexOs << llvm::toHex(digest, /*LowerCase=*/true);
-  return result;
+  return llvm::toHex(digest, /*LowerCase=*/true);
 }
 
 } // namespace mlir::tt

--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -6,7 +6,6 @@
 #define TTMLIR_TARGET_UTILS_FUNCOPTOPROGRAM_H
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "flatbuffers/flatbuffers.h"
@@ -57,11 +56,11 @@ inline Value getOperandThroughDPSOps(Value value) {
 }
 
 template <typename OpT, typename FnT, typename TensorFnT>
-Program<OpT> funcOpToProgram(
-    FlatbufferObjectCache &cache, func::FuncOp entry, FnT fn,
-    TensorFnT tensorValueToFlatbuffer,
-    const llvm::StringMap<uint32_t> &programIndexMap,
-    const llvm::StringMap<llvm::SmallString<64>> &constEvalFuncHashes) {
+Program<OpT>
+funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry, FnT fn,
+                TensorFnT tensorValueToFlatbuffer,
+                const llvm::StringMap<uint32_t> &programIndexMap,
+                const llvm::StringMap<std::string> &constEvalFuncHashes) {
   OpPrintingFlags printFlags;
   printFlags = printFlags.elideLargeElementsAttrs()
                    .elideLargeResourceString()


### PR DESCRIPTION
### Ticket
[TT-XLA 2977](https://github.com/tenstorrent/tt-xla/issues/2977)

### Problem description
As part of #6474, `std::string`s were changed to `llvm::SmallString` in the implementation of the function hashing mechanism.

However, using `llvm::SmallString` exposed a bug where the underlying buffer which was provided to the flatbuffer op factory function **wasn't null terminated**, which caused wrong hash value to be read in the runtime (the reading continued up to the first `\0` character). 

This further led to duplicate entires in the const-eval cache (since cache misses were triggered, even though the function caches were the same), which ultimately led to OOM.

### What's changed
- Reverted to the previous implementation, which uses `std::string`, so that a null-terminated buffer can be obtained

### Checklist
- [ ] New/Existing tests provide coverage for changes
