### PR TITLE
feat: Added StableHLO compare ops (eq, ne, ge, gt, le, lt) 

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -385,6 +385,78 @@ def module_subtract(builder: StableHLOBuilder):
         return builder.subtract(in0, in1, unit_attrs=unit_attrs)
 
 
+def module_compare_eq(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_eq(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_eq(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_ne(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_ne(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_ne(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_ge(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_ge(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_ge(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_gt(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_gt(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_gt(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_le(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_le(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_le(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_lt(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_lt(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_lt(in0, in1, unit_attrs=unit_attrs)
+
+
 def module_broadcast_in_dim(builder: StableHLOBuilder):
     @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
     def broadcast_in_dim(
@@ -426,6 +498,27 @@ def module_broadcast_in_dim(builder: StableHLOBuilder):
     ],
 )
 def test_binary_ops(test_fn: Callable, target: str, request, device):
+    compile_and_execute_shlo(
+        test_fn,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize(
+    "test_fn",
+    [
+        module_compare_eq,
+        module_compare_ne,
+        module_compare_ge,
+        module_compare_gt,
+        module_compare_le,
+        module_compare_lt,
+    ],
+)
+def test_compare_ops(test_fn: Callable, target: str, request, device):
     compile_and_execute_shlo(
         test_fn,
         **get_request_kwargs(request),

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4428,6 +4428,84 @@ def stablehlo_subtract_golden(
     return torch.subtract(input_tensor, other_tensor).to(output_dtype)
 
 
+def stablehlo_compare_eq_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with EQ (equal) direction.
+
+    Performs element-wise equality comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.eq(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
+def stablehlo_compare_ne_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with NE (not equal) direction.
+
+    Performs element-wise not-equal comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.ne(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
+def stablehlo_compare_ge_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with GE (greater or equal) direction.
+
+    Performs element-wise greater-or-equal comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.ge(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
+def stablehlo_compare_gt_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with GT (greater than) direction.
+
+    Performs element-wise greater-than comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.gt(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
+def stablehlo_compare_le_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with LE (less or equal) direction.
+
+    Performs element-wise less-or-equal comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.le(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
+def stablehlo_compare_lt_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare with LT (less than) direction.
+
+    Performs element-wise less-than comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    result_bool = torch.lt(input_tensor, other_tensor)
+    return result_bool.to(output_dtype)
+
+
 def stablehlo_shift_right_logical_golden(
     input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
 ) -> GoldenMapTensor:
@@ -5776,6 +5854,21 @@ def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
             return tilize_golden
         else:
             return untilize_golden
+
+    # Handle StableHLO CompareOp with comparison_direction parameter
+    if ttir_op_class == stablehlo.CompareOp and "comparison_direction" in kwargs:
+        direction = kwargs["comparison_direction"]
+        compare_golden_map = {
+            "EQ": stablehlo_compare_eq_golden,
+            "NE": stablehlo_compare_ne_golden,
+            "GE": stablehlo_compare_ge_golden,
+            "GT": stablehlo_compare_gt_golden,
+            "LE": stablehlo_compare_le_golden,
+            "LT": stablehlo_compare_lt_golden,
+        }
+        if direction in compare_golden_map:
+            return compare_golden_map[direction]
+        assert False, f"Unknown comparison direction: {direction}"
 
     if ttir_op_class in GOLDEN_MAPPINGS:
         return GOLDEN_MAPPINGS[ttir_op_class]


### PR DESCRIPTION
### Ticket
#4872 

### Problem description
Add Compare ops

### What's changed
 - Add compare operations (`compare_eq`, `compare_ne`, `compare_ge`, `compare_gt`, `compare_le`, `compare_lt`) to `StableHLOBuilder`
 - Add corresponding golden functions for each comparison direction in `mapping.py`
 - Add test cases for all 6 compare operations in `test_stablehlo_ops.py`


### Checklist
- [x] New/Existing tests provide coverage for changes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212832436210782