### PR TITLE
Uplift third_party/tt-metal to 0b10c51bdab06d4401f300c332d41b20d3596a96 2026-01-27

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=13443498f02b024813c115c0dd31eedebeed836c
+ARG TT_METAL_DEPENDENCIES_COMMIT=0b10c51bdab06d4401f300c332d41b20d3596a96
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "a7d0da940efa838c201eb2b609ca2b4aab047832")
+set(TT_METAL_VERSION "0b10c51bdab06d4401f300c332d41b20d3596a96")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 0b10c51bdab06d4401f300c332d41b20d3596a96

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/21413202423
  - [x] [tt-xla (mlir-uplift-qualification)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/21415345947
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): tt-xla examples failing for uplfit with tt-mlir override set: https://github.com/tenstorrent/tt-xla/issues/3017
  - [x] **Frontend fix PRs** ready (if needed by this uplift):