### PR TITLE
Fix gather sharding rule to use replication for collapsed_slice_dim

### DIFF
--- a/env/patches/shardy.patch
+++ b/env/patches/shardy.patch
@@ -648,9 +648,25 @@ index a73917b..78cc827 100644
                       llvm::SmallDenseSet<Value>& seenValues) {
    EdgeNode target = edge.target;
 diff --git a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
-index ab93067..283d6ad 100644
+index ab93067..b181797 100644
 --- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
 +++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+@@ -187,12 +187,12 @@ void addGatherScatterFactors(
+
+   // We add factors for all collapsed slice dimensions.
+   for (int64_t collapsedSliceDim : collapsedSliceDims) {
+-    // To keep the operand dim sharded for gather, we need an all-reduce on the
+-    // result.
++    // For gather: use kNeedReplication to all-gather operand before gather,
++    // instead of kReduction which would insert all-reduce after gather.
+     addUnblockedFactorFn(
+         collapsedSliceDim, /*indicesDim=*/kNullDim,
+         /*slicesDim=*/kNullDim, inputType.getDimSize(collapsedSliceDim),
+-        isScatter ? FactorType::kPassThrough : FactorType::kReduction);
++        isScatter ? FactorType::kPassThrough : FactorType::kNeedReplication);
+   }
+
+   // Add a factor for the index-vector-dim, if it's present.
 @@ -303,6 +303,37 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
          }
          return builder.build();

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/gather_2d_mesh.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/gather_2d_mesh.mlir
@@ -1,0 +1,17 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=2,4" %s 2>&1 | FileCheck %s
+
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @gather_allreduce_overlap_bug(
+      %arg0: tensor<32x64xi1> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>},
+      %arg1: tensor<32x64x2xi64> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}, {}]>}
+  ) -> tensor<32x64xi1> {
+    // CHECK: stablehlo.all_gather
+    // CHECK-SAME: (tensor<16x64
+    // CHECK-SAME: -> tensor<32x64x
+    // CHECK: stablehlo.gather
+    %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, slice_sizes = array<i64: 1, 1>}> : (tensor<32x64xi1>, tensor<32x64x2xi64>) -> tensor<32x64xi1>
+    return %0 : tensor<32x64xi1>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/6756)

### Problem description
When operand is sharded along collapsed_slice_dims, the default Shardy gather rule using kReduction causes InsertExplicitReshardsPass to insert sdy.all_reduce after the gather operation. However, this leads to an error:

 'sdy.all_reduce' op reduction axis "_axis_0" overlaps with operand dimension sharding or replicated axes

### What's changed
This happens because the propagated output sharding conflicts with the reduction axis of the all_reduce operation.

Change kReduction to kNeedReplication for gather's collapsed_slice_dims. This forces an all-gather on the operand before the gather operation instead of an all-reduce after, avoiding the axis overlap issue.

- kReduction: keep operand sharded -> gather -> all-reduce (causes error)
- kNeedReplication: all-gather -> gather (works correctly)

### Checklist
- [ ] New/Existing tests provide coverage for changes
