### PR TITLE
Add pass to convert sdy.constant to stablehlo.constant

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -108,13 +108,13 @@ def ConvertXlaSdyToSdyPass : Pass<"convert-xla-sdy-to-sdy", "::mlir::ModuleOp">
   ];
 }
 
-def LegalizeSdyToStablehloPass : Pass<"legalize-sdy-to-stablehlo", "::mlir::ModuleOp">
+def PartiallyConvertSdyToStableHLOPass : Pass<"partially-convert-sdy-to-stablehlo", "::mlir::ModuleOp">
 {
-  let summary = "Legalize sdy operations to stablehlo operations.";
+  let summary = "Partially convert Shardy operations to StableHLO operations.";
   let description = [{
-    This pass legalizes sdy operations to their stablehlo equivalents.
-    This is needed because tt-xla may receive graphs from XLA containing sdy operations,
-    but tt-mlir does not need or handle sdy operations beyond sharding annotations.
+    This pass partially converts Shardy operations to their StableHLO equivalents.
+    This is needed because tt-xla may receive graphs from XLA containing Shardy operations,
+    but tt-mlir does not need or handle them beyond sharding annotations.
 
     Currently, this pass converts sdy.constant operations to stablehlo.constant operations.
 

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -25,8 +25,8 @@ void createStableHLOPipeline(OpPassManager &pm,
   // Convert any xla.sdy ops to sdy ops.
   pm.addPass(createConvertXlaSdyToSdyPass());
 
-  // Legalize sdy operations to stablehlo.
-  pm.addPass(createLegalizeSdyToStablehloPass());
+  // Partially convert sdy ops to stablehlo.
+  pm.addPass(createPartiallyConvertSdyToStableHLOPass());
 
   // Annotate arguments with whether they are already pre-sharded or not.
   pm.addPass(createApplyArgumentShardStatusPass());

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   ConvertXlaSdyToSdy.cpp
   DecoupleConstFanout.cpp
   FlattenComposite.cpp
-  LegalizeSdyToStablehlo.cpp
+  PartiallyConvertSdyToStableHLO.cpp
   RegisterCustomShardingRule.cpp
   ReoutlineComposite.cpp
   ShardyCCLToStableHLOCCLPatterns.cpp

--- a/lib/Dialect/StableHLO/Transforms/PartiallyConvertSdyToStableHLO.cpp
+++ b/lib/Dialect/StableHLO/Transforms/PartiallyConvertSdyToStableHLO.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,10 +10,11 @@
 #include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir::tt::stablehlo {
-#define GEN_PASS_DEF_LEGALIZESDYTOSTABLEHLOPASS
+#define GEN_PASS_DEF_PARTIALLYCONVERTSDYTOSTABLEHLOPASS
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
 
-class LegalizeSdyConstPattern : public OpRewritePattern<mlir::sdy::ConstantOp> {
+class PartiallyConvertSdyConstPattern
+    : public OpRewritePattern<mlir::sdy::ConstantOp> {
   using OpRewritePattern<mlir::sdy::ConstantOp>::OpRewritePattern;
 
 public:
@@ -25,21 +26,21 @@ public:
   }
 };
 
-class LegalizeSdyToStablehloPass
-    : public impl::LegalizeSdyToStablehloPassBase<LegalizeSdyToStablehloPass> {
+class PartiallyConvertSdyToStableHLOPass
+    : public impl::PartiallyConvertSdyToStableHLOPassBase<
+          PartiallyConvertSdyToStableHLOPass> {
 public:
-  using impl::LegalizeSdyToStablehloPassBase<
-      LegalizeSdyToStablehloPass>::LegalizeSdyToStablehloPassBase;
+  using impl::PartiallyConvertSdyToStableHLOPassBase<
+      PartiallyConvertSdyToStableHLOPass>::
+      PartiallyConvertSdyToStableHLOPassBase;
 
   void runOnOperation() final {
     mlir::ModuleOp module = getOperation();
     MLIRContext *context = module.getContext();
 
-    // Set up rewrite patterns.
     RewritePatternSet patterns(context);
-    patterns.add<LegalizeSdyConstPattern>(context);
+    patterns.add<PartiallyConvertSdyConstPattern>(context);
 
-    // Apply the patterns to legalize sdy operations to stablehlo.
     if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
       signalPassFailure();
       return;

--- a/test/ttmlir/Dialect/StableHLO/partially_convert_sdy_to_stablehlo/partially_convert_sdy_to_stablehlo.mlir
+++ b/test/ttmlir/Dialect/StableHLO/partially_convert_sdy_to_stablehlo/partially_convert_sdy_to_stablehlo.mlir
@@ -1,8 +1,8 @@
 // REQUIRES: stablehlo
-// RUN: ttmlir-opt --legalize-sdy-to-stablehlo %s | FileCheck %s
+// RUN: ttmlir-opt --partially-convert-sdy-to-stablehlo %s | FileCheck %s
 
-// CHECK-LABEL: func.func @legalize_sdy_constant
-func.func @legalize_sdy_constant() -> tensor<2x3xf32> {
+// CHECK-LABEL: func.func @partially_convert_sdy_constant
+func.func @partially_convert_sdy_constant() -> tensor<2x3xf32> {
   // CHECK: stablehlo.constant dense<1.000000e+00> : tensor<2x3xf32>
   // CHECK-NOT: sdy.constant
   %0 = sdy.constant dense<1.0> : tensor<2x3xf32>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2840

### Problem description
Graphs returned by XLA contains sdy.constant, which are marked illegal in tt-mlir.

### What's changed
A new pass is added to convert sdy.constant to stablehlo.constant.

### Checklist
- [x] New/Existing tests provide coverage for changes
