### PR TITLE
Fix repeat & typecast ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -82,8 +82,17 @@ def TTNN_TypecastOp : TTNN_Op<"typecast"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         TTCore_DataTypeAttr:$dtype);
+                         TTCore_DataTypeAttr:$dtype,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
+
+    let builders =
+    [
+      OpBuilder<(ins "Type": $resultType, "Value": $input, "ttcore::DataTypeAttr": $dtype),
+      [{
+        build($_builder, $_state, resultType, input, dtype, /*memory_config=*/nullptr);
+      }]>
+    ];
 
     let hasFolder = 1;
     let hasCanonicalizeMethod = 1;
@@ -1366,7 +1375,7 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape", [TTNN_MemoryConfigOpInterface]> {
     }];
 }
 
-def TTNN_RepeatOp : TTNN_Op<"repeat"> {
+def TTNN_RepeatOp : TTNN_Op<"repeat", [TTNN_MemoryConfigOpInterface]> {
     let summary = "Repeat op.";
     let description = [{
       Returns a new tensor filled with repetition of input tensor according to number of times specified in repeat_dims.
@@ -1377,9 +1386,18 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         TTNN_ShapeAttr:$repeat_dims);
+                         TTNN_ShapeAttr:$repeat_dims,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let builders =
+    [
+      OpBuilder<(ins "Type": $resultType, "Value": $input, "ttnn::ShapeAttr": $repeat_dims),
+      [{
+        build($_builder, $_state, resultType, input, repeat_dims, /*memory_config=*/nullptr);
+      }]>
+    ];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Target/TTNN/operations/data_movement.fbs
+++ b/include/ttmlir/Target/TTNN/operations/data_movement.fbs
@@ -65,6 +65,7 @@ table RepeatOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
   repeat_dims: [int64];
+  memcfg: tt.target.ttnn.MemoryConfig;
 }
 
 table ReshapeOp {

--- a/include/ttmlir/Target/TTNN/operations/layout.fbs
+++ b/include/ttmlir/Target/TTNN/operations/layout.fbs
@@ -38,5 +38,6 @@ table ToMemoryConfigOp {
 table TypecastOp {
   in: tt.target.ttnn.TensorRef;
   dtype: tt.target.DataType;
+  memcfg: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1933,11 +1933,12 @@ public:
     auto resultType = op.getType();
     ttnn::TTNNLayoutAttr outputLayoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
-    ttcore::DataType outputDataType = outputLayoutAttr.getDataType();
+    ttcore::DataTypeAttr outputDataTypeAttr = ttcore::DataTypeAttr::get(
+        op.getContext(), outputLayoutAttr.getDataType());
 
     rewriter.replaceOpWithNewOp<ttnn::TypecastOp>(
         op, this->getTypeConverter()->convertType(resultType),
-        adaptor.getInput(), outputDataType);
+        adaptor.getInput(), outputDataTypeAttr);
     return success();
   }
 };

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -327,10 +327,11 @@ createOp(FlatbufferObjectCache &cache, TypecastOp op) {
   ::tt::target::DataType dtype = toFlatbuffer(cache, op.getDtype());
   auto output =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
-
                                   /*local_shape*/ std::nullopt);
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 
-  return ::tt::target::ttnn::CreateTypecastOp(*cache.fbb, input, dtype, output);
+  return ::tt::target::ttnn::CreateTypecastOp(*cache.fbb, input, dtype,
+                                              memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToDeviceOp>
@@ -2228,7 +2229,6 @@ createRandOp(FlatbufferObjectCache &cache, RandOp op) {
       seed, dtype, layout, memoryConfig, out);
 }
 
-template <typename RepeatOp>
 ::flatbuffers::Offset<::tt::target::ttnn::RepeatOp>
 createRepeatOp(FlatbufferObjectCache &cache, RepeatOp op) {
   auto in = cache.at<::tt::target::ttnn::TensorRef>(
@@ -2236,11 +2236,12 @@ createRepeatOp(FlatbufferObjectCache &cache, RepeatOp op) {
   ::llvm::ArrayRef<int64_t> repeatDims = op.getRepeatDims().getShape();
   auto out =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
-
                                   /*local_shape*/ std::nullopt);
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 
   return ::tt::target::ttnn::CreateRepeatOp(
-      *cache.fbb, in, out, cache.fbb->CreateVector<int64_t>(repeatDims));
+      *cache.fbb, in, out, cache.fbb->CreateVector<int64_t>(repeatDims),
+      memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::PadOp>

--- a/runtime/lib/ttnn/operations/data_movement/repeat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat.cpp
@@ -6,6 +6,8 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 
+#include "tt/runtime/detail/ttnn/utils.h"
+
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::RepeatOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -13,9 +15,13 @@ void run(const ::tt::target::ttnn::RepeatOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
   const auto *fbShape = op->repeat_dims();
-  const std::vector<uint32_t> repeatDims(fbShape->begin(), fbShape->end());
-  ::ttnn::Shape repeatDimsShape(repeatDims);
-  ::ttnn::Tensor out = ::ttnn::repeat(in, repeatDimsShape);
+  const ::ttsl::SmallVector<uint32_t> repeatDims(fbShape->begin(),
+                                                 fbShape->end());
+
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
+  ::ttnn::Tensor out = ::ttnn::repeat(in, repeatDims, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/layout/typecast.cpp
+++ b/runtime/lib/ttnn/operations/layout/typecast.cpp
@@ -20,7 +20,11 @@ void run(const ::tt::target::ttnn::TypecastOp *op, ProgramContext &context) {
   ::ttnn::DataType targetDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(op->dtype());
 
-  ::ttnn::Tensor out = ::ttnn::typecast(inputTensor, targetDataType);
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
+  ::ttnn::Tensor out =
+      ::ttnn::typecast(inputTensor, targetDataType, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2418,9 +2418,9 @@ TEST_F(OpModelBase, typecastOp) {
   RankedTensorType rankedTensorTypeF32 =
       RankedTensorType::get(tensorShape, builder.getF32Type());
 
-  auto typecast =
-      builder.create<TypecastOp>(builder.getUnknownLoc(), rankedTensorTypeF32,
-                                 input, ttcore::DataType::Float32);
+  auto typecast = builder.create<TypecastOp>(
+      builder.getUnknownLoc(), rankedTensorTypeF32, input,
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32));
 
   auto constraintsExp = getOpConstraints(typecast.getOperation());
   if (constraintsExp) {


### PR DESCRIPTION
For both of these ops:
- add memory config if needed in runtime
- add missing fb serialisation
- handle it properly in op model lib

Typecast op was missing memory config in .td schema.

