### PR TITLE
[EIO] Add commute patterns for Softmax with Reshape

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
@@ -300,6 +300,9 @@ extern void populateReduceCommutePatterns(MLIRContext *ctx,
 template <CommuteDirection commuteDirection>
 extern void populateRMSNormCommutePatterns(MLIRContext *ctx,
                                            RewritePatternSet &patterns);
+template <CommuteDirection commuteDirection>
+extern void populateSoftmaxCommutePatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns);
 
 } // namespace mlir::tt::ttir
 

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRTTIREraseInverseOps
         RMSNormCommutePatterns.cpp
         SliceCommutePatterns.cpp
         ReduceCommutePatterns.cpp
+        SoftmaxCommutePatterns.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.cpp
@@ -155,6 +155,7 @@ private:
     populateSliceCommutePatterns<commuteDirection>(&getContext(), patterns);
     populateReduceCommutePatterns<commuteDirection>(&getContext(), patterns);
     populateRMSNormCommutePatterns<commuteDirection>(&getContext(), patterns);
+    populateSoftmaxCommutePatterns<commuteDirection>(&getContext(), patterns);
 
     populateTTIRTMFusionPatterns(&getContext(), patterns);
     return patterns;

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/SoftmaxCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/SoftmaxCommutePatterns.cpp
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+
+namespace mlir::tt::ttir {
+
+namespace {
+
+int64_t
+findNewSoftmaxDimByStrideAndReductionLen(llvm::ArrayRef<int64_t> inputShape,
+                                         llvm::ArrayRef<int64_t> outputShape,
+                                         int64_t softmaxDim) {
+  // Stride of new softmax dim in new shape must match stride of old
+  // softmax dim in old shape, and same for length.
+  //
+  // Example 1 (Valid commute):
+  //   Input shape      = [2, 3, 4]
+  //   Softmax dim      = 2  (stride = 1, reduction length = 4)
+  //   Reshape          = [6, 4]
+  // The new softmax dim is 1, since output dim 1 still has stride = 1 and
+  // reduction length = 4.
+  //
+  // Example 2 (Invalid Commute)
+  //   Input shape      = [2, 3, 4]
+  //   Softmax dim      = 1  (stride = 4, reduction length = 3)
+  //   Reshape          = [2, 12]
+  //   output strides = [12, 1],  Hence, we can't apply softmax because no
+  //   dimension in output has stride 4 and reduction len = 3
+  int64_t inputDims = inputShape.size();
+  int64_t outputDims = outputShape.size();
+
+  if (softmaxDim < 0) {
+    softmaxDim += inputDims;
+  }
+
+  assert(softmaxDim >= 0 && softmaxDim < inputDims &&
+         "Invalid softmax Dimension");
+
+  int64_t softmaxReductionLength = inputShape[softmaxDim];
+  int64_t inputStride = 1;
+  for (int64_t i = softmaxDim + 1; i < inputDims; ++i) {
+    inputStride *= inputShape[i];
+  };
+
+  // Commute is valid if
+  // 1. Input Stride of softmax dimension is preserved in output, and
+  // 2. The number of elements the over which softmax normalizes/reduces should
+  // also match
+  int64_t outputStride = 1;
+  for (int64_t dim = outputDims - 1; dim >= 0; dim--) {
+    if (outputStride == inputStride &&
+        outputShape[dim] == softmaxReductionLength) {
+      return dim;
+    }
+    outputStride *= outputShape[dim];
+  };
+
+  return -1;
+}
+
+template <CommuteDirection commuteDirection>
+// <TMOp, Op, CommuteDirection>
+class TTIRCommuteReshapeThroughSoftmax
+    : public TTIRCommuteOpRewritePattern<ReshapeOp, SoftmaxOp,
+                                         commuteDirection> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ReshapeOp, SoftmaxOp, commuteDirection>::TTIRCommuteOpRewritePattern;
+
+  // Consider the following IR pseudocode:
+  // Before commuting reshape op upwards
+  //   %a = softmax(%arg0, dim)
+  //   %b = reshape(%a)
+  // After commuting reshape op upwards
+  //   %x = reshape(%arg0)
+  //   %y = softmax(%x, UpdatedDim)
+  void performCommuteUpwardsRewrite(SoftmaxOp op, ReshapeOp reshapeUser,
+                                    PatternRewriter &rewriter) const override {
+    auto softmaxInputType = cast<RankedTensorType>(op.getInput().getType());
+    auto outputReshapeType =
+        cast<RankedTensorType>(reshapeUser.getResult().getType());
+
+    auto softmaxInputShape = softmaxInputType.getShape();
+    auto outputReshapeShape = outputReshapeType.getShape();
+    int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+    // We are mapping the softmax axis from softmax input to reshape user output
+    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+        softmaxInputShape, outputReshapeShape, softmaxDim);
+    assert(newSoftmaxDim != -1 &&
+           "Invalid Softmax Dimension, isCommuteUpwardsFavorable should have "
+           "handled this");
+
+    // Create a new Reshape before the Softmax op
+    auto newInputReshapeType = RankedTensorType::get(
+        outputReshapeType.getShape(), softmaxInputType.getElementType(),
+        outputReshapeType.getEncoding());
+    SmallVector<int32_t> newReshapeShape(outputReshapeShape.begin(),
+                                         outputReshapeShape.end());
+
+    auto newInputReshape = rewriter.create<ReshapeOp>(
+        reshapeUser->getLoc(), newInputReshapeType, op.getInput(),
+        rewriter.getI32ArrayAttr(newReshapeShape));
+
+    auto newSoftmaxDimAttr = rewriter.getSI32IntegerAttr(newSoftmaxDim);
+
+    // Create a new Softmax Op with updated dimension attribute
+    auto newSoftmaxOp = rewriter.create<SoftmaxOp>(
+        op->getLoc(), outputReshapeType, newInputReshape.getResult(),
+        newSoftmaxDimAttr, op.getNumericStableAttr());
+
+    // All users must be identical TMs.
+    SmallVector<Operation *> users(op->getUsers());
+    assert(llvm::all_of(users,
+                        [&](Operation *user) {
+                          return checkIdenticalTms(reshapeUser, user);
+                        }) &&
+           "isCommuteUpwardsViable/Favorable should have ensured all users "
+           "are identical TMs");
+
+    for (auto *user : users) {
+      rewriter.replaceOp(user, newSoftmaxOp.getResult());
+    };
+  }
+
+  // Consider the following IR pseudocode:
+  // Before commuting reshape op downwards
+  //   %x = reshape(%arg0)
+  //   %y = softmax(%x, dim)
+  // After commuting reshape op downwards
+  //   %a = softmax(%arg0, updatedDim)
+  //   %b = reshape(%a)
+  void
+  performCommuteDownwardsRewrite(SoftmaxOp op, ReshapeOp reshapeOperand,
+                                 PatternRewriter &rewriter) const override {
+    auto reshapeOperandOutputShape =
+        reshapeOperand.getResult().getType().getShape();
+    auto reshapeOperandInputShape =
+        reshapeOperand.getInput().getType().getShape();
+    int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+    // We are mapping the softmax axis from reshape operand output to reshape
+    // operand input
+    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+        reshapeOperandOutputShape, reshapeOperandInputShape, softmaxDim);
+    assert(newSoftmaxDim != -1 &&
+           "Invalid Softmax Dimension, isCommuteDownwardsFavorable should have "
+           "handled this");
+
+    // Create the Softmax Op on the Reshape Operand's input
+    auto newSoftmaxInputType =
+        cast<RankedTensorType>(reshapeOperand.getInput().getType());
+
+    auto newSoftmaxDimAttr = rewriter.getSI32IntegerAttr(newSoftmaxDim);
+
+    // Create new Softmax Op with updated dimension attribute
+    auto newSoftmaxOp = rewriter.create<SoftmaxOp>(
+        op->getLoc(), newSoftmaxInputType, reshapeOperand.getInput(),
+        newSoftmaxDimAttr, op.getNumericStableAttr());
+
+    // Create new reshape Op
+    auto originalSoftmaxOpType =
+        cast<RankedTensorType>(op.getResult().getType());
+    auto originalSoftmaxOpShape = originalSoftmaxOpType.getShape();
+    SmallVector<int32_t> reshapeTargetShape(originalSoftmaxOpShape.begin(),
+                                            originalSoftmaxOpShape.end());
+    auto newReshapeOp = rewriter.create<ReshapeOp>(
+        reshapeOperand->getLoc(), op.getType(), newSoftmaxOp.getResult(),
+        rewriter.getI32ArrayAttr(reshapeTargetShape));
+
+    rewriter.replaceOp(op, newReshapeOp.getResult());
+  }
+
+private:
+  bool isCommuteUpwardsViable(SoftmaxOp op,
+                              ReshapeOp reshapeUser) const override {
+    return true;
+  }
+
+  bool isCommuteUpwardsFavorable(SoftmaxOp op,
+                                 ReshapeOp reshapeUser) const override {
+    // Check if the softmax dimension was not split or merged by reshape, if it
+    // does then we can't commute
+    auto softmaxInputShape =
+        cast<RankedTensorType>(op.getInput().getType()).getShape();
+    auto outputReshapeShape =
+        cast<RankedTensorType>(reshapeUser.getResult().getType()).getShape();
+    int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+
+    // We are mapping the softmax axis from softmax input to reshape user output
+    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+        softmaxInputShape, outputReshapeShape, softmaxDim);
+    if (newSoftmaxDim == -1) {
+      return false;
+    }
+
+    // Otherwise, We should always commute a reshape above softmax op if all
+    // users are an identical TMs/reshapes. This includes the case where there
+    // is one user.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+
+  bool isCommuteDownwardsViable(SoftmaxOp op,
+                                ReshapeOp reshapeOperand) const override {
+    return true;
+  }
+
+  bool isCommuteDownwardsFavorable(SoftmaxOp op,
+                                   ReshapeOp reshapeOperand) const override {
+    // We need to ensure the softmax dim on the reshape is not the axis
+    // which gets split or merged from the input
+    // For example consider
+    // %x -- Input
+    // %y = reshape(%x) : [2,3,4] -> [2,12]
+    // %z = softmax(%y, dim=1) // reduces over 12
+    // If we commute the reshape down the softmax
+    // softmax(%x, dim = ?)
+    // No axis where reduction length is 12.
+    auto reshapeOperandOutputShape =
+        reshapeOperand.getResult().getType().getShape();
+    auto reshapeOperandInputShape =
+        reshapeOperand.getInput().getType().getShape();
+    int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+
+    // We are mapping the softmax axis from reshape operand output to reshape
+    // operand input
+    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+        reshapeOperandOutputShape, reshapeOperandInputShape, softmaxDim);
+    if (newSoftmaxDim == -1) {
+      return false;
+    }
+
+    // If the above condition satisfies, then commuting a reshape downwards
+    // through a softmax op is always favorable as
+    // softmax only has one operand, and here we know it is a reshape.
+    return true;
+  }
+};
+} // namespace
+
+template <CommuteDirection commuteDirection>
+void populateSoftmaxCommutePatterns(MLIRContext *ctx,
+                                    RewritePatternSet &patterns) {
+  patterns.insert<TTIRCommuteReshapeThroughSoftmax<commuteDirection>>(ctx);
+}
+
+template void populateSoftmaxCommutePatterns<CommuteDirection::UPWARDS>(
+    MLIRContext *ctx, RewritePatternSet &patterns);
+
+template void populateSoftmaxCommutePatterns<CommuteDirection::DOWNWARDS>(
+    MLIRContext *ctx, RewritePatternSet &patterns);
+
+} // namespace mlir::tt::ttir

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_softmax.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_softmax.mlir
@@ -1,0 +1,56 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="enable-commute-upwards=false" -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module {
+    func.func @test_reshape_softmax_commute_downwards_flatten(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%arg0
+        // CHECK: dimension = 3
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SOFTMAX]]
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.softmax"(%1) <{dimension = 2 : si32}> : (tensor<1x25600x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+    func.func @test_reshape_softmax_commute_downwards_unflatten(%arg0: tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16> {
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%arg0
+        // CHECK: dimension = 2
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SOFTMAX]]
+        // CHECK: shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]}> : (tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.softmax"(%1) <{dimension = 3 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        return %2 : tensor<1x160x160x128xbf16>
+
+    }
+    func.func @test_reshape_softmax_commute_downwards_split_on_softmax_dim(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%[[RESHAPE]]
+        // CHECK: dimension = 1
+        // CHECK: return %[[SOFTMAX]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.softmax"(%1) <{dimension = 1 : si32}> : (tensor<1x25600x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+    func.func @test_reshape_softmax_commute_downwards_merge_on_softmax_dim(%arg0: tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK: shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%[[RESHAPE]]
+        // CHECK: dimension = 2
+        // CHECK: return %[[SOFTMAX]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]}> : (tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.softmax"(%1) <{dimension = 2 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        return %2 : tensor<1x160x160x128xbf16>
+    }
+    func.func @test_reshape_softmax_commute_downwards_negative_softmax_dim(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%arg0
+        // CHECK: dimension = 3
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SOFTMAX]]
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.softmax"(%1) <{dimension = -1 : si32}> : (tensor<1x25600x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_softmax.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_softmax.mlir
@@ -1,0 +1,74 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=true enable-commute-downwards=false" -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module {
+    func.func @test_reshape_softmax_commute_flatten(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%[[RESHAPE]]
+        // CHECK: dimension = 2
+        // CHECK: return %[[SOFTMAX]]
+        %1 = "ttir.softmax"(%arg0) <{dimension = 3 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+    func.func @test_reshape_softmax_commute_unflatten(%arg0: tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK: shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%[[RESHAPE]]
+        // CHECK: dimension = 3
+        // CHECK: return %[[SOFTMAX]]
+        %1 = "ttir.softmax"(%arg0) <{dimension = 2 : si32}> : (tensor<1x25600x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]}> : (tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16>
+        return %2 : tensor<1x160x160x128xbf16>
+    }
+    func.func @test_reshape_softmax_no_commute_merge_softmax_dim(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%arg0
+        // CHECK: dimension = 1
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SOFTMAX]]
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.softmax"(%arg0) <{dimension = 1 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+    func.func @test_reshape_softmax_no_commute_split_softmax_dim(%arg0: tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16> {
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%arg0
+        // CHECK: dimension = 1
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SOFTMAX]]
+        // CHECK: shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.softmax"(%arg0) <{dimension = 1 : si32}> : (tensor<1x25600x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 160 : i32, 160 : i32, 128 : i32]}> : (tensor<1x25600x128xbf16>) -> tensor<1x160x160x128xbf16>
+        return %2 : tensor<1x160x160x128xbf16>
+    }
+    func.func @test_reshape_softmax_commute_negative_dim(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: %[[SOFTMAX:[0-9]+]] = "ttir.softmax"(%[[RESHAPE]]
+        // CHECK: dimension = 2
+        // CHECK: return %[[SOFTMAX]]
+        %1 = "ttir.softmax"(%arg0) <{dimension = -1 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2 : tensor<1x25600x128xbf16>
+    }
+    // If softmax has multiple users that are same reshapes, they can commute upwards.
+    func.func @test_reshape_softmax_commute_two_same_reshapes(%arg0: tensor<1x160x160x128xbf16>) -> (tensor<1x25600x128xbf16>, tensor<1x25600x128xbf16>) {
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.softmax"
+        %1 = "ttir.softmax"(%arg0) <{dimension = 3 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        %3 = "ttir.reshape"(%1) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        return %2, %3 : tensor<1x25600x128xbf16>, tensor<1x25600x128xbf16>
+    }
+    // If softmax has multiple and not all are same reshapes, they cannot commute upwards.
+    func.func @test_reshape_softmax_commute_two_different_reshapes(%arg0: tensor<1x160x160x128xbf16>) -> (tensor<1x1x25600x128xbf16>, tensor<1x10x2560x128xbf16>) {
+        // CHECK: "ttir.softmax"
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.reshape"
+        %1 = "ttir.softmax"(%arg0) <{dimension = 3 : si32}> : (tensor<1x160x160x128xbf16>) -> tensor<1x160x160x128xbf16>
+        %3 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x1x25600x128xbf16>
+        %5 = "ttir.reshape"(%1) <{shape = [1 : i32, 10 : i32, 2560 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x10x2560x128xbf16>
+        return %3, %5 : tensor<1x1x25600x128xbf16>, tensor<1x10x2560x128xbf16>
+    }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/5951)

### Problem description
Commute Patterns for Softmax with Reshape.
This commit adds changes to commute upwards and downwards the reshape op through the softmax using stride and reduction length of the softmax dimension.

### What's changed
Added Commute Patterns for Softmax with Reshape. Now,  Inverse TensorManipulation Ops like Reshape can be folded by commuting them upwards or downwards through the graph, improving the performance.

For eg, swin model as it has 24 softmax-es each surrounded by two reshapes, which could be folded away.

```
%345 = "ttnn.reshape"(%344)  tensor<1083x49x49xbf16> -> tensor<361x3x49x49xbf16>
%346 = "ttnn.softmax"(%345) <{dimension = 3 : si32, numericStable = true}> 
%347 = "ttnn.reshape"(%346)  tensor<361x3x49x49xbf16> -> tensor<1083x49x49xbf16>
```

which would be rewritten with this commute as just:

```
%346 = "ttnn.softmax"(%345) <{dimension = 2 : si32, numericStable = true}>
```

### Notes

#### Update Softmax Dimension with Stride and reduction Length

Maps a softmax axis across a reshape by matching both: 
1. The reduction length of the axis, and 
2. Its contiguous stride.

```
     Consider a Tensor with shape = [2, 3, 4]
       i=0,j=0,k=0
       i=0,j=0,k=1
       i=0,j=0,k=2
       i=0,j=0,k=3
       i=0,j=1,k=0
       ...
     strides = [3*4, 4, 1]

Example 1 (Valid commute):
       Input shape      = [2, 3, 4]
       Softmax dim      = 2  (stride = 1, reduction length = 4)
       Reshape          = [6, 4]
The new softmax dim is 1, since output dim 1 still has stride = 1 and reduction length = 4.
     
Example 2 (Invalid Commute)
       Input shape      = [2, 3, 4]
       Softmax dim      = 1  (stride = 4, reduction length = 3)
       Reshape          = [2, 12]
output strides = [12, 1],  Hence, we can't apply softmax because no dimension in output has stride 4 and reduction len = 3
```

#### Upwards

```
   %0 = softmax(%arg0 : tensor<1x160x160x128xbf16>) <{dimension = 3}>
   %1 = reshape(%0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}>
to
   %0 = reshape(%arg0 : tensor<1x160x160x128xbf16>) <{shape = [1 : i32, 25600 : i32, 128 : i32]}>
   %1 = softmax(%0) <{dimension = 2}>
```


#### Downwards
```
   %0 = reshape(%arg0 : tensor<1x160x160x128xbf16>) <{shape = [1 : i32, 25600 : i32, 128 : i32]}>
   %1 = softmax(%0) <{dimension = 2}>
 
to
   
   %0 = softmax(%arg0 : tensor<1x160x160x128xbf16>) <{dimension = 3}>
   %1 = reshape(%0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}>
```

### Testing

```
pre-commit run --show-diff-on-failure --color=always --all-files
black....................................................................Passed
clang-format.............................................................Passed
Check copyright notices..................................................Passed
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for added large files..............................................Passed
Fix include style........................................................Passed
```

```
llvm-lit -sv ./test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_softmax.mlir 

Testing Time: 0.28s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

```
llvm-lit -sv ./test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_softmax.mlir 

Testing Time: 0.07s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

### Checklist
- [X] New/Existing tests provide coverage for changes
