### PR TITLE
Include compute kernel config in TTNN OpModel

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h
@@ -75,9 +75,11 @@ struct Conv2dAttrs {
 
 struct MatmulAttrs {
   std::optional<mlir::Attribute> matmulProgramConfig;
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig;
 
   bool operator==(const MatmulAttrs &other) const {
-    return matmulProgramConfig == other.matmulProgramConfig;
+    return matmulProgramConfig == other.matmulProgramConfig &&
+           computeKernelConfig == other.computeKernelConfig;
   }
   bool operator!=(const MatmulAttrs &other) const { return !(*this == other); }
 
@@ -91,6 +93,16 @@ struct MatmulAttrs {
       result += "matmulProgramConfig=" + attrStr;
     } else {
       result += "matmulProgramConfig=<null>";
+    }
+    result += ", ";
+    if (computeKernelConfig.has_value() && computeKernelConfig.value()) {
+      std::string attrStr;
+      llvm::raw_string_ostream stream(attrStr);
+      stream << computeKernelConfig.value();
+      stream.flush();
+      result += "computeKernelConfig=" + attrStr;
+    } else {
+      result += "computeKernelConfig=<null>";
     }
     result += "}";
     return result;

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -975,7 +975,9 @@ struct OpModel<LinearOp> {
       std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
       bool transposeA, bool transposeB,
       std::optional<llvm::StringRef> activation,
-      std::optional<mlir::Attribute> programConfigAttr = std::nullopt);
+      std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+          std::nullopt);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -996,7 +998,9 @@ struct OpModel<MatmulOp> {
       TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
       TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
       bool transposeB, std::optional<llvm::StringRef> activation = std::nullopt,
-      std::optional<mlir::Attribute> programConfigAttr = std::nullopt);
+      std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+          std::nullopt);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,

--- a/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpConfigAnalysis.cpp
@@ -251,7 +251,8 @@ void LegalOpConfigAnalysis::fillOpSpecificAttrs() {
           auto programConfig =
               generateMatmulProgramConfig(op, opConfig.outputLayout);
           if (programConfig.has_value()) {
-            opConfig.opSpecificAttrs = MatmulAttrs{programConfig.value()};
+            opConfig.opSpecificAttrs =
+                MatmulAttrs{programConfig.value(), matmulOp.getComputeConfig()};
           }
           TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                        "Filled op specific attrs for matmul/linear op {}, "

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2868,7 +2868,7 @@ static MatmulAttrs unpackMatmulAttrs(const OpConfig::OpSpecificAttrs &attrs,
          "Please create a MatmulAttrs or leave it to be uninitialized.");
 
   if (std::holds_alternative<UninitializedAttrs>(attrs)) {
-    return MatmulAttrs{op.getMatmulProgramConfig()};
+    return MatmulAttrs{op.getMatmulProgramConfig(), op.getComputeConfig()};
   }
 
   MatmulAttrs matmulAttrs = std::get<MatmulAttrs>(attrs);
@@ -2877,7 +2877,11 @@ static MatmulAttrs unpackMatmulAttrs(const OpConfig::OpSpecificAttrs &attrs,
   return MatmulAttrs{(matmulAttrs.matmulProgramConfig.has_value() &&
                       matmulAttrs.matmulProgramConfig.value())
                          ? matmulAttrs.matmulProgramConfig
-                         : op.getMatmulProgramConfig()};
+                         : op.getMatmulProgramConfig(),
+                     (matmulAttrs.computeKernelConfig.has_value() &&
+                      matmulAttrs.computeKernelConfig.value())
+                         ? matmulAttrs.computeKernelConfig
+                         : op.getComputeConfig()};
 }
 
 llvm::Expected<op_model::OpConstraints>
@@ -2915,7 +2919,7 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       op_model::OpModel<LinearOp>::getOpConstraints, *this, deviceGrid,
       inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
       opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
-      attr.matmulProgramConfig);
+      attr.matmulProgramConfig, attr.computeKernelConfig);
 }
 
 llvm::Expected<size_t>
@@ -2988,7 +2992,8 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<MatmulOp>::getOpConstraints, *this, deviceGrid,
       inputShapeA, inputs[0], inputShapeB, inputs[1], opConfig.outputLayout,
-      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig);
+      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig,
+      attr.computeKernelConfig);
 }
 
 llvm::Expected<size_t>

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4090,7 +4090,8 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
     bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr) {
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4130,12 +4131,16 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig>
+      computeKernelConfigConverted =
+          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
+
   // Create query closure
   auto linearOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
         transposeB, outputMemoryConfig, outputDType, programConfig,
-        activationStr, /*compute_kernel_config=*/std::nullopt,
+        activationStr, computeKernelConfigConverted,
         /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
         /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
@@ -4210,7 +4215,8 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     TTNNLayoutAttr inputLayoutA, llvm::ArrayRef<int64_t> inputShapeB,
     TTNNLayoutAttr inputLayoutB, TTNNLayoutAttr outputLayout, bool transposeA,
     bool transposeB, std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr) {
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4243,12 +4249,16 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig>
+      computeKernelConfigConverted =
+          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
+
   // Create query closure
   auto matmulOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
         outputMemoryConfig, outputDType, programConfig, activationStr,
-        /*compute_kernel_config=*/std::nullopt, /*core_grid=*/std::nullopt,
+        computeKernelConfigConverted, /*core_grid=*/std::nullopt,
         /*output_tile=*/std::nullopt, /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };


### PR DESCRIPTION
Matmuls were invoked in TTNNOpModel without compute kernel config creating discrepancy between op model and runtime.

