### PR TITLE
[EmitPy] Remove redundant GetGlobalOp

### DIFF
--- a/include/ttmlir/Dialect/EmitPy/IR/EmitPyOps.td
+++ b/include/ttmlir/Dialect/EmitPy/IR/EmitPyOps.td
@@ -446,26 +446,6 @@ def EmitPy_GlobalStatementOp : EmitPy_Op<"global_statement",
   let assemblyFormat = "$name `:` type($result) attr-dict";
 }
 
-def EmitPy_GetGlobalOp : EmitPy_Op<"get_global",
-    [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
-  let summary = "Obtain access to a global variable";
-  let description = [{
-    The `emitpy.get_global` operation retrieves the value of a named global variable.
-
-    Example:
-
-    ```mlir
-    %1 = emitpy.get_global @x : !emitpy.opaque<"[ttnn.Tensor]">
-    ```
-  }];
-
-  let arguments = (ins FlatSymbolRefAttr:$name);
-  let results = (outs AnyType:$result);
-
-  let hasVerifier = 1;
-  let assemblyFormat = "$name `:` type($result) attr-dict";
-}
-
 def EmitPy_AssignGlobalOp : EmitPy_Op<"assign_global",
     [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Assign a value to a global variable";

--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -734,20 +734,6 @@ GlobalStatementOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// GetGlobalOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult GetGlobalOp::verify() {
-  StringRef name = getName();
-  return isValidPythonIdentifier(getOperation(), name);
-}
-
-LogicalResult
-GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyNearestGlobalSymbol<GetGlobalOp>(*this, symbolTable);
-}
-
-//===----------------------------------------------------------------------===//
 // CreateDictOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/Python/TranslateToPython.cpp
+++ b/lib/Target/Python/TranslateToPython.cpp
@@ -315,7 +315,7 @@ static bool hasDeferredEmission(Operation *op) {
   if (auto exprOp = dyn_cast_or_null<ExpressionOp>(op)) {
     return !exprOp.getDoNotInline();
   }
-  return isa_and_nonnull<LiteralOp, GetGlobalOp>(op);
+  return isa_and_nonnull<LiteralOp>(op);
 }
 
 StringRef PythonEmitter::getOrCreateName(Value value, std::string name) {
@@ -871,10 +871,6 @@ LogicalResult PythonEmitter::emitOperation(Operation &op) {
                 GlobalStatementOp, CreateDictOp, SetValueForDictKeyOp,
                 GetValueForDictKeyOp, ExpressionOp, YieldOp>(
               [&](auto op) { return printOperation(*this, op); })
-          .Case<GetGlobalOp>([&](auto op) {
-            registerDeferredValue(op.getResult(), op.getName());
-            return success();
-          })
           .Case<LiteralOp>([&](auto op) {
             registerDeferredValue(op.getResult(), op.getValue());
             return success();

--- a/test/ttmlir/Dialect/EmitPy/global.mlir
+++ b/test/ttmlir/Dialect/EmitPy/global.mlir
@@ -34,8 +34,8 @@ module {
   emitpy.global @tensor_global = #emitpy.opaque<"[ttnn.Tensor]">
 
   func.func @get_tensor() -> !emitpy.opaque<"[ttnn.Tensor]"> {
-    // CHECK: %{{.*}} = emitpy.get_global @tensor_global : !emitpy.opaque<"[ttnn.Tensor]">
-    %0 = emitpy.get_global @tensor_global : !emitpy.opaque<"[ttnn.Tensor]">
+    // CHECK: %{{.*}} = emitpy.global_statement @tensor_global : !emitpy.opaque<"[ttnn.Tensor]">
+    %0 = emitpy.global_statement @tensor_global : !emitpy.opaque<"[ttnn.Tensor]">
     return %0 : !emitpy.opaque<"[ttnn.Tensor]">
   }
 }
@@ -47,8 +47,8 @@ module {
   emitpy.global @counter = 0 : i64
 
   func.func @get_counter() -> i64 {
-    // CHECK: %{{.*}} = emitpy.get_global @counter : i64
-    %0 = emitpy.get_global @counter : i64
+    // CHECK: %{{.*}} = emitpy.global_statement @counter : i64
+    %0 = emitpy.global_statement @counter : i64
     return %0 : i64
   }
 }
@@ -120,8 +120,8 @@ module {
     %0 = emitpy.global_statement @global_var : !emitpy.opaque<"[ttnn.Tensor]">
     // CHECK: emitpy.assign_global @global_var = %{{.*}} : !emitpy.opaque<"[ttnn.Tensor]">
     emitpy.assign_global @global_var = %arg0 : !emitpy.opaque<"[ttnn.Tensor]">
-    // CHECK: %{{.*}} = emitpy.get_global @global_var : !emitpy.opaque<"[ttnn.Tensor]">
-    %1 = emitpy.get_global @global_var : !emitpy.opaque<"[ttnn.Tensor]">
+    // CHECK: %{{.*}} = emitpy.global_statement @global_var : !emitpy.opaque<"[ttnn.Tensor]">
+    %1 = emitpy.global_statement @global_var : !emitpy.opaque<"[ttnn.Tensor]">
     return %1 : !emitpy.opaque<"[ttnn.Tensor]">
   }
 }
@@ -137,12 +137,12 @@ module {
   emitpy.global @global_c = 0 : i64
 
   func.func @use_multiple() -> i64 {
-    // CHECK: %{{.*}} = emitpy.get_global @global_a : !emitpy.opaque<"None">
-    %0 = emitpy.get_global @global_a : !emitpy.opaque<"None">
-    // CHECK: %{{.*}} = emitpy.get_global @global_b : !emitpy.opaque<"[ttnn.Tensor]">
-    %1 = emitpy.get_global @global_b : !emitpy.opaque<"[ttnn.Tensor]">
-    // CHECK: %{{.*}} = emitpy.get_global @global_c : i64
-    %2 = emitpy.get_global @global_c : i64
+    // CHECK: %{{.*}} = emitpy.global_statement @global_a : !emitpy.opaque<"None">
+    %0 = emitpy.global_statement @global_a : !emitpy.opaque<"None">
+    // CHECK: %{{.*}} = emitpy.global_statement @global_b : !emitpy.opaque<"[ttnn.Tensor]">
+    %1 = emitpy.global_statement @global_b : !emitpy.opaque<"[ttnn.Tensor]">
+    // CHECK: %{{.*}} = emitpy.global_statement @global_c : i64
+    %2 = emitpy.global_statement @global_c : i64
     return %2 : i64
   }
 }

--- a/test/ttmlir/Dialect/EmitPy/global_negative.mlir
+++ b/test/ttmlir/Dialect/EmitPy/global_negative.mlir
@@ -39,18 +39,6 @@ module {
 module {
   emitpy.global @typed_global = 0
 
-  func.func @get_global_type_mismatch() -> !emitpy.opaque<"[ttnn.Tensor]"> {
-    // CHECK: error: 'emitpy.get_global' op result type ('!emitpy.opaque<"[ttnn.Tensor]">') does not match global's type ('i64')
-    %0 = emitpy.get_global @typed_global : !emitpy.opaque<"[ttnn.Tensor]">
-    return %0 : !emitpy.opaque<"[ttnn.Tensor]">
-  }
-}
-
-// -----
-
-module {
-  emitpy.global @typed_global = 0
-
   func.func @assign_global_type_mismatch(%arg0: !emitpy.opaque<"[ttnn.Tensor]">) -> () {
     // CHECK: error: 'emitpy.assign_global' op value type ('!emitpy.opaque<"[ttnn.Tensor]">') does not match global's type ('i64')
     emitpy.assign_global @typed_global = %arg0 : !emitpy.opaque<"[ttnn.Tensor]">
@@ -66,28 +54,6 @@ module {
   func.func @global_statement_type_mismatch() -> !emitpy.opaque<"[ttnn.Tensor]"> {
     // CHECK: error: 'emitpy.global_statement' op result type ('!emitpy.opaque<"[ttnn.Tensor]">') does not match global's type ('i64')
     %0 = emitpy.global_statement @typed_global : !emitpy.opaque<"[ttnn.Tensor]">
-    return %0 : !emitpy.opaque<"[ttnn.Tensor]">
-  }
-}
-
-// -----
-
-module {
-  func.func @get_global_nonexistent() -> !emitpy.opaque<"[ttnn.Tensor]"> {
-    // CHECK: error: 'emitpy.get_global' op 'nonexistent_global' does not reference a valid emitpy.global
-    %0 = emitpy.get_global @nonexistent_global : !emitpy.opaque<"[ttnn.Tensor]">
-    return %0 : !emitpy.opaque<"[ttnn.Tensor]">
-  }
-}
-
-// -----
-
-module {
-  emitpy.global @global_var = #emitpy.opaque<"None">
-
-  func.func @get_another_global_nonexistent() -> !emitpy.opaque<"[ttnn.Tensor]"> {
-    // CHECK: error: 'emitpy.get_global' op 'global_var_1' does not reference a valid emitpy.global
-    %0 = emitpy.get_global @global_var_1 : !emitpy.opaque<"[ttnn.Tensor]">
     return %0 : !emitpy.opaque<"[ttnn.Tensor]">
   }
 }

--- a/test/ttmlir/Translate/EmitPy/global.mlir
+++ b/test/ttmlir/Translate/EmitPy/global.mlir
@@ -55,8 +55,8 @@ module {
     %0 = emitpy.global_statement @global_var_3 : i64
     // CHECK: global global_var_4
     %1 = emitpy.global_statement @global_var_4 : i64
-    %2 = emitpy.get_global @global_var_3 : i64
-    %3 = emitpy.get_global @global_var_4 : i64
+    %2 = emitpy.global_statement @global_var_3 : i64
+    %3 = emitpy.global_statement @global_var_4 : i64
     // CHECK: global_var_3 = global_var_4
     emitpy.assign_global @global_var_3 = %3 : i64
     return


### PR DESCRIPTION
### Problem description
`GetGlobalOp` was originally introduced to handle global variable retrieval within function scopes during the initial implementation of globals in the EmitPy dialect. However, this functionality is redundant because GlobalStatementOp already provides the necessary logic for modeling Python globals and is a fundamental operation for this dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
