### PR TITLE
[Optimizer] Make fallback selection deterministic

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -368,37 +368,37 @@ bool tryFallbacks(Operation *operation,
                           /*currentDistance*/ 0.0, allCombinations);
 
   // Sort combinations by total distance (ascending)
-  // Use stable_sort to maintain deterministic ordering when distances are equal
-  std::stable_sort(
-      allCombinations.begin(), allCombinations.end(),
-      [](const CombinationCandidate &a, const CombinationCandidate &b) {
-        if (a.totalDistance != b.totalDistance) {
-          return a.totalDistance < b.totalDistance;
-        }
-        // Tiebreaker: content-based lexicographic comparison for full
-        // determinism across runs when distances are equal
-        for (size_t i = 0; i < a.layouts.size() && i < b.layouts.size(); ++i) {
-          const auto &aLayout = a.layouts[i];
-          const auto &bLayout = b.layouts[i];
+  // Comparator includes full tiebreaker for deterministic ordering
+  std::sort(allCombinations.begin(), allCombinations.end(),
+            [](const CombinationCandidate &a, const CombinationCandidate &b) {
+              if (a.totalDistance != b.totalDistance) {
+                return a.totalDistance < b.totalDistance;
+              }
+              // Tiebreaker: content-based lexicographic comparison for full
+              // determinism across runs when distances are equal
+              for (size_t i = 0; i < a.layouts.size() && i < b.layouts.size();
+                   ++i) {
+                const auto &aLayout = a.layouts[i];
+                const auto &bLayout = b.layouts[i];
 
-          // Compare layout type first (RowMajor before Tile based on enum
-          // order)
-          if (aLayout.getLayout() != bLayout.getLayout()) {
-            return static_cast<int>(aLayout.getLayout()) <
-                   static_cast<int>(bLayout.getLayout());
-          }
-          if (aLayout.getDataType() != bLayout.getDataType()) {
-            return static_cast<int>(aLayout.getDataType()) <
-                   static_cast<int>(bLayout.getDataType());
-          }
-          if (aLayout.getBufferType() != bLayout.getBufferType()) {
-            return static_cast<int>(aLayout.getBufferType()) <
-                   static_cast<int>(bLayout.getBufferType());
-          }
-        }
-        // All layouts match - combinations are equivalent
-        return false;
-      });
+                // Compare layout type first (RowMajor before Tile based on enum
+                // order)
+                if (aLayout.getLayout() != bLayout.getLayout()) {
+                  return static_cast<int>(aLayout.getLayout()) <
+                         static_cast<int>(bLayout.getLayout());
+                }
+                if (aLayout.getDataType() != bLayout.getDataType()) {
+                  return static_cast<int>(aLayout.getDataType()) <
+                         static_cast<int>(bLayout.getDataType());
+                }
+                if (aLayout.getBufferType() != bLayout.getBufferType()) {
+                  return static_cast<int>(aLayout.getBufferType()) <
+                         static_cast<int>(bLayout.getBufferType());
+                }
+              }
+              // All layouts match - combinations are equivalent
+              return false;
+            });
 
   TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
                "Generated {} combinations, testing by distance",


### PR DESCRIPTION
### Problem description
Observed non-deterministic behavior on tt-xla `tests/runner/test_models.py::test_all_models_torch[yoloworld/pytorch-small_640-single_device-inference]` with `optimization_level=1`. 

Origin of the behavior was in `lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp`:
The input of `ttnn.argmax` was sometimes converted to `tiled+bf16`, and other times to `row-major+si32`. Both fallbacks have equal heuristic cost (MID_COST = 2.0), and the selection depended on:
1. Hash collision order in `std::unordered_set`
2. Non-stable sorting of equal-distance combinations

### What's changed
- Replaced `std::unordered_set` with `std::set` using content-based comparator for deterministic iteration order
- Changed `std::sort` to have full lexicographic tiebreaker (Layout → DataType → BufferType) for equal-distance combinations

### Note
- [x] Tested on Performance Benchmarks to ensure no perf degradation:
- before changes: https://github.com/tenstorrent/tt-xla/actions/runs/21519254931
- after changes: https://github.com/tenstorrent/tt-xla/actions/runs/21520154901
