### PR TITLE
Add eltwise op interfaces to TTNN dialect

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNDeviceOperandInterface.h"
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNWorkaroundInterface.h"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -7,6 +7,7 @@
 
 include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td"
 include "ttmlir/Dialect/TTNN/Interfaces/TTNNDeviceOperandInterface.td"
+include "ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.td"
 include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
@@ -141,7 +142,7 @@ def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
 }
 
 class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface] # traits> {
+    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_EltwiseUnaryOpInterface] # traits> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -165,7 +166,7 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_DtypeOpInterface] # traits> {
+    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_DtypeOpInterface, TTNN_EltwiseBinaryOpInterface] # traits> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -201,7 +202,7 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTNN_ElementwiseBinaryCompositeOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface] # traits> {
+    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_EltwiseBinaryOpInterface] # traits> {
     let summary = "Eltwise binary composite op.";
     let description = [{
       Eltwise binary composite op.
@@ -229,7 +230,7 @@ class TTNN_ElementwiseBinaryCompositeOp<string mnemonic, list<Trait> traits = []
 }
 
 class TTNN_ElementwiseBinaryCompositeScalarOp<string mnemonic, list<Trait> traits = []> :
-  TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface] # traits> {
+  TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_EltwiseBinaryOpInterface] # traits> {
   let summary = "Eltwise binary composite op.";
   let description = [{
     Eltwise binary composite op where the first input is a tensor and the second is a scalar.
@@ -251,7 +252,7 @@ class TTNN_ElementwiseBinaryCompositeScalarOp<string mnemonic, list<Trait> trait
 }
 
 class TTNN_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface] # traits> {
+    TTNN_Op<mnemonic, [TTNN_MemoryConfigOpInterface, TTNN_EltwiseTernaryOpInterface] # traits> {
     let summary = "Eltwise ternary op.";
     let description = [{
       Eltwise ternary op.

--- a/include/ttmlir/Dialect/TTNN/Interfaces/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_interface(TTNNDeviceOperandInterface)
+add_mlir_interface(TTNNEltwiseOpInterface)
 add_mlir_interface(TTNNOpModelInterface)
 add_mlir_interface(TTNNWorkaroundInterface)
 add_mlir_interface(TTNNTensorSpecInterface)

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.h
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_H
+#define TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_H
+
+#include "mlir/IR/OpDefinition.h"
+
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.h.inc"
+
+#endif // TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_H

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNEltwiseOpInterface.td
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_TD
+#define TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_TD
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// TTNN Elementwise Op Interfaces
+//===----------------------------------------------------------------------===//
+
+// Interface to identify elementwise operations in TTNN dialect.
+// This provides a unified way to check if an operation is elementwise
+// instead of using mlir::isa with multiple op types.
+
+def TTNN_EltwiseOpInterface : OpInterface<"EltwiseOpInterface"> {
+  let cppNamespace = "::mlir::tt::ttnn";
+  let description = [{
+    Interface for operations that perform elementwise computations.
+    This includes unary, binary, and ternary elementwise operations.
+  }];
+}
+
+def TTNN_EltwiseUnaryOpInterface : OpInterface<"EltwiseUnaryOpInterface", [TTNN_EltwiseOpInterface]> {
+  let cppNamespace = "::mlir::tt::ttnn";
+  let description = [{
+    Interface for unary elementwise operations.
+    These operations take a single input tensor and produce an output tensor
+    where each element is computed independently from the corresponding input element.
+  }];
+}
+
+def TTNN_EltwiseBinaryOpInterface : OpInterface<"EltwiseBinaryOpInterface", [TTNN_EltwiseOpInterface]> {
+  let cppNamespace = "::mlir::tt::ttnn";
+  let description = [{
+    Interface for binary elementwise operations.
+    These operations take two input tensors and produce an output tensor
+    where each element is computed independently from the corresponding input elements.
+  }];
+}
+
+def TTNN_EltwiseTernaryOpInterface : OpInterface<"EltwiseTernaryOpInterface", [TTNN_EltwiseOpInterface]> {
+  let cppNamespace = "::mlir::tt::ttnn";
+  let description = [{
+    Interface for ternary elementwise operations.
+    These operations take three input tensors and produce an output tensor
+    where each element is computed independently from the corresponding input elements.
+  }];
+}
+
+#endif // TTMLIR_DIALECT_TTNN_INTERFACES_TTNNELTWISEOPINTERFACE_TD


### PR DESCRIPTION
## Ticket
Fixes #6834

## Problem description
There is no trait to identify eltwise ops in TTNN dialect right now. This leads to code using `mlir::isa` to match every eltwise op, which is verbose and error-prone.

## What's changed
Added new op interfaces to identify eltwise operations in the TTNN dialect:

- `TTNN_EltwiseOpInterface` - Base interface for all elementwise operations
- `TTNN_EltwiseUnaryOpInterface` - Interface for unary elementwise operations (inherits from EltwiseOpInterface)
- `TTNN_EltwiseBinaryOpInterface` - Interface for binary elementwise operations (inherits from EltwiseOpInterface)
- `TTNN_EltwiseTernaryOpInterface` - Interface for ternary elementwise operations (inherits from EltwiseOpInterface)

These interfaces are applied to the corresponding TTNN elementwise op classes:
- `TTNN_ElementwiseUnaryOp`
- `TTNN_ElementwiseBinaryOp`
- `TTNN_ElementwiseBinaryCompositeOp`
- `TTNN_ElementwiseBinaryCompositeScalarOp`
- `TTNN_ElementwiseTernaryOp`

### Before
```cpp
if (llvm::isa<ttnn::AddOp, ttnn::MultiplyOp, ttnn::MinimumOp>(op)) {
  // ...
}
```

### After
```cpp
if (llvm::isa<ttnn::EltwiseBinaryOpInterface>(op)) {
  // ...
}
```

## Checklist
- [x] New interfaces provide a clean way to identify eltwise ops
- [ ] Tests need to be added (pending build verification)