### PR TITLE
Virtual Grid View Handling and Cleanup

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -38,6 +38,18 @@ computeDimConstraints(mlir::ArrayRef<mlir::AffineMap> indexingMaps,
 SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
                                     AffineMap indexingMap);
 
+// Gets the underlying physical grid shape corresponding to the tensor or
+// memref. For views/streams, this 'physical' grid corresponds to the compute
+// grid shape used if the tensor/memref was the output of a GenericOp.
+SmallVector<int64_t> getPhysicalGridShape(Value tensorOrMemref);
+
+// Finds a 2D grid (y, x) such that y * x = gridVolume. The returned grid aims
+// to be as square as possible while respecting the provided target grid shape
+// bounds. If either MxN or NxM grids are feasible where M > N, MxN is chosen.
+SmallVector<int64_t>
+findLegalPhysicalGridForVolume(int64_t gridVolume,
+                               ArrayRef<int64_t> targetGridShape);
+
 } // namespace mlir::tt::d2m::utils
 
 #endif

--- a/include/ttmlir/Dialect/D2M/Utils/VirtualGrid.h
+++ b/include/ttmlir/Dialect/D2M/Utils/VirtualGrid.h
@@ -5,79 +5,24 @@
 #ifndef TTMLIR_DIALECT_D2M_UTILS_VIRTUALGRID_H
 #define TTMLIR_DIALECT_D2M_UTILS_VIRTUALGRID_H
 
-#include "ttmlir/Asserts.h"
-#include "ttmlir/Utils.h"
-
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/SmallVector.h"
+
+#include <utility>
 
 namespace ttmlir::d2m::utils::grids {
 
-inline mlir::AffineMap prependResult(mlir::AffineMap map,
-                                     mlir::AffineExpr result) {
-  if (!map) {
-    return map;
-  }
-  return map.insertResult(result, 0);
-}
-inline mlir::AffineMap extendWithIdentityDimsAndResults(mlir::AffineMap map,
-                                                        unsigned extraDims) {
-  if (!map) {
-    return map;
-  }
-  llvm::SmallVector<mlir::AffineExpr> extendedResults =
-      llvm::to_vector(map.getResults());
-  for (unsigned i = map.getNumDims(); i < map.getNumDims() + extraDims; i++) {
-    extendedResults.push_back(getAffineDimExpr(i, map.getContext()));
-  }
+mlir::AffineMap prependResult(mlir::AffineMap map, mlir::AffineExpr result);
 
-  return mlir::AffineMap::get(map.getNumDims() + extraDims, map.getNumSymbols(),
-                              extendedResults, map.getContext());
-}
+mlir::AffineMap extendWithIdentityDimsAndResults(mlir::AffineMap map,
+                                                 unsigned extraDims);
 
-inline mlir::AffineMap createCollapseMap(mlir::MLIRContext *context,
-                                         llvm::ArrayRef<int64_t> virtualGrid) {
+mlir::AffineMap createCollapseMap(mlir::MLIRContext *context,
+                                  llvm::ArrayRef<int64_t> virtualGrid);
 
-  int64_t virtualGridRank = virtualGrid.size();
-  mlir::AffineExpr collapseExpr =
-      getAffineDimExpr(virtualGrid.size() - 1, context);
-  mlir::AffineExpr strideExpr =
-      getAffineConstantExpr(virtualGrid.back(), context);
-  for (int64_t i = virtualGrid.size() - 2; i >= 0; i--) {
-    collapseExpr = collapseExpr + getAffineDimExpr(i, context) * strideExpr;
-    strideExpr = strideExpr * getAffineConstantExpr(virtualGrid[i], context);
-  }
-  llvm::SmallVector<mlir::AffineExpr> collapseMapExprs = {collapseExpr};
-  auto map =
-      mlir::AffineMap::get(virtualGridRank, 0, collapseMapExprs, context);
-  return map;
-}
-
-inline mlir::AffineMap create1DtoNDMap(mlir::MLIRContext *context,
-                                       llvm::ArrayRef<int64_t> targetGrid) {
-
-  TT_assertv(!targetGrid.empty(), "Target grid must have at least one dim");
-  for (int64_t size : targetGrid) {
-    TT_assertv(size > 0, "Target grid dimensions must be positive");
-  }
-
-  llvm::SmallVector<mlir::AffineExpr> expandMapExprs;
-  expandMapExprs.resize(targetGrid.size());
-
-  mlir::AffineExpr linearIdx = getAffineDimExpr(0, context);
-  mlir::AffineExpr strideExpr = getAffineConstantExpr(1, context);
-  for (int64_t dim = targetGrid.size() - 1; dim >= 0; --dim) {
-    mlir::AffineExpr sizeExpr = getAffineConstantExpr(targetGrid[dim], context);
-    expandMapExprs[dim] = linearIdx.floorDiv(strideExpr) % sizeExpr;
-    strideExpr = strideExpr * sizeExpr;
-  }
-
-  auto map = mlir::AffineMap::get(1, 0, expandMapExprs, context);
-  return map;
-}
+mlir::AffineMap create1DtoNDMap(mlir::MLIRContext *context,
+                                llvm::ArrayRef<int64_t> targetGrid);
 
 /// Generates a pair of forward and inverse affine maps that allow
 /// implementing a virtual grid as a physical-view pair of tensors/memrefs.
@@ -91,62 +36,11 @@ inline mlir::AffineMap create1DtoNDMap(mlir::MLIRContext *context,
 /// map is restricted to only the grid dimensions; shard dims CANNOT
 /// participate in virtual grid dim exprs (and vice-versa) or reblocking will
 /// not work reliably.
-inline std::pair<mlir::AffineMap, mlir::AffineMap>
+std::pair<mlir::AffineMap, mlir::AffineMap>
 createCoreVirtMaps(mlir::MLIRContext *context,
                    llvm::ArrayRef<int64_t> virtualGrid,
-                   llvm::ArrayRef<int64_t> targetGrid) {
+                   llvm::ArrayRef<int64_t> targetGrid);
 
-  TT_assertv(targetGrid.size() == 2ul, "Target grid must have 2 dimensions {}",
-             targetGrid.size());
-
-  int64_t virtualGridRank = virtualGrid.size();
-  if (virtualGridRank != 2) {
-    auto forwardMap = extendWithIdentityDimsAndResults(
-        create1DtoNDMap(context, targetGrid)
-            .compose(createCollapseMap(context, virtualGrid)),
-        virtualGrid.size());
-
-    auto inverseMap =
-        prependResult(create1DtoNDMap(context, virtualGrid)
-                          .compose(createCollapseMap(context, targetGrid)),
-                      getAffineConstantExpr(0, context));
-
-    return {forwardMap, inverseMap};
-  }
-
-  bool is2DWidthSharded = (virtualGridRank == 2) && virtualGrid[0] == 1;
-  bool is2DHeightSharded = (virtualGridRank == 2) && virtualGrid[1] == 1;
-
-  TT_assertv((is2DWidthSharded || is2DHeightSharded),
-             "Only supporting 2D width or height sharding (actual grid shape = "
-             "{})",
-             ttmlir::utils::formatIterable(virtualGrid, "x"));
-
-  llvm::SmallVector<mlir::AffineExpr> forwardMapExprs;
-  llvm::SmallVector<mlir::AffineExpr> inverseMapExprs;
-
-  mlir::AffineExpr d0 = getAffineDimExpr(0, context);
-  mlir::AffineExpr d1 = getAffineDimExpr(1, context);
-  mlir::AffineExpr d2 = getAffineDimExpr(2, context);
-  mlir::AffineExpr d3 = getAffineDimExpr(3, context);
-  mlir::AffineExpr zero = getAffineConstantExpr(0, context);
-  mlir::AffineExpr gridColStride =
-      getAffineConstantExpr(targetGrid[1], context);
-
-  if (is2DWidthSharded) {
-    forwardMapExprs = {d1.floorDiv(gridColStride), d1 % gridColStride, d2, d3};
-    inverseMapExprs = {zero, d0 * gridColStride + d1};
-  } else if (is2DHeightSharded) {
-    forwardMapExprs = {d0.floorDiv(gridColStride), d0 % gridColStride, d2, d3};
-    inverseMapExprs = {d0 * gridColStride + d1, zero};
-  }
-  auto forward =
-      mlir::AffineMap::get(2 * virtualGridRank, 0, forwardMapExprs, context);
-  auto inverse =
-      mlir::AffineMap::get(virtualGridRank, 0, inverseMapExprs, context);
-  inverse = prependResult(inverse, zero);
-  return {forward, inverse};
-}
 } // namespace ttmlir::d2m::utils::grids
 
 #endif // TTMLIR_DIALECT_D2M_UTILS_VIRTUALGRID_H

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
@@ -53,12 +53,6 @@ def TTCore_DeviceLayoutInterface : AttrInterface<"DeviceLayoutInterface"> {
       }]
     >,
     InterfaceMethod<
-      "Returns the physical grid shape of the associated tensor",
-      "llvm::SmallVector<int64_t>", "getPhysicalGridShape", (ins "ShapedType":$shapedType),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{ return ::llvm::to_vector(getGridShape(shapedType)); }]
-    >,
-    InterfaceMethod<
       "Returns the virtualization affine map associated with the layout if defined, otherwise returns an empty map.",
       "std::optional<mlir::AffineMap>", "getVirtualizationMapIfExists", (ins),
       /*methodBody=*/"",

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -289,13 +289,11 @@ def TTCore_ShardLayoutAttr : TTCore_Attr<"ShardLayout", "shard", [TTCore_DeviceL
     AffineMap getAffineMap() const;
 
     std::optional<mlir::AffineMap> getVirtualizationMapIfExists() {
-      return getCoreVirtualizationMap();
+      auto vmap = getCoreVirtualizationMap();
+      return (vmap.isEmpty()) ? std::nullopt : std::make_optional(vmap);
     }
 
     unsigned getRank() const { return getStride().size(); }
-
-    // Computes the implied physical grid shape using the grid shape and index map (if present)
-    llvm::SmallVector<int64_t> getPhysicalGridShape(ShapedType tensorType) const;
   }];
 }
 
@@ -510,11 +508,9 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
     // Returns the full rank (including grid dimensions).
     unsigned getRank() const { return getNormalizedIntervals().size(); }
 
-    // Computes the implied physical grid shape using the grid shape and index map (if present)
-    llvm::SmallVector<int64_t> getPhysicalGridShape(ShapedType tensorType) const;
-
     std::optional<mlir::AffineMap> getVirtualizationMapIfExists() {
-      return getIndexAffineMap();
+      auto vmap = getIndexAffineMap();
+      return (vmap.isEmpty()) ? std::nullopt : std::make_optional(vmap);
     }
 
     // Returns true if this layout has two or more dims collapsed into a single dim

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -17,6 +17,7 @@
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/MemoryBuffer.h"
 
+#include <cassert>
 #include <cstdint>
 #include <numeric>
 #include <tuple>

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -246,7 +246,7 @@ public:
       TT_assertv(shardLayout, "Expected shardLayoutAttr for the output of a "
                               "generic op with a virtual grid.");
 
-      auto physicalGridShape = shardLayout.getPhysicalGridShape(outputType);
+      auto physicalGridShape = d2m::utils::getPhysicalGridShape(output);
       // TTNN grids are (Width, Height), while D2M grids are (Height, Width).
       endCoreRange = {physicalGridShape[1] - 1, physicalGridShape[0] - 1};
     } else {

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1090,14 +1090,14 @@ void d2m::GenericOp::build(mlir::OpBuilder &builder,
   TT_assertv(outputs.size() == 1u, "expected single output");
 
   if (!grid) {
-    auto gridShape = ttcore::getGridShape(outputs[0]);
+    auto output = outputs[0];
+    auto gridShape = ttcore::getGridShape(output);
 
     // Check if output operand has a virtual grid and IS NOT a view. If so,
     // infer a physical grid shape and inverse map for the grid attr such that
     // invMap(physGrid) = virtGrid
-    bool outputIsView = mlir::isa<ViewOpInterface>(outputs[0].getDefiningOp());
-    auto layout = ttcore::getDeviceLayout(
-        mlir::dyn_cast<ShapedType>(outputs[0].getType()));
+    auto layout =
+        ttcore::getDeviceLayout(mlir::dyn_cast<ShapedType>(output.getType()));
     auto metalLayout = mlir::dyn_cast<ttcore::MetalLayoutAttr>(layout);
 
     // Only consider non-identity index maps for virtualization. Identity maps
@@ -1108,27 +1108,37 @@ void d2m::GenericOp::build(mlir::OpBuilder &builder,
       hasNonIdentityIndexMap = !indexMap.isEmpty() && !indexMap.isIdentity();
     }
 
-    if (!outputIsView && metalLayout && hasNonIdentityIndexMap) {
-      auto shapedType = mlir::cast<ShapedType>(outputs[0].getType());
-      auto physicalGridShape = metalLayout.getPhysicalGridShape(shapedType);
+    if (metalLayout && hasNonIdentityIndexMap) {
 
-      // Check if the grid actually exceeds the physical grid (needs
-      // virtualization)
-      bool needsVirtualization = !llvm::equal(gridShape, physicalGridShape);
+      // 2D->2D permutation index maps are special case that isn't a standard
+      // reblocking (i.e. reshape), but a _transpose_ of the grid indices.
+      auto indexMap = metalLayout.getIndexAffineMap();
+      constexpr size_t kExpectedDimsFor2DDeviceShape = 2 * 2;
+      bool indexMapIs2DPermutation =
+          indexMap.isPermutation() &&
+          indexMap.getNumResults() == kExpectedDimsFor2DDeviceShape &&
+          indexMap.getNumInputs() == kExpectedDimsFor2DDeviceShape;
 
-      if (needsVirtualization) {
-        // True virtualization: map virtual grid to physical hardware
-        auto [_, invMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
-            builder.getContext(), gridShape, physicalGridShape);
-        grid = builder.getAttr<ttcore::GridAttr>(gridShape, invMap);
-      } else {
-        // If the operand has index_map but doesn't exceed physical grid (e.g.,
-        // reblocking, transpose), derive the grid inverse map from the
-        // output's index_map to ensure roundtrip consistency.
-        auto indexMap = metalLayout.getIndexAffineMap();
-        auto invMap = ttmlir::utils::createGridInverseMapFromIndexMap(
+      // If the underlying physical grid shape differs from the virtual grid,
+      // assume it is a standard reblocking operation and generate both
+      // forward and inverse maps accordingly using createCoreVirtMaps.
+      SmallVector<int64_t> physGridShape =
+          d2m::utils::getPhysicalGridShape(output);
+      bool virtualReblock = !llvm::equal(gridShape, physGridShape);
+
+      if (indexMapIs2DPermutation) {
+        auto invMap = ttmlir::utils::createGridInverseMapFor2DPermutation(
             indexMap, gridShape.size(), builder.getContext());
         grid = builder.getAttr<ttcore::GridAttr>(gridShape, invMap);
+      } else if (virtualReblock) {
+        // True virtualization: map virtual grid to physical hardware
+        auto [_, invMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
+            builder.getContext(), gridShape, physGridShape);
+        grid = builder.getAttr<ttcore::GridAttr>(gridShape, invMap);
+      } else {
+        // output aligns with its underlying physical grid shape and has no
+        // permuted indices; no need to have a virtualization mapping.
+        grid = builder.getAttr<ttcore::GridAttr>(gridShape);
       }
     } else {
       grid = builder.getAttr<ttcore::GridAttr>(gridShape);
@@ -1437,6 +1447,11 @@ static mlir::LogicalResult verifyAffineBlocking(
     }
   }
 
+  // Determine if any outputs are views or streams.
+  bool outputIsViewOrStream = llvm::any_of(getOutputs(), [](Value output) {
+    return output.getDefiningOp<ViewOpInterface>() != nullptr;
+  });
+
   if (!getGrid().getMapping().isEmpty()) {
 
     if (getGrid().getMapping().getNumInputs() != 2ul) {
@@ -1447,50 +1462,78 @@ static mlir::LogicalResult verifyAffineBlocking(
     // Generic op with defined physical->virtual mapping in its grid attr should
     // have output operand(s) with a virtual->physical mapping defined in the
     // layout attr.
-    for (auto output : getOutputs()) {
+    for (Value output : getOutputs()) {
       mlir::ShapedType outputType =
           mlir::cast<mlir::ShapedType>(output.getType());
 
-      std::optional<AffineMap> maybeFwdMap =
-          ttcore::getDeviceLayout(outputType).getVirtualizationMapIfExists();
-      if (!maybeFwdMap) {
-        return emitOpError(
-            "GenericOp with virtual grid attribute must have an output operand "
-            "with a non-empty virtual grid mapping.");
-      }
-      AffineMap fwdMap = *maybeFwdMap;
-
-      fwdMap = ttmlir::utils::affineMapDropBackResults(
-          fwdMap, fwdMap.getNumResults() - 2);
-      // first result is deviceID, so drop it
-      auto invMap = getGrid().getMapping().dropResult(0);
-
-      if (invMap.getNumInputs() != fwdMap.getNumResults()) {
-        return emitOpError(
-            "GenericOp grid and output operand mapping functions do not "
-            "compose (mismatched number of inputs and results).");
-      }
-
-      // Check roundtrip consistency between physical->virtual and
-      // virtual->physical mappings; inv(fwd(shape)) == shape.
-      auto roundtripMap = invMap.compose(fwdMap);
-
-      bool success = true;
-      auto virtGridShape = getGrid().getShape();
-      ttmlir::utils::sample(virtGridShape, [&](ArrayRef<int64_t> point) {
-        // Pad point with dummy shard dims to align with expected fwdMap args.
-        SmallVector<int64_t> dummyShardDims(point.size(), 0);
-        SmallVector<int64_t> pointWithDummyShardDims = llvm::to_vector(
-            llvm::concat<int64_t>(SmallVector<int64_t>(point), dummyShardDims));
-
-        auto roundtripPoint = roundtripMap.compose(pointWithDummyShardDims);
-        if (roundtripPoint != point) {
-          success = false;
+      // Only do roundtrip consistency check if the output is physical.
+      // Streaming relaxes the requirement of aligning each compute worker with
+      // the actual physical grid.
+      if (!outputIsViewOrStream) {
+        std::optional<AffineMap> maybeFwdMap =
+            ttcore::getDeviceLayout(outputType).getVirtualizationMapIfExists();
+        if (!maybeFwdMap) {
+          return emitOpError("GenericOp with virtual grid attribute must have "
+                             "an output operand "
+                             "with a non-empty virtual grid mapping.");
         }
-      });
-      if (!success) {
-        return emitOpError(
-            "roundtrip virtual grid mapping consistency check failed");
+        AffineMap fwdMap = *maybeFwdMap;
+
+        fwdMap = ttmlir::utils::affineMapDropBackResults(
+            fwdMap, fwdMap.getNumResults() - 2);
+
+        // first result is deviceID, so drop it.
+        AffineMap invMap = getGrid().getMapping().dropResult(0);
+
+        if (invMap.getNumInputs() != fwdMap.getNumResults()) {
+          return emitOpError(
+              "GenericOp grid and output operand mapping functions do not "
+              "compose (mismatched number of inputs and results).");
+        }
+
+        // Check roundtrip consistency between physical->virtual and
+        // virtual->physical mappings; inv(fwd(shape)) == shape.
+        AffineMap roundtripMap = invMap.compose(fwdMap);
+
+        bool success = true;
+        ArrayRef<int64_t> virtGridShape = getGrid().getShape();
+        ttmlir::utils::sample(virtGridShape, [&](ArrayRef<int64_t> point) {
+          // Pad point with dummy shard dims to align with expected fwdMap args.
+          SmallVector<int64_t> dummyShardDims(point.size(), 0);
+          SmallVector<int64_t> pointWithDummyShardDims =
+              llvm::to_vector(llvm::concat<int64_t>(SmallVector<int64_t>(point),
+                                                    dummyShardDims));
+
+          SmallVector<int64_t, 4> roundtripPoint =
+              roundtripMap.compose(pointWithDummyShardDims);
+          if (roundtripPoint != point) {
+            success = false;
+          }
+        });
+        if (!success) {
+          return emitOpError(
+              "roundtrip virtual grid mapping consistency check failed");
+        }
+      } else {
+        // For view outputs, verify that the inverse map applied to the physical
+        // grid shape produces a virtual grid shape matching the output's grid
+        // shape.
+        SmallVector<int64_t> physicalGridShape =
+            d2m::utils::getPhysicalGridShape(output);
+
+        // Drop the deviceID result (first result) from the inverse map.
+        AffineMap invMap = getGrid().getMapping().dropResult(0);
+
+        SmallVector<int64_t> impliedVirtShape =
+            ttmlir::utils::evalShape(invMap, physicalGridShape);
+
+        ArrayRef<int64_t> outputGridShape = ttcore::getGridShape(output);
+
+        if (SmallVector<int64_t>(outputGridShape) != impliedVirtShape) {
+          return emitOpError(
+              "view output grid shape does not match implied virtual "
+              "grid shape from physical grid and inverse mapping");
+        }
       }
     }
   }
@@ -1502,8 +1545,8 @@ static mlir::LogicalResult verifyAffineBlocking(
         "all indexing maps must have the same number of dimensions");
   }
 
-  auto numIterators = getIteratorTypes().size();
-  auto blockFactors = getBlockFactorsValue();
+  size_t numIterators = getIteratorTypes().size();
+  SmallVector<int64_t> blockFactors = getBlockFactorsValue();
   if (numIterators > 0) {
     if (blockFactors.size() != numIterators) {
       return emitOpError("number of block factors[")
@@ -1940,10 +1983,8 @@ d2m::GenericOp::getOperandShardShapes(bool convertTileToScalar) {
 }
 
 mlir::SmallVector<int64_t> d2m::GenericOp::getPhysicalGridShape() {
-  auto outputType = mlir::cast<ShapedType>(getOutputs().front().getType());
-  ttcore::DeviceLayoutInterface deviceLayout =
-      ttcore::getDeviceLayout(outputType);
-  return deviceLayout.getPhysicalGridShape(outputType);
+  TT_assert(getOutputs().size() == 1u);
+  return d2m::utils::getPhysicalGridShape(getOutputs().front());
 }
 
 mlir::SmallVector<int64_t> d2m::GenericOp::getLoopBounds() {

--- a/lib/Dialect/D2M/Utils/CMakeLists.txt
+++ b/lib/Dialect/D2M/Utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(MLIRD2MUtils
   Utils.cpp
   AffineMapAnalysis.cpp
+  VirtualGrid.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -12,6 +12,10 @@
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/IR/AffineExpr.h"
 
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+
 namespace mlir::tt::d2m::utils {
 
 llvm::SmallVector<int64_t>
@@ -131,6 +135,93 @@ SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
 
   TT_assert(indices.size() == indexingMap.getNumResults());
   return indices;
+}
+
+static llvm::SmallVector<int64_t>
+getPhysicalGridShapeFromShapeAndMap(ArrayRef<int64_t> overallDeviceShape,
+                                    AffineMap map) {
+  TT_assert(map.getNumResults() >= 2u);
+  auto gridResultMap = ttmlir::utils::affineMapTakeFrontResults(map, 2);
+  TT_assert(overallDeviceShape.size() == gridResultMap.getNumDims());
+  return ttmlir::utils::evalShape(gridResultMap, overallDeviceShape);
+}
+
+SmallVector<int64_t> getPhysicalGridShape(Value tensorOrMemref) {
+  // Handle view-like ops first.
+  if (auto viewOp = tensorOrMemref.getDefiningOp<d2m::ViewOpInterface>()) {
+    ttcore::DeviceAttr device = ttcore::lookupDevice(viewOp);
+    auto deviceGridShape = device.getWorkerGrid().getShape();
+    auto outputGridShape = ttcore::getGridShape(tensorOrMemref);
+
+    bool rankMismatch = outputGridShape.size() != deviceGridShape.size();
+    bool outOfDeviceGridBounds = (outputGridShape[0] > deviceGridShape[0]) &&
+                                 (outputGridShape[1] > deviceGridShape[1]);
+
+    // For views, assume that if direct 1:1 mapping to device grid shape is
+    // impossible, the physical grid shape is given by
+    // findLegalPhysicalGridForVolume(). This is checked against actual gridAttr
+    // inverse map and output virtual grid shape in GenericOp::verify().
+    if (rankMismatch || outOfDeviceGridBounds) {
+      auto physicalGridShape = findLegalPhysicalGridForVolume(
+          ttmlir::utils::volume<int64_t>(outputGridShape), deviceGridShape);
+      return physicalGridShape;
+    }
+    // View virtual and physical grid shapes are equivalent if directly mappable
+    // to device grid.
+    return SmallVector<int64_t>(outputGridShape);
+  }
+
+  // If not a view, extract DeviceLayoutInterface and get physical grid shape
+  // by applying virtualization map to device shape.
+  auto shapeType = tensorOrMemref.getType();
+  ttcore::DeviceLayoutInterface layout;
+  SmallVector<int64_t> deviceShape;
+  layout = ttcore::getDeviceLayout(tensorOrMemref);
+  TT_assert(layout);
+  deviceShape = llvm::to_vector(
+      dyn_cast<ShapedType>(tensorOrMemref.getType()).getShape());
+
+  if (auto vmap = layout.getVirtualizationMapIfExists()) {
+    TT_assert(!vmap->isEmpty());
+    return getPhysicalGridShapeFromShapeAndMap(deviceShape, *vmap);
+  }
+  // If no virtualization map, physical grid shape == virtual grid shape.
+  SmallVector<int64_t> gridShape =
+      to_vector(layout.getGridShape(dyn_cast<ShapedType>(shapeType)));
+  return gridShape;
+}
+
+SmallVector<int64_t>
+findLegalPhysicalGridForVolume(int64_t gridVolume,
+                               ArrayRef<int64_t> targetGridShape) {
+  assert(gridVolume > 0 && "Grid volume must be positive");
+  assert(targetGridShape.size() >= 2u &&
+         "Target grid shape must provide at least two dimensions");
+  assert((targetGridShape[0] > 0 && targetGridShape[1] > 0) &&
+         "Target grid dimensions must be positive");
+
+  auto fitsTarget = [&](int64_t dimY, int64_t dimX) {
+    return dimY <= targetGridShape[0] && dimX <= targetGridShape[1];
+  };
+
+  int64_t y = 1;
+  // Find the largest factor of grid volume that is <= sqrt(gridVolume).
+  for (int64_t i = static_cast<int64_t>(std::sqrt(gridVolume)); i > 0; --i) {
+    if (gridVolume % i == 0) {
+      int64_t candidateY = i;
+      int64_t candidateX = gridVolume / i;
+      if (fitsTarget(candidateY, candidateX)) {
+        return {candidateY, candidateX};
+      }
+      if (fitsTarget(candidateX, candidateY)) {
+        return {candidateX, candidateY};
+      }
+      if (y == 1) {
+        y = candidateY;
+      }
+    }
+  }
+  return {};
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/lib/Dialect/D2M/Utils/VirtualGrid.cpp
+++ b/lib/Dialect/D2M/Utils/VirtualGrid.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
+#include "ttmlir/Asserts.h"
+
+namespace ttmlir::d2m::utils::grids {
+
+mlir::AffineMap prependResult(mlir::AffineMap map, mlir::AffineExpr result) {
+  if (!map) {
+    return map;
+  }
+  return map.insertResult(result, 0);
+}
+
+mlir::AffineMap extendWithIdentityDimsAndResults(mlir::AffineMap map,
+                                                 unsigned extraDims) {
+  if (!map) {
+    return map;
+  }
+  llvm::SmallVector<mlir::AffineExpr> extendedResults =
+      llvm::to_vector(map.getResults());
+  for (unsigned i = map.getNumDims(); i < map.getNumDims() + extraDims; i++) {
+    extendedResults.push_back(getAffineDimExpr(i, map.getContext()));
+  }
+
+  return mlir::AffineMap::get(map.getNumDims() + extraDims, map.getNumSymbols(),
+                              extendedResults, map.getContext());
+}
+
+mlir::AffineMap createCollapseMap(mlir::MLIRContext *context,
+                                  llvm::ArrayRef<int64_t> virtualGrid) {
+
+  int64_t virtualGridRank = virtualGrid.size();
+  mlir::AffineExpr collapseExpr =
+      getAffineDimExpr(virtualGrid.size() - 1, context);
+  mlir::AffineExpr strideExpr =
+      getAffineConstantExpr(virtualGrid.back(), context);
+  for (int64_t i = virtualGrid.size() - 2; i >= 0; i--) {
+    collapseExpr = collapseExpr + getAffineDimExpr(i, context) * strideExpr;
+    strideExpr = strideExpr * getAffineConstantExpr(virtualGrid[i], context);
+  }
+  llvm::SmallVector<mlir::AffineExpr> collapseMapExprs = {collapseExpr};
+  auto map =
+      mlir::AffineMap::get(virtualGridRank, 0, collapseMapExprs, context);
+  return map;
+}
+
+mlir::AffineMap create1DtoNDMap(mlir::MLIRContext *context,
+                                llvm::ArrayRef<int64_t> targetGrid) {
+
+  TT_assertv(!targetGrid.empty(), "Target grid must have at least one dim");
+  for (int64_t size : targetGrid) {
+    TT_assertv(size > 0, "Target grid dimensions must be positive");
+  }
+
+  llvm::SmallVector<mlir::AffineExpr> expandMapExprs;
+  expandMapExprs.resize(targetGrid.size());
+
+  mlir::AffineExpr linearIdx = getAffineDimExpr(0, context);
+  mlir::AffineExpr strideExpr = getAffineConstantExpr(1, context);
+  for (int64_t dim = targetGrid.size() - 1; dim >= 0; --dim) {
+    mlir::AffineExpr sizeExpr = getAffineConstantExpr(targetGrid[dim], context);
+    expandMapExprs[dim] = linearIdx.floorDiv(strideExpr) % sizeExpr;
+    strideExpr = strideExpr * sizeExpr;
+  }
+
+  auto map = mlir::AffineMap::get(1, 0, expandMapExprs, context);
+  return map;
+}
+
+std::pair<mlir::AffineMap, mlir::AffineMap>
+createCoreVirtMaps(mlir::MLIRContext *context,
+                   llvm::ArrayRef<int64_t> virtualGrid,
+                   llvm::ArrayRef<int64_t> targetGrid) {
+
+  TT_assertv(targetGrid.size() == 2ul, "Target grid must have 2 dimensions {}",
+             targetGrid.size());
+
+  auto forwardMap = extendWithIdentityDimsAndResults(
+      create1DtoNDMap(context, targetGrid)
+          .compose(createCollapseMap(context, virtualGrid)),
+      virtualGrid.size());
+
+  auto inverseMap =
+      prependResult(create1DtoNDMap(context, virtualGrid)
+                        .compose(createCollapseMap(context, targetGrid)),
+                    getAffineConstantExpr(0, context));
+
+  return {forwardMap, inverseMap};
+}
+
+} // namespace ttmlir::d2m::utils::grids

--- a/test/python/golden/test_metal_virtual_grids.py
+++ b/test/python/golden/test_metal_virtual_grids.py
@@ -79,6 +79,10 @@ def create_tileid_debug_tensor(shape: Shape, dtype: torch.dtype):
         (32, 4096),
         (4096, 32),
         (2048, 32),
+        (32, 1280),  # uses 1x40 grid
+        (1536, 64),  # uses 48x1 grid
+        (1120, 32),  # uses 35x1 grid
+        (32, 768),  # uses 1x24 grid
         (1, 1, 1, 1, 128, 128),
         (1, 1, 1, 1, 2, 32, 512),
         (1, 1, 1, 1, 32, 32),

--- a/test/ttmlir/Conversion/TTIRToD2M/ttnn_height_sharded_translation.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/ttnn_height_sharded_translation.mlir
@@ -5,17 +5,17 @@
 
 
 // CHECK:#layout = #ttcore.metal_layout<logical_shape = 384x32, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 2, d0 mod 2, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 2) mod 6, (d0 + d1) mod 2, d2, d3)>
 // CHECK: #layout1 = #ttcore.metal_layout<logical_shape = 384x32, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 6, d0 mod 6, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 6) mod 2, (d0 + d1) mod 6, d2, d3)>
 // CHECK: #layout2 = #ttcore.metal_layout<logical_shape = 384x64, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 2, d0 mod 2, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 2) mod 6, (d0 + d1) mod 2, d2, d3)>
 // CHECK: #layout3 = #ttcore.metal_layout<logical_shape = 384x64, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 6, d0 mod 6, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 6) mod 2, (d0 + d1) mod 6, d2, d3)>
 // CHECK: #layout4 = #ttcore.metal_layout<logical_shape = 2x384x32, dim_alignments = 1x32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 2, d0 mod 2, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 2) mod 6, (d0 + d1) mod 2, d2, d3)>
 // CHECK: #layout5 = #ttcore.metal_layout<logical_shape = 2x2x384x32, dim_alignments = 1x1x32x32, collapsed_intervals
-// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (d0 floordiv 2, d0 mod 2, d2, d3)>
+// CHECK-SAME: index_map = (d0, d1, d2, d3) -> (((d0 + d1) floordiv 2) mod 6, (d0 + d1) mod 2, d2, d3)>
 
 
 // Width Sharded - Rank 2 layouts
@@ -47,7 +47,7 @@ func.func @test_lower_height_sharded_l1(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<384x32xbf16, #ttnn_layout> -> tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<384x32xbf16, #ttnn_layout> -> tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 2 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 2) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
   // CHECK-DAG: d2m.tile_abs
@@ -65,7 +65,7 @@ func.func @test_lower_height_sharded_l1_1(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<384x32xbf16, #ttnn_layout1> -> tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout1>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<384x32xbf16, #ttnn_layout1> -> tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout1>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 6 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 6) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout1>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x1x1x!ttcore.tile<32x32, bf16>, #layout1>)
   // CHECK-DAG: d2m.tile_abs
@@ -82,7 +82,7 @@ func.func @test_lower_height_sharded_l1_2(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<384x64xbf16, #ttnn_layout2> -> tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout2>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<384x64xbf16, #ttnn_layout2> -> tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout2>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 2 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 2) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout2>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout2>)
   // CHECK-DAG: d2m.tile_abs
@@ -99,7 +99,7 @@ func.func @test_lower_height_sharded_l1_3(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<384x64xbf16, #ttnn_layout3> -> tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<384x64xbf16, #ttnn_layout3> -> tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 6 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 6) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout3>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x1x2x!ttcore.tile<32x32, bf16>, #layout3>)
   // CHECK-DAG: d2m.tile_abs
@@ -116,7 +116,7 @@ func.func @test_lower_height_sharded_l1_4(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<2x384x32xbf16, #ttnn_layout4> -> tensor<12x1x2x1x!ttcore.tile<32x32, bf16>, #layout4>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<2x384x32xbf16, #ttnn_layout4> -> tensor<12x1x2x1x!ttcore.tile<32x32, bf16>, #layout4
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 2 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 2) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x2x1x!ttcore.tile<32x32, bf16>, #layout4>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x2x1x!ttcore.tile<32x32, bf16>, #layout4>)
   // CHECK-DAG: d2m.tile_abs
@@ -132,7 +132,7 @@ func.func @test_lower_height_sharded_l1_5(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<2x2x384x32xbf16, #ttnn_layout5> -> tensor<12x1x4x1x!ttcore.tile<32x32, bf16>, #layout5>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<2x2x384x32xbf16, #ttnn_layout5> -> tensor<12x1x4x1x!ttcore.tile<32x32, bf16>, #layout5>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, d0 * 2 + d1, 0)>
+  // CHECK-SAME: grid = #ttcore.grid<12x1, (d0, d1) -> (0, (d1 + d0 * 2) mod 12, 0)>
   // CHECK: ins(%[[CAST0]] : tensor<12x1x4x1x!ttcore.tile<32x32, bf16>, #layout5>)
   // CHECK: outs(%[[CAST1]] : tensor<12x1x4x1x!ttcore.tile<32x32, bf16>, #layout5>)
   // CHECK-DAG: d2m.tile_abs

--- a/test/ttmlir/Conversion/TTIRToD2M/ttnn_width_sharded_translation.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/ttnn_width_sharded_translation.mlir
@@ -4,17 +4,17 @@
 #l1 = #ttnn.buffer_type<l1>
 
 // CHECK: #layout = #ttcore.metal_layout<logical_shape = 32x384, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 2, d1 mod 2, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 2) mod 6, d1 mod 2, d2, d3)
 // CHECK: #layout1 = #ttcore.metal_layout<logical_shape = 32x384, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 6, d1 mod 6, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 6) mod 2, d1 mod 6, d2, d3)
 // CHECK: #layout2 = #ttcore.metal_layout<logical_shape = 64x384, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 2, d1 mod 2, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 2) mod 6, d1 mod 2, d2, d3)
 // CHECK: #layout3 = #ttcore.metal_layout<logical_shape = 64x384, dim_alignments = 32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 6, d1 mod 6, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 6) mod 2, d1 mod 6, d2, d3)
 // CHECK: #layout4 = #ttcore.metal_layout<logical_shape = 2x32x384, dim_alignments = 1x32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 2, d1 mod 2, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 2) mod 6, d1 mod 2, d2, d3)
 // CHECK: #layout5 = #ttcore.metal_layout<logical_shape = 2x2x32x384, dim_alignments = 1x1x32x32, collapsed_intervals
-// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> (d1 floordiv 2, d1 mod 2, d2, d3)
+// CHECK-SAME: l1, sharded, index_map = (d0, d1, d2, d3) -> ((d1 floordiv 2) mod 6, d1 mod 2, d2, d3)
 
 
 // Width Sharded - Rank 2 layouts
@@ -45,7 +45,7 @@ func.func @test_lower_width_sharded_l1(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x384xbf16, #ttnn_layout> -> tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<32x384xbf16, #ttnn_layout> -> tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 2 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 2) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout>)
   // CHECK-DAG: d2m.tile_abs
@@ -63,7 +63,7 @@ func.func @test_lower_width_sharded_l1_1(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<32x384xbf16, #ttnn_layout1> -> tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout1>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<32x384xbf16, #ttnn_layout1> -> tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout1>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 6 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 6) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout1>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x1x1x!ttcore.tile<32x32, bf16>, #layout1>)
   // CHECK-DAG: d2m.tile_abs
@@ -80,7 +80,7 @@ func.func @test_lower_width_sharded_l1_2(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x384xbf16, #ttnn_layout2> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout2>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<64x384xbf16, #ttnn_layout2> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout2>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 2 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 2) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout2>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout2>)
   // CHECK-DAG: d2m.tile_abs
@@ -98,7 +98,7 @@ func.func @test_lower_width_sharded_l1_3(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<64x384xbf16, #ttnn_layout3> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<64x384xbf16, #ttnn_layout3> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout3>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 6 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 6) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout3>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout3>)
   // CHECK-DAG: d2m.tile_abs
@@ -116,7 +116,7 @@ func.func @test_lower_width_sharded_l1_4(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<2x32x384xbf16, #ttnn_layout4> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout4>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<2x32x384xbf16, #ttnn_layout4> -> tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout4
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 2 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 2) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout4>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x2x1x!ttcore.tile<32x32, bf16>, #layout4>)
   // CHECK-DAG: d2m.tile_abs
@@ -133,7 +133,7 @@ func.func @test_lower_width_sharded_l1_5(
   // CHECK: %[[CAST0:.*]] = ttir.ttnn_metal_layout_cast %arg0 : tensor<2x2x32x384xbf16, #ttnn_layout5> -> tensor<1x12x4x1x!ttcore.tile<32x32, bf16>, #layout5>
   // CHECK: %[[CAST1:.*]] = ttir.ttnn_metal_layout_cast %0 : tensor<2x2x32x384xbf16, #ttnn_layout5> -> tensor<1x12x4x1x!ttcore.tile<32x32, bf16>, #layout5>
   // CHECK: %[[RESULT:.*]] = d2m.generic
-  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, d0 * 2 + d1)>
+  // CHECK-SAME: grid = #ttcore.grid<1x12, (d0, d1) -> (0, 0, (d1 + d0 * 2) mod 12)>
   // CHECK: ins(%[[CAST0]] : tensor<1x12x4x1x!ttcore.tile<32x32, bf16>, #layout5>)
   // CHECK: outs(%[[CAST1]] : tensor<1x12x4x1x!ttcore.tile<32x32, bf16>, #layout5>)
   // CHECK-DAG: d2m.tile_abs

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
@@ -58,7 +58,7 @@ module {
  // -----
 
  // CHECK-AFTER: #[[LAYOUT_STREAM_0:.*]] = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x32,  {{.*}} index_map = (d0, d1, d2, d3) -> (d1 floordiv 8, d1 mod 8, d2, d3)>
- // CHECK-AFTER: #[[LAYOUT_STREAM_1:.*]] = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x256, {{.*}} index_map = (d0, d1, d2, d3) -> (d1 floordiv 8, d1 mod 8, d2, d3)>
+ // CHECK-AFTER: #[[LAYOUT_STREAM_1:.*]] = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x256, {{.*}} index_map = (d0, d1, d2, d3) -> ((d1 floordiv 8) mod 8, d1 mod 8, d2, d3)>
  // CHECK-AFTER: #[[LAYOUT_STREAM_2:.*]] = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x256, {{.*}} index_map = (d0, d1, d2, d3) -> (0, (d1 mod 64) floordiv 4, 0, d1 mod 4)>
  #layout_stream = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded, index_map = (d0,d1,d2,d3) -> (d1 floordiv 8, d1 mod 8, d2, d3) >
  #layout_stream2 = #ttcore.metal_layout<logical_shape = 32x2048, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded, index_map = (d0,d1,d2,d3) -> (0, d3 floordiv 4, 0, d3 mod 4) >

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_hw_sharding.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_hw_sharding.mlir
@@ -1,0 +1,59 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --canonicalize %s | FileCheck %s
+
+#any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+module attributes {ttcore.device = #any_device} {
+  func.func @test_height_sharded_virtual_grid(%arg0: tensor<2048x32xf32>) -> tensor<2048x32xf32> {
+    // CHECK-LABEL: func.func @test_height_sharded_virtual_grid
+    // CHECK: d2m.empty() : tensor<64x1x1x1x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<64x1,
+    %0 = "ttir.exp"(%arg0) : (tensor<2048x32xf32>) -> tensor<2048x32xf32>
+    return %0 : tensor<2048x32xf32>
+  }
+}
+
+// -----
+
+#any_device_2 = #ttcore.device<workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+module attributes {ttcore.device = #any_device_2} {
+  func.func @test_width_sharded_virtual_grid(%arg0: tensor<32x2048xf32>) -> tensor<32x2048xf32> {
+    // CHECK-LABEL: func.func @test_width_sharded_virtual_grid
+    // CHECK: d2m.empty() : tensor<1x64x1x1x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<1x64,
+    %0 = "ttir.exp"(%arg0) : (tensor<32x2048xf32>) -> tensor<32x2048xf32>
+    return %0 : tensor<32x2048xf32>
+  }
+}
+
+// -----
+
+#any_device_3 = #ttcore.device<workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+module attributes {ttcore.device = #any_device_3} {
+  func.func @test_width_sharded_sub64(%arg0: tensor<32x1280xf32>) -> tensor<32x1280xf32> {
+    // Physical shape in tiles: 1x40. Block sharding gives 1x8 = 8 cores.
+    // Virtual grid should select 1x40, packed into 5x8 physical grid.
+    // CHECK-LABEL: func.func @test_width_sharded_sub64
+    // CHECK: d2m.empty() : tensor<1x40x1x1x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<1x40,
+    %0 = "ttir.exp"(%arg0) : (tensor<32x1280xf32>) -> tensor<32x1280xf32>
+    return %0 : tensor<32x1280xf32>
+  }
+}
+
+// -----
+
+#any_device_2 = #ttcore.device<workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+module attributes {ttcore.device = #any_device_2} {
+  func.func @test_height_sharded_sub64(%arg0: tensor<1536x32xf32>) -> tensor<1536x32xf32> {
+    // Physical shape in tiles: 48x1. Block sharding gives 8x1 = 8 cores.
+    // Virtual grid should select 48x1, packed into 6x8 physical grid.
+    // CHECK-LABEL: func.func @test_height_sharded_sub64
+    // CHECK: d2m.empty() : tensor<48x1x1x1x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<48x1,
+    %0 = "ttir.exp"(%arg0) : (tensor<1536x32xf32>) -> tensor<1536x32xf32>
+    return %0 : tensor<1536x32xf32>
+  }
+}


### PR DESCRIPTION
Fixed handling of _GenericOp_ outputs that are views/streams requiring virtual grid support. This allows applying arbitrary views to a GenericOp output.

Viewed outputs do not require virtual grid forward and inverse affine maps align with L1 storage (in general reblocked case, this is impossible anyway), so verification is relaxed somewhat.

Refactored how physical grid shapes are queried; it isn't possible to determine if a `MetalLayoutAttr` is a view by itself, so it is necessary to have a free function `d2m::utils::getPhysicalGridShape` that traces memref/tensor _Values_ to disambiguate views from raw memref/tensors.

Cleaned up GenericOp::build logic for determining how to infer inverse virtual grid maps. 
