### PR TITLE
[d2m] set reductions keep_dim=True and add reshapes to remove dim 

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -323,6 +323,26 @@ def TTIRDecomposeComplexReshape: Pass<"ttir-decompose-complex-reshape", "::mlir:
   }];
 }
 
+def TTIRReductionForceKeepDim: Pass<"ttir-reduction-force-keep-dim", "::mlir::ModuleOp">
+{
+  let summary = "Force all reductions to use keep_dim=true.";
+  let description = [{
+    This pass converts all reduction operations with keep_dim=false to
+    keep_dim=true, inserting a reshape after the reduction to restore the
+    original output shape.
+
+    Example:
+      Before:
+        %0 = "ttir.sum"(%input) {dim_arg = [1], keep_dim = false} : (tensor<2x3x4xf32>) -> tensor<2x4xf32>
+
+      After:
+        %0 = "ttir.sum"(%input) {dim_arg = [1], keep_dim = true} : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+        %1 = "ttir.reshape"(%0) <{shape = [2, 4]}> : (tensor<2x1x4xf32>) -> tensor<2x4xf32>
+  }];
+
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 def TTIRMultiDeviceTensorAnnotation: Pass<"ttir-multi-device-tensor-annotation", "::mlir::ModuleOp">
 {
   let summary = "TTIR multi-device tensor annotation pass.";

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         MoveReshapeToConstant.cpp
         Quantization.cpp
         QuantDequantConversion.cpp
+        ReductionForceKeepDim.cpp
         Transforms.cpp
         TTIRFusing.cpp
         MultiDeviceTensorAnnotation.cpp

--- a/lib/Dialect/TTIR/Transforms/ReductionForceKeepDim.cpp
+++ b/lib/Dialect/TTIR/Transforms/ReductionForceKeepDim.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRREDUCTIONFORCEKEEPDIM
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+// For any reduction with keep_dim=false, set keep_dim=true and insert a reshape
+// after to squeeze the reduced dimensions back out, preserving the original
+// output shape.
+template <typename ReductionOpTy>
+class ForceKeepDimPattern : public mlir::OpRewritePattern<ReductionOpTy> {
+  using mlir::OpRewritePattern<ReductionOpTy>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(ReductionOpTy reductionOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    if (reductionOp.getKeepDim()) {
+      return mlir::failure();
+    }
+
+    ArrayRef<int64_t> inputShape = reductionOp.getInput().getType().getShape();
+
+    // Compute the intermediate output shape for keep_dim=true: start from the
+    // input shape and set each reduced dimension to 1 (instead of removing it).
+    // E.g. input <2x3x4>, reduce dim 1 → keep_dim shape <2x1x4>.
+    llvm::SmallVector<int64_t> keepDimShape(inputShape);
+
+    if (!reductionOp.getDimArg()) {
+      // No dim_arg means reduce over all dimensions (per TTIR_ReductionOp
+      // semantics), so every dimension becomes 1.
+      keepDimShape.assign(inputShape.size(), 1);
+    } else {
+      mlir::ArrayAttr reduceDims = *reductionOp.getDimArg();
+      for (mlir::Attribute reduceDim : reduceDims) {
+        int64_t reduceDimInt =
+            mlir::cast<mlir::IntegerAttr>(reduceDim).getInt();
+        reduceDimInt = (reduceDimInt + inputShape.size()) % inputShape.size();
+        keepDimShape[reduceDimInt] = 1;
+      }
+    }
+
+    auto originalType = reductionOp.getResult().getType();
+    auto decomposedType =
+        RankedTensorType::get(keepDimShape, originalType.getElementType(),
+                              originalType.getEncoding());
+
+    auto newReduction = rewriter.create<ReductionOpTy>(
+        reductionOp.getLoc(), decomposedType, reductionOp.getInput(),
+        /*keep_dim=*/rewriter.getBoolAttr(true), reductionOp.getDimArgAttr());
+
+    llvm::SmallVector<int32_t> outputShapeI32(originalType.getShape().begin(),
+                                              originalType.getShape().end());
+    rewriter.replaceOpWithNewOp<ReshapeOp>(
+        reductionOp, originalType, newReduction.getResult(),
+        rewriter.getI32ArrayAttr(outputShapeI32));
+
+    return mlir::success();
+  }
+};
+
+class TTIRReductionForceKeepDim
+    : public impl::TTIRReductionForceKeepDimBase<TTIRReductionForceKeepDim> {
+public:
+  using impl::TTIRReductionForceKeepDimBase<
+      TTIRReductionForceKeepDim>::TTIRReductionForceKeepDimBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+
+    patterns
+        .add<ForceKeepDimPattern<SumOp>, ForceKeepDimPattern<MeanOp>,
+             ForceKeepDimPattern<MaxOp>, ForceKeepDimPattern<MinOp>,
+             ForceKeepDimPattern<ProdOp>, ForceKeepDimPattern<ReduceAndOp>,
+             ForceKeepDimPattern<ReduceOrOp>, ForceKeepDimPattern<ArgMaxOp>>(
+            &getContext());
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -85,6 +85,7 @@ void createTTIRToTTMetalFrontendPipeline(
   pm.addPass(tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(ttir::createTTIRMoveReshapeToConstant());
   pm.addPass(ttir::createTTIRFoldConstantReshapeBroadcast());
+  pm.addPass(ttir::createTTIRReductionForceKeepDim());
   pm.addPass(d2m::createD2MRankNormalization());
   pm.addPass(ttir::createTTIRDecomposeComplexReshape());
   pm.addPass(createCanonicalizerPassWithOptions(options));

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -42,7 +42,7 @@ def create_reductions_constrained_inputs(input_shape, reduce_type, dim_arg, keep
 @pytest.mark.parametrize("m", [4, 8, 16])
 @pytest.mark.parametrize("n", [2, 4, 8])
 @pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_sum(
     m: int,
@@ -72,7 +72,7 @@ def test_sum(
 @pytest.mark.parametrize("m", [4, 8])
 @pytest.mark.parametrize("n", [2, 4])
 @pytest.mark.parametrize("dim_arg", [[1], [2], [1, 2]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_sum_3d(
     b: int,
@@ -84,6 +84,11 @@ def test_sum_3d(
     request,
     device,
 ):
+    if len(dim_arg) >= 2 and not keep_dim:
+        pytest.skip(
+            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
+        )
+
     tile_size = 32
     shape = (
         b,
@@ -105,7 +110,7 @@ def test_sum_3d(
 @pytest.mark.parametrize("m", [4, 8])
 @pytest.mark.parametrize("n", [2, 4])
 @pytest.mark.parametrize("dim_arg", [[2], [3], [2, 3]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_sum_4d(
     a: int,
@@ -118,6 +123,11 @@ def test_sum_4d(
     request,
     device,
 ):
+    if len(dim_arg) >= 2 and not keep_dim:
+        pytest.skip(
+            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
+        )
+
     tile_size = 32
     shape = (
         a,
@@ -138,7 +148,7 @@ def test_sum_4d(
 @pytest.mark.parametrize("m", [4, 8, 16])
 @pytest.mark.parametrize("n", [2, 4, 8])
 @pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_max(
     m: int, n: int, dim_arg: int, keep_dim: bool, target: str, request, device
@@ -167,7 +177,7 @@ def test_max(
     [(100, 50), (37, 61), (50, 100), (129, 65)],
 )
 @pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_sum_unaligned(
     shape: tuple,
@@ -191,7 +201,7 @@ def test_sum_unaligned(
     [(100, 50), (37, 61), (50, 100), (129, 65)],
 )
 @pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True])
+@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_max_unaligned(
     shape: tuple,

--- a/test/ttmlir/Dialect/TTIR/Transforms/ReductionForceKeepDim/force_keep_dim.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ReductionForceKeepDim/force_keep_dim.mlir
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-reduction-force-keep-dim %s | FileCheck %s
+
+// Verify that reductions with keep_dim=false are converted to keep_dim=true
+// with a reshape inserted after to restore the original output shape.
+
+module {
+  func.func @force_keep_dim_sum(%arg0: tensor<2x3x4xf32>) -> tensor<2x4xf32> {
+    // CHECK-LABEL: func.func @force_keep_dim_sum
+    // CHECK: "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<2x1x4xf32>) -> tensor<2x4xf32>
+    %0 = "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<2x3x4xf32>) -> tensor<2x4xf32>
+    return %0 : tensor<2x4xf32>
+  }
+}
+
+// -----
+module {
+  func.func @force_keep_dim_mean(%arg0: tensor<4x8x16xf32>) -> tensor<4x16xf32> {
+    // CHECK-LABEL: func.func @force_keep_dim_mean
+    // CHECK: "ttir.mean"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<4x8x16xf32>) -> tensor<4x1x16xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<4x1x16xf32>) -> tensor<4x16xf32>
+    %0 = "ttir.mean"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<4x8x16xf32>) -> tensor<4x16xf32>
+    return %0 : tensor<4x16xf32>
+  }
+}
+
+// -----
+module {
+  func.func @force_keep_dim_max_last_dim(%arg0: tensor<2x3x4xf32>) -> tensor<2x3xf32> {
+    // CHECK-LABEL: func.func @force_keep_dim_max_last_dim
+    // CHECK: "ttir.max"(%arg0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<2x3x4xf32>) -> tensor<2x3x1xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<2x3x1xf32>) -> tensor<2x3xf32>
+    %0 = "ttir.max"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<2x3x4xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+}
+
+// -----
+module {
+  func.func @force_keep_dim_min_first_dim(%arg0: tensor<2x3x4xf32>) -> tensor<3x4xf32> {
+    // CHECK-LABEL: func.func @force_keep_dim_min_first_dim
+    // CHECK: "ttir.min"(%arg0) <{dim_arg = [0 : i32], keep_dim = true}> : (tensor<2x3x4xf32>) -> tensor<1x3x4xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x3x4xf32>) -> tensor<3x4xf32>
+    %0 = "ttir.min"(%arg0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<2x3x4xf32>) -> tensor<3x4xf32>
+    return %0 : tensor<3x4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/ReductionForceKeepDim/no_transform.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ReductionForceKeepDim/no_transform.mlir
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-reduction-force-keep-dim %s | FileCheck %s
+
+// Verify reductions that already have keep_dim=true are not modified.
+module {
+  func.func @already_keep_dim_sum(%arg0: tensor<2x3x4xf32>) -> tensor<2x1x4xf32> {
+    // CHECK-LABEL: func.func @already_keep_dim_sum
+    // CHECK: "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+    // CHECK-NEXT: return
+    %0 = "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+    return %0 : tensor<2x1x4xf32>
+  }
+}
+
+// -----
+module {
+  func.func @already_keep_dim_mean(%arg0: tensor<4x8x16xf32>) -> tensor<4x1x16xf32> {
+    // CHECK-LABEL: func.func @already_keep_dim_mean
+    // CHECK: "ttir.mean"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<4x8x16xf32>) -> tensor<4x1x16xf32>
+    // CHECK-NEXT: return
+    %0 = "ttir.mean"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<4x8x16xf32>) -> tensor<4x1x16xf32>
+    return %0 : tensor<4x1x16xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #6645 

### Problem description
`keep_dim=False` on reductions is unsupported in D2M. Current solution to get these working thru the pipeline initially is to add reshapes after removing the dim and setting `keep_dim=True` to compile thru D2M pipeline

### What's changed
Added a pass that goes thru and sets `keep_dim=True` on reductions where they are set to false and adds reshapes after that remove the dim
Added lit testing for this pass
Added `keep_dim=False` to builder tests for metal reductions

### Checklist
- [ ] New/Existing tests provide coverage for changes
