### PR TITLE
Save failed ops in op-by-op

### DIFF
--- a/tools/op-by-op-infra/op_by_op_infra/workflow.py
+++ b/tools/op-by-op-infra/op_by_op_infra/workflow.py
@@ -112,9 +112,7 @@ def _sanitize_filename(name: str) -> str:
     return sanitized
 
 
-def _save_failed_ops(
-    execution_results: list, folder_path: str
-) -> None:
+def _save_failed_ops(execution_results: list, folder_path: str) -> None:
     """Saves the last_generated_module for each failed op to a file in the specified folder."""
     failed_results = [
         (i, result)


### PR DESCRIPTION
### Ticket
/

### Problem description 
Op-by-op infra didn't have a way to save failed ops automatically

### What's changed
Save modules from ops that failed in a file

### Checklist
- [ ] New/Existing tests provide coverage for changes
