### PR TITLE
Add TopK op support

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2857,6 +2857,38 @@ def TTIR_SortOp : TTIR_NamedOp<"sort"> {
   let hasVerifier = 1;
 }
 
+def TTIR_TopKOp : TTIR_NamedOp<"topk"> {
+  let summary = "TopK operation.";
+  let description = [{
+    Returns top `k` values and their indices along a given dimension.
+
+    Input:
+      - input: AnyRankedTensor
+
+    Attributes:
+      - k (uint32): number of values to select.
+      - dim (int32): dimension to select from (default: -1, the last dim).
+      - largest (bool): if true, return largest values; else smallest.
+      - sorted (bool): if true, results are sorted along `dim`.
+
+    Returns a tuple:
+      - values: the top-k values tensor.
+      - indices: the indices of the selected values.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       UI32Attr:$k,
+                       DefaultValuedAttr<SI32Attr, "-1">:$dim,
+                       DefaultValuedAttr<BoolAttr, "true">:$largest,
+                       DefaultValuedAttr<BoolAttr, "true">:$sorted);
+
+  let results = (outs AnyRankedTensor:$values,
+                      AnyRankedTensor:$indices);
+
+  let hasVerifier = 1;
+}
+
+
 def TTIR_TransposeOp : TTIR_NamedOp<"transpose", [TTIR_TensorManipulation]> {
     let summary = "Tensor transpose operation.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1286,6 +1286,33 @@ def TTNN_SortOp : TTNN_Op<"sort"> {
   let hasVerifier = 1;
 }
 
+def TTNN_TopKOp : TTNN_Op<"topk"> {
+  let summary = "TopK op.";
+  let description = [{
+    Returns top `k` values and their indices along a given dimension.
+
+    Parameters:
+      - `input`: The input tensor.
+      - `k`: The number of elements to select.
+      - `dim`: The dimension to select from.
+      - `largest`: Whether to return the largest values.
+      - `sorted`: Whether to return results sorted along `dim`.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       UI32Attr:$k,
+                       DefaultValuedAttr<SI8Attr, "-1">:$dim,
+                       DefaultValuedAttr<BoolAttr, "true">:$largest,
+                       DefaultValuedAttr<BoolAttr, "true">:$sorted,
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+  let results = (outs AnyRankedTensor:$values,
+                      AnyRankedTensor:$indices);
+
+  let hasVerifier = 1;
+}
+
+
 def TTNN_TransposeOp : TTNN_Op<"transpose"> {
     let summary = "Transpose op.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -80,6 +80,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/pool/upsample/upsample.hpp"
 #include "ttnn/operations/rand/rand.hpp"
 #include "ttnn/operations/reduction/argmax/argmax.hpp"
+#include "ttnn/operations/reduction/topk/topk.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -962,6 +962,26 @@ struct OpModel<SortOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// TopKOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<TopKOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, uint32_t k, int dim,
+                   bool largest, bool sorted, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             uint32_t k, int dim, bool largest,
+                                             bool sorted,
+                                             TTNNLayoutAttr outputLayout);
+};
+
+
+//===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -568,6 +568,28 @@ public:
     return success();
   }
 };
+
+namespace {
+class TopKOpConversionPattern : public OpConversionPattern<ttir::TopKOp> {
+public:
+  using OpConversionPattern<ttir::TopKOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::TopKOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes))) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<ttnn::TopKOp>(
+        op, resultTypes, adaptor.getInput(), adaptor.getK(), adaptor.getDim(),
+        adaptor.getLargest(), adaptor.getSorted(), ttnn::MemoryConfigAttr());
+    return success();
+  }
+};
+} // namespace
+
 } // namespace
 
 namespace {
@@ -3026,6 +3048,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            RepeatInterleaveOpConversionPattern,
            SoftmaxOpConversionPattern,
            SortOpConversionPattern,
+           TopKOpConversionPattern,
            TypecastOpConversionPattern,
            ClampOpConversionPattern<ttir::ClampScalarOp, ttnn::ClampScalarOp>,
            ClampOpConversionPattern<ttir::ClampTensorOp, ttnn::ClampTensorOp>,

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2686,6 +2686,73 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// TopKOp
+//===----------------------------------------------------------------------===//
+
+// TopKOp verification
+::mlir::LogicalResult mlir::tt::ttnn::TopKOp::verify() {
+  auto inputType = getInput().getType();
+  auto valuesType = mlir::cast<RankedTensorType>(getValues().getType());
+  auto indicesType = mlir::cast<RankedTensorType>(getIndices().getType());
+
+  int32_t dim = getDim();
+  auto rank = inputType.getRank();
+  if (dim >= rank || dim < -rank) {
+    return emitOpError("Dimension out of range (expected to be in range of [")
+           << -rank << ", " << (rank - 1) << "], but got " << dim << ")";
+  }
+
+  if (dim < 0) {
+    dim += rank;
+  }
+
+  uint32_t k = getK();
+  if (k == 0) {
+    return emitOpError("k must be greater than 0");
+  }
+
+  if (valuesType.getRank() != rank || indicesType.getRank() != rank) {
+    return emitOpError("Values/indices rank must match input rank");
+  }
+
+  if (valuesType.getShape() != indicesType.getShape()) {
+    return emitOpError("Values and indices shapes must match");
+  }
+
+  if (valuesType.getElementType() != inputType.getElementType()) {
+    return emitOpError("Values element type must match input element type");
+  }
+
+  if (!mlir::isa<IntegerType>(indicesType.getElementType())) {
+    return emitOpError("Expected integer data type for indices but got ")
+           << indicesType.getElementType();
+  }
+
+  auto inputShape = inputType.getShape();
+  auto valuesShape = valuesType.getShape();
+  for (int64_t i = 0; i < rank; ++i) {
+    if (i == dim) {
+      if (inputShape[i] != ShapedType::kDynamic && k > inputShape[i]) {
+        return emitOpError("k cannot be greater than input dimension size");
+      }
+      if (valuesShape[i] != ShapedType::kDynamic &&
+          static_cast<int64_t>(k) != valuesShape[i]) {
+        return emitOpError("Values dimension does not match k");
+      }
+    } else {
+      if (inputShape[i] != ShapedType::kDynamic &&
+          valuesShape[i] != ShapedType::kDynamic &&
+          valuesShape[i] != inputShape[i]) {
+        return emitOpError("Values shape does not match input shape");
+      }
+    }
+  }
+
+  return success();
+}
+
+
+//===----------------------------------------------------------------------===//
 // BatchNorm verification helpers
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_op.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func public @topk_custom_call(%arg0: tensor<4x16xbf16>) -> (tensor<4x8xbf16>, tensor<4x8xi32>) {
+    // CHECK-LABEL: func.func public @topk_custom_call(
+    // CHECK: %[[VAL:[0-9]+]], %[[IDX:[0-9]+]] = "ttir.topk"(%arg0)
+    // CHECK-SAME: <{dim = -1 : si32, k = 8 : ui32, largest = true, sorted = true}>
+    // CHECK-SAME: (tensor<4x16xbf16>) -> (tensor<4x8xbf16>, tensor<4x8xi32>)
+    %0:2 = stablehlo.custom_call @mhlo.topk(%arg0) {backend_config = "{\"k\": 8, \"dim\": -1, \"largest\": true, \"sorted\": true}"} : (tensor<4x16xbf16>) -> (tensor<4x8xbf16>, tensor<4x8xi32>)
+    return %0#0, %0#1 : tensor<4x8xbf16>, tensor<4x8xi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/topk/topk_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/topk/topk_tests_negative.mlir
@@ -1,0 +1,46 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for topk operation
+
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>) {
+    // CHECK: error: 'ttir.topk' op Dimension out of range (expected to be in range of [-2, 1], but got -3)
+    %1, %2 = "ttir.topk"(%arg0) <{k = 8 : ui32, dim = -3 : si32}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>) {
+    // CHECK: error: 'ttir.topk' op k must be greater than 0
+    %1, %2 = "ttir.topk"(%arg0) <{k = 0 : ui32, dim = -1 : si32}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xbf16>) {
+    // CHECK: error: 'ttir.topk' op Expected integer data type for indices but got bf16
+    %1, %2 = "ttir.topk"(%arg0) <{k = 8 : ui32, dim = -1 : si32}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xbf16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xbf16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x7xbf16>, tensor<64x7xi16>) {
+    // CHECK: error: 'ttir.topk' op Values dimension does not match k
+    %1, %2 = "ttir.topk"(%arg0) <{k = 8 : ui32, dim = -1 : si32}> : (tensor<64x128xbf16>) -> (tensor<64x7xbf16>, tensor<64x7xi16>)
+    return %1, %2 : tensor<64x7xbf16>, tensor<64x7xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x256xbf16>, tensor<64x256xi16>) {
+    // CHECK: error: 'ttir.topk' op k cannot be greater than input dimension size
+    %1, %2 = "ttir.topk"(%arg0) <{k = 256 : ui32, dim = -1 : si32}> : (tensor<64x128xbf16>) -> (tensor<64x256xbf16>, tensor<64x256xi16>)
+    return %1, %2 : tensor<64x256xbf16>, tensor<64x256xi16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/topk/simple_topk.mlir
+++ b/test/ttmlir/Dialect/TTNN/topk/simple_topk.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module attributes {} {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>) {
+    // CHECK-LABEL: @test_topk
+    // CHECK: %{{.*}}, %{{.*}} = "ttnn.topk"(%arg0)
+    // CHECK-SAME: <{dim = -1 : si8, k = 8 : ui32, largest = true, sorted = true}>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> (tensor<64x8xbf16,
+    // CHECK-SAME: tensor<64x8xui16,
+    %0, %1 = "ttir.topk"(%arg0) <{k = 8 : ui32, dim = -1 : si32, largest = true, sorted = true}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>)
+    return %0, %1 : tensor<64x8xbf16>, tensor<64x8xi16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/topk/topk_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/topk/topk_tests_negative.mlir
@@ -1,0 +1,46 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for topk operation
+
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>) {
+    // CHECK: error: 'ttnn.topk' op Dimension out of range (expected to be in range of [-2, 1], but got -3)
+    %1, %2 = "ttnn.topk"(%arg0) <{k = 8 : ui32, dim = -3 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>) {
+    // CHECK: error: 'ttnn.topk' op k must be greater than 0
+    %1, %2 = "ttnn.topk"(%arg0) <{k = 0 : ui32, dim = -1 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xi16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xbf16>) {
+    // CHECK: error: 'ttnn.topk' op Expected integer data type for indices but got bf16
+    %1, %2 = "ttnn.topk"(%arg0) <{k = 8 : ui32, dim = -1 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x8xbf16>, tensor<64x8xbf16>)
+    return %1, %2 : tensor<64x8xbf16>, tensor<64x8xbf16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x7xbf16>, tensor<64x7xi16>) {
+    // CHECK: error: 'ttnn.topk' op Values dimension does not match k
+    %1, %2 = "ttnn.topk"(%arg0) <{k = 8 : ui32, dim = -1 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x7xbf16>, tensor<64x7xi16>)
+    return %1, %2 : tensor<64x7xbf16>, tensor<64x7xi16>
+  }
+}
+
+// -----
+module {
+  func.func @test_topk(%arg0: tensor<64x128xbf16>) -> (tensor<64x256xbf16>, tensor<64x256xi16>) {
+    // CHECK: error: 'ttnn.topk' op k cannot be greater than input dimension size
+    %1, %2 = "ttnn.topk"(%arg0) <{k = 256 : ui32, dim = -1 : si8}> : (tensor<64x128xbf16>) -> (tensor<64x256xbf16>, tensor<64x256xi16>)
+    return %1, %2 : tensor<64x256xbf16>, tensor<64x256xi16>
+  }
+}


### PR DESCRIPTION
## Summary
Implements #3131: Add TopK operation for selecting top-k values along a dimension.

## Changes
### Dialect Definitions
- **TTIR TopKOp** (`TTIROps.td`): k, dim, largest, sorted attributes with verifier
- **TTNN TopKOp** (`TTNNOps.td`): Same attributes plus memory_config support

### Conversions
- **StableHLO → TTIR**: Handles `mhlo.topk` custom_call with flexible backend_config parsing (DictionaryAttr, JSON string, raw integer)
- **TTIR → TTNN**: Direct lowering with memory_config passthrough

### OpModel
- Added `OpModel<TopKOp>` with `getOpConstraints()` and `getOpRuntime()` following SortOp/ArgMaxOp patterns

### Tests
- `test/ttmlir/Conversion/StableHLOToTTIR/reduction/topk_op.mlir` - Conversion test
- `test/ttmlir/Dialect/TTIR/topk/topk_tests_negative.mlir` - Verifier negative cases
- `test/ttmlir/Dialect/TTNN/topk/simple_topk.mlir` - Lowering test
- `test/ttmlir/Dialect/TTNN/topk/topk_tests_negative.mlir` - TTNN verifier negative cases

## Testing
Added comprehensive tests for:
- StableHLO custom_call conversion with JSON backend_config
- Dimension validation (out of range)
- k validation (k=0, k > dim size)
- Shape matching between values/indices and input
- Element type validation

Closes #3131