### PR TITLE
Fix reduce_window lowering for 3D inputs

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2487,7 +2487,7 @@ public:
       }
     }
     int64_t inputRank = firstInputType.getRank();
-    if (!llvm::is_contained({1, 2, 4}, inputRank)) {
+    if (inputRank > 4) {
       return rewriter.notifyMatchFailure(srcOp, "Invalid input tensor rank.");
     }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
@@ -110,4 +110,19 @@ module @moreh_cumsum attributes {} {
     }) : (tensor<1x1xi32>, tensor<i32>) -> tensor<1x1xi32>
     return %1 : tensor<1x1xi32>
   }
+
+  func.func @reduce_window_3d_input_to_cumsum(%arg0: tensor<1x25x34xf32>) -> tensor<1x25x34xf32> {
+    // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"(%arg0)
+    // CHECK-SAME: <{dim = 1 : i64}>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1 = "stablehlo.reduce_window"(%arg0, %cst) <{
+      padding = dense<[[0, 0], [24, 0], [0, 0]]> : tensor<3x2xi64>,
+      window_dimensions = array<i64: 1, 25, 1>
+    }> ({
+    ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+      %sum = stablehlo.add %arg1, %arg2 : tensor<f32>
+      stablehlo.return %sum : tensor<f32>
+    }) : (tensor<1x25x34xf32>, tensor<f32>) -> tensor<1x25x34xf32>
+    return %1 : tensor<1x25x34xf32>
+  }
 }


### PR DESCRIPTION
Lowering to CumSumOp is allowed for 3D inputs (found in resnet50 for example). Added a test as well to cover this case.