### PR TITLE
Fix null input function creation for functions without inputs

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -272,8 +272,8 @@ protected:
       mlir::func::FuncOp inputFuncOp;
       // Only create input function if the forward function has inputs
       if (!forwardFuncOp.getFunctionType().getInputs().empty()) {
-        inputFuncOp = createInputFunctionImpl(
-            rewriter, forwardFuncOp.getLoc(), forwardFuncOp, functionPrefix);
+        inputFuncOp = createInputFunctionImpl(rewriter, forwardFuncOp.getLoc(),
+                                              forwardFuncOp, functionPrefix);
       }
       forwardAndInputFuncOps.emplace_back(forwardFuncOp, inputFuncOp);
     }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -5,6 +5,7 @@ module {
   // CHECK-LABEL: @add_const_eval_0
   // CHECK-LABEL: @add(
 
+  // CHECK-NOT: @create_inputs_for_func_no_inputs
   // CHECK-LABEL: @create_inputs_for_add
   // CHECK: %[[ARG0:.*]] = "ttnn.ones"
   // CHECK: %[[ARG1:.*]] = "ttnn.ones"
@@ -14,5 +15,11 @@ module {
     %0 = "ttir.add"(%arg0, %arg0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %1 = "ttir.subtract"(%arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %1 : tensor<32x32xbf16>
+  }
+
+  func.func @func_no_inputs() -> (tensor<64x64xbf16>) {
+    %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64x64xbf16>}> :
+        () -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_load_input_tensors.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_load_input_tensors.mlir
@@ -11,21 +11,29 @@
 // RUN: FileCheck %s --check-prefix=CUSTOM-FULL --input-file=%t.custom_full.mlir
 
 module {
+  // DEFAULT-NOT: @load_inputs_for_func_no_inputs()
+  // DEFAULT: @load_inputs_for_add()
   // DEFAULT: "ttnn.load_tensor"
   // DEFAULT-SAME: file_path = "arg0.tensorbin"
   // DEFAULT-NEXT: "ttnn.load_tensor"
   // DEFAULT-SAME: file_path = "arg1.tensorbin"
 
+  // CUSTOM-DIR-NOT: @load_inputs_for_func_no_inputs()
+  // CUSTOM-DIR: @load_inputs_for_add()
   // CUSTOM-DIR: "ttnn.load_tensor"
   // CUSTOM-DIR-SAME: file_path = "tensors/arg0.tensorbin"
   // CUSTOM-DIR-NEXT: "ttnn.load_tensor"
   // CUSTOM-DIR-SAME: file_path = "tensors/arg1.tensorbin"
 
+  // CUSTOM-PREFIX-NOT: @load_inputs_for_func_no_inputs()
+  // CUSTOM-PREFIX: @load_inputs_for_add()
   // CUSTOM-PREFIX: "ttnn.load_tensor"
   // CUSTOM-PREFIX-SAME: file_path = "input0.tensorbin"
   // CUSTOM-PREFIX-NEXT: "ttnn.load_tensor"
   // CUSTOM-PREFIX-SAME: file_path = "input1.tensorbin"
 
+  // CUSTOM-FULL-NOT: @load_inputs_for_func_no_inputs()
+  // CUSTOM-FULL: @load_inputs_for_add()
   // CUSTOM-FULL: "ttnn.load_tensor"
   // CUSTOM-FULL-SAME: file_path = "tensors/input0.tensorbin"
   // CUSTOM-FULL-NEXT: "ttnn.load_tensor"
@@ -34,5 +42,11 @@ module {
     %0 = "ttir.add"(%arg0, %arg0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %1 = "ttir.subtract"(%arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %1 : tensor<32x32xbf16>
+  }
+
+  func.func @func_no_inputs() -> (tensor<64x64xbf16>) {
+    %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64x64xbf16>}> :
+        () -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
   }
 }


### PR DESCRIPTION
### Ticket
Solves https://github.com/tenstorrent/tt-mlir/issues/6871

### Problem description
Emitpy/EmitC pipelines fail when the forward function has no input arguments.

### What's changed
This PR fixes an issue where input functions were being created even for forward functions that have no input parameters. The change adds a check to only create input functions when the forward function actually has inputs.

### Checklist
- [x] New/Existing tests provide coverage for changes
