### PR TITLE
Add CSE pass to TTNN pipeline

### DIFF
--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -182,6 +182,7 @@ void createTTNNPipelineWorkaroundPass(
 
   pm.addPass(createTTNNWorkarounds(workaroundOptions));
   pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
 }
 
 void createTTNNPipelineLayoutDecompositionPass(
@@ -220,6 +221,7 @@ void createTTIRToTTNNDevicePipeline(
   pm.addPass(ttcore::createTTCoreMarkFunctionsAsForwardPass());
 
   pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
 
   // Create device module, if not already present.
   pm.addPass(ttcore::createTTCoreWrapDeviceModulePass());


### PR DESCRIPTION
### Ticket
#6877 

### Problem description
This PR adds CSE (Common Subexpression Elimination) pass to the TTIR -> TTNN pipeline, which allows optimizing-out some repeated subexpressions which previously caused OOM issues.

### Before
```
func.func private @main_const_eval_171() -> (tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>) attributes {tt.function_type = "const_eval"} {
        %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x8>}> : () -> !ttnn.device loc(#loc1)
        %1 = "ttnn.full"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, fill_value = 0.000000e+00 : f32, layout = #ttnn.layout<tile>, shape = #ttnn.shape<>}> : (!ttnn.device) -> tensor<f32, #ttnn_layout35> loc(#loc)
        %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32, #ttnn_layout35>) -> tensor<1x1x1x1xf32, #ttnn_layout34> loc(#loc)
        "ttnn.deallocate"(%1) <{force = false}> : (tensor<f32, #ttnn_layout35>) -> () loc(#loc)
        %3 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc91)
        %4 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc92)
        %5 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc93)
        %6 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc94)
        %7 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc95)
        %8 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc96)
        %9 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc97)
        %10 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc98)
        %11 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc99)
        %12 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc100)
        %13 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc101)
        %14 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc102)
        %15 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc103)
        %16 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc104)
        %17 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc105)
        %18 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc106)
        %19 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc107)
        %20 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc108)
        %21 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc109)
        %22 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc110)
        %23 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc111)
        %24 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc112)
        %25 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc113)
        %26 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc114)
        %27 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc115)
        %28 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc116)
        %29 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc117)
        %30 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc118)
        %31 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc119)
        %32 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc120)
        %33 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc121)
        %34 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc122)
        "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x1x1x1xf32, #ttnn_layout34>) -> () loc(#loc122)
        return %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34 : tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49>, tensor<1x4x136x136xf32, #ttnn_layout49> loc(#loc)
} loc(#loc)
```

### After
```
func.func private @main_const_eval_257() -> tensor<1x4x136x136xf32, #ttnn_layout52> attributes {tt.function_type = "const_eval"} {
        %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x8>}> : () -> !ttnn.device
        %1 = "ttnn.full"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, fill_value = 0.000000e+00 : f32, layout = #ttnn.layout<tile>, shape = #ttnn.shape<>}> : (!ttnn.device) -> tensor<f32, #ttnn_layout32>
        %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32, #ttnn_layout32>) -> tensor<1x1x1x1xf32, #ttnn_layout45>
        "ttnn.deallocate"(%1) <{force = false}> : (tensor<f32, #ttnn_layout32>) -> ()
        %3 = "ttnn.repeat"(%2) <{repeat_dims = #ttnn.shape<1x4x136x136>}> : (tensor<1x1x1x1xf32, #ttnn_layout45>) -> tensor<1x4x136x136xf32, #ttnn_layout52>
        "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x1x1x1xf32, #ttnn_layout45>) -> ()
        return %3 : tensor<1x4x136x136xf32, #ttnn_layout52>
}
```
 
### Checklist
- [ ] New/Existing tests provide coverage for changes
