### PR TITLE
[Conv2d/ConvTranspose2d] Revert to storing config tensors in DRAM by default

### DIFF
--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -395,11 +395,6 @@ createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *config) {
         *config->enable_kernel_stride_folding();
   }
 
-  // TODO(vkovacevic): Failing with tt-metal error:
-  // "CB page size 64 should be greater than the config tensor page size 132"
-  // Disabled until fixed in tt-metal
-  // https://github.com/tenstorrent/tt-metal/issues/35207
-
   if (config->config_tensors_in_dram()) {
     conv2dConfig.config_tensors_in_dram = *config->config_tensors_in_dram();
   }

--- a/test/ttmlir/Silicon/TTNN/n150/conv/split_conv.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/conv/split_conv.mlir
@@ -1,5 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// UNSUPPORTED: true
+
+// TODO(jserbedzija): Failing with tt-metal error:
+// "CB page size 64 should be greater than the config tensor page size 132"
+// Disabled until fixed in tt-metal
+// https://github.com/tenstorrent/tt-metal/issues/35207
 
 module {
   func.func @test_conv_sliced_batch_group_count() -> tensor<1x768x768xbf16> {


### PR DESCRIPTION
### Problem description
Recently, we changed the default behavior to store config tensors in L1 for Conv2d/ConvTranspose2d ops because a test in tt-mlir was failing.

### What's changed
Revert the behavior to store config tensors in DRAM by default, and mark the failing test as unsupported until the fix lands in metal.

### Checklist
- [ ] New/Existing tests provide coverage for changes
