### PR TITLE
Fix `ttnn.pad` logical shape and padded shape mismatch

### DIFF
--- a/test/ttmlir/Silicon/TTNN/n300/runtime/host_pad_write_tensor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n300/runtime/host_pad_write_tensor.mlir
@@ -1,0 +1,27 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+// After ttnn.pad on a host tensor, the logical shape may not match the padded
+// shape. The write_tensor runtime aligns them before writing to device.
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#dram = #ttnn.buffer_type<dram>
+#layout_host = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 96 + d1 * 3 + d2, d3), <1x1>, memref<6144x3xf32, #system_memory>>
+#layout_host_padded = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 96 + d1 * 3 + d2, d3), <1x1>, memref<6144x32xf32, #system_memory>>
+#layout_device = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 96 + d1 * 3 + d2, d3), <1x1>, memref<6144x32xf32, #dram>, <interleaved>>
+
+func.func @test_pad_host_to_device(%arg0: tensor<64x32x3x3xf32, #layout_host>) -> tensor<64x32x3x32xf32, #layout_device> {
+  %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+
+  // CHECK: ttnn.pad
+  %padded = "ttnn.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 29>, value = 0.0 : f32, use_multicore = false}> : (tensor<64x32x3x3xf32, #layout_host>) -> tensor<64x32x3x32xf32, #layout_host_padded>
+
+  // CHECK: ttnn.empty
+  %empty = "ttnn.empty"(%device) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<64x32x3x32>}> : (!ttnn.device) -> tensor<64x32x3x32xf32, #layout_device>
+
+  // CHECK: ttnn.write_tensor
+  "ttnn.write_tensor"(%padded, %empty) <{blocking = false, cq_id = 0 : ui32}> : (tensor<64x32x3x32xf32, #layout_host_padded>, tensor<64x32x3x32xf32, #layout_device>) -> ()
+
+  return %empty : tensor<64x32x3x32xf32, #layout_device>
+}


### PR DESCRIPTION
`ttnn::pad` may not update logical shape to match the padded shape after explicit padding. This causes `write_tensor` to fail when writing a padded host tensor to device.

### Problem description
The `ttnn.pad` operation does not work correctly for 4D+ tensors, especially when the result tensor of this operation is used by `ttnn.write_tensor` operation. The TTNN runtime reports a logical shape mismatch error when we try to write such a padded tensor to the device.

### What's changed
The `experimental::view` is used to change the metadata of the tensor to have the same logical and padded shape. This is a workaround and the proper fix should be in tt-metal's pad implementation.

A unit test has been added to exercise this path. I did a `ttrt run --save-artifacts` on the unit test as well and found that there are no runtime issues and the device tensor has same values as the padded host tensor after this change.

### Checklist
- [x] New/Existing tests provide coverage for changes
