### PR TITLE
Fix `OperationValidationAndFallback` pass

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -154,10 +154,6 @@ public:
     bool validationFailed = false;
 
     moduleOp->walk([&](func::FuncOp func) {
-      if (!ttmlir::utils::isForwardDeviceFunc(func)) {
-        return;
-      }
-
       func.walk([&](Operation *operation) -> WalkResult {
         if (auto toLayoutOp = mlir::dyn_cast<ttnn::ToLayoutOp>(operation)) {
           // Skip ToLayout operations - they will be decomposed later, so there


### PR DESCRIPTION
### Ticket
N/A

### Problem description
As part of #6633, `OperationValidationAndFallback` pass was mistakenly modified to operate only on forward-device functions, which excluded const-eval functions. This PR reverts the change.

### Checklist
- [ ] New/Existing tests provide coverage for changes
