### PR TITLE
Set metal lib dir to the right one

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,10 @@ message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
 set(TTMETAL_BUILD_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build_${CMAKE_BUILD_TYPE})
 set(TTMETAL_BUILD_SYMLINK ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build)
-set(TTMETAL_LIBRARY_DIR ${TTMETAL_BUILD_DIR}/lib)
+# tt-metal uses GNUInstallDirs which sets CMAKE_INSTALL_LIBDIR to "lib" or "lib64" based on the system
+# We need to use the same value to find the installed libraries
+include(GNUInstallDirs)
+set(TTMETAL_LIBRARY_DIR ${TTMETAL_BUILD_DIR}/${CMAKE_INSTALL_LIBDIR})
 
 set(TRACY_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/922

### Problem description
Metal will set lib output dir dynamically based on the system, while we use hardcoded value.
tt-xla manylinux build fails because of it.

### What's changed
Pickup right value for metal libs directory

### Checklist
- [ ] New/Existing tests provide coverage for changes
