### PR TITLE
Re-enable bfp16 tests for metal matmul

### DIFF
--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.frontend("ttir")
 #    output, which is too slow.
 # Solution: constraint the input range to within (0.001, 0.999) to avoid large
 # differences of magnitudes in the calculation.
-def create_matmul_constrained_inputs(lhs_shape, rhs_shape, dtype =torch.float32):
+def create_matmul_constrained_inputs(lhs_shape, rhs_shape, dtype=torch.float32):
     def module(builder: TTIRBuilder):
         @builder.func([lhs_shape, rhs_shape], [dtype, dtype])
         def matmul_constrained_inputs(
@@ -137,7 +137,7 @@ def test_matmul_ttnn_shapes_single_buffered(
         (1024, 2048, 2048),
     ):
         pytest.xfail(reason="bf16 PCC below threshold for these shapes")
-    
+
     lhs = (
         shape[0],
         shape[1],


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6904

### Problem description
Not testing bfp16 for metal matmul tests. 

### What's changed
- re-enable bpf16 tests for matmul w/ lower PCC=0.96 threshold

Note: 
- singled buffered `1024x2048x2048` and `2048x2048x2048` xfailed as they have PCC~=0.88

### Checklist
- [ ] New/Existing tests provide coverage for changes
