### PR TITLE
Generalize CacheFillUpdatePattern to also handle constant and unsqueezed indices

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -4463,8 +4463,8 @@ public:
         mlir::cast<RankedTensorType>((*CachePositions).getType());
     SmallVector<int64_t> cacheUpdateInputShape(cacheUpdateInputType.getShape());
 
-    // Reshape to 1D if needed
-    if (!isEffectively1D(cacheUpdateInputShape)) {
+    // Flatten to 1D if needed
+    if (cacheUpdateInputShape.size() != 1) {
       int64_t volume = ttmlir::utils::product(cacheUpdateInputShape.begin(),
                                               cacheUpdateInputShape.end());
       CachePositions = ttir::utils::createReshapeOp(


### PR DESCRIPTION
### Ticket
closes #6907

### Problem description
Turning on experimental compile brought down a unit test which uncovered some limitations of the pattern

### What's changed
Generalized the pattern

Heads up to perf team, I insert a reshape in one case. I expect cases that already worked to not enter that branch, and I expect the reshape to get folded/EIOd away, but there's a small chance is pops up and impacts perf.

PR in draft until 1) I run some test suites to validate correctness 2) Potentially add more tests

### Checklist
- [X] New/Existing tests provide coverage for changes
