### PR TITLE
feat: Implement stablehlo.CompareOp builder and golden functions

### DIFF
--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4608,6 +4608,52 @@ def stablehlo_shift_right_logical_golden(
     return shifted.to(output_dtype)
 
 
+def stablehlo_compare_golden(
+    lhs_tensor: GoldenMapTensor,
+    rhs_tensor: GoldenMapTensor,
+    comparison_direction: str,
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    """
+    Golden function for stablehlo.compare operation.
+
+    Performs elementwise comparison based on the specified direction.
+
+    Parameters
+    ----------
+    lhs_tensor : GoldenMapTensor
+        Left-hand side tensor.
+    rhs_tensor : GoldenMapTensor
+        Right-hand side tensor.
+    comparison_direction : str
+        The comparison direction: EQ, NE, GE, GT, LE, LT.
+    output_type_mlir : Type
+        MLIR output type.
+
+    Returns
+    -------
+    GoldenMapTensor
+        Boolean tensor containing the comparison results.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    comparison_ops = {
+        "EQ": torch.eq,
+        "NE": torch.ne,
+        "GE": torch.ge,
+        "GT": torch.gt,
+        "LE": torch.le,
+        "LT": torch.lt,
+    }
+
+    if comparison_direction not in comparison_ops:
+        raise ValueError(f"Unsupported comparison direction: {comparison_direction}")
+
+    compare_fn = comparison_ops[comparison_direction]
+    result = compare_fn(lhs_tensor, rhs_tensor)
+    return result.to(output_dtype)
+
+
 # The following golden implementation is taken from the op spec: https://openxla.org/stablehlo/spec#dynamic_update_slice
 def stablehlo_dynamic_update_slice_golden(
     input_tensor: GoldenMapTensor,
@@ -5834,6 +5880,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.TransposeOp: stablehlo_transpose_golden,
     stablehlo.SelectOp: stablehlo_select_golden,
     stablehlo.PadOp: stablehlo_pad_golden,
+    stablehlo.CompareOp: stablehlo_compare_golden,
     # CCL (Collective Communication Library) operations
     stablehlo.AllGatherOp: stablehlo_all_gather_golden,
     stablehlo.AllReduceOp: stablehlo_all_reduce_golden,


### PR DESCRIPTION
## Summary

This PR implements the Compare ops for the stablehlo builder as requested in issue #4872 ($100 bounty).

## Changes

### tools/golden/mapping.py
- Added `stablehlo_compare_golden()` function that handles all six comparison directions:
  - EQ (equal)
  - NE (not equal)
  - GE (greater or equal)
  - GT (greater than)
  - LE (less or equal)
  - LT (less than)
- Registered `stablehlo.CompareOp` in the golden function mapping dictionary

### tools/builder/stablehlo/stablehlo_builder.py
- Added `compare()` method with full `@tag`, `@parse`, and `@split` decorator support
- Parameters support:
  - `comparison_direction`: EQ, NE, GE, GT, LE, LT
  - `compare_type`: FLOAT, SIGNED, UNSIGNED, TOTALORDER
- Added convenience methods for cleaner API:
  - `equal()`
  - `not_equal()`
  - `greater_equal()`
  - `greater_than()`
  - `less_equal()`
  - `less_than()`

### test/python/golden/test_stablehlo_ops.py
- Added test modules for all comparison directions with float tensors
- Added test modules for integer tensor comparisons (EQ, GT with SIGNED type)
- Added parametrized test `test_compare_ops_float` covering all float comparisons
- Added parametrized test `test_compare_ops_int` for integer comparisons
- Added `test_compare_convenience_methods` to verify the convenience method API

## Testing

The implementation follows the existing patterns established in the codebase:
- Uses the same golden function pattern as other stablehlo ops
- Follows the builder pattern with tag/parse/split decorators
- Tests use `pcc=-1.0` since comparison ops produce boolean results

## Related Issue

Fixes #4872

---

This is my first contribution to tt-mlir. Happy to address any feedback!