### PR TITLE
feat(builder): Add ShiftLeftOp, RemOp, Atan2Op support [Bounty #4862]

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -187,6 +187,42 @@ def module_shift_right_logical(builder: StableHLOBuilder):
         return builder.shift_right_logical(in0, in1, unit_attrs=unit_attrs)
 
 
+def module_shift_left(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.int32, torch.int32])
+    def shift_left(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.shift_left(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_remainder(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def remainder(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.remainder(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_atan2(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def atan2(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.atan2(in0, in1, unit_attrs=unit_attrs)
+
+
 def module_clamp(builder: StableHLOBuilder):
     @builder.func(
         [(128, 128), (128, 128), (128, 128)],
@@ -423,6 +459,9 @@ def module_broadcast_in_dim(builder: StableHLOBuilder):
             )
         ),
         module_subtract,
+        module_shift_left,
+        module_remainder,
+        module_atan2,
     ],
 )
 def test_binary_ops(test_fn: Callable, target: str, request, device):

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4608,6 +4608,85 @@ def stablehlo_shift_right_logical_golden(
     return shifted.to(output_dtype)
 
 
+def stablehlo_shift_left_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for stablehlo.ShiftLeftOp.
+
+    Performs element-wise left shift operation.
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Input tensor to be shifted.
+    other_tensor : GoldenMapTensor
+        Number of bits to shift by.
+    output_type_mlir : Type
+        The MLIR output type.
+
+    Returns
+    -------
+    GoldenMapTensor
+        Tensor with values shifted left by the specified number of bits.
+    """
+    shifted = logical_left_shift_golden(input_tensor, other_tensor)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return shifted.to(output_dtype)
+
+
+def stablehlo_remainder_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for stablehlo.RemOp (remainder operation).
+
+    Performs element-wise remainder operation.
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Dividend tensor.
+    other_tensor : GoldenMapTensor
+        Divisor tensor.
+    output_type_mlir : Type
+        The MLIR output type.
+
+    Returns
+    -------
+    GoldenMapTensor
+        Tensor containing element-wise remainders.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return torch.remainder(input_tensor, other_tensor).to(output_dtype)
+
+
+def stablehlo_atan2_golden(
+    input_tensor: GoldenMapTensor, other_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    """
+    Golden function for stablehlo.Atan2Op.
+
+    Performs element-wise atan2 operation (arc tangent of y/x with quadrant handling).
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Y-coordinate tensor.
+    other_tensor : GoldenMapTensor
+        X-coordinate tensor.
+    output_type_mlir : Type
+        The MLIR output type.
+
+    Returns
+    -------
+    GoldenMapTensor
+        Tensor containing element-wise atan2 results in radians.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return torch.atan2(input_tensor, other_tensor).to(output_dtype)
+
+
 # The following golden implementation is taken from the op spec: https://openxla.org/stablehlo/spec#dynamic_update_slice
 def stablehlo_dynamic_update_slice_golden(
     input_tensor: GoldenMapTensor,
@@ -5825,6 +5904,9 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.SubtractOp: stablehlo_subtract_golden,
     stablehlo.PowOp: stablehlo_pow_golden,
     stablehlo.ShiftRightLogicalOp: stablehlo_shift_right_logical_golden,
+    stablehlo.ShiftLeftOp: stablehlo_shift_left_golden,
+    stablehlo.RemOp: stablehlo_remainder_golden,
+    stablehlo.Atan2Op: stablehlo_atan2_golden,
     stablehlo.ReverseOp: stablehlo_reverse_golden,
     stablehlo.DotGeneralOp: dot_general_golden,
     stablehlo.DynamicSliceOp: dynamic_slice_golden,


### PR DESCRIPTION
## Summary

This PR implements three missing elementwise binary ops for the StableHLO builder as part of bounty issue #4862 (\$150 Elementwise binary ops).

## Ops Implemented

| StableHLO Op | TTIR Target Op | Description |
|--------------|----------------|-------------|
| `ShiftLeftOp` | `LogicalLeftShiftOp` | Element-wise left bit shift |
| `RemOp` | `RemainderOp` | Element-wise remainder operation |
| `Atan2Op` | `Atan2Op` | Element-wise arc tangent of y/x |

## Changes

### tools/golden/mapping.py
- Added `stablehlo_shift_left_golden` using existing `logical_left_shift_golden`
- Added `stablehlo_remainder_golden` using `torch.remainder`
- Added `stablehlo_atan2_golden` using `torch.atan2`
- Added mappings for all three ops to `GOLDEN_MAPPINGS`

### tools/builder/stablehlo/stablehlo_builder.py
For each op, implemented:
- Main builder method (`shift_left()`, `remainder()`, `atan2()`)
- Parser method for parsing existing ops
- Split method for splitting into submodules

### test/python/golden/test_stablehlo_ops.py
- Added `module_shift_left` test module (int32 inputs)
- Added `module_remainder` test module (float32 inputs)
- Added `module_atan2` test module (float32 inputs)
- Added all three tests to `test_binary_ops` parametrize list

## Implementation Details

All three ops follow the existing binary op patterns (add, max, pow) and include:
- Proper golden function validation
- Unit attribute support
- Sharding attribute support
- Parse and split functionality

Closes #4862

## Bounty Info
- **Issue**: [Bounty \$150] Elementwise binary ops #4862
- **Bounty Amount**: \$150
- **Difficulty**: Warmup