### PR TITLE
Fix tablegen build warning

### DIFF
--- a/include/ttmlir/Dialect/Debug/IR/DebugOps.td
+++ b/include/ttmlir/Dialect/Debug/IR/DebugOps.td
@@ -31,7 +31,7 @@ include "mlir/IR/CommonTypeConstraints.td"
 //===----------------------------------------------------------------------===//
 
 class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
-    Debug_Op<mnemonic, [Pure, SameOperandsAndResultType]> {
+    Debug_Op<mnemonic, [Pure, SameOperandsAndResultType] # traits> {
 
     let summary = "Base class for debug op.";
     let description = [{


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Build of tablegen files gives warning:
```
[2/322] Building DebugOpsDialect.h.inc...
/localdev/azecevic/tt-mlir/include/ttmlir/Dialect/Debug/IR/DebugOps.td:33:49: warning: unused template argument: Debug_BaseOp:traits
class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
                                                ^
[3/320] Building DebugOps.cpp.inc...
/localdev/azecevic/tt-mlir/include/ttmlir/Dialect/Debug/IR/DebugOps.td:33:49: warning: unused template argument: Debug_BaseOp:traits
class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
                                                ^
[4/320] Building DebugOps.h.inc...
/localdev/azecevic/tt-mlir/include/ttmlir/Dialect/Debug/IR/DebugOps.td:33:49: warning: unused template argument: Debug_BaseOp:traits
class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
                                                ^
[5/319] Building DebugOpsDialect.cpp.inc...
/localdev/azecevic/tt-mlir/include/ttmlir/Dialect/Debug/IR/DebugOps.td:33:49: warning: unused template argument: Debug_BaseOp:traits
class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
                                                ^
```
This is a legitimate warning, as possible non-empty list of traits that extending class uses are ignored.
