### PR TITLE
Add `try-recover-structure` option in TTIR->EmitC pipeline

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -439,6 +439,14 @@ struct TTNNToEmitCDevicePipelineOptions
                            llvm::cl::desc("Tailor passes for dylib target."),
                            llvm::cl::init(false)};
 
+  Option<bool> tryRecoverStructure{
+      *this, "try-recover-structure",
+      llvm::cl::desc(
+          "Enable pipelines and passes that try to recover structure of the "
+          "original IR/code. Highly experimental; please file issues at "
+          "https://github.com/tenstorrent/tt-mlir/issues"),
+      llvm::cl::init(false)};
+
   Option<bool> tuplifyInputIfEmpty{
       *this, "tuplify-input-if-empty",
       llvm::cl::desc("Whether to create an empty tuple if no inputs to forward "
@@ -490,8 +498,10 @@ struct TTNNToEmitPyDevicePipelineOptions
 
   Option<bool> tryRecoverStructure{
       *this, "try-recover-structure",
-      llvm::cl::desc("Enable pipelines and passes that try to recover "
-                     "structure of the original IR/code."),
+      llvm::cl::desc(
+          "Enable pipelines and passes that try to recover structure of the "
+          "original IR/code. Highly experimental; please file issues at "
+          "https://github.com/tenstorrent/tt-mlir/issues"),
       llvm::cl::init(false)};
 };
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -377,8 +377,6 @@ void createRecoverStructureXLATorchPipeline(
 //
 void createTTNNToEmitCDevicePipeline(
     OpPassManager &pm, const TTNNToEmitCDevicePipelineOptions &options) {
-  pm.addPass(createTTNNAdjustDeallocs());
-
   // Unwrapping the device module.
   //
   // TODO(dmilinkovic): Should be removed after support for generating
@@ -386,6 +384,15 @@ void createTTNNToEmitCDevicePipeline(
   // pipeline - issue #6100.
   //
   pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
+
+  // These passes operate on TTNN IR inside the (now unwrapped) top-level
+  // module.
+  //
+  pm.addPass(createTTNNAdjustDeallocs());
+  if (options.tryRecoverStructure) {
+    createRecoverStructureXLATorchPipeline(
+        pm, RecoverStructureXLATorchPipelineOptions());
+  }
 
   if (options.targetDylib) {
     // In dylib path, only run tuplification with forced settings.

--- a/test/ttmlir/Dialect/EmitC/recover_structure_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/recover_structure_sanity.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttir-to-emitc-pipeline="try-recover-structure=true system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+//
+// This IR was generated using tt-xla's example found in
+// https://github.com/tenstorrent/tt-xla/tree/main/examples/pytorch/codegen
+//
+// Check that structure recovery creates functions based on source locations.
+//
+// CHECK: func.func private @FirstModule
+// CHECK: func.func private @SecondModule
+// CHECK: func.func private @forward
+// CHECK: func.func @main
+
+#loc1 = loc("-1|unknown|unknown|-1|xla__device_data")
+module @SyncTensorsGraph.17 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+  ttcore.device_module {
+    builtin.module @SyncTensorsGraph.17 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false, ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x1>]>} {
+      func.func @main(%arg0: tensor<64x128xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "l__self___m2_w"} loc("-1|unknown|unknown|-1|xla__device_data"), %arg1: tensor<32x64xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "l__self___m1_w"} loc("-1|unknown|unknown|-1|xla__device_data"), %arg2: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<unsharded>, ttir.name = "args_0"} loc("-1|unknown|unknown|-1|xla__device_data")) -> (tensor<32x128xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+        %0 = "ttir.reshape"(%arg2) <{shape = [1 : i32, 32 : i32, 32 : i32]}> : (tensor<32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc2)
+        %1 = "ttir.reshape"(%0) <{shape = [32 : i32, 32 : i32]}> : (tensor<1x32x32xbf16>) -> tensor<32x32xbf16> loc(#loc2)
+        %2 = "ttir.reshape"(%arg1) <{shape = [1 : i32, 32 : i32, 64 : i32]}> : (tensor<32x64xbf16>) -> tensor<1x32x64xbf16> loc(#loc2)
+        %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 64 : i32]}> : (tensor<1x32x64xbf16>) -> tensor<32x64xbf16> loc(#loc2)
+        %4 = "ttir.dot_general"(%1, %3) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<32x32xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16> loc(#loc3)
+        %5 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<64x128xbf16>) -> tensor<1x64x128xbf16> loc(#loc2)
+        %6 = "ttir.reshape"(%5) <{shape = [64 : i32, 128 : i32]}> : (tensor<1x64x128xbf16>) -> tensor<64x128xbf16> loc(#loc2)
+        %7 = "ttir.dot_general"(%4, %6) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<32x64xbf16>, tensor<64x128xbf16>) -> tensor<32x128xbf16> loc(#loc4)
+        %8 = "ttir.multiply"(%7, %7) : (tensor<32x128xbf16>, tensor<32x128xbf16>) -> tensor<32x128xbf16> loc(#loc5)
+        return %8 : tensor<32x128xbf16> loc(#loc)
+      } loc(#loc)
+    } loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc = loc(unknown)
+#loc2 = loc("-1|unknown|unknown|-1|aten__view")
+#loc3 = loc("0|FirstModule[m1]|/repos/tt-xla/examples/pytorch/codegen/prettify_example.py:27|forward|28|aten__mm")
+#loc4 = loc("1|SecondModule[m2]|/repos/tt-xla/examples/pytorch/codegen/prettify_example.py:36|forward|37|aten__mm")
+#loc5 = loc("2|/repos/tt-xla/examples/pytorch/codegen/prettify_example.py:46|forward|52|aten__mul")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3059

### Problem description
The `try-recover-structure` option was recently added in TTIR->EmitPy pipeline. Since it doesn't depend on concrete codegen (Python, C++), we can enable it for C++ codegen as well. It's still highly experimental, so bugs are expected at this point.

### Checklist
- [x] New/Existing tests provide coverage for changes
