### PR TITLE
Add support for d2m.experimental.force_virtual_grid_layout attribute

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -792,6 +792,13 @@ private:
         loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
         rewriter.getArrayAttr(iteratorTypes));
 
+    // Propagate d2m::experimental::force_virtual_grid_layout attribute if
+    // present
+    if (auto attr =
+            op->getAttr("d2m::experimental::force_virtual_grid_layout")) {
+      generic->setAttr("d2m::experimental::force_virtual_grid_layout", attr);
+    }
+
     // Create one bb in 'generic''s region and set its arguments.
     auto insertPoint = rewriter.saveInsertionPoint();
     rewriter.startOpModification(generic);
@@ -939,6 +946,13 @@ private:
     auto generic = rewriter.create<d2m::GenericOp>(
         loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
         rewriter.getArrayAttr(iteratorTypes));
+
+    // Propagate d2m::experimental::force_virtual_grid_layout attribute if
+    // present
+    if (auto attr =
+            op->getAttr("d2m::experimental::force_virtual_grid_layout")) {
+      generic->setAttr("d2m::experimental::force_virtual_grid_layout", attr);
+    }
 
     // Create one bb in 'generic''s region and set its arguments.
     auto insertPoint = rewriter.saveInsertionPoint();
@@ -1215,6 +1229,13 @@ private:
     auto generic = rewriter.create<d2m::GenericOp>(
         loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
         rewriter.getArrayAttr(iteratorTypes));
+
+    // Propagate d2m::experimental::force_virtual_grid_layout attribute if
+    // present
+    if (auto attr =
+            op->getAttr("d2m::experimental::force_virtual_grid_layout")) {
+      generic->setAttr("d2m::experimental::force_virtual_grid_layout", attr);
+    }
 
     // Create one bb in 'generic''s region and set its arguments.
     auto insertPoint = rewriter.saveInsertionPoint();
@@ -1516,6 +1537,13 @@ public:
 
           builder.create<d2m::YieldOp>(bodyLoc, storeResult);
         });
+
+    // Propagate d2m::experimental::force_virtual_grid_layout attribute if
+    // present
+    if (auto attr =
+            op->getAttr("d2m::experimental::force_virtual_grid_layout")) {
+      generic->setAttr("d2m::experimental::force_virtual_grid_layout", attr);
+    }
 
     rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
                                           op->getResult(0).getType()));

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -226,11 +226,11 @@ shouldImplementAsVirtualGrid(RankedTensorType tensorType,
   return lowGridUtilization;
 }
 
-static std::pair<llvm::SmallVector<int64_t>, bool>
-computeOptimalGrid(mlir::RankedTensorType tensorType,
-                   ArrayRef<int64_t> physicalShape,
-                   ArrayRef<int64_t> targetSquareGridShape) {
-  if (shouldImplementAsVirtualGrid(tensorType, physicalShape,
+static std::pair<llvm::SmallVector<int64_t>, bool> computeOptimalGrid(
+    mlir::RankedTensorType tensorType, ArrayRef<int64_t> physicalShape,
+    ArrayRef<int64_t> targetSquareGridShape, bool forceVirtualGrid = false) {
+  if (forceVirtualGrid ||
+      shouldImplementAsVirtualGrid(tensorType, physicalShape,
                                    targetSquareGridShape)) {
     auto virtualGrid =
         computeOptimalVirtualGrid(physicalShape, targetSquareGridShape);
@@ -603,9 +603,10 @@ analyzeOperandsAndComputeGrids(d2m::GenericOp genericOp,
     llvm::SmallVector<int64_t> physShape = computePhysicalShape(
         operandLayout, operandType, targetSquareGridShape, builder);
 
-    // Interleaved tensors do not support virtual grids
-    auto [optimalGrid, isVirtualGrid] =
-        computeOptimalGrid(operandType, physShape, targetSquareGridShape);
+    bool forceVirtualGrid =
+        genericOp->hasAttr("d2m::experimental::force_virtual_grid_layout");
+    auto [optimalGrid, isVirtualGrid] = computeOptimalGrid(
+        operandType, physShape, targetSquareGridShape, forceVirtualGrid);
 
     optimalOperandGrids.push_back(optimalGrid);
 
@@ -628,8 +629,11 @@ analyzeOperandsAndComputeGrids(d2m::GenericOp genericOp,
 
           llvm::SmallVector<int64_t> inputPhysShape = computePhysicalShape(
               inputLayout, inputType, targetSquareGridShape, builder);
-          auto [inputOptimalGrid, isVirtualGrid] = computeOptimalGrid(
-              inputType, inputPhysShape, targetSquareGridShape);
+          bool forceVirtualGrid =
+              genericOp->hasAttr("experimental::force_virtual_grid");
+          auto [inputOptimalGrid, isVirtualGrid] =
+              computeOptimalGrid(inputType, inputPhysShape,
+                                 targetSquareGridShape, forceVirtualGrid);
 
           toLayoutsToUpdate.push_back(
               {toLayoutOp, inputOptimalGrid, isVirtualGrid});
@@ -1089,9 +1093,11 @@ computeTTNNGenericGridShapes(GenericOp genericOp,
       auto physicalShape =
           computePhysicalShape(baseMetalLayout, metalTensorType,
                                constrainedTargetGridShape, builder);
+      bool forceVirtualGrid =
+          genericOp->hasAttr("experimental::force_virtual_grid");
       optimalOperandGrids[operandIdx] =
           computeOptimalGrid(metalTensorType, physicalShape,
-                             constrainedTargetGridShape)
+                             constrainedTargetGridShape, forceVirtualGrid)
               .first;
     }
   }


### PR DESCRIPTION
Adds support for detecting a string attribute `"d2m.experimental.force_virtual_grid_layout"` that forces selection of virtual grid layouts for all operands on the corresponding op. This attribute is propagated from named ttir ops to d2m.generic ops.