### PR TITLE
[CI] Set create_draft_pr fallback to false for scheduled uplifts

### DIFF
--- a/.github/workflows/schedule-nightly-uplift.yml
+++ b/.github/workflows/schedule-nightly-uplift.yml
@@ -143,7 +143,7 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main
-          draft: ${{ inputs.create_draft_pr }}
+          draft: ${{ inputs.create_draft_pr || false }}
           commit-message: "Uplift ${{ env.TT_METAL_SUBMODULE_PATH }} to ${{ env.UPLIFTED_TT_METAL_VERSION }} ${{ env.TODAY }}"
           title: "Uplift ${{ env.TT_METAL_SUBMODULE_PATH }} to ${{ env.UPLIFTED_TT_METAL_VERSION }} ${{ env.TODAY }}"
           body: |


### PR DESCRIPTION
### Ticket
/

### Problem description
When a scheduled uplift is ran, the input ${{ inputs.create_draft_pr}} is unavailable so the action that it's passed to as an argument fails. 
(When a workflow is triggered by a schedule it can't have inputs)

### What's changed
Create a fallback (false) for scheduled uplift workflows.

### Checklist
- [ ] New/Existing tests provide coverage for changes
