### PR TITLE
Decompose all_reduce into recude_scatter + all_gather if beneficial

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -267,6 +267,41 @@ def TTIRFoldConstantReshapeBroadcast: Pass<"ttir-fold-constant-reshape-broadcast
   let dependentDialects = ["mlir::tt::ttcore::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
 }
 
+def TTIRAllReduceDecomposition: Pass<"ttir-all-reduce-decomposition", "::mlir::ModuleOp">
+{
+  let summary = "Decompose fusable all_reduce ops to reduce_scatter+all_gather and fuse.";
+  let description = [{
+    This pass identifies pairs of all_reduce operations that flow into a common
+    commutable join point (elementwise operation) and:
+
+    1. Decomposes each all_reduce into reduce_scatter + all_gather
+    2. Commutes the all_gather operations through unary ops (reshape, silu, etc.)
+       toward the join point
+    3. Fuses the all_gather operations at the elementwise join point
+
+
+    Example:
+      Before:
+        %0 = ttir.matmul(%input, %w0)
+        %1 = ttir.all_reduce(%0, cluster_axis=0)
+        %2 = ttir.silu(%1)
+        %3 = ttir.matmul(%input, %w1)
+        %4 = ttir.all_reduce(%3, cluster_axis=0)
+        %5 = ttir.multiply(%2, %4)
+
+      After:
+        %0 = ttir.matmul(%input, %w0)
+        %1 = ttir.reduce_scatter(%0, scatter_dim=1, cluster_axis=0)
+        %2 = ttir.silu(%1)
+        %3 = ttir.matmul(%input, %w1)
+        %4 = ttir.reduce_scatter(%3, scatter_dim=1, cluster_axis=0)
+        %5 = ttir.multiply(%2, %4)
+        %6 = ttir.all_gather(%5, all_gather_dim=1, cluster_axis=0)
+  }];
+
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 def TTIRMultiDeviceTensorAnnotation: Pass<"ttir-multi-device-tensor-annotation", "::mlir::ModuleOp">
 {
   let summary = "TTIR multi-device tensor annotation pass.";

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -257,6 +257,11 @@ struct TTIRToTTNNDevicePipelineOptions
       *this, "enable-erase-inverse-ops-pass",
       llvm::cl::desc("Enable erase inverse ops pass."), llvm::cl::init(true)};
 
+  Option<bool> allReduceDecompositionEnabled{
+      *this, "enable-all-reduce-decomposition-pass",
+      llvm::cl::desc("Enable all-reduce decomposition pass."),
+      llvm::cl::init(true)};
+
   Option<bool> enableQuantDequantConversion{
       *this, "enable-quant-dequant-conversion-pass",
       llvm::cl::desc("Enable quant-dequant conversion pass."),

--- a/lib/Dialect/TTIR/Transforms/AllReduceDecomposition.cpp
+++ b/lib/Dialect/TTIR/Transforms/AllReduceDecomposition.cpp
@@ -1,0 +1,486 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_TTIRALLREDUCEDECOMPOSITION
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Represents a group of all_reduce operations that can be fused.
+/// All all_reduces in a group:
+/// - Have the same cluster_axis
+/// - Flow into a common elementwise (commutable) join point
+struct FusableAllReduceGroup {
+  SmallVector<AllReduceOp> allReduces;
+  Operation *joinPoint;
+  uint32_t clusterAxis;
+  int32_t scatterDim;
+};
+
+/// Get the mesh size for a given cluster axis from the module's meshes
+/// attribute.
+static std::optional<int64_t> getMeshSizeForAxis(ModuleOp module,
+                                                 uint32_t clusterAxis) {
+  auto meshes =
+      module->getAttrOfType<ttcore::MeshesAttr>(ttcore::MeshesAttr::name);
+  if (!meshes || meshes.getMeshes().empty()) {
+    return std::nullopt;
+  }
+  auto meshAttr = meshes.getMeshes()[0];
+  auto shape = meshAttr.getShape();
+  if (clusterAxis >= shape.size()) {
+    return std::nullopt;
+  }
+  return shape[clusterAxis];
+}
+
+/// Check if an operation is an elementwise binary operation that could be a
+/// join point.
+static bool isElementwiseBinaryJoinPoint(Operation *op) {
+  return isa<ElementwiseBinary>(op);
+}
+
+/// Trace from an all_reduce operation through commutable operations to find
+/// a potential join point. Returns the join point if found, nullptr otherwise.
+static Operation *findJoinPointFromAllReduce(AllReduceOp allReduceOp) {
+  // Follow the chain of single-use operations to find where this all_reduce's
+  // value flows.
+  Value current = allReduceOp.getResult();
+
+  while (true) {
+    // If there are multiple users, we can't trace further.
+    if (!current.hasOneUse()) {
+      return nullptr;
+    }
+
+    Operation *user = *current.user_begin();
+
+    // If user is an elementwise binary op, it could be a join point.
+    if (isElementwiseBinaryJoinPoint(user)) {
+      return user;
+    }
+
+    // If user is a commutable unary op, continue tracing.
+    if (isa<ElementwiseUnary>(user) || isa<ReshapeOp>(user)) {
+      if (user->getNumResults() != 1) {
+        return nullptr;
+      }
+      current = user->getResult(0);
+      continue;
+    }
+
+    // Can't trace through non-commutable operations.
+    return nullptr;
+  }
+}
+
+/// Check if we can trace from a given value back to an all_reduce with the
+/// specified cluster axis, going only through commutable operations.
+static AllReduceOp traceBackToAllReduce(Value value, uint32_t clusterAxis) {
+  Operation *definingOp = value.getDefiningOp();
+  if (!definingOp) {
+    return nullptr;
+  }
+
+  // Check if this is directly an all_reduce.
+  if (auto allReduce = dyn_cast<AllReduceOp>(definingOp)) {
+    if (allReduce.getClusterAxis() == clusterAxis) {
+      return allReduce;
+    }
+    return nullptr;
+  }
+
+  // Check if this is a commutable unary operation.
+  if ((isa<ElementwiseUnary>(definingOp) || isa<ReshapeOp>(definingOp)) &&
+      definingOp->getNumOperands() >= 1) {
+    return traceBackToAllReduce(definingOp->getOperand(0), clusterAxis);
+  }
+
+  return nullptr;
+}
+
+/// Find all fusable all_reduce groups in the module.
+static SmallVector<FusableAllReduceGroup> findFusableGroups(ModuleOp module) {
+  SmallVector<FusableAllReduceGroup> groups;
+  DenseSet<Operation *> processedJoinPoints;
+  DenseSet<AllReduceOp> processedAllReduces;
+
+  module.walk([&](AllReduceOp allReduceOp) {
+    if (processedAllReduces.contains(allReduceOp)) {
+      return;
+    }
+
+    Operation *joinPoint = findJoinPointFromAllReduce(allReduceOp);
+    if (!joinPoint || processedJoinPoints.contains(joinPoint)) {
+      return;
+    }
+
+    // Check if the join point has multiple operands that trace back to
+    // all_reduces with the same cluster_axis.
+    uint32_t clusterAxis = allReduceOp.getClusterAxis();
+    SmallVector<AllReduceOp> groupAllReduces;
+
+    for (Value operand : joinPoint->getOperands()) {
+      if (auto tracedAllReduce = traceBackToAllReduce(operand, clusterAxis)) {
+        if (!processedAllReduces.contains(tracedAllReduce)) {
+          groupAllReduces.push_back(tracedAllReduce);
+        }
+      }
+    }
+
+    // Need at least 2 all_reduces to form a fusable group.
+    if (groupAllReduces.size() >= 2) {
+      // Determine scatter dimension based on the tensor shape.
+      // Use the last dimension as the scatter dimension (common pattern).
+      auto inputType = cast<RankedTensorType>(allReduceOp.getInput().getType());
+      int32_t scatterDim = inputType.getRank() - 1;
+
+      FusableAllReduceGroup group;
+      group.allReduces = std::move(groupAllReduces);
+      group.joinPoint = joinPoint;
+      group.clusterAxis = clusterAxis;
+      group.scatterDim = scatterDim;
+      groups.push_back(std::move(group));
+
+      processedJoinPoints.insert(joinPoint);
+      for (auto ar : groups.back().allReduces) {
+        processedAllReduces.insert(ar);
+      }
+    }
+  });
+
+  return groups;
+}
+
+/// Pattern to decompose all_reduce into reduce_scatter + all_gather.
+class DecomposeAllReducePattern : public OpRewritePattern<AllReduceOp> {
+public:
+  DecomposeAllReducePattern(MLIRContext *context,
+                            const DenseSet<Operation *> &targets,
+                            int64_t meshSize)
+      : OpRewritePattern<AllReduceOp>(context), targetOps(targets),
+        meshSize(meshSize) {}
+
+  LogicalResult matchAndRewrite(AllReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    // Only decompose targeted all_reduce operations.
+    if (!targetOps.contains(op.getOperation())) {
+      return failure();
+    }
+
+    auto inputType = cast<RankedTensorType>(op.getInput().getType());
+    auto resultType = cast<RankedTensorType>(op.getResult().getType());
+
+    // Determine scatter dimension - use the last dimension.
+    int32_t scatterDim = inputType.getRank() - 1;
+
+    // Compute the reduced shape after reduce_scatter.
+    SmallVector<int64_t> reducedShape(inputType.getShape());
+    if (reducedShape[scatterDim] % meshSize != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "scatter dimension not divisible by mesh size");
+    }
+    reducedShape[scatterDim] /= meshSize;
+
+    auto reducedType = RankedTensorType::get(
+        reducedShape, inputType.getElementType(), inputType.getEncoding());
+
+    // Create reduce_scatter operation.
+    auto reduceScatterOp = rewriter.create<ReduceScatterOp>(
+        op.getLoc(), reducedType, op.getInput(), op.getReduceType(), scatterDim,
+        op.getClusterAxis());
+
+    // Create all_gather operation to restore the original shape.
+    auto allGatherOp = rewriter.create<AllGatherOp>(
+        op.getLoc(), resultType, reduceScatterOp.getResult(), scatterDim,
+        op.getClusterAxis());
+
+    rewriter.replaceOp(op, allGatherOp.getResult());
+    return success();
+  }
+
+private:
+  DenseSet<Operation *> targetOps;
+  int64_t meshSize;
+};
+
+/// Pattern to commute all_gather through reshape operations.
+/// reshape(all_gather(x)) -> all_gather(reshape(x))
+/// This pattern moves all_gather operations toward their join points.
+class CommuteAllGatherThroughReshapePattern
+    : public OpRewritePattern<ReshapeOp> {
+public:
+  using OpRewritePattern<ReshapeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ReshapeOp reshapeOp,
+                                PatternRewriter &rewriter) const override {
+    auto allGatherOp = reshapeOp.getInput().getDefiningOp<AllGatherOp>();
+    if (!allGatherOp || !allGatherOp->hasOneUse()) {
+      return failure();
+    }
+
+    auto preGatherType =
+        cast<RankedTensorType>(allGatherOp.getInput().getType());
+    auto postGatherType = cast<RankedTensorType>(allGatherOp.getType());
+    auto reshapeOutputType = cast<RankedTensorType>(reshapeOp.getType());
+
+    int32_t allGatherDim = allGatherOp.getAllGatherDim();
+
+    // Get mesh size from the all_gather operation.
+    auto module = reshapeOp->getParentOfType<ModuleOp>();
+    auto meshSizeOpt = getMeshSizeForAxis(module, allGatherOp.getClusterAxis());
+    if (!meshSizeOpt) {
+      return failure();
+    }
+    int64_t meshSize = *meshSizeOpt;
+
+    // The gathered dimension size after all_gather.
+    int64_t gatheredDimSize = postGatherType.getDimSize(allGatherDim);
+
+    // Find which dimension in the output has the same size as the gathered
+    // dimension. This is where the gather will happen after commuting.
+    int32_t newGatherDim = -1;
+    for (int64_t i = 0; i < reshapeOutputType.getRank(); ++i) {
+      if (reshapeOutputType.getDimSize(i) == gatheredDimSize) {
+        newGatherDim = i;
+        break;
+      }
+    }
+
+    if (newGatherDim < 0) {
+      // The gathered dimension is not preserved in the reshape.
+      return failure();
+    }
+
+    // Compute new reshape shape for the pre-gathered input.
+    // The new gather dimension should be divided by meshSize.
+    SmallVector<int64_t> newReshapeShape(reshapeOutputType.getShape());
+    if (newReshapeShape[newGatherDim] % meshSize != 0) {
+      return failure();
+    }
+    newReshapeShape[newGatherDim] /= meshSize;
+
+    // Verify that the total number of elements matches.
+    int64_t preGatherElements = 1;
+    for (int64_t dim : preGatherType.getShape()) {
+      preGatherElements *= dim;
+    }
+    int64_t newReshapeElements = 1;
+    for (int64_t dim : newReshapeShape) {
+      newReshapeElements *= dim;
+    }
+    if (preGatherElements != newReshapeElements) {
+      return failure();
+    }
+
+    auto newReshapeType =
+        RankedTensorType::get(newReshapeShape, preGatherType.getElementType(),
+                              preGatherType.getEncoding());
+
+    // Create new reshape on the pre-gathered input.
+    SmallVector<int32_t> shapeAttr(newReshapeShape.begin(),
+                                   newReshapeShape.end());
+    auto newReshapeOp = rewriter.create<ReshapeOp>(
+        reshapeOp.getLoc(), newReshapeType, allGatherOp.getInput(),
+        rewriter.getI32ArrayAttr(shapeAttr));
+
+    // Create new all_gather after reshape.
+    auto newAllGatherOp = rewriter.create<AllGatherOp>(
+        allGatherOp.getLoc(), reshapeOutputType, newReshapeOp.getResult(),
+        newGatherDim, allGatherOp.getClusterAxis());
+
+    rewriter.replaceOp(reshapeOp, newAllGatherOp.getResult());
+    return success();
+  }
+};
+
+/// Pattern to commute all_gather through elementwise unary operations.
+/// unary(all_gather(x)) -> all_gather(unary(x))
+class CommuteAllGatherThroughUnaryPattern
+    : public OpInterfaceRewritePattern<ElementwiseUnary> {
+public:
+  using OpInterfaceRewritePattern<ElementwiseUnary>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(ElementwiseUnary op,
+                                PatternRewriter &rewriter) const override {
+    // Check if the operand is an all_gather.
+    auto allGatherOp = op->getOperand(0).getDefiningOp<AllGatherOp>();
+    if (!allGatherOp || !allGatherOp->hasOneUse()) {
+      return failure();
+    }
+
+    auto preGatherType =
+        cast<RankedTensorType>(allGatherOp.getInput().getType());
+    auto postGatherType = cast<RankedTensorType>(allGatherOp.getType());
+    auto resultType = cast<RankedTensorType>(op->getResult(0).getType());
+
+    // The unary op result type should match the all_gather output type.
+    if (resultType != postGatherType) {
+      return failure();
+    }
+
+    // Create new unary result type (same as pre-gather type but with same
+    // element type as result).
+    auto newUnaryType = RankedTensorType::get(preGatherType.getShape(),
+                                              resultType.getElementType(),
+                                              preGatherType.getEncoding());
+
+    // Create new unary op on pre-gathered input.
+    Operation *newUnary = rewriter.create(
+        op->getLoc(), rewriter.getStringAttr(op->getName().getStringRef()),
+        ValueRange{allGatherOp.getInput()}, newUnaryType, op->getAttrs());
+
+    // Create new all_gather after unary.
+    auto newAllGatherOp = rewriter.create<AllGatherOp>(
+        allGatherOp.getLoc(), resultType, newUnary->getResult(0),
+        allGatherOp.getAllGatherDim(), allGatherOp.getClusterAxis());
+
+    rewriter.replaceOp(op, newAllGatherOp.getResult());
+    return success();
+  }
+};
+
+/// Pattern to fuse all_gathers at an elementwise binary join point.
+/// multiply(all_gather(a), all_gather(b)) -> all_gather(multiply(a, b))
+class FuseAllGathersAtJoinPointPattern
+    : public OpInterfaceRewritePattern<ElementwiseBinary> {
+public:
+  using OpInterfaceRewritePattern<ElementwiseBinary>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(ElementwiseBinary op,
+                                PatternRewriter &rewriter) const override {
+    // Check if both operands are all_gathers with the same parameters.
+    auto lhsAllGather = op->getOperand(0).getDefiningOp<AllGatherOp>();
+    auto rhsAllGather = op->getOperand(1).getDefiningOp<AllGatherOp>();
+
+    if (!lhsAllGather || !rhsAllGather) {
+      return failure();
+    }
+
+    // Must have same cluster_axis and all_gather_dim.
+    if (lhsAllGather.getClusterAxis() != rhsAllGather.getClusterAxis() ||
+        lhsAllGather.getAllGatherDim() != rhsAllGather.getAllGatherDim()) {
+      return failure();
+    }
+
+    // Each all_gather should only be used by this join point.
+    if (!lhsAllGather->hasOneUse() || !rhsAllGather->hasOneUse()) {
+      return failure();
+    }
+
+    auto lhsPreGatherType =
+        cast<RankedTensorType>(lhsAllGather.getInput().getType());
+    auto rhsPreGatherType =
+        cast<RankedTensorType>(rhsAllGather.getInput().getType());
+    auto resultType = cast<RankedTensorType>(op->getResult(0).getType());
+
+    // Pre-gather shapes should match.
+    if (lhsPreGatherType.getShape() != rhsPreGatherType.getShape()) {
+      return failure();
+    }
+
+    // Create new result type for the pre-gathered elementwise op.
+    auto newResultType = RankedTensorType::get(lhsPreGatherType.getShape(),
+                                               resultType.getElementType(),
+                                               lhsPreGatherType.getEncoding());
+
+    // Create new elementwise op on pre-gathered inputs.
+    Operation *newElementwise = rewriter.create(
+        op->getLoc(), rewriter.getStringAttr(op->getName().getStringRef()),
+        ValueRange{lhsAllGather.getInput(), rhsAllGather.getInput()},
+        newResultType, op->getAttrs());
+
+    // Create single all_gather after the elementwise op.
+    auto newAllGatherOp = rewriter.create<AllGatherOp>(
+        op->getLoc(), resultType, newElementwise->getResult(0),
+        lhsAllGather.getAllGatherDim(), lhsAllGather.getClusterAxis());
+
+    rewriter.replaceOp(op, newAllGatherOp.getResult());
+    return success();
+  }
+};
+
+class TTIRAllReduceDecomposition
+    : public impl::TTIRAllReduceDecompositionBase<TTIRAllReduceDecomposition> {
+public:
+  using impl::TTIRAllReduceDecompositionBase<
+      TTIRAllReduceDecomposition>::TTIRAllReduceDecompositionBase;
+
+  void runOnOperation() final {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+
+    // Step 1: Analysis - find fusable all_reduce groups.
+    auto groups = findFusableGroups(module);
+
+    if (groups.empty()) {
+      return; // Nothing to optimize.
+    }
+
+    // Get mesh size for decomposition.
+    auto meshSizeOpt = getMeshSizeForAxis(module, groups[0].clusterAxis);
+    if (!meshSizeOpt) {
+      return;
+    }
+    int64_t meshSize = *meshSizeOpt;
+
+    // Collect all all_reduces that should be decomposed.
+    DenseSet<Operation *> targetOps;
+    for (auto &group : groups) {
+      for (auto allReduce : group.allReduces) {
+        targetOps.insert(allReduce.getOperation());
+      }
+    }
+
+    // Step 2: Decompose the fusable all_reduces.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<DecomposeAllReducePattern>(ctx, targetOps, meshSize);
+      if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+        signalPassFailure();
+        return;
+      }
+    }
+
+    // Step 3: Commute all_gathers through unary ops toward join points.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<CommuteAllGatherThroughReshapePattern>(ctx);
+      patterns.add<CommuteAllGatherThroughUnaryPattern>(ctx);
+      if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+        signalPassFailure();
+        return;
+      }
+    }
+
+    // Step 4: Fuse all_gathers at elementwise join points.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<FuseAllGathersAtJoinPointPattern>(ctx);
+      if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(EraseInverseOps)
 add_mlir_dialect_library(MLIRTTIRTransforms
+        AllReduceDecomposition.cpp
         Broadcast.cpp
         ExplicateTMs.cpp
         FlattenSlidingWindow.cpp

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -65,6 +65,12 @@ void createTTNNPipelineTTIRPasses(
   // Flattening sliding window ops for compatibility with conversion to TTNN
   pm.addPass(mlir::tt::ttir::createTTIRFlattenSlidingWindow());
 
+  // Decompose all_reduce to reduce_scatter+all_gather if all_gathers are
+  // fusable.
+  if (options.allReduceDecompositionEnabled) {
+    pm.addPass(mlir::tt::ttir::createTTIRAllReduceDecomposition());
+  }
+
   // Add pass to erase inverse ops. We will explicate TMs so that
   // erase inverse ops can commute TMs through otherwise implicit
   // broadcasts, and handle rank-changing reshape ops which are

--- a/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/decompose_and_fuse.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/decompose_and_fuse.mlir
@@ -1,0 +1,24 @@
+// RUN: ttmlir-opt --ttir-all-reduce-decomposition %s | FileCheck %s
+
+// Test: Two all_reduce ops with the same cluster_axis flowing into a multiply
+// should be decomposed to reduce_scatter + all_gather, and the all_gathers
+// should be fused.
+
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+  ttcore.device_module {
+    builtin.module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+      func.func @test_decompose_and_fuse(%arg0: tensor<4096x4608xbf16>, %arg1: tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16> {
+        // CHECK-LABEL: func.func @test_decompose_and_fuse
+        // CHECK: %[[RS0:.*]] = "ttir.reduce_scatter"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}>
+        // CHECK: %[[RS1:.*]] = "ttir.reduce_scatter"(%arg1) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}>
+        // CHECK: %[[MUL:.*]] = "ttir.multiply"(%[[RS0]], %[[RS1]])
+        // CHECK: %[[AG:.*]] = "ttir.all_gather"(%[[MUL]]) <{all_gather_dim = 1 : si32, cluster_axis = 0 : ui32}>
+        // CHECK: return %[[AG]]
+        %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %1 = "ttir.all_reduce"(%arg1) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %2 = "ttir.multiply"(%0, %1) : (tensor<4096x4608xbf16>, tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        return %2 : tensor<4096x4608xbf16>
+      }
+    }
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/mlp_pattern.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/mlp_pattern.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttir-all-reduce-decomposition %s | FileCheck %s
+
+// Test: MLP-style pattern with reshape and silu operations between
+// all_reduce and the join point. The all_gathers should be commuted through
+// reshape and silu, then fused at the multiply join point.
+
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+  ttcore.device_module {
+    builtin.module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+      func.func @test_mlp_pattern(%arg0: tensor<4096x4608xbf16>, %arg1: tensor<4096x4608xbf16>) -> tensor<128x32x4608xbf16> {
+        // CHECK-LABEL: func.func @test_mlp_pattern
+        // CHECK: %[[RS0:.*]] = "ttir.reduce_scatter"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<4096x4608xbf16>) -> tensor<4096x2304xbf16>
+        // CHECK: %[[RESHAPE0:.*]] = "ttir.reshape"(%[[RS0]]) <{shape = [128 : i32, 32 : i32, 2304 : i32]}> : (tensor<4096x2304xbf16>) -> tensor<128x32x2304xbf16>
+        // CHECK: %[[SILU:.*]] = "ttir.silu"(%[[RESHAPE0]]) : (tensor<128x32x2304xbf16>) -> tensor<128x32x2304xbf16>
+        // CHECK: %[[RS1:.*]] = "ttir.reduce_scatter"(%arg1) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 1 : si32}> : (tensor<4096x4608xbf16>) -> tensor<4096x2304xbf16>
+        // CHECK: %[[RESHAPE1:.*]] = "ttir.reshape"(%[[RS1]]) <{shape = [128 : i32, 32 : i32, 2304 : i32]}> : (tensor<4096x2304xbf16>) -> tensor<128x32x2304xbf16>
+        // CHECK: %[[MUL:.*]] = "ttir.multiply"(%[[SILU]], %[[RESHAPE1]]) : (tensor<128x32x2304xbf16>, tensor<128x32x2304xbf16>) -> tensor<128x32x2304xbf16>
+        // CHECK: %[[AG:.*]] = "ttir.all_gather"(%[[MUL]]) <{all_gather_dim = 2 : si32, cluster_axis = 0 : ui32}> : (tensor<128x32x2304xbf16>) -> tensor<128x32x4608xbf16>
+        // CHECK: return %[[AG]]
+        %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %1 = "ttir.reshape"(%0) <{shape = [128 : i32, 32 : i32, 4608 : i32]}> : (tensor<4096x4608xbf16>) -> tensor<128x32x4608xbf16>
+        %2 = "ttir.silu"(%1) : (tensor<128x32x4608xbf16>) -> tensor<128x32x4608xbf16>
+        %3 = "ttir.all_reduce"(%arg1) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %4 = "ttir.reshape"(%3) <{shape = [128 : i32, 32 : i32, 4608 : i32]}> : (tensor<4096x4608xbf16>) -> tensor<128x32x4608xbf16>
+        %5 = "ttir.multiply"(%2, %4) : (tensor<128x32x4608xbf16>, tensor<128x32x4608xbf16>) -> tensor<128x32x4608xbf16>
+        return %5 : tensor<128x32x4608xbf16>
+      }
+    }
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/no_decompose_different_axis.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/no_decompose_different_axis.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttir-all-reduce-decomposition %s | FileCheck %s
+
+// Test: Two all_reduce ops with DIFFERENT cluster_axis should NOT be
+// decomposed or fused.
+
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+  ttcore.device_module {
+    builtin.module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+      func.func @test_no_decompose_different_axis(%arg0: tensor<4096x4608xbf16>, %arg1: tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16> {
+        // CHECK-LABEL: func.func @test_no_decompose_different_axis
+        // Different cluster_axis values should prevent fusion.
+        // CHECK: "ttir.all_reduce"{{.*}}cluster_axis = 0
+        // CHECK: "ttir.all_reduce"{{.*}}cluster_axis = 1
+        // CHECK-NOT: "ttir.reduce_scatter"
+        // CHECK-NOT: "ttir.all_gather"
+        %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %1 = "ttir.all_reduce"(%arg1) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        %2 = "ttir.multiply"(%0, %1) : (tensor<4096x4608xbf16>, tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        return %2 : tensor<4096x4608xbf16>
+      }
+    }
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/no_decompose_single.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/AllReduceDecomposition/no_decompose_single.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttir-all-reduce-decomposition %s | FileCheck %s
+
+// Test: A single all_reduce without a fusable pair should NOT be decomposed.
+
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+  ttcore.device_module {
+    builtin.module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+      func.func @test_no_decompose_single(%arg0: tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16> {
+        // CHECK-LABEL: func.func @test_no_decompose_single
+        // A single all_reduce without a fusable pair should remain unchanged.
+        // CHECK: "ttir.all_reduce"
+        // CHECK-NOT: "ttir.reduce_scatter"
+        // CHECK-NOT: "ttir.all_gather"
+        %0 = "ttir.all_reduce"(%arg0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<4096x4608xbf16>) -> tensor<4096x4608xbf16>
+        return %0 : tensor<4096x4608xbf16>
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3047)

### Problem description
we always preform all_reduce as reduce_scatter followed by all_gather. It can be beneficial to split them up since the ag can be commuted through eltwise/reshape ops and combined in some cases. 

### What's changed
Added a pass to split ar into rs+ag when the ag's can be commuted. 

### Checklist
- [x] New/Existing tests provide coverage for changes
