### PR TITLE
Support presharded/unsharded graphs in builder

### DIFF
--- a/include/ttmlir/Dialect/TTCore/Utils/Mesh.h
+++ b/include/ttmlir/Dialect/TTCore/Utils/Mesh.h
@@ -17,7 +17,7 @@ namespace mlir::tt::ttcore::utils {
 // Determine hardware mesh config for DeviceAttr.
 // If none exists, the empty meshShape leads to single device config.
 // If either option.meshShape or meshes exists, use one of them.
-// If both exist, compare mesh and throw error if they are different.
+// If both exist, use mesh shape found in module.
 inline llvm::Expected<llvm::SmallVector<int64_t>>
 determineMeshShape(mlir::ModuleOp module, llvm::ArrayRef<int64_t> meshShape) {
   if (auto meshesAttr = module->getAttrOfType<MeshesAttr>(MeshesAttr::name)) {
@@ -27,12 +27,6 @@ determineMeshShape(mlir::ModuleOp module, llvm::ArrayRef<int64_t> meshShape) {
     }
     // For now, use the first meshShape.
     llvm::ArrayRef<int64_t> meshFromMeshes = meshAttr[0].getShape();
-    // If both meshes exist, they should be identical. Otherwise, throw error.
-    if (!meshShape.empty() && !llvm::equal(meshShape, meshFromMeshes)) {
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Option.meshShape and mesh info from graph should be identical.");
-    }
     return llvm::SmallVector<int64_t>(meshFromMeshes);
   }
   return llvm::SmallVector<int64_t>(meshShape);

--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -231,11 +231,7 @@ public:
           getTypeConverter()->convertType(opResult.getType()));
       auto meshShardOp = rewriter.create<mlir::tt::ttir::MeshShardOp>(
           loc, outputType, returnOperand.get(),
-          // Explicitly set the shard type to Identity for outputs to prevent
-          // each device from having the same redundant full copy of the tensor.
-          // This mesh_shard op will eventually fully be removed in the future.
-          // See: https://github.com/tenstorrent/tt-xla/issues/2375
-          mlir::tt::ttcore::MeshShardType::Identity,
+          shardyMeshSharding->getShardType(),
           shardyMeshSharding->getShardDirection(),
           shardyMeshSharding->getShardShape(),
           shardyMeshSharding->getShardDims());

--- a/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
@@ -37,6 +37,12 @@ updateShardStatus(MLIRContext *context, mlir::ModuleOp &module,
       newArgAttrs =
           llvm::SmallVector<mlir::NamedAttribute>(argAttrDict.getValue());
 
+      // If the argument already has a RuntimeTensorShardingAttr, we skip it.
+      if (argAttrDict.contains(
+              mlir::tt::ttcore::RuntimeTensorShardingAttr::name)) {
+        continue;
+      }
+
       // We want to find the @Sharding custom call followed by the
       // @SPMDFullToShardShape custom call to determine the sharded type. The
       // pattern looks like: %0 = stablehlo.custom_call @Sharding(%arg0)
@@ -44,6 +50,7 @@ updateShardStatus(MLIRContext *context, mlir::ModuleOp &module,
       // tensor<1024x1024xf32> %1 = stablehlo.custom_call
       // @SPMDFullToShardShape(%0) {mhlo.sharding = "{manual}"} :
       // (tensor<1024x1024xf32>) -> tensor<128x1024xf32>
+
       if (argAttrDict.contains(mlir::tt::gspmd_utils::kXlaShardingAttr)) {
         shardStatus = mlir::tt::ttcore::ShardStatus::Presharded;
 
@@ -141,6 +148,12 @@ updateShardStatus(MLIRContext *context, mlir::ModuleOp &module,
     if (resultAttrDict) {
       newResultAttrs =
           llvm::SmallVector<mlir::NamedAttribute>(resultAttrDict.getValue());
+
+      // If the result already has a RuntimeTensorShardingAttr, we skip it.
+      if (resultAttrDict.contains(
+              mlir::tt::ttcore::RuntimeTensorShardingAttr::name)) {
+        continue;
+      }
 
       if (resultAttrDict.contains(mlir::tt::gspmd_utils::kXlaShardingAttr)) {
         shardStatus = mlir::tt::ttcore::ShardStatus::Presharded;

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -551,5 +551,40 @@ void populateTTModule(nb::module_ &m) {
       .def_prop_ro("meshes", [](const tt::ttcore::MeshesAttr &meshes) {
         return meshes.getMeshes().vec();
       });
+
+  nb::enum_<mlir::tt::ttcore::ShardStatus>(m, "ShardStatus")
+      .value("Presharded", mlir::tt::ttcore::ShardStatus::Presharded)
+      .value("Unsharded", mlir::tt::ttcore::ShardStatus::Unsharded);
+
+  tt_attribute_class<tt::ttcore::ShardStatusAttr>(m, "ShardStatusAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, mlir::tt::ttcore::ShardStatus shardStatus) {
+            return wrap(
+                tt::ttcore::ShardStatusAttr::get(unwrap(ctx), shardStatus));
+          })
+      .def_prop_ro("value", [](tt::ttcore::ShardStatusAttr self) {
+        return self.getValue();
+      });
+
+  tt_attribute_class<tt::ttcore::RuntimeTensorShardingAttr>(
+      m, "RuntimeTensorShardingAttr")
+      .def_static("get",
+                  [](MlirContext ctx, MlirAttribute shardStatusAttr,
+                     MlirType localShape) {
+                    return wrap(tt::ttcore::RuntimeTensorShardingAttr::get(
+                        unwrap(ctx),
+                        mlir::cast<tt::ttcore::ShardStatusAttr>(
+                            unwrap(shardStatusAttr)),
+                        mlir::cast<RankedTensorType>(unwrap(localShape))));
+                  })
+      .def_prop_ro("shard_status",
+                   [](const tt::ttcore::RuntimeTensorShardingAttr &attr) {
+                     return attr.getShardStatus();
+                   })
+      .def_prop_ro("local_shape",
+                   [](const tt::ttcore::RuntimeTensorShardingAttr &attr) {
+                     return attr.getLocalShape().getShape().vec();
+                   });
 }
 } // namespace mlir::ttmlir::python

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -396,6 +396,15 @@ void registerRuntimeBindings(nb::module_ &m) {
       },
       "Create a multi-device host tensor with owned memory");
   m.def(
+      "create_multi_device_host_tensor_from_shards",
+      [](std::vector<tt::runtime::Tensor> &tensorShards,
+         const std::unordered_map<std::string, std::string> &strategy,
+         const std::vector<uint32_t> &meshShape) {
+        return tt::runtime::createMultiDeviceHostTensor(tensorShards, strategy,
+                                                        meshShape);
+      },
+      "Create a multi-device host tensor from tensor shards");
+  m.def(
       "create_multi_device_borrowed_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,
          const std::vector<std::uint32_t> &shape,

--- a/test/python/golden/mlir_snippets/ttir/ttir_presharded_args.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_presharded_args.mlir
@@ -1,0 +1,8 @@
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
+  func.func @model(%arg0: tensor<1x1x256x512xf32> {ttcore.runtime_tensor_sharding = #ttcore<runtime_tensor_sharding shard_status = <presharded>, local_shape = tensor<1x1x256x256xf32>>}) -> tensor<1x1x256x512xf32> {
+    %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: -1, 3>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #ttcore.shard_type<identity>}> : (tensor<1x1x256x512xf32>) -> tensor<1x1x256x256xf32>
+    %1 = "ttir.exp"(%0) : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
+    %2 = "ttir.mesh_shard"(%1) <{shard_dims = array<i64: -1, 3>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #ttcore.shard_type<devices>}> : (tensor<1x1x256x256xf32>) -> tensor<1x1x256x512xf32>
+    return %2 : tensor<1x1x256x512xf32>
+  }
+}

--- a/test/python/golden/test_parse_split_ops.py
+++ b/test/python/golden/test_parse_split_ops.py
@@ -32,6 +32,7 @@ skip_split_ttir_tests = [
     "ttir_mesh_shard.mlir",
     "ttir_device_module_nested_func.mlir",
     "ttir_nested_funcs.mlir",
+    "ttir_presharded_args.mlir",
 ]
 ttir_snippets_dir_path = os.path.join(os.path.dirname(__file__), "mlir_snippets/ttir")
 for filename in os.listdir(ttir_snippets_dir_path):

--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -50,14 +50,7 @@ def test_sharding_constraint(
             )
 
             builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
-
-            sharded_out = builder.add(in0, in1)
-            # Currently, builder doesn't support evaluating graphs that return sharded
-            # tensors. So we all_gather the sharded output to make it fully replicated.
-            # TODO(hshahTT): Remove this once sharded tensor evaluation is supported.
-            partially_sharded_out = builder.all_gather(sharded_out, 0, [[0]])
-            replicated_out = builder.all_gather(partially_sharded_out, 1, [[0]])
-            return replicated_out
+            return builder.add(in0, in1)
 
     compile_and_execute_shlo(
         module,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -33,7 +33,7 @@ module @jit_matmul_shardy0 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_r
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>
 
 // -----
 
@@ -68,7 +68,7 @@ module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
 // CHECK-SAME: shard_dims = array<i64: 0, -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -103,7 +103,7 @@ module @jit_matmul_shardy2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>
 
 // -----
 
@@ -127,7 +127,7 @@ module @jit_neg_shardy0 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: 1, 3>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 2, 1, 4>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -151,7 +151,7 @@ module @jit_neg_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: 1, -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 2, 1, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -175,7 +175,7 @@ module @jit_neg_shardy2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: -1, 3>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 4>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -199,7 +199,7 @@ module @jit_neg_shardy3 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: 3, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 4, 1, 2>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -223,7 +223,7 @@ module @jit_neg_shardy4 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 4, 1, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -247,7 +247,7 @@ module @jit_neg_shardy5 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: 3, -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 2>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -271,7 +271,7 @@ module @jit_neg_shardy6 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: -1, 3>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -294,7 +294,7 @@ module @sdy_manual_computation_constant {
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>
 
 // -----
 
@@ -318,7 +318,7 @@ module @jit_neg_shardy7 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8, 1, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -340,7 +340,7 @@ module @jit_reshape attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 0>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 8, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 
@@ -426,7 +426,7 @@ module @jit_matmul_shardy_automatic_test1 attributes {mhlo.num_partitions = 8 : 
 // CHECK-SAME: shard_dims = array<i64: 0, -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 
 // -----
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_dp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_dp_shardy.mlir
@@ -161,4 +161,4 @@ module @jit_loss_dp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_shardy.mlir
@@ -173,4 +173,4 @@ module @jit_loss_fsdp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replic
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_tp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_tp_shardy.mlir
@@ -208,4 +208,4 @@ module @jit_loss_fsdp_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_rep
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<replicate>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_tp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_tp_shardy.mlir
@@ -120,7 +120,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<full_to_shard>
@@ -140,7 +140,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<full_to_shard>
@@ -160,7 +160,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<full_to_shard>
@@ -180,7 +180,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<full_to_shard>
@@ -200,7 +200,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<full_to_shard>
@@ -220,4 +220,4 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/mixed_single_multi_tensors.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/mixed_single_multi_tensors.mlir
@@ -46,7 +46,7 @@ module @mixed_single_multi_tensors {
 // CHECK-SAME: shard_dims = array<i64: -1, 3>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 2>
-// CHECK-SAME: shard_type = #ttcore.shard_type<identity>
+// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
 // CHECK: "ttir.reshape"
 // CHECK: "ttir.broadcast"
 // CHECK: "ttir.maximum"

--- a/test/ttmlir/Silicon/StableHLO/llmbox/sdy_all_slice.mlir
+++ b/test/ttmlir/Silicon/StableHLO/llmbox/sdy_all_slice.mlir
@@ -6,7 +6,6 @@ module {
   sdy.mesh @mesh = <["model"=1, "batch"=8]>
   func.func @all_slice_replicated_input(%arg0: tensor<1x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<1x32xbf16> {
     %0 = sdy.all_slice [{}, {"batch"}] %arg0 out_sharding=<@mesh, [{}, {"batch"}]> : tensor<1x32xbf16>
-    %1 = sdy.all_gather [{}, {"batch"}] %0 out_sharding=<@mesh, [{}, {}]> : tensor<1x32xbf16>
-    return %1 : tensor<1x32xbf16>
+    return %0 : tensor<1x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n300/sdy_all_slice.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n300/sdy_all_slice.mlir
@@ -6,7 +6,6 @@ module {
   sdy.mesh @mesh = <["model"=1, "batch"=2]>
   func.func @all_slice_replicated_input(%arg0: tensor<1x32xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}) -> tensor<1x32xbf16> {
     %0 = sdy.all_slice [{}, {"batch"}] %arg0 out_sharding=<@mesh, [{}, {"batch"}]> : tensor<1x32xbf16>
-    %1 = sdy.all_gather [{}, {"batch"}] %0 out_sharding=<@mesh, [{}, {}]> : tensor<1x32xbf16>
-    return %1 : tensor<1x32xbf16>
+    return %0 : tensor<1x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n300/sdy_fill_cache1x2.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n300/sdy_fill_cache1x2.mlir
@@ -20,7 +20,7 @@ module @ClosedUpdateOpenInput {
     ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
       stablehlo.return %arg5 : tensor<f32>
     }) : (tensor<1x8x1024x128xf32>, tensor<64x1xi64>, tensor<1x8x64x128xf32>) -> tensor<1x8x1024x128xf32>
-    %9 = stablehlo.custom_call @Sharding(%8) {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding_per_value<[<@mesh, [{}, {}, {}, {}]>]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}"} : (tensor<1x8x1024x128xf32>) -> tensor<1x8x1024x128xf32>
+    %9 = stablehlo.custom_call @Sharding(%8) {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding_per_value<[<@mesh, [{}, {\22model\22}, {}, {}]>]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}"} : (tensor<1x8x1024x128xf32>) -> tensor<1x8x1024x128xf32>
     return %9 : tensor<1x8x1024x128xf32>
   }
 }

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from ttmlir.ir import *
 from ttmlir.dialects import tensor, quant, func, ttir, ttcore, stablehlo, ttnn, debug
 from ttmlir.passes import GoldenTensor, DataType
-from golden import GoldenMapTensor, get_golden_function
+from golden import GoldenMapTensor, get_golden_function, apply_sharding
 
 from builder.base.builder_utils import (
     process_multi_return_result,
@@ -92,6 +92,7 @@ class Builder(metaclass=BuilderMeta):
             self._meshes[name] = mesh
 
         self._mesh_shape = tuple(mesh_dict[0].values())
+        self._mesh_name = mesh_name[0]
 
         # Internal values to keep track
         self._root_module_insertion_point = None
@@ -298,13 +299,35 @@ class Builder(metaclass=BuilderMeta):
             if arg_number == operand.arg_number:
                 new_arg_attr = {}
                 for attr in arg_attrs:
-                    new_arg_attr[attr.name.value] = attr
+                    new_arg_attr[attr.name] = attr.attr
                 new_arg_attr[new_attr_name] = new_attr
                 new_arg_attr_list.append(DictAttr.get(new_arg_attr))
             else:
                 new_arg_attr_list.append(arg_attrs)
 
         func_op.arg_attrs = ArrayAttr.get(new_arg_attr_list)
+
+    def preshard_arg(self, operand: Operand, shard_dims: List[int]):
+        golden_tensor = self._get_golden_tensor(operand)
+        sharded_golden_tensor = apply_sharding(
+            golden_tensor, self._mesh_shape, shard_dims
+        )
+
+        # Generate new multi-device golden if it's presharded
+        if not self._disable_golden_check:
+            self._set_golden_tensor(operand, sharded_golden_tensor)
+
+        local_shape = sharded_golden_tensor.shape
+        local_shape_attr = RankedTensorType.get(local_shape, F32Type.get(self._ctx))
+        new_attr_name: str = "ttcore.runtime_tensor_sharding"
+        shard_status_attr = ttcore.ir.ShardStatusAttr.get(
+            self._ctx, ttcore.ir.ShardStatus.Presharded
+        )
+        new_attr = ttcore.ir.RuntimeTensorShardingAttr.get(
+            self._ctx, shard_status_attr, local_shape_attr
+        )
+
+        self.set_arg_attribute(operand, new_attr_name, new_attr)
 
     # ----- Private methods -----
 
@@ -796,8 +819,73 @@ class Builder(metaclass=BuilderMeta):
             )
         ]
 
+    def generate_golden_tensors(
+        self, parsed_func: func.FuncOp
+    ) -> List[Dict[int, torch.Tensor]]:
+        golden_inputs = []
+
+        arg_attr_list = parsed_func.arg_attrs
+        for arg_number, arg_attrs in enumerate(arg_attr_list):
+            found_runtime_tensor_sharding_attr = False
+            for named_attr in arg_attrs:
+                if named_attr.name == "ttcore.runtime_tensor_sharding":
+                    runtime_tensor_sharding_attr = (
+                        ttcore.ir.RuntimeTensorShardingAttr.maybe_downcast(
+                            named_attr.attr
+                        )
+                    )
+                    arg = parsed_func.arguments[arg_number]
+                    ranked_tensor_type = arg.type
+                    local_shape = ranked_tensor_type.shape
+
+                    if (
+                        runtime_tensor_sharding_attr.shard_status.value
+                        == ttcore.ir.ShardStatus.Presharded
+                    ):
+                        local_shape = runtime_tensor_sharding_attr.local_shape
+
+                    device_golden_info = {}
+                    for device_id in range(self._mesh_shape[0] * self._mesh_shape[1]):
+                        device_golden_info[device_id] = self.generate_random_tensor(
+                            local_shape, ranked_tensor_type.element_type
+                        )
+                    golden_inputs.append(device_golden_info)
+                    found_runtime_tensor_sharding_attr = True
+                    break
+
+            if not found_runtime_tensor_sharding_attr:
+                arg = parsed_func.arguments[arg_number]
+                ranked_tensor_type = arg.type
+                golden_input = self.generate_random_tensor(
+                    ranked_tensor_type.shape, ranked_tensor_type.element_type
+                )
+                golden_inputs.append({0: golden_input})
+
+        return golden_inputs
+
+    def generate_random_tensor(self, shape: Shape, dtype: Type) -> torch.Tensor:
+        torch_dtype = self._get_torch_dtype_from_type(dtype)
+
+        if torch_dtype.is_floating_point or torch_dtype.is_complex:
+            if len(shape) == 0:
+                return torch.randn(1, dtype=torch_dtype).squeeze()
+            else:
+                return torch.randn(*shape, dtype=torch_dtype)
+        elif torch_dtype == torch.bool:
+            if len(shape) == 0:
+                return torch.randint(0, 2, (), dtype=torch.bool)
+            else:
+                return torch.randint(0, 2, shape, dtype=torch.bool)
+        else:
+            if len(shape) == 0:
+                return torch.randint(0, 256, (), dtype=torch_dtype)
+            else:
+                return torch.randint(0, 256, shape, dtype=torch_dtype)
+
     def parse_root_module(
-        self, parsed_root_module: Module, golden_inputs: Dict[str, [List[torch.tensor]]]
+        self,
+        parsed_root_module: Module,
+        golden_inputs: Dict[str, [List[Dict[int, torch.tensor]]]],
     ):
         found_cpu_module = False
 
@@ -864,7 +952,7 @@ class Builder(metaclass=BuilderMeta):
     def parse_builtin_module(
         self,
         parsed_builtin_module: Module,
-        golden_inputs: Dict[str, [List[torch.tensor]]],
+        golden_inputs: Dict[str, [List[Dict[int, torch.tensor]]]],
     ):
         new_builtin_module = Module.create()
         cloned_op = new_builtin_module.operation.clone()
@@ -880,36 +968,17 @@ class Builder(metaclass=BuilderMeta):
         return cloned_op
 
     def parse_func(
-        self, parsed_func: func.FuncOp, golden_inputs: Dict[str, [List[torch.tensor]]]
+        self,
+        parsed_func: func.FuncOp,
+        golden_inputs: Dict[str, [List[Dict[int, torch.tensor]]]],
     ):
         fn_input_types = self.get_input_types(parsed_func)
 
         parsed_func_golden_inputs = []
         if parsed_func.name.value in golden_inputs.keys():
-            parsed_func_golden_inputs = golden_inputs[parsed_func.name.value]
+            parsed_func_golden_inputs.extend(golden_inputs[parsed_func.name.value])
         else:
-            for ttype in fn_input_types:
-                shape = ttype.shape
-                dtype = self._get_torch_dtype_from_type(ttype.element_type)
-
-                if dtype.is_floating_point or dtype.is_complex:
-                    if len(shape) == 0:
-                        golden_input = torch.randn(1, dtype=dtype).squeeze()
-                    else:
-                        golden_input = torch.randn(*shape, dtype=dtype)
-                    parsed_func_golden_inputs.append(golden_input)
-                elif dtype == torch.bool:
-                    if len(shape) == 0:
-                        golden_input = torch.randint(0, 2, (), dtype=dtype)
-                    else:
-                        golden_input = torch.randint(0, 2, shape, dtype=dtype)
-                    parsed_func_golden_inputs.append(golden_input)
-                else:
-                    if len(shape) == 0:
-                        golden_input = torch.randint(0, 256, (), dtype=dtype)
-                    else:
-                        golden_input = torch.randint(0, 256, shape, dtype=dtype)
-                    parsed_func_golden_inputs.append(golden_input)
+            parsed_func_golden_inputs.extend(self.generate_golden_tensors(parsed_func))
 
         ordered_inputs = []
         ordered_outputs = []
@@ -917,8 +986,10 @@ class Builder(metaclass=BuilderMeta):
         @func.func(*fn_input_types, name=parsed_func.name.value)
         def decorated_func(*inputs):
             golden_dict = {}
-            for operand, torch_golden in zip(inputs, parsed_func_golden_inputs):
-                golden_dict[operand] = torch_golden
+            for operand, torch_golden_dictionary in zip(
+                inputs, parsed_func_golden_inputs
+            ):
+                golden_dict[operand] = torch_golden_dictionary
 
             input_goldens: Dict[
                 Operand, GoldenMapTensor
@@ -961,6 +1032,16 @@ class Builder(metaclass=BuilderMeta):
 
         new_func_op = decorated_func.func_op
         self._func_ops_generated[new_func_op] = [ordered_inputs, ordered_outputs]
+
+        parsed_func_op_arg_attr_list = parsed_func.arg_attrs
+        new_func_op_arg_attr_list = []
+        for arg_number, arg_attrs in enumerate(parsed_func_op_arg_attr_list):
+            new_arg_attr = {}
+            for attr in arg_attrs:
+                new_arg_attr[attr.name] = attr.attr
+            new_func_op_arg_attr_list.append(DictAttr.get(new_arg_attr))
+        new_func_op.arg_attrs = ArrayAttr.get(new_func_op_arg_attr_list)
+
         return new_func_op
 
     def parse_nested_func(

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -133,6 +133,12 @@ def _compile(root_func: Callable, builder: Builder):
 
     if isinstance(builder, StableHLOBuilder):
         new_module.body.append(builder._get_mesh())
+    elif isinstance(builder, TTIRBuilder):
+        mesh = ttcore.ir.MeshAttr.get(
+            builder._ctx, builder._mesh_name, builder._mesh_shape
+        )
+        meshes = ttcore.ir.MeshesAttr.get(builder._ctx, [mesh])
+        new_module.operation.attributes["ttcore.meshes"] = meshes
 
     with InsertionPoint(new_module.body):
         root_func(builder)

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -109,23 +109,36 @@ def runtime_str_dtype_to_torch_dtype(dtype):
     raise ValueError(f"unsupported dtype: {dtype}")
 
 
-def create_tensor(tensor):
-    isEmptyTensor = not all(tensor.shape)
+def create_tensor(tensor_shards, mesh_shape):
+    first_tensor = tensor_shards[0]
+    isEmptyTensor = not all(first_tensor.shape)
+
     if isEmptyTensor:
         return tt_runtime.runtime.create_owned_host_tensor(
-            tensor.data_ptr(),
-            list(tensor.shape),
-            list(tensor.stride()),
-            tensor.element_size(),
-            torch_dtype_to_runtime_dtype(tensor.dtype),
+            first_tensor.data_ptr(),
+            list(first_tensor.shape),
+            list(first_tensor.stride()),
+            first_tensor.element_size(),
+            torch_dtype_to_runtime_dtype(first_tensor.dtype),
+        )
+
+    if len(tensor_shards.keys()) > 1:
+        return tt_runtime.runtime.create_multi_device_borrowed_host_tensor(
+            [t.data_ptr() for t in tensor_shards.values()],
+            list(first_tensor.shape),
+            list(first_tensor.stride()),
+            first_tensor.element_size(),
+            torch_dtype_to_runtime_dtype(first_tensor.dtype),
+            {},  # strategy: not used
+            mesh_shape,
         )
 
     return tt_runtime.runtime.create_borrowed_host_tensor(
-        tensor.data_ptr(),
-        list(tensor.shape),
-        list(tensor.stride()),
-        tensor.element_size(),
-        torch_dtype_to_runtime_dtype(tensor.dtype),
+        first_tensor.data_ptr(),
+        list(first_tensor.shape),
+        list(first_tensor.stride()),
+        first_tensor.element_size(),
+        torch_dtype_to_runtime_dtype(first_tensor.dtype),
     )
 
 
@@ -732,7 +745,7 @@ def execute_fb(
         for i, i_dict in enumerate(input_dict):
             if not disable_golden:
                 golden_inputs_torch.append(
-                    golden_input_output_tensors[program_index][f"input_{i}"][0]
+                    golden_input_output_tensors[program_index][f"input_{i}"]
                 )
             else:
                 torch_tensor = torch.randn(
@@ -748,7 +761,7 @@ def execute_fb(
         for i, o_dict in enumerate(output_dict):
             if not disable_golden:
                 golden_outputs_torch.append(
-                    golden_input_output_tensors[program_index][f"output_{i}"][0]
+                    golden_input_output_tensors[program_index][f"output_{i}"]
                 )
 
             torch_tensor = torch.zeros(
@@ -757,12 +770,12 @@ def execute_fb(
                     o_dict["desc"]["layout"]["memory_desc"]["data_type"]
                 ),
             )
-            outputs_torch.append(torch_tensor)
+            outputs_torch.append({0: torch_tensor})
 
         inputs = []
         outputs = []
         for i in golden_inputs_torch:
-            new_input = create_tensor(i)
+            new_input = create_tensor(i, device.get_mesh_shape())
             inputs.append(new_input)
         converted_inputs = convert_input_layouts(
             device,
@@ -772,7 +785,7 @@ def execute_fb(
         )
 
         for i in outputs_torch:
-            new_output = create_tensor(i)
+            new_output = create_tensor(i, (1, 1))
             outputs.append(new_output)
 
         start_submit = time.perf_counter_ns()
@@ -803,9 +816,16 @@ def execute_fb(
             if disable_golden:
                 continue
 
+            combined_output_tensor = output_host
+            if fbb.file_identifier != "TTM0":
+                combined_output_tensor = (
+                    tt_runtime.runtime.create_multi_device_host_tensor_from_shards(
+                        [output_host], {}, (1, 1)
+                    )
+                )
             tt_runtime.runtime.memcpy(
                 outputs[i],
-                output_host,
+                combined_output_tensor,
             )
             tt_runtime.runtime.deallocate_tensor(runtime_output_tensor, force=True)
 
@@ -822,7 +842,7 @@ def execute_fb(
                     dtype=runtime_dtype_to_torch_dtype(outputs[i].get_dtype()),
                 ).reshape(outputs[i].get_shape())
 
-            golden_tensor_torch = golden_outputs_torch[i]
+            golden_tensor_torch = golden_outputs_torch[i][0]
             results = check_outputs(
                 golden_tensor_torch,
                 output_tensor_torch,
@@ -1160,8 +1180,8 @@ def execute_cpp(
 
                 for input_index, template_input in enumerate(inputs):
                     # Use the layout from the template_input to convert the golden input
-                    golden_input = golden_input_outputs[f"input_{input_index}"][0]
-                    new_input = create_tensor(golden_input)
+                    golden_input = golden_input_outputs[f"input_{input_index}"]
+                    new_input = create_tensor(golden_input, (1, 1))
                     corrected_inputs.append(new_input)
 
                 inputs = convert_input_layouts(

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -7906,7 +7906,7 @@ class StableHLOBuilder(Builder):
     def from_module(
         ctx: Context,
         mlir_text: str,
-        golden_inputs: Dict[str, List[torch.tensor]] = None,
+        golden_inputs: Dict[str, List[Dict[int, torch.tensor]]] = None,
     ) -> Tuple(Module, StableHLOBuilder):
         if golden_inputs is None:
             golden_inputs = {}

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -12837,7 +12837,7 @@ class TTIRBuilder(Builder):
     def from_module(
         ctx: Context,
         mlir_text: str,
-        golden_inputs: Dict[str, List[torch.tensor]] = None,
+        golden_inputs: Dict[str, List[Dict[int, torch.tensor]]] = None,
     ) -> Tuple(Module, TTIRBuilder):
         if golden_inputs is None:
             golden_inputs = {}
@@ -12864,6 +12864,11 @@ class TTIRBuilder(Builder):
 
             ttir_builder = TTIRBuilder(ctx, loc, mesh_name, mesh_shape)
             new_module = ttir_builder.parse_root_module(root_module, golden_inputs)
+            new_mesh = ttcore.ir.MeshAttr.get(
+                ttir_builder._ctx, ttir_builder._mesh_name, ttir_builder._mesh_shape
+            )
+            new_meshes = ttcore.ir.MeshesAttr.get(ttir_builder._ctx, [new_mesh])
+            new_module.operation.attributes["ttcore.meshes"] = new_meshes
 
         return new_module, ttir_builder
 

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -4750,7 +4750,7 @@ class TTNNBuilder(Builder):
     def from_module(
         ctx: Context,
         mlir_text: str,
-        golden_inputs: Dict[str, List[torch.tensor]] = None,
+        golden_inputs: Dict[str, List[Dict[int, torch.tensor]]] = None,
     ) -> Tuple(Module, TTNNBuilder):
         if golden_inputs is None:
             golden_inputs = {}

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -188,6 +188,11 @@ class GoldenMapTensor:
     def __rsub__(self, other):
         return self._binary_map(other, lambda a, b: operator.sub(b, a))
 
+    def __str__(self) -> str:
+        return (
+            f"GoldenMapTensor(mesh_shape={self._mesh_shape}, shards={self._shard_map})"
+        )
+
     @staticmethod
     def _walk_tree(*trees) -> Iterable:
         # Yield leaves in a nested structure.
@@ -3920,6 +3925,8 @@ def ttir_mesh_shard_golden(
     if shard_direction == ttcore.ir.MeshShardDirection.FullToShard:
         if shard_type == ttcore.ir.MeshShardType.Replicate:
             shard_dims = [None] * len(mesh_shape)
+        elif shard_type == ttcore.ir.MeshShardType.Identity:
+            return input.clone().to(output_dtype)
         return apply_sharding(input, mesh_shape, shard_dims)
     elif shard_direction == ttcore.ir.MeshShardDirection.ShardToFull:
         if shard_type == ttcore.ir.MeshShardType.Replicate:

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -47,6 +47,7 @@ try:
         create_empty_tensor,
         create_multi_device_host_tensor,
         create_multi_device_borrowed_host_tensor,
+        create_multi_device_host_tensor_from_shards,
         set_fabric_config,
         wait,
         to_host,


### PR DESCRIPTION
This PR supports presharded args in builder ecosystem.

Users can now annotate operands with a shard status with `builder.preshard_arg` API.
```
def module3(builder: TTIRBuilder):
    @builder.func([(1, 1, 256, 512)], [torch.float32])
    def model(in0: Operand, builder: TTIRBuilder):
        builder.preshard_arg(in0, shard_dims=(-1, 3))
        in_shard = builder.mesh_shard(
            in0,
            shard_direction=MeshShardDirection.FullToShard.value,
            shard_type=MeshShardType.Identity.value,
            shard_shape=(1, 1, 1, 2),
            shard_dims=(-1, 3),
        )
        exp = builder.exp(in_shard)
        out_shard = builder.mesh_shard(
            exp,
            shard_direction=MeshShardDirection.ShardToFull.value,
            shard_type=MeshShardType.Devices.value,
            shard_shape=(1, 1, 1, 2),
            shard_dims=(-1, 3),
        )
        return out_shard
```

Users can also load presharded mlir graphs and pass in presharded tensors as inputs.

Golden evaluation and runtime is updated to handle such cases.