### PR TITLE
Skip CPU-hoisting creation ops in const-eval subgraphs

### DIFF
--- a/test/ttmlir/Dialect/TTNN/cpu_hoisted_const_eval/creation_ops.mlir
+++ b/test/ttmlir/Dialect/TTNN/cpu_hoisted_const_eval/creation_ops.mlir
@@ -13,7 +13,9 @@ module {
   // CHECK: builtin.module
 
   // Const-eval function with zeros op.
+  // Zeros op shouldn't be CPU-hoisted, as it is returned from the const-eval function.
   // CHECK-LABEL: func.func private @forward_with_zeros_const_eval_0{{.*}} -> (tensor<32x32xbf16{{.*}}>, tensor<32x32xbf16{{.*}}>)
+  // CHECK: ttnn.zeros
   // CHECK: call @cpu_hoisted_const_eval_{{.*}}
 
   // CHECK-LABEL: func.func @forward_with_zeros
@@ -21,6 +23,7 @@ module {
                                 %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x32xbf16> {
     // CHECK: [[CE:%[0-9]+]]:2 = ttcore.load_cached{{.*}}%arg1
 
+    // CHECK-NOT: ttnn.zeros
     %0 = "ttir.zeros"() <{shape = array<i32:32, 32>}> : () -> tensor<32x32xbf16>
     // CHECK-NOT: "ttnn.add"(%arg1,
     %1 = "ttir.add"(%arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
@@ -34,7 +37,9 @@ module {
   }
 
   // Const-eval function with full op.
+  // Full op should be CPU-hoisted.
   // CHECK-LABEL: func.func private @forward_with_full_const_eval_0{{.*}} -> tensor<32x32xbf16
+  // CHECK-NOT: ttnn.full
   // CHECK: call @cpu_hoisted_const_eval_{{.*}}
 
   // CHECK-LABEL: func.func @forward_with_full
@@ -51,7 +56,7 @@ module {
     return %2 : tensor<32x32xbf16>
   }
 
-  // CHECK-LABEL: func.func private @cpu_hoisted_const_eval_{{.*}} -> (tensor<32x32xf32{{.*}}>, tensor<32x32xf32{{.*}}>)
+  // CHECK-LABEL: func.func private @cpu_hoisted_const_eval_{{.*}} -> tensor<32x32xf32
   // CHECK-LABEL: func.func private @cpu_hoisted_const_eval_{{.*}} -> tensor<32x32xf32
 
   // CHECK: ttcore.cpu_module {

--- a/test/ttmlir/EmitPy/cpu_hoisted_const_eval.mlir
+++ b/test/ttmlir/EmitPy/cpu_hoisted_const_eval.mlir
@@ -6,9 +6,7 @@
 // RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
 // RUN: FileCheck %s --input-file=%t.py
 
-// Verify that 5 CPU-hoisted functions are generated with golden_function calls.
-// CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}
-// CHECK: golden_function
+// Verify that 4 CPU-hoisted functions are generated with golden_function calls.
 // CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}
 // CHECK: golden_function
 // CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}


### PR DESCRIPTION
### Ticket
#6939 

### Problem description
If creation ops from const-eval subgraphs are CPU-hoisted, downstream passes might not be able to extract constant/splat values from such ops. For example, this breaks SDPA TTNN fusing pattern.

### What's changed
- Enabled skipping creation ops if they are results of the const-eval functions (together with other "transparent" ops leading up to the creation ops)

### Checklist
- [ ] New/Existing tests provide coverage for changes
