### PR TITLE
Temporarily disable CPU-hoisted const-eval

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -319,7 +319,7 @@ struct TTIRToTTNNDevicePipelineOptions
   Option<bool> enableCPUHoistedConstEval{
       *this, "enable-cpu-hoisted-const-eval",
       llvm::cl::desc("Enable hoisting const-eval ops to CPU module."),
-      llvm::cl::init(true)};
+      llvm::cl::init(false)};
 
   // Force const-eval function inputs to system memory.
   Option<bool> enableConstEvalInputsToSystemMemory{


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, CPU-hoisted const-eval is enabled by default on TT-MLIR, but is still disabled by default on TT-XLA.

I've expected a smoother transition towards enabling the feature in TT-XLA, but some more ops popped out which require new TTIR -> Linalg patterns / TTIR decompositions (#6898).

Additionally, impact on the perf hasn't been properly evaluated, which led to regressions such as #6939.

Generally, having the flag mismatched between TT-MLIR and TT-XLA for a long period makes debugging harder. Thus, I'm temporarily disabling the flag.

### Checklist
- [x] New/Existing tests provide coverage for changes
