### PR TITLE
Fixing trace for multichip execution

### DIFF
--- a/test/ttmlir/Dialect/TTNN/trace/multichip.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/multichip.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2 enable-trace=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that mesh shard ops aren't hoisted into the trace functions.
+
+module {
+    // Verify that capture trace creates valid local shape tensors.
+    // CHECK-LABEL: func.func private @run_and_capture_trace_0_main
+    // CHECK-SAME: %arg0: tensor<5x128x512xbf16,
+    // CHECK-SAME: %arg1: tensor<5x128x512xbf16,
+    // CHECK: "ttnn.empty"
+    // CHECK-SAME: -> tensor<5x128x512xbf16,
+    // CHECK: "ttnn.empty"
+    // CHECK-SAME: -> tensor<5x128x512xbf16,
+
+    // CHECK-LABEL: func.func @main(
+    // CHECK: "ttnn.mesh_shard"
+    // CHECK: "ttnn.mesh_shard"
+    func.func @main(%arg0: tensor<10x128x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.runtime_tensor_sharding = #ttcore<runtime_tensor_sharding shard_status = <presharded>, local_shape = tensor<5x128x512xbf16>>} loc("p0.2"), %arg1: tensor<10x128x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.runtime_tensor_sharding = #ttcore<runtime_tensor_sharding shard_status = <presharded>, local_shape = tensor<5x128x512xbf16>>} loc("p1.3")) -> (tensor<10x128x512xbf16> {ttcore.runtime_tensor_sharding = #ttcore<runtime_tensor_sharding shard_status = <unsharded>, local_shape = tensor<10x128x512xbf16>>}) {
+        %0 = "ttir.mesh_shard"(%arg0) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<10x128x512xbf16>) -> tensor<5x128x512xbf16>
+        %1 = "ttir.mesh_shard"(%arg1) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<10x128x512xbf16>) -> tensor<5x128x512xbf16>
+        %2 = "ttir.add"(%1, %0) : (tensor<5x128x512xbf16>, tensor<5x128x512xbf16>) -> tensor<5x128x512xbf16>
+        %3 = "ttir.mesh_shard"(%2) <{shard_dims = array<i64: -1, 0>, shard_direction = #ttcore.shard_direction<shard_to_full>, shard_shape = array<i64: 2, 1, 1>, shard_type = #ttcore.shard_type<identity>}> : (tensor<5x128x512xbf16>) -> tensor<10x128x512xbf16>
+        return %3 : tensor<10x128x512xbf16>
+    }
+}


### PR DESCRIPTION
### Ticket
Closes #6947

### Problem description
Multichip TTNN IRs with trace feature enabled fail in runtime with:

```
TT_FATAL: Host tensor has different shape (assert.hpp:104)

RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
```

The issue is that we hoist mesh_shard ops from a main function into the main trace function, which leads to a shape mismatch during host-to-device transfers while capturing trace. 
```mlir
func.func private @run_and_capture_trace_0_main(%arg0: tensor<10x128x512xbf16, #ttnn_layout> {presharded, local_shape=(5x128x512)}
...
%1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<10x128x512>}> : (!ttnn.device) -> tensor<10x128x512xbf16, #ttnn_layout>
...
%3 = "ttnn.from_device"(%arg0) : (tensor<10x128x512xbf16, #ttnn_layout>) -> tensor<10x128x512xbf16, #ttnn_layout1>
"ttnn.write_tensor"(%3, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<10x128x512xbf16, #ttnn_layout1>, tensor<10x128x512xbf16, #ttnn_layout>) -> ()
```
As shown above, the input arg is presharded, hence the runtime shape of that tensor on device is actually **5x128x512** (not 10x128x512xbf16), hence we are creating an empty op that is replicated among all devices with the shape 10x128x512. This fails at runtime as shapes are not compatible.

### What's changed
The entire tracing mechanism should operate strictly on local shapes, not global ones, hence this PR forbids the hoisting of mesh shard ops. Instead, they are executed before capturing the trace, hence in capturing function we have all local shapes, and we are creating the empty op with the correct shape:
```mlir
func.func private @run_and_capture_trace_0_main(%arg0: tensor<5x128x512xbf16, #ttnn_layout> 
...
%1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<5x128x512>}> : (!ttnn.device) -> tensor<5x128x512xbf16, #ttnn_layout>
...
%3 = "ttnn.from_device"(%arg0) : (tensor<5x128x512xbf16, #ttnn_layout>) -> tensor<5x128x512xbf16, #ttnn_layout1>
"ttnn.write_tensor"(%3, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<5x128x512xbf16, #ttnn_layout1>, tensor<5x128x512xbf16, #ttnn_layout>) -> ()
```

### Checklist
- [x] New/Existing tests provide coverage for changes
