### PR TITLE
Check for "uplift" label to determine whether to run all tests

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -36,8 +36,8 @@ jobs:
     uses: ./.github/workflows/call-prepare-run.yml
     with:
       builder_build: true
-      build_all: ${{ github.event.pull_request.head.ref == 'uplift' || contains(github.event.pull_request.labels.*.name, 'build_all') }}
-      min_timeout: ${{ contains(github.event.pull_request.labels.*.name, 'build_all') && 180 || 40 }}
+      build_all: ${{ github.event.pull_request.head.ref == 'uplift' || contains(github.event.pull_request.labels.*.name, 'build_all') || contains(github.event.pull_request.labels.*.name, 'uplift') }}
+      min_timeout: ${{ (contains(github.event.pull_request.labels.*.name, 'build_all') || contains(github.event.pull_request.labels.*.name, 'uplift')) && 180 || 40 }}
     secrets: inherit
   release-build:
     needs: [ prepare-run, build-image ]


### PR DESCRIPTION
### Ticket
None

### Problem description
Running all tests is needed to properly qualify metal uplift. A PR is determined to be an uplift by exact branch name match to "uplift" which is not suitable given uplift branch can be named arbitrarily.

### What's changed
Use uplift label to determine whether to run all tests for a looser check. Uplift label is always applied to the uplift PR generated from the nightly-uplift workflow, which is the expected uplifter workflow.

### Checklist
- [x] New/Existing tests provide coverage for changes
