### PR TITLE
Uplift third_party/tt-metal to 430d1f4d95d8401df010d0d932807258e8605ab1 2026-02-07

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=845e68e669d8d9406b9c60fa0bd678de37c68bf1
+ARG TT_METAL_DEPENDENCIES_COMMIT=430d1f4d95d8401df010d0d932807258e8605ab1
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "f99d6797c496854b0e1447f3e116048bb33861b6")
+set(TT_METAL_VERSION "430d1f4d95d8401df010d0d932807258e8605ab1")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 430d1f4d95d8401df010d0d932807258e8605ab1

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/21831381947
  - [x] [tt-xla (mlir-uplift-qualification)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/21831395934
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):