### PR TITLE
Fold FullOp to scalar if users support implicit broadcasting

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -294,4 +294,29 @@ def TTIRMultiDeviceTensorAnnotation: Pass<"ttir-multi-device-tensor-annotation",
   let dependentDialects = ["mlir::tt::ttcore::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
 }
 
+def TTIRFoldFullToScalar: Pass<"ttir-fold-full-to-scalar", "::mlir::ModuleOp"> {
+  let summary = "Fold creation ops into scalar when all users support implicit broadcasting.";
+  let description = [{
+    This pass finds ttir.full, ttir.zeros, and ttir.ones ops whose users all
+    have the Broadcastable trait and replaces them with a volume-1 (scalar)
+    equivalent. Broadcastable ops will implicitly broadcast the scalar to
+    the required shape, saving memory by materializing only a single element
+    instead of a full tensor.
+
+    When the creation op was the shape carrier for a consumer, the consumer's
+    result type is updated and an explicit broadcast is added on its output
+    to preserve the original shape.
+
+    Example:
+      Before:
+        %0 = "ttir.full"() <{shape = array<i32: 64, 32>, fill_value = 1.0 : f32}> : () -> tensor<64x32xf32>
+        %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+
+      After:
+        %0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1.0 : f32}> : () -> tensor<1xf32>
+        %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<1xf32>) -> tensor<64x32xf32>
+  }];
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 #endif

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -5,18 +5,63 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SetVector.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRIMPLICITBROADCASTFOLD
+#define GEN_PASS_DEF_TTIRFOLDFULLTOSCALAR
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
-// This algorithm works by first removing all explicit broadcasts from the
-// operands of an operation. While doing so, it calculates the result shape that
-// would result from implicit broadcasting, taking all operands into
-// consideration. If this shape differs from the target shape, we add an
-// explicit broadcast to the operation’s output to match the target shape.
+// Compute the implicit broadcast shape from `op`'s current operand types.
+// If it differs from the result shape, update the result type and add a
+// BroadcastOp on the output to restore the original shape.
+// Returns true when the output was modified.
+static bool addOutputBroadcastIfNeeded(Operation *op,
+                                       PatternRewriter &rewriter) {
+  llvm::SmallVector<int64_t> implicitShape;
+  for (Value operand : op->getOperands()) {
+    auto shape = mlir::cast<RankedTensorType>(operand.getType()).getShape();
+    llvm::SmallVector<int64_t> prev = implicitShape;
+    assert(
+        mlir::OpTrait::util::getBroadcastedShape(prev, shape, implicitShape) &&
+        "Operands must be broadcast-compatible");
+  }
+
+  auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+  llvm::ArrayRef<int64_t> resultShape = resultType.getShape();
+
+  if (implicitShape == resultShape) {
+    return false;
+  }
+
+  auto newResultType =
+      mlir::RankedTensorType::get(implicitShape, resultType.getElementType());
+  rewriter.modifyOpInPlace(op,
+                           [&]() { op->getResult(0).setType(newResultType); });
+
+  rewriter.setInsertionPointAfter(op);
+  auto broadcastDimensions = ttmlir::utils::getBroadcastDimensions<int64_t>(
+      implicitShape, resultShape);
+  auto broadcastOp = rewriter.create<ttir::BroadcastOp>(
+      op->getLoc(),
+      RankedTensorType::get(resultShape, newResultType.getElementType(),
+                            newResultType.getEncoding()),
+      op->getResult(0), broadcastDimensions);
+  rewriter.replaceAllUsesExcept(op->getResult(0), broadcastOp.getResult(),
+                                broadcastOp);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// TTIRImplicitBroadcastFold
+//===----------------------------------------------------------------------===//
+
+// Remove explicit broadcasts from the operands of Broadcastable ops.
+// If the resulting implicit broadcast shape differs from the result shape,
+// add a broadcast on the output to compensate.
 class TTIRImplicitBroadcastFoldRewriter : public RewritePattern {
 public:
   TTIRImplicitBroadcastFoldRewriter(MLIRContext *ctx)
@@ -29,56 +74,22 @@ public:
     }
 
     bool operandsChanged = false;
-    llvm::SmallVector<int64_t> implicitBroadcastedShape;
 
-    // Remove all explicit broadcasts from the operands and compute the shape
-    // that would result from implicit broadcasting.
+    // Remove all explicit broadcasts from the operands.
     for (int64_t i = 0; i < op->getNumOperands(); ++i) {
-      mlir::Value operand = op->getOperand(i);
-      ::llvm::ArrayRef<int64_t> originalOperandShape;
       if (auto broadcastOp = mlir::dyn_cast_if_present<ttir::BroadcastOp>(
-              operand.getDefiningOp())) {
-        originalOperandShape = broadcastOp.getInput().getType().getShape();
+              op->getOperand(i).getDefiningOp())) {
         rewriter.modifyOpInPlace(
             op, [&]() { op->setOperand(i, broadcastOp.getInput()); });
         operandsChanged = true;
-      } else {
-        originalOperandShape =
-            mlir::cast<RankedTensorType>(operand.getType()).getShape();
       }
-
-      llvm::SmallVector<int64_t> prevShape = implicitBroadcastedShape;
-      assert(mlir::OpTrait::util::getBroadcastedShape(
-                 prevShape, originalOperandShape, implicitBroadcastedShape) &&
-             "Operands must be broadcast-compatible");
     }
 
-    auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
-    llvm::ArrayRef<int64_t> resultShape = resultType.getShape();
-
-    if (implicitBroadcastedShape == resultShape) {
-      return llvm::success(operandsChanged);
+    if (addOutputBroadcastIfNeeded(op, rewriter)) {
+      return llvm::success();
     }
 
-    // If the shape from implicit broadcasting differs from the target shape,
-    // add an explicit broadcast to the operation’s output.
-    auto newResultType = mlir::RankedTensorType::get(
-        implicitBroadcastedShape, resultType.getElementType());
-    rewriter.modifyOpInPlace(
-        op, [&]() { op->getResult(0).setType(newResultType); });
-
-    rewriter.setInsertionPointAfter(op);
-    auto broadcastDimensions = ttmlir::utils::getBroadcastDimensions<int64_t>(
-        implicitBroadcastedShape, resultShape);
-    auto broadcastOp = rewriter.create<ttir::BroadcastOp>(
-        op->getLoc(),
-        RankedTensorType::get(resultShape, newResultType.getElementType(),
-                              newResultType.getEncoding()),
-        op->getResult(0), broadcastDimensions);
-    rewriter.replaceAllUsesExcept(op->getResult(0), broadcastOp.getResult(),
-                                  broadcastOp);
-
-    return llvm::success();
+    return llvm::success(operandsChanged);
   }
 };
 
@@ -101,6 +112,100 @@ public:
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::tt::ttir::TTIRDialect>();
     registry.insert<mlir::tt::ttcore::TTCoreDialect>();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// TTIRFoldFullToScalar
+//===----------------------------------------------------------------------===//
+
+// Fold creation ops (full, zeros, ones) to volume-1 tensors when all users
+// are Broadcastable. If the creation op was the shape carrier for a consumer,
+// a broadcast is added on the consumer's output to restore the original shape.
+template <typename OpTy>
+class CreationToScalarRewriter : public OpRewritePattern<OpTy> {
+public:
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    if (ttmlir::utils::volume(op.getType().getShape()) == 1) {
+      return failure();
+    }
+
+    if (!llvm::all_of(op.getResult().getUsers(), [](Operation *user) {
+          return user->hasTrait<ttir::Broadcastable>();
+        })) {
+      return failure();
+    }
+
+    llvm::SmallVector<int64_t> onesShape(op.getType().getRank(), 1);
+    auto scalarType =
+        RankedTensorType::get(onesShape, op.getType().getElementType());
+    Value scalar = convertToScalar(op, scalarType, rewriter);
+    rewriter.replaceOp(op, scalar);
+
+    // If the shrunk creation op was the shape carrier for a consumer,
+    // the consumer's result shape may no longer match the implicit
+    // broadcast of its operands.
+    llvm::SetVector<Operation *> users(scalar.getUsers().begin(),
+                                       scalar.getUsers().end());
+    for (auto *user : users) {
+      addOutputBroadcastIfNeeded(user, rewriter);
+    }
+
+    return success();
+  }
+
+protected:
+  virtual Value convertToScalar(OpTy op, RankedTensorType scalarType,
+                                PatternRewriter &rewriter) const = 0;
+};
+
+class FullToScalarRewriter : public CreationToScalarRewriter<ttir::FullOp> {
+  using CreationToScalarRewriter::CreationToScalarRewriter;
+
+  Value convertToScalar(ttir::FullOp op, RankedTensorType scalarType,
+                        PatternRewriter &rewriter) const override {
+    return rewriter
+        .create<ttir::FullOp>(op.getLoc(), scalarType, op.getFillValueAttr())
+        .getResult();
+  }
+};
+
+template <typename OpTy>
+class NamedFullToScalarRewriter : public CreationToScalarRewriter<OpTy> {
+  using CreationToScalarRewriter<OpTy>::CreationToScalarRewriter;
+
+  Value convertToScalar(OpTy op, RankedTensorType scalarType,
+                        PatternRewriter &rewriter) const override {
+    return rewriter
+        .create<OpTy>(op.getLoc(), scalarType,
+                      SmallVector<int32_t>(scalarType.getRank(), 1))
+        .getResult();
+  }
+};
+
+class TTIRFoldFullToScalar
+    : public impl::TTIRFoldFullToScalarBase<TTIRFoldFullToScalar> {
+public:
+  using impl::TTIRFoldFullToScalarBase<
+      TTIRFoldFullToScalar>::TTIRFoldFullToScalarBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<FullToScalarRewriter, NamedFullToScalarRewriter<ttir::ZerosOp>,
+                 NamedFullToScalarRewriter<ttir::OnesOp>>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+
+    if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
   }
 };
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -79,6 +79,7 @@ void createTTNNPipelineTTIRPasses(
   if (options.enableFusing) {
     pm.addPass(mlir::tt::ttir::createTTIRFusing(fusingOptions));
   }
+  pm.addPass(mlir::tt::ttir::createTTIRFoldFullToScalar());
 }
 
 void createTTNNPipelineAnalysisPasses(

--- a/test/ttmlir/Dialect/TTIR/Transforms/fold_full_to_scalar.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/fold_full_to_scalar.mlir
@@ -1,0 +1,72 @@
+// RUN: ttmlir-opt --ttir-fold-full-to-scalar %s | FileCheck %s
+
+// FullOp with all broadcastable users should fold to tensor<1x1xf32>.
+// CHECK-LABEL: func.func @fold_full_all_broadcastable
+func.func @fold_full_all_broadcastable(%arg0: tensor<64x32xf32>) -> tensor<64x32xf32> {
+  // CHECK: %[[FULL:.*]] = "ttir.full"() <{fill_value = 1.000000e+00 : f32, shape = array<i32: 1, 1>}> : () -> tensor<1x1xf32>
+  %0 = "ttir.full"() <{shape = array<i32: 64, 32>, fill_value = 1.0 : f32}> : () -> tensor<64x32xf32>
+  // CHECK: "ttir.add"(%arg0, %[[FULL]])
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1 : tensor<64x32xf32>
+}
+
+// FullOp with mixed broadcastable and non-broadcastable users should NOT fold.
+// CHECK-LABEL: func.func @no_fold_mixed_users
+func.func @no_fold_mixed_users(%arg0: tensor<64x32xf32>) -> (tensor<64x32xf32>, tensor<64x32xf32>) {
+  // CHECK: %[[FULL:.*]] = "ttir.full"() <{fill_value = 2.000000e+00 : f32, shape = array<i32: 64, 32>}> : () -> tensor<64x32xf32>
+  %0 = "ttir.full"() <{shape = array<i32: 64, 32>, fill_value = 2.0 : f32}> : () -> tensor<64x32xf32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1, %0 : tensor<64x32xf32>, tensor<64x32xf32>
+}
+
+// FullOp already volume-1 should NOT fold (no-op).
+// CHECK-LABEL: func.func @no_fold_already_scalar
+func.func @no_fold_already_scalar(%arg0: tensor<64x32xf32>) -> tensor<64x32xf32> {
+  // CHECK: %[[FULL:.*]] = "ttir.full"() <{fill_value = 3.000000e+00 : f32, shape = array<i32: 1>}> : () -> tensor<1xf32>
+  %0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 3.0 : f32}> : () -> tensor<1xf32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<1xf32>) -> tensor<64x32xf32>
+  return %1 : tensor<64x32xf32>
+}
+
+// ZerosOp with all broadcastable users should fold to tensor<1x1xf32>.
+// CHECK-LABEL: func.func @fold_zeros_all_broadcastable
+func.func @fold_zeros_all_broadcastable(%arg0: tensor<64x32xf32>) -> tensor<64x32xf32> {
+  // CHECK: %[[ZEROS:.*]] = "ttir.zeros"() <{shape = array<i32: 1, 1>}> : () -> tensor<1x1xf32>
+  %0 = "ttir.zeros"() <{shape = array<i32: 64, 32>}> : () -> tensor<64x32xf32>
+  // CHECK: "ttir.add"(%arg0, %[[ZEROS]])
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1 : tensor<64x32xf32>
+}
+
+// OnesOp with all broadcastable users should fold to tensor<1x1xf32>.
+// CHECK-LABEL: func.func @fold_ones_all_broadcastable
+func.func @fold_ones_all_broadcastable(%arg0: tensor<64x32xf32>) -> tensor<64x32xf32> {
+  // CHECK: %[[ONES:.*]] = "ttir.ones"() <{shape = array<i32: 1, 1>}> : () -> tensor<1x1xf32>
+  %0 = "ttir.ones"() <{shape = array<i32: 64, 32>}> : () -> tensor<64x32xf32>
+  // CHECK: "ttir.multiply"(%arg0, %[[ONES]])
+  %1 = "ttir.multiply"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1 : tensor<64x32xf32>
+}
+
+// ZerosOp with mixed users should NOT fold.
+// CHECK-LABEL: func.func @no_fold_zeros_mixed_users
+func.func @no_fold_zeros_mixed_users(%arg0: tensor<64x32xf32>) -> (tensor<64x32xf32>, tensor<64x32xf32>) {
+  // CHECK: %[[ZEROS:.*]] = "ttir.zeros"() <{shape = array<i32: 64, 32>}> : () -> tensor<64x32xf32>
+  %0 = "ttir.zeros"() <{shape = array<i32: 64, 32>}> : () -> tensor<64x32xf32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1, %0 : tensor<64x32xf32>, tensor<64x32xf32>
+}
+
+// FullOp is the shape carrier — the other operand is smaller.
+// After folding, the consumer's implicit shape shrinks, so a broadcast
+// is added on the consumer's output to restore the original shape.
+// CHECK-LABEL: func.func @fold_full_shape_carrier
+func.func @fold_full_shape_carrier(%arg0: tensor<1x32xf32>) -> tensor<64x32xf32> {
+  // CHECK: %[[FULL:.*]] = "ttir.full"() <{fill_value = 1.000000e+00 : f32, shape = array<i32: 1, 1>}> : () -> tensor<1x1xf32>
+  %0 = "ttir.full"() <{shape = array<i32: 64, 32>, fill_value = 1.0 : f32}> : () -> tensor<64x32xf32>
+  // CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %[[FULL]]) : (tensor<1x32xf32>, tensor<1x1xf32>) -> tensor<1x32xf32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<1x32xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  // CHECK: %[[BCAST:.*]] = "ttir.broadcast"(%[[ADD]]) <{broadcast_dimensions = array<i64: 64, 1>}> : (tensor<1x32xf32>) -> tensor<64x32xf32>
+  // CHECK: return %[[BCAST]]
+  return %1 : tensor<64x32xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/cpu_hoisted_const_eval/creation_ops.mlir
+++ b/test/ttmlir/Dialect/TTNN/cpu_hoisted_const_eval/creation_ops.mlir
@@ -14,7 +14,7 @@ module {
 
   // Const-eval function with zeros op.
   // Zeros op shouldn't be CPU-hoisted, as it is returned from the const-eval function.
-  // CHECK-LABEL: func.func private @forward_with_zeros_const_eval_0{{.*}} -> (tensor<32x32xbf16{{.*}}>, tensor<32x32xbf16{{.*}}>)
+  // CHECK-LABEL: func.func private @forward_with_zeros_const_eval_0{{.*}} -> (tensor<1x1xbf16{{.*}}>, tensor<32x32xbf16{{.*}}>)
   // CHECK: ttnn.zeros
   // CHECK: call @cpu_hoisted_const_eval_{{.*}}
 

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/logicalleftshift/simple_logicalleftshift.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/logicalleftshift/simple_logicalleftshift.mlir
@@ -1,10 +1,8 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-func.func @forward(%arg0: tensor<1x18xi32>, %arg1: tensor<1x18xi32>) -> tensor<1x18xui32> {
-  %0 = "ttir.constant"() <{value = dense<5> : tensor<1x18xui32>}> : () -> tensor<1x18xui32>
-  %1 = "ttir.constant"() <{value = dense<1> : tensor<1x18xui32>}> : () -> tensor<1x18xui32>
-  %2 = "ttir.logical_left_shift"(%0, %1) : (tensor<1x18xui32>, tensor<1x18xui32>) -> tensor<1x18xui32>
+func.func @forward(%arg0: tensor<1x18xui32>, %arg1: tensor<1x18xui32>) -> tensor<1x18xui32> {
+  %2 = "ttir.logical_left_shift"(%arg0, %arg1) : (tensor<1x18xui32>, tensor<1x18xui32>) -> tensor<1x18xui32>
   // CHECK: "ttnn.logical_left_shift"
   // CHECK-SAME: tensor<1x18xui32
   // CHECK-SAME: tensor<1x18xui32

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/logicalrightshift/simple_logicalrightshift.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/logicalrightshift/simple_logicalrightshift.mlir
@@ -1,10 +1,8 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-func.func @forward(%arg0: tensor<1x18xi32>, %arg1: tensor<1x18xi32>) -> tensor<1x18xui32> {
-  %0 = "ttir.constant"() <{value = dense<5> : tensor<1x18xui32>}> : () -> tensor<1x18xui32>
-  %1 = "ttir.constant"() <{value = dense<1> : tensor<1x18xui32>}> : () -> tensor<1x18xui32>
-  %2 = "ttir.logical_right_shift"(%0, %1) : (tensor<1x18xui32>, tensor<1x18xui32>) -> tensor<1x18xui32>
+func.func @forward(%arg0: tensor<1x18xui32>, %arg1: tensor<1x18xui32>) -> tensor<1x18xui32> {
+  %2 = "ttir.logical_right_shift"(%arg0, %arg1) : (tensor<1x18xui32>, tensor<1x18xui32>) -> tensor<1x18xui32>
   // CHECK: "ttnn.logical_right_shift"
   // CHECK-SAME: tensor<1x18xui32
   // CHECK-SAME: tensor<1x18xui32


### PR DESCRIPTION
### Ticket
#6877 

### Problem description
The following attention masking patterns occur in the llama 1B graph (attached in the issue):

#### Pattern 1

```
%2 = "ttir.constant"() <{value = dense<0xFF80> : tensor<2x1x128x128xbf16>}> : () -> tensor<2x1x128x128xbf16> loc(#loc)
...
%111 = "ttir.where"(%110, %3, %2) : (tensor<2x1x128x128xi1>, tensor<2x1x128x128xbf16>, tensor<2x1x128x128xbf16>) -> tensor<2x1x128x128xbf16> loc(#loc241)
```

#### Pattern 2

```
%1 = "ttir.constant"() <{value = dense<0xFFF0000000000000> : tensor<2x32x128x128xf64>}> : () -> tensor<2x32x128x128xf64> loc(#loc)
...
// many times:
%A = "ttir.eq"(%B, %1) : (tensor<2x32x128x128xf64>, tensor<2x32x128x128xf64>) -> tensor<2x32x128x128xi1> loc(#loc547)
```

The mask tensor size is proportional to the square of the sequence length, which takes a large portion of DRAM space, since these tensors are const-evaled, and thus never deallocated.

### What's changed
- Implemented folding `FullOp`, `ZerosOp` and `OnesOp` to 1-volume tensors if all their users support implicit operand broadcasting
  - This will lead to a negligible performance penalty, since TTNN ops should handle such implicit broadcasts as scalar broadcasts, but will lead to significant DRAM savings

### Note

Mask from the aforementioned Pattern 1 will still get explicitly broadcasted, since `WhereOp` has `ExplicateOperandBroadcastsTrait` The efforts for validating the current state of implicit broadcasting for `WhereOp` are WIP - #6995.

### Checklist
- [x] New/Existing tests provide coverage for changes
