### PR TITLE
Skip PR CI when Draft PR becomes Ready for Review

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: boolean
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches: [ "main" ]
 
 permissions:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`On PR` CI workflow re-triggers after PR state is changed from `Draft` to `Ready for Review`. 

This initiates an unnecessary CI run.


### Checklist
- [ ] New/Existing tests provide coverage for changes
