### PR TITLE
Adding device ops handling to profiler package

### DIFF
--- a/tools/profiler/profiler.py
+++ b/tools/profiler/profiler.py
@@ -13,7 +13,7 @@ from tracy.process_ops_logs import process_ops
 
 
 @contextmanager
-def trace(log_dir: str, port: int, host_only: bool = False):
+def trace(log_dir: str, port: int):
     os.makedirs(log_dir, exist_ok=True)
 
     TT_METAL_RUNTIME_ROOT = os.environ.get(
@@ -29,12 +29,11 @@ def trace(log_dir: str, port: int, host_only: bool = False):
         TT_METAL_RUNTIME_ROOT + "/generated/profiler/reports/ops_perf_results.csv"
     )
     os.environ["TRACY_PORT"] = str(port)
-    if not host_only:
-        os.environ["TT_METAL_CLEAR_L1"] = "1"
-        os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
-        os.environ["TTNN_OP_PROFILER"] = "1"
-        os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
-        os.environ["TT_METAL_PROFILER_CPP_POST_PROCESS"] = "1"
+    os.environ["TT_METAL_CLEAR_L1"] = "1"
+    os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
+    os.environ["TTNN_OP_PROFILER"] = "1"
+    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+    os.environ["TT_METAL_PROFILER_CPP_POST_PROCESS"] = "1"
 
     if os.path.exists(profiler_logs_dir):
         shutil.rmtree(profiler_logs_dir)


### PR DESCRIPTION
### Ticket
None

### Problem description
Profiler doesn't support device ops

### What's changed
Added environment variable handling for device profiling.
Fixed `profiler_logs_dir` doesn't exist bug

### Checklist
- [ ] New/Existing tests provide coverage for changes
