### PR TITLE
Retrigger docker build on exalens ref change

### DIFF
--- a/.github/workflows/schedule-nightly-uplift.yml
+++ b/.github/workflows/schedule-nightly-uplift.yml
@@ -115,14 +115,17 @@ jobs:
           CURRENT_INSTALL_DEPS_SHA=$(gh api repos/tenstorrent/tt-metal/contents/install_dependencies.sh?ref=$CURRENT_TT_METAL_VERSION --jq '.sha' 2>/dev/null || echo "not_found")
           CURRENT_SFPI_INFO_SHA=$(gh api repos/tenstorrent/tt-metal/contents/tt_metal/sfpi-info.sh?ref=$CURRENT_TT_METAL_VERSION --jq '.sha' 2>/dev/null || echo "not_found")
           CURRENT_SFPI_VERSION_SHA=$(gh api repos/tenstorrent/tt-metal/contents/tt_metal/sfpi-version?ref=$CURRENT_TT_METAL_VERSION --jq '.sha' 2>/dev/null || echo "not_found")
+          CURRENT_EXALENS_VERSION_SHA=$(gh api repos/tenstorrent/tt-metal/contents/scripts/ttexalens_ref.txt?ref=$CURRENT_TT_METAL_VERSION --jq '.sha' 2>/dev/null || echo "not_found")
 
           # Fetch file hashes from uplifted version
           LATEST_INSTALL_DEPS_SHA=$(gh api repos/tenstorrent/tt-metal/contents/install_dependencies.sh?ref=${{ env.UPLIFTED_TT_METAL_VERSION }} --jq '.sha' 2>/dev/null || echo "not_found")
           LATEST_SFPI_INFO_SHA=$(gh api repos/tenstorrent/tt-metal/contents/tt_metal/sfpi-info.sh?ref=${{ env.UPLIFTED_TT_METAL_VERSION }} --jq '.sha' 2>/dev/null || echo "not_found")
           LATEST_SFPI_VERSION_SHA=$(gh api repos/tenstorrent/tt-metal/contents/tt_metal/sfpi-version?ref=${{ env.UPLIFTED_TT_METAL_VERSION }} --jq '.sha' 2>/dev/null || echo "not_found")
+          LATEST_EXALENS_VERSION_SHA=$(gh api repos/tenstorrent/tt-metal/contents/scripts/ttexalens_ref.txt?ref=${{ env.UPLIFTED_TT_METAL_VERSION }} --jq '.sha' 2>/dev/null || echo "not_found")
 
           if [ "$CURRENT_INSTALL_DEPS_SHA" != "$LATEST_INSTALL_DEPS_SHA" ] || \
              [ "$CURRENT_SFPI_INFO_SHA" != "$LATEST_SFPI_INFO_SHA" ] || \
+             [ "$CURRENT_EXALENS_VERSION_SHA" != "$LATEST_EXALENS_VERSION_SHA" ] || \
              [ "$CURRENT_SFPI_VERSION_SHA" != "$LATEST_SFPI_VERSION_SHA" ]; then
             # Update the commit hash in Dockerfile.base
             sed -i "s|ARG TT_METAL_DEPENDENCIES_COMMIT=.*|ARG TT_METAL_DEPENDENCIES_COMMIT=${{ env.UPLIFTED_TT_METAL_VERSION }}|" .github/Dockerfile.base


### PR DESCRIPTION
### Ticket
/

### Problem description
On uplifts, when the tt-metal version is changed it won't trigger docker rebuild.

### What's changed
Add tt-metal/scripts/ttexalens_ref.txt to list of files whose change triggers a docker rebuild in tt-mlir.

### Checklist
- [ ] New/Existing tests provide coverage for changes
