### PR TITLE
Improved debug dialect ops and runtime support

### DIFF
--- a/include/ttmlir/Dialect/Debug/IR/DebugOps.td
+++ b/include/ttmlir/Dialect/Debug/IR/DebugOps.td
@@ -35,7 +35,6 @@ class Debug_BaseOp<string mnemonic, list<Trait> traits = []> :
 
     let summary = "Base class for debug op.";
     let description = [{
-      Each debug op inherits from this base op.
       Ensures that the operations that produce the `operand` are executed before any
       operations that depend on the `result` and prevents compiler transformations
       from moving operations across the barrier. Other than that, the operation is
@@ -64,34 +63,30 @@ def Debug_AnnotateOp : Debug_BaseOp<"annotate", []> {
   );
 }
 
-def Debug_BreakpointOp : Debug_BaseOp<"breakpoint", []> {
+def Debug_BreakpointOp : Op<Debug_Dialect, "breakpoint", [MemoryEffects<[MemWrite]>]> {
   let summary = "Breakpoint operation";
   let description = [{
     Inserts a breakpoint in runtime execution.
 
     Example:
     ```mlir
-    %1 = "debug.breakpoint"(%0) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    "debug.breakpoint"(%0) : (tensor<32x32xf32>) -> ()
     ```
   }];
 
   let arguments = (ins
     AnyRankedTensor:$operand
   );
-
-  let results = (outs
-    AnyRankedTensor:$result
-  );
 }
 
-def Debug_PrintOp : Debug_BaseOp<"print", []> {
+def Debug_PrintOp : Op<Debug_Dialect, "print", [MemoryEffects<[MemWrite]>]> {
   let summary = "Print operation";
   let description = [{
     Print a message during runtime.
 
     Example:
     ```mlir
-    %1 = "debug.print"(%0) <{message = "This is from KV cache"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    "debug.print"(%0) <{message = "execution has reached here"}> : (tensor<32x32xf32>) -> ()
     ```
   }];
 
@@ -99,20 +94,16 @@ def Debug_PrintOp : Debug_BaseOp<"print", []> {
     AnyRankedTensor:$operand,
     StrAttr:$message
   );
-
-  let results = (outs
-    AnyRankedTensor:$result
-  );
 }
 
-def Debug_DumpOp : Debug_BaseOp<"dump", []> {
+def Debug_DumpOp : Op<Debug_Dialect, "dump", [MemoryEffects<[MemWrite]>]> {
   let summary = "Dump operation";
   let description = [{
     Save a tensor to disk.
 
     Example:
     ```mlir
-    %1 = "debug.dump"(%0) <{file_path = "system_tensor.tensorbin"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    "debug.dump"(%0) <{file_path = "add0_dump.tensorbin"}> : (tensor<32x32xf32>) -> ()
     ```
   }];
 
@@ -120,11 +111,67 @@ def Debug_DumpOp : Debug_BaseOp<"dump", []> {
     AnyRankedTensor:$operand,
     StrAttr:$file_path
   );
+}
+
+def Debug_MemorySnapshotOp : Op<Debug_Dialect, "memory_snapshot", [MemoryEffects<[MemWrite]>]> {
+  let summary = "Memory snapshot operation";
+  let description = [{
+    Capture memory state of device.
+
+    Example:
+    ```mlir
+    "debug.memory_snapshot"(%0) <{file_path = "memory_dump.txt"}> : (tensor<32x32xf32>) -> ()
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$file_path
+  );
+}
+
+def Debug_RegionStartOp : Debug_Op<"region_start",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Region start operation";
+  let description = [{
+    Mark the start of a region.
+
+    Example:
+    ```mlir
+    %1 = "debug.region_start"(%0) <{region_id = "embedding_region"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$region_id
+  );
 
   let results = (outs
     AnyRankedTensor:$result
   );
+}
 
+def Debug_RegionEndOp : Debug_Op<"region_end",
+  [Pure, SameOperandsAndResultType]> {
+  let summary = "Region end operation";
+  let description = [{
+    Mark the end of a region.
+
+    Example:
+    ```mlir
+    %3 = "debug.region_end"(%2) <{region_id = "embedding_region"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    StrAttr:$region_id
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
 }
 
 def Debug_OverwriteOp : Debug_BaseOp<"overwrite",
@@ -214,50 +261,6 @@ def Debug_EndTraceOp : Debug_Op<"end_trace",
   );
 }
 
-def Debug_RegionStartOp : Debug_Op<"region_start",
-  [Pure, SameOperandsAndResultType]> {
-  let summary = "Region start operation";
-  let description = [{
-    Mark the start of a region.
-
-    Example:
-    ```mlir
-    %0 = debug.region_start %arg0 <{region_id = "region0"}> : tensor<32x32xf32>
-    ```
-  }];
-
-  let arguments = (ins
-    AnyRankedTensor:$operand,
-    StrAttr:$region_id
-  );
-
-  let results = (outs
-    AnyRankedTensor:$result
-  );
-}
-
-def Debug_RegionEndOp : Debug_Op<"region_end",
-  [Pure, SameOperandsAndResultType]> {
-  let summary = "Region end operation";
-  let description = [{
-    Mark the end of a region.
-
-    Example:
-    ```mlir
-    %1 = debug.region_end %0 <{region_id = "region0"}> : tensor<32x32xf32>, tensor<32x32xf32>
-    ```
-  }];
-
-  let arguments = (ins
-    AnyRankedTensor:$operand,
-    StrAttr:$region_id
-  );
-
-  let results = (outs
-    AnyRankedTensor:$result
-  );
-}
-
 def Debug_ProfilerStartOp : Debug_Op<"profiler_start",
   [Pure, SameOperandsAndResultType]> {
   let summary = "Profiler start operation";
@@ -295,28 +298,6 @@ def Debug_ProfilerEndOp : Debug_Op<"profiler_end",
   let arguments = (ins
     AnyRankedTensor:$operand,
     StrAttr:$scope_id
-  );
-
-  let results = (outs
-    AnyRankedTensor:$result
-  );
-}
-
-def Debug_MemorySnapshotOp : Debug_Op<"memory_snapshot",
-  [Pure, SameOperandsAndResultType]> {
-  let summary = "Memory snapshot operation";
-  let description = [{
-    Capture memory state of device.
-
-    Example:
-    ```mlir
-    %1 = "debug.memory_snapshot"(%0) <{file_path = "/path/to/memory/file.json"}> : (tensor<32x32xf32>) -> tensor<32x32xf32>
-    ```
-  }];
-
-  let arguments = (ins
-    AnyRankedTensor:$operand,
-    StrAttr:$file_path
   );
 
   let results = (outs

--- a/include/ttmlir/Target/TTNN/operations/debug.fbs
+++ b/include/ttmlir/Target/TTNN/operations/debug.fbs
@@ -11,11 +11,26 @@ table AnnotateOp {
 
 table BreakpointOp {
   operand: tt.target.ttnn.TensorRef;
-  result: tt.target.ttnn.TensorRef;
+}
+
+table PrintOp {
+  operand: tt.target.ttnn.TensorRef;
+  message: string;
 }
 
 table MemorySnapshotOp {
   operand: tt.target.ttnn.TensorRef;
-  result: tt.target.ttnn.TensorRef;
   file_path: string;
+}
+
+table RegionStartOp {
+  operand: tt.target.ttnn.TensorRef;
+  result: tt.target.ttnn.TensorRef;
+  region_id: string;
+}
+
+table RegionEndOp {
+  operand: tt.target.ttnn.TensorRef;
+  result: tt.target.ttnn.TensorRef;
+  region_id: string;
 }

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -126,7 +126,10 @@ union OpType {
   LoadTensorOp,
   AnnotateOp,
   BreakpointOp,
+  PrintOp,
   MemorySnapshotOp,
+  RegionStartOp,
+  RegionEndOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -5,6 +5,8 @@
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/Debug/IR/Debug.h"
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
@@ -2981,6 +2983,24 @@ public:
 };
 } // namespace
 
+namespace {
+// Conversion pattern for debug operations
+template <typename DebugOpTy, typename TTNNOpTy,
+          typename OpAdaptor = typename DebugOpTy::Adaptor>
+class DebugOpConversionPattern : public OpConversionPattern<DebugOpTy> {
+public:
+  using OpConversionPattern<DebugOpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(DebugOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TTNNOpTy>(op, adaptor.getFilePath(),
+                                          adaptor.getOperand());
+    return success();
+  }
+};
+} // namespace
+
 namespace mlir::tt {
 
 void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
@@ -3113,7 +3133,8 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            PagedScaledDotProductAttentionDecodeOpConversionPattern,
            SplitQueryKeyValueAndSplitHeadsOpConversionPattern,
            GeluBackwardOpConversionPattern,
-           DropoutOpConversionPattern
+           DropoutOpConversionPattern,
+           DebugOpConversionPattern<debug::DumpOp, ttnn::DumpTensorOp>
            >(typeConverter, ctx);
   // ANCHOR_END: op_rewriter_pattern_set
   // clang-format on

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "ttmlir/Dialect/Debug/IR/Debug.h"
+#include "ttmlir/Dialect/Debug/IR/DebugOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
@@ -47,6 +48,15 @@ struct ConvertTTIRToTTNNPass
     target.addLegalOp<ttcore::DeviceOp>();
     target.addLegalOp<ttcore::OptimizationBarrierOp>();
     target.addLegalOp<ttcore::LoadCachedOp>();
+
+    // Debug dialect ops.
+    target.addLegalOp<debug::AnnotateOp>();
+    target.addLegalOp<debug::BreakpointOp>();
+    target.addLegalOp<debug::PrintOp>();
+    target.addLegalOp<debug::MemorySnapshotOp>();
+    target.addLegalOp<debug::RegionStartOp>();
+    target.addLegalOp<debug::RegionEndOp>();
+    target.addIllegalOp<debug::DumpOp>();
 
     TypeConverter typeConverter;
     // All types map 1:1.

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3371,26 +3371,55 @@ createOp(FlatbufferObjectCache &cache, debug::AnnotateOp op) {
 createOp(FlatbufferObjectCache &cache, debug::BreakpointOp op) {
   auto operand = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getOperand()));
-  auto result =
-      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
 
-                                  /*local_shape*/ std::nullopt);
+  return ::tt::target::ttnn::CreateBreakpointOp(*cache.fbb, operand);
+}
 
-  return ::tt::target::ttnn::CreateBreakpointOp(*cache.fbb, operand, result);
+::flatbuffers::Offset<::tt::target::ttnn::PrintOp>
+createOp(FlatbufferObjectCache &cache, debug::PrintOp op) {
+  auto operand = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getOperand()));
+  auto message = toFlatbuffer(cache, op.getMessage());
+
+  return ::tt::target::ttnn::CreatePrintOp(*cache.fbb, operand, message);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::MemorySnapshotOp>
 createOp(FlatbufferObjectCache &cache, debug::MemorySnapshotOp op) {
   auto operand = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getOperand()));
+  auto filePath = toFlatbuffer(cache, op.getFilePath());
+
+  return ::tt::target::ttnn::CreateMemorySnapshotOp(*cache.fbb, operand,
+                                                    filePath);
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::RegionStartOp>
+createOp(FlatbufferObjectCache &cache, debug::RegionStartOp op) {
+  auto operand = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getOperand()));
   auto result =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
 
                                   /*local_shape*/ std::nullopt);
-  auto filePath = toFlatbuffer(cache, op.getFilePath());
+  auto regionId = toFlatbuffer(cache, op.getRegionId());
 
-  return ::tt::target::ttnn::CreateMemorySnapshotOp(*cache.fbb, operand, result,
-                                                    filePath);
+  return ::tt::target::ttnn::CreateRegionStartOp(*cache.fbb, operand, result,
+                                                 regionId);
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::RegionEndOp>
+createOp(FlatbufferObjectCache &cache, debug::RegionEndOp op) {
+  auto operand = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getOperand()));
+  auto result =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+
+                                  /*local_shape*/ std::nullopt);
+  auto regionId = toFlatbuffer(cache, op.getRegionId());
+
+  return ::tt::target::ttnn::CreateRegionEndOp(*cache.fbb, operand, result,
+                                               regionId);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::Operation>
@@ -4077,10 +4106,22 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
     return createOperation(cache, createOp(cache, breakpointOp), debugString,
                            locInfo);
   }
+  if (auto printOp = dyn_cast<debug::PrintOp>(op); printOp) {
+    return createOperation(cache, createOp(cache, printOp), debugString,
+                           locInfo);
+  }
   if (auto memorySnapshotOp = dyn_cast<debug::MemorySnapshotOp>(op);
       memorySnapshotOp) {
     return createOperation(cache, createOp(cache, memorySnapshotOp),
                            debugString, locInfo);
+  }
+  if (auto regionStartOp = dyn_cast<debug::RegionStartOp>(op); regionStartOp) {
+    return createOperation(cache, createOp(cache, regionStartOp), debugString,
+                           locInfo);
+  }
+  if (auto regionEndOp = dyn_cast<debug::RegionEndOp>(op); regionEndOp) {
+    return createOperation(cache, createOp(cache, regionEndOp), debugString,
+                           locInfo);
   }
 
   llvm_unreachable("unhandled op in emitTTNNOperation");

--- a/runtime/lib/ttnn/operations/debug/debug.cpp
+++ b/runtime/lib/ttnn/operations/debug/debug.cpp
@@ -22,12 +22,11 @@ void run(const ::tt::target::ttnn::AnnotateOp *op, ProgramContext &context) {
 }
 
 void run(const ::tt::target::ttnn::BreakpointOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &operand =
-      tensorPool.getTTNNTensorAndValidate(op->operand());
-  tensorPool.insertTTNNTensorAndValidate(op->result(), operand);
-
   invoke_pdb();
+}
+
+void run(const ::tt::target::ttnn::PrintOp *op, ProgramContext &context) {
+  LOG_INFO(op->message()->str());
 }
 
 void run(const ::tt::target::ttnn::MemorySnapshotOp *op,
@@ -51,7 +50,16 @@ void run(const ::tt::target::ttnn::MemorySnapshotOp *op,
             << "\n";
   }
   outFile.close();
+}
 
+void run(const ::tt::target::ttnn::RegionStartOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &operand =
+      tensorPool.getTTNNTensorAndValidate(op->operand());
+  tensorPool.insertTTNNTensorAndValidate(op->result(), operand);
+}
+
+void run(const ::tt::target::ttnn::RegionEndOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &operand =
       tensorPool.getTTNNTensorAndValidate(op->operand());

--- a/runtime/lib/ttnn/operations/debug/debug.h
+++ b/runtime/lib/ttnn/operations/debug/debug.h
@@ -12,8 +12,11 @@ namespace tt::runtime::ttnn::operations::debug {
 
 void run(const ::tt::target::ttnn::AnnotateOp *op, ProgramContext &context);
 void run(const ::tt::target::ttnn::BreakpointOp *op, ProgramContext &context);
+void run(const ::tt::target::ttnn::PrintOp *op, ProgramContext &context);
 void run(const ::tt::target::ttnn::MemorySnapshotOp *op,
          ProgramContext &context);
+void run(const ::tt::target::ttnn::RegionStartOp *op, ProgramContext &context);
+void run(const ::tt::target::ttnn::RegionEndOp *op, ProgramContext &context);
 
 } // namespace tt::runtime::ttnn::operations::debug
 

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -510,8 +510,17 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::BreakpointOp: {
     return operations::debug::run(op->type_as_BreakpointOp(), getContext());
   }
+  case ::tt::target::ttnn::OpType::PrintOp: {
+    return operations::debug::run(op->type_as_PrintOp(), getContext());
+  }
   case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
     return operations::debug::run(op->type_as_MemorySnapshotOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::RegionStartOp: {
+    return operations::debug::run(op->type_as_RegionStartOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::RegionEndOp: {
+    return operations::debug::run(op->type_as_RegionEndOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::NONE: {
     LOG_FATAL("Unsupported operation type: ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1315,7 +1315,10 @@ getOpOutputRef(OpContext opContextHandle,
   case ::tt::target::ttnn::OpType::CaptureOrExecuteTraceOp:
   case ::tt::target::ttnn::OpType::NLPCreateQKVHeadsDecodeOp:
   case ::tt::target::ttnn::OpType::SplitQueryKeyValueAndSplitHeadsOp:
-  case ::tt::target::ttnn::OpType::DumpTensorOp: {
+  case ::tt::target::ttnn::OpType::DumpTensorOp:
+  case ::tt::target::ttnn::OpType::BreakpointOp:
+  case ::tt::target::ttnn::OpType::PrintOp:
+  case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
     LOG_WARNING("getting output tensor is not supported for ",
                 ::tt::target::ttnn::EnumNamesOpType()[static_cast<size_t>(
                     opContext.type_type())]);
@@ -1338,12 +1341,12 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_AnnotateOp()->result();
     break;
   }
-  case ::tt::target::ttnn::OpType::BreakpointOp: {
-    tensorRef = opContext.type_as_BreakpointOp()->result();
+  case ::tt::target::ttnn::OpType::RegionStartOp: {
+    tensorRef = opContext.type_as_RegionStartOp()->result();
     break;
   }
-  case ::tt::target::ttnn::OpType::MemorySnapshotOp: {
-    tensorRef = opContext.type_as_MemorySnapshotOp()->result();
+  case ::tt::target::ttnn::OpType::RegionEndOp: {
+    tensorRef = opContext.type_as_RegionEndOp()->result();
     break;
   }
   case ::tt::target::ttnn::OpType::NONE: {
@@ -1820,8 +1823,20 @@ getOpInputRefs(OpContext opContextHandle,
     tensorRefs = {opContext.type_as_AnnotateOp()->operand()};
     break;
   }
+  case ::tt::target::ttnn::OpType::RegionStartOp: {
+    tensorRefs = {opContext.type_as_RegionStartOp()->operand()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::RegionEndOp: {
+    tensorRefs = {opContext.type_as_RegionEndOp()->operand()};
+    break;
+  }
   case ::tt::target::ttnn::OpType::BreakpointOp: {
     tensorRefs = {opContext.type_as_BreakpointOp()->operand()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::PrintOp: {
+    tensorRefs = {opContext.type_as_PrintOp()->operand()};
     break;
   }
   case ::tt::target::ttnn::OpType::MemorySnapshotOp: {

--- a/test/python/golden/debug/test_ttir_debug_ops.py
+++ b/test/python/golden/debug/test_ttir_debug_ops.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import Callable, List, Optional, Tuple, Union
+from collections import OrderedDict
+from functools import reduce
+import operator
+from conftest import x86_only, get_request_kwargs
+
+from builder.base.builder_utils import Operand, Shape, TypeInfo
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir, build_module
+from builder.base.builder_enums import *
+from ttmlir.ir import DenseI32ArrayAttr
+from test_utils import (
+    Marks,
+    shape_str,
+    shapes_list_str,
+    make_shard_shape,
+    shard_wrap_factory,
+)
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_annotate_op(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_annotate(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            annotate0 = builder.annotate(add0, "This is from KV cache")
+            sigmoid0 = builder.sigmoid(annotate0)
+            return sigmoid0
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_breakpoint_op(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_breakpoint(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.breakpoint(add0)
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    build_module(module, "ttir")
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_print_op(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_print(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.print(add0, "execution has reached here")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_memory_snapshot_op(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_memory_snapshot(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.memory_snapshot(add0, "/tmp/memory_dump.txt")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_dump_op(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_dump(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.dump(add0, "/tmp/add0_dump.tensorbin")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_region_ops(target: str, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_regions(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            region_start0 = builder.region_start(add0, "embedding_region")
+            sigmoid0 = builder.sigmoid(region_start0)
+            region_end0 = builder.region_end(sigmoid0, "embedding_region")
+            return region_end0
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )

--- a/test/python/golden/debug/test_ttnn_debug_ops.py
+++ b/test/python/golden/debug/test_ttnn_debug_ops.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import Callable, List, Optional, Tuple, Union
+from collections import OrderedDict
+from functools import reduce
+import operator
+from conftest import x86_only, get_request_kwargs
+
+from builder.base.builder_utils import Operand, Shape, TypeInfo
+from builder.ttnn.ttnn_builder import TTNNBuilder
+from builder.base.builder_apis import compile_and_execute_ttnn, build_module
+from builder.base.builder_enums import *
+from ttmlir.ir import DenseI32ArrayAttr
+from test_utils import (
+    Marks,
+    shape_str,
+    shapes_list_str,
+    make_shard_shape,
+    shard_wrap_factory,
+)
+
+pytestmark = pytest.mark.frontend("ttnn")
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_annotate_op(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_annotate(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            annotate0 = builder.annotate(add0, "This is from KV cache")
+            sigmoid0 = builder.sigmoid(annotate0)
+            return sigmoid0
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_breakpoint_op(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_breakpoint(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.breakpoint(add0)
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    build_module(module, "ttnn")
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_print_op(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_print(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.print(add0, "execution has reached here")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_memory_snapshot_op(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_memory_snapshot(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.memory_snapshot(add0, "/tmp/memory_dump.txt")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_dump_op(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_dump(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            builder.dump_tensor(add0, "/tmp/add0_dump.tensorbin")
+            sigmoid0 = builder.sigmoid(add0)
+            return sigmoid0
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_debug_region_ops(target: str, request, device):
+    def module(builder: TTNNBuilder):
+        @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+        def debug_regions(
+            in0: Operand,
+            in1: Operand,
+            builder: TTNNBuilder,
+        ):
+            add0 = builder.add(in0, in1)
+            region_start0 = builder.region_start(add0, "embedding_region")
+            sigmoid0 = builder.sigmoid(region_start0)
+            region_end0 = builder.region_end(sigmoid0, "embedding_region")
+            return region_end0
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -1866,12 +1866,47 @@ for optimal_module in optimal_modules:
 
 ```python
 def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def debug_breakpoint(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+    ):
+        add0 = builder.add(in0, in1)
+        builder.breakpoint(add0)
+        sigmoid0 = builder.sigmoid(add0)
+        return sigmoid0
 
-  @builder.func([(32, 32)], [torch.float32])
-  def modela(in0: Operand, builder: TTIRBuilder):
-      sigmoid0 = builder.sigmoid(in0)
-      breakpoint0 = builder.breakpoint(sigmoid0)
-      return breakpoint0
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 2)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+## debug dialect print
+
+```python
+def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def debug_print(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+    ):
+        add0 = builder.add(in0, in1)
+        builder.print(add0, "execution has reached here")
+        sigmoid0 = builder.sigmoid(add0)
+        return sigmoid0
 
 import _ttmlir_runtime as tt_runtime
 
@@ -1893,12 +1928,47 @@ tt_runtime.runtime.close_mesh_device(device)
 
 ```python
 def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def debug_memory_snapshot(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+    ):
+        add0 = builder.add(in0, in1)
+        builder.memory_snapshot(add0, "memory_dump.txt")
+        sigmoid0 = builder.sigmoid(add0)
+        return sigmoid0
 
-  @builder.func([(32, 32)], [torch.float32])
-  def modela(in0: Operand, builder: TTIRBuilder):
-      sigmoid0 = builder.sigmoid(in0)
-      memory0 = builder.memory_snapshot(sigmoid0, "sigmoid_memory_snapshot.json")
-      return memory0
+import _ttmlir_runtime as tt_runtime
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 2)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+compile_and_execute_ttir(
+    module0,
+    device=device,
+)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
+## debug dialect dump tensor
+
+```python
+def module0(builder: TTIRBuilder):
+    @builder.func([(32, 32), (32, 32)], [torch.float32, torch.float32])
+    def debug_dump(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+    ):
+        add0 = builder.add(in0, in1)
+        builder.dump(add0, "add0_dump.tensorbin")
+        sigmoid0 = builder.sigmoid(add0)
+        return sigmoid0
 
 import _ttmlir_runtime as tt_runtime
 

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -1264,7 +1264,7 @@ class Builder(metaclass=BuilderMeta):
         self,
         operand: Operand,
         loc: Optional[str] = None,
-    ) -> OpResult:
+    ):
         debug_op = self.get_opview_from_method(Builder.breakpoint)
 
         if loc is None:
@@ -1272,19 +1272,28 @@ class Builder(metaclass=BuilderMeta):
         else:
             loc = Location.name(loc)
 
-        op = debug_op(
-            operand,
-            loc=loc,
-        )
-        op_result = op.result
+        debug_op(operand, loc=loc)
 
-        if not self._disable_golden_check:
-            input0 = self._get_golden_tensor(operand)
-            op_golden_function = get_golden_function(debug_op)
-            golden_output = op_golden_function(input0)
-            self._set_golden_tensor(op_result, golden_output)
+        return
 
-        return op_result
+    @tag(debug.PrintOp)
+    def print(
+        self,
+        operand: Operand,
+        message: str,
+        loc: Optional[str] = None,
+    ):
+        debug_op = self.get_opview_from_method(Builder.print)
+        message_attr = StringAttr.get(message)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        debug_op(operand, message=message_attr, loc=loc)
+
+        return
 
     @tag(debug.MemorySnapshotOp)
     def memory_snapshot(
@@ -1292,7 +1301,7 @@ class Builder(metaclass=BuilderMeta):
         operand: Operand,
         file_path: str,
         loc: Optional[str] = None,
-    ) -> OpResult:
+    ):
         debug_op = self.get_opview_from_method(Builder.memory_snapshot)
         file_path_attr = StringAttr.get(file_path)
 
@@ -1301,9 +1310,47 @@ class Builder(metaclass=BuilderMeta):
         else:
             loc = Location.name(loc)
 
+        debug_op(operand, file_path=file_path_attr, loc=loc)
+
+        return
+
+    @tag(debug.DumpOp)
+    def dump(
+        self,
+        operand: Operand,
+        file_path: str,
+        loc: Optional[str] = None,
+    ):
+        debug_op = self.get_opview_from_method(Builder.dump)
+        file_path_attr = StringAttr.get(file_path)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        debug_op(operand, file_path=file_path_attr, loc=loc)
+
+        return
+
+    @tag(debug.RegionStartOp)
+    def region_start(
+        self,
+        operand: Operand,
+        region_id: str,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        debug_op = self.get_opview_from_method(Builder.region_start)
+        region_id_attr = StringAttr.get(region_id)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
         op = debug_op(
             operand,
-            file_path=file_path_attr,
+            region_id=region_id_attr,
             loc=loc,
         )
         op_result = op.result
@@ -1311,7 +1358,37 @@ class Builder(metaclass=BuilderMeta):
         if not self._disable_golden_check:
             input0 = self._get_golden_tensor(operand)
             op_golden_function = get_golden_function(debug_op)
-            golden_output = op_golden_function(input0, file_path_attr)
+            golden_output = op_golden_function(input0, region_id_attr)
+            self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @tag(debug.RegionEndOp)
+    def region_end(
+        self,
+        operand: Operand,
+        region_id: str,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        debug_op = self.get_opview_from_method(Builder.region_end)
+        region_id_attr = StringAttr.get(region_id)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = debug_op(
+            operand,
+            region_id=region_id_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if not self._disable_golden_check:
+            input0 = self._get_golden_tensor(operand)
+            op_golden_function = get_golden_function(debug_op)
+            golden_output = op_golden_function(input0, region_id_attr)
             self._set_golden_tensor(op_result, golden_output)
 
         return op_result

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -4587,6 +4587,50 @@ class TTNNBuilder(Builder):
 
         return new_op, {old_op.result: new_op_result}
 
+    ############### ttnn.DumpTensorOp ###############
+
+    @tag(ttnn.DumpTensorOp)
+    def dump_tensor(
+        self,
+        in0: Operand,
+        file_path: str,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> None:
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.dump_tensor)
+        file_path_attr = StringAttr.get(file_path)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        ttnn_op(
+            file_path_attr,
+            in0,
+            loc=loc,
+        )
+
+        return
+
+    @parse(ttnn.DumpTensorOp)
+    def dump_tensor_parser(
+        self,
+        old_op: ttnn.DumpTensorOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(TTNNBuilder.dump_tensor_parser)
+        in0 = global_dict[old_op.input]
+
+        ttnn_op(
+            old_op.file_path,
+            in0,
+            loc=old_op.location,
+        )
+
+        return None, {}
+
     def _op_proxy_l1_sharded_executed_op_with_dram_final_output(
         self,
         op_function: Callable,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -5900,15 +5900,16 @@ def debug_annotate_golden(
     return input_tensor.clone()
 
 
-def debug_breakpoint_golden(
+def debug_region_start_golden(
     input_tensor: GoldenMapTensor,
+    region_id_attr: StringAttr,
 ) -> GoldenMapTensor:
     return input_tensor.clone()
 
 
-def debug_memory_snapshot_golden(
+def debug_region_end_golden(
     input_tensor: GoldenMapTensor,
-    file_path_attr: StringAttr,
+    region_id_attr: StringAttr,
 ) -> GoldenMapTensor:
     return input_tensor.clone()
 
@@ -6202,8 +6203,8 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.ClampTensorOp: ttnn_clamp_tensor_golden,
     # ----- DEBUG OPS -----
     debug.AnnotateOp: debug_annotate_golden,
-    debug.BreakpointOp: debug_breakpoint_golden,
-    debug.MemorySnapshotOp: debug_memory_snapshot_golden,
+    debug.RegionStartOp: debug_region_start_golden,
+    debug.RegionEndOp: debug_region_end_golden,
 }
 
 


### PR DESCRIPTION
This PR adds improvements to debug dialect ops. We now support the following

- debug.annotate
- debug.breakpoint
- debug.print
- debug.dump (this gets lowered into ttnn.dump_tensor)
- debug.memory_snapshot
- debug.region_start / debug.region_end