### PR TITLE
[EIO] Add @mvasiljevicTT as CODEOWNER for EraseInverseOps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,9 +108,9 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /test/unittests/Allocation @tenstorrent/forge-developers-mlir-d2m
 
 # TTIR Erase Inverse Ops Optimization Pass
-/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT
-/lib/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT
-/test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @azecevicTT @odjuricicTT
+/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT @mvasiljevicTT
+/lib/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT @mvasiljevicTT
+/test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @azecevicTT @odjuricicTT @mvasiljevicTT
 
 # TTIR Fusing Passes
 /lib/Dialect/TTIR/Transforms/TTIRFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT


### PR DESCRIPTION
Added @mvasiljevicTT as CODEOWNER on files related to Erase Inverse Ops pass, as agreed with @odjuricicTT
