### PR TITLE
Add @mvasiljevicTT as CODEOWNER for TTIRFusing and TTNNFusing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,8 +113,8 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @azecevicTT @odjuricicTT @mvasiljevicTT
 
 # TTIR Fusing Passes
-/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT
-/test/ttmlir/Dialect/TTIR/fusing/ @tenstorrent/forge-developers-mlir-core @odjuricicTT
+/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
+/test/ttmlir/Dialect/TTIR/fusing/ @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
 
 # TTNN Dialects
 /include/ttmlir/Dialect/TTNN/ @tenstorrent/forge-developers-mlir-core
@@ -142,8 +142,8 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /test/unittests/TestScheduler/ @tenstorrent/forge-developers-mlir-optimizer
 
 # TTNN Fusing Passes
-/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT
-/test/ttmlir/Dialect/TTNN/fusing/ @tenstorrent/forge-developers-mlir-core @odjuricicTT
+/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
+/test/ttmlir/Dialect/TTNN/fusing/ @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT
 
 # LLVM Target
 /include/ttmlir/Target/LLVM/ @vwellsTT @mtopalovicTT


### PR DESCRIPTION
Added @mvasiljevicTT as CODEOWNER for TTIR and TTNN fusing files, as agreed with @odjuricicTT.