### PR TITLE
ASan fixes

### DIFF
--- a/include/ttmlir/Target/Python/Utils.h
+++ b/include/ttmlir/Target/Python/Utils.h
@@ -22,14 +22,13 @@ namespace mlir::ttmlir::python {
 
 inline nb::capsule wrapInCapsule(std::shared_ptr<void> underlying) {
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  std::shared_ptr<void> *binary = static_cast<std::shared_ptr<void> *>(
-      std::malloc(sizeof(std::shared_ptr<void>)));
+  auto *binary = new std::shared_ptr<void>(std::move(underlying));
   assert(binary);
-  *binary = underlying;
   return nb::capsule(
-      static_cast<void *>(
-          binary), // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-      +[](void *data) noexcept { std::free(data); });
+      static_cast<void *>(binary), +[](void *data) noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        delete static_cast<std::shared_ptr<void> *>(data);
+      });
 }
 
 } // namespace mlir::ttmlir::python

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5200,7 +5200,7 @@ private:
     RankedTensorType updateType =
         mlir::cast<RankedTensorType>(op.getUpdates()[0].getType());
     RankedTensorType indexType = indexTensor.getType();
-    ArrayRef<int64_t> indexShape = indexType.getShape();
+    llvm::SmallVector<int64_t> indexShape(indexType.getShape());
     ArrayRef<int64_t> updateShape = updateType.getShape();
 
     if (indexShape.size() < updateShape.size()) {

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1155,8 +1155,8 @@ void d2m::GenericOp::build(mlir::OpBuilder &builder,
         ttmlir::utils::concatInversePermutationMap(maps, /*reverse=*/true);
 
     SmallVector<int64_t> flattenedOperandGridShapes;
-    for (Value v :
-         llvm::reverse(llvm::to_vector(llvm::concat<Value>(inputs, outputs)))) {
+    const auto values = llvm::to_vector(llvm::concat<Value>(inputs, outputs));
+    for (Value v : llvm::reverse(values)) {
       auto shapedType = mlir::cast<ShapedType>(v.getType());
       ttcore::DeviceLayoutInterface layout =
           ttcore::getDeviceLayout(shapedType);

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -98,8 +98,9 @@ computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
   // Find the largest factor of the sharded dimension that fits within the
   // target grid volume.
   int64_t bestFactor = 0;
-  for (int64_t factor : llvm::reverse(
-           ttmlir::utils::getFactors(physicalShape[shardedDimIndex]))) {
+  const auto factors =
+      ttmlir::utils::getFactors(physicalShape[shardedDimIndex]);
+  for (int64_t factor : llvm::reverse(factors)) {
     if (factor <= targetGridVolume) {
       auto physGrid =
           utils::findLegalPhysicalGridForVolume(factor, targetSquareGridShape);

--- a/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
+++ b/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
@@ -13,7 +13,7 @@ func.func @test_expression_no_terminator(%arg0: !emitpy.opaque<"int">) -> !emitp
 // -----
 
 // Test: Yield must provide a value
-// Note: This test actually triggers a different error since yield is defined within expression
+// Note: This test triggers compiler heap overflow since yield is defined within expression
 func.func @test_expression_yield_no_value(%arg0: !emitpy.opaque<"float">) -> !emitpy.opaque<"float"> {
   // expected-error @+1 {{yielded value not defined within expression}}
   %0 = "emitpy.expression"(%arg0) ({


### PR DESCRIPTION
Fix several issues caught by ASan:
- Avoid creating `ArrayRef` of temporary objects.
- Use `new/delete` to properly construct & destruct `std::shared_ptr`.