### PR TITLE
Changed float casting

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3653,7 +3653,8 @@ public:
       if (auto constOp =
               initValue_.getDefiningOp<mlir::stablehlo::ConstantOp>()) {
         auto valAttr = mlir::cast<DenseFPElementsAttr>(constOp.getValue());
-        fillValue = valAttr.getValues<APFloat>()[0].convertToFloat();
+        fillValue = static_cast<float>(
+            valAttr.getValues<APFloat>()[0].convertToDouble());
       } else {
         llvm::report_fatal_error("initValue_ must be a stablehlo.constant");
       }


### PR DESCRIPTION
In the reduce-window lowering pattern, the initial fill value is extracted from a `DenseFPElementsAttr`. Previously, `APFloat::convertToFloat()` was called directly, which asserts when the StableHLO graph contains a reduce-window op with a non-f32 init value. The fix replaces `convertToFloat()` with `convertToDouble()` (which handles any floating-point semantics) followed by a `static_cast<float>`.