### PR TITLE
[tt-explorer] Pull metal deps based on tt-mlir's tt-metal commit hash

### DIFF
--- a/tools/explorer/Dockerfile.explorer
+++ b/tools/explorer/Dockerfile.explorer
@@ -79,11 +79,18 @@ rm -rf /var/lib/apt/lists/*
 EOT
 
 # Download and run TT-Metal dependencies installer
+ARG TT_METAL_COMMIT
 RUN <<EOT
 set -e
-wget https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/install_dependencies.sh
-wget https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/sfpi-version
-wget https://raw.githubusercontent.com/tenstorrent/tt-metal/refs/heads/main/tt_metal/sfpi-info.sh
+if [ -z "${TT_METAL_COMMIT}" ]; then
+    echo "ERROR: TT_METAL_COMMIT build arg is required"
+    exit 1
+fi
+echo "Using tt-metal commit: ${TT_METAL_COMMIT}"
+
+wget https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_COMMIT}/install_dependencies.sh
+wget https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_COMMIT}/tt_metal/sfpi-version
+wget https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_COMMIT}/tt_metal/sfpi-info.sh
 chmod u+x install_dependencies.sh sfpi-info.sh
 bash install_dependencies.sh --docker
 rm install_dependencies.sh

--- a/tools/explorer/hosted/Makefile
+++ b/tools/explorer/hosted/Makefile
@@ -2,6 +2,9 @@
 
 .PHONY: help build up down logs shell clean restart status local-up local-down local-logs local-build
 
+# Extract TT_METAL_COMMIT from third_party/CMakeLists.txt (must match tt-mlir's pinned version)
+export TT_METAL_COMMIT := $(shell sed -n 's/set(TT_METAL_VERSION "\([^"]*\)").*/\1/p' ../../../third_party/CMakeLists.txt)
+
 # Default target
 help:
 	@echo "TT-Explorer Docker Compose Management"
@@ -58,9 +61,11 @@ setup:
 
 # Production targets
 build:
+	@if [ -z "$(TT_METAL_COMMIT)" ]; then echo "ERROR: Failed to extract TT_METAL_COMMIT from CMakeLists.txt"; exit 1; fi
 	docker compose -p tt-explorer -f docker-compose.yml build
 
 build-full:
+	@if [ -z "$(TT_METAL_COMMIT)" ]; then echo "ERROR: Failed to extract TT_METAL_COMMIT from CMakeLists.txt"; exit 1; fi
 	docker compose -p tt-explorer -f docker-compose.yml build --no-cache
 
 up:
@@ -74,6 +79,7 @@ logs:
 
 # Local development targets
 local-build:
+	@if [ -z "$(TT_METAL_COMMIT)" ]; then echo "ERROR: Failed to extract TT_METAL_COMMIT from CMakeLists.txt"; exit 1; fi
 	docker compose -f docker-compose.local.yml build
 
 local-up:

--- a/tools/explorer/hosted/docker-compose.local.yml
+++ b/tools/explorer/hosted/docker-compose.local.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile.explorer
+      args:
+        TT_METAL_COMMIT: ${TT_METAL_COMMIT}
     container_name: tt-explorer-app-local
     restart: unless-stopped
     command: ["-u", "0.0.0.0", "-x"]

--- a/tools/explorer/hosted/docker-compose.yml
+++ b/tools/explorer/hosted/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile.explorer
+      args:
+        TT_METAL_COMMIT: ${TT_METAL_COMMIT}
     container_name: tt-explorer-app
     restart: unless-stopped
     command: ["-u", "0.0.0.0", "-x"]


### PR DESCRIPTION
### Problem description
tt-explorer's hosted app failing to update due to mismatching deps. When building the explorer Docker we were pulling tt-metals deps from main, which can be different from deps versions in tt-mlir's tt-metal commit, causing conflicts during the build and publishing job.

### What's changed
Pulling tt-metal deps from the same commit as in third_party/CMakefile.txt

### Checklist
- [x] Tested changes directly on VM and I was able to pull the latests changes a build the app
