### PR TITLE
Add LLVM affine symbol-vars patch to env toolchain build.

### DIFF
--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -52,7 +52,7 @@ if(TTMLIR_BUILD_LLVM)
         llvm-project
         # Super hacky way to install the python dependencies before the build
         # Sync nanobind with tt-metal's pinned version to avoid ODR violations
-        PATCH_COMMAND bash -c "source ${CMAKE_CURRENT_SOURCE_DIR}/activate && pip install -r mlir/python/requirements.txt && pip install --force-reinstall 'nanobind==2.10.2'"
+        PATCH_COMMAND bash -c "source ${CMAKE_CURRENT_SOURCE_DIR}/activate && pip install -r mlir/python/requirements.txt && pip install --force-reinstall 'nanobind==2.10.2' && git config user.email \"tt-mlir@tenstorrent.com\" && git config user.name \"tenstorrent\" && git apply --index \"${CMAKE_CURRENT_LIST_DIR}/patches/affine-allow-symbol-vars.patch\" && git commit -m \"tt-mlir related patch\""
         CMAKE_GENERATOR Ninja
         CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${LLVM_BUILD_TYPE}

--- a/env/patches/affine-allow-symbol-vars.patch
+++ b/env/patches/affine-allow-symbol-vars.patch
@@ -1,0 +1,24 @@
+--- a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
++++ b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+@@ -1055,12 +1055,6 @@
+     LDBG() << "Unable to compute source's domain";
+     return std::nullopt;
+   }
+-  // As the set difference utility currently cannot handle symbols in its
+-  // operands, validity of the slice cannot be determined.
+-  if (srcConstraints.getNumSymbolVars() > 0) {
+-    LDBG() << "Cannot handle symbols in source domain";
+-    return std::nullopt;
+-  }
+   // TODO: Handle local vars in the source domains while using the 'projectOut'
+   // utility below. Currently, aligning is not done assuming that there will be
+   // no local vars in the source domain.
+@@ -1081,6 +1075,8 @@
+   // domain completely in terms of source's IVs.
+   sliceConstraints.projectOut(ivs.size(),
+                               sliceConstraints.getNumVars() - ivs.size());
++  srcConstraints.projectOut(ivs.size(),
++                            srcConstraints.getNumVars() - ivs.size());
+
+   LDBG() << "Domain of the source of the slice:\n"
+          << "Source constraints:" << srcConstraints


### PR DESCRIPTION
Applies very small code changes in https://github.com/llvm/llvm-project/pull/180709 to unblock use of affine loop fusion ahead of LLVM uplift.