### PR TITLE
d2m: broadcast non tiled dim

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -765,18 +765,13 @@ private:
     std::tie(bcastIndexingMaps, tileBcastTypes) =
         getImplicitBcastInfo(rewriter, origInputs, origOutputs);
 
-    const bool hasTileBcast = llvm::any_of(tileBcastTypes, [](auto type) {
-      return type != d2m::TileBcastType::None;
-    });
     // Implicit bcast if tile-level bcast exists or any input indexing map is
     // not identity.
-    const bool hasBroadcastIndexingMap =
+    const bool isImplicitBcast =
         !bcastIndexingMaps.empty() &&
         llvm::any_of(ArrayRef<mlir::AffineMap>(bcastIndexingMaps)
                          .take_front(origInputs.size()),
                      [](mlir::AffineMap map) { return !map.isIdentity(); });
-    const bool isImplicitBcast = hasTileBcast || hasBroadcastIndexingMap;
-
     auto [inputs, outputs] =
         toLayoutOperandsAndResults(rewriter, {origInputs, origOutputs},
                                    /*tiled*/ true, isImplicitBcast);

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
@@ -211,49 +211,6 @@ def test_binary_ops(
     )
 
 
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [(1, 2, 1, 32), (1, 1, 1, 32)],
-        [(1, 16, 1, 32), (1, 1, 1, 32)],
-        [(1, 1, 1, 32), (1, 2, 1, 32)],  # broadcast dim1
-        [(2, 2, 1, 32), (1, 2, 1, 32)],  # broadcast dim0
-    ],
-    ids=shapes_list_str,
-)
-@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize(
-    "test_fn",
-    [add, subtract, multiply],
-    ids=["add", "subtract", "multiply"],
-)
-def test_binary_ops_broadcast_shard_dims(
-    test_fn: Callable,
-    shapes: List[Shape],
-    dtype: torch.dtype,
-    target: str,
-    request,
-    device,
-):
-    def module(builder: TTIRBuilder):
-        @builder.func(shapes, [dtype, dtype])
-        def binary_broadcast(
-            in0: Operand,
-            in1: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            return test_fn(in0, in1, builder, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        module,
-        **get_request_kwargs(request),
-        target=target,
-        device=device,
-    )
-
-
 # Logical binary ops with custom golden tensors containing mix of 0s and non-0s
 logical_ops = [
     logical_and,
@@ -920,6 +877,57 @@ def test_implicit_bcast_inner_2D(
             )
             in_F1 = builder.add(in_C1, in_R1, unit_attrs=unit_attrs)
             return builder.add(in_F1, in_S0, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [(1, 2, 1, 32), (1, 1, 1, 32)],
+        [(1, 16, 1, 32), (1, 1, 1, 32)],
+        [(1, 1, 1, 32), (1, 2, 1, 32)],  # broadcast dim1
+        [(2, 2, 1, 32), (1, 2, 1, 32)],  # broadcast dim0
+        # 3D shape
+        [(1, 16, 32), (1, 16, 32)],
+        # 5D shape
+        [(1, 1, 1, 32, 32), (1, 1, 8, 32, 32)],
+        # Larger tensors
+        [(1, 2, 64, 64), (1, 1, 64, 64)],
+        [(1, 4, 64, 128), (1, 1, 64, 128)],
+        [(1, 1, 8, 64, 64), (1, 1, 1, 64, 64)],
+    ],
+    ids=shapes_list_str,
+)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize(
+    "test_fn",
+    [add, subtract, multiply],
+    ids=["add", "subtract", "multiply"],
+)
+def test_binary_ops_broadcast_shard_dims(
+    test_fn: Callable,
+    shapes: List[Shape],
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, [dtype, dtype])
+        def binary_broadcast(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return test_fn(in0, in1, builder, unit_attrs=unit_attrs)
 
     compile_and_execute_ttir(
         module,


### PR DESCRIPTION
### Ticket
Resolves #7064 

### Problem description
isImplicitBcast was true only if tileBcastTypes had row/col/scalar broadcast. That only captures broadcast in tile-local dims, not broadcast on earlier tensor dims.

Also added builder test. 