### PR TITLE
[D2M] Split semaphore_wait properly during DMA lowering

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -325,6 +325,10 @@ def D2M_GenericOp
                getIndexingMaps().empty() &&
                getIteratorTypes().empty();
       }
+      bool isUnifiedForm() {
+        return getNumRegions() == 1 &&
+               getRegionThreadType(0) == ThreadType::Unified;
+      }
       bool isExternalSymbolForm() { return getRegions().empty(); }
       SmallVector<SmallVector<int64_t>> getOperandGridShapes();
       SmallVector<int64_t> getLoopBounds();

--- a/include/ttmlir/Dialect/D2M/Utils/DMAUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/DMAUtils.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_UTILS_DMAUTILS_H
+#define TTMLIR_DIALECT_D2M_UTILS_DMAUTILS_H
+
+#include "mlir/IR/Block.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::d2m::utils {
+
+// Recursively check that there are no illegal semaphore ops in a block and its
+// nested regions. Semaphore_inc, semaphore_set, and semaphore_wait with reset
+// are not supported in regions that will be replicated across multiple threads,
+// as all threads would execute the operation, creating a race condition on the
+// shared semaphore.
+LogicalResult checkForIllegalSemaphoreOps(Block *block);
+
+} // namespace mlir::tt::d2m::utils
+
+#endif

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
@@ -1623,6 +1624,14 @@ static mlir::LogicalResult verifyAffineBlocking(
                              opGridMap, opGridShape, emitDiag);
     if (failed(blockFactorResult)) {
       return blockFactorResult;
+    }
+  }
+
+  // Unified form will be replicated across compute and datamovement threads.
+  // Reject semaphore ops that would create race conditions when replicated.
+  if (isUnifiedForm()) {
+    if (failed(utils::checkForIllegalSemaphoreOps(&getRegion(0).front()))) {
+      return failure();
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -170,6 +171,13 @@ public:
       return failure();
     }
     Block *dmBlock = &dmRegion.front();
+
+    // Check that there are no illegal semaphore ops in the datamovement region.
+    // Replicating these across multiple threads would create a race condition
+    // on the shared semaphore.
+    if (failed(utils::checkForIllegalSemaphoreOps(dmBlock))) {
+      return failure();
+    }
 
     // Collect all DMA operations and their CB associations.
     SmallVector<std::pair<Operation *, unsigned>> dmaOps;

--- a/lib/Dialect/D2M/Utils/CMakeLists.txt
+++ b/lib/Dialect/D2M/Utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRD2MUtils
+  DMAUtils.cpp
   Utils.cpp
   AffineMapAnalysis.cpp
   VirtualGrid.cpp

--- a/lib/Dialect/D2M/Utils/DMAUtils.cpp
+++ b/lib/Dialect/D2M/Utils/DMAUtils.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
+
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+
+namespace mlir::tt::d2m::utils {
+
+LogicalResult checkForIllegalSemaphoreOps(Block *block) {
+  for (Operation &op : block->getOperations()) {
+    if (isa<SemaphoreIncOp>(&op)) {
+      return op.emitError()
+             << "semaphore_inc is not supported in regions that will be "
+                "replicated across multiple threads, as all threads would "
+                "increment the semaphore, creating a race condition on the "
+                "shared semaphore.";
+    }
+    if (isa<SemaphoreSetOp>(&op)) {
+      return op.emitError()
+             << "semaphore_set is not supported in regions that will be "
+                "replicated across multiple threads, as all threads would "
+                "set the semaphore, creating a race condition on the "
+                "shared semaphore.";
+    }
+    if (auto waitOp = dyn_cast<SemaphoreWaitOp>(&op)) {
+      if (waitOp.getResetValue()) {
+        return waitOp.emitError()
+               << "semaphore_wait with reset is not supported in regions that "
+                  "will be replicated across multiple threads, as all threads "
+                  "would execute the reset, creating a race condition on the "
+                  "shared semaphore.";
+      }
+    }
+    for (Region &region : op.getRegions()) {
+      if (!region.empty()) {
+        if (failed(checkForIllegalSemaphoreOps(&region.front()))) {
+          return failure();
+        }
+      }
+    }
+  }
+  return success();
+}
+
+} // namespace mlir::tt::d2m::utils

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
@@ -1,0 +1,130 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-split-unified-thread %s 2>&1 | FileCheck %s
+
+// This test file verifies that d2m.semaphore_wait ops (without reset values) are
+// properly replicated when splitting a unified thread into datamovement and compute
+// regions.
+//
+// IMPORTANT: d2m.semaphore_wait with reset values are NOT supported in unified thread
+// form. The pass will emit an error if a semaphore_wait with reset is encountered,
+// because replicating the reset across both threads would break synchronization.
+// Use separate d2m.semaphore_set ops if reset functionality is needed.
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [1 : i32], [ 0x0x0x0]>
+
+module attributes {ttcore.system_desc = #system_desc} {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+
+  // Test 1: semaphore_wait alongside remote_load
+  // Verifies:
+  // - semaphore_wait is replicated into both datamovement and compute regions
+  // - remote_load remains only in datamovement
+  // - compute ops (wait, linalg.generic, pop) remain only in compute
+  // - relative order of semaphore_wait is preserved in each region
+  // CHECK-LABEL: func.func @test_semaphore_wait_with_remote_load
+  // CHECK: d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+  func.func @test_semaphore_wait_with_remote_load(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>) {
+    %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+    %stream = "d2m.stream_layout"(%arg0, %alloc_0) : (memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #dram>
+
+    // CHECK: ^datamovement0
+    // CHECK: scf.for
+    // CHECK: d2m.core_index(0)
+    // CHECK: d2m.core_index(1)
+    // CHECK: scf.for
+    // CHECK: arith.addi
+    // CHECK: arith.addi
+    // CHECK: d2m.remote_load %{{.*}}[%{{.*}}, %{{.*}}] into %{{.*}}
+    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK-NOT: d2m.wait
+    // CHECK-NOT: linalg.generic
+    // CHECK-NOT: d2m.pop
+
+    // CHECK: ^compute0
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK: d2m.wait %{{.*}}
+    // CHECK: linalg.generic
+    // CHECK: d2m.pop %{{.*}}
+    // CHECK-NOT: d2m.remote_load
+    // CHECK-NOT: d2m.core_index
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%stream : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #dram>)
+        outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    ^unified0(%cb0: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>, %cb1: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>, %sem0: !d2m.semaphore):
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg1 = %c0 to %c1 step %c1 {
+        %core0 = d2m.core_index(0) : index
+        %core1 = d2m.core_index(1) : index
+        scf.for %arg2 = %c0 to %c1 step %c1 {
+          %0 = arith.addi %core0, %arg1 : index
+          %1 = arith.addi %core1, %arg2 : index
+          d2m.remote_load %stream[%0, %1] into %cb0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<map(4)>, #dram> into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+          d2m.semaphore_wait %sem0, %c1
+          %2 = d2m.wait %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%2 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%2 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %3 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %3 : !ttcore.tile<32x32, f32>
+          }
+          d2m.pop %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+        } {d2m.outer_loop}
+      } {d2m.outer_loop}
+    }
+    return
+  }
+
+  // Test 2: semaphore_wait with no remote ops
+  // Verifies semaphore_wait is replicated even when the datamovement region
+  // has no remote_load or remote_store.
+  // CHECK-LABEL: func.func @test_semaphore_wait_no_remote
+  // CHECK: d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
+  func.func @test_semaphore_wait_no_remote(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+
+    // CHECK: ^datamovement0
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK-NOT: d2m.wait
+    // CHECK-NOT: linalg.generic
+    // CHECK-NOT: d2m.pop
+
+    // CHECK: ^compute0
+    // CHECK: scf.for
+    // CHECK: scf.for
+    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK: d2m.wait %{{.*}}
+    // CHECK: linalg.generic
+    // CHECK: d2m.pop %{{.*}}
+    // CHECK-NOT: d2m.remote_load
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%arg0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+        outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    ^unified0(%cb0: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>, %cb1: !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>, %sem0: !d2m.semaphore):
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg1 = %c0 to %c1 step %c1 {
+        scf.for %arg2 = %c0 to %c1 step %c1 {
+          d2m.semaphore_wait %sem0, %c1
+          %0 = d2m.wait %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%0 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
+          ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
+            %1 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+            linalg.yield %1 : !ttcore.tile<32x32, f32>
+          }
+          d2m.pop %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+        } {d2m.outer_loop}
+      } {d2m.outer_loop}
+    }
+    return
+  }
+}


### PR DESCRIPTION
Semaphore waits are replicated to all split regions in `SplitUnifiedThread` and `ScheduleDMA` passes.

Semaphore wait _with optional reset value_, semaphore set, and semaphore inc are all illegal in Unified generic op form (for now). It isn't clear there is a need for more semaphore operations, nor how they should be implemented.