### PR TITLE
Fix main: Builder test failing pcc: test_polygamma

### DIFF
--- a/test/python/golden/test_composite_functions.py
+++ b/test/python/golden/test_composite_functions.py
@@ -408,6 +408,11 @@ def test_polygamma(
     request,
     device,
 ):
+    if k == 1:
+        pytest.skip(
+            "Failing PCC. Issue: https://github.com/tenstorrent/tt-mlir/issues/7089"
+        )
+
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         # choose


### PR DESCRIPTION
### Problem description
The following test is failing pcc on main:
`test/python/golden/test_composite_functions.py::test_polygamma[ttmetal-f32-shape0-1]`
Resulting in `on push` being red. This PR skips the test so that we're back to green until the actual issue is root caused.
Issues to track the actual failure: https://github.com/tenstorrent/tt-mlir/issues/7089 https://github.com/tenstorrent/tt-mlir/issues/7084


### Link to GH actions
- [X] [On push GH action](https://github.com/tenstorrent/tt-mlir/actions/runs/22149228196) ✅ 
- [X] [On PR GH action](https://github.com/tenstorrent/tt-mlir/actions/runs/22149213919) ✅ 
- [X] [Link to the first failed on-push prior to this PR](https://github.com/tenstorrent/tt-mlir/actions/runs/22106703345)

### Checklist
- [X] New/Existing tests provide coverage for changes
