### PR TITLE
fix(ttrt): add torch>=2.3.0 to install_requires

### DIFF
--- a/tools/ttrt/setup.py
+++ b/tools/ttrt/setup.py
@@ -44,6 +44,7 @@ perflibs = []
 metallibs = []
 install_requires = []
 install_requires += ["nanobind==2.10.2"]
+install_requires += ["torch>=2.3.0"]
 
 if enable_ttnn:
     runlibs += ["_ttnncpp.so"]


### PR DESCRIPTION
## Summary
Fixes #3480

Adds `torch>=2.3.0` to `install_requires` in `tools/ttrt/setup.py` so that `pip install ttrt` pulls in a compatible PyTorch version automatically.

## Details

- Users who already have torch installed (including CPU-only builds) satisfy the constraint - no forced reinstall.
- Users installing `ttrt` fresh get a working torch from PyPI.
- The existing `requirements.txt` pins `torch==2.7.0` with CPU index URL for development/CI use, which is unaffected.

## Testing

- Verified `pip install .` in a clean venv correctly pulls torch.
- Verified existing installs with torch already present are not modified.