### PR TITLE
D2M: concat op

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -52,6 +52,31 @@ def D2M_ViewLayoutOp
   let hasCanonicalizer = 1;
 }
 
+def D2M_CompositeViewOp : D2M_Op<"composite_view",
+                                 [Pure, D2M_ViewOpInterface,
+                                  DeclareOpInterfaceMethods<D2M_ViewOpInterface,
+                                                            ["getInput",
+                                                             "isComposite",
+                                                             "getCompositeInputs"]>,
+                                  DeclareOpInterfaceMethods<BufferizableOpInterface,
+                                                            ["bufferizesToMemoryRead",
+                                                             "bufferizesToMemoryWrite",
+                                                             "bufferize",
+                                                             "getAliasingValues",
+                                                             "getBufferType"]>]> {
+  let summary = "Piecewise view over multiple input tensors";
+  let description = [{
+    Represents a piecewise-affine view that aggregates multiple input tensors
+    along a certain dimension.
+  }];
+
+  let arguments = (ins Variadic<AnyRankedTensorOrMemRef>:$inputs, SI32Attr:$dim);
+
+  let results = (outs AnyRankedTensorOrMemRef:$result);
+
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Layout transition and streaming ops (D2M variants)
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
@@ -61,7 +61,7 @@ def D2M_ViewOpInterface : OpInterface<"ViewOpInterface"> {
   let cppNamespace = "::mlir::tt::d2m";
   let methods = [
     InterfaceMethod<
-      /*desc=*/[{Get the input of the view op.}],
+      /*desc=*/[{Get the (only) input of the view op.}],
       /*retTy=*/"mlir::Value",
       /*methodName=*/"getInput"
     >,
@@ -71,12 +71,20 @@ def D2M_ViewOpInterface : OpInterface<"ViewOpInterface"> {
       /*methodName=*/"getResult"
     >,
     InterfaceMethod<
-      /*desc=*/[{Recursively apply view ops until a shard layout is reached, returning underlying memref and view map.}],
-      /*retTy=*/"std::pair<mlir::MemRefType, mlir::AffineMap>",
-      /*methodName=*/"applyViews",
+      /*desc=*/[{Return whether this is a composite view or not.}],
+      /*retTy=*/"bool",
+      /*methodName=*/"isComposite",
       /*args=*/(ins),
       /*methodBody=*/"",
-      /*defaultImplementation=*/"return ::mlir::tt::d2m::applyViews($_op);"
+      /*defaultImplementation=*/"return false;"
+    >,
+    InterfaceMethod<
+      /*desc=*/[{Get all the inputs of the (potentially composite) view op.}],
+      /*retTy=*/"mlir::SmallVector<mlir::Value>",
+      /*methodName=*/"getCompositeInputs",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return {$_op.getInput()};"
     >,
   ];
 }

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -898,6 +898,17 @@ def D2MLowerLoadStoreOpsToDMA : Pass<"d2m-lower-load-store-ops-to-dma", "::mlir:
   let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
 }
 
+def D2MExpandDMAReadCompositeView : Pass<"d2m-expand-dma-read-composite-view", "::mlir::ModuleOp"> {
+  let summary = "Expand shard-level DMA reads that act on composite views.";
+  let description = [{
+    This pass expands GenericOps that contain shard-level DMA reads that act on
+    composite views. The original "place holder" composite view operand is
+    replaced with the list of the actual inputs. The dma read is expanded to
+    an if-else chain of fully-indexed DMA reads that assembles the inputs.
+  }];
+  let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
+}
+
 def D2MLowerDMAToFullyIndexedForm : Pass<"d2m-lower-dma-to-fully-indexed-form", "::mlir::ModuleOp"> {
   let summary = "Lower shard-level DMA ops to fully indexed form.";
   let description = [{

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -116,6 +116,16 @@ AffineMap getMemoryMap(ttcore::DeviceAttr device,
                        std::pair<MemRefType, AffineMap> memrefAndView,
                        size_t pageSize, size_t baseOffset = 0);
 
+// User-facing get memory map util function.
+AffineMap getMemoryMap(ttcore::DeviceAttr device, Value input, bool isRemote);
+
+template <typename Builder>
+SmallVector<Value> applyMap(Builder &builder, Location loc, AffineMap map,
+                            ValueRange index, bool isRemote);
+
+std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+getLoopBounds(OpBuilder &builder, Location loc, ArrayRef<int64_t> shardShape);
+
 // Finds a 2D grid (y, x) such that y * x = gridVolume. The returned grid aims
 // to be as square as possible while respecting the provided target grid shape
 // bounds. If either MxN or NxM grids are feasible where M > N, MxN is chosen.

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -1717,6 +1717,51 @@ private:
 };
 } // namespace
 
+namespace {
+class D2MConcatRewriter final
+    : public mlir::OpConversionPattern<ttir::ConcatOp>,
+      D2MNamedRewriterCommon {
+  using ConcreteOp = ttir::ConcatOp;
+
+public:
+  D2MConcatRewriter(const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
+                    ttcore::MemorySpace defaultInputMemSpace,
+                    ttcore::MemorySpace defaultOutputMemSpace,
+                    bool /*ttnnMode*/, bool /*collapseTensors*/,
+                    bool enableMulticastInference)
+      : OpConversionPattern<ConcreteOp>(typeConverter, ctx),
+        D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
+                               /*ttnnMode=*/false, /*collapseTensors=*/false,
+                               enableMulticastInference) {}
+
+  LogicalResult
+  matchAndRewrite(ConcreteOp op, typename ConcreteOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const final {
+    auto origInputs = adaptor.getOperands();
+    assert(origInputs.size() > 1);
+
+    auto origOutputs =
+        createDpsOutputs(op.getLoc(), rewriter, {op.getResult().getType()});
+
+    auto [inputs, outputs] =
+        toLayoutOperandsAndResults(rewriter, {origInputs, origOutputs},
+                                   /*tiled=*/true, /*noCollapse=*/true);
+
+    int32_t dim = op.getDim();
+    if (dim < 0) {
+      dim += mlir::cast<RankedTensorType>(origInputs[0].getType()).getRank();
+    }
+
+    auto compositeView = rewriter.create<d2m::CompositeViewOp>(
+        op.getLoc(), outputs[0].getType(), inputs, dim);
+
+    rewriter.replaceOp(op, unLayoutResult(rewriter, compositeView->getResult(0),
+                                          op.getResult().getType()));
+    return success();
+  }
+};
+} // namespace
+
 // Conversion for ttir.to_layout -> d2m.to_layout.
 class D2MToLayoutOpRewriter : public D2MNamedRewriterCommon,
                               public OpConversionPattern<ttir::ToLayoutOp> {
@@ -2630,9 +2675,10 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     // Data movement.
     D2MNamedElementwiseRewriter<ttir::TypecastOp,        d2m::TileTypecastOp>,
     // Tensor manipulation/View ops.
-    D2MTensorManipulationOpRewriter<ttir::RearrangeOp, rearrangeLogicalInfo>,
-    D2MTensorManipulationOpRewriter<ttir::ReshapeOp, reshapeLogicalInfo>,
-    D2MTensorManipulationOpRewriter<ttir::SliceStaticOp, sliceLogicalInfo>,
+    D2MConcatRewriter,
+    D2MTensorManipulationOpRewriter<ttir::RearrangeOp,        rearrangeLogicalInfo>,
+    D2MTensorManipulationOpRewriter<ttir::ReshapeOp,          reshapeLogicalInfo>,
+    D2MTensorManipulationOpRewriter<ttir::SliceStaticOp,      sliceLogicalInfo>,
     D2MTensorManipulationOpRewriter<ttir::ConcatenateHeadsOp, concatenateHeadsLogicalInfo>,
     // Permute (handles transpose ops, since they're canonicalized into permutes).
     D2MPermuteRewriter,

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -15,7 +15,6 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -29,7 +28,6 @@
 
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/IR/ValueRange.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -1423,6 +1421,119 @@ void d2m::ViewLayoutOp::getCanonicalizationPatterns(
     return success();
   });
   // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+//===----------------------------------------------------------------------===//
+// CompositeViewOp
+//===----------------------------------------------------------------------===//
+
+Value d2m::CompositeViewOp::getInput() {
+  llvm_unreachable("Composite view must have all its inputs handled");
+}
+
+bool d2m::CompositeViewOp::isComposite() { return true; }
+
+SmallVector<Value> d2m::CompositeViewOp::getCompositeInputs() {
+  return SmallVector<Value>(getInputs().begin(), getInputs().end());
+}
+
+bool d2m::CompositeViewOp::bufferizesToMemoryRead(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  return false;
+}
+
+bool d2m::CompositeViewOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  return false;
+}
+
+LogicalResult d2m::CompositeViewOp::bufferize(
+    mlir::RewriterBase &rewriter,
+    const mlir::bufferization::BufferizationOptions &options,
+    mlir::bufferization::BufferizationState &state) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  SmallVector<Value> bufferizedInputs;
+  for (Value input : getInputs()) {
+    auto maybeBuffer =
+        mlir::bufferization::getBuffer(rewriter, input, options, state);
+    if (failed(maybeBuffer)) {
+      return maybeBuffer;
+    }
+    bufferizedInputs.push_back(*maybeBuffer);
+  }
+
+  SmallVector<Value> invocationStack;
+  auto outMemrefTypeOr =
+      getBufferType(getResult(), options, state, invocationStack);
+  if (failed(outMemrefTypeOr)) {
+    return outMemrefTypeOr;
+  }
+
+  auto outMemrefType = mlir::cast<MemRefType>(*outMemrefTypeOr);
+  auto newOp = rewriter.create<d2m::CompositeViewOp>(
+      getLoc(), outMemrefType, bufferizedInputs, getDim());
+  mlir::bufferization::replaceOpWithBufferizedValues(rewriter, *this,
+                                                     newOp.getResult());
+  return success();
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+// This isn't aliasing any single input and is meant to create a new tensor.
+mlir::bufferization::AliasingValueList d2m::CompositeViewOp::getAliasingValues(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  mlir::bufferization::AliasingValueList result;
+  return result;
+}
+
+mlir::FailureOr<mlir::bufferization::BufferLikeType>
+d2m::CompositeViewOp::getBufferType(
+    mlir::Value value, const mlir::bufferization::BufferizationOptions &,
+    const mlir::bufferization::BufferizationState &, SmallVector<Value> &) {
+  return ttcore::getBufferType(value.getType(), /*isView=*/true);
+}
+
+mlir::LogicalResult d2m::CompositeViewOp::verify() {
+  auto resultType = this->getResult().getType();
+  const bool isMemrefType = mlir::isa<MemRefType>(resultType);
+
+  auto outShape = isMemrefType
+                      ? mlir::cast<MemRefType>(resultType).getShape()
+                      : mlir::cast<RankedTensorType>(resultType).getShape();
+  const int32_t rank = static_cast<int32_t>(outShape.size()) / 2;
+  const int32_t compositeDim = this->getDim();
+  if (compositeDim < 0 || compositeDim >= rank) {
+    return emitOpError("Composite view dim out of range.");
+  }
+
+  if (this->getInputs().size() < 2) {
+    return emitOpError("Composite view should have at least two inputs.");
+  }
+
+  int64_t accum = 0;
+  for (auto input : this->getInputs()) {
+    auto inShape =
+        isMemrefType ? mlir::cast<MemRefType>(input.getType()).getShape()
+                     : mlir::cast<RankedTensorType>(input.getType()).getShape();
+    if (inShape.size() != static_cast<size_t>(2 * rank)) {
+      return emitOpError("Incompatible input/output shapes.");
+    }
+
+    for (int32_t i = 0; i < rank; i++) {
+      if (i == compositeDim) {
+        accum += inShape[i] * inShape[i + rank];
+      } else if (inShape[i] * inShape[i + rank] !=
+                 outShape[i] * outShape[i + rank]) {
+        return emitOpError("Incompatible non-composite dim.");
+      }
+    }
+  }
+
+  // The output's composite dim could have been aligned-up.
+  if (accum > outShape[compositeDim] * outShape[compositeDim + rank]) {
+    return emitOpError("Incompatible composite dim.");
+  }
+
+  return mlir::success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/D2M/IR/D2MOpsInterfaces.cpp
+++ b/lib/Dialect/D2M/IR/D2MOpsInterfaces.cpp
@@ -28,6 +28,9 @@ mlir::tt::d2m::applyViews(mlir::Operation *op) {
         resultMemref, mlir::AffineMap::getMultiDimIdentityMap(
                           resultMemref.getRank(), resultMemref.getContext()));
   }
+  // applyViews is meant to be 1-1, composite views should have been expanded
+  // before reaching this point (assuming no nested composite views).
+  assert(!viewOp.isComposite());
 
   mlir::AffineMap map;
   if (auto viewLayoutOp = mlir::dyn_cast<mlir::tt::d2m::ViewLayoutOp>(op)) {

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -25,7 +25,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <algorithm>
-#include <numeric>
 #include <optional>
 
 //===---------------------------------------------------------------------===//
@@ -167,6 +166,14 @@ struct MemrefValueContext {
 
 using OperandDefChain = llvm::SmallVector<Operation *, 4>;
 
+// The single root discovered by `analyzeOperandDefChain`.
+// Normal operands produce one; composite views produce one per input tensor.
+struct ChainRoot {
+  Value root = nullptr;
+  MemRefType type = nullptr;
+  OperandDefChain defChain;
+};
+
 struct OperandContext {
   // Link to the operand in the incoming IR.
   OpOperand *operand = nullptr;
@@ -176,12 +183,14 @@ struct OperandContext {
     return operand->getOperandNumber();
   }
 
-  // The Value (either a memref.alloc or a block arg) that is
-  // the source of this operand's data, possibly through a view/cast chain.
-  Value root;
-  // This collects the set of ops defining an operand all the way to its
-  // root `memref::AllocOp` or block arg.
-  OperandDefChain defChain;
+  // The Value (either a memref.alloc or a block arg) that is the source of
+  // this operand's data, possibly through a view/cast chain. For composite
+  // operands this is the first root.
+  Value primaryRoot;
+  // This collects the set of ops defining an operand all the way to its root
+  // `memref::AllocOp` or block arg. For composite operands all chains and roots
+  // are collected separately.
+  SmallVector<ChainRoot> chainRoots;
   // `true` is if this corresponds to a generic op output.
   bool isOutput = false;
   // To be able to plan possible pressure on L1, this precomputes
@@ -532,7 +541,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       analysis.sequencing.positionMap.emplace_back(op);
 
       if (llvm::isa<memref::AllocOp, d2m::ViewLayoutOp, d2m::StreamLayoutOp,
-                    d2m::CreateGlobalSemaphoreOp>(op)) {
+                    d2m::CompositeViewOp, d2m::CreateGlobalSemaphoreOp>(op)) {
         // Skip memref.alloc operations that have a genericOp as parent
         if (llvm::isa<memref::AllocOp>(op) &&
             op->getParentOfType<d2m::GenericOp>()) {
@@ -831,16 +840,29 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       operandCtx.operand = &operand;
       operandCtx.isOutput = genericOp.isOutputOperandIdx(operandIndex);
 
-      // Find `operand`s "root" memref and the op chain that links to it.
-      // This sets `operandCtx.root` and `operandCtx.defChain` and updates
-      // this memref's slot in `analysis.memrefs`.
+      // Find the operand's root memref(s) and the op chain(s) that links to
+      // them.
+      SmallVector<ChainRoot> chainRoots =
+          analyzeOperandDefChain(genericOp, operand.get());
+      TT_assert(!chainRoots.empty());
+      operandCtx.chainRoots = chainRoots;
 
-      MemRefType memrefType = nullptr;
-      std::tie(operandCtx.root, memrefType) =
-          analyzeOperandDefChain(genericOp, operand.get(), operandCtx.defChain);
-      TT_ALLOC_DEBUG("\tadding memref value ctx: root {}, memref type {}",
-                     asOperand(operandCtx.root), memrefType);
+      // Use the first root as the primary root for the OperandContext.
+      operandCtx.primaryRoot = chainRoots.front().root;
 
+      if (TT_DEBUG_ENABLED()) {
+        for ([[maybe_unused]] const auto &[rootIdx, chainRoot] :
+             llvm::enumerate(chainRoots)) {
+          TT_ALLOC_DEBUG(
+              "\tadding memref value ctx (root {}/{}): root {}, memref type {}",
+              rootIdx, chainRoots.size(), asOperand(chainRoot.root),
+              chainRoot.type);
+        }
+      }
+
+      // Right now it's OK to use the 1st root's memref because we assert that
+      // all roots must be in the same memory space.
+      auto memrefType = chainRoots.front().type;
       if (isOperandExemptFromStreaming(operandCtx,
                                        ttcore::getMemorySpace(memrefType))) {
         // For now, disabled `allow-l1-output-spilling` also means
@@ -850,24 +872,26 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         // stream_layout ops are not expected at this point.
       }
 
-      MemrefValueContext &memrefCtx = addMemrefValueContext(
-          rewriter, analysis, operandCtx.root, memrefType, device);
+      // Register ALL roots in analysis.memrefs and genericUseClosure.
+      for (const ChainRoot &chainRoot : chainRoots) {
+        MemrefValueContext &rootMemrefCtx = addMemrefValueContext(
+            rewriter, analysis, chainRoot.root, chainRoot.type, device);
 
-      memrefCtx.genericUsers.insert(genericOp);
-      memrefCtx.isMemspaceBound |= genericCtx.isExplicitDatamovement;
-      memrefCtx.usedForOutput |= operandCtx.isOutput;
-      if (!operandCtx.isOutput && genericOp.isScratchInput(operandIndex)) {
-        memrefCtx.usedAsScratchInput = true;
-        memrefCtx.isMemspaceBound = true;
-      }
+        rootMemrefCtx.genericUsers.insert(genericOp);
+        rootMemrefCtx.isMemspaceBound |= genericCtx.isExplicitDatamovement;
+        rootMemrefCtx.usedForOutput |= operandCtx.isOutput;
+        if (!operandCtx.isOutput && genericOp.isScratchInput(operandIndex)) {
+          rootMemrefCtx.usedAsScratchInput = true;
+          rootMemrefCtx.isMemspaceBound = true;
+        }
 
-      if (memref::AllocOp allocOp =
-              operandCtx.root.getDefiningOp<memref::AllocOp>()) {
-        // Update the union set of all `allocOp` generic users.
-        OperationSet &allocOpGenericUsers = genericUseClosure[allocOp];
-        allocOpGenericUsers.insert(genericOp.getOperation());
-        allocOpGenericUsers.insert(operandCtx.defChain.begin(),
-                                   operandCtx.defChain.end());
+        if (memref::AllocOp allocOp =
+                chainRoot.root.getDefiningOp<memref::AllocOp>()) {
+          OperationSet &allocOpGenericUsers = genericUseClosure[allocOp];
+          allocOpGenericUsers.insert(genericOp.getOperation());
+          allocOpGenericUsers.insert(chainRoot.defChain.begin(),
+                                     chainRoot.defChain.end());
+        }
       }
 
       if (haveIterationSpaceInfo) {
@@ -908,7 +932,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       }
 
       // Finally, insert `operandCtx` into `genericCtx`.
-
+      // Even for composite view it's one OperandContext per GenericOp operand.
       genericCtx.operands.push_back(std::move(operandCtx));
     }
     TT_assert(genericCtx.operands.size() ==
@@ -1096,7 +1120,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
             // different operand positions; each position will have its own
             // stream.
             for (OperandContext &operandCtx : genericCtx.operands) {
-              if (operandCtx.root != memref) {
+              if (operandCtx.primaryRoot != memref) {
                 continue;
               }
 
@@ -1317,11 +1341,13 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       for (auto [operandIndex, operand] : llvm::enumerate(newOperands)) {
         OperandContext operandCtx = oldOperandContexts[operandIndex];
         operandCtx.operand = &operand;
-        operandCtx.defChain.clear();
+        operandCtx.chainRoots.clear();
 
-        MemRefType memrefType = nullptr;
-        std::tie(operandCtx.root, memrefType) = analyzeOperandDefChain(
-            reblocked->genericOp, operand.get(), operandCtx.defChain);
+        SmallVector<ChainRoot> chainRoots =
+            analyzeOperandDefChain(reblocked->genericOp, operand.get());
+        operandCtx.chainRoots = chainRoots;
+        operandCtx.primaryRoot = chainRoots.front().root;
+
         updatedCtx.operands.push_back(std::move(operandCtx));
       }
 
@@ -1365,28 +1391,42 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       llvm::DenseMap<Value, int32_t> preStreamOperandIndices;
 
       for (const OperandContext &operandCtx : genericCtx.operands) {
-        const auto *memrefIt = analysis.memrefs.find(operandCtx.root);
-        TT_debug(memrefIt != analysis.memrefs.end());
-        const MemrefValueContext &memrefCtx = memrefIt->second;
+        std::optional<MemorySpace> remappedMemSpace;
+        for (const ChainRoot &chainRoot : operandCtx.chainRoots) {
+          const auto *memrefIt = analysis.memrefs.find(chainRoot.root);
+          TT_debug(memrefIt != analysis.memrefs.end());
+          const MemrefValueContext &memrefCtx = memrefIt->second;
 
-        const MemorySpace remappedMemSpace = *memrefCtx.remappedMemSpace;
-
-        for (Operation *opOnChain : operandCtx.defChain) {
-          if (!visited.insert(opOnChain).second) {
-            // Assigning final memspace is idempotent, but no need to do this
-            // repeatedly.
-            continue;
+          TT_assert(memrefCtx.remappedMemSpace.has_value());
+          const MemorySpace rootRemappedMemSpace = *memrefCtx.remappedMemSpace;
+          if (!remappedMemSpace.has_value()) {
+            remappedMemSpace = rootRemappedMemSpace;
+          } else {
+            TT_assert(*remappedMemSpace == rootRemappedMemSpace);
           }
-          llvm::TypeSwitch<Operation *, void>(opOnChain)
-              .Case([&](memref::AllocOp op) {
-                remap(rewriter, op, remappedMemSpace);
-              })
-              .Case([&](d2m::ViewLayoutOp op) {
-                remap(rewriter, op, remappedMemSpace);
-              });
-        }
 
-        if (isOperandExemptFromStreaming(operandCtx, remappedMemSpace)) {
+          for (Operation *opOnChain : chainRoot.defChain) {
+            if (!visited.insert(opOnChain).second) {
+              // Assigning final memspace is idempotent, but no need to do this
+              // repeatedly.
+              continue;
+            }
+            llvm::TypeSwitch<Operation *, void>(opOnChain)
+                .Case([&](memref::AllocOp op) {
+                  remap(rewriter, op, rootRemappedMemSpace);
+                })
+                .Case([&](d2m::ViewLayoutOp op) {
+                  remap(rewriter, op, rootRemappedMemSpace);
+                })
+                .Case([&](d2m::CompositeViewOp op) {
+                  remap(rewriter, op, rootRemappedMemSpace);
+                });
+          }
+        }
+        TT_assert(remappedMemSpace.has_value());
+        const MemorySpace finalRemappedMemSpace = *remappedMemSpace;
+
+        if (isOperandExemptFromStreaming(operandCtx, *remappedMemSpace)) {
           continue;
         }
 
@@ -1395,7 +1435,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         // DRAM operands always need streams regardless of indexing map
         // patterns, because data must physically move between DRAM and L1.
 
-        if (inferStreamRequirement(genericOp, operandCtx, remappedMemSpace)) {
+        if (inferStreamRequirement(genericOp, operandCtx, *remappedMemSpace)) {
 
           // Record all aliases along the operand def-chain.
           // This is needed because a generic operand may have several aliases
@@ -1404,11 +1444,13 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
           // Nested remote ops may still reference the old aliases.
           preStreamOperandIndices[operandCtx.operand->get()] =
               operandCtx.operandIndex();
-          preStreamOperandIndices[operandCtx.root] = operandCtx.operandIndex();
-          for (Operation *opOnChain : operandCtx.defChain) {
-            if (opOnChain->getNumResults() == 1) {
-              preStreamOperandIndices[opOnChain->getResult(0)] =
-                  operandCtx.operandIndex();
+          for (const ChainRoot &chainRoot : operandCtx.chainRoots) {
+            preStreamOperandIndices[chainRoot.root] = operandCtx.operandIndex();
+            for (Operation *opOnChain : chainRoot.defChain) {
+              if (opOnChain->getNumResults() == 1) {
+                preStreamOperandIndices[opOnChain->getResult(0)] =
+                    operandCtx.operandIndex();
+              }
             }
           }
 
@@ -1418,16 +1460,17 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
           auto &operand = *operandCtx.operand;
 
-          const PlannerSpace finalPlacement = asPlannerSpace(remappedMemSpace);
+          const PlannerSpace finalPlacement =
+              asPlannerSpace(finalRemappedMemSpace);
           const int32_t reqIdx = operandCtx.reqIndex[ordinal(finalPlacement)];
           const Planner::Request *req =
               reqIdx >= 0 ? &L1solution.request(reqIdx) : nullptr;
 
-          if (failed(insertStream(rewriter, operand, genericOp, req, operandCtx,
-                                  (remappedMemSpace == MemorySpace::DeviceDRAM
-                                       ? DRAMAttr
-                                       : L1Attr),
-                                  L1memInfo, analysis.sequencing))) {
+          if (failed(insertStream(
+                  rewriter, operand, genericOp, req, operandCtx,
+                  (finalRemappedMemSpace == MemorySpace::DeviceDRAM ? DRAMAttr
+                                                                    : L1Attr),
+                  L1memInfo, analysis.sequencing))) {
             return failure();
           }
         }
@@ -1460,7 +1503,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       for (const OperandContext &operandCtx : genericCtx.operands) {
         const auto operandIndex = operandCtx.operand->getOperandNumber();
 
-        const auto *memrefIt2 = analysis.memrefs.find(operandCtx.root);
+        const auto *memrefIt2 = analysis.memrefs.find(operandCtx.primaryRoot);
         TT_debug(memrefIt2 != analysis.memrefs.end());
         const MemorySpace operandMemSpace = *memrefIt2->second.remappedMemSpace;
 
@@ -1778,10 +1821,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   /// non-identity affine map.
   /// @return `true` if any ViewLayoutOp in the chain has a non-identity map.
   static bool isNonTrivialView(const OperandContext &operandCtx) {
-    for (Operation *op : operandCtx.defChain) {
-      if (auto view = llvm::dyn_cast<d2m::ViewLayoutOp>(op)) {
-        if (!view.getRemapping().isIdentity()) {
-          return true;
+    for (ChainRoot chainRoot : operandCtx.chainRoots) {
+      for (Operation *op : chainRoot.defChain) {
+        if (auto view = llvm::dyn_cast<d2m::ViewLayoutOp>(op)) {
+          if (!view.getRemapping().isIdentity()) {
+            return true;
+          }
         }
       }
     }
@@ -2001,17 +2046,17 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   /// `view/stream_layout`s.
   ///
   /// Besides the above, determine a few more things:
-  ///  1. the "root" `Value` that terminates the chain (used as a unique key for
-  ///  the chain);
-  ///  2. the "effective memref type" to associate with the root Value (either
-  ///  the actual type of this Value or the type it is being cast to by a ttnn
+  ///  1. the ChainRoot values that terminates each chain (used as a unique key
+  ///  for the chain);
+  ///  2. the "effective memref type" to associate with the ChainRoot (either
+  ///  the actual type of its Value or the type it is being cast to by a ttnn
   ///  bridge cast).
   ///
-  static std::pair<Value, MemRefType>
-  analyzeOperandDefChain(d2m::GenericOp genericOp, Value operand,
-                         SmallVector<Operation *, 4> &chain) {
+  static SmallVector<ChainRoot> analyzeOperandDefChain(d2m::GenericOp genericOp,
+                                                       Value operand) {
     [[maybe_unused]] AsOperandPrinter asOperand{genericOp->getParentOp()};
 
+    OperandDefChain chain;
     MemRefType type = nullptr;
 
     Value value = operand;
@@ -2021,21 +2066,37 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       chain.emplace_back(definingOp);
 
       if (auto op = llvm::dyn_cast<memref::AllocOp>(definingOp)) {
-        if (type == nullptr) {
-          type = mlir::cast<MemRefType>(op->getResultTypes().front());
-        }
-        break;
+        type = mlir::cast<MemRefType>(op->getResultTypes().front());
+        return {{value, type, chain}};
       }
       if (auto op = llvm::dyn_cast<ttir::TTNNMetalLayoutCastOp>(definingOp)) {
         value = op.getInput();
-        if (type == nullptr) {
-          type = mlir::cast<MemRefType>(op->getResultTypes().front());
-        }
-        break;
+        type = mlir::cast<MemRefType>(op->getResultTypes().front());
+        return {{value, type, chain}};
       }
 
       if (auto op = llvm::dyn_cast<d2m::ViewLayoutOp>(definingOp)) {
         value = op.getInput();
+      } else if (auto op = llvm::dyn_cast<d2m::CompositeViewOp>(definingOp)) {
+        // Recurse into each input of the composite view to collect all the
+        // chains & roots. Prefix each child chain with the current chain to
+        // preserve per-root context.
+        SmallVector<ChainRoot> allRoots;
+        for (Value input : op.getCompositeInputs()) {
+          SmallVector<ChainRoot> inputRoots =
+              analyzeOperandDefChain(genericOp, input);
+          for (ChainRoot &inputRoot : inputRoots) {
+            OperandDefChain prefixedChain;
+            prefixedChain.reserve(chain.size() + inputRoot.defChain.size());
+            prefixedChain.append(chain.begin(), chain.end());
+            prefixedChain.append(inputRoot.defChain.begin(),
+                                 inputRoot.defChain.end());
+            inputRoot.defChain = std::move(prefixedChain);
+
+            allRoots.push_back(std::move(inputRoot));
+          }
+        }
+        return allRoots;
       } else if (auto op =
                      llvm::dyn_cast<d2m::CreateGlobalSemaphoreOp>(definingOp)) {
         value = op.getInput();
@@ -2056,7 +2117,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       type = mlir::cast<MemRefType>(arg.getType());
     }
 
-    return {value, type};
+    return {{value, type, chain}};
   }
 
   // Factor out defaults passed into DeviceAttr::getMemrefSizeBytes()
@@ -2127,6 +2188,16 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     rewriter.modifyOpInPlace(op, [&]() { memref.setType(newType); });
   }
 
+  /// @return 'op' with given memory space override
+  static void remap(RewriterBase &rewriter, d2m::CompositeViewOp op,
+                    MemorySpace memspace) {
+    auto memref = op->getResult(0);
+    MemRefType memrefType = llvm::cast<MemRefType>(memref.getType());
+    MemRefType newType = remap(rewriter, memrefType, memspace);
+
+    rewriter.modifyOpInPlace(op, [&]() { memref.setType(newType); });
+  }
+
   // Recursive helper for `analyzeAllocOps(func::FuncOp funcOp...)`.
   // Note: the overall traversal cost can be reduced by memoizing
   // final maxLast values and/or visiting Values in a reverse topological
@@ -2140,7 +2211,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     for (Operation *user : op->getResult(0).getUsers()) {
       if (graph.contains(user)) {
         if (llvm::isa<d2m::ViewLayoutOp, d2m::StreamLayoutOp,
-                      d2m::CreateGlobalSemaphoreOp>(user)) {
+                      d2m::CompositeViewOp, d2m::CreateGlobalSemaphoreOp>(
+                user)) {
           last = std::max(last, resolve(user, graph));
         }
       }

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_dialect_library(MLIRD2MTransforms
         LowerDMAToFullyIndexedForm.cpp
         LowerLoadStoreOpsToDMA.cpp
         LowerLoadStoreOpsToExplicitCBForm.cpp
+        ExpandDMAReadCompositeView.cpp
         ConvertLocalLoadStoreOpsToAliasedCBs.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
+++ b/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/AffineExpr.h"
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MEXPANDDMAREADCOMPOSITEVIEW
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+static LogicalResult expandCompositeDMARead(IRRewriter &rewriter,
+                                            DMAReadOp dmaRead,
+                                            ValueRange expandedInputs,
+                                            const int32_t concatDim) {
+  assert(dmaRead.isShardLevel());
+  ttcore::DeviceAttr device = ttcore::lookupDevice(dmaRead);
+
+  int64_t gridRank = static_cast<int64_t>(dmaRead.getSrcIndices().size());
+  assert(concatDim >= 0 && concatDim < gridRank);
+
+  auto compositeType = mlir::cast<MemRefType>(dmaRead.getSrc().getType());
+  TT_assert(compositeType.getRank() == 2 * gridRank);
+
+  const int64_t concatGridDim = concatDim;
+  const int64_t concatShardDim = concatDim + gridRank;
+
+  // Number of tiles in the composite view's concat dim, potentially aligned-up.
+  auto compositeDeviceShape = compositeType.getShape();
+  const int64_t compositeExtent = compositeDeviceShape[concatGridDim] *
+                                  compositeDeviceShape[concatShardDim];
+
+  // Number of tiles for each & all of the composite view inputs.
+  int64_t totalInputExtent = 0;
+  SmallVector<int64_t> inputExtents;
+  SmallVector<AffineMap> inputMemoryMaps;
+  SmallVector<SmallVector<int64_t>> inputShardShapes;
+
+  for (Value input : expandedInputs) {
+    auto inputType = mlir::cast<MemRefType>(input.getType());
+    TT_assert(inputType.getRank() == compositeType.getRank());
+    auto inputDeviceShape = inputType.getShape();
+    const int64_t inputExtent =
+        inputDeviceShape[concatGridDim] * inputDeviceShape[concatShardDim];
+
+    totalInputExtent += inputExtent;
+    inputExtents.push_back(inputExtent);
+    inputMemoryMaps.push_back(
+        utils::getMemoryMap(device, input, /*isRemote=*/true));
+    inputShardShapes.emplace_back(inputDeviceShape.drop_front(gridRank).begin(),
+                                  inputDeviceShape.drop_front(gridRank).end());
+  }
+  TT_assert(totalInputExtent <= compositeExtent);
+
+  Value localMemref = dmaRead.getDst();
+  AffineMap localMemoryMap =
+      utils::getMemoryMap(device, localMemref, /*isRemote=*/false);
+
+  rewriter.setInsertionPoint(dmaRead);
+
+  Location loc = dmaRead.getLoc();
+
+  SmallVector<Value> gridIndices(dmaRead.getSrcIndices());
+  SmallVector<int64_t> outputShardShape(
+      mlir::cast<MemRefType>(localMemref.getType()).getShape());
+  TT_assert(outputShardShape.size() == static_cast<size_t>(gridRank));
+
+  auto emitDMAReadForInput = [&](OpBuilder &builder, Location innerLoc,
+                                 ValueRange shardIters, Value globalConcatIdx,
+                                 const int inputIdx,
+                                 const int64_t pieceOffset) {
+    // Calculate the full index (grid x shard) of the current input tile.
+    SmallVector<Value> inputFullIdx(2 * gridRank);
+    for (int dim = 0; dim < gridRank; dim++) {
+      Value globalDimIdx = nullptr;
+      if (dim == concatGridDim) {
+        // Shift-back the output's tile index with this input's cumulative
+        // offset so it points to the right tile of the input.
+        if (pieceOffset == 0) {
+          globalDimIdx = globalConcatIdx;
+        } else {
+          Value offsetVal = builder.create<arith::ConstantOp>(
+              innerLoc, builder.getIndexType(),
+              builder.getIndexAttr(pieceOffset));
+          globalDimIdx = builder.create<arith::SubIOp>(
+              innerLoc, globalConcatIdx, offsetVal);
+        }
+      } else {
+        // Otherwise it's just: grid_idx * tiles_per_shard + shard_idx.
+        Value outShardExtent = builder.create<arith::ConstantOp>(
+            innerLoc, builder.getIndexType(),
+            builder.getIndexAttr(outputShardShape[dim]));
+        Value baseIdx = builder.create<arith::MulIOp>(
+            innerLoc, gridIndices[dim], outShardExtent);
+        globalDimIdx =
+            builder.create<arith::AddIOp>(innerLoc, baseIdx, shardIters[dim]);
+      }
+
+      Value inShardExtent = builder.create<arith::ConstantOp>(
+          innerLoc, builder.getIndexType(),
+          builder.getIndexAttr(inputShardShapes[inputIdx][dim]));
+      // grid_idx = idx // shard_size
+      Value inputGridIdx =
+          builder.create<arith::DivSIOp>(innerLoc, globalDimIdx, inShardExtent);
+      // shard_idx = idx % shard_size
+      Value inputShardIdx =
+          builder.create<arith::RemSIOp>(innerLoc, globalDimIdx, inShardExtent);
+
+      inputFullIdx[dim] = inputGridIdx;
+      inputFullIdx[dim + gridRank] = inputShardIdx;
+    }
+
+    SmallVector<Value> remoteIndices = utils::applyMap(
+        builder, innerLoc, inputMemoryMaps[inputIdx], inputFullIdx,
+        /*isRemote=*/true);
+    SmallVector<Value> localIndices = utils::applyMap(
+        builder, innerLoc, localMemoryMap, shardIters, /*isRemote=*/false);
+
+    // One tile at a time, no coalescing.
+    Value dmaTx = builder.create<DMAReadOp>(
+        innerLoc, expandedInputs[inputIdx], remoteIndices, localMemref,
+        localIndices, builder.getI64IntegerAttr(1));
+    builder.create<DMAWaitOp>(innerLoc, dmaTx);
+  };
+
+  auto [lbs, ubs, steps] =
+      utils::getLoopBounds(rewriter, loc, outputShardShape);
+
+  scf::buildLoopNest(
+      rewriter, loc, lbs, ubs, steps,
+      [&](OpBuilder &loopBuilder, Location innerLoc, ValueRange shardIters) {
+        // Global index along the concat dim of a given tile:
+        // idx = grid_idx * tiles_per_shard + shard_idx
+        Value concatShardExtent = loopBuilder.create<arith::ConstantOp>(
+            innerLoc, loopBuilder.getIndexType(),
+            loopBuilder.getIndexAttr(outputShardShape[concatDim]));
+        Value baseConcatIdx = loopBuilder.create<arith::MulIOp>(
+            innerLoc, gridIndices[concatGridDim], concatShardExtent);
+        Value globalConcatIdx = loopBuilder.create<arith::AddIOp>(
+            innerLoc, baseConcatIdx, shardIters[concatDim]);
+
+        // Recursively generate the if-else chain for all inputs.
+        std::function<void(OpBuilder &, const int, const int64_t)>
+            emitIfElseChain = [&](OpBuilder &builder, const int inputIdx,
+                                  const int64_t startOffset) {
+              // Base case: reaching the end of the chain (the last 'else').
+              if (inputIdx + 1 == static_cast<int>(expandedInputs.size())) {
+                emitDMAReadForInput(builder, innerLoc, shardIters,
+                                    globalConcatIdx, inputIdx, startOffset);
+                return;
+              }
+
+              // Recursive case:
+              // - Emit DMA reads for the current input's contribution.
+              // - Recurse into the 'else' branch for the next input.
+              const int64_t boundary = startOffset + inputExtents[inputIdx];
+              Value boundaryVal = builder.create<arith::ConstantOp>(
+                  innerLoc, builder.getIndexType(),
+                  builder.getIndexAttr(boundary));
+              Value cond = builder.create<arith::CmpIOp>(
+                  innerLoc, arith::CmpIPredicate::ult, globalConcatIdx,
+                  boundaryVal);
+
+              auto ifOp = builder.create<scf::IfOp>(innerLoc, TypeRange{}, cond,
+                                                    /*hasElse=*/true);
+
+              OpBuilder thenBuilder = ifOp.getThenBodyBuilder();
+              emitDMAReadForInput(thenBuilder, innerLoc, shardIters,
+                                  globalConcatIdx, inputIdx, startOffset);
+
+              OpBuilder elseBuilder = ifOp.getElseBodyBuilder();
+              emitIfElseChain(elseBuilder, inputIdx + 1, boundary);
+            };
+
+        // Skip out-of-bound portions if the output was aligned up.
+        if (totalInputExtent < compositeExtent) {
+          Value totalExtentVal = loopBuilder.create<arith::ConstantOp>(
+              innerLoc, loopBuilder.getIndexType(),
+              loopBuilder.getIndexAttr(totalInputExtent));
+          Value inBounds = loopBuilder.create<arith::CmpIOp>(
+              innerLoc, arith::CmpIPredicate::ult, globalConcatIdx,
+              totalExtentVal);
+          auto guardOp = loopBuilder.create<scf::IfOp>(
+              innerLoc, TypeRange{}, inBounds, /*hasElse=*/false);
+          OpBuilder guardBuilder = guardOp.getThenBodyBuilder();
+          emitIfElseChain(guardBuilder, /*inputIdx=*/0, /*startOffset=*/0);
+        } else {
+          emitIfElseChain(loopBuilder, /*inputIdx=*/0, /*startOffset=*/0);
+        }
+      });
+
+  for (Operation *user : llvm::make_early_inc_range(dmaRead->getUsers())) {
+    if (auto waitOp = mlir::dyn_cast<DMAWaitOp>(user)) {
+      rewriter.eraseOp(waitOp);
+    }
+  }
+  rewriter.eraseOp(dmaRead);
+
+  return success();
+}
+
+static DenseI64ArrayAttr remapScratchInputs(OpBuilder &builder,
+                                            DenseI64ArrayAttr oldScratchInputs,
+                                            const int64_t expandedInputIndex,
+                                            const int64_t extraInputs) {
+  if (!oldScratchInputs || oldScratchInputs.size() == 0) {
+    return nullptr;
+  }
+
+  SmallVector<int64_t> remapped;
+  remapped.reserve(oldScratchInputs.size());
+  for (int64_t scratchInput : oldScratchInputs.asArrayRef()) {
+    remapped.push_back(scratchInput > expandedInputIndex
+                           ? scratchInput + extraInputs
+                           : scratchInput);
+  }
+  return builder.getDenseI64ArrayAttr(remapped);
+}
+
+static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
+                                                   GenericOp gOp) {
+  CompositeViewOp compositeView = nullptr;
+  gOp.walk([&](DMAReadOp dmaRead) {
+    auto maybeCompositeView = dmaRead.getSrc().getDefiningOp<CompositeViewOp>();
+    if (maybeCompositeView) {
+      assert(compositeView == nullptr &&
+             "Unsupported multiple composite views in one GenericOp (#7600).");
+      compositeView = maybeCompositeView;
+    }
+  });
+  assert(compositeView != nullptr);
+
+  SmallVector<Value> compositeInputs = compositeView.getCompositeInputs();
+  assert(compositeInputs.size() > 1);
+
+  int64_t oldNumInputs = static_cast<int64_t>(gOp.getInputs().size());
+  int64_t extraNumInputs = static_cast<int64_t>(compositeInputs.size() - 1);
+
+  // Step 1: recreate the GenericOp w/ expanded list of inputs.
+  SmallVector<Value> newInputs;
+  newInputs.reserve(oldNumInputs + extraNumInputs);
+  for (auto input : gOp.getInputs()) {
+    if (input == compositeView.getResult()) {
+      newInputs.append(compositeInputs.begin(), compositeInputs.end());
+      continue;
+    }
+    newInputs.push_back(input);
+  }
+
+  int64_t compositeOperandIdx = gOp.getOperandIndex(compositeView.getResult());
+  DenseI64ArrayAttr newScratchInputs =
+      remapScratchInputs(rewriter, gOp.getScratchInputsAttr(),
+                         compositeOperandIdx, extraNumInputs);
+
+  rewriter.setInsertionPoint(gOp);
+  // Passing empty block_factors/indexing_maps/iterator_types.
+  assert(gOp.isExplicitDatamovementForm());
+  auto newGOp = rewriter.create<GenericOp>(
+      gOp.getLoc(), gOp.getResultTypes(), newInputs, gOp.getOutputs(),
+      gOp.getAdditionalArgs(), gOp.getGrid(), rewriter.getI64ArrayAttr({}),
+      rewriter.getAffineMapArrayAttr({}), rewriter.getArrayAttr({}),
+      gOp.getThreads(), newScratchInputs, gOp.getNumRegions());
+
+  // Step 2: clone old regions into the new GenericOp and fix up d2m.get_cb
+  // operand indices that shifted due to the input list expansion.
+  for (auto [oldRegion, newRegion] :
+       llvm::zip(gOp.getRegions(), newGOp.getRegions())) {
+    Block *oldBlock = &oldRegion.front();
+    Block *newBlock = rewriter.createBlock(
+        &newRegion, newRegion.end(), oldBlock->getArgumentTypes(),
+        SmallVector<Location>(oldBlock->getNumArguments(), gOp.getLoc()));
+    rewriter.setInsertionPointToStart(newBlock);
+
+    IRMapping mapping;
+    // Map whatever block args that still exist.
+    for (auto [oldArg, newArg] :
+         llvm::zip(oldBlock->getArguments(), newBlock->getArguments())) {
+      mapping.map(oldArg, newArg);
+    }
+
+    for (Operation &op : oldBlock->without_terminator()) {
+      rewriter.clone(op, mapping);
+    }
+    if (oldBlock->mightHaveTerminator()) {
+      rewriter.clone(*oldBlock->getTerminator(), mapping);
+    }
+
+    // Shift the affected d2m.get_cb ops.
+    for (Operation &op : newBlock->getOperations()) {
+      auto getCBOp = mlir::dyn_cast<GetCBOp>(&op);
+      if (!getCBOp || !getCBOp.getOperandIndexAttr()) {
+        continue;
+      }
+      const int64_t oldIdx = getCBOp.getOperandIndexAttr().getInt();
+      if (oldIdx > compositeOperandIdx) {
+        const int64_t newIdx = oldIdx + extraNumInputs;
+        getCBOp.setOperandIndexAttr(rewriter.getI64IntegerAttr(newIdx));
+        getCBOp.setPortAttr(rewriter.getI64IntegerAttr(newIdx));
+      }
+    }
+  }
+
+  // Step 3: lower the composite DMA read in the new GenericOp.
+  DMAReadOp clonedCompositeRead = nullptr;
+  newGOp.walk([&](DMAReadOp dmaRead) {
+    auto maybeCompositeView = dmaRead.getSrc().getDefiningOp<CompositeViewOp>();
+    if (maybeCompositeView) {
+      assert(dmaRead.getSrc() == compositeView.getResult());
+      assert(clonedCompositeRead == nullptr);
+      clonedCompositeRead = dmaRead;
+    }
+  });
+  assert(clonedCompositeRead != nullptr);
+
+  auto expandedGenericInputs =
+      newGOp.getInputs().slice(compositeOperandIdx, compositeInputs.size());
+  if (failed(expandCompositeDMARead(rewriter, clonedCompositeRead,
+                                    expandedGenericInputs,
+                                    compositeView.getDim()))) {
+    return failure();
+  }
+
+  rewriter.replaceOp(gOp, newGOp.getResults());
+  return success();
+}
+
+static LogicalResult expandCompositeViews(ModuleOp moduleOp) {
+  IRRewriter rewriter(moduleOp.getContext());
+  SmallVector<GenericOp> genericsToExpand;
+
+  moduleOp.walk([&](GenericOp gOp) {
+    gOp.walk([&](DMAReadOp dmaRead) {
+      if (dmaRead.getSrc().getDefiningOp<CompositeViewOp>()) {
+        genericsToExpand.push_back(gOp);
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+  });
+
+  for (GenericOp gOp : genericsToExpand) {
+    if (failed(expandCompositeViewsInGeneric(rewriter, gOp))) {
+      return failure();
+    }
+  }
+
+  auto status = success();
+  moduleOp.walk([&](CompositeViewOp compositeView) {
+    if (compositeView->use_empty()) {
+      compositeView.erase();
+    } else {
+      compositeView.emitError(
+          "Composite view has remaining uses after expansion.");
+      status = failure();
+    }
+  });
+  return status;
+}
+
+namespace {
+class D2MExpandDMAReadCompositeView
+    : public impl::D2MExpandDMAReadCompositeViewBase<
+          D2MExpandDMAReadCompositeView> {
+public:
+  using impl::D2MExpandDMAReadCompositeViewBase<
+      D2MExpandDMAReadCompositeView>::D2MExpandDMAReadCompositeViewBase;
+
+  void runOnOperation() final {
+    if (failed(expandCompositeViews(getOperation()))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -4,7 +4,6 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
-#include "ttmlir/AffineMapAnalysis.h"
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
@@ -59,10 +58,6 @@ findMaxDimAndAspectRatio(ArrayRef<int64_t> physicalShape) {
   }
   return {maxDimIndex, aspectRatio};
 }
-
-static llvm::SmallVector<int64_t>
-computeOptimalBlockShardedGrid(ArrayRef<int64_t> physicalShape,
-                               ArrayRef<int64_t> targetSquareGridShape);
 
 static llvm::SmallVector<int64_t>
 computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
@@ -584,12 +579,19 @@ struct ViewLayoutUpdateInfo {
   llvm::SmallVector<int64_t> grid;
 };
 
+struct CompositeViewUpdateInfo {
+  d2m::CompositeViewOp op;
+  unsigned operandIndex;
+  llvm::SmallVector<int64_t> grid;
+};
+
 struct GridAnalysisResult {
   llvm::SmallVector<llvm::SmallVector<int64_t>> optimalOperandGrids;
   llvm::SmallVector<ToLayoutUpdateInfo> toLayouts;
   llvm::SmallVector<TTNNTensorUpdateInfo> ttnnTensors;
   llvm::SmallVector<EmptyUpdateInfo> emptyOps;
   llvm::SmallVector<ViewLayoutUpdateInfo> viewLayouts;
+  llvm::SmallVector<CompositeViewUpdateInfo> compositeViews;
 };
 
 // This function normalizes the operand grids for a generic operation by
@@ -759,6 +761,9 @@ analyzeOperandsAndComputeGrids(d2m::GenericOp genericOp,
           result.toLayouts.push_back({toLayoutOp, idx, inputOptimalGrid});
         }
       }
+    } else if (auto compositeViewOp =
+                   operand.getDefiningOp<d2m::CompositeViewOp>()) {
+      result.compositeViews.push_back({compositeViewOp, idx, optimalGrid});
     } else if (auto toLayoutOp = operand.getDefiningOp<d2m::ToLayoutOp>()) {
       result.toLayouts.push_back({toLayoutOp, idx, optimalGrid});
     } else if (auto emptyOp = operand.getDefiningOp<d2m::EmptyOp>()) {
@@ -826,6 +831,67 @@ updateTTNNTensors(ArrayRef<TTNNTensorUpdateInfo> TTNNTensorsToUpdate,
     } else {
       llvm_unreachable("Expected a TTNNMetalLayoutCastOp or a ViewLayoutOp");
     }
+  }
+}
+
+static void
+updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
+                       const GridSelectionConfig &config) {
+  if (compositeViewsToUpdate.empty()) {
+    return;
+  }
+
+  OpBuilder builder(compositeViewsToUpdate.front().op->getContext());
+  for (const auto &info : compositeViewsToUpdate) {
+    auto compositeView = info.op;
+
+    // The composite_view handles its own inputs instead of relying on
+    // updateToLayoutOps, and does not use computePhysicalShape to recreate the
+    // input with its grid-aligned shape.
+    // Views don't own the data and we want to stack other views on top of the
+    // composite_view, it might be difficult to update the upstream to_layout:
+    // e.g. one input is from a slicing view.
+    SmallVector<Value> reblockedInputs;
+    for (Value input : compositeView.getInputs()) {
+      auto inputType = mlir::cast<RankedTensorType>(input.getType());
+      auto inputLayout =
+          mlir::dyn_cast<ttcore::MetalLayoutAttr>(inputType.getEncoding());
+      if (!inputLayout) {
+        reblockedInputs.push_back(input);
+        continue;
+      }
+
+      auto tileType = mlir::cast<ttcore::TileType>(inputType.getElementType());
+      auto inputPhysShape = inputLayout.getPhysicalShape(tileType.getShape());
+      auto inputOptimalGrid =
+          computeOptimalGrid(inputType, inputPhysShape, config);
+
+      auto currentGrid = inputLayout.getGridShape(inputType);
+      if (llvm::ArrayRef(currentGrid) == llvm::ArrayRef(inputOptimalGrid)) {
+        reblockedInputs.push_back(input);
+        continue;
+      }
+
+      auto viewTensorType = mlir::cast<RankedTensorType>(
+          utils::reblockShapedType(inputType, inputOptimalGrid));
+      builder.setInsertionPoint(compositeView);
+      auto view = builder.create<d2m::ViewLayoutOp>(compositeView.getLoc(),
+                                                    viewTensorType, input);
+      reblockedInputs.push_back(view.getResult());
+    }
+
+    auto outType =
+        mlir::cast<RankedTensorType>(compositeView.getResult().getType());
+    RankedTensorType newOutType =
+        tensorWithOptimalGrid(outType, config, info.grid, builder);
+
+    builder.setInsertionPoint(compositeView);
+    auto newCompositeView = builder.create<d2m::CompositeViewOp>(
+        compositeView.getLoc(), newOutType, reblockedInputs,
+        compositeView.getDim());
+
+    compositeView.getResult().replaceAllUsesWith(newCompositeView.getResult());
+    compositeView.erase();
   }
 }
 
@@ -1029,6 +1095,8 @@ static void assignGrids(d2m::GenericOp genericOp,
   updateTTNNTensors(analysis.ttnnTensors, config);
 
   updateEmptyOps(analysis.emptyOps, config);
+
+  updateCompositeViewOps(analysis.compositeViews, config);
 
   updateViewLayoutOps(analysis.viewLayouts, config);
 

--- a/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerDMAToFullyIndexedForm.cpp
@@ -4,18 +4,12 @@
 
 #include "ttmlir/AffineMapAnalysis.h"
 #include "ttmlir/AffineMapUtils.h"
-#include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
-#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
-#include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
-#include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -26,90 +20,11 @@ namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERDMATOFULLYINDEXEDFORM
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
-static std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
-getLoopBounds(OpBuilder &builder, Location loc, ArrayRef<int64_t> shardShape) {
-  Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                 builder.getIndexAttr(0));
-  Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                                builder.getIndexAttr(1));
-  SmallVector<Value> lbs(shardShape.size(), zero);
-  SmallVector<Value> ubs(llvm::map_range(shardShape, [&](int64_t dim) {
-    return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
-                                             builder.getIndexAttr(dim));
-  }));
-  SmallVector<Value> step(shardShape.size(), one);
-  return std::make_tuple(lbs, ubs, step);
-}
-
 static size_t getElementSizeBytes(MemRefType memref) {
   mlir::Type elementType = memref.getElementType();
   auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
   return tileType ? tileType.getSizeBytes()
                   : elementType.getIntOrFloatBitWidth() / 8;
-}
-
-static AffineMap canonicalStridedMap(MLIRContext *context,
-                                     ArrayRef<int64_t> shape, Type elementType,
-                                     AffineMap map) {
-  assert(map.isIdentity() && "Only identity maps are supported for now.");
-  auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
-  int64_t elementSizeBytes = tileType ? tileType.getSizeBytes()
-                                      : elementType.getIntOrFloatBitWidth() / 8;
-  int64_t currentStride = elementSizeBytes;
-  int64_t rank = shape.size();
-  mlir::AffineExpr strideExpr = mlir::getAffineConstantExpr(0, context);
-  for (int64_t i = rank - 1; i >= 0; i--) {
-    mlir::AffineExpr dim = mlir::getAffineDimExpr(i, context);
-    mlir::AffineExpr stride =
-        mlir::getAffineConstantExpr(currentStride, context);
-    strideExpr = dim * stride + strideExpr;
-    currentStride *= shape[i];
-  }
-  return mlir::AffineMap::get(shape.size(), 0, strideExpr, context);
-}
-
-static AffineMap getMemoryMap(ttcore::DeviceAttr device, Value input,
-                              bool isRemote) {
-  if (isRemote) {
-    // d2m::utils::getMemoryMap handles view tracing (applyViews) and
-    // VGM lookup (getVirtualGridForwardMapping) internally.
-    return d2m::utils::getMemoryMap(device, input, /*pageSize=*/0);
-  }
-
-  // For local memrefs (including CB values), get the underlying memref type.
-  MemRefType inputType;
-  if (auto cbType = mlir::dyn_cast<CBType>(input.getType())) {
-    inputType = cbType.getUnderlyingAs<MemRefType>();
-  } else {
-    inputType = mlir::cast<MemRefType>(input.getType());
-  }
-  auto layoutMap = d2m::utils::resolveEffectiveAffineMap(input, inputType);
-  return canonicalStridedMap(device.getContext(), inputType.getShape(),
-                             inputType.getElementType(), layoutMap);
-}
-
-template <typename Builder>
-static SmallVector<Value> applyMap(Builder &builder, Location loc,
-                                   AffineMap map, ValueRange index,
-                                   bool isRemote) {
-  auto affineApply = [&](AffineMap map, ValueRange index) {
-    return builder.template create<affine::AffineApplyOp>(loc, map, index);
-  };
-
-  if (isRemote) {
-    assert(map.getNumResults() == 4);
-    // Break the map into respective gridY, gridX, offset "single result"
-    // parts. AffineApply only supports single result affine maps.
-    map = map.dropResults(0); // Drop the device index.
-    auto gridY = map.dropResults({1, 2});
-    auto gridX = map.dropResults({0, 2});
-    auto offset = map.dropResults({0, 1});
-    return {affineApply(gridY, index), affineApply(gridX, index),
-            affineApply(offset, index)};
-  }
-
-  assert(map.getNumResults() == 1);
-  return {affineApply(map, index)};
 }
 
 // Calculates coalescing factor using analytical method with sampling fallback.
@@ -225,15 +140,16 @@ static Value generateFullyIndexedDMAOps(
     }
 
     remoteIndices =
-        applyMap(builder, loc, remoteMemoryMap, remoteIndices, true);
-    localIndices = applyMap(builder, loc, localMemoryMap, localIndices, false);
+        utils::applyMap(builder, loc, remoteMemoryMap, remoteIndices, true);
+    localIndices =
+        utils::applyMap(builder, loc, localMemoryMap, localIndices, false);
 
     return createDMAOp(builder, loc, remoteIndices, localIndices,
                        coalescingFactor);
   }
 
   // Strided/non-contiguous: generate loops with guarded DMAs.
-  auto [lbs, ubs, steps] = getLoopBounds(builder, loc, shardShape);
+  auto [lbs, ubs, steps] = utils::getLoopBounds(builder, loc, shardShape);
   auto nullDmaTx = builder.create<NullTxOp>(loc);
 
   scf::LoopNest loopNest = scf::buildLoopNest(
@@ -246,10 +162,10 @@ static Value generateFullyIndexedDMAOps(
         SmallVector<Value> localIndices = llvm::to_vector(iters);
 
         // Apply memory maps.
-        remoteIndices = applyMap(loopBuilder, innerLoc, remoteMemoryMap,
-                                 remoteIndices, true);
-        localIndices = applyMap(loopBuilder, innerLoc, localMemoryMap,
-                                localIndices, false);
+        remoteIndices = utils::applyMap(loopBuilder, innerLoc, remoteMemoryMap,
+                                        remoteIndices, true);
+        localIndices = utils::applyMap(loopBuilder, innerLoc, localMemoryMap,
+                                       localIndices, false);
 
         // Create guarded DMA operation based on coalescing factor.
         Value cfExpr = loopBuilder.create<arith::ConstantOp>(
@@ -340,8 +256,8 @@ public:
     ArrayRef<int64_t> shardShape = deviceLayout.getShardShape(remoteShapedType);
 
     ttcore::DeviceAttr device = ttcore::lookupDevice(op);
-    AffineMap remoteMemoryMap = getMemoryMap(device, remoteMemref, true);
-    AffineMap localMemoryMap = getMemoryMap(device, localMemref, false);
+    AffineMap remoteMemoryMap = utils::getMemoryMap(device, remoteMemref, true);
+    AffineMap localMemoryMap = utils::getMemoryMap(device, localMemref, false);
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor = calculateCoalescingFactorWithFallback(
@@ -391,7 +307,8 @@ public:
     if (op.isMcast()) {
       // Mcast write: local-to-local, compute local memory map and apply to
       // zero indices to get the fully-indexed form.
-      AffineMap localMemoryMap = getMemoryMap(device, localMemref, false);
+      AffineMap localMemoryMap =
+          utils::getMemoryMap(device, localMemref, false);
 
       MemRefType localType = op.getSrcMemRefType();
       ArrayRef<int64_t> shardShape = localType.getShape();
@@ -404,7 +321,7 @@ public:
         localIndices.push_back(zero);
       }
       localIndices =
-          applyMap(rewriter, loc, localMemoryMap, localIndices, false);
+          utils::applyMap(rewriter, loc, localMemoryMap, localIndices, false);
 
       Value newTx = rewriter.create<DMAWriteOp>(
           loc, localMemref, localIndices, dstMemref, localIndices,
@@ -427,8 +344,8 @@ public:
     ArrayRef<int64_t> gridShape = deviceLayout.getGridShape(remoteShapedType);
     ArrayRef<int64_t> shardShape = deviceLayout.getShardShape(remoteShapedType);
 
-    AffineMap remoteMemoryMap = getMemoryMap(device, dstMemref, true);
-    AffineMap localMemoryMap = getMemoryMap(device, localMemref, false);
+    AffineMap remoteMemoryMap = utils::getMemoryMap(device, dstMemref, true);
+    AffineMap localMemoryMap = utils::getMemoryMap(device, localMemref, false);
 
     size_t elemSizeBytes = getElementSizeBytes(remoteMemrefType);
     size_t coalescingFactor = calculateCoalescingFactorWithFallback(

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -5,9 +5,7 @@
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
-#include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -364,6 +364,9 @@ std::optional<AffineMap> getVirtualGridInverseMapping(Value val) {
 
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
+      if (viewOp.isComposite()) {
+        return std::nullopt;
+      }
       return getVirtualGridInverseMapping(viewOp.getInput());
     }
 
@@ -412,6 +415,9 @@ std::optional<AffineMap> getVirtualGridForwardMapping(Value val) {
 
     // Trace through view/stream ops via ViewOpInterface.
     if (auto viewOp = mlir::dyn_cast<ViewOpInterface>(defOp)) {
+      if (viewOp.isComposite()) {
+        return std::nullopt;
+      }
       return getVirtualGridForwardMapping(viewOp.getInput());
     }
 
@@ -618,6 +624,93 @@ AffineMap getMemoryMap(ttcore::DeviceAttr device,
                        size_t pageSize, size_t baseOffset) {
   return getMemoryMapImpl(device, memrefAndView.first, pageSize,
                           memrefAndView.second, baseOffset);
+}
+
+static AffineMap canonicalStridedMap(MLIRContext *context,
+                                     ArrayRef<int64_t> shape, Type elementType,
+                                     AffineMap map) {
+  assert(map.isIdentity() && "Only identity maps are supported for now.");
+  auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
+  int64_t elementSizeBytes = tileType ? tileType.getSizeBytes()
+                                      : elementType.getIntOrFloatBitWidth() / 8;
+  int64_t currentStride = elementSizeBytes;
+  int64_t rank = shape.size();
+  mlir::AffineExpr strideExpr = mlir::getAffineConstantExpr(0, context);
+  for (int64_t i = rank - 1; i >= 0; i--) {
+    mlir::AffineExpr dim = mlir::getAffineDimExpr(i, context);
+    mlir::AffineExpr stride =
+        mlir::getAffineConstantExpr(currentStride, context);
+    strideExpr = dim * stride + strideExpr;
+    currentStride *= shape[i];
+  }
+  return mlir::AffineMap::get(shape.size(), 0, strideExpr, context);
+}
+
+AffineMap getMemoryMap(ttcore::DeviceAttr device, Value input, bool isRemote) {
+  if (isRemote) {
+    // d2m::utils::getMemoryMap handles view tracing (applyViews) and
+    // VGM lookup (getVirtualGridForwardMapping) internally.
+    return d2m::utils::getMemoryMap(device, input,
+                                    /*pageSize=*/static_cast<size_t>(0));
+  }
+
+  // For local memrefs (including CB values), get the underlying memref type.
+  MemRefType inputType;
+  if (auto cbType = mlir::dyn_cast<CBType>(input.getType())) {
+    inputType = cbType.getUnderlyingAs<MemRefType>();
+  } else {
+    inputType = mlir::cast<MemRefType>(input.getType());
+  }
+  auto layoutMap = d2m::utils::resolveEffectiveAffineMap(input, inputType);
+  return canonicalStridedMap(device.getContext(), inputType.getShape(),
+                             inputType.getElementType(), layoutMap);
+}
+
+template <typename Builder>
+SmallVector<Value> applyMap(Builder &builder, Location loc, AffineMap map,
+                            ValueRange index, bool isRemote) {
+  auto affineApply = [&](AffineMap map, ValueRange index) {
+    return builder.template create<affine::AffineApplyOp>(loc, map, index);
+  };
+
+  if (isRemote) {
+    assert(map.getNumResults() == 4);
+    // Break the map into respective gridY, gridX, offset "single result"
+    // parts. AffineApply only supports single result affine maps.
+    map = map.dropResults(0); // Drop the device index.
+    auto gridY = map.dropResults({1, 2});
+    auto gridX = map.dropResults({0, 2});
+    auto offset = map.dropResults({0, 1});
+    return {affineApply(gridY, index), affineApply(gridX, index),
+            affineApply(offset, index)};
+  }
+
+  assert(map.getNumResults() == 1);
+  return {affineApply(map, index)};
+}
+
+// Instantiate for the two types of builders.
+template SmallVector<Value> applyMap<OpBuilder>(OpBuilder &builder,
+                                                Location loc, AffineMap map,
+                                                ValueRange index,
+                                                bool isRemote);
+template SmallVector<Value>
+applyMap<PatternRewriter>(PatternRewriter &builder, Location loc, AffineMap map,
+                          ValueRange index, bool isRemote);
+
+std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+getLoopBounds(OpBuilder &builder, Location loc, ArrayRef<int64_t> shardShape) {
+  Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                 builder.getIndexAttr(0));
+  Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                builder.getIndexAttr(1));
+  SmallVector<Value> lbs(shardShape.size(), zero);
+  SmallVector<Value> ubs(llvm::map_range(shardShape, [&](int64_t dim) {
+    return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                             builder.getIndexAttr(dim));
+  }));
+  SmallVector<Value> step(shardShape.size(), one);
+  return std::make_tuple(lbs, ubs, step);
 }
 
 llvm::SmallVector<int64_t>

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -235,6 +235,7 @@ void createTTIRToTTMetalMiddleendPipeline(
   pm.addPass(d2m::createD2MPreallocateMcastSemaphores());
   pm.addPass(d2m::createD2MScheduleDMA());
   pm.addPass(d2m::createD2MLowerLoadStoreOpsToDMA());
+  pm.addPass(d2m::createD2MExpandDMAReadCompositeView());
   pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm());
 
   createOptimizationPasses(pm, options);

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -17,29 +17,72 @@ pytestmark = pytest.mark.frontend("ttir")
 
 # Concat tests
 @pytest.mark.parametrize(
-    "shapes",
+    "shapes,dim",
     [
-        [
-            (64, 128),
-            (32, 128),
-            (16, 128),
-        ]
+        ##################################
+        #               2D               #
+        ##################################
+        # Trivial aligned inputs
+        ([(32, 32), (32, 32)], 1),
+        ([(32, 32), (32, 32)], 0),
+        # Larger aligned inputs
+        ([(64, 96), (64, 1024)], 1),
+        ([(96, 64), (1024, 64)], 0),
+        ([(256, 256), (256, 256)], 1),
+        ([(256, 256), (256, 256)], 0),
+        # Unaligned in the non-concat dim
+        ([(7, 64), (7, 96)], 1),
+        ([(96, 3), (64, 3)], 0),
+        # 3-concat, last input unaligned in the concat dim
+        ([(128, 64), (128, 32), (128, 16)], 1),
+        ([(64, 128), (32, 128), (16, 128)], 0),
+        # 4-concat
+        ([(64, 64), (64, 32), (64, 128), (64, 96)], 1),
+        ([(64, 64), (32, 64), (128, 64), (96, 64)], 0),
+        # Max-concat (limited by max 32 CBs on WH)
+        ([(64, 32)] * 31, 1),
+        ([(32, 64)] * 31, 0),
+        ##################################
+        #               3D               #
+        ##################################
+        # Aligned inputs
+        ([(17, 32, 64), (17, 32, 96)], 2),
+        ([(19, 64, 32), (19, 96, 32)], 1),
+        ([(11, 64, 64), (13, 64, 64)], 0),
+        # 3-concat
+        ([(10, 64, 32), (10, 64, 64), (10, 64, 96)], 2),
+        ([(10, 96, 64), (10, 32, 64), (10, 64, 64)], 1),
+        ([(11, 64, 64), (12, 64, 64), (13, 64, 64)], 0),
+        ##################################
+        #               4D               #
+        ##################################
+        # Aligned inputs
+        ([(3, 7, 32, 64), (3, 7, 32, 96)], 3),
+        ([(7, 3, 64, 64), (7, 3, 32, 64)], 2),
+        ([(2, 6, 64, 32), (2, 9, 64, 32)], 1),
+        ([(8, 5, 32, 64), (3, 5, 32, 64)], 0),
+        # 3-concat
+        ([(2, 3, 64, 32), (2, 3, 64, 64), (2, 3, 64, 96)], 3),
+        ([(3, 2, 96, 64), (3, 2, 32, 64), (3, 2, 64, 64)], 2),
+        ([(4, 2, 64, 64), (4, 1, 64, 64), (4, 3, 64, 64)], 1),
+        ([(3, 3, 64, 64), (2, 3, 64, 64), (1, 3, 64, 64)], 0),
     ],
-    ids=shapes_list_str,
 )
-@pytest.mark.parametrize("dim", [0])
-@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+@pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitpy"])
 def test_concat(shapes: List[Shape], dim: int, target: str, request, device):
     def module(builder: TTIRBuilder):
-        @builder.func(shapes, [torch.float32, torch.float32, torch.float32])
+        # Generate dtypes list dynamically based on number of shapes
+        dtypes = [torch.float32] * len(shapes)
+
+        @builder.func(shapes, dtypes)
         def concat_wrapper(
-            in0: Operand,
-            in1: Operand,
-            in2: Operand,
-            builder: TTIRBuilder,
+            *args,
             unit_attrs: Optional[List[str]] = None,
         ):
-            return builder.concat([in0, in1, in2], dim, unit_attrs)
+            # args is (in0, in1, ..., inN, builder)
+            inputs = args[:-1]  # All input tensors
+            builder = args[-1]  # Last argument is the builder
+            return builder.concat(list(inputs), dim, unit_attrs)
 
     compile_and_execute_ttir(
         module,

--- a/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
@@ -355,6 +355,15 @@ module {
     return %0 : tensor<32x32xf32>
   }
 
+  // CHECK-LABEL: func @named_concat
+  func.func @named_concat(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x64xf32> {
+    // CHECK-NOT: concat
+    // CHECK: "d2m.composite_view"{{.+}} -> tensor<1x1x1x2x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.generic
+    %0 = "ttir.concat"(%arg0, %arg1) <{dim = -1 : si32}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x64xf32>
+    return %0 : tensor<32x64xf32>
+  }
+
   // CHECK-LABEL: func @named_clamp_scalar
   func.func @named_clamp_scalar(%arg: !ttype) -> (!ttype) {
     // named clamp_scalar op, unary with scalar attributes:

--- a/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/expand_dma_read_composite_view.mlir
@@ -1,0 +1,70 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-expand-dma-read-composite-view %s | FileCheck %s
+
+#l1 = #ttcore.memory_space<l1>
+module attributes {} {
+  // CHECK-LABEL: func.func @test_composite_view_small
+  func.func @test_composite_view_small() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 111904 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x2>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^datamovement0:
+      %1 = d2m.get_cb(1) operand_index = 1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      // CHECK: d2m.reserve
+      %2 = d2m.reserve %1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: scf.if
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      // CHECK: else
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+      // CHECK: d2m.push
+      d2m.push %1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    memref.dealloc %alloc_0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    memref.dealloc %alloc_1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    return %alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  }
+
+  // CHECK-LABEL: func.func @test_composite_view_large_grid_padded
+  func.func @test_composite_view_large_grid_padded() -> memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1> {
+    %alloc_0 = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    %alloc_1 = memref.alloc() {address = 132384 : i64, alignment = 16 : i64} : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    %view_0 = d2m.view_layout %alloc_0 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 mod 7)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1> -> memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %view_1 = d2m.view_layout %alloc_1 remapping = affine_map<(d0, d1, d2, d3) -> (0, 0, 0, d1 mod 7)> : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1> -> memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    // CHECK-NOT: d2m.composite_view
+    %0 = "d2m.composite_view"(%view_0, %view_1) <{dim = 1 : si32}> : (memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x7x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>) -> memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    %alloc_2 = memref.alloc() {address = 161056 : i64, alignment = 16 : i64} : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x8>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%0 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>)
+        outs(%alloc_2 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    ^datamovement0:
+      %1 = d2m.get_cb(1) operand_index = 1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+      %core0 = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
+      // CHECK: d2m.reserve
+      %2 = d2m.reserve %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: scf.if
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      // CHECK: else
+      // CHECK: d2m.dma_read
+      // CHECK: d2m.dma_wait
+      %tx = d2m.dma_read %0[%core0, %core1], %2, <0> : (memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x2x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+      // CHECK: d2m.push
+      d2m.push %1 : <memref<1x2x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    memref.dealloc %alloc_0 : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    memref.dealloc %alloc_1 : memref<1x1x1x7x!ttcore.tile<32x32, f32>, #ttcore.shard<28672x4096, 1>, #l1>
+    return %alloc_2 : memref<1x8x1x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
@@ -98,3 +98,71 @@ module {
      return %output : tensor<40x40xbf16>
    }
  }
+
+// -----
+
+#layout_in_S = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#layout_out_S = #ttcore.metal_layout<logical_shape = 32x64, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+module  {
+  func.func @test_reblock_composite_view_small(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x64xf32> {
+    // CHECK-AFTER-LABEL: func.func @test_reblock_composite_view_small
+    %0 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>
+    %1 = d2m.to_layout %arg0, %0 : tensor<32x32xf32> into tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S> -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>
+    %2 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>
+    %3 = d2m.to_layout %arg1, %2 : tensor<32x32xf32> into tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S> -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>
+    // CHECK-AFTER: "d2m.composite_view"{{.+}} -> tensor<1x2x1x1x!ttcore.tile<32x32, f32>
+    %4 = "d2m.composite_view"(%1, %3) <{dim = 1 : si32}> : (tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>, tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout_in_S>) -> tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>
+    %5 = d2m.empty() : tensor<32x64xf32>
+    %6 = d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>
+    // CHECK-AFTER: d2m.generic {{.+}} grid = #ttcore.grid<1x2>
+    %7 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+        ins(%4 : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>)
+        outs(%6 : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>)
+     {
+      %9 = tensor.empty() : tensor<1x2x!ttcore.tile<32x32, f32>>
+      %10 = tensor.empty() : tensor<1x2x!ttcore.tile<32x32, f32>>
+      %block0 = d2m.block_index(0) : index
+      %block1 = d2m.block_index(1) : index
+      %11 = d2m.remote_load %9 %4[%block0, %block1] : tensor<1x2x!ttcore.tile<32x32, f32>>, tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S> -> tensor<1x2x!ttcore.tile<32x32, f32>>
+      %12 = d2m.remote_store %6[%block0, %block1] %11 : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>, tensor<1x2x!ttcore.tile<32x32, f32>> -> tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>
+      d2m.yield %12 : (tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>)
+    } : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S>
+    %8 = d2m.to_layout %7, %5 : tensor<1x1x1x2x!ttcore.tile<32x32, f32>, #layout_out_S> into tensor<32x64xf32> -> tensor<32x64xf32>
+    return %8 : tensor<32x64xf32>
+  }
+}
+
+// -----
+
+#layout_in_L = #ttcore.metal_layout<logical_shape = 256x256, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#layout_out_L = #ttcore.metal_layout<logical_shape = 256x512, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+module  {
+  func.func @test_reblock_composite_view_large(%arg0: tensor<256x256xf32>, %arg1: tensor<256x256xf32>) -> tensor<256x512xf32> attributes {tt.function_type = "forward_device"} {
+    // CHECK-AFTER-LABEL: func.func @test_reblock_composite_view_large
+    %0 = d2m.empty() : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>
+    %1 = d2m.to_layout %arg0, %0 : tensor<256x256xf32> into tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L> -> tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>
+    %2 = d2m.empty() : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>
+    %3 = d2m.to_layout %arg1, %2 : tensor<256x256xf32> into tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L> -> tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>
+    // CHECK-AFTER: "d2m.composite_view"{{.+}} -> tensor<8x8x1x2x!ttcore.tile<32x32, f32>
+    %4 = "d2m.composite_view"(%1, %3) <{dim = 1 : si32}> : (tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>, tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_in_L>) -> tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>
+    %5 = d2m.empty() : tensor<256x512xf32>
+    %6 = d2m.empty() : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>
+    // CHECK-AFTER: d2m.generic {{.+}} grid = #ttcore.grid<8x8>
+    %7 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+        ins(%4 : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>)
+        outs(%6 : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>)
+     {
+      %9 = tensor.empty() : tensor<8x16x!ttcore.tile<32x32, f32>>
+      %10 = tensor.empty() : tensor<8x16x!ttcore.tile<32x32, f32>>
+      %block0 = d2m.block_index(0) : index
+      %block1 = d2m.block_index(1) : index
+      %11 = d2m.remote_load %9 %4[%block0, %block1] : tensor<8x16x!ttcore.tile<32x32, f32>>, tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L> -> tensor<8x16x!ttcore.tile<32x32, f32>>
+      %12 = d2m.remote_store %6[%block0, %block1] %11 : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>, tensor<8x16x!ttcore.tile<32x32, f32>> -> tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>
+      d2m.yield %12 : (tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>)
+    } : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L>
+    %8 = d2m.to_layout %7, %5 : tensor<1x1x8x16x!ttcore.tile<32x32, f32>, #layout_out_L> into tensor<256x512xf32> -> tensor<256x512xf32>
+    return %8 : tensor<256x512xf32>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-allocate 2>&1 -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// CHECK-LABEL: func.func @test_composite_view
+func.func @test_composite_view() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>> {
+  // CHECK: %[[ALLOC_LHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_0 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+  // CHECK: %[[ALLOC_RHS:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_1 = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  %0 = "d2m.composite_view"(%alloc_0, %alloc_1) <{dim = 1 : si32}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>) -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+
+  // CHECK: %[[ALLOC_OUT:.+]] = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_2 = memref.alloc() : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+
+  d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x2>, indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>], threads = [#d2m.thread<unified>]}
+      ins(%0 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>)
+      outs(%alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>)
+   {
+    %block_factor0 = d2m.get_block_factor(0) : index
+    %block_factor1 = d2m.get_block_factor(1) : index
+    affine.for %arg2 = 0 to %block_factor0 {
+      affine.for %arg3 = 0 to %block_factor1 {
+        %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ttcore.tile<32x32, f32>>
+        %block_offset0 = d2m.block_offset(0) : index
+        %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
+        %block_offset1 = d2m.block_offset(1) : index
+        %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
+        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+      } {d2m.blocking_loop = 1 : i64}
+    } {d2m.blocking_loop = 0 : i64}
+  }
+
+  // CHECK: return %[[ALLOC_OUT]]
+  return %alloc_2 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+}


### PR DESCRIPTION
### Ticket
Related-To: #3026

### Problem description
This PR implements the concat op for the simple case of tile-aligned sizes on the concat dim, and all inputs & output fit in L1.

### What's changed
- At high-level, the concat op is modeled as piecewise-affine data movement
  - Along the concat dimension, different regions of the output tensor map to different input tensors
  - At compile-time, generate index calculation logic and if-else DMA chains to realize the piecewiseness
  - At run-time, output tiles determine which input tile to fetch using their grid + shard coordinates
- The core idea: introduce a new `d2m.composite_view` op
  - `ttir.concat` is lowered to this lightweight metadata view that aggregates multiple tensors
  - This op implements `ViewOpInterface` and behave like a regular view through most of the pipeline
  - Concat-specific lowering is deferred until right before the `LowerDMAToFullyIndexedForm` pass
    - A new `ExpandDMAReadCompositeView` pass lowers straight to fully-indexed DMA reads
    - GenericOp expanded to the actual list of inputs
    - Piecewise indexing logic and if-else fully-indexed DMA chain generation
    - Shared util functions are moved to `Utils.cpp`
- Multiple compiler infrastructure updates for multi-input views was required
  - Currently there are strong assumption of 1-1 tensor/memref/view/etc. everywhere
  - The concat op / composite view is inherently multi-rooted & fine-grained & run-time determined
  - Several passes (notably D2MAllocate, GridSelection, and view utilities) were extended to handle composite views
- In multiple passes the existing lowering logic are avoided and the composite view gets its own handler
  - This is also to prepare for the follow up work of sub-tile concat, which is even more alien to existing logic and demands fine-grained control

### Checklist
- [x] New/Existing tests provide coverage for changes
