### PR TITLE
Set parallelization level to 16 build jobs during docker build

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -53,7 +53,7 @@ build_and_push() {
             target="--target $3"
         fi
         # Toolchain build causes the OOM error if parallel level is not limited
-        export CMAKE_BUILD_PARALLEL_LEVEL=32
+        export CMAKE_BUILD_PARALLEL_LEVEL=16
 
         echo "Building image $image_name:$DOCKER_TAG"
         docker build \


### PR DESCRIPTION
### Ticket
/

### Problem description
Docker buliding process has started failing ocassionally during the toolchain build.
This has happened due to build being parallelized on 32 jobs which takes up too much host RAM and causes an OOM error.

### What's changed
Reduce number of parallelized jobs during build to 16.

### Checklist
- [ ] New/Existing tests provide coverage for changes
