### PR TITLE
[TTIRFusing] Match RMSNormFusionPattern only for same type inputs

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -3209,8 +3209,8 @@ public:
                                          rewriter.getI32ArrayAttr(targetShape));
     }
 
-    // Although the op can work with different dtypes, this is the indication
-    // that the matching is not correct.
+    // Although the op can work with different dtypes, this is
+    // the indication that the matching is not correct.
     auto inputType = mlir::cast<RankedTensorType>(x.getType());
     if (inputType.getElementType() != gammaType.getElementType()) {
       return mlir::failure();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/6754)

### Problem description
When rms norm is decomposed during lowering, all eltwise ops get `bf16->f32` typecasts on inputs and `f32->bf16` typecast on the output. 

The pattern is written to catch those typecast when possible and make op with `bf16` inputs and outputs and `f32 dest acc`.

In `Qwen/Qwen3-Embedding-8B` model run through vllm typecasts are further from the input nodes, so the pattern is not able to catch them, leaving one of the inputs at `f32`, and therefore also the output, resulting in L1 OOM:

<img height="900" alt="image" src="https://github.com/user-attachments/assets/2521f36b-d9ea-459b-bbf7-a3858727a373" />


### What's changed
Original inputs from torch are expected to have same types, and if the pattern cannot be matched that way, the match is considered incomplete. 

We lose some generality with this limitation, but the matching is safer.

### Checklist
- [ ] New/Existing tests provide coverage for changes
