### PR TITLE
3d batch norm

### DIFF
--- a/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_reshape_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_reshape_test.mlir
@@ -49,4 +49,21 @@ module {
     // CHECK: "ttir.reshape"({{.*}}) <{shape = [4 : i32, 8 : i32]}>
     return %1 : tensor<4x8xf32>
   }
+
+  // Test 4: 3D input with dimension=1 and tile-aligned S - should split S into [S/32, 32]
+  // CHECK-LABEL: func.func public @test_batch_norm_3d_dim1_tile_aligned
+  func.func public @test_batch_norm_3d_dim1_tile_aligned(%arg0: tensor<2x3x64xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>) -> tensor<2x3x64xf32> {
+    // 3D input: [2, 3, 64], dimension=1
+    // S=64 is tile-aligned (64 % 32 == 0), so reshape to [2, 3, 2, 32]
+    // instead of the non-tile-aligned fallback [2, 3, 64, 1]
+    %1 = "ttir.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) <{dimension = 1 : i32, epsilon = 1.000000e-05 : f32}> : (tensor<2x3x64xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x64xf32>
+    // CHECK: "ttir.reshape"(%arg0) <{shape = [2 : i32, 3 : i32, 2 : i32, 32 : i32]}>
+    // CHECK-DAG: "ttir.reshape"(%arg1) <{shape = [1 : i32, 3 : i32, 1 : i32, 1 : i32]}>
+    // CHECK-DAG: "ttir.reshape"(%arg2) <{shape = [1 : i32, 3 : i32, 1 : i32, 1 : i32]}>
+    // CHECK-DAG: "ttir.reshape"(%arg3) <{shape = [1 : i32, 3 : i32, 1 : i32, 1 : i32]}>
+    // CHECK-DAG: "ttir.reshape"(%arg4) <{shape = [1 : i32, 3 : i32, 1 : i32, 1 : i32]}>
+    // CHECK: "ttir.batch_norm_inference"({{.*}}) <{dimension = 1 : i32, epsilon = {{.*}}}>
+    // CHECK: "ttir.reshape"({{.*}}) <{shape = [2 : i32, 3 : i32, 64 : i32]}>
+    return %1 : tensor<2x3x64xf32>
+  }
 }


### PR DESCRIPTION
### Problem description
3d batch norm had a trailing 1 dim appended to it so we could use the 4d ttnn batch norm op. This is a lot more math/memory than needed since the one gets padded to tile dim. 

### What's changed
If the S dim is divisible by 32, split it into even tiles. 

### Checklist
- [x] New/Existing tests provide coverage for changes
