### PR TITLE
[d2m] view(stream) canonicalization pattern

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -45,6 +45,7 @@ def D2M_ViewLayoutOp
 
   let hasVerifier = 1;
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
### Problem description
When running TMs such as reshape that involve a stream layout followed by a compute op, we run into 
```
Encountered unsupported op.
UNREACHABLE executed at /localdev/dloke/tt-mlir/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp:1023!
```

This is due to a `d2m.stream_layout` surviving thru the pipeline because its not being composed properly with the `d2m.view_layout` that is created when the `d2m.to_layout` that takes the TM's output and sends it back to host is folded with the `d2m.to_layout` that grabs the tensor from host and brings it to device.

### What's changed
Added a folding pattern for views of a stream that composes their affine maps and turns it into one stream op which is lowered properly downstream


### Checklist
- [ ] New/Existing tests provide coverage for changes
