### PR TITLE
[Optimizer] Categorize BFP8 as low precision in op validation fallback

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -573,6 +573,8 @@ double calculateDataTypeDistance(ttcore::DataType from, ttcore::DataType to) {
       return {TypeInfo::Category::FLOATING, TypeInfo::Precision::LOW};
     case ttcore::DataType::Float32:
       return {TypeInfo::Category::FLOATING, TypeInfo::Precision::HIGH};
+    case ttcore::DataType::BFP_BFloat8:
+      return {TypeInfo::Category::FLOATING, TypeInfo::Precision::LOW};
     default:
       // For unknown types, assume high precision floating point
       return {TypeInfo::Category::FLOATING, TypeInfo::Precision::HIGH};


### PR DESCRIPTION
### Problem description
The calculateDataTypeDistance function is used during op validation to determine how "far" a data type conversion is. Without this change, BFP_BFloat8 hits the default case and gets treated as high-precision, which incorrectly makes it appear equidistant to Float32 — leading to wrong fallback decisions when the optimizer tries to find a valid data type for an operation.

### What's changed
Add BFP_BFloat8 to the data type distance calculation in OperationValidationAndFallback.cpp, categorizing it as low-precision floating point (same category as BFloat16) rather than letting it fall through to the default high-precision bucket (same as Float32)

### Checklist
- [x] Optimizer / OpModel tests work