### PR TITLE
Fix on-pr.yml call to manual-benchmark.yml

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -105,9 +105,6 @@ jobs:
             gh workflow run ${{ env.WORKFLOW_NAME }} \
               --repo ${{ env.TARGET_REPO }} --ref main \
               --raw-field mlir_override=${{ github.event.pull_request.head.sha }} \
-              --raw-field same_branch=false \
-              --raw-field tt_forge_branch=main \
-              --raw-field test_filter= \
               --raw-field sh-runner=false
 
           else


### PR DESCRIPTION
### Ticket
Closes #7126

### Problem description
on-pr.yml downstream checks failed on tt-metal uplift due to changes in benchmark worfklow (manual-benchmark.yml) in tt-xla.

### What's changed
Aligned inputs with recent tt-xla changes.