### PR TITLE
Add torch==2.3.0 dependency to ttrt wheel

### DIFF
--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -5,5 +5,5 @@ pytest-json-report
 pytest-forked
 setuptools
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.7.0
+torch==2.3.0
 einops

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -1,1 +1,1 @@
-torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
+torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu

--- a/tools/ttrt/setup.py
+++ b/tools/ttrt/setup.py
@@ -44,6 +44,7 @@ perflibs = []
 metallibs = []
 install_requires = []
 install_requires += ["nanobind==2.10.2"]
+install_requires += ["torch==2.3.0"]
 
 if enable_ttnn:
     runlibs += ["_ttnncpp.so"]


### PR DESCRIPTION
Fixes #3480. This PR adds torch==2.3.0 as a dependency to the ttrt wheel and updates the requirements files to use the correct index URL (https://download.pytorch.org/whl/cpu).