### PR TITLE
Suppress some nanobind leak warnings

### DIFF
--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -943,6 +943,7 @@ def execute_py(
     )
     output_tensors = {}
     golden_report = {}
+    module_name = None
 
     try:
         # Parse the AST to find function names from the compiled source
@@ -1044,6 +1045,9 @@ def execute_py(
 
     except Exception as e:
         raise TTBuilderRuntimeException(e) from e
+    finally:
+        if module_name is not None:
+            sys.modules.pop(module_name, None)
 
     return golden_report, output_tensors
 


### PR DESCRIPTION
### Ticket
Related-To: #7136

### What's changed
- Import `ttnn` before `torch` and `_ttmlir_runtime` so that nanobind's leak checker is executed after CPython destroys `ttnn`.
- Clean up the emitpy dynamic module from `sys.modules` after execution and clear the `DeviceGetter` singleton on session finish.

This suppresses some but not all warnings, so at least we can see the pytest results without scrolling through hundreds of lines of warnings.