### PR TITLE
[D2M][Fusion] Fix d2m fusion ordering with multiple legs

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNND2MFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNND2MFusing.cpp
@@ -218,7 +218,21 @@ private:
     }
 
     Operation *firstOp = fusionGroup.front();
-    rewriter.setInsertionPoint(firstOp);
+    // Place the subgraph after the last op that defines any input, so all
+    // inputs dominate the subgraph.
+    Operation *lastInputDefiner = nullptr;
+    for (Value v : inputs) {
+      Operation *defOp = v.getDefiningOp();
+      if (defOp &&
+          (!lastInputDefiner || lastInputDefiner->isBeforeInBlock(defOp))) {
+        lastInputDefiner = defOp;
+      }
+    }
+    if (lastInputDefiner) {
+      rewriter.setInsertionPointAfter(lastInputDefiner);
+    } else {
+      rewriter.setInsertionPoint(firstOp);
+    }
     Location loc = firstOp->getLoc();
 
     // Get device for creating empty output buffers for DPS.
@@ -230,6 +244,7 @@ private:
 
     llvm::SmallVector<Type> outputTypes;
     llvm::SmallVector<Value> outputBuffers;
+    Operation *lastEmptyOp = nullptr;
     for (Value v : outputs) {
       auto tensorType = mlir::cast<RankedTensorType>(v.getType());
       outputTypes.push_back(tensorType);
@@ -247,6 +262,7 @@ private:
           loc, tensorType, device, shapeAttr, dtypeAttr, tensorLayoutAttr,
           memoryConfigAttr);
       outputBuffers.push_back(emptyOp.getResult());
+      lastEmptyOp = emptyOp.getOperation();
     }
 
     auto funcType = rewriter.getFunctionType(inputTypes, outputTypes);
@@ -283,7 +299,15 @@ private:
                     [&](Value v) { return mapping.lookup(v); });
     rewriter.create<func::ReturnOp>(loc, returnValues);
 
-    rewriter.setInsertionPoint(firstOp);
+    // Place subgraph after all its operands: after last input definer and after
+    // the empty output buffers we just created (so output buffers dominate).
+    if (lastEmptyOp) {
+      rewriter.setInsertionPointAfter(lastEmptyOp);
+    } else if (lastInputDefiner) {
+      rewriter.setInsertionPointAfter(lastInputDefiner);
+    } else {
+      rewriter.setInsertionPoint(firstOp);
+    }
     auto dispatchOp = rewriter.create<D2MSubgraphOp>(
         loc, outputTypes, inputs.getArrayRef(), outputBuffers,
         SymbolRefAttr::get(rewriter.getContext(), funcName));

--- a/test/ttmlir/Dialect/TTNN/dispatch_d2m/d2m_fusing_insertion_point_dominance.mlir
+++ b/test/ttmlir/Dialect/TTNN/dispatch_d2m/d2m_fusing_insertion_point_dominance.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-d2m-fusing %s | FileCheck %s
+//
+// Pattern: SLICE_0 -> ADD_0 (fused) -> SLICE_1 -> ADD_1 (fused) -> MULTIPLY (fused).
+// firstOp = ADD_0. Inputs = SLICE_0, SLICE_1, scalar. lastInputDefiner = SLICE_1.
+// The subgraph must be inserted after SLICE_1 (and after BUFFER), not at ADD_0.
+
+#l1 = #ttnn.buffer_type<l1>
+#layout_256 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x8x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout_128 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+
+module {
+  func.func @d2m_fusing_two_legs_insertion_dominance(%arg0: tensor<64x256xbf16, #layout_256>, %arg1: tensor<64x128xbf16, #layout_128>) -> tensor<64x128xbf16, #layout_128> {
+    %0 = "ttnn.slice_static"(%arg0) <{begins = [0 : i32, 0 : i32], ends = [64 : i32, 128 : i32], step = [1 : i32, 1 : i32]}> : (tensor<64x256xbf16, #layout_256>) -> tensor<64x128xbf16, #layout_128>
+    %1 = "ttnn.add"(%0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x128xbf16, #layout_128>, tensor<64x128xbf16, #layout_128>) -> tensor<64x128xbf16, #layout_128>
+    %2 = "ttnn.slice_static"(%arg0) <{begins = [0 : i32, 128 : i32], ends = [64 : i32, 256 : i32], step = [1 : i32, 1 : i32]}> : (tensor<64x256xbf16, #layout_256>) -> tensor<64x128xbf16, #layout_128>
+    %3 = "ttnn.add"(%2, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x128xbf16, #layout_128>, tensor<64x128xbf16, #layout_128>) -> tensor<64x128xbf16, #layout_128>
+    %4 = "ttnn.multiply"(%1, %3) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x128xbf16, #layout_128>, tensor<64x128xbf16, #layout_128>) -> tensor<64x128xbf16, #layout_128>
+    return %4 : tensor<64x128xbf16, #layout_128>
+  }
+}
+// CHECK-LABEL: func.func @d2m_fusing_two_legs_insertion_dominance
+// CHECK: %[[SLICE_0:.*]] = "ttnn.slice_static"(%arg0)
+// CHECK: %[[SLICE_1:.*]] = "ttnn.slice_static"(%arg0)
+// CHECK: %[[BUFFER:.*]] = "ttnn.empty"
+// CHECK: %[[D2M_OUTPUT:.*]] = ttnn.d2m_subgraph @d2m_subgraph_0
+// CHECK: return %[[D2M_OUTPUT]]
+
+// CHECK: func.func private @d2m_subgraph_0
+// CHECK: %[[ADD_0:.*]] = "ttnn.add"
+// CHECK: %[[ADD_1:.*]] = "ttnn.add"
+// CHECK: %[[MULTIPLY:.*]] = "ttnn.multiply"(%[[ADD_0]], %[[ADD_1]])
+// CHECK: return %[[MULTIPLY]]


### PR DESCRIPTION
### Problem description
D2M fusing placed the `d2m_subgraph` at the first fused op in block order. When the fusion group has multiple “legs” (e.g. gate path then up path), some subgraph inputs are defined later in the block, so the pass could emit IR that uses a value before it is defined (“operand does not dominate this use”).

### What's changed
Insert the subgraph after the last op that defines any of its inputs, and after the empty output buffers, so every subgraph operand dominates the subgraph.

### Related Issue
This fix is related to gtp-oss bring up with D2M enabled (see [the issue](https://github.com/tenstorrent/tt-mlir/issues/7107)) where a similar pattern is observed.

### Checklist
- [X] New/Existing tests provide coverage for changes
