### PR TITLE
Enable ttnn.mesh_partition op workaround when optimizer is enabled

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -660,6 +660,7 @@ private:
 const std::set<mlir::StringRef>
     TTNNWorkarounds::TTNNWorkarounds::enabledOpsForWorkaroundWithOptimizer = {
         ttnn::WhereOp::getOperationName(), ttnn::FullOp::getOperationName(),
-        ttnn::EmbeddingOp::getOperationName()};
+        ttnn::EmbeddingOp::getOperationName(),
+        ttnn::MeshPartitionOp::getOperationName()};
 
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_partition.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_partition.mlir
@@ -1,5 +1,5 @@
-// // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=2,4" -o %t %s
-// // RUN: FileCheck %s --input-file=%t
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=2,4" -o %t %s
+// RUN: FileCheck %s --input-file=%t
 
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
   ttcore.device_module {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The TTNN mesh_partition op has an [issue](https://github.com/tenstorrent/tt-metal/issues/37676) where it crashes when its input is a TILED 1D tensor. We want to make sure that the workaround to force the inputs to ROW_MAJOR is enabled in all cases (including when optimizer is enabled).

### What's changed
- Added `ttnn::MeshPartitionOp` to `enabledOpsForWorkaroundWithOptimizer`
- Fixed a typo in `test/ttmlir/Dialect/TTNN/ccl/mesh_partition.mlir`

### Checklist
- [x] New/Existing tests provide coverage for changes
