### PR TITLE
Remove traceback log from eth connections

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -74,7 +74,7 @@ getAllDeviceConnections(const std::vector<::tt::tt_metal::IDevice *> &devices) {
         connectedDevice = device->get_connected_ethernet_core(ethernetCore);
       } catch (const std::runtime_error &e) {
         LOG_WARNING("Skipping ethernet core (", ethernetCore.str(),
-                    ") on chip ", device->id(), ": ", e.what());
+                    ") on chip ", device->id());
         continue;
       }
       addConnection(device->id(), ethernetCore, std::get<0>(connectedDevice),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fetching device connections displayed the entire metal traceback. We originally included this to help identify false negatives (where an eth connection exists, but the metal API can't use it). Since we haven't encountered this scenario yet, the traceback was just causing confusion.

### What's changed
Remove traceback logging in system descriptor creation.

### Checklist
- [ ] New/Existing tests provide coverage for changes
