### PR TITLE
Cast attr to float instead of double

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -502,8 +502,7 @@ inline llvm::APFloat attributeToAPFloat(mlir::Attribute attr) {
     return floatAttr.getValue();
   }
   if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
-    return llvm::APFloat(
-        static_cast<double>(intAttr.getValue().getSExtValue()));
+    return llvm::APFloat(static_cast<float>(intAttr.getValue().getSExtValue()));
   }
   llvm_unreachable("Unsupported attribute type: expected FloatAttr or "
                    "IntegerAttr");


### PR DESCRIPTION
### Problem description
After https://github.com/tenstorrent/tt-mlir/pull/6853 Swin was [failing in perf benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/22347373785/job/64669164561) with error: 
```
/home/build/tt-mlir/env/build/llvm-project-prefix/src/llvm-project/llvm/lib/Support/APFloat.cpp:6147: float llvm::APFloat::convertToFloat() const: Assertion `isRepresentableBy(getSemantics(), semIEEEsingle) && "Float semantics is not representable by IEEEsingle"' failed.
```

This is caused by casting Integer attributes to double:

https://github.com/tenstorrent/tt-mlir/blob/c794d678ec17e6610e3842a97b8086b75904cf49/include/ttmlir/Utils.h#L505-L506

and then using convertToFloat (that expects IEEEsingle or shorter semantics) in getOpConstraints of ClampScalarOp:

https://github.com/tenstorrent/tt-mlir/blob/c794d678ec17e6610e3842a97b8086b75904cf49/lib/OpModel/TTNN/TTNNOpModel.cpp#L6397-L6398

### What's changed

Cast to float instead of double.

### Checklist
- [ ] [Swin in perf benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/22392522706)
