### PR TITLE
Fix manylinux docker env build

### DIFF
--- a/.github/Dockerfile.cibuildwheel
+++ b/.github/Dockerfile.cibuildwheel
@@ -40,7 +40,7 @@ RUN git log -1
 
 
 RUN export CMAKE_BUILD_PARALLEL_LEVEL=12 && \
-    cmake -B env/build env && \
+    cmake -B env/build env -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ && \
     cmake --build env/build
 
 # Final stage

--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -52,15 +52,15 @@ if(TTMLIR_BUILD_LLVM)
         llvm-project
         # Super hacky way to install the python dependencies before the build
         # Sync nanobind with tt-metal's pinned version to avoid ODR violations
-        PATCH_COMMAND bash -c "source ${CMAKE_CURRENT_SOURCE_DIR}/activate && pip install -r mlir/python/requirements.txt && pip install --force-reinstall 'nanobind==2.10.2'"
+        PATCH_COMMAND bash -c "source ${CMAKE_CURRENT_SOURCE_DIR}/activate && pip install -r mlir/python/requirements.txt && pip install --force-reinstall 'nanobind==2.10.2' && git config user.email \"tt-mlir@tenstorrent.com\" && git config user.name \"tenstorrent\" && git apply --index \"${CMAKE_CURRENT_LIST_DIR}/patches/affine-allow-symbol-vars.patch\" && git commit -m \"tt-mlir related patch\""
         CMAKE_GENERATOR Ninja
         CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${LLVM_BUILD_TYPE}
         -DPython3_FIND_VIRTUALENV=ONLY
         -DPython3_EXECUTABLE=${TTMLIR_TOOLCHAIN_DIR}/venv/bin/python
         -DCMAKE_INSTALL_PREFIX=${TTMLIR_TOOLCHAIN_DIR}
-        -DCMAKE_C_COMPILER=clang
-        -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         -DLLVM_ENABLE_PROJECTS=mlir,lld
         -DLLVM_INSTALL_UTILS=ON
         -DLLVM_INSTALL_GTEST=ON


### PR DESCRIPTION
### Ticket

### Problem description
Manylinux built wheels fail tests with LLVM Error

### What's changed
https://github.com/tenstorrent/tt-mlir/commit/145374352617cde7d395cd9598f9f5c2277ed079 Changed option from clang to CMAKE_C_COMPILER but not in cibuildwheel docker (causing default gcc to be used for llvm env build which causes incompatibility with the rest of the project).

### Checklist
- [ ] New/Existing tests provide coverage for changes
