### PR TITLE
Fix sort op memory config in flatbuffer

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3245,7 +3245,9 @@ createOp(FlatbufferObjectCache &cache, NLPCreateQKVHeadsDecodeOp op) {
 
                                   /*local_shape*/ std::nullopt);
 
-  auto memoryConfig = getMemoryConfigIfNeeded(cache, op, op.getQuery());
+  auto memoryConfig = op.getMemoryConfig()
+                          ? toFlatbuffer(cache, op.getMemoryConfig().value())
+                          : 0;
 
   return ::tt::target::ttnn::CreateNLPCreateQKVHeadsDecodeOp(
       *cache.fbb, in, outQuery, outKey, outValue, numHeads, numKVHeads,


### PR DESCRIPTION
### Ticket
#6993 

### Problem description
In step of converting TTNN-IR to flattbuffer, the sort op was only using the memory config if it was explicitly set on the op attribute. If no explicit memory config was set, it passed 0 (null) to the flatbuffer.

### What's changed
Create a memory config based on the output tensor type (like other ops do) when no explicit memory config is set on the op.
This almost matches the standard pattern used by other ops like Pool2d, Slice, Repeat, Typecast, etc. but Sort has multiple results so we specifically take the first result ("getValues()") output tensor type. Now there is an overload to pass the result Value explicitly.

### Checklist
- [ ] New/Existing tests provide coverage for changes
