### PR TITLE
Remove PadOp datatype workaround

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -703,7 +703,6 @@ TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds() {
 }
 
 // Factory method to create a set of workarounds for Pad op operands.
-// tt-metal only supports float32 and bfloat16 data types.
 // tt-metal does not support front padding for tile layout.
 // https://github.com/tenstorrent/tt-metal/issues/10987
 TTNNOperandsWorkarounds
@@ -723,10 +722,6 @@ TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
 
   if (isFrontPadding && layoutAttr.isTiled()) {
     operandWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
-  }
-  if (isa<IntegerType>(input.getType().getElementType())) {
-    operandWorkaround.tensorDataTypeWorkaround =
-        mlir::tt::ttcore::DataType::BFloat16;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(operandWorkaround)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
@@ -8,18 +8,18 @@ module attributes {} {
   func.func @test_pad_workaround(%arg0: tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1> {
     // CHECK-LABEL: @test_pad_workaround
     // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: <{dtype = #ttcore.supportedDataTypes<bf16>,
+    // CHECK-SAME: <{dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME: layout = #ttnn.layout<row_major>,
     // CHECK-SAME: tensor<1x30x30xsi32,
-    // CHECK-SAME: -> tensor<1x30x30xbf16,
+    // CHECK-SAME: -> tensor<1x30x30xsi32,
     // CHECK: %[[PAD:[0-9]+]] = "ttnn.pad"(%[[ARG0]])
-    // CHECK-SAME: tensor<1x30x30xbf16
-    // CHECK-SAME: -> tensor<1x32x32xbf16,
+    // CHECK-SAME: tensor<1x30x30xsi32
+    // CHECK-SAME: -> tensor<1x32x32xsi32,
     %0 = "ttnn.pad"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>, padding = array<i32: 0, 0, 1, 1, 1, 1>, use_multicore = true, value = 0.000000e+00 : f32}> : (tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1>
     // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]])
     // CHECK-SAME: <{dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME: layout = #ttnn.layout<tile>
-    // CHECK-SAME: tensor<1x32x32xbf16,
+    // CHECK-SAME: tensor<1x32x32xsi32,
     // CHECK-SAME: -> tensor<1x32x32xsi32,
     return %0 : tensor<1x32x32xsi32, #ttnn_layout1>
   }


### PR DESCRIPTION
### Ticket
closes #7187 

### Problem description
A data type workaround was added for PadOp for Integer inputs which is no longer required. 

### What's changed
Remove data type workaround for PadOp.

### Checklist
- [X] Existing tests provide coverage for changes
