### PR TITLE
[ttrt] fix ttrt perf --artifact-dir

### DIFF
--- a/tools/ttrt/common/perf.py
+++ b/tools/ttrt/common/perf.py
@@ -519,7 +519,8 @@ class Perf:
 
                     # copy all relevant files into perf folder for this test
                     perf_folder_path = self.artifacts.get_binary_perf_folder_path(bin)
-                    self.file_manager.create_directory(perf_folder_path)
+                    if not self.file_manager.check_directory_exists(perf_folder_path):
+                        self.file_manager.create_directory(perf_folder_path)
                     self.file_manager.copy_file(perf_folder_path, tracy_file_path)
                     self.file_manager.copy_file(
                         perf_folder_path, tracy_ops_times_file_path


### PR DESCRIPTION
### Problem description
Running something like `ttrt perf --artifact-dir generated/test/ *.ttm` would crash with following error
```
Traceback (most recent call last):
  File "/localdev/vtang/tt-mlir/build/python_packages/ttrt/common/util.py", line 476, in copy_file
    shutil.copy2(src_file_path, dest_file_path)
  File "/usr/lib/python3.12/shutil.py", line 475, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.12/shutil.py", line 262, in copyfile
    with open(dst, 'wb') as fdst:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'generated/test//ttmetal_compiled.ttm/perf'
```

### What's changed
- create the folder
