### PR TITLE
Remove concat op workaround

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1318,17 +1318,6 @@ def TTNN_ConcatOp : TTNN_Op<"concat", [TTNN_MemoryConfigOpInterface]> {
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        ::mlir::Operation::operand_range inputs = getInputs();
-        int64_t numOperands = getOperands().size();
-        int32_t dim = getDim();
-        return
-          wa::TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
-                                                        inputs, numOperands, dim);
-      }
-    }];
-
     let hasVerifier = 1;
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -259,11 +259,6 @@ public:
   static TTNNOperandsWorkarounds
   createScatterOpOperandsWorkarounds(mlir::Operation *op);
 
-  // Create workarounds for concat op operands.
-  static TTNNOperandsWorkarounds
-  createConcatOpOperandsWorkarounds(mlir::Operation::operand_range inputs,
-                                    int64_t numOperands, int32_t dim);
-
   // Create workarounds for static slice op operands.
   static TTNNOperandsWorkarounds
   createSliceStaticOpOperandsWorkarounds(ttnn::SliceStaticOp op);

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -2,29 +2,6 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
-  func.func public @test_concat_datatype_workaround(%arg0: tensor<2x53xsi32>, %arg1: tensor<2x1xsi32>) -> tensor<2x54xsi32> {
-    // CHECK-LABEL: func.func public @test_concat_datatype_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<2x53xsi32
-    // CHECK-SAME: -> tensor<2x53xbf16
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<2x1xsi32
-    // CHECK-SAME: -> tensor<2x1xbf16
-    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]])
-    // CHECK-SAME: dim = 1 : si32
-    // CHECK-SAME: tensor<2x53xbf16
-    // CHECK-SAME: tensor<2x1xbf16
-    // CHECK-SAME: -> tensor<2x54xbf16
-    %0 = "ttir.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<2x53xsi32>, tensor<2x1xsi32>) -> tensor<2x54xsi32>
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[CONCAT]])
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
-    // CHECK-SAME: tensor<2x54xbf16
-    // CHECK-SAME: -> tensor<2x54xsi32
-    return %0 : tensor<2x54xsi32>
-  }
-
   func.func public @test_concat_reshape_workaround(%arg0: tensor<53xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xf32>) -> tensor<55xf32> {
     // CHECK-LABEL: @test_concat_reshape_workaround
     // CHECK: %[[ARG0:[0-9]+]] = "ttnn.reshape"(%arg0)

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
@@ -72,26 +72,14 @@ module @jit_concat attributes {} {
     return %0 : tensor<32x32x32x96xf32>
   }
 
-  func.func public @test_concat_datatype_workaround(%arg0: tensor<2x53xi64>, %arg1: tensor<2x1xi64>) -> tensor<2x54xi64> {
-    // CHECK-LABEL: func.func public @test_concat_datatype_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<2x53xsi32
-    // CHECK-SAME: -> tensor<2x53xbf16
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.typecast"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<2x1xsi32
-    // CHECK-SAME: -> tensor<2x1xbf16
-    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]])
+  func.func public @test_concat_integer(%arg0: tensor<2x53xi64>, %arg1: tensor<2x1xi64>) -> tensor<2x54xi64> {
+    // CHECK-LABEL: func.func public @test_concat_integer
+    // CHECK: "ttnn.concat"(%arg0, %arg1)
     // CHECK-SAME: dim = 1 : si32
-    // CHECK-SAME: tensor<2x53xbf16
-    // CHECK-SAME: tensor<2x1xbf16
-    // CHECK-SAME: -> tensor<2x54xbf16
-    %0 = stablehlo.concatenate %arg0, %arg1, dim = 1 : (tensor<2x53xi64>, tensor<2x1xi64>) -> tensor<2x54xi64>
-    // CHECK: "ttnn.typecast"(%[[CONCAT]])
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
-    // CHECK-SAME: tensor<2x54xbf16
+    // CHECK-SAME: tensor<2x53xsi32
+    // CHECK-SAME: tensor<2x1xsi32
     // CHECK-SAME: -> tensor<2x54xsi32
+    %0 = stablehlo.concatenate %arg0, %arg1, dim = 1 : (tensor<2x53xi64>, tensor<2x1xi64>) -> tensor<2x54xi64>
     return %0 : tensor<2x54xi64>
   }
 


### PR DESCRIPTION
### Ticket
closes #7204 

### Problem description
A data type workaround was added for ConcatOp for Integer inputs which is no longer required.

### What's changed
Remove data type workaround for ConcatOp.

### Checklist
- [X] Existing tests provide coverage for changes
