### PR TITLE
Debloat ttrt wheel dependencies

### DIFF
--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -5,5 +5,5 @@ pytest-json-report
 pytest-forked
 setuptools
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.7.0
+torch==2.9.1+cpu
 einops

--- a/tools/tt-alchemist/csrc/python_runner/CMakeLists.txt
+++ b/tools/tt-alchemist/csrc/python_runner/CMakeLists.txt
@@ -39,14 +39,19 @@ target_include_directories(${PYTHON_RUNNER_LIBRARY_NAME}
     ${TTMETAL_INCLUDE_DIRS}
 )
 
+target_link_directories(${PYTHON_RUNNER_LIBRARY_NAME}
+  PUBLIC
+    ${TTMETAL_LIBRARY_DIR}
+)
+
 target_link_libraries(${PYTHON_RUNNER_LIBRARY_NAME}
   PUBLIC
     nanobind-static
     Python::Python
-    ${TTMETAL_LIBRARY_DIR}/libtt_metal.so
-    ${TTMETAL_LIBRARY_DIR}/_ttnncpp.so
-    ${TTMETAL_LIBRARY_DIR}/libtt_stl.so
-    ${TTMETAL_LIBRARY_DIR}/libfmt$<IF:$<CONFIG:Debug>,d,>.so
+    TTMETAL_LIBRARY
+    TTNN_LIBRARY
+    TT_STL_LIBRARY
+    fmt$<IF:$<CONFIG:Debug>,d,>
 )
 
 set_target_properties(${PYTHON_RUNNER_LIBRARY_NAME} PROPERTIES

--- a/tools/ttrt/CMakeLists.txt
+++ b/tools/ttrt/CMakeLists.txt
@@ -8,9 +8,16 @@ foreach (filename ${TTRT_FILES})
     list(APPEND TTRT_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/${relative_filename}")
 endforeach (filename)
 
+set(TTRT_PIP_PERF_REQUIREMENTS_COMMAND)
+if(TT_RUNTIME_ENABLE_PERF_TRACE)
+  set(TTRT_PIP_PERF_REQUIREMENTS_COMMAND
+      COMMAND python -m pip install -r "${CMAKE_CURRENT_BINARY_DIR}/requirements-perf.txt")
+endif()
+
 add_custom_command(
   COMMAND rm -rf build
   COMMAND python -m pip install -r "${CMAKE_CURRENT_BINARY_DIR}/requirements.txt"
+  ${TTRT_PIP_PERF_REQUIREMENTS_COMMAND}
   COMMAND TTMLIR_ENABLE_RUNTIME=${TTMLIR_ENABLE_RUNTIME}
           TT_RUNTIME_ENABLE_TTNN=${TT_RUNTIME_ENABLE_TTNN}
           TT_RUNTIME_ENABLE_TTMETAL=${TT_RUNTIME_ENABLE_TTMETAL}
@@ -24,8 +31,8 @@ add_custom_command(
           TTMLIR_VERSION_PATCH=${TTMLIR_VERSION_PATCH}
           CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}
           SOURCE_ROOT=${TTMLIR_SOURCE_DIR}
-          python -m pip wheel . --wheel-dir build
-  COMMAND python -m pip install build/*.whl --force-reinstall
+          python -m pip wheel . --wheel-dir build --no-deps
+  COMMAND python -m pip install build/ttrt-*.whl --force-reinstall --no-deps
   COMMAND touch ${CMAKE_CURRENT_BINARY_DIR}/build/.installed
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS ${TTRT_SOURCES} ${TTRT_FILES} TTMLIRRuntime TTRuntimeTTNNTypes TTRuntimeTTNNUtils _ttmlir_runtime

--- a/tools/ttrt/requirements-perf.txt
+++ b/tools/ttrt/requirements-perf.txt
@@ -1,0 +1,6 @@
+loguru
+pandas
+seaborn
+graphviz
+pyyaml
+click

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -1,1 +1,3 @@
-torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.9.1+cpu
+nanobind==2.10.2

--- a/tools/ttrt/setup.py
+++ b/tools/ttrt/setup.py
@@ -14,6 +14,24 @@ TTMLIR_VERSION_PATCH = os.getenv("TTMLIR_VERSION_PATCH", "0")
 
 __version__ = f"{TTMLIR_VERSION_MAJOR}.{TTMLIR_VERSION_MINOR}.{TTMLIR_VERSION_PATCH}"
 
+
+def load_requirements(filename):
+    requirements = []
+    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    with open(filepath, encoding="utf-8") as requirements_file:
+        for raw_line in requirements_file:
+            requirement = raw_line.strip()
+            if (
+                not requirement
+                or requirement.startswith("#")
+                or requirement.startswith("--")
+            ):
+                continue
+            requirements.append(requirement)
+
+    return requirements
+
+
 src_dir = os.environ.get(
     "SOURCE_ROOT",
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."),
@@ -42,10 +60,7 @@ dylibs = []
 runlibs = []
 perflibs = []
 metallibs = []
-install_requires = [
-    "torch==2.7.0",
-    "nanobind==2.10.2",
-]
+install_requires = load_requirements("requirements.txt")
 
 if enable_ttnn:
     runlibs += ["_ttnncpp.so"]
@@ -209,12 +224,7 @@ package_dir = {
     "ttrt.runtime": f"{ttmlir_build_dir}/python_packages/ttrt/runtime",
 }
 if enable_perf:
-    install_requires += ["loguru"]
-    install_requires += ["pandas"]
-    install_requires += ["seaborn"]
-    install_requires += ["graphviz"]
-    install_requires += ["pyyaml"]
-    install_requires += ["click"]
+    install_requires += load_requirements("requirements-perf.txt")
     packages += ["tracy"]
     packages += ["tt_metal"]
     package_dir["tracy"] = f"{ttmetalhome}/tools/tracy"


### PR DESCRIPTION
### Problem description
ttrt's `setup.py` depends on the default GPU-enabled torch, bringing in CUDA & triton dependencies.
Everytime `cmake --build build` is executed all these dependencies are reinstalled, even if the ttrt wheel isn't rebuilt!

### What's changed
- Pin pytorch to 2.9.1, same as tt-xla, closes #6991
- Extract ttrt's dependencies & versions to txt files, force CPU-only torch
- `setup.py` reads these txt instead, maintaining a single source of truth
- Let cmake install the dependencies explicitly & avoid reinstalling them
- Fix latent cmake linking bug uncovered by the change: stop using raw `.so` paths

### Known issue
- The chisel tool still specifies unpinned GPU-torch in `setup.py`, leaving it alone for now