### PR TITLE
Fix linking

### DIFF
--- a/lib/Target/TTMetal/CMakeLists.txt
+++ b/lib/Target/TTMetal/CMakeLists.txt
@@ -11,4 +11,5 @@ add_mlir_translation_library(TTMetalTargetFlatbuffer
     MLIRTTIRDialect
     MLIRTTCoreDialect
     TTMLIRTTKernelToEmitC
+    MLIRD2MUtils
 )

--- a/lib/Target/TTNN/CMakeLists.txt
+++ b/lib/Target/TTNN/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_translation_library(TTNNTargetFlatbuffer
     MLIRTTNNTransforms
     TTMLIRTTNNToEmitC
     MLIRQuantDialect
+    MLIRDebugDialect
 )


### PR DESCRIPTION
### Ticket
None

### Problem description
Clean compilation locally inside lima VM, `Ubuntu 24.04.4 LTS`.
```
[113/117] Linking CXX executable bin/ttmlir-translate
FAILED: [code=1] bin/ttmlir-translate 
: && /usr/bin/clang++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -Wl,-rpath-link,/Users/vtsilytskyi/tt-mlir/build/lib  -Wl,--gc-sections  -Xlinker --dependency-file=tools/ttmlir-translate/CMakeFiles/ttmlir-translate.dir/link.d tools/ttmlir-translate/CMakeFiles/ttmlir-translate.dir/ttmlir-translate.cpp.o -o bin/ttmlir-translate  -Wl,-rpath,"\$ORIGIN/../lib:/opt/ttmlir-toolchain/lib:"  lib/libTTMLIRCompilerStatic.a  /opt/ttmlir-toolchain/lib/libMLIRTranslateLib.a  /opt/ttmlir-toolchain/lib/libMLIRTestDynDialect.a  /opt/ttmlir-toolchain/lib/libMLIRTosaTestPasses.a  /opt/ttmlir-toolchain/lib/libMLIRXeGPUTestPasses.a  lib/libMLIRTTNNPipelines.a  lib/libMLIRTTIRPipelines.a  lib/libMLIRTTMetalPipelines.a  lib/libMLIRTTIRTransforms.a  lib/libMLIRTTIREraseInverseOps.a  lib/libMLIRTTIRHoistCPUOps.a  lib/libMLIRTTKernelPipelines.a  lib/libMLIRTTKernelTransforms.a  lib/libMLIRLLVMTransforms.a  lib/libMLIRD2MTransforms.a  lib/libMLIRTTUtils.a  lib/libMLIRDebugDialect.a  lib/libTTMLIRTosaToTTIR.a  lib/libTTMLIRTTIRToTTIRDecomposition.a  lib/libTTMLIRD2MToTTNN.a  lib/libTTMLIRTTIRToD2M.a  lib/libMLIRD2MDialect.a  lib/libMLIRD2MUtils.a  lib/libTTMLIRArithToD2MTileOps.a  lib/libTTMLIRMathToD2MTileOps.a  lib/libTTMLIRTTIRToLinalg.a  lib/libTTMLIRD2MToTTKernel.a  lib/libMLIRD2MAnalysis.a  lib/libMLIRD2MAllocation.a  lib/libTTMLIRD2MToTTMetal.a  lib/libTTMLIRSFPIToEmitC.a  lib/libMLIRSFPIDialect.a  lib/libTTMLIRTTNNToTTIR.a  /opt/ttmlir-toolchain/lib/libMLIRFuncAllExtensions.a  /opt/ttmlir-toolchain/lib/libMLIRFuncInlinerExtension.a  /opt/ttmlir-toolchain/lib/libMLIRFuncShardingExtensions.a  /opt/ttmlir-toolchain/lib/libMLIRTensorAllExtensions.a  /opt/ttmlir-toolchain/lib/libMLIRTensorShardingExtensions.a  lib/libTTMLIRTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTargetIRDLToCpp.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVTranslateRegistration.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVDeserialization.a  /opt/ttmlir-toolchain/lib/libMLIRToLLVMIRTranslationRegistration.a  /opt/ttmlir-toolchain/lib/libMLIRArmNeonToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRArmSMEToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRArmSVEToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIROpenACCToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIROpenMPToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRPtrToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRVCIXToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRFromLLVMIRTranslationRegistration.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMIRToNVVMTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRExportSMTLIB.a  /opt/ttmlir-toolchain/lib/libMLIRTargetWasmImport.a  /opt/ttmlir-toolchain/lib/libMLIRTestFromLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMIRToLLVMTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRTestToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRBuiltinToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRTestDialect.a  /opt/ttmlir-toolchain/lib/libMLIRDerivedAttributeOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRReduce.a  lib/libTTMetalTargetFlatbuffer.a  lib/libTTMLIRTTKernelToEmitC.a  lib/libTTNNTargetFlatbuffer.a  lib/libMLIRTTNNTransforms.a  lib/libMLIRTTNNAnalysis.a  lib/libMLIRScheduler.a  lib/libMLIRTTNNValidation.a  lib/libMLIRTTNNDialect.a  lib/libMLIRTTNNInterfaces.a  lib/OpModel/TTNN/libTTNNOpModelLib.a  lib/libTTMLIRTTNNToEmitPy.a  lib/libTTMLIRTTIRToTTNN.a  lib/libTTMLIRTTNNUtils.a  lib/libTTMLIRTTNNToEmitC.a  lib/libMLIRTTTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTargetCpp.a  lib/libTTLLVMToDynamicLib.a  /opt/ttmlir-toolchain/lib/liblldELF.a  /opt/ttmlir-toolchain/lib/liblldCommon.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64Disassembler.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMARMDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMAVRDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMBPFDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMHexagonDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMLanaiDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMLoongArchDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMMipsDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMMSP430Disassembler.a  /opt/ttmlir-toolchain/lib/libLLVMPowerPCDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMRISCVDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMSparcDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMSystemZDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMVEDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMX86Disassembler.a  /opt/ttmlir-toolchain/lib/libLLVMXCoreDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMLTO.a  /opt/ttmlir-toolchain/lib/libLLVMExtensions.a  /opt/ttmlir-toolchain/lib/libLLVMOption.a  lib/libTTKernelTargetCpp.a  lib/libMLIRTTIRDialect.a  lib/libTTMLIRTTIRUtils.a  lib/libMLIRTTKernelDialect.a  lib/libMLIRTTCoreDialect.a  lib/libMLIRTTMetalDialect.a  lib/libEmitPyTargetPython.a  lib/libMLIREmitPyDialect.a  lib/libMLIREmitPyInterfaces.a  lib/libTTMLIRSupport.a  /opt/ttmlir-toolchain/lib/libMLIRRegisterAllPasses.a  /opt/ttmlir-toolchain/lib/libMLIRAffineTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRAMDGPUTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRArithValueBoundsOpInterfaceImpl.a  /opt/ttmlir-toolchain/lib/libMLIRArmNeonVectorTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRArmSVEVectorTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRAsyncTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRBufferizationPipelines.a  /opt/ttmlir-toolchain/lib/libMLIRBufferizationTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRDLTITransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRFuncTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRFuncUtils.a  /opt/ttmlir-toolchain/lib/libMLIRGPUTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRGPUPipelines.a  /opt/ttmlir-toolchain/lib/libMLIRVCIXDialect.a  /opt/ttmlir-toolchain/lib/libMLIRMathTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRMLProgramTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRNVGPUTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRNVGPUTransforms.a  /opt/ttmlir-toolchain/lib/libMLIROpenACCTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRQuantTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRSCFTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRShapeOpsTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRSparseTensorPipelines.a  /opt/ttmlir-toolchain/lib/libMLIRSparseTensorTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRLinalgTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRSparseTensorTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRSparseTensorUtils.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVModuleCombiner.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTensorInferTypeOpInterfaceImpl.a  /opt/ttmlir-toolchain/lib/libMLIRTensorTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDebugExtension.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDialectIRDLExtension.a  /opt/ttmlir-toolchain/lib/libMLIRIRDL.a  /opt/ttmlir-toolchain/lib/libMLIRTransformLoopExtension.a  /opt/ttmlir-toolchain/lib/libMLIRTransformPDLExtension.a  /opt/ttmlir-toolchain/lib/libMLIRTransformSMTExtension.a  /opt/ttmlir-toolchain/lib/libMLIRSMT.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDialectTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTransformTuneExtension.a  /opt/ttmlir-toolchain/lib/libMLIRVectorTransformOps.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDialect.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDialectInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRTransformDialectUtils.a  /opt/ttmlir-toolchain/lib/libMLIRWasmSSADialect.a  /opt/ttmlir-toolchain/lib/libMLIRXeGPUTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTargetLLVMIRTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTargetLLVMIRImport.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64AsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMARMAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMAVRAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMBPFAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMLoongArchAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMMipsAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMMSP430AsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMPowerPCAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMRISCVAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMSparcAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMSystemZAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMVEAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMX86AsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64CodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMARMCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMAVRCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMBPFCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMHexagonCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMHexagonAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMLanaiCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMLanaiAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMLoongArchCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMMipsCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMMSP430CodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMPowerPCCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMRISCVCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMSparcCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMSystemZCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMVECodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyUtils.a  /opt/ttmlir-toolchain/lib/libLLVMX86CodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMXCoreCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64Desc.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64Utils.a  /opt/ttmlir-toolchain/lib/libLLVMARMDesc.a  /opt/ttmlir-toolchain/lib/libLLVMARMUtils.a  /opt/ttmlir-toolchain/lib/libLLVMAVRDesc.a  /opt/ttmlir-toolchain/lib/libLLVMBPFDesc.a  /opt/ttmlir-toolchain/lib/libLLVMHexagonDesc.a  /opt/ttmlir-toolchain/lib/libLLVMLanaiDesc.a  /opt/ttmlir-toolchain/lib/libLLVMLoongArchDesc.a  /opt/ttmlir-toolchain/lib/libLLVMMipsDesc.a  /opt/ttmlir-toolchain/lib/libLLVMMSP430Desc.a  /opt/ttmlir-toolchain/lib/libLLVMPowerPCDesc.a  /opt/ttmlir-toolchain/lib/libLLVMRISCVDesc.a  /opt/ttmlir-toolchain/lib/libLLVMSparcDesc.a  /opt/ttmlir-toolchain/lib/libLLVMSystemZDesc.a  /opt/ttmlir-toolchain/lib/libLLVMVEDesc.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyDesc.a  /opt/ttmlir-toolchain/lib/libLLVMX86Desc.a  /opt/ttmlir-toolchain/lib/libLLVMMCDisassembler.a  /opt/ttmlir-toolchain/lib/libLLVMXCoreDesc.a  /opt/ttmlir-toolchain/lib/libLLVMAArch64Info.a  /opt/ttmlir-toolchain/lib/libLLVMARMInfo.a  /opt/ttmlir-toolchain/lib/libLLVMAVRInfo.a  /opt/ttmlir-toolchain/lib/libLLVMBPFInfo.a  /opt/ttmlir-toolchain/lib/libLLVMHexagonInfo.a  /opt/ttmlir-toolchain/lib/libLLVMLanaiInfo.a  /opt/ttmlir-toolchain/lib/libLLVMLoongArchInfo.a  /opt/ttmlir-toolchain/lib/libLLVMMipsInfo.a  /opt/ttmlir-toolchain/lib/libLLVMMSP430Info.a  /opt/ttmlir-toolchain/lib/libLLVMPowerPCInfo.a  /opt/ttmlir-toolchain/lib/libLLVMRISCVInfo.a  /opt/ttmlir-toolchain/lib/libLLVMSparcInfo.a  /opt/ttmlir-toolchain/lib/libLLVMSystemZInfo.a  /opt/ttmlir-toolchain/lib/libLLVMVEInfo.a  /opt/ttmlir-toolchain/lib/libLLVMWebAssemblyInfo.a  /opt/ttmlir-toolchain/lib/libLLVMX86Info.a  /opt/ttmlir-toolchain/lib/libLLVMXCoreInfo.a  /opt/ttmlir-toolchain/lib/libMLIRXeVMTarget.a  /opt/ttmlir-toolchain/lib/libMLIRXeVMToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libLLVMSPIRVCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMSPIRVAnalysis.a  /opt/ttmlir-toolchain/lib/libLLVMSPIRVDesc.a  /opt/ttmlir-toolchain/lib/libLLVMSPIRVInfo.a  /opt/ttmlir-toolchain/lib/libMLIRArithToAMDGPU.a  /opt/ttmlir-toolchain/lib/libMLIRArithToArmSME.a  /opt/ttmlir-toolchain/lib/libMLIRArmNeon2dToIntr.a  /opt/ttmlir-toolchain/lib/libMLIRArmSMEToSCF.a  /opt/ttmlir-toolchain/lib/libMLIRArmSMEToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRArmSMETransforms.a  /opt/ttmlir-toolchain/lib/libMLIRBufferizationToMemRef.a  /opt/ttmlir-toolchain/lib/libMLIRComplexToLibm.a  /opt/ttmlir-toolchain/lib/libMLIRComplexToROCDLLibraryCalls.a  /opt/ttmlir-toolchain/lib/libMLIRComplexToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRComplexToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRComplexToStandard.a  /opt/ttmlir-toolchain/lib/libMLIRComplexDivisionConversion.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowToSCF.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRConvertToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIRArithToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIRFuncToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToLLVMSPV.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToNVVMTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToROCDLTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRAMDGPUToROCDL.a  /opt/ttmlir-toolchain/lib/libMLIRAMDGPUUtils.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRIndexToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRLinalgToStandard.a  /opt/ttmlir-toolchain/lib/libMLIRMathToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIRMathToFuncs.a  /opt/ttmlir-toolchain/lib/libMLIRMathToLibm.a  /opt/ttmlir-toolchain/lib/libMLIRMathToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRMathToROCDL.a  /opt/ttmlir-toolchain/lib/libMLIRMathToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIRShardToMPI.a  /opt/ttmlir-toolchain/lib/libMLIRMPIToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRMPIDialect.a  /opt/ttmlir-toolchain/lib/libMLIRNVGPUToNVVM.a  /opt/ttmlir-toolchain/lib/libMLIRGPUToGPURuntimeTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRAsyncToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRConvertToLLVMPass.a  /opt/ttmlir-toolchain/lib/libMLIRConvertToLLVMInterface.a  /opt/ttmlir-toolchain/lib/libMLIRNVVMToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIROpenACCToSCF.a  /opt/ttmlir-toolchain/lib/libMLIROpenACCDialect.a  /opt/ttmlir-toolchain/lib/libMLIROpenMPToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRPtrToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRPtrDialect.a  /opt/ttmlir-toolchain/lib/libMLIRReconcileUnrealizedCasts.a  /opt/ttmlir-toolchain/lib/libMLIRSCFToControlFlow.a  /opt/ttmlir-toolchain/lib/libMLIRSCFToEmitC.a  /opt/ttmlir-toolchain/lib/libMLIREmitCTransforms.a  /opt/ttmlir-toolchain/lib/libMLIREmitCDialect.a  /opt/ttmlir-toolchain/lib/libMLIRSCFToGPU.a  /opt/ttmlir-toolchain/lib/libMLIRGPUTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRAMDGPUDialect.a  /opt/ttmlir-toolchain/lib/libMLIRAsyncDialect.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVTarget.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVSerialization.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVBinaryUtils.a  /opt/ttmlir-toolchain/lib/libMLIRNVVMTarget.a  /opt/ttmlir-toolchain/lib/libMLIRNVVMToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libLLVMNVPTXCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMNVPTXDesc.a  /opt/ttmlir-toolchain/lib/libLLVMNVPTXInfo.a  /opt/ttmlir-toolchain/lib/libMLIRROCDLTarget.a  /opt/ttmlir-toolchain/lib/libMLIRROCDLToLLVMIRTranslation.a  /opt/ttmlir-toolchain/lib/libMLIRROCDLDialect.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUAsmParser.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMAsmPrinter.a  /opt/ttmlir-toolchain/lib/libLLVMMIRParser.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUDesc.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUUtils.a  /opt/ttmlir-toolchain/lib/libLLVMAMDGPUInfo.a  /opt/ttmlir-toolchain/lib/libMLIRTargetLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRExecutionEngineUtils.a  /opt/ttmlir-toolchain/lib/libLLVMPasses.a  /opt/ttmlir-toolchain/lib/libLLVMCoroutines.a  /opt/ttmlir-toolchain/lib/libLLVMipo.a  /opt/ttmlir-toolchain/lib/libLLVMVectorize.a  /opt/ttmlir-toolchain/lib/libLLVMSandboxIR.a  /opt/ttmlir-toolchain/lib/libLLVMLinker.a  /opt/ttmlir-toolchain/lib/libLLVMCFGuard.a  /opt/ttmlir-toolchain/lib/libLLVMGlobalISel.a  /opt/ttmlir-toolchain/lib/libLLVMSelectionDAG.a  /opt/ttmlir-toolchain/lib/libLLVMCodeGen.a  /opt/ttmlir-toolchain/lib/libLLVMTarget.a  /opt/ttmlir-toolchain/lib/libLLVMCodeGenTypes.a  /opt/ttmlir-toolchain/lib/libLLVMCGData.a  /opt/ttmlir-toolchain/lib/libLLVMBitWriter.a  /opt/ttmlir-toolchain/lib/libLLVMHipStdPar.a  /opt/ttmlir-toolchain/lib/libLLVMIRPrinter.a  /opt/ttmlir-toolchain/lib/libLLVMInstrumentation.a  /opt/ttmlir-toolchain/lib/libLLVMObjCARCOpts.a  /opt/ttmlir-toolchain/lib/libMLIRAffineToStandard.a  /opt/ttmlir-toolchain/lib/libMLIRSCFToOpenMP.a  /opt/ttmlir-toolchain/lib/libMLIROpenMPDialect.a  /opt/ttmlir-toolchain/lib/libMLIROpenACCMPCommon.a  /opt/ttmlir-toolchain/lib/libMLIRSCFToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRIndexToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRShapeToStandard.a  /opt/ttmlir-toolchain/lib/libMLIRShapeDialect.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVUtils.a  /opt/ttmlir-toolchain/lib/libMLIRFuncToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRArithToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVAttrToLLVMConversion.a  /opt/ttmlir-toolchain/lib/libMLIRTensorToLinalg.a  /opt/ttmlir-toolchain/lib/libMLIRLinalgTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRShardTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTosaShardingInterfaceImpl.a  /opt/ttmlir-toolchain/lib/libMLIRTensorTilingInterfaceImpl.a  /opt/ttmlir-toolchain/lib/libMLIRTensorToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRArithToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRFuncToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRTosaToArith.a  /opt/ttmlir-toolchain/lib/libMLIRTosaToLinalg.a  /opt/ttmlir-toolchain/lib/libMLIRTosaToMLProgram.a  /opt/ttmlir-toolchain/lib/libMLIRMLProgramDialect.a  /opt/ttmlir-toolchain/lib/libMLIRTosaToSCF.a  /opt/ttmlir-toolchain/lib/libMLIRTosaToTensor.a  /opt/ttmlir-toolchain/lib/libMLIRTosaTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTosaDialect.a  /opt/ttmlir-toolchain/lib/libMLIRQuantUtils.a  /opt/ttmlir-toolchain/lib/libMLIRQuantDialect.a  /opt/ttmlir-toolchain/lib/libMLIRUBToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToAMX.a  /opt/ttmlir-toolchain/lib/libMLIRLinalgUtils.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToArmSME.a  /opt/ttmlir-toolchain/lib/libMLIRArmSMEDialect.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToGPU.a  /opt/ttmlir-toolchain/lib/libMLIRNVGPUUtils.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToLLVMPass.a  /opt/ttmlir-toolchain/lib/libMLIRAMXTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRAMXDialect.a  /opt/ttmlir-toolchain/lib/libMLIRArmNeonTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRArmNeonDialect.a  /opt/ttmlir-toolchain/lib/libMLIRArmSVETransforms.a  /opt/ttmlir-toolchain/lib/libMLIRArmSVEDialect.a  /opt/ttmlir-toolchain/lib/libMLIRX86VectorTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRX86VectorDialect.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRArithAttrToLLVMConversion.a  /opt/ttmlir-toolchain/lib/libMLIRTargetLLVMIRExport.a  /opt/ttmlir-toolchain/lib/libMLIRTranslateLib.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMIRTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRNVVMDialect.a  /opt/ttmlir-toolchain/lib/libLLVMFrontendOpenMP.a  /opt/ttmlir-toolchain/lib/libLLVMFrontendOffloading.a  /opt/ttmlir-toolchain/lib/libLLVMObjectYAML.a  /opt/ttmlir-toolchain/lib/libLLVMScalarOpts.a  /opt/ttmlir-toolchain/lib/libLLVMAggressiveInstCombine.a  /opt/ttmlir-toolchain/lib/libLLVMInstCombine.a  /opt/ttmlir-toolchain/lib/libLLVMFrontendAtomic.a  /opt/ttmlir-toolchain/lib/libLLVMFrontendDirective.a  /opt/ttmlir-toolchain/lib/libLLVMTransformUtils.a  /opt/ttmlir-toolchain/lib/libLLVMAnalysis.a  /opt/ttmlir-toolchain/lib/libLLVMFrontendHLSL.a  /opt/ttmlir-toolchain/lib/libLLVMProfileData.a  /opt/ttmlir-toolchain/lib/libLLVMSymbolize.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoGSYM.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoDWARF.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoDWARFLowLevel.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoPDB.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoCodeView.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoMSF.a  /opt/ttmlir-toolchain/lib/libLLVMDebugInfoBTF.a  /opt/ttmlir-toolchain/lib/libLLVMObject.a  /opt/ttmlir-toolchain/lib/libLLVMMCParser.a  /opt/ttmlir-toolchain/lib/libLLVMMC.a  /opt/ttmlir-toolchain/lib/libLLVMIRReader.a  /opt/ttmlir-toolchain/lib/libLLVMBitReader.a  /opt/ttmlir-toolchain/lib/libLLVMTextAPI.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToSCF.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRUBToSPIRV.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVConversion.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVDialect.a  /opt/ttmlir-toolchain/lib/libMLIRSPIRVImageInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRVectorTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRGPUUtils.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRArithTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRFuncTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRShardingInterface.a  /opt/ttmlir-toolchain/lib/libMLIRShardDialect.a  /opt/ttmlir-toolchain/lib/libMLIRNVGPUDialect.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefUtils.a  /opt/ttmlir-toolchain/lib/libMLIRVectorToXeGPU.a  /opt/ttmlir-toolchain/lib/libMLIRXeGPUUtils.a  /opt/ttmlir-toolchain/lib/libMLIRXeVMToLLVM.a  /opt/ttmlir-toolchain/lib/libMLIRXeGPUToXeVM.a  /opt/ttmlir-toolchain/lib/libMLIRSCFTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRBufferizationTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTensorTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRAffineTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRSCFUtils.a  /opt/ttmlir-toolchain/lib/libMLIRLinalgDialect.a  /opt/ttmlir-toolchain/lib/libMLIRBufferizationDialect.a  /opt/ttmlir-toolchain/lib/libMLIRSparseTensorDialect.a  /opt/ttmlir-toolchain/lib/libMLIRParser.a  /opt/ttmlir-toolchain/lib/libMLIRBytecodeReader.a  /opt/ttmlir-toolchain/lib/libMLIRAsmParser.a  /opt/ttmlir-toolchain/lib/libMLIRTensorUtils.a  /opt/ttmlir-toolchain/lib/libMLIRVectorUtils.a  /opt/ttmlir-toolchain/lib/libMLIRTilingInterface.a  /opt/ttmlir-toolchain/lib/libMLIRXeGPUDialect.a  /opt/ttmlir-toolchain/lib/libMLIRAffineUtils.a  /opt/ttmlir-toolchain/lib/libMLIRAffineAnalysis.a  /opt/ttmlir-toolchain/lib/libMLIRSCFDialect.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowDialect.a  /opt/ttmlir-toolchain/lib/libMLIRFuncDialect.a  /opt/ttmlir-toolchain/lib/libMLIRGPUDialect.a  /opt/ttmlir-toolchain/lib/libMLIRDLTIDialect.a  /opt/ttmlir-toolchain/lib/libMLIRMathDialect.a  /opt/ttmlir-toolchain/lib/libMLIRIndexDialect.a  /opt/ttmlir-toolchain/lib/libMLIRXeVMDialect.a  /opt/ttmlir-toolchain/lib/libLLVMAsmParser.a  /opt/ttmlir-toolchain/lib/libMLIRVectorDialect.a  /opt/ttmlir-toolchain/lib/libMLIRTensorDialect.a  /opt/ttmlir-toolchain/lib/libMLIRAffineDialect.a  /opt/ttmlir-toolchain/lib/libMLIRMemRefDialect.a  /opt/ttmlir-toolchain/lib/libMLIRArithUtils.a  /opt/ttmlir-toolchain/lib/libMLIRComplexDialect.a  /opt/ttmlir-toolchain/lib/libMLIRArithDialect.a  /opt/ttmlir-toolchain/lib/libMLIRDialect.a  /opt/ttmlir-toolchain/lib/libMLIRCastInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRInferIntRangeCommon.a  /opt/ttmlir-toolchain/lib/libMLIRShapedOpInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRParallelCombiningOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRUBDialect.a  /opt/ttmlir-toolchain/lib/libMLIRIndexingMapOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRVectorInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRMaskableOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRMaskingOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRDialectUtils.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMCommonConversion.a  /opt/ttmlir-toolchain/lib/libMLIRLLVMDialect.a  /opt/ttmlir-toolchain/lib/libMLIRPtrMemorySpaceInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRTransforms.a  /opt/ttmlir-toolchain/lib/libMLIRTransformUtils.a  /opt/ttmlir-toolchain/lib/libMLIRSubsetOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRValueBoundsOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRDestinationStyleOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRRewrite.a  /opt/ttmlir-toolchain/lib/libMLIRRewritePDL.a  /opt/ttmlir-toolchain/lib/libMLIRPDLToPDLInterp.a  /opt/ttmlir-toolchain/lib/libMLIRPDLInterpDialect.a  /opt/ttmlir-toolchain/lib/libMLIRPDLDialect.a  /opt/ttmlir-toolchain/lib/libMLIRPass.a  /opt/ttmlir-toolchain/lib/libMLIRAnalysis.a  /opt/ttmlir-toolchain/lib/libMLIRControlFlowInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRPresburger.a  /opt/ttmlir-toolchain/lib/libMLIRLoopLikeInterface.a  /opt/ttmlir-toolchain/lib/libMLIRViewLikeInterface.a  /opt/ttmlir-toolchain/lib/libMLIRInferIntRangeInterface.a  /opt/ttmlir-toolchain/lib/libMLIRDataLayoutInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRInferTypeOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRSideEffectInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRFunctionInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRCallInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRMemorySlotInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRMemOpInterfaces.a  /opt/ttmlir-toolchain/lib/libMLIRRuntimeVerifiableOpInterface.a  /opt/ttmlir-toolchain/lib/libMLIRIR.a  /opt/ttmlir-toolchain/lib/libMLIRSupport.a  /opt/ttmlir-toolchain/lib/libLLVMCore.a  /opt/ttmlir-toolchain/lib/libLLVMBinaryFormat.a  /opt/ttmlir-toolchain/lib/libLLVMTargetParser.a  /opt/ttmlir-toolchain/lib/libLLVMRemarks.a  /opt/ttmlir-toolchain/lib/libLLVMBitstreamReader.a  /opt/ttmlir-toolchain/lib/libLLVMSupport.a  -lrt  -ldl  -lm  /usr/lib/aarch64-linux-gnu/libz.so  /opt/ttmlir-toolchain/lib/libLLVMDemangle.a && :
/usr/bin/ld: lib/libTTMetalTargetFlatbuffer.a(TTMetalToFlatbuffer.cpp.o): in function `mlir::tt::ttmetal::getPhysicalGridShapeForVirtualGrid(mlir::tt::ttcore::ShardLayoutAttr, mlir::tt::ttcore::DeviceAttr, mlir::MemRefType, std::optional<mlir::AffineMap>)':
TTMetalToFlatbuffer.cpp:(.text._ZN4mlir2tt7ttmetalL34getPhysicalGridShapeForVirtualGridENS0_6ttcore15ShardLayoutAttrENS2_10DeviceAttrENS_10MemRefTypeESt8optionalINS_9AffineMapEE+0xdc): undefined reference to `ttmlir::d2m::utils::grids::getPhysicalGridExtent(llvm::ArrayRef<long>, llvm::ArrayRef<long>)'
/usr/bin/ld: lib/libTTNNTargetFlatbuffer.a(TTNNToFlatbuffer.cpp.o): in function `mlir::tt::ttnn::createOp(mlir::tt::FlatbufferObjectCache&, mlir::tt::debug::AnnotateOp)':
TTNNToFlatbuffer.cpp:(.text._ZN4mlir2tt4ttnn8createOpERNS0_21FlatbufferObjectCacheENS0_5debug10AnnotateOpE+0x12c): undefined reference to `mlir::tt::debug::AnnotateOp::getAnnotation()'
/usr/bin/ld: lib/libTTNNTargetFlatbuffer.a(TTNNToFlatbuffer.cpp.o): in function `mlir::tt::ttnn::createOp(mlir::tt::FlatbufferObjectCache&, mlir::tt::debug::MemorySnapshotOp)':
TTNNToFlatbuffer.cpp:(.text._ZN4mlir2tt4ttnn8createOpERNS0_21FlatbufferObjectCacheENS0_5debug16MemorySnapshotOpE+0x12c): undefined reference to `mlir::tt::debug::MemorySnapshotOp::getFilePath()'
/usr/bin/ld: lib/libTTNNTargetFlatbuffer.a(TTNNToFlatbuffer.cpp.o): in function `llvm::DefaultDoCastIfPossible<mlir::tt::debug::AnnotateOp, mlir::Operation*, llvm::CastInfo<mlir::tt::debug::AnnotateOp, mlir::Operation*, void> >::doCastIfPossible(mlir::Operation*)':
TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug10AnnotateOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug10AnnotateOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x24): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::AnnotateOp, void>::id'
/usr/bin/ld: TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug10AnnotateOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug10AnnotateOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x28): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::AnnotateOp, void>::id'
/usr/bin/ld: lib/libTTNNTargetFlatbuffer.a(TTNNToFlatbuffer.cpp.o): in function `llvm::DefaultDoCastIfPossible<mlir::tt::debug::BreakpointOp, mlir::Operation*, llvm::CastInfo<mlir::tt::debug::BreakpointOp, mlir::Operation*, void> >::doCastIfPossible(mlir::Operation*)':
TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug12BreakpointOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug12BreakpointOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x24): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::BreakpointOp, void>::id'
/usr/bin/ld: TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug12BreakpointOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug12BreakpointOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x28): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::BreakpointOp, void>::id'
/usr/bin/ld: lib/libTTNNTargetFlatbuffer.a(TTNNToFlatbuffer.cpp.o): in function `llvm::DefaultDoCastIfPossible<mlir::tt::debug::MemorySnapshotOp, mlir::Operation*, llvm::CastInfo<mlir::tt::debug::MemorySnapshotOp, mlir::Operation*, void> >::doCastIfPossible(mlir::Operation*)':
TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug16MemorySnapshotOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug16MemorySnapshotOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x24): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::MemorySnapshotOp, void>::id'
/usr/bin/ld: TTNNToFlatbuffer.cpp:(.text._ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug16MemorySnapshotOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_[_ZN4llvm23DefaultDoCastIfPossibleIN4mlir2tt5debug16MemorySnapshotOpEPNS1_9OperationENS_8CastInfoIS4_S6_vEEE16doCastIfPossibleES6_]+0x28): undefined reference to `mlir::detail::TypeIDResolver<mlir::tt::debug::MemorySnapshotOp, void>::id'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

### What's changed
Link libs in cmake files.

### Checklist
- [ ] New/Existing tests provide coverage for changes
