### PR TITLE
d2m: add script to compile MLIR snippets in parallel

### DIFF
--- a/tools/scripts/compile_snippets.py
+++ b/tools/scripts/compile_snippets.py
@@ -24,6 +24,9 @@ from threading import Event
 
 SCRIPT_PATH = os.path.abspath(__file__)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_FUNC_DEF_RE = re.compile(
+    r'\s*func\.func(?:\s+(?:public|private|nested))?\s+@(?P<symbol>"(?:\\.|[^"\\])*"|[^\s(]+)'
+)
 
 
 def _strip_ansi(text):
@@ -57,43 +60,127 @@ def _extract_error_summary(stderr_text):
     return "No stderr captured"
 
 
+def _update_brace_depth(line, depth):
+    in_string = False
+    prev_ch = None
+    saw_open = False
+    for ch in line:
+        if ch == '"' and prev_ch != "\\":
+            in_string = not in_string
+        elif not in_string:
+            if ch == "{":
+                depth += 1
+                saw_open = True
+            elif ch == "}":
+                depth -= 1
+        prev_ch = ch
+    return depth, saw_open
+
+
+def _sanitize_symbol_name(symbol):
+    raw = symbol
+    if raw.startswith('"') and raw.endswith('"'):
+        raw = raw[1:-1]
+    safe = re.sub(r"[^0-9A-Za-z._-]+", "_", raw).strip("._")
+    return safe or "func"
+
+
 def _extract_functions_from_text(mlir_text):
     """Extract ``func.func`` ops from module text.
 
-    Returns a list of *(func_name, standalone_module_text)* pairs.
+    Returns a list of *(func_name, standalone_module_text, dir_name)* tuples.
     """
-    funcs = []
     lines = mlir_text.split("\n")
+    funcs = []
+    used_dir_names = set()
+
+    def unique_dir_name(symbol):
+        base = _sanitize_symbol_name(symbol)
+        if base not in used_dir_names:
+            used_dir_names.add(base)
+            return base
+        idx = 2
+        while f"{base}_{idx}" in used_dir_names:
+            idx += 1
+        name = f"{base}_{idx}"
+        used_dir_names.add(name)
+        return name
+
+    module_start = None
+    module_end = None
+    for i, line in enumerate(lines):
+        if re.match(r"\s*module\b", line):
+            depth = 0
+            found_brace = False
+            for j in range(i, len(lines)):
+                depth, saw_open = _update_brace_depth(lines[j], depth)
+                found_brace = found_brace or saw_open
+                if found_brace and depth == 0:
+                    module_start = i
+                    module_end = j
+                    break
+            if module_start is not None:
+                break
+
+    if module_start is not None and module_end is not None:
+        module_funcs = []
+        depth = 0
+        i = module_start
+        while i <= module_end:
+            if depth == 1:
+                match = _FUNC_DEF_RE.match(lines[i])
+                if match:
+                    symbol = match.group("symbol")
+                    start = i
+                    func_depth = 0
+                    found_brace = False
+                    while i <= module_end:
+                        func_depth, saw_open = _update_brace_depth(lines[i], func_depth)
+                        found_brace = found_brace or saw_open
+                        if found_brace and func_depth == 0:
+                            i += 1
+                            break
+                        i += 1
+                    module_funcs.append((symbol, start, i))
+                    continue
+            depth, _ = _update_brace_depth(lines[i], depth)
+            i += 1
+
+        for idx, (func_name, start, end) in enumerate(module_funcs):
+            remove_lines = set()
+            for other_idx, (_, other_start, other_end) in enumerate(module_funcs):
+                if other_idx != idx:
+                    remove_lines.update(range(other_start, other_end))
+            snippet_lines = [
+                lines[line_idx]
+                for line_idx in range(module_start, module_end + 1)
+                if line_idx not in remove_lines
+            ]
+            funcs.append(
+                (func_name, "\n".join(snippet_lines), unique_dir_name(func_name))
+            )
+        return funcs
+
     i = 0
     while i < len(lines):
-        match = re.match(r"\s*func\.func\s+@([\w]+)", lines[i])
-        if match:
-            func_name = match.group(1)
-            depth = 0
-            start = i
-            found_brace = False
-            while i < len(lines):
-                in_string = False
-                prev_ch = None
-                for ch in lines[i]:
-                    if ch == '"' and prev_ch != "\\":
-                        in_string = not in_string
-                    elif not in_string:
-                        if ch == "{":
-                            depth += 1
-                            found_brace = True
-                        elif ch == "}":
-                            depth -= 1
-                    prev_ch = ch
-                if found_brace and depth == 0:
-                    i += 1
-                    break
-                i += 1
-            func_text = "\n".join(lines[start:i])
-            snippet = f"module {{\n{func_text}\n}}"
-            funcs.append((func_name, snippet))
-        else:
+        match = _FUNC_DEF_RE.match(lines[i])
+        if not match:
             i += 1
+            continue
+        func_name = match.group("symbol")
+        depth = 0
+        start = i
+        found_brace = False
+        while i < len(lines):
+            depth, saw_open = _update_brace_depth(lines[i], depth)
+            found_brace = found_brace or saw_open
+            if found_brace and depth == 0:
+                i += 1
+                break
+            i += 1
+        func_text = "\n".join(lines[start:i])
+        snippet = f"module {{\n{func_text}\n}}"
+        funcs.append((func_name, snippet, unique_dir_name(func_name)))
     return funcs
 
 
@@ -112,19 +199,21 @@ def _collect_artifacts(comp_dir, mlir_path):
     return artifacts
 
 
-def _compile_one(func_name, snippet_text, output_dir, system_desc, timeout_sec, log):
+def _compile_one(
+    func_name, dir_name, snippet_text, output_dir, system_desc, timeout_sec, log
+):
     """Compile a single snippet in an isolated subprocess.
 
     Returns *(func_name, result_dict)*.
     """
-    comp_dir = os.path.join(output_dir, func_name)
+    comp_dir = os.path.join(output_dir, dir_name)
     os.makedirs(comp_dir, exist_ok=True)
 
-    mlir_path = os.path.join(comp_dir, f"{func_name}.mlir")
+    mlir_path = os.path.join(comp_dir, f"{dir_name}.mlir")
     stdout_path = os.path.join(comp_dir, "compile_stdout.txt")
     stderr_path = os.path.join(comp_dir, "compile_stderr.txt")
 
-    with open(mlir_path, "w") as f:
+    with open(mlir_path, "w", encoding="utf-8") as f:
         f.write(snippet_text)
 
     result = {
@@ -153,15 +242,17 @@ def _compile_one(func_name, snippet_text, output_dir, system_desc, timeout_sec, 
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_sec,
         )
         elapsed = time.monotonic() - start
         result["duration_sec"] = round(elapsed, 3)
         result["exit_code"] = proc.returncode
 
-        with open(stdout_path, "w") as f:
+        with open(stdout_path, "w", encoding="utf-8") as f:
             f.write(proc.stdout or "")
-        with open(stderr_path, "w") as f:
+        with open(stderr_path, "w", encoding="utf-8") as f:
             f.write(proc.stderr or "")
 
         if proc.returncode < 0:
@@ -186,9 +277,9 @@ def _compile_one(func_name, snippet_text, output_dir, system_desc, timeout_sec, 
             stdout_data = stdout_data.decode("utf-8", errors="replace")
         if isinstance(stderr_data, bytes):
             stderr_data = stderr_data.decode("utf-8", errors="replace")
-        with open(stdout_path, "w") as f:
+        with open(stdout_path, "w", encoding="utf-8") as f:
             f.write(stdout_data)
-        with open(stderr_path, "w") as f:
+        with open(stderr_path, "w", encoding="utf-8") as f:
             f.write(stderr_data)
 
     except Exception as exc:
@@ -197,7 +288,7 @@ def _compile_one(func_name, snippet_text, output_dir, system_desc, timeout_sec, 
         result["error_summary"] = f"Infrastructure error: {exc}"
         for p in (stdout_path, stderr_path):
             if not os.path.exists(p):
-                with open(p, "w") as f:
+                with open(p, "w", encoding="utf-8") as f:
                     pass
 
     status_tag = result["status"].upper()
@@ -212,7 +303,7 @@ def _run_worker(mlir_path, system_desc):
         load_mlir_file,
     )
 
-    with open(mlir_path, "r") as f:
+    with open(mlir_path, "r", encoding="utf-8") as f:
         mlir_text = f.read()
 
     artifact_dir = os.path.dirname(os.path.abspath(mlir_path))
@@ -262,7 +353,7 @@ def _write_results(path, args_snippets_mlir, args_system_desc, timeout_sec, comp
         "summary": summary,
         "components": components,
     }
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
     return summary
 
@@ -352,7 +443,7 @@ def main():
     console_h.setFormatter(fmt)
     log.addHandler(console_h)
 
-    file_h = logging.FileHandler(os.path.join(output_dir, "run.log"))
+    file_h = logging.FileHandler(os.path.join(output_dir, "run.log"), encoding="utf-8")
     file_h.setFormatter(fmt)
     log.addHandler(file_h)
 
@@ -368,7 +459,7 @@ def main():
 
     # ── Step 1: Parse ───────────────────────────────────────────────────
     log.info("[1/2] Parsing MLIR and extracting functions ...")
-    with open(args.snippets_mlir, "r") as f:
+    with open(args.snippets_mlir, "r", encoding="utf-8") as f:
         mlir_text = f.read()
 
     try:
@@ -392,55 +483,74 @@ def main():
     components = {}
     cancel_event = Event()
 
+    executor = ThreadPoolExecutor(max_workers=args.jobs)
+    futures = {}
+    interrupted = False
     try:
-        with ThreadPoolExecutor(max_workers=args.jobs) as executor:
-            futures = {}
-            for func_name, snippet in funcs:
-                if cancel_event.is_set():
-                    break
-                fut = executor.submit(
-                    _compile_one,
-                    func_name,
-                    snippet,
-                    output_dir,
-                    args.system_desc,
-                    args.timeout_sec,
-                    log,
-                )
-                futures[fut] = func_name
+        for func_name, snippet, dir_name in funcs:
+            if cancel_event.is_set():
+                break
+            fut = executor.submit(
+                _compile_one,
+                func_name,
+                dir_name,
+                snippet,
+                output_dir,
+                args.system_desc,
+                args.timeout_sec,
+                log,
+            )
+            futures[fut] = (func_name, dir_name)
 
-            for fut in as_completed(futures):
-                try:
-                    name, result = fut.result()
-                    components[name] = result
-                except Exception as exc:
-                    name = futures[fut]
-                    log.error("  [INFRA_ERROR] %s: %s", name, exc)
-                    comp_dir = os.path.join(output_dir, name)
-                    components[name] = {
-                        "status": "infra_error",
-                        "duration_sec": 0.0,
-                        "exit_code": None,
-                        "signal": None,
-                        "dir": os.path.abspath(comp_dir),
-                        "snippet_path": os.path.abspath(
-                            os.path.join(comp_dir, f"{name}.mlir")
-                        ),
-                        "stdout_path": os.path.abspath(
-                            os.path.join(comp_dir, "compile_stdout.txt")
-                        ),
-                        "stderr_path": os.path.abspath(
-                            os.path.join(comp_dir, "compile_stderr.txt")
-                        ),
-                        "error_summary": f"Infrastructure error: {exc}",
-                        "artifact_paths": [],
-                    }
+        for fut in as_completed(futures):
+            try:
+                name, result = fut.result()
+                components[name] = result
+            except Exception as exc:
+                name, dir_name = futures[fut]
+                log.error("  [INFRA_ERROR] %s: %s", name, exc)
+                comp_dir = os.path.join(output_dir, dir_name)
+                components[name] = {
+                    "status": "infra_error",
+                    "duration_sec": 0.0,
+                    "exit_code": None,
+                    "signal": None,
+                    "dir": os.path.abspath(comp_dir),
+                    "snippet_path": os.path.abspath(
+                        os.path.join(comp_dir, f"{dir_name}.mlir")
+                    ),
+                    "stdout_path": os.path.abspath(
+                        os.path.join(comp_dir, "compile_stdout.txt")
+                    ),
+                    "stderr_path": os.path.abspath(
+                        os.path.join(comp_dir, "compile_stderr.txt")
+                    ),
+                    "error_summary": f"Infrastructure error: {exc}",
+                    "artifact_paths": [],
+                }
     except KeyboardInterrupt:
         if args.stop_on_keyboard_interrupt:
             cancel_event.set()
+            interrupted = True
+            for fut in futures:
+                fut.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
             log.warning("  Keyboard interrupt – writing partial results ...")
+            for fut, (name, _) in futures.items():
+                if not fut.done() or name in components:
+                    continue
+                if fut.cancelled():
+                    continue
+                try:
+                    done_name, result = fut.result()
+                    components[done_name] = result
+                except Exception as exc:
+                    log.error("  [INFRA_ERROR] %s: %s", name, exc)
         else:
             raise
+    finally:
+        if not interrupted:
+            executor.shutdown(wait=True)
 
     # ── Write results ───────────────────────────────────────────────────
     results_path = os.path.join(output_dir, "compile_results.json")


### PR DESCRIPTION
Introduce tools/scripts/compile_snippets.py to compile each func.func snippet from a multi-function MLIR module in its own subprocess. The use case is large model-derived snippet sets where one bad snippet (assert/crash/hang) should not stop the rest of the run. 

How to use:

Generate snippet functions (with d2m-discover --emit-funcs) so the input file contains one or more top-level func.func entries.

Run compile_snippets.py with a required system descriptor and optional output/parallelism/timeout controls.

Inspect output_dir/compile_results.json for status and metadata, and output_dir/<component>/ for snippet source, 
stdout/stderr logs, and compile artifacts for successful runs.

Use the JSON as input to failure analysis and filing workflows.

Example command:

python tools/scripts/compile_snippets.py <snippets.mlir> --system-desc ttrt-artifacts/system_desc.ttsys -o <output_dir> -j 4 --timeout-sec 120