### PR TITLE
Fix zero volume tensor affine map calculations

### DIFF
--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -690,6 +690,12 @@ mlir::AffineMap collapsedLinearAffineMap(
   auto map = mlir::AffineMap::getMinorIdentityMap(shape.size(),
                                                   numResultsClamped, context);
 
+  if (ttmlir::utils::volume(shape) == 0u) {
+    while (map.getNumResults() < gridShape.size()) {
+      map = map.insertResult(getAffineConstantExpr(0, context), 0);
+    }
+    return mlir::simplifyAffineMap(map);
+  }
   std::int64_t minimumDim = static_cast<std::int64_t>(shape.size());
   for (auto [begin, end] : collapseIntervals) {
     if (begin < 0) {

--- a/test/ttmlir/Dialect/TTNN/data_movement/concat/simple_concat.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/concat/simple_concat.mlir
@@ -7,3 +7,9 @@ module attributes {} {
     return %1 : tensor<32x96xf32>
   }
 }
+
+func.func @concat_zero_dim_in_collapse_range(%arg0: tensor<1x0x1024xf32>, %arg1: tensor<1x8x1024xf32>) -> tensor<1x8x1024xf32> {
+  // CHECK-NOT: "ttnn.concat"
+  %1 = "ttir.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<1x0x1024xf32>, tensor<1x8x1024xf32>) -> tensor<1x8x1024xf32>
+  return %1 : tensor<1x8x1024xf32>
+}


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/6786

### Problem description
The polynomial collapsing logic uses dimension sizes as multipliers, so a size-0 dimension zeroes out neighboring dimensions contributions. Since the zeroed-out dimension is no longer a function of its dim variable, the assertion `Dim does not participate in AffineMap RHS` is triggered.

### What's changed
Added a safety check when any dimension is 0 to that creates a map of adequate size.

### Checklist
- [x] New/Existing tests provide coverage for changes
