### PR TITLE
Fix dtype attribute handling when changing op output layout

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -743,6 +743,12 @@ void applyFallbackTransformations(
           operation->getContext(), result.actualOutputLayout.getLayout()));
     }
 
+    if (TTNNDtypeOpInterface dtypeOp =
+            mlir::dyn_cast<TTNNDtypeOpInterface>(operation)) {
+      dtypeOp.setDtypeAttr(ttcore::DataTypeAttr::get(
+          operation->getContext(), result.actualOutputLayout.getDataType()));
+    }
+
     // Step 2: Add revert ToLayoutOp to convert back to expected layout for
     // consumers
     applyOutputLayoutRevert(operation, result.actualOutputLayout,


### PR DESCRIPTION
Fix `applyFallbackTransformations` to update the `dtype` attribute when changing an operation's output layout, preventing verification failures like `'ttnn.constant' op output tensor layout data type bf16 must match output data type attribute f32`. Other passes already correctly update the `dtype` attribute via `TTNNDtypeOpInterface::setDtypeAttr()`.