### PR TITLE
Causal mask canonicalization and folding patterns

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1341,6 +1341,8 @@ def TTIR_LessEqualOp : TTIR_ElementwiseBinaryOp<"le"> {
 
       Mathematical definition: less_equal(x, y) = x <= y
     }];
+
+    let hasCanonicalizer = 1;
 }
 
 // TODO (azecevic): NaN != NaN, otherwise lt(x, x) == 0.
@@ -1374,6 +1376,8 @@ def TTIR_LessThanOp : TTIR_ElementwiseBinaryOp<"lt"> {
 
       Mathematical definition: less_than(x, y) = x < y
     }];
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_LogicalAndOp : TTIR_ElementwiseBinaryOp<"logical_and", [TTIR_BinaryIdempotence]> {
@@ -1406,6 +1410,8 @@ def TTIR_LogicalAndOp : TTIR_ElementwiseBinaryOp<"logical_and", [TTIR_BinaryIdem
 
       Mathematical definition: logical_and(x, y) = x && y
     }];
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_LogicalOrOp : TTIR_ElementwiseBinaryOp<"logical_or", [TTIR_BinaryIdempotence]> {
@@ -1438,6 +1444,8 @@ def TTIR_LogicalOrOp : TTIR_ElementwiseBinaryOp<"logical_or", [TTIR_BinaryIdempo
 
       Mathematical definition: logical_or(x, y) = x || y
     }];
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_LogicalXorOp : TTIR_ElementwiseBinaryOp<"logical_xor"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -159,6 +159,202 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// LessEqualOp
+//===----------------------------------------------------------------------===//
+
+// LessEqualOp canonicalization: le(a, b) -> ge(b, a)
+void mlir::tt::ttir::LessEqualOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  patterns.add(
+      +[](mlir::tt::ttir::LessEqualOp op, mlir::PatternRewriter &rewriter) {
+        rewriter.replaceOpWithNewOp<mlir::tt::ttir::GreaterEqualOp>(
+            op, op.getResult().getType(), op.getRhs(), op.getLhs());
+        return mlir::success();
+      });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+//===----------------------------------------------------------------------===//
+// LessThanOp
+//===----------------------------------------------------------------------===//
+
+// LessThanOp canonicalization: lt(a, b) -> gt(b, a)
+void mlir::tt::ttir::LessThanOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  patterns.add(
+      +[](mlir::tt::ttir::LessThanOp op, mlir::PatternRewriter &rewriter) {
+        rewriter.replaceOpWithNewOp<mlir::tt::ttir::GreaterThanOp>(
+            op, op.getResult().getType(), op.getRhs(), op.getLhs());
+        return mlir::success();
+      });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+//===----------------------------------------------------------------------===//
+// Constant value helpers
+//===----------------------------------------------------------------------===//
+
+// Helper to create a scalar attribute from an element type and a double value.
+static mlir::Attribute makeScalarAttr(mlir::Type elemType, double val) {
+  if (auto floatType = mlir::dyn_cast<mlir::FloatType>(elemType)) {
+    return mlir::FloatAttr::get(floatType, val);
+  }
+  if (auto intType = mlir::dyn_cast<mlir::IntegerType>(elemType)) {
+    return mlir::IntegerAttr::get(intType, static_cast<int64_t>(val));
+  }
+  return {};
+}
+
+// Extract constant fill value by looking through layout ops (broadcast,
+// reshape, typecast, repeat_interleave) to find a FullOp, ZerosOp, or OnesOp.
+static mlir::Attribute getConstantValue(mlir::Value value) {
+  mlir::Operation *op =
+      mlir::tt::ttir::utils::lookThroughLayoutOps(value).getDefiningOp();
+
+  if (auto fullOp = mlir::dyn_cast_if_present<mlir::tt::ttir::FullOp>(op)) {
+    return fullOp.getFillValueAttr();
+  }
+
+  if (mlir::isa_and_present<mlir::tt::ttir::ZerosOp>(op)) {
+    return makeScalarAttr(
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
+            .getElementType(),
+        0.0);
+  }
+  if (mlir::isa_and_present<mlir::tt::ttir::OnesOp>(op)) {
+    return makeScalarAttr(
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType())
+            .getElementType(),
+        1.0);
+  }
+
+  return {};
+}
+
+// Check if the attribute represents zero.
+static bool isZeroAttr(mlir::Attribute attr) {
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(attr)) {
+    return floatAttr.getValue().isZero();
+  }
+  if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+    return intAttr.getValue().isZero();
+  }
+  return false;
+}
+
+static bool isConstantZero(mlir::Value value) {
+  mlir::Attribute attr = getConstantValue(value);
+  return attr && isZeroAttr(attr);
+}
+
+static bool isConstantNonZero(mlir::Value value) {
+  mlir::Attribute attr = getConstantValue(value);
+  return attr && !isZeroAttr(attr);
+}
+
+// Helper to extract the shape of a RankedTensorType as a vector of i32.
+static llvm::SmallVector<int32_t>
+getShapeAsI32(mlir::RankedTensorType tensorType) {
+  return llvm::to_vector_of<int32_t>(tensorType.getShape());
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalAndOp
+//===----------------------------------------------------------------------===//
+
+// LogicalAndOp canonicalization:
+//   and(zero, x)    -> ZerosOp        (absorbing)
+//   and(nonzero, x) -> x (i1) or OnesOp (identity, both const nonzero)
+void mlir::tt::ttir::LogicalAndOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  patterns.add(
+      +[](mlir::tt::ttir::LogicalAndOp op, mlir::PatternRewriter &rewriter) {
+        auto resultType =
+            mlir::cast<mlir::RankedTensorType>(op.getResult().getType());
+        bool isI1 = resultType.getElementType().isInteger(1);
+
+        // Absorbing: and(zero, x) -> 0
+        if (isConstantZero(op.getLhs()) || isConstantZero(op.getRhs())) {
+          rewriter.replaceOpWithNewOp<mlir::tt::ttir::ZerosOp>(
+              op, resultType,
+              rewriter.getDenseI32ArrayAttr(getShapeAsI32(resultType)));
+          return mlir::success();
+        }
+
+        // Identity: and(nonzero, x) -> x when x is guaranteed boolean (i1)
+        if (isConstantNonZero(op.getLhs()) && isI1) {
+          rewriter.replaceOp(op, op.getRhs());
+          return mlir::success();
+        }
+        if (isConstantNonZero(op.getRhs()) && isI1) {
+          rewriter.replaceOp(op, op.getLhs());
+          return mlir::success();
+        }
+
+        // Both constant nonzero -> OnesOp
+        if (isConstantNonZero(op.getLhs()) && isConstantNonZero(op.getRhs())) {
+          rewriter.replaceOpWithNewOp<mlir::tt::ttir::OnesOp>(
+              op, resultType,
+              rewriter.getDenseI32ArrayAttr(getShapeAsI32(resultType)));
+          return mlir::success();
+        }
+
+        return mlir::failure();
+      });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalOrOp
+//===----------------------------------------------------------------------===//
+
+// LogicalOrOp canonicalization:
+//   or(nonzero, x) -> OnesOp          (absorbing)
+//   or(zero, x)    -> x (i1) or ZerosOp (identity, both const zero)
+void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+  patterns.add(
+      +[](mlir::tt::ttir::LogicalOrOp op, mlir::PatternRewriter &rewriter) {
+        auto resultType =
+            mlir::cast<mlir::RankedTensorType>(op.getResult().getType());
+        bool isI1 = resultType.getElementType().isInteger(1);
+
+        // Absorbing: or(nonzero, x) -> 1
+        if (isConstantNonZero(op.getLhs()) || isConstantNonZero(op.getRhs())) {
+          rewriter.replaceOpWithNewOp<mlir::tt::ttir::OnesOp>(
+              op, resultType,
+              rewriter.getDenseI32ArrayAttr(getShapeAsI32(resultType)));
+          return mlir::success();
+        }
+
+        // Identity: or(zero, x) -> x when x is guaranteed boolean (i1)
+        if (isConstantZero(op.getLhs()) && isI1) {
+          rewriter.replaceOp(op, op.getRhs());
+          return mlir::success();
+        }
+        if (isConstantZero(op.getRhs()) && isI1) {
+          rewriter.replaceOp(op, op.getLhs());
+          return mlir::success();
+        }
+
+        // Both constant zero -> ZerosOp
+        if (isConstantZero(op.getLhs()) && isConstantZero(op.getRhs())) {
+          rewriter.replaceOpWithNewOp<mlir::tt::ttir::ZerosOp>(
+              op, resultType,
+              rewriter.getDenseI32ArrayAttr(getShapeAsI32(resultType)));
+          return mlir::success();
+        }
+
+        return mlir::failure();
+      });
+  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+}
+
+//===----------------------------------------------------------------------===//
 // BroadcastOp
 //===----------------------------------------------------------------------===//
 
@@ -346,31 +542,6 @@ void mlir::tt::ttir::ClampScalarOp::getCanonicalizationPatterns(
   }
 
   return success();
-}
-
-// Helper function to extract constant value.
-static mlir::Attribute getConstantValue(mlir::Value value) {
-  mlir::Operation *op = value.getDefiningOp();
-  while (mlir::isa_and_present<mlir::tt::ttir::BroadcastOp,
-                               mlir::tt::ttir::ReshapeOp,
-                               mlir::tt::ttir::TypecastOp>(op)) {
-    op = op->getOperand(0).getDefiningOp();
-  }
-
-  auto fullOp = mlir::dyn_cast_if_present<mlir::tt::ttir::FullOp>(op);
-  if (!fullOp) {
-    return {};
-  }
-
-  mlir::Attribute fillValueAttr = fullOp.getFillValueAttr();
-
-  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(fillValueAttr)) {
-    return floatAttr;
-  }
-  if (auto integerAttr = mlir::dyn_cast<mlir::IntegerAttr>(fillValueAttr)) {
-    return integerAttr;
-  }
-  return {};
 }
 
 // ClampTensorOp canonicalization

--- a/test/ttmlir/Dialect/TTIR/canonicalize/comparison_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/comparison_canonicalize_tests.mlir
@@ -1,0 +1,35 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // le(a, b) -> ge(b, a)
+  func.func @le_to_ge(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    // CHECK-NOT: "ttir.le"
+    // CHECK: "ttir.ge"(%arg1, %arg0)
+    %1 = "ttir.le"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+
+  // lt(a, b) -> gt(b, a)
+  func.func @lt_to_gt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    // CHECK-NOT: "ttir.lt"
+    // CHECK: "ttir.gt"(%arg1, %arg0)
+    %1 = "ttir.lt"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+
+  // le with integer tensors
+  func.func @le_to_ge_integer(%arg0: tensor<32x32xi32>, %arg1: tensor<32x32xi32>) -> tensor<32x32xi32> {
+    // CHECK-NOT: "ttir.le"
+    // CHECK: "ttir.ge"(%arg1, %arg0)
+    %1 = "ttir.le"(%arg0, %arg1) : (tensor<32x32xi32>, tensor<32x32xi32>) -> tensor<32x32xi32>
+    return %1 : tensor<32x32xi32>
+  }
+
+  // lt with integer tensors
+  func.func @lt_to_gt_integer(%arg0: tensor<32x32xi32>, %arg1: tensor<32x32xi32>) -> tensor<32x32xi32> {
+    // CHECK-NOT: "ttir.lt"
+    // CHECK: "ttir.gt"(%arg1, %arg0)
+    %1 = "ttir.lt"(%arg0, %arg1) : (tensor<32x32xi32>, tensor<32x32xi32>) -> tensor<32x32xi32>
+    return %1 : tensor<32x32xi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/logical_identity_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/logical_identity_fold_tests.mlir
@@ -1,0 +1,193 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // and(0, x) -> zeros(result_type) (absorbing)
+  func.func @logical_and_zero_absorb(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_zero_absorb
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%zero, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // and(x, 0) -> zeros(result_type) (absorbing, rhs)
+  func.func @logical_and_zero_absorb_rhs(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_zero_absorb_rhs
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%arg0, %zero) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // and(integer zero, x) -> zeros(result_type)
+  func.func @logical_and_zero_int(%arg0: tensor<64x64xi32>) -> tensor<64x64xi32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0 : i32}> : () -> tensor<64x64xi32>
+    // CHECK-LABEL: func.func @logical_and_zero_int
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%zero, %arg0) : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi32>
+    return %1 : tensor<64x64xi32>
+  }
+
+  // and(zeros_op, x) -> zeros(result_type)
+  func.func @logical_and_zeros_op(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_zeros_op
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%zero, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // and(broadcast(reshape(full(0))), x) -> zeros(result_type) (look through layout ops)
+  func.func @logical_and_broadcast_zero(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.full"() <{shape = array<i32: 1, 1>, fill_value = 0.000000e+00 : f32}> : () -> tensor<1x1xf32>
+    %reshaped = "ttir.reshape"(%zero) <{shape = [1 : i32, 1 : i32]}> : (tensor<1x1xf32>) -> tensor<1x1xf32>
+    %broadcasted = "ttir.broadcast"(%reshaped) <{broadcast_dimensions = array<i64: 64, 64>}> : (tensor<1x1xf32>) -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_broadcast_zero
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%broadcasted, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(nonzero, x) -> ones(result_type) (absorbing)
+  func.func @logical_or_nonzero_absorb(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_nonzero_absorb
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%ones, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(x, nonzero) -> ones(result_type) (absorbing, rhs)
+  func.func @logical_or_nonzero_absorb_rhs(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_nonzero_absorb_rhs
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%arg0, %ones) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(5.0, x) -> ones(result_type) (non-one nonzero constant still folds correctly)
+  func.func @logical_or_nonone_absorb(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %five = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 5.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_nonone_absorb
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%five, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(ones_op, x) -> ones(result_type) (named OnesOp)
+  func.func @logical_or_ones_op(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_ones_op
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%ones, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(broadcast(reshape(full(1))), x) -> ones(result_type) (look through layout ops)
+  func.func @logical_or_broadcast_nonzero(%arg0: tensor<64x64xi32>) -> tensor<64x64xi32> {
+    %ones = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %reshaped = "ttir.reshape"(%ones) <{shape = [1 : i32, 1 : i32]}> : (tensor<1xi32>) -> tensor<1x1xi32>
+    %broadcasted = "ttir.broadcast"(%reshaped) <{broadcast_dimensions = array<i64: 64, 64>}> : (tensor<1x1xi32>) -> tensor<64x64xi32>
+    // CHECK-LABEL: func.func @logical_or_broadcast_nonzero
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%broadcasted, %arg0) : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi32>
+    return %1 : tensor<64x64xi32>
+  }
+
+  // Identity: and(nonzero, x) -> x for i1
+  func.func @logical_and_identity_i1(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
+    %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
+    // CHECK-LABEL: func.func @logical_and_identity_i1
+    // CHECK-NOT: "ttir.logical_and"
+    %1 = "ttir.logical_and"(%ones, %arg0) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
+    return %1 : tensor<64x64xi1>
+  }
+
+  // Identity: and(x, nonzero) -> x for i1
+  func.func @logical_and_identity_i1_rhs(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
+    %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
+    // CHECK-LABEL: func.func @logical_and_identity_i1_rhs
+    // CHECK-NOT: "ttir.logical_and"
+    %1 = "ttir.logical_and"(%arg0, %ones) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
+    return %1 : tensor<64x64xi1>
+  }
+
+  // Identity: or(zero, x) -> x for i1
+  func.func @logical_or_identity_i1(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
+    %zero = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
+    // CHECK-LABEL: func.func @logical_or_identity_i1
+    // CHECK-NOT: "ttir.logical_or"
+    %1 = "ttir.logical_or"(%zero, %arg0) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
+    return %1 : tensor<64x64xi1>
+  }
+
+  // Identity: or(x, zero) -> x for i1
+  func.func @logical_or_identity_i1_rhs(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
+    %zero = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
+    // CHECK-LABEL: func.func @logical_or_identity_i1_rhs
+    // CHECK-NOT: "ttir.logical_or"
+    %1 = "ttir.logical_or"(%arg0, %zero) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
+    return %1 : tensor<64x64xi1>
+  }
+
+  // and(nonzero, one_const) -> ones(result_type) (both nonzero)
+  func.func @logical_and_nonzero_one_const(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %five = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 5.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %one = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_nonzero_one_const
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_and"(%five, %one) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // and(nonzero, nonzero_non_one) -> ones(result_type)
+  func.func @logical_and_both_nonzero(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %five = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 5.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %three = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 3.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_both_nonzero
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_and"(%five, %three) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // or(zero, zero) -> zeros(result_type) (both zero)
+  func.func @logical_or_both_zero(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero1 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %zero2 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_both_zero
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_or"(%zero1, %zero2) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // Verify identity folds are NOT applied for non-boolean dynamic inputs.
+  func.func @logical_and_no_identity_fold(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_no_identity_fold
+    // CHECK: "ttir.logical_and"
+    %1 = "ttir.logical_and"(%ones, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @logical_or_no_identity_fold(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_no_identity_fold
+    // CHECK: "ttir.logical_or"
+    %1 = "ttir.logical_or"(%zero, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/compare/simple_compare.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/compare/simple_compare.mlir
@@ -55,7 +55,8 @@ module attributes {} {
 module attributes {} {
   func.func @less_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
     %1 = "ttir.le"(%arg0, %arg1) : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
-    // CHECK: "ttnn.le"
+    // Canonicalization of less_equal to greater_equal with swapped operands.
+    // CHECK: "ttnn.ge"
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: -> tensor<13x31xf32
@@ -68,7 +69,8 @@ module attributes {} {
 module attributes {} {
   func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
     %1 = "ttir.lt"(%arg0, %arg1) : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
-    // CHECK: "ttnn.lt"
+    // Canonicalization of less_than to greater_than with swapped operands
+    // CHECK: "ttnn.gt"
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: -> tensor<13x31xf32

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/compare_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/compare_op.mlir
@@ -48,7 +48,8 @@ module @jit_eltwise_compare attributes {} {
 
   func.func public @test_le(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_le
-    // CHECK: ttnn.le
+    // Canonicalization of less_equal to greater_equal with swapped operands.
+    // CHECK: ttnn.ge
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: -> tensor<64x128xbf16,
@@ -58,7 +59,8 @@ module @jit_eltwise_compare attributes {} {
 
   func.func public @test_lt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_lt
-    // CHECK: ttnn.lt
+    // Canonicalization of less_than to greater_than with swapped operands.
+    // CHECK: ttnn.gt
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: -> tensor<64x128xbf16,

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/compare/simple_compare.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/compare/simple_compare.mlir
@@ -49,7 +49,8 @@ module attributes {} {
 
   func.func @less_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
     %1 = "ttir.le"(%arg0, %arg1) : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
-    // CHECK: "ttnn.le"
+    // Canonicalization of less_equal to greater_equal with swapped operands.
+    // CHECK: "ttnn.ge"
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: -> tensor<13x31xf32
@@ -58,7 +59,8 @@ module attributes {} {
 
   func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
     %1 = "ttir.lt"(%arg0, %arg1) : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
-    // CHECK: "ttnn.lt"
+    // Canonicalization of less_than to greater_than with swapped operands.
+    // CHECK: "ttnn.gt"
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: -> tensor<13x31xf32

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/runtime_support_typecast_slice.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved/runtime_support_typecast_slice.mlir
@@ -36,8 +36,8 @@ module @L1InterleavedRuntimeSupportTypecastSlice attributes {} {
     // CHECK: %{{.*}} = "ttnn.typecast"{{.*}} -> tensor<1x32x8400xf32, #[[DRAM_LAYOUT3]]>
     %5 = "ttir.typecast"(%4) : (tensor<1x32x8400xbf16>) -> tensor<1x32x8400xf32>
 
-    // Less than comparison - not upgraded to L1 because not immediately consumed by its user (schedule)
-    // CHECK: %{{.*}} = "ttnn.lt"{{.*}} -> tensor<1x32x8400xf32, #[[DRAM_LAYOUT3]]>
+    // Less than comparison (canonicalized to greater than with swapped operands) - not upgraded to L1 because not immediately consumed by its user (schedule)
+    // CHECK: %{{.*}} = "ttnn.gt"{{.*}} -> tensor<1x32x8400xf32, #[[DRAM_LAYOUT3]]>
     %6 = "ttir.lt"(%3, %5) : (tensor<1x32x8400xf32>, tensor<1x32x8400xf32>) -> tensor<1x32x8400xf32>
 
     // CHECK: %{{.*}} = "ttnn.slice_static"{{.*}} -> tensor<1x32x8400xbf16, #[[DRAM_LAYOUT5]]>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_lt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_lt.mlir
@@ -4,7 +4,8 @@
 module attributes {} {
   func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
     %1 = "ttir.lt"(%arg0, %arg1) : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
-    // CHECK: "ttnn.lt"
+    // Canonicalization of less_than to greater_than with swapped operands.
+    // CHECK: "ttnn.gt"
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: tensor<13x31xf32
     // CHECK-SAME: -> tensor<13x31xf32


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some models that use causal (lower-triangular) attention masks generate a redundant chain of ops in TTIR:

```
%false_broadcast = broadcast(reshape(constant(false))) → tensor<32768x32768xi1>
%ge   = ge(row_indices, col_indices)                   → tensor<32768x32768xi1>  // row >= col
%or   = logical_or(%false_broadcast, %ge)              → tensor<32768x32768xi1>  // false OR mask (redundant)
%le   = le(col_indices, row_indices)                   → tensor<32768x32768xi1>  // col <= row (same as ge)
%and  = logical_and(%or, %le)                          → tensor<32768x32768xi1>  // mask AND mask (redundant)
%mask = slice_static(reshape(%and))                    → tensor<1x1x4x4xi1>
```

Example model: `qwen_2_5_coder/causal_lm/jax-0.5B-single_device-inference`

After canonicalization + CSE, this simplifies to:

```
%ge   = ge(row_indices, col_indices)                   → tensor<32768x32768xi1>  // row >= col
%mask = slice_static(reshape(%ge))                     → tensor<1x1x4x4xi1>
```

### What's changed
Canonicalizations and folds added:

- `le(a, b)` → `ge(b, a)` — enables CSE to deduplicate with the existing `ge`
- `lt(a, b)` → `gt(b, a)` — same pattern for strict comparisons
- `logical_or(zero, x)` → `x` — identity fold, eliminates the redundant `or`
- `logical_or(nonzero, x)` → `nonzero` — absorbing element fold
- `logical_and(nonzero, x)` → `x` — identity fold
- `logical_and(zero, x)` → `zero` — absorbing element fold
- `logical_and(x, x)` → `x` — already handled by `BinaryIdempotence` trait; fires after CSE deduplicates the `ge`/`le` pair

### Checklist
- [x] New/Existing tests provide coverage for changes