### PR TITLE
Allow skippable job to be skipped in check-all-green

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -141,5 +141,5 @@ jobs:
         id: check-jobs
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: debug-build, lint, release-build, test, downstream-checks
+          allowed-skips: debug-build, lint, release-build, test, downstream-checks, ttsim-test
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### Ticket
/

### Problem description
`ttsim-test` step can be skipped in some cases (when small PR changes have been made) but check-all-green will still require it to always be ran and successfull.

### What's changed
Check-all-green allows the ttsim-test to be skipped.

### Checklist
- [ ] New/Existing tests provide coverage for changes
