### PR TITLE
Fixing reording when inlining composite ops

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -19,6 +19,8 @@ inline constexpr llvm::StringLiteral
     kReoutlineOrigNameAttr("reoutline.orig_name");
 inline constexpr llvm::StringLiteral
     kReoutlineCompAttrsAttr("reoutline.comp_attrs");
+inline constexpr llvm::StringLiteral
+    kReoutlineArgOperandIndicesAttr("reoutline.arg_operand_indices");
 
 // Composite op related string definitions.
 inline constexpr llvm::StringLiteral kCompDecompositionKey("decomposition");

--- a/lib/Dialect/StableHLO/Transforms/FlattenComposite.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FlattenComposite.cpp
@@ -115,6 +115,30 @@ flattenOneComposite(mlir::stablehlo::CompositeOp comp,
     clonedOps.push_back(cloned);
   }
 
+  // 4b) Annotate cloned ops with original composite operand indices.
+  llvm::DenseMap<mlir::Value, int64_t> captureToArgIndex;
+  for (int64_t i = 0; i < static_cast<int64_t>(comp->getNumOperands()); ++i) {
+    captureToArgIndex.try_emplace(comp->getOperand(i), i);
+  }
+
+  for (mlir::Operation *cloned : clonedOps) {
+    bool hasCapture = false;
+    llvm::SmallVector<int64_t> argIndices;
+    argIndices.reserve(cloned->getNumOperands());
+    for (mlir::Value operand : cloned->getOperands()) {
+      if (captureToArgIndex.find(operand) != captureToArgIndex.end()) {
+        argIndices.push_back(captureToArgIndex.find(operand)->second);
+        hasCapture = true;
+      } else {
+        argIndices.push_back(-1);
+      }
+    }
+    if (hasCapture) {
+      cloned->setAttr(utils::kReoutlineArgOperandIndicesAttr,
+                      builder.getDenseI64ArrayAttr(argIndices));
+    }
+  }
+
   // 5) Handle callee terminator: replace composite results with mapped return
   // values. We expect a func.return with N operands, matching the composite's
   // results.

--- a/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
@@ -115,9 +115,44 @@ static bool analyzeBoundary(const llvm::SmallVector<mlir::Operation *> &ops,
     return isOpBefore(defA, defB);
   };
 
+  // Build a map from captured value to its original composite operand index
+  // using annotations set during flattening.
+  llvm::DenseMap<mlir::Value, int64_t> captureArgIndex;
+  for (auto *op : sorted) {
+    auto argIndicesAttr = op->getAttrOfType<mlir::DenseI64ArrayAttr>(
+        utils::kReoutlineArgOperandIndicesAttr);
+    if (!argIndicesAttr) {
+      continue;
+    }
+    llvm::ArrayRef<int64_t> argIndices = argIndicesAttr.asArrayRef();
+    for (auto [j, idx] : llvm::enumerate(argIndices)) {
+      if (idx >= 0) {
+        mlir::Value operand = op->getOperand(j);
+        if (captureSet.contains(operand)) {
+          captureArgIndex[operand] = idx;
+        }
+      }
+    }
+  }
+
+  // Sort captures by original arg index, with unknowns falling back to block
+  // position.
   captures.assign(captureSet.begin(), captureSet.end());
+  llvm::sort(captures, [&](mlir::Value a, mlir::Value b) {
+    auto itA = captureArgIndex.find(a);
+    auto itB = captureArgIndex.find(b);
+    bool hasA = (itA != captureArgIndex.end());
+    bool hasB = (itB != captureArgIndex.end());
+    if (hasA && hasB) {
+      return itA->second < itB->second;
+    }
+    if (hasA != hasB) {
+      return hasA; // known args before unknowns
+    }
+    return orderByBlockPos(a, b); // both unknown: fallback
+  });
+
   escapes.assign(escapeSet.begin(), escapeSet.end());
-  llvm::sort(captures, orderByBlockPos);
   llvm::sort(escapes, orderByBlockPos);
 
   return true;

--- a/lib/Dialect/StableHLO/Utils/StableHLOUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/StableHLOUtils.cpp
@@ -57,6 +57,9 @@ mlir::func::FuncOp createPrivateFunction(
     if (cloned->hasAttr(utils::kReoutlineSeedAttr)) {
       cloned->removeAttr(utils::kReoutlineSeedAttr);
     }
+    if (cloned->hasAttr(utils::kReoutlineArgOperandIndicesAttr)) {
+      cloned->removeAttr(utils::kReoutlineArgOperandIndicesAttr);
+    }
   }
 
   // Emit return with remapped escape values.

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_arg_order.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_arg_order.mlir
@@ -1,0 +1,23 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --reoutline-composite -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that reoutlining preserves the original composite operand order
+// when captures are defined in a different block position order.
+
+// CHECK-LABEL: func.func @main
+module @CompositeArgOrder attributes {} {
+  func.func @main(%arg0: tensor<32x16xf32>, %arg1: tensor<32x16xf32>) -> tensor<32x16xf32> {
+    %0 = stablehlo.reshape %arg0 : (tensor<32x16xf32>) -> tensor<1x32x16xf32>
+    // CHECK: [[V1:%[^ ]+]] = stablehlo.reshape{{.*}}(tensor<1x32x16xf32>) -> tensor<32x16xf32>
+    %1 = stablehlo.reshape %0 : (tensor<1x32x16xf32>) -> tensor<32x16xf32>
+    %2 = stablehlo.reshape %arg1 : (tensor<32x16xf32>) -> tensor<2x16x16xf32>
+    // CHECK: [[V3:%[^ ]+]] = stablehlo.reshape{{.*}}(tensor<2x16x16xf32>) -> tensor<32x16xf32>
+    %3 = stablehlo.reshape %2 : (tensor<2x16x16xf32>) -> tensor<32x16xf32>
+    // CHECK: stablehlo.composite "test.subtract" [[V3]], [[V1]]
+    %4 = stablehlo.subtract %3, %1 {reoutline.group = "composite_test.subtract.impl", reoutline.seed, reoutline.orig_name = "test.subtract", reoutline.comp_attrs = {}, reoutline.arg_operand_indices = array<i64: 0, 1>} : tensor<32x16xf32>
+    return %4 : tensor<32x16xf32>
+  }
+}
+// CHECK: func.func private @outlined_composite_test.subtract.impl
+// CHECK: stablehlo.subtract %arg0, %arg1


### PR DESCRIPTION
Fixes a bug where the `reoutline-composite` pass could swap operands of reoutlined composite ops, producing invalid TTIR The root cause was that `ReoutlineComposite` sorted captured operands by block position instead of preserving the original composite argument order.                                              

The fix introduces a new `reoutline.arg_operand_indices` attribute — a `DenseI64ArrayAttr` attached during flattening to any cloned op that references a composite operand. Each entry maps an operand position to its original composite argument index (-1 for non-capture operands).

`FlattenComposite` records these indices after inlining, `ReoutlineComposite` reads them in `analyzeBoundary` to sort captures by original arg index (falling back to block position for unannotated values).

Fixes https://github.com/tenstorrent/tt-xla/issues/3289