### PR TITLE
[Bounty #4872] Add comparison operators (EQ, NE, GT, LT, GE, LE) to stablehlo_builder.py

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -1904,3 +1904,103 @@ def test_broadcast_ops(
         target=target,
         device=device,
     )
+
+
+# ----- Comparison Operations -----
+
+
+def module_compare_eq(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_eq(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_eq(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_ne(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_ne(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_ne(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_gt(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_gt(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_gt(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_lt(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_lt(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_lt(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_ge(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_ge(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_ge(in0, in1, unit_attrs=unit_attrs)
+
+
+def module_compare_le(builder: StableHLOBuilder):
+    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
+    def compare_le(
+        in0: Operand,
+        in1: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.compare_le(in0, in1, unit_attrs=unit_attrs)
+
+
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize(
+    "test_fn",
+    [
+        module_compare_eq,
+        module_compare_ne,
+        module_compare_gt,
+        module_compare_lt,
+        module_compare_ge,
+        module_compare_le,
+    ],
+)
+def test_compare_ops(
+    test_fn: Callable, shape: Shape, dtype: torch.dtype, target: str, request, device
+):
+    compile_and_execute_shlo(
+        test_fn,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+    )

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -6260,6 +6260,317 @@ class StableHLOBuilder(Builder):
             sharding_attr=sharding_attr,
         )
 
+    # ----- Comparison Operations -----
+
+    def _compare(
+        self,
+        in0: Operand,
+        in1: Operand,
+        direction: str,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        direction_attr = stablehlo.ComparisonDirectionAttr.get(direction, self._ctx)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo.CompareOp(
+            in0,
+            in1,
+            direction_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if sharding_attr is not None:
+            op.operation.attributes["sdy.sharding"] = sharding_attr
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        input0 = self._get_golden_tensor(in0)
+        input1 = self._get_golden_tensor(in1)
+        op_golden_function = get_golden_function(stablehlo.CompareOp)
+        golden_output = op_golden_function(input0, input1, direction=direction)
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    def compare_eq(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction EQ.
+
+        *Elementwise equality comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding elements of the inputs are equal.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare EQ, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [1.0, 0.0, 3.0]
+            // result: [true, false, true]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise equality results.
+        """
+        return self._compare(
+            in0, in1, "EQ", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
+    def compare_ne(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction NE.
+
+        *Elementwise not-equal comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding elements of the inputs are not equal.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare NE, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [1.0, 0.0, 3.0]
+            // result: [false, true, false]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise not-equal results.
+        """
+        return self._compare(
+            in0, in1, "NE", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
+    def compare_gt(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction GT.
+
+        *Elementwise greater-than comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding element of ``in0`` is strictly greater than ``in1``.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare GT, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [0.0, 2.0, 4.0]
+            // result: [true, false, false]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise greater-than results.
+        """
+        return self._compare(
+            in0, in1, "GT", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
+    def compare_lt(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction LT.
+
+        *Elementwise less-than comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding element of ``in0`` is strictly less than ``in1``.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare LT, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [0.0, 2.0, 4.0]
+            // result: [false, false, true]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise less-than results.
+        """
+        return self._compare(
+            in0, in1, "LT", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
+    def compare_ge(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction GE.
+
+        *Elementwise greater-than-or-equal comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding element of ``in0`` is greater than or equal to ``in1``.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare GE, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [0.0, 2.0, 4.0]
+            // result: [true, true, false]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise greater-than-or-equal results.
+        """
+        return self._compare(
+            in0, in1, "GE", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
+    def compare_le(
+        self,
+        in0: Operand,
+        in1: Operand,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        """
+        Creates ``stablehlo.compare`` with direction LE.
+
+        *Elementwise less-than-or-equal comparison.*
+
+        Returns a boolean tensor where each element is ``True`` if the
+        corresponding element of ``in0`` is less than or equal to ``in1``.
+
+        .. code-block:: mlir
+
+            %result = stablehlo.compare LE, %lhs, %rhs : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xi1>
+            // lhs: [1.0, 2.0, 3.0]
+            // rhs: [0.0, 2.0, 4.0]
+            // result: [false, true, true]
+
+        Parameters
+        ----------
+        in0 : Operand
+            Left-hand side tensor.
+        in1 : Operand
+            Right-hand side tensor.
+        loc : *Optional[str]*
+            Optional source location string.
+        unit_attrs : *Optional[List[str]]*
+            Optional list of unit attributes.
+        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*
+            Optional sharding attribute.
+
+        Returns
+        -------
+        (*OpResult*)
+            Boolean tensor with elementwise less-than-or-equal results.
+        """
+        return self._compare(
+            in0, in1, "LE", loc=loc, unit_attrs=unit_attrs, sharding_attr=sharding_attr
+        )
+
     # ----- Reduce Operations -----
 
     def _reduce_op_proxy(

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2758,6 +2758,44 @@ def stablehlo_not_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTe
         return torch.bitwise_not(input_tensor)
 
 
+def stablehlo_compare_golden(
+    input_tensor: GoldenMapTensor,
+    other_tensor: GoldenMapTensor,
+    direction: str,
+    **kwargs,
+) -> GoldenMapTensor:
+    """
+    Golden function for StableHLO compare operation.
+
+    Performs elementwise comparison between two tensors according to the
+    specified comparison direction, returning a boolean tensor.
+
+    Parameters
+    ----------
+    input_tensor : GoldenMapTensor
+        Left-hand side tensor.
+    other_tensor : GoldenMapTensor
+        Right-hand side tensor.
+    direction : str
+        Comparison direction: one of "EQ", "NE", "GT", "LT", "GE", "LE".
+
+    Returns
+    -------
+    GoldenMapTensor
+        Boolean tensor containing the elementwise comparison results.
+    """
+    _compare_ops = {
+        "EQ": torch.eq,
+        "NE": torch.ne,
+        "GT": torch.gt,
+        "LT": torch.lt,
+        "GE": torch.ge,
+        "LE": torch.le,
+    }
+    assert direction in _compare_ops, f"Unsupported comparison direction: {direction}"
+    return _compare_ops[direction](input_tensor, other_tensor)
+
+
 ################ Golden Utilities ###############
 
 
@@ -6120,6 +6158,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.OrOp: stablehlo_or_golden,
     stablehlo.XorOp: stablehlo_xor_golden,
     stablehlo.NotOp: stablehlo_not_golden,
+    stablehlo.CompareOp: stablehlo_compare_golden,
     stablehlo.SliceOp: stablehlo_slice_golden,
     stablehlo.GetDimensionSizeOp: stablehlo_get_dimension_size_golden,
     stablehlo.MaxOp: stablehlo_maximum_golden,


### PR DESCRIPTION
## Summary

Closes #4872

Adds all 6 StableHLO comparison operators to `stablehlo_builder.py` following the existing patterns in the codebase:

- `compare_eq` — elementwise equality (EQ)
- `compare_ne` — elementwise not-equal (NE)
- `compare_gt` — elementwise greater-than (GT)
- `compare_lt` — elementwise less-than (LT)
- `compare_ge` — elementwise greater-than-or-equal (GE)
- `compare_le` — elementwise less-than-or-equal (LE)

## Changes

### `tools/builder/stablehlo/stablehlo_builder.py`
- Added `_compare()` private helper that uses `stablehlo.CompareOp` with `stablehlo.ComparisonDirectionAttr`, sets golden tensors, and supports `unit_attrs` / `sharding_attr`
- Added `compare_eq`, `compare_ne`, `compare_gt`, `compare_lt`, `compare_ge`, `compare_le` public methods with full docstrings following the existing pattern

### `tools/golden/mapping.py`
- Added `stablehlo_compare_golden()` golden function that dispatches to the appropriate `torch` comparison op based on `direction`
- Registered it in `GOLDEN_MAPPINGS` as `stablehlo.CompareOp: stablehlo_compare_golden`

### `test/python/golden/test_stablehlo_ops.py`
- Added 6 test module functions (`module_compare_eq`, `module_compare_ne`, etc.)
- Added `test_compare_ops` parametrized test covering all 6 directions with `float32` tensors

## Test plan

- [ ] `pytest test/python/golden/test_stablehlo_ops.py::test_compare_ops -v` covers all 6 directions
- [ ] Existing tests unaffected