### PR TITLE
[TTNN->EmitPy] Do NOT read mem cfg off output layout for to_layout op

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1151,6 +1151,9 @@ public:
         emitter.emit(toLayoutOp.getInput()),
         emitter.emit(toLayoutOp.getLayout()),
         emitter.emit(toLayoutOp.getDtype()),
+        // Emit MemoryConfig only if it exists as an argument to the op.
+        // Most other ops will read the TTNNLayout object on the output tensor
+        // as well, but we are skipping that here as runtime skips it as well.
         emitter.emit(toLayoutOp.getMemoryConfig(), "memory_config"),
     };
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/7328

### Problem description
TTNN->EmitPy conversion for `ttnn.to_layout` creates memory config object from the output tensor layout. This is a common practice and is used across most (all?) other ops. Runtime path doesn't do this for this specific op, it only checks for memory config object from the existing op argument list.

This causes a mismatch in the way ops are called and (coincidentally) results in an assert firing for the Python path. Repro in the ticket

### What's changed
Removed the read of memory config from output tensor layout object.

### Checklist
- [ ] New/Existing tests provide coverage for changes
