### PR TITLE
Fix ClampScalar dtype mismatch for INT32 inputs

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1521,13 +1521,13 @@ struct OpModel<ClampScalarOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(ttcore::GridAttr deviceGrid,
                    llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, llvm::APFloat min,
-                   llvm::APFloat max, TTNNLayoutAttr outputLayout);
+                   TTNNLayoutAttr inputLayout, mlir::Attribute min,
+                   mlir::Attribute max, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
-                                             llvm::APFloat min,
-                                             llvm::APFloat max,
+                                             mlir::Attribute min,
+                                             mlir::Attribute max,
                                              TTNNLayoutAttr outputLayout);
 };
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -185,6 +185,10 @@ llvm::hash_code hash_value(const std::vector<T> &arg) {
 namespace llvm {
 // The following definitions are not found by compiler in any header file. LLVM
 // needs to know how to hash all argument types of TTNN ops.
+inline hash_code hash_value(mlir::Attribute attr) {
+  return hash_value(attr.getAsOpaquePointer());
+}
+
 template <typename T>
 hash_code hash_value(const llvm::SmallVector<T> &arg) {
   return hash_combine_range(arg);

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3966,8 +3966,7 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], ttmlir::utils::attributeToAPFloat(getMin()),
-      ttmlir::utils::attributeToAPFloat(getMax()), opConfig.outputLayout);
+      inputShape, inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3979,8 +3978,7 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<ClampScalarOp>::getOpRuntime, *this, inputShape,
-      inputs[0], ttmlir::utils::attributeToAPFloat(getMin()),
-      ttmlir::utils::attributeToAPFloat(getMax()), opConfig.outputLayout);
+      inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6389,18 +6389,29 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampScalar
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+/// Convert a clamp min/max mlir::Attribute (F32Attr or I32Attr) to the
+/// std::variant tt-metal expects, mirroring the runtime's NumberType dispatch.
+static std::optional<std::variant<float, int32_t>>
+clampAttrToVariant(mlir::Attribute attr) {
+  if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+    return static_cast<int32_t>(intAttr.getValue().getSExtValue());
+  }
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(attr)) {
+    return static_cast<float>(floatAttr.getValueAsDouble());
+  }
+  return std::nullopt;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    TTNNLayoutAttr inputLayout, llvm::APFloat min, llvm::APFloat max,
+    TTNNLayoutAttr inputLayout, mlir::Attribute min, mlir::Attribute max,
     TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-
-  // Convert float
-  float minVal = min.convertToFloat();
-  float maxVal = max.convertToFloat();
 
   auto inputSpecExp =
       detail::convertToTensorSpec(device, inputShape, inputLayout);
@@ -6409,11 +6420,13 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  // Create query closure
+  auto memConfig = detail::getNullableMemoryConfig(outputLayout);
+  auto minVariant = clampAttrToVariant(min);
+  auto maxVariant = clampAttrToVariant(max);
+
   auto clampScalarQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::clamp, device, inputSpec, minVal, maxVal,
-        detail::getNullableMemoryConfig(outputLayout));
+        ::ttnn::clamp, device, inputSpec, minVariant, maxVariant, memConfig);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
@@ -6425,15 +6438,11 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
 
 llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::APFloat min, llvm::APFloat max, TTNNLayoutAttr outputLayout) {
+    mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-
-  // Convert float
-  float minVal = min.convertToFloat();
-  float maxVal = max.convertToFloat();
 
   auto inputSpecExp =
       detail::convertToTensorSpec(device, inputShape, inputLayout);
@@ -6442,11 +6451,13 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  // Create query closure
+  auto memConfig = detail::getNullableMemoryConfig(outputLayout);
+  auto minVariant = clampAttrToVariant(min);
+  auto maxVariant = clampAttrToVariant(max);
+
   auto clampScalarQuery = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::clamp, device, inputSpec, minVal, maxVal,
-        detail::getNullableMemoryConfig(outputLayout));
+    return ::ttnn::graph::query_op_runtime(::ttnn::clamp, device, inputSpec,
+                                           minVariant, maxVariant, memConfig);
   };
 
   return operation::getOpRuntime(clampScalarQuery);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -3383,9 +3383,13 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
               inputVirtualGrid] = std::get<0>(params);
   const auto [outputShape, outputTensorLayout, outputBufferType,
               outputVirtualGrid] = std::get<1>(params);
-  const auto minVal = llvm::APFloat(std::get<2>(params));
-  const auto maxVal = llvm::APFloat(std::get<3>(params));
+  const float minFloat = std::get<2>(params);
+  const float maxFloat = std::get<3>(params);
   const auto expectedLegal = std::get<4>(params);
+
+  mlir::Builder builder(&context);
+  mlir::Attribute minAttr = builder.getF32FloatAttr(minFloat);
+  mlir::Attribute maxAttr = builder.getF32FloatAttr(maxFloat);
 
   const TTNNLayoutAttr inputLayout = CreateTiledLayout(
       inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
@@ -3393,7 +3397,7 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
   auto constraintsExp = OpModel<ClampScalarOp>::getOpConstraints(
-      CreateWorkerGrid(), inputShape, inputLayout, minVal, maxVal,
+      CreateWorkerGrid(), inputShape, inputLayout, minAttr, maxAttr,
       outputLayout);
   if (!constraintsExp) {
     std::cout << "Error: " << llvm::toString(constraintsExp.takeError())
@@ -3413,7 +3417,7 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
   }
 
   auto runtimeExp = OpModel<ClampScalarOp>::getOpRuntime(
-      inputShape, inputLayout, minVal, maxVal, outputLayout);
+      inputShape, inputLayout, minAttr, maxAttr, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -3431,6 +3435,29 @@ INSTANTIATE_TEST_SUITE_P(ClampScalarTests, OpModelClampScalarParam,
                                                 TensorMemoryLayout::Interleaved,
                                                 BufferType::L1},
                              1.0, 5.0, true)));
+
+// Verify that clamp with si32 input and I32Attr min/max preserves si32 dtype.
+TEST_F(OpModelTest, ClampScalarInt32DtypePreserved) {
+  llvm::SmallVector<int64_t> shape{1, 1, 128, 32};
+  const TTNNLayoutAttr inputLayout = CreateTiledLayoutInt32(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayoutInt32(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  mlir::Builder builder(&context);
+  mlir::Attribute minAttr = builder.getI32IntegerAttr(0);
+  mlir::Attribute maxAttr = builder.getI32IntegerAttr(2);
+
+  auto constraintsExp = OpModel<ClampScalarOp>::getOpConstraints(
+      CreateWorkerGrid(), shape, inputLayout, minAttr, maxAttr, outputLayout);
+  ASSERT_TRUE(static_cast<bool>(constraintsExp))
+      << "Constraints failed: " << llvm::toString(constraintsExp.takeError());
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBacks] = constraintsExp.get();
+  ASSERT_FALSE(outputLayoutReadBacks.empty());
+  ExpectLayoutsEQ(outputLayout, outputLayoutReadBacks[0]);
+}
 
 class OpModelClampTensorParam : public OpModelTest,
                                 public testing::WithParamInterface<


### PR DESCRIPTION
## Summary
- Fix ClampScalar op model always converting min/max to float, which caused tt-metal to typecast INT32 inputs to FLOAT32
- Pass `mlir::Attribute` directly to the op model and dispatch `int32_t` vs `float` based on attribute type, mirroring the runtime's `NumberType` check
- Add unit test reproducing the INT32 dtype preservation bug

## Test plan
- [x] Existing `ClampScalarParam` float test passes
- [x] New `ClampScalarInt32DtypePreserved` test passes (previously failed with `Expected si32, got f32`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)