### PR TITLE
Fix embedding op crash for dynamic weights with sharded inputs

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -694,10 +694,19 @@ private:
     // If the output data type is untilizable on device, untilize on device then
     // move to host
     if (info.shouldUntilize() && canUntilizeDataTypeOnDevice(input.dataType)) {
-      currentInput =
-          this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
-      currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
-                                                          currentInput, info);
+      // If input is L1 sharded, unshard first since untilize doesn't support
+      // sharded input with sharded output.
+      if (input.isL1Sharded()) {
+        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
+                                                            currentInput, info);
+        currentInput =
+            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
+      } else {
+        currentInput =
+            this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
+        currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
+                                                            currentInput, info);
+      }
       currentInput =
           this->createFromDeviceOpIfNeeded(op, rewriter, currentInput, info);
       op.getResult().replaceAllUsesWith(currentInput);


### PR DESCRIPTION

Also reorder DecomposeLayouts to unshard (toMemoryConfig) before untilize (toLayout) when input is L1 sharded, since untilize_with_unpadding does not support sharded input with sharded output.


