### PR TITLE
[ttnn.jit] Add gpt-oss subgraph to ttnn.jit demo

### DIFF
--- a/test/ttnn-jit/demo/test_gpt_oss_20b_gate_up.py
+++ b/test/ttnn-jit/demo/test_gpt_oss_20b_gate_up.py
@@ -116,7 +116,7 @@ def gptoss_gateup_subgraph_not_jit(
 
 def test_oss_gateup_subgraph(device):
     shape = (2, 32, 3072)
-    dtype = torch.float32
+    dtype = torch.bfloat16
     limit = 7.0
     bias = 1.0
     alpha = 1.702


### PR DESCRIPTION
### What's changed
Add gpt-oss gate up subgraph from #7107 as a ttnn-jit demo. Subgraph is successfully running through ttnn-jit.

### Checklist
- [x] New/Existing tests provide coverage for changes
