### PR TITLE
[d2m] bf16 and uint16 tilize tests

### DIFF
--- a/test/python/golden/test_metal_tilize.py
+++ b/test/python/golden/test_metal_tilize.py
@@ -19,12 +19,12 @@ pytestmark = pytest.mark.frontend("ttir")
 
 
 @pytest.mark.parametrize("shape", [(32, 64), (64, 32), (64, 64), (64, 128)])
-@pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
     "dtype",
-    [torch.float32, torch.int32],
-    ids=["f32", "i32"],
+    [torch.float32, torch.int32, torch.bfloat16, torch.uint16],
+    ids=["f32", "i32", "bf16", "u16"],
 )
+@pytest.mark.parametrize("target", ["ttmetal"])
 def test_tilize(shape: Shape, target: str, dtype: torch.dtype, request, device):
     def module(builder: D2MBuilder):
         @builder.func([shape], [dtype])
@@ -36,7 +36,9 @@ def test_tilize(shape: Shape, target: str, dtype: torch.dtype, request, device):
 
             to_device = builder.tilize(
                 in0,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=True),
+                output_type=builder.get_metal_tensor_layout(
+                    shape, tiled=True, element_dtype=dtype
+                ),
                 unit_attrs=unit_attrs,
             )
 
@@ -44,7 +46,9 @@ def test_tilize(shape: Shape, target: str, dtype: torch.dtype, request, device):
             id_map = AffineMap.get_identity(2 * len(shape), builder._ctx)
             view_as_rm = builder.view_layout(
                 to_device,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=False),
+                output_type=builder.get_metal_tensor_layout(
+                    shape, tiled=False, element_dtype=dtype
+                ),
                 remapping=id_map,
                 reinterpret_layout=True,
                 unit_attrs=unit_attrs,
@@ -68,12 +72,12 @@ def test_tilize(shape: Shape, target: str, dtype: torch.dtype, request, device):
 
 
 @pytest.mark.parametrize("shape", [(32, 64), (64, 32), (64, 64), (64, 128)])
-@pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
     "dtype",
-    [torch.float32, torch.int32],
-    ids=["f32", "i32"],
+    [torch.float32, torch.int32, torch.bfloat16, torch.uint16],
+    ids=["f32", "i32", "bf16", "u16"],
 )
+@pytest.mark.parametrize("target", ["ttmetal"])
 def test_untilize(shape: Shape, target: str, dtype: torch.dtype, request, device):
     def module(builder: D2MBuilder):
         @builder.func([shape], [dtype])
@@ -85,7 +89,7 @@ def test_untilize(shape: Shape, target: str, dtype: torch.dtype, request, device
             to_device = builder.to_layout(
                 in0,
                 output_type=builder.get_metal_tensor_layout(
-                    shape, tiled=False, grid=(1, 1)
+                    shape, tiled=False, grid=(1, 1), element_dtype=dtype
                 ),
                 unit_attrs=unit_attrs,
             )
@@ -95,7 +99,7 @@ def test_untilize(shape: Shape, target: str, dtype: torch.dtype, request, device
             view_as_tiled = builder.view_layout(
                 to_device,
                 output_type=builder.get_metal_tensor_layout(
-                    shape, grid=(1, 1), tiled=True
+                    shape, grid=(1, 1), tiled=True, element_dtype=dtype
                 ),
                 remapping=id_map,
                 reinterpret_layout=True,
@@ -120,12 +124,12 @@ def test_untilize(shape: Shape, target: str, dtype: torch.dtype, request, device
 
 
 @pytest.mark.parametrize("shape", [(32, 64), (64, 32), (64, 64)])
-@pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize(
     "dtype",
-    [torch.float32, torch.int32],
-    ids=["f32", "i32"],
+    [torch.float32, torch.int32, torch.bfloat16, torch.uint16],
+    ids=["f32", "i32", "bf16", "u16"],
 )
+@pytest.mark.parametrize("target", ["ttmetal"])
 def test_tilize_untilize(
     shape: Shape, target: str, dtype: torch.dtype, request, device
 ):
@@ -139,7 +143,7 @@ def test_tilize_untilize(
             to_device = builder.tilize(
                 in0,
                 output_type=builder.get_metal_tensor_layout(
-                    shape, tiled=True, grid=(1, 1)
+                    shape, tiled=True, grid=(1, 1), element_dtype=dtype
                 ),
                 unit_attrs=unit_attrs,
             )

--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -736,6 +736,7 @@ class Builder(metaclass=BuilderMeta):
         self,
         logical_shape: Shape,
         tiled=False,
+        element_dtype: torch.dtype = torch.float32,
         oobVal=None,  # Will default to ttcore.OOBVal.Undef in the utility
         memorySpace=None,  # Will default to ttcore.MemorySpace.DeviceL1 in the utility
         grid: Optional[Tuple[int, int]] = None,
@@ -759,6 +760,7 @@ class Builder(metaclass=BuilderMeta):
             self._ctx,
             logical_shape,
             tiled,
+            element_dtype,
             oobVal,
             memorySpace,
             grid,

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -186,6 +186,7 @@ def get_metal_tensor_layout(
     ctx: Context,
     logical_shape: Shape,
     tiled=False,
+    element_dtype: torch.dtype = torch.float32,
     oobVal=ttcore.OOBVal.Undef,
     memorySpace=ttcore.MemorySpace.DeviceL1,
     grid: Optional[Tuple[int, int]] = None,
@@ -221,6 +222,9 @@ def get_metal_tensor_layout(
         Optional explicit dimension alignments. When specified, the tensor
         will be padded to these alignments regardless of tile size. Useful
         for testing masking of complete out-of-bounds tiles.
+    element_dtype : torch.dtype
+        Element dtype for the resulting tensor. Supports torch.float32,
+        torch.int32, torch.uint16, and torch.bfloat16.
 
     Returns
     -------
@@ -271,11 +275,24 @@ def get_metal_tensor_layout(
         grid_shape, [32, 32] if tiled else [1, 1]
     )
 
-    elemType = F32Type.get(ctx)
+    if element_dtype == torch.float32:
+        elemType = F32Type.get(ctx)
+        tile_elem_dtype = ttcore.DataType.Float32
+    elif element_dtype == torch.int32:
+        elemType = IntegerType.get_signed(32, ctx)
+        tile_elem_dtype = ttcore.DataType.Int32
+    elif element_dtype == torch.uint16:
+        elemType = IntegerType.get_unsigned(16, ctx)
+        tile_elem_dtype = ttcore.DataType.UInt16
+    elif element_dtype == torch.bfloat16:
+        elemType = BF16Type.get(ctx)
+        tile_elem_dtype = ttcore.DataType.BFloat16
+    else:
+        raise ValueError(f"Unsupported dtype for metal layout: {element_dtype}")
 
     # For tiled layouts, ensure the device shape accounts for tiles.
     if tiled:
-        elemType = ttcore.ir.TileType.get(ctx, 32, 32, ttcore.DataType.Float32)
+        elemType = ttcore.ir.TileType.get(ctx, 32, 32, tile_elem_dtype)
         if grid is None or grid == (1, 1):
             # For default 1x1 grid, use tile count based on aligned shape.
             # If dim_alignments is specified, use that; otherwise use logical_shape.


### PR DESCRIPTION
### What's changed
Added tests for tilize/untilize bf16 and uint16 so we can catch regressions during metal uplifts if underlying LLKs change

### Checklist
- [ ] New/Existing tests provide coverage for changes
