### PR TITLE
Update Reverse Op Decomposition

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -121,10 +121,10 @@ struct ReverseOpConversionPattern
         current, permutation);
 
     // Step 2: Reshape to 2D [N_reversing, N_non_reversing].
-    int64_t nReversing = std::accumulate(
+    int32_t nReversing = std::accumulate(
         permutedShape.begin(), permutedShape.begin() + dimensions.size(),
-        int64_t{1}, std::multiplies<>());
-    int64_t nNonReversing =
+        int32_t{1}, std::multiplies<>());
+    int32_t nNonReversing =
         std::accumulate(permutedShape.begin() + dimensions.size(),
                         permutedShape.end(), int64_t{1}, std::multiplies<>());
 
@@ -159,10 +159,8 @@ struct ReverseOpConversionPattern
         rewriter.create<ttir::ReshapeOp>(loc, permType, current, permShapeAttr);
 
     // Step 6: Inverse permute back to original shape.
-    SmallVector<int64_t> invPerm(rank);
-    for (int64_t i = 0; i < rank; i++) {
-      invPerm[permutation[i]] = i;
-    }
+    SmallVector<int64_t> invPerm =
+        ttmlir::utils::inversePermutation(permutation);
     current = rewriter.create<ttir::PermuteOp>(
         loc,
         RankedTensorType::get(shape, inputType.getElementType(),

--- a/test/ttmlir/Dialect/TTIR/Decomposition/reverse.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/reverse.mlir
@@ -3,12 +3,12 @@
 
 module {
   func.func @reverse_op(%arg0: tensor<3x3x32x64xf32>) -> tensor<3x3x32x64xf32> {
-    // CHECK: "ttir.permute"
-    // CHECK: "ttir.reshape"
-    // CHECK: "ttir.constant"
-    // CHECK: "ttir.embedding"
-    // CHECK: "ttir.reshape"
-    // CHECK: "ttir.permute"
+    // CHECK: %[[V0:[0-9]+]] = "ttir.permute"(%arg0) <{permutation = array<i64: 1, 2, 0, 3>}> : (tensor<3x3x32x64xf32>) -> tensor<3x32x3x64xf32>
+    // CHECK: %[[V1:[0-9]+]] = "ttir.reshape"(%[[V0]]) <{shape = [96 : i32, 192 : i32]}> : (tensor<3x32x3x64xf32>) -> tensor<96x192xf32>
+    // CHECK: %[[V2:[0-9]+]] = "ttir.constant"() <{value = dense<[95, 94, 93, {{.*}}, 2, 1, 0]> : tensor<96xsi32>}> : () -> tensor<96xsi32>
+    // CHECK: %[[V3:[0-9]+]] = "ttir.embedding"(%[[V2]], %[[V1]]) : (tensor<96xsi32>, tensor<96x192xf32>) -> tensor<96x192xf32>
+    // CHECK: %[[V4:[0-9]+]] = "ttir.reshape"(%[[V3]]) <{shape = [3 : i32, 32 : i32, 3 : i32, 64 : i32]}> : (tensor<96x192xf32>) -> tensor<3x32x3x64xf32>
+    // CHECK: %[[V5:[0-9]+]] = "ttir.permute"(%[[V4]]) <{permutation = array<i64: 2, 0, 1, 3>}> : (tensor<3x32x3x64xf32>) -> tensor<3x3x32x64xf32>
     %1 = "ttir.reverse"(%arg0) <{dimensions = array<i64: 1,2>}> : (tensor<3x3x32x64xf32>) -> tensor<3x3x32x64xf32>
     return %1 : tensor<3x3x32x64xf32>
   }


### PR DESCRIPTION
### Ticket
x

### Problem description
TTIR Reverse Op sometimes produces TTIR Gather Ops, but we want to remove the generic TTIR Gather Op that mimics StableHLO Gather (https://github.com/tenstorrent/tt-mlir/issues/6579).

### What's changed
Now TTIR Reverse Op decomposes into TTIR Embedding OP directly.

The new approach decomposes TTIR Reverse Op into Permute → Reshape + Constant → Embedding → Reshape → Permute. The strategy:
  1. Permute – moves the dimensions to be reversed to the front (sorted), non-reversed dims to the back.
  2. Reshape – flattens to 2D [nReversing, nNonReversing], treating all reversing dims as a single axis.
  3. Constant – builds reversed row indices [N-1, N-2, ..., 0].
  4. Embedding – uses EmbeddingOp to reorder rows via the reversed index, effectively reversing the combined axis.
  5. Reshape – restores permuted shape.
  6. Permute – applies inverse permutation to restore original dimension order with the target dims reversed.

### Checklist
- updated `/localdev/sdjukic/tt-mlir/test/ttmlir/Dialect/TTIR/Decomposition/reverse.mlir`
- checked that builder tests cover all cases and pass