### PR TITLE
Disabling permute-matmul-fusion by default to false

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -291,7 +291,7 @@ def TTIRFusing: Pass<"ttir-fusing", "::mlir::ModuleOp">
              "Controls if we should enable the Conv2dWithMultiply pattern">,
       Option<"permuteMatmulEnabled",
              "enable-permute-matmul-fusion",
-             "bool", /*default=*/"true",
+             "bool", /*default=*/"false",
              "Fuse permute ops into matmul/linear transpose attributes">,
   ];
 }

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -293,7 +293,7 @@ struct TTIRToTTNNDevicePipelineOptions
       *this, "enable-permute-matmul-fusion",
       llvm::cl::desc(
           "Fuse permute ops into matmul/linear transpose attributes."),
-      llvm::cl::init(true)};
+      llvm::cl::init(false)};
 
   Option<ttcore::TTArgumentTypeMap, ttcore::ArgumentTypeMapParser>
       argumentTypeMap{


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7368

### Problem description
Permute + matmul fusion pattern introduces accuracy issues, and per this comment, we don't need it anymore:
https://github.com/tenstorrent/tt-xla/issues/3591#issuecomment-4004478902

### What's changed
Disabling the fusion pattern by default until we find some time to investigate accuracy issues with the fused op.

### Checklist
- [ ] New/Existing tests provide coverage for changes
