### PR TITLE
[d2m] heuristic allocation within L1 scratchpad

### DIFF
--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -109,15 +109,9 @@ private:
       return a.numElements > b.numElements;
     });
 
+    Block &block = region.front();
     computeLiveness(allocations, block, region);
     int64_t peakUsage = assignOffsets(allocations);
-
-    OpBuilder builder(&block, block.begin());
-    builder.setInsertionPointAfterValue(scratchCB);
-    auto scratchFromCBOp =
-        builder.create<GetScratchFromCBOp>(genericOp.getLoc(), scratchCB);
-    Value scratchMemRef = scratchFromCBOp.getResult();
-    auto scratchMemRefType = mlir::cast<MemRefType>(scratchMemRef.getType());
 
     // Verify allocations fit in the scratch buffer.
     assert(!llvm::is_contained(scratchMemRefType.getShape(),
@@ -141,81 +135,6 @@ private:
     scratchInit.erase();
 
     return success();
-  }
-
-  // Compute liveness ranges for scratch allocations.
-  //
-  // Each allocation's live range spans from its definition to its last use.
-  void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
-                       Block &block, Region &region) {
-    // Assign sequential position indices to top-level operations in the block.
-    DenseMap<Operation *, int64_t> opPositions;
-    int64_t pos = 0;
-    for (Operation &op : block) {
-      opPositions[&op] = pos++;
-    }
-
-    // Helper: walk up to find the enclosing operation that lives directly in
-    // the region's entry block.
-    auto getTopLevelOp = [&](Operation *op) -> Operation * {
-      while (op->getParentRegion() != &region) {
-        op = op->getParentOp();
-      }
-      return op;
-    };
-
-    for (auto &info : allocations) {
-      Operation *topLevelDef = getTopLevelOp(info.op.getOperation());
-      info.startPosition = opPositions[topLevelDef];
-      info.endPosition = info.startPosition;
-
-      for (OpOperand &use : info.op.getResult().getUses()) {
-        Operation *topLevelUser = getTopLevelOp(use.getOwner());
-        int64_t userPos = opPositions[topLevelUser];
-        info.endPosition = std::max(info.endPosition, userPos);
-      }
-    }
-  }
-
-  // Assign element offsets using a first-fit-decreasing heuristic.
-  //
-  // Allocations are already sorted descending by size. Each "outer" allocation
-  // reserves a region of scratch memory. Smaller allocations whose live ranges
-  // do not overlap with the outer allocation are packed inside its footprint,
-  // reusing the same memory at different sub-offsets.
-  //
-  // Returns the peak scratch usage (total elements required).
-  int64_t assignOffsets(SmallVectorImpl<ScratchAllocationInfo> &allocations) {
-    int64_t currentOffset = 0;
-    for (size_t i = 0; i < allocations.size(); ++i) {
-      auto &outer = allocations[i];
-      assert(outer.numElements > 0 && "scratch allocation must be non-empty");
-      if (outer.packed) {
-        continue;
-      }
-
-      outer.elementOffset = currentOffset;
-      int64_t innerOffset = currentOffset;
-
-      // Try to pack smaller, non-conflicting allocations inside this one.
-      for (size_t j = i + 1; j < allocations.size(); ++j) {
-        auto &inner = allocations[j];
-        if (inner.packed) {
-          continue;
-        }
-
-        bool fits = (innerOffset + inner.numElements) <=
-                    (currentOffset + outer.numElements);
-        if (!livesOverlap(outer, inner) && fits) {
-          inner.packed = true;
-          inner.elementOffset = innerOffset;
-          innerOffset += inner.numElements;
-        }
-      }
-
-      currentOffset += outer.numElements;
-    }
-    return currentOffset;
   }
 
   // Compute liveness ranges for scratch allocations.

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -10,7 +10,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "llvm/Support/Debug.h"
+#include "mlir/IR/PatternMatch.h"
 
 #define DEBUG_TYPE "d2m-lower-scratch-allocate"
 
@@ -103,8 +103,6 @@ private:
       return success();
     }
 
-    Block &block = region.front();
-
     // Sort descending by size so larger allocations are placed first, giving
     // the best chance for smaller ones to be packed inside them.
     llvm::sort(allocations, [](const auto &a, const auto &b) {
@@ -113,11 +111,6 @@ private:
 
     computeLiveness(allocations, block, region);
     int64_t peakUsage = assignOffsets(allocations);
-
-    // Get the scratch operand value (CB block arg or memref.alloc).
-    int64_t scratchInputIdx = scratchInputsAttr[0];
-    Value scratchValue =
-        d2m::GenericOp::getOperandAlloc(region, scratchInputIdx);
 
     OpBuilder builder(&block, block.begin());
     builder.setInsertionPointAfterValue(scratchCB);

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -10,6 +10,9 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "d2m-lower-scratch-allocate"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERSCRATCHALLOCATE
@@ -17,13 +20,28 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Information about a single scratch allocation.
+// Information about a single scratch allocation, including its liveness range.
 struct ScratchAllocationInfo {
   ScratchAllocateOp op;
   int64_t slotId;
   int64_t numElements;   // Number of elements (tiles) requested.
   int64_t elementOffset; // Starting element offset in scratch buffer.
+
+  // Liveness range: positions of the definition and last use within the
+  // top-level operation ordering of the entry block.
+  int64_t startPosition = -1;
+  int64_t endPosition = -1;
+
+  // Whether this allocation was packed inside a larger, non-conflicting
+  // allocation's footprint by the offset assignment heuristic.
+  bool packed = false;
 };
+
+// Returns true if two live ranges overlap.
+static bool livesOverlap(const ScratchAllocationInfo &a,
+                         const ScratchAllocationInfo &b) {
+  return a.startPosition <= b.endPosition && b.startPosition <= a.endPosition;
+}
 
 class D2MLowerScratchAllocatePass
     : public impl::D2MLowerScratchAllocateBase<D2MLowerScratchAllocatePass> {
@@ -85,18 +103,28 @@ private:
       return success();
     }
 
-    // Sort by slot ID for deterministic layout.
+    Block &block = region.front();
+
+    // Sort descending by size so larger allocations are placed first, giving
+    // the best chance for smaller ones to be packed inside them.
     llvm::sort(allocations, [](const auto &a, const auto &b) {
-      return a.slotId < b.slotId;
+      return a.numElements > b.numElements;
     });
 
-    // Compute sequential element offsets.
-    int64_t currentOffset = 0;
-    for (auto &info : allocations) {
-      assert(info.numElements > 0 && "scratch allocation must be non-empty");
-      info.elementOffset = currentOffset;
-      currentOffset += info.numElements;
-    }
+    computeLiveness(allocations, block, region);
+    int64_t peakUsage = assignOffsets(allocations);
+
+    // Get the scratch operand value (CB block arg or memref.alloc).
+    int64_t scratchInputIdx = scratchInputsAttr[0];
+    Value scratchValue =
+        d2m::GenericOp::getOperandAlloc(region, scratchInputIdx);
+
+    OpBuilder builder(&block, block.begin());
+    builder.setInsertionPointAfterValue(scratchCB);
+    auto scratchFromCBOp =
+        builder.create<GetScratchFromCBOp>(genericOp.getLoc(), scratchCB);
+    Value scratchMemRef = scratchFromCBOp.getResult();
+    auto scratchMemRefType = mlir::cast<MemRefType>(scratchMemRef.getType());
 
     // Verify allocations fit in the scratch buffer.
     assert(!llvm::is_contained(scratchMemRefType.getShape(),
@@ -104,9 +132,9 @@ private:
            "scratch memrefs must be static");
     int64_t scratchCapacity =
         ttmlir::utils::volume<int64_t>(scratchMemRefType.getShape());
-    if (currentOffset > scratchCapacity) {
+    if (peakUsage > scratchCapacity) {
       return genericOp.emitOpError()
-             << "total scratch allocations (" << currentOffset
+             << "total scratch allocations (" << peakUsage
              << " elements) exceed scratch buffer capacity (" << scratchCapacity
              << " elements)";
     }
@@ -120,6 +148,156 @@ private:
     scratchInit.erase();
 
     return success();
+  }
+
+  // Compute liveness ranges for scratch allocations.
+  //
+  // Each allocation's live range spans from its definition to its last use.
+  void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
+                       Block &block, Region &region) {
+    // Assign sequential position indices to top-level operations in the block.
+    DenseMap<Operation *, int64_t> opPositions;
+    int64_t pos = 0;
+    for (Operation &op : block) {
+      opPositions[&op] = pos++;
+    }
+
+    // Helper: walk up to find the enclosing operation that lives directly in
+    // the region's entry block.
+    auto getTopLevelOp = [&](Operation *op) -> Operation * {
+      while (op->getParentRegion() != &region) {
+        op = op->getParentOp();
+      }
+      return op;
+    };
+
+    for (auto &info : allocations) {
+      Operation *topLevelDef = getTopLevelOp(info.op.getOperation());
+      info.startPosition = opPositions[topLevelDef];
+      info.endPosition = info.startPosition;
+
+      for (OpOperand &use : info.op.getResult().getUses()) {
+        Operation *topLevelUser = getTopLevelOp(use.getOwner());
+        int64_t userPos = opPositions[topLevelUser];
+        info.endPosition = std::max(info.endPosition, userPos);
+      }
+    }
+  }
+
+  // Assign element offsets using a first-fit-decreasing heuristic.
+  //
+  // Allocations are already sorted descending by size. Each "outer" allocation
+  // reserves a region of scratch memory. Smaller allocations whose live ranges
+  // do not overlap with the outer allocation are packed inside its footprint,
+  // reusing the same memory at different sub-offsets.
+  //
+  // Returns the peak scratch usage (total elements required).
+  int64_t assignOffsets(SmallVectorImpl<ScratchAllocationInfo> &allocations) {
+    int64_t currentOffset = 0;
+    for (size_t i = 0; i < allocations.size(); ++i) {
+      auto &outer = allocations[i];
+      assert(outer.numElements > 0 && "scratch allocation must be non-empty");
+      if (outer.packed) {
+        continue;
+      }
+
+      outer.elementOffset = currentOffset;
+      int64_t innerOffset = currentOffset;
+
+      // Try to pack smaller, non-conflicting allocations inside this one.
+      for (size_t j = i + 1; j < allocations.size(); ++j) {
+        auto &inner = allocations[j];
+        if (inner.packed) {
+          continue;
+        }
+
+        bool fits = (innerOffset + inner.numElements) <=
+                    (currentOffset + outer.numElements);
+        if (!livesOverlap(outer, inner) && fits) {
+          inner.packed = true;
+          inner.elementOffset = innerOffset;
+          innerOffset += inner.numElements;
+        }
+      }
+
+      currentOffset += outer.numElements;
+    }
+    return currentOffset;
+  }
+
+  // Compute liveness ranges for scratch allocations.
+  //
+  // Each allocation's live range spans from its definition to its last use.
+  void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
+                       Block &block, Region &region) {
+    // Assign sequential position indices to top-level operations in the block.
+    DenseMap<Operation *, int64_t> opPositions;
+    int64_t pos = 0;
+    for (Operation &op : block) {
+      opPositions[&op] = pos++;
+    }
+
+    // Helper: walk up to find the enclosing operation that lives directly in
+    // the region's entry block.
+    auto getTopLevelOp = [&](Operation *op) -> Operation * {
+      while (op->getParentRegion() != &region) {
+        op = op->getParentOp();
+      }
+      return op;
+    };
+
+    for (auto &info : allocations) {
+      Operation *topLevelDef = getTopLevelOp(info.op.getOperation());
+      info.startPosition = opPositions[topLevelDef];
+      info.endPosition = info.startPosition;
+
+      for (OpOperand &use : info.op.getResult().getUses()) {
+        Operation *topLevelUser = getTopLevelOp(use.getOwner());
+        int64_t userPos = opPositions[topLevelUser];
+        info.endPosition = std::max(info.endPosition, userPos);
+      }
+    }
+  }
+
+  // Assign element offsets using a first-fit-decreasing heuristic.
+  //
+  // Allocations are already sorted descending by size. Each "outer" allocation
+  // reserves a region of scratch memory. Smaller allocations whose live ranges
+  // do not overlap with the outer allocation are packed inside its footprint,
+  // reusing the same memory at different sub-offsets.
+  //
+  // Returns the peak scratch usage (total elements required).
+  int64_t assignOffsets(SmallVectorImpl<ScratchAllocationInfo> &allocations) {
+    int64_t currentOffset = 0;
+    for (size_t i = 0; i < allocations.size(); ++i) {
+      auto &outer = allocations[i];
+      assert(outer.numElements > 0 && "scratch allocation must be non-empty");
+      if (outer.packed) {
+        continue;
+      }
+
+      outer.elementOffset = currentOffset;
+      int64_t innerOffset = currentOffset;
+
+      // Try to pack smaller, non-conflicting allocations inside this one.
+      for (size_t j = i + 1; j < allocations.size(); ++j) {
+        auto &inner = allocations[j];
+        if (inner.packed) {
+          continue;
+        }
+
+        bool fits = (innerOffset + inner.numElements) <=
+                    (currentOffset + outer.numElements);
+        if (!livesOverlap(outer, inner) && fits) {
+          inner.packed = true;
+          inner.elementOffset = innerOffset;
+          innerOffset += inner.numElements;
+        }
+      }
+
+      currentOffset += outer.numElements;
+    }
+    return currentOffset;
   }
 
   /// Replace a scratch_allocate with a rank-reducing subview of the scratch

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -10,9 +10,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/PatternMatch.h"
-
-#define DEBUG_TYPE "d2m-lower-scratch-allocate"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERSCRATCHALLOCATE
@@ -106,11 +103,14 @@ private:
     // Sort descending by size so larger allocations are placed first, giving
     // the best chance for smaller ones to be packed inside them.
     llvm::sort(allocations, [](const auto &a, const auto &b) {
-      return a.numElements > b.numElements;
+      if (a.numElements != b.numElements) {
+        return a.numElements > b.numElements;
+      }
+      return a.slotId < b.slotId;
     });
 
     Block &block = region.front();
-    computeLiveness(allocations, block, region);
+    computeLiveness(allocations, block);
     int64_t peakUsage = assignOffsets(allocations);
 
     // Verify allocations fit in the scratch buffer.
@@ -121,7 +121,7 @@ private:
         ttmlir::utils::volume<int64_t>(scratchMemRefType.getShape());
     if (peakUsage > scratchCapacity) {
       return genericOp.emitOpError()
-             << "total scratch allocations (" << peakUsage
+             << "peak scratch usage (" << peakUsage
              << " elements) exceed scratch buffer capacity (" << scratchCapacity
              << " elements)";
     }
@@ -141,7 +141,7 @@ private:
   //
   // Each allocation's live range spans from its definition to its last use.
   void computeLiveness(SmallVectorImpl<ScratchAllocationInfo> &allocations,
-                       Block &block, Region &region) {
+                       Block &block) {
     // Assign sequential position indices to top-level operations in the block.
     DenseMap<Operation *, int64_t> opPositions;
     int64_t pos = 0;
@@ -149,22 +149,21 @@ private:
       opPositions[&op] = pos++;
     }
 
-    // Helper: walk up to find the enclosing operation that lives directly in
-    // the region's entry block.
     auto getTopLevelOp = [&](Operation *op) -> Operation * {
-      while (op->getParentRegion() != &region) {
-        op = op->getParentOp();
-      }
-      return op;
+      return block.findAncestorOpInBlock(*op);
     };
 
     for (auto &info : allocations) {
       Operation *topLevelDef = getTopLevelOp(info.op.getOperation());
+      assert(opPositions.contains(topLevelDef) &&
+             "scratch allocation must have a top-level position");
       info.startPosition = opPositions[topLevelDef];
       info.endPosition = info.startPosition;
 
       for (OpOperand &use : info.op.getResult().getUses()) {
         Operation *topLevelUser = getTopLevelOp(use.getOwner());
+        assert(opPositions.contains(topLevelUser) &&
+               "scratch allocation user must have a top-level position");
         int64_t userPos = opPositions[topLevelUser];
         info.endPosition = std::max(info.endPosition, userPos);
       }

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
@@ -48,32 +48,32 @@ func.func @single_scratch_store_load() {
 // CHECK-LABEL: func.func @two_scratch_conflicting
 func.func @two_scratch_conflicting() {
   %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
-  %scratch_buf = memref.alloc() : memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>
   %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
   d2m.generic {
     block_factors = [1, 1], grid = #ttcore.grid<1x1>,
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>],
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
     iterator_types = [#parallel, #parallel],
-    scratch_inputs = array<i64: 1>,
     threads = [#d2m.thread<unified>]
   }
-  ins(%in, %scratch_buf : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>)
+  ins(%in : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
   outs(%out : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
   ^bb0():
     %alloc_cb3 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
-    %alloc_cb4 = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
-    %alloc_cb5 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb4 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK-NOT: d2m.scratch_init
+    %scratch = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
-    // CHECK: d2m.get_cb(1)
-    // CHECK: %[[SCRATCH:.*]] = d2m.get_scratch_from_cb %{{.*}}
 
-    // Slot 0 (1 tile): lives [1, 4]. Conflicts with slot 1 [2, 5].
-    // Sorted by size: slot 1 gets offset 0, slot 0 gets offset 2.
+    // Slot 0 (1 tile) is defined first and last-used before slot 1's last use,
+    // but their live ranges overlap so they cannot share storage.
+    // Sorted by size descending: slot 1 (2 tiles) gets offset 0,
+    // slot 0 (1 tile) cannot pack inside it and gets offset 2.
     // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 2] [1, 1] [1, 1]
     // CHECK-SAME: to memref<1x!ttcore.tile<32x32, f32>
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<1x!ttcore.tile<32x32, f32>, #l1>
 
-    // Slot 1 (2 tiles): lives [2, 5]. Conflicts with slot 0 [1, 4].
     // CHECK: %[[SV1:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 2] [1, 1]
     // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
@@ -95,24 +95,23 @@ func.func @two_scratch_conflicting() {
 // CHECK-LABEL: func.func @packing_non_conflicting
 func.func @packing_non_conflicting() {
   %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
-  %scratch_buf = memref.alloc() : memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>
   %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
   d2m.generic {
     block_factors = [1, 1], grid = #ttcore.grid<1x1>,
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>],
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
     iterator_types = [#parallel, #parallel],
-    scratch_inputs = array<i64: 1>,
     threads = [#d2m.thread<unified>]
   }
-  ins(%in, %scratch_buf : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>)
+  ins(%in : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
   outs(%out : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
   ^bb0():
     %alloc_cb11 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
-    %alloc_cb12 = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
-    %alloc_cb13 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb12 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK-NOT: d2m.scratch_init
+    %scratch = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
-    // CHECK: d2m.get_cb(1)
-    // CHECK: %[[SCRATCH:.*]] = d2m.get_scratch_from_cb %{{.*}}
 
     // Slot 2 (5 tiles): defined and last-used here. Dies before slots 0/1.
     // CHECK: %[[SV2:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 5] [1, 1]
@@ -138,7 +137,7 @@ func.func @packing_non_conflicting() {
   return
 }
 
-// --- Test 4: Generic without scratch_inputs is unchanged ---
+// --- Test 4: Generic without scratch_init is unchanged ---
 
 // CHECK-LABEL: func.func @no_scratch_noop
 func.func @no_scratch_noop() {

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
@@ -137,7 +137,57 @@ func.func @packing_non_conflicting() {
   return
 }
 
-// --- Test 4: Generic without scratch_init is unchanged ---
+// --- Test 4: Allocation between in-place read and write ---
+// Slot 0 is read, then slot 1 is allocated before slot 0 is written in place.
+// The two equal-sized slots cannot share storage because slot 0 remains live
+// across slot 1's allocation.
+// Tie-breaking by slot id makes slot 0 offset 0 and slot 1 offset 2.
+
+// CHECK-LABEL: func.func @allocation_between_in_place_read_write
+func.func @allocation_between_in_place_read_write() {
+  %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+  %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+  d2m.generic {
+    block_factors = [1, 1], grid = #ttcore.grid<1x1>,
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = [#parallel, #parallel],
+    threads = [#d2m.thread<unified>]
+  }
+  ins(%in : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+  outs(%out : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+  ^bb0():
+    %alloc_cb13 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x4x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK-NOT: d2m.scratch_init
+    %scratch = memref.alloc() : memref<1x4x!ttcore.tile<32x32, f32>, #l1>
+    d2m.scratch_init %scratch : memref<1x4x!ttcore.tile<32x32, f32>, #l1>
+    %c0 = arith.constant 0 : index
+
+    // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 2] [1, 1]
+    // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
+    %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
+
+    %producer_value = memref.load %alloc_cb13[%c0, %c0] : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: memref.store %{{.*}}, %[[SV0]][%{{.*}}]
+    memref.store %producer_value, %s0[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+
+    // CHECK: %[[TILE:.*]] = memref.load %[[SV0]][%{{.*}}]
+    %tile = memref.load %s0[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+
+    // CHECK: %[[SV1:.*]] = memref.subview %[[SCRATCH]][0, 2] [1, 2] [1, 1]
+    // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
+    %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
+
+    // CHECK: memref.store %[[TILE]], %[[SV0]][%{{.*}}]
+    // CHECK: memref.store %[[TILE]], %[[SV1]][%{{.*}}]
+    memref.store %tile, %s0[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %tile, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+  }
+  // CHECK-NOT: d2m.scratch_allocate
+  return
+}
+
+// --- Test 5: Generic without scratch_init is unchanged ---
 
 // CHECK-LABEL: func.func @no_scratch_noop
 func.func @no_scratch_noop() {
@@ -160,7 +210,7 @@ func.func @no_scratch_noop() {
   return
 }
 
-// --- Test 5: Scratch with bf16 tiles ---
+// --- Test 6: Scratch with bf16 tiles ---
 
 // CHECK-LABEL: func.func @scratch_bf16
 func.func @scratch_bf16() {

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
@@ -111,7 +111,8 @@ func.func @packing_non_conflicting() {
     %alloc_cb12 = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     %alloc_cb13 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
-    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>,
+    // CHECK: d2m.get_cb(1)
+    // CHECK: %[[SCRATCH:.*]] = d2m.get_scratch_from_cb %{{.*}}
 
     // Slot 2 (5 tiles): defined and last-used here. Dies before slots 0/1.
     // CHECK: %[[SV2:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 5] [1, 1]

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate.mlir
@@ -40,42 +40,44 @@ func.func @single_scratch_store_load() {
   return
 }
 
-// --- Test 2: Two scratch_allocates with sequential offsets ---
-// slot 0 requests 1 tile  -> subview at offset 0
-// slot 1 requests 2 tiles -> subview at offset 1
+// --- Test 2: Two conflicting scratch_allocates ---
+// Both slots are alive at the same time, so they cannot be packed together.
+// Sorted by size descending: slot 1 (2 tiles) then slot 0 (1 tile).
+// slot 1 -> offset 0, slot 0 -> offset 2.
 
-// CHECK-LABEL: func.func @two_scratch_allocates
-func.func @two_scratch_allocates() {
+// CHECK-LABEL: func.func @two_scratch_conflicting
+func.func @two_scratch_conflicting() {
   %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+  %scratch_buf = memref.alloc() : memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>
   %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
   d2m.generic {
     block_factors = [1, 1], grid = #ttcore.grid<1x1>,
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>],
     iterator_types = [#parallel, #parallel],
+    scratch_inputs = array<i64: 1>,
     threads = [#d2m.thread<unified>]
   }
-  ins(%in : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
+  ins(%in, %scratch_buf : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>)
   outs(%out : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
   ^bb0():
     %alloc_cb3 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
-    %alloc_cb4 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
-    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
-    // CHECK-NOT: d2m.scratch_init
-    %scratch = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
-    d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb4 = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb5 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
     %c0 = arith.constant 0 : index
+    // CHECK: d2m.get_cb(1)
+    // CHECK: %[[SCRATCH:.*]] = d2m.get_scratch_from_cb %{{.*}}
 
-    // Slot 0: 1 tile at offset 0.
-    // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 1] [1, 1]
+    // Slot 0 (1 tile): lives [1, 4]. Conflicts with slot 1 [2, 5].
+    // Sorted by size: slot 1 gets offset 0, slot 0 gets offset 2.
+    // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 2] [1, 1] [1, 1]
     // CHECK-SAME: to memref<1x!ttcore.tile<32x32, f32>
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<1x!ttcore.tile<32x32, f32>, #l1>
 
-    // Slot 1: 2 tiles at offset 1 (after slot 0's 1 tile).
-    // CHECK: %[[SV1:.*]] = memref.subview %[[SCRATCH]][0, 1] [1, 2] [1, 1]
+    // Slot 1 (2 tiles): lives [2, 5]. Conflicts with slot 0 [1, 4].
+    // CHECK: %[[SV1:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 2] [1, 1]
     // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
 
-    // Verify stores go to the correct subviews.
     %tile = memref.load %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
     memref.store %tile, %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
     memref.store %tile, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
@@ -84,7 +86,58 @@ func.func @two_scratch_allocates() {
   return
 }
 
-// --- Test 3: Generic without scratch_init is unchanged ---
+// --- Test 3: Packing non-conflicting allocations ---
+// slot 2 (5 tiles) is defined and last-used early, then goes dead.
+// slots 0 and 1 are alive later. They are packed inside slot 2's footprint,
+// reducing peak usage from 8 to 5.
+// slot 2 -> offset 0 (outer), slot 1 -> offset 0 (packed), slot 0 -> offset 2 (packed)
+
+// CHECK-LABEL: func.func @packing_non_conflicting
+func.func @packing_non_conflicting() {
+  %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+  %scratch_buf = memref.alloc() : memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>
+  %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+  d2m.generic {
+    block_factors = [1, 1], grid = #ttcore.grid<1x1>,
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (0, 0)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = [#parallel, #parallel],
+    scratch_inputs = array<i64: 1>,
+    threads = [#d2m.thread<unified>]
+  }
+  ins(%in, %scratch_buf : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<1x1x1x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #l1>)
+  outs(%out : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+  ^bb0():
+    %alloc_cb11 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb12 = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    %alloc_cb13 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
+    %c0 = arith.constant 0 : index
+    // CHECK: %[[SCRATCH:.*]] = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>,
+
+    // Slot 2 (5 tiles): defined and last-used here. Dies before slots 0/1.
+    // CHECK: %[[SV2:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 5] [1, 1]
+    // CHECK-SAME: to memref<5x!ttcore.tile<32x32, f32>
+    %s2 = d2m.scratch_allocate {slot = 2 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
+    %tile_early = memref.load %s2[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
+
+    // Slot 0 (1 tile): packed inside slot 2 at offset 2.
+    // CHECK: %[[SV0:.*]] = memref.subview %[[SCRATCH]][0, 2] [1, 1] [1, 1]
+    // CHECK-SAME: to memref<1x!ttcore.tile<32x32, f32>
+    %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<1x!ttcore.tile<32x32, f32>, #l1>
+
+    // Slot 1 (2 tiles): packed inside slot 2 at offset 0.
+    // CHECK: %[[SV1:.*]] = memref.subview %[[SCRATCH]][0, 0] [1, 2] [1, 1]
+    // CHECK-SAME: to memref<2x!ttcore.tile<32x32, f32>
+    %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<2x!ttcore.tile<32x32, f32>, #l1>
+
+    %tile = memref.load %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %tile, %s0[%c0] : memref<1x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %tile, %s1[%c0] : memref<2x!ttcore.tile<32x32, f32>, #l1>
+  }
+  // CHECK-NOT: d2m.scratch_allocate
+  return
+}
+
+// --- Test 4: Generic without scratch_inputs is unchanged ---
 
 // CHECK-LABEL: func.func @no_scratch_noop
 func.func @no_scratch_noop() {
@@ -107,7 +160,7 @@ func.func @no_scratch_noop() {
   return
 }
 
-// --- Test 4: Scratch with bf16 tiles ---
+// --- Test 5: Scratch with bf16 tiles ---
 
 // CHECK-LABEL: func.func @scratch_bf16
 func.func @scratch_bf16() {

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
@@ -11,7 +11,7 @@ module {
 func.func @scratch_overflow() {
   %in = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
   %out = memref.alloc() : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
-  // CHECK: error: 'd2m.generic' op total scratch allocations (10 elements) exceed scratch buffer capacity (8 elements)
+  // CHECK: error: 'd2m.generic' op peak scratch usage (10 elements) exceed scratch buffer capacity (8 elements)
   d2m.generic {
     block_factors = [1, 1], grid = #ttcore.grid<1x1>,
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
@@ -27,6 +27,10 @@ func.func @scratch_overflow() {
     d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
+    // Both slots are used after both are defined, so their live ranges overlap
+    // and they cannot be packed together. Total = 10 > capacity 8.
+    %t0 = memref.load %s0[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
+    memref.store %t0, %s1[%c0] : memref<5x!ttcore.tile<32x32, f32>, #l1>
   }
   return
 }

--- a/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/lower_scratch_allocate_oom.mlir
@@ -25,6 +25,7 @@ func.func @scratch_overflow() {
     %alloc_cb1 = memref.alloc() : memref<4x4x!ttcore.tile<32x32, f32>, #l1>
     %scratch = memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
     d2m.scratch_init %scratch : memref<1x8x!ttcore.tile<32x32, f32>, #l1>
+    %c0 = arith.constant 0 : index
     %s0 = d2m.scratch_allocate {slot = 0 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
     %s1 = d2m.scratch_allocate {slot = 1 : i64} : memref<5x!ttcore.tile<32x32, f32>, #l1>
     // Both slots are used after both are defined, so their live ranges overlap


### PR DESCRIPTION
### Problem description
`scratch_allocate` buffers are being assigned sequential positions within the scratch buffer. This can be wasteful and cause the pipeline to fail if not enough scratch is available.

### What's changed
Implemented a liveness analysis of `scratch_allocate` buffers and a simple heuristic allocation (first-fit-decreasing) within the available scratch. Buffers whose live ranges don't overlap can now be assigned the same offset within the scratch.