### PR TITLE
Fix shard status for compiler frontend

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
@@ -180,6 +180,9 @@ public:
     llvm::SmallVector<int64_t> resultPreshardedRef = llvm::to_vector(
         llvm::map_range(resultPresharded, [](int64_t val) { return val; }));
     rootModule.walk([&](func::FuncOp funcOp) {
+      if (!funcOp.isPublic()) {
+        return;
+      }
       if (failed(mlir::tt::stablehlo::updateResultShardStatus(
               context, rootModule, builder, funcOp, resultPreshardedRef))) {
         rootModule.emitError("Failed to update shard status");


### PR DESCRIPTION
### Problem description
Two issues are encountered when integrating shard status into tt-xla (https://github.com/tenstorrent/tt-xla/pull/3459):
1. `resultPresharded` has a shape mismatch
2. GSPMD-annotated graphs have missing shard status on result sharding ops

This is also blocking tt-mlir uplift in tt-xla (https://github.com/tenstorrent/tt-xla/pull/3562).

### What's changed
Corresponding fixes are added:
1. Only apply result shard status to public functions.
2. Add back the function call `updateShardStatusForResult` if it is a GSPMD graph
