### PR TITLE
[Builder] Add tag, parse, and split support for ttir.gelu

### DIFF
--- a/test/python/golden/mlir_snippets/ttir/ttir_gelu.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_gelu.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @gelu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %1 = "ttir.gelu"(%arg0) : (tensor<128x128xf32>) -> tensor<128x128xf32>
+    return %1 : tensor<128x128xf32>
+  }
+}

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -7760,6 +7760,118 @@ class TTIRBuilder(Builder):
 
         return sigmoid_module, sigmoid_builder
 
+    ############### ttir.GeluOp ###############
+
+    @tag(ttir.GeluOp)
+    def gelu(
+        self,
+        in0: Operand,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttir_op = self.get_opview_from_method(TTIRBuilder.gelu)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, mlir_output_type)
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttir_op(
+            result,
+            in0,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttir.GeluOp)
+    def gelu_parser(
+        self,
+        old_op: ttir.GeluOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.gelu_parser)
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
+
+        new_op = ttir_op(
+            result,
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, result.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.GeluOp)
+    def gelu_split(
+        self,
+        old_op: ttir.GeluOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(TTIRBuilder.gelu_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            gelu_module = Module.create()
+            gelu_builder = TTIRBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(gelu_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="gelu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttir_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    gelu_builder._set_golden_tensor(new_op_result, old_op_result)
+                    gelu_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                gelu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return gelu_module, gelu_builder
+
     ################ ttir.HardsigmoidOp ###############
 
     @tag(ttir.HardsigmoidOp)
@@ -9821,41 +9933,6 @@ class TTIRBuilder(Builder):
             // [1.0, 0.4795, 0.1573, 1.8427]
         """
         return self._op_proxy(ttir.ErfcOp, [in0], unit_attrs)
-
-    def gelu(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
-        """
-        Creates ``ttir.gelu``.
-
-        *Elementwise GELU operation.*
-
-        Computes the GELU (Gaussian Error Linear Unit) of each element in the input tensor.
-        GELU is a smooth, non-monotonic activation function that approximates the cumulative
-        distribution function of a standard normal distribution.
-
-        Mathematical definition: gelu(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
-
-        .. code-block:: mlir
-
-            // Compute GELU of all elements
-            %result = ttir.gelu(%input, %output) : tensor<4xf32>, tensor<4xf32> -> tensor<4xf32>
-            // Input tensor:
-            // [1.0, -0.5, 2.0, -2.0]
-            // Output tensor:
-            // [0.841, -0.154, 1.954, -0.046]
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor
-        unit_attrs : *Optional[List[str]]*, optional
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor containing the GELU values of each element in the input tensor
-        """
-        return self._op_proxy(ttir.GeluOp, [in0], unit_attrs)
 
     def gelu_backward(
         self,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3740,6 +3740,13 @@ def ttir_floor_golden(
     return torch.floor(input_tensor).to(output_dtype)
 
 
+def ttir_gelu_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return torch.nn.functional.gelu(input_tensor).to(output_dtype)
+
+
 def ttir_exp_golden(
     input_tensor: GoldenMapTensor, output_type_mlir: Type
 ) -> GoldenMapTensor:
@@ -5174,7 +5181,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.ErfOp: ttir_erf_golden,
     ttir.ErfcOp: torch.erfc,
     ttir.FloorOp: ttir_floor_golden,
-    ttir.GeluOp: torch.nn.functional.gelu,
+    ttir.GeluOp: ttir_gelu_golden,
     ttir.GeluBackwardOp: torch.ops.aten.gelu_backward,
     ttir.IsFiniteOp: ttir_isfinite_golden,
     ttir.MishOp: torch.nn.functional.mish,


### PR DESCRIPTION
### Ticket
Fixes #7258 
Part of #7242 

### Problem description
The ttir.gelu operation was previously implemented using a basic _op_proxy wrapper. This approach lacked the necessary infrastructure for advanced compiler stages required by XLA models. Specifically, it was missing the tagging, parsing and splitting stage.

### What's changed
Replaced the legacy _op_proxy call for gelu with explicit methods decorated with @tag, @parse, and @split
Implementation Details:
- @tag: Ensures GeluOp correctly attaches location data and handles target output types.
- @parse: Implements the reconstruction logic to map IR back to the Python builder state.
- @split: Provides the infrastructure to encapsulate gelu within a dedicated func.func for partitioning.

Added Golden Test Snippet: Created test/python/golden/mlir_snippets/ttir/ttir_gelu.mlir to provide automated coverage for the new Parse and Split functionality.

### Checklist
- [x] New/Existing tests provide coverage for changes
