### PR TITLE
Miscellaneous builder tests fixes and improvements

### DIFF
--- a/.github/workflows/call-test-ttsim.yml
+++ b/.github/workflows/call-test-ttsim.yml
@@ -147,6 +147,8 @@ jobs:
           export TT_METAL_HOME="$WORK_DIR/third_party/tt-metal/src/tt-metal"
           export LD_LIBRARY_PATH="$INSTALL_DIR/lib:${TTMLIR_TOOLCHAIN_DIR}/lib:${LD_LIBRARY_PATH}"
           export SYSTEM_DESC_PATH="${GITHUB_WORKSPACE}/ttrt-artifacts/system_desc.ttsys"
+          export TT_METAL_INSPECTOR="0"
+          export TT_METAL_INSPECTOR_RPC="0"
           mkdir -p test_reports
 
           run_sim_test() {

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -157,6 +157,8 @@ jobs:
         TTRT_LOGGER_LEVEL: "WARNING"
         LOGURU_LEVEL: "ERROR"
         TT_METAL_LOGGER_LEVEL: "FATAL"
+        TT_METAL_INSPECTOR: "0"
+        TT_METAL_INSPECTOR_RPC: "0"
       run: |
         # Run Tests
         source env/activate

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -586,7 +586,7 @@ def _extract_frontend(item: pytest.Item) -> None:
     raise KeyError("No frontend marker found!")
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_setup(item: pytest.Item):
     """
     Extract test metadata during setup phase for XML reporting.
@@ -630,7 +630,7 @@ def pytest_runtest_setup(item: pytest.Item):
     </properties>
 
     Note that the above example excludes the "failure_stage" entry. This is
-    handled by the hookwrapper for `pytest_runtest_makereport` below
+    handled by the wrapper for `pytest_runtest_call` below
     """
     yield
 
@@ -642,7 +642,7 @@ def pytest_runtest_setup(item: pytest.Item):
         _extract_frontend(item)
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item: pytest.Item):
     """
     Extract runtime information from tests that actually execute.
@@ -668,9 +668,8 @@ def pytest_runtest_call(item: pytest.Item):
 
     failure_stage = "success"  # Default to success.
 
-    outcome = yield
     try:
-        outcome.get_result()
+        yield
     except Exception as exc:
         exc_type = type(exc)
         exc_name = exc_type.__name__

--- a/test/python/golden/test_composite_functions.py
+++ b/test/python/golden/test_composite_functions.py
@@ -408,11 +408,6 @@ def test_polygamma(
     request,
     device,
 ):
-    if k == 1:
-        pytest.skip(
-            "Failing PCC. Issue: https://github.com/tenstorrent/tt-mlir/issues/7089"
-        )
-
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         # choose

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -244,7 +244,6 @@ def test_matmul_ttnn_shapes_double_buffered(
     )
 
 
-@pytest.mark.skip_config(["ttmetal", "p150"], reason="See issue #5341")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/test/python/golden/test_metal_tensor_collapsing.py
+++ b/test/python/golden/test_metal_tensor_collapsing.py
@@ -86,11 +86,7 @@ def module_transpose_inner_dims(builder: TTIRBuilder):
         (module_elementwise_multiply_3d_multiply, "3d_multiply"),
         (module_unary_exp_2d_exp, "3d_exp"),
         # 4D element-wise operations (working with non-collapsed tensors)
-        pytest.param(
-            module_elementwise_add_4d_add,
-            "4d_add",
-            marks=pytest.mark.xfail(reason="Golden failure"),
-        ),
+        pytest.param(module_elementwise_add_4d_add, "4d_add"),
         (module_unary_exp_4d_exp, "4d_exp"),
         # Batched matmul (fixed in #6648)
         (module_batch_matmul, "matmul"),

--- a/test/python/golden/test_metal_virtual_grids.py
+++ b/test/python/golden/test_metal_virtual_grids.py
@@ -72,7 +72,6 @@ def create_tileid_debug_tensor(shape: Shape, dtype: torch.dtype):
     return tile_id.to(dtype)
 
 
-@pytest.mark.skip_config(["p150"], ["p300"], reason="See issue #6248")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -480,20 +480,10 @@ def module_broadcast_in_dim(builder: StableHLOBuilder):
     "test_fn",
     [
         module_add,
-        module_max
-        | Marks(
-            pytest.mark.skip_config(
-                ["ttmetal"], reason="https://github.com/tenstorrent/tt-mlir/issues/5016"
-            )
-        ),
-        module_min | Marks(pytest.mark.skip_config(["ttmetal"])),
+        module_max,
+        module_min,
         module_mul,
-        module_pow
-        | Marks(
-            pytest.mark.skip_config(
-                ["ttnn"], reason="https://github.com/tenstorrent/tt-metal/pull/33904"
-            )
-        ),
+        module_pow,
         module_subtract,
     ],
 )

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1547,7 +1547,6 @@ def test_topk(
         pytest.param(
             [(33, 32), (512, 128)],
             [torch.float32] * 2,
-            marks=[pytest.mark.skip_config(["ttmetal"])],
         ),
     ],
 )
@@ -1806,7 +1805,7 @@ def test_gather(
 )
 @pytest.mark.parametrize(
     "target",
-    ["ttnn", "ttmetal" | Marks(pytest.mark.xfail(reason="Unhoisted ttir.zeros"))],
+    ["ttnn", "ttmetal"],
 )
 def test_hoisted_gather(
     input_shape: Shape,

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -63,7 +63,6 @@ def test_concat(shapes: List[Shape], dim: int, target: str, request, device):
 )
 @pytest.mark.parametrize("dim", [0])
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
-@pytest.mark.xfail(reason="Compile failure on CPU target")
 def test_cpu_hoistable_concat_op(
     shapes: List[Shape],
     dim: int,
@@ -385,6 +384,8 @@ def test_cpu_hoistable_reshape_op(
         ((1024, 1024), [3, 2], [64 * 11, 64 * 13], [11, 13]),
         # Simple 3D
         ((2, 64, 32), [0, 0, 0], [1, 64, 32], None),
+        # Crop 3D
+        ((19, 160, 64), [0, 0, 0], [19, 96, 32], None),
         # Interleaved 3D
         ((2, 64, 32), [0, 1, 0], [1, 64, 32], [1, 2, 1]),
         ((2, 64, 32), [0, 1, 0], [1, 64, 32], [1, 2, 2]),

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
@@ -394,12 +394,7 @@ scalar_binary_ops = [
     (add_scalar, 2.5),
     (multiply_scalar, 3.0),
     (subtract_scalar, 1.5),
-    (div_scalar, 3.0)
-    | Marks(
-        pytest.mark.xfail(
-            reason="Fails atol and rtol, issue here: https://github.com/tenstorrent/tt-mlir/issues/5924"
-        )
-    ),
+    (div_scalar, 3.0),
     (pow_scalar, 2.0),
 ]
 
@@ -840,7 +835,6 @@ implicit_bcast_inner_2D_shapes = [
 ]
 
 
-@pytest.mark.skip_config(["p150"], ["p300"], reason="See issue #6565")
 @pytest.mark.parametrize("shape", implicit_bcast_inner_2D_shapes, ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 @pytest.mark.parametrize("target", ["ttmetal"])

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
@@ -219,7 +219,7 @@ unary_ops = [
     abs,
     atan | Marks(pytest.mark.skip_config(["ttmetal"])),
     cbrt | Marks(pytest.mark.skip_config(["ttmetal"])),
-    ceil | Marks(pytest.mark.skip_config(["ttmetal"])),
+    ceil,
     cos,
     erf,
     erfc,
@@ -341,7 +341,7 @@ def leaky_relu(
     return builder.leaky_relu(in0, parameter, unit_attrs=unit_attrs)
 
 
-unary_ops_with_float_param = [leaky_relu | SkipIf("ttmetal")]
+unary_ops_with_float_param = [leaky_relu]
 
 
 @pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -198,10 +198,6 @@ def test_hoisted_softmax(
     device,
     dtype: torch.dtype = torch.float32,
 ):
-    pytest.skip(
-        reason="Softmax does not lower to loops properly https://github.com/tenstorrent/tt-mlir/issues/3232"
-    )
-
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def softmax(

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -5,6 +5,6 @@ pytest-json-report
 pytest-forked
 setuptools
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu; sys_platform == "linux"
+torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl; sys_platform == "linux"
 torch==2.9.1; sys_platform == "darwin"
 einops

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3493,7 +3493,7 @@ def ttir_slice_golden(
 
     shard_map = {}
     for device_id, shard in input_tensor.shard_map.items():
-        shard_map[device_id] = shard[slices]
+        shard_map[device_id] = shard[tuple(slices)]
 
     return GoldenMapTensor(shard_map, input_tensor.mesh_shape).to(output_dtype)
 

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu; sys_platform == "linux"
+torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl; sys_platform == "linux"
 torch==2.9.1; sys_platform == "darwin"
 nanobind==2.10.2

--- a/tools/ttrt/setup.py
+++ b/tools/ttrt/setup.py
@@ -27,6 +27,11 @@ def load_requirements(filename):
                 or requirement.startswith("--")
             ):
                 continue
+
+            # Skip torch requirements - we'll handle them separately based on platform
+            if requirement.startswith("torch"):
+                continue
+
             requirements.append(requirement)
 
     return requirements
@@ -61,6 +66,14 @@ runlibs = []
 perflibs = []
 metallibs = []
 install_requires = load_requirements("requirements.txt")
+
+# Add platform-specific torch requirement
+if platform.system() == "Linux":
+    install_requires.append(
+        "torch @ https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl"
+    )
+elif platform.system() == "Darwin":
+    install_requires.append("torch==2.9.1")
 
 if enable_ttnn:
     runlibs += ["_ttnncpp.so"]


### PR DESCRIPTION
### What's changed
- Disable Metal inspector in CI builder tests
  - Inspector adds `-g` to the SFPI compilation args, lead to 4x kernel size increase and I/O stress in the CI
- Install CPU torch on Linux using explicit URLs
  - Closes: #7291
- Enable builder tests that are actually passing
  - Closes: #5924
  - Closes: #6565
  - Closes: #7084
- Fix builder end-of-test warnings about deprecated `hookwrapper` usage