### PR TITLE
[EIO] Change test path in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -112,7 +112,7 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 # TTIR Erase Inverse Ops Optimization Pass
 /include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT @mvasiljevicTT
 /lib/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT @mvasiljevicTT
-/test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @azecevicTT @odjuricicTT @mvasiljevicTT
+/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @azecevicTT @odjuricicTT @mvasiljevicTT
 
 # TTIR Fusing Passes
 /lib/Dialect/TTIR/Transforms/TTIRFusing.cpp @tenstorrent/forge-developers-mlir-core @odjuricicTT @mvasiljevicTT


### PR DESCRIPTION
### Problem description
EIO codeowners are listed for `/test/ttmlir/Dialect/TTIR/erase_inverse_ops/`, and tests are at `/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/`.

### What's changed
Changed the path for EIO tests in the CODEOWNERS file. 

