### PR TITLE
Modify TTIIR ClampScalarOp Verifier to Only Check Shape Equality

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -380,7 +380,7 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
   const RankedTensorType outputTensorType =
       mlir::cast<RankedTensorType>(getResult().getType());
 
-  if (inputTensorType != outputTensorType) {
+  if (inputTensorType.getShape() != outputTensorType.getShape()) {
     return emitOpError("input and output must have same shape.");
   }
 

--- a/test/ttnn-jit/lit/test_tracing_ir.py
+++ b/test/ttnn-jit/lit/test_tracing_ir.py
@@ -310,11 +310,32 @@ if __name__ == "__main__":
     # CHECK: return %[[CONVERTED]] : [[OUT_TYPE]]
     test_ir_generation(sqrt_func, input_a)
 
-    # Skipped. Issue #7319: ttir.clamp_scalar verifier rejects valid IR when input has
-    # encoding but output does not (compares full type instead of shape).
-    # test_ir_generation(clamp_min_max_func, input_a)
-    # test_ir_generation(clamp_min_only_func, input_a)
-    # test_ir_generation(clamp_max_only_func, input_a)
+    # CHECK: ---- IR Dump after TracingCompiler (Tracing-based) ----
+    # CHECK: func.func @clamp_min_max_func
+    # CHECK-SAME: (%arg0: [[IN_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout>]])
+    # CHECK-SAME: -> [[OUT_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout[0-9]*>]]
+    # CHECK: %[[VAL:[0-9]+]] = "ttir.clamp_scalar"(%arg0) <{{.*max = 1.000000e-03 : f32, min = -1.000000e-03 : f32.*}}> : ([[IN_TYPE]]) -> tensor<{{.*}}>
+    # CHECK: %[[CONVERTED:[0-9]+]] = ttir.to_layout %[[VAL]]{{.*}} -> [[OUT_TYPE]]
+    # CHECK: return %[[CONVERTED]] : [[OUT_TYPE]]
+    test_ir_generation(clamp_min_max_func, input_a)
+
+    # CHECK: ---- IR Dump after TracingCompiler (Tracing-based) ----
+    # CHECK: func.func @clamp_min_only_func
+    # CHECK-SAME: (%arg0: [[IN_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout>]])
+    # CHECK-SAME: -> [[OUT_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout[0-9]*>]]
+    # CHECK: %[[VAL:[0-9]+]] = "ttir.clamp_scalar"(%arg0) <{{.*min = -1.000000e-03 : f32.*}}> : ([[IN_TYPE]]) -> tensor<{{.*}}>
+    # CHECK: %[[CONVERTED:[0-9]+]] = ttir.to_layout %[[VAL]]{{.*}} -> [[OUT_TYPE]]
+    # CHECK: return %[[CONVERTED]] : [[OUT_TYPE]]
+    test_ir_generation(clamp_min_only_func, input_a)
+
+    # CHECK: ---- IR Dump after TracingCompiler (Tracing-based) ----
+    # CHECK: func.func @clamp_max_only_func
+    # CHECK-SAME: (%arg0: [[IN_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout>]])
+    # CHECK-SAME: -> [[OUT_TYPE:tensor<[0-9]+x[0-9]+xbf16, #ttnn_layout[0-9]*>]]
+    # CHECK: %[[VAL:[0-9]+]] = "ttir.clamp_scalar"(%arg0) <{{.*max = 1.000000e-03 : f32.*}}> : ([[IN_TYPE]]) -> tensor<{{.*}}>
+    # CHECK: %[[CONVERTED:[0-9]+]] = ttir.to_layout %[[VAL]]{{.*}} -> [[OUT_TYPE]]
+    # CHECK: return %[[CONVERTED]] : [[OUT_TYPE]]
+    test_ir_generation(clamp_max_only_func, input_a)
 
     # CHECK: ---- IR Dump after TracingCompiler (Tracing-based) ----
     # CHECK: func.func @clamp_tensor_bounds_func

--- a/test/ttnn-jit/test_eltwise_smoketest.py
+++ b/test/ttnn-jit/test_eltwise_smoketest.py
@@ -376,7 +376,6 @@ def _clamp_tensor_bounds(input_tensor, min_tensor, max_tensor):
     return ttnn.clamp(input_tensor, min=min_tensor, max=max_tensor)
 
 
-@pytest.mark.skip(reason="Skipping clamp test due to verifier failure. Issue #7319")
 @pytest.mark.parametrize(
     "buffer_type, use_tensor_bounds",
     [


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7319

### Problem description
The TTIR ClampScalarOp fails verification with error message "input and output must have same shape." when input and output tensors have the same shape but different layouts/encodings. i.e. the following is considered illegal:
```
#ttnn_layout =  #ttnn.ttnn_layout<...>
%arg0: tensor<32x32xbf16, #ttnn_layout>
%1 = ttir.clamp_scalar(%arg0) {...} : tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16>
```

This is a problem for TTNN JIT/TTNN-D2M integration as the input can be a `func.func` arg with a layout, while the output can be an intermediate whose layout is determined later by the D2M compiler.

### What's changed
- Modified the TTIR ClampScalarOp verifier to match that of the [TTNN ClampScalarOp
](https://github.com/tenstorrent/tt-mlir/blob/main/lib/Dialect/TTNN/IR/TTNNOps.cpp#L242)  
  - Instead of checking for full equality between input and output tensor types, explicitly check the shapes
  - This matches the intention of the error message and the existing lit test for clamp op verification
- Reenable TTNN JIT tests for the clamp up. These had to be disabled when the JIT frontend stopped setting intermediate layouts 

### Checklist
- [X] New/Existing tests provide coverage for changes
