### PR TITLE
Complex type conversion and stablehlo complex/ real/ imag op support

### DIFF
--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -86,6 +86,7 @@ ExternalProject_Add(stablehlo
    CONFIGURE_COMMAND ""
    BUILD_COMMAND ""
    INSTALL_COMMAND ""
+   PATCH_COMMAND git config user.email "tt-mlir@tenstorrent.com" && git config user.name "tenstorrent" && git apply --index "${CMAKE_CURRENT_LIST_DIR}/patches/stablehlo-complex-mul-expander.patch" && git commit -m "tt-mlir related patch"
 )
 
 ExternalProject_Add(shardy

--- a/env/patches/stablehlo-complex-mul-expander.patch
+++ b/env/patches/stablehlo-complex-mul-expander.patch
@@ -1,0 +1,26 @@
+--- a/stablehlo/transforms/StablehloComplexMathExpanderPatterns.td
++++ b/stablehlo/transforms/StablehloComplexMathExpanderPatterns.td
+@@ -722,3 +722,23 @@
+             (StableHLO_SineOp:$sn $y, ConstDefaultResultAccuracyAttr)),
+           $e2),
+         (StableHLO_MulOp $e, $sn))))>;
++
++// Multiplication on complex inputs:
++//
++//       (a + bi) * (c + di) = (ac - bd) + (bc + ad)i
++//
++//     where a, b are real/imaginary parts of lhs, and c, d are real/imaginary
++//     parts of rhs.
++//
++def MulOp_ComplexElementType_ComplexMathExpander: Pat<(StableHLO_MulOp ComplexElementType:$lhs, ComplexElementType:$rhs),
++  (StableHLO_ComplexOp
++    (StableHLO_SubtractOp
++      (StableHLO_MulOp
++        (StableHLO_RealOp:$a $lhs),
++        (StableHLO_RealOp:$c $rhs)),
++      (StableHLO_MulOp
++        (StableHLO_ImagOp:$b $lhs),
++        (StableHLO_ImagOp:$d $rhs))),
++    (StableHLO_AddOp
++      (StableHLO_MulOp $b, $c),
++      (StableHLO_MulOp $a, $d)))>;

--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -9,6 +9,32 @@ include "mlir/Pass/PassBase.td"
 include "shardy/dialect/sdy/ir/dialect.td"
 include "shardy/dialect/sdy/ir/op_interface.td"
 
+def StableHLOComplexDataTypeConversionPass : Pass<"stablehlo-complex-data-type-conversion", "::mlir::ModuleOp"> {
+  let summary = "Convert complex data types to float pair representations in StableHLO.";
+  let description = [{
+    This pass converts StableHLO operations with complex element types to
+    equivalent operations using float pair representations. Complex tensors of
+    type tensor<...xcomplex<fN>> are converted to tensor<...x2xfN>, where the
+    last dimension stores [real, imag] components.
+
+    Complex specific ops, such as stablehlo.complex, stablehlo.real, and stablehlo.imag transpose
+    the trailing dimension to the front for tilize/ untilize performance.
+
+    Concretely, the pass handles:
+      - stablehlo.complex -> stablehlo.reshape + stablehlo.concatenate + stablehlo.transpose
+      - stablehlo.real / stablehlo.imag -> stablehlo.transpose + stablehlo.slice + stablehlo.reshape
+      - stablehlo.constant with complex element type -> float-pair constant
+      - stablehlo.reshape with complex result type -> float-pair reshape
+      - stablehlo.broadcast_in_dim with complex result type -> float-pair broadcast_in_dim
+      - func signatures and return ops with complex types
+
+    This pass is intended to run after `stablehlo-complex-math-expander` (real-domain elementwise ops).
+    To add support for elementwise ops with complex types, please register them in `stablehlo-complex-math-expander` pass.
+  }];
+  let dependentDialects = ["mlir::func::FuncDialect",
+                           "::mlir::stablehlo::StablehloDialect"];
+}
+
 def RegisterCustomShardingRulePass : Pass<"register-custom-sharding-rule", "::mlir::ModuleOp">
 {
   let summary = "Register custom sharding rules for operations.";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3422,7 +3422,7 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
     let summary = "Scaled dot product attention operation.";
     let description = [{
       Scaled dot product attention.
-      The implementation is FlashAttention-2."
+      The implementation is FlashAttention-2.
 
       Args:
           query (AnyRankedTensor): The query tensor.          [batch x num_heads x query_seq_len x head_size]

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   AnalyzeMesh.cpp
   AnnotateLocalShapes.cpp
   ApplyArgumentShardStatus.cpp
+  ComplexDataTypeConversion.cpp
   ConvertXlaSdyToSdy.cpp
   DecoupleConstFanout.cpp
   FlattenComposite.cpp
@@ -22,6 +23,8 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
 
   LINK_LIBS PUBLIC
   TTMLIRStableHLOUtils
+  MLIRFuncDialect
+  MLIRFuncTransforms
   SdyDialect
   SdyRegister
   SdyTransformsPropagationOpShardingRuleBuilder

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+using namespace mlir;
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_STABLEHLOCOMPLEXDATATYPECONVERSIONPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+//===----------------------------------------------------------------------===//
+// ComplexDataTypeConversion overview
+//===----------------------------------------------------------------------===//
+// Runs after `stablehlo-complex-math-expander` (real-domain elementwise ops).
+//
+//  (1) Unpack complex dtypes — append trailing dim of 2: [re0, im0, re1, ...]
+//        tensor<4xcomplex<f32>>    -->  tensor<4x2xf32>
+//        tensor<3x4xcomplex<f32>>  -->  tensor<3x4x2xf32>
+//      Affected: func args/returns, constants, reshape, broadcast_in_dim.
+//
+//  (2) Decompose complex/real/imag --> slice/concat/reshape.
+//      Trailing dim of 2 is not tile-divisible; decompositions transiently
+//      move it to the leading position before operating on it.
+//
+//===----------------------------------------------------------------------===//
+
+// ---------------------------------------------------------------------------
+// Transpose helpers
+// ---------------------------------------------------------------------------
+
+// Moves the trailing dimension to the front:
+//   tensor<d0 x d1 x ... x dN>  -->  tensor<dN x d0 x d1 x ... x d(N-1)>
+static Value transposeTrailingToLeading(Location loc, Value input,
+                                        OpBuilder &builder) {
+  auto type = mlir::cast<RankedTensorType>(input.getType());
+  int64_t rank = type.getRank();
+
+  SmallVector<int64_t> perm;
+  perm.push_back(rank - 1);
+  for (int64_t i = 0; i < rank - 1; ++i) {
+    perm.push_back(i);
+  }
+
+  SmallVector<int64_t> newShape;
+  newShape.push_back(type.getShape()[rank - 1]);
+  for (int64_t i = 0; i < rank - 1; ++i) {
+    newShape.push_back(type.getShape()[i]);
+  }
+
+  auto newType = RankedTensorType::get(newShape, type.getElementType());
+  return builder
+      .create<mlir::stablehlo::TransposeOp>(loc, newType, input,
+                                            builder.getDenseI64ArrayAttr(perm))
+      .getResult();
+}
+
+// Moves the leading dimension to the back:
+//   tensor<d0 x d1 x ... x dN>  -->  tensor<d1 x d2 x ... x dN x d0>
+static Value transposeLeadingToTrailing(Location loc, Value input,
+                                        OpBuilder &builder) {
+  auto type = mlir::cast<RankedTensorType>(input.getType());
+  int64_t rank = type.getRank();
+
+  SmallVector<int64_t> perm;
+  for (int64_t i = 1; i < rank; ++i) {
+    perm.push_back(i);
+  }
+  perm.push_back(0);
+
+  SmallVector<int64_t> newShape;
+  for (int64_t i = 1; i < rank; ++i) {
+    newShape.push_back(type.getShape()[i]);
+  }
+  newShape.push_back(type.getShape()[0]);
+
+  auto newType = RankedTensorType::get(newShape, type.getElementType());
+  return builder
+      .create<mlir::stablehlo::TransposeOp>(loc, newType, input,
+                                            builder.getDenseI64ArrayAttr(perm))
+      .getResult();
+}
+
+// ---------------------------------------------------------------------------
+// Conversion patterns
+// ---------------------------------------------------------------------------
+
+// Decomposes complex(re, im) -> tensor<...x2xf32>:
+//
+//   re: tensor<d0x...xdN>    im: tensor<d0x...xdN>
+//       |                            |
+//    reshape                      reshape
+//       |                            |
+//   tensor<1xd0x...xdN>      tensor<1xd0x...xdN>
+//       \                           /
+//              concatenate(dim=0)
+//                     |
+//          tensor<2xd0x...xdN>   <- [re_slice, im_slice, ...]
+//                     |
+//           transposeLeadingToTrailing
+//                     |
+//          tensor<d0x...xdNx2>   <- unpacked complex layout
+//
+namespace {
+class StablehloComplexToDecomposedPattern
+    : public OpConversionPattern<mlir::stablehlo::ComplexOp> {
+  using OpConversionPattern<mlir::stablehlo::ComplexOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::ComplexOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto lhsType = mlir::cast<RankedTensorType>(adaptor.getLhs().getType());
+
+    SmallVector<int64_t> unsqueezedShape;
+    unsqueezedShape.push_back(1);
+    for (auto d : lhsType.getShape()) {
+      unsqueezedShape.push_back(d);
+    }
+    auto unsqueezedType =
+        RankedTensorType::get(unsqueezedShape, lhsType.getElementType());
+    auto reshapedLhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+        loc, unsqueezedType, adaptor.getLhs());
+    auto reshapedRhs = rewriter.create<mlir::stablehlo::ReshapeOp>(
+        loc, unsqueezedType, adaptor.getRhs());
+
+    SmallVector<int64_t> concatShape;
+    concatShape.push_back(2);
+    for (auto d : lhsType.getShape()) {
+      concatShape.push_back(d);
+    }
+    auto concatType =
+        RankedTensorType::get(concatShape, lhsType.getElementType());
+    auto concatOp = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+        loc, concatType,
+        ValueRange{reshapedLhs.getResult(), reshapedRhs.getResult()},
+        /*dimension=*/0);
+
+    auto transposed =
+        transposeLeadingToTrailing(loc, concatOp.getResult(), rewriter);
+    rewriter.replaceOp(op, transposed);
+    return success();
+  }
+};
+} // namespace
+
+// Decomposes real(x) / imag(x) -> tensor<...xf32>:
+//
+//   tensor<d0x...xdNx2>   <- unpacked complex layout
+//          |
+//   transposeTrailingToLeading
+//          |
+//   tensor<2xd0x...xdN>
+//          |
+//   slice(dim=0, offset=0 or 1, len=1)   <- 0=real, 1=imag
+//          |
+//   tensor<1xd0x...xdN>
+//          |
+//       reshape
+//          |
+//   tensor<d0x...xdN>     <- extracted component
+namespace {
+template <typename OpTy>
+class StablehloRealImagToDecomposedPattern : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  static constexpr int Offset =
+      std::is_same_v<OpTy, mlir::stablehlo::RealOp> ? 0 : 1;
+
+public:
+  LogicalResult
+  matchAndRewrite(OpTy op,
+                  typename OpConversionPattern<OpTy>::OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    auto transposed =
+        transposeTrailingToLeading(loc, adaptor.getOperand(), rewriter);
+    auto transposedType = mlir::cast<RankedTensorType>(transposed.getType());
+    int64_t rank = transposedType.getRank();
+    auto transposedShape = transposedType.getShape();
+
+    SmallVector<int64_t> begins(rank, 0),
+        ends(transposedShape.begin(), transposedShape.end()), steps(rank, 1);
+    begins[0] = Offset;
+    ends[0] = Offset + 1;
+    SmallVector<int64_t> sliceShape(transposedShape.begin(),
+                                    transposedShape.end());
+    sliceShape[0] = 1;
+    auto sliceOp = rewriter.create<mlir::stablehlo::SliceOp>(
+        loc, RankedTensorType::get(sliceShape, transposedType.getElementType()),
+        transposed, rewriter.getDenseI64ArrayAttr(begins),
+        rewriter.getDenseI64ArrayAttr(ends),
+        rewriter.getDenseI64ArrayAttr(steps));
+
+    auto resultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(
+        op, resultType, sliceOp.getResult());
+    return success();
+  }
+};
+} // namespace
+
+// Rewrites ops that produce complex-typed tensors to operate on the equivalent
+// unpacked real representation (trailing dim of size 2).
+namespace {
+template <typename OpTy>
+class ComplexTypeDefaultConversionPattern : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(OpTy op,
+                  typename OpConversionPattern<OpTy>::OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto newResultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+    rewriter.replaceOpWithNewOp<OpTy>(op, newResultType, adaptor.getOperands());
+    return success();
+  }
+};
+} // namespace
+
+// Rewrites stablehlo::ConstantOp with complex-typed tensor results by
+// unpacking each complex element into a pair of floats (real, imag) and
+// producing a new constant over the equivalent real tensor type.
+namespace {
+class ComplexConstantOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::ConstantOp> {
+  using OpConversionPattern<mlir::stablehlo::ConstantOp>::OpConversionPattern;
+
+public:
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::ConstantOp op,
+      OpConversionPattern<mlir::stablehlo::ConstantOp>::OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto newResultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+
+    auto denseAttr = mlir::cast<DenseElementsAttr>(op.getValue());
+    SmallVector<APFloat> floatValues;
+    for (auto complexVal : denseAttr.getValues<std::complex<APFloat>>()) {
+      floatValues.push_back(complexVal.real());
+      floatValues.push_back(complexVal.imag());
+    }
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+        op, newResultType, DenseElementsAttr::get(newResultType, floatValues));
+    return success();
+  }
+};
+
+// Rewrites stablehlo::BroadcastInDimOp with complex-typed tensor results
+// by appending the trailing real/imag dimension to the broadcast dimensions
+// and producing a new broadcast over the equivalent real tensor type.
+class ComplexBroadcastInDimOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::BroadcastInDimOp> {
+  using OpConversionPattern<
+      mlir::stablehlo::BroadcastInDimOp>::OpConversionPattern;
+
+public:
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::BroadcastInDimOp op,
+      OpConversionPattern<mlir::stablehlo::BroadcastInDimOp>::OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto newResultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+
+    auto dims = op.getBroadcastDimensions();
+    SmallVector<int64_t> newDims(dims.begin(), dims.end());
+    newDims.push_back(newResultType.getRank() - 1);
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::BroadcastInDimOp>(
+        op, newResultType, adaptor.getOperand(),
+        rewriter.getDenseI64ArrayAttr(newDims));
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+struct StableHLOComplexDataTypeConversionPass
+    : public impl::StableHLOComplexDataTypeConversionPassBase<
+          StableHLOComplexDataTypeConversionPass> {
+  using impl::StableHLOComplexDataTypeConversionPassBase<
+      StableHLOComplexDataTypeConversionPass>::
+      StableHLOComplexDataTypeConversionPassBase;
+
+  void runOnOperation() override {
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<mlir::stablehlo::StablehloDialect>();
+
+    auto isNotComplexType = [](mlir::Operation *op) {
+      auto resultType =
+          mlir::cast<RankedTensorType>(op->getResult(0).getType());
+      return !mlir::isa<mlir::ComplexType>(resultType.getElementType());
+    };
+
+    target.addDynamicallyLegalOp<mlir::stablehlo::ConstantOp,
+                                 mlir::stablehlo::ReshapeOp,
+                                 mlir::stablehlo::BroadcastInDimOp>(
+        isNotComplexType);
+
+    target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
+                        mlir::stablehlo::ImagOp>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    typeConverter.addConversion(
+        [](RankedTensorType type) -> std::optional<Type> {
+          auto complexTy =
+              mlir::dyn_cast<mlir::ComplexType>(type.getElementType());
+          if (!complexTy) {
+            return std::nullopt;
+          }
+          auto floatTy =
+              mlir::dyn_cast<mlir::FloatType>(complexTy.getElementType());
+          if (!floatTy) {
+            return std::nullopt;
+          }
+          SmallVector<int64_t> newShape(type.getShape());
+          newShape.push_back(2);
+          return RankedTensorType::get(newShape, floatTy);
+        });
+
+    RewritePatternSet patterns(&getContext());
+    patterns
+        .add<ComplexBroadcastInDimOpConversionPattern,
+             ComplexConstantOpConversionPattern,
+             ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
+             StablehloComplexToDecomposedPattern,
+             StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
+             StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
+            typeConverter, &getContext());
+
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+             typeConverter.isLegal(&op.getBody());
+    });
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::ReturnOp>(
+        [&](func::ReturnOp op) { return typeConverter.isLegal(op); });
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+} // namespace mlir::tt::stablehlo

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -36,6 +36,7 @@
 #include "stablehlo/conversions/linalg/transforms/Passes.h"
 #include "stablehlo/transforms/Passes.h"
 #include "stablehlo/transforms/optimization/Passes.h"
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
 #endif
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
@@ -63,12 +64,20 @@ void createStableHLOToTTIRPipeline(
   }
   pm.addPass(createLegalizeStableHLOCompositeToTTIRPass());
   if (options.legalizeCompositeToCallEnabled) {
-    pm.addPass(stablehlo::createStablehloLegalizeCompositeToCallPass());
+    pm.addPass(::mlir::stablehlo::createStablehloLegalizeCompositeToCallPass());
   }
   pm.addPass(mlir::createInlinerPass());
   if (options.enableAggressiveSimplification) {
-    pm.addPass(stablehlo::createStablehloAggressiveSimplificationPass());
+    pm.addPass(
+        ::mlir::stablehlo::createStablehloAggressiveSimplificationPass());
   }
+  // Expand complex math ops (e.g. mul, sqrt, log) into real arithmetic before
+  // converting complex types to float-pair representation.
+  pm.addPass(::mlir::stablehlo::createStablehloComplexMathExpanderPass());
+  // Convert complex types to float-pair representation before lowering.
+  pm.addPass(
+      mlir::tt::stablehlo::createStableHLOComplexDataTypeConversionPass());
+
   ttir::ConvertStableHLOToTTIROptions passOptions;
   passOptions.enablePartialConversion = options.enableCPUFallback;
   pm.addPass(createConvertStableHLOToTTIRPass(passOptions));
@@ -270,7 +279,7 @@ void createTTIRToLLVMCPUPipeline(OpPassManager &pm,
 
 #ifdef TTMLIR_ENABLE_STABLEHLO
   // Directly convert any hoisted SHLO ops into linalg ops.
-  cpuPm.addPass(stablehlo::createStablehloLegalizeToLinalgPass());
+  cpuPm.addPass(::mlir::stablehlo::createStablehloLegalizeToLinalgPass());
 #endif
 
   // Decomp TTIR to reduce number of conversions we need to support in

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -62,6 +62,7 @@
 #include "shardy/dialect/sdy/ir/register.h"
 #include "shardy/dialect/sdy/transforms/passes.h"
 #include "stablehlo/dialect/Register.h"
+#include "stablehlo/transforms/Passes.h"
 #include "ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h"
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
 #endif
@@ -157,6 +158,7 @@ void mlir::tt::registerAllPasses() {
 
 #if TTMLIR_ENABLE_STABLEHLO
   mlir::tt::stablehlo::registerPasses();
+  mlir::stablehlo::registerStablehloComplexMathExpanderPass();
 #endif
 
   // Register pipelines.

--- a/test/ttmlir/Conversion/StableHLOToTTIR/complex/complex_chain.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/complex/complex_chain.mlir
@@ -1,0 +1,50 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Test chained complex ops: complex(real, imag) then real and imag extraction.
+module {
+  func.func @test_complex_real_imag_chain(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> (tensor<3xf32>, tensor<3xf32>) {
+    // CHECK: "ttir.reshape"(%arg0)
+    // CHECK-SAME: (tensor<3xf32>) -> tensor<1x3xf32>
+    // CHECK: "ttir.reshape"(%arg1)
+    // CHECK-SAME: (tensor<3xf32>) -> tensor<1x3xf32>
+    // CHECK: "ttir.concat"
+    // CHECK-SAME: {dim = 0 : si32}
+    // CHECK-SAME: (tensor<1x3xf32>, tensor<1x3xf32>) -> tensor<2x3xf32>
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: {permutation = array<i64: 1, 0>}
+    // CHECK-SAME: (tensor<2x3xf32>) -> tensor<3x2xf32>
+    %c = "stablehlo.complex"(%arg0, %arg1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xcomplex<f32>>
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: {begins = [0 : i32, 0 : i32], ends = [1 : i32, 3 : i32], step = [1 : i32, 1 : i32]}
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x3xf32>) -> tensor<3xf32>
+    %r = "stablehlo.real"(%c) : (tensor<3xcomplex<f32>>) -> tensor<3xf32>
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: {begins = [1 : i32, 0 : i32], ends = [2 : i32, 3 : i32], step = [1 : i32, 1 : i32]}
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x3xf32>) -> tensor<3xf32>
+    %i = "stablehlo.imag"(%c) : (tensor<3xcomplex<f32>>) -> tensor<3xf32>
+    return %r, %i : tensor<3xf32>, tensor<3xf32>
+  }
+
+  // Test real/imag on a complex constant.
+  func.func @test_complex_constant_real_imag() -> (tensor<16x8xf32>, tensor<16x8xf32>) {
+    %cst = stablehlo.constant dense<(1.0, 0.000000e+00)> : tensor<16x8xcomplex<f32>>
+    %r = "stablehlo.real"(%cst) : (tensor<16x8xcomplex<f32>>) -> tensor<16x8xf32>
+    %i = "stablehlo.imag"(%cst) : (tensor<16x8xcomplex<f32>>) -> tensor<16x8xf32>
+    // CHECK: "ttir.constant"
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: {permutation = array<i64: 2, 0, 1>}
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32]
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x16x8xf32>) -> tensor<16x8xf32>
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [1 : i32, 0 : i32, 0 : i32]
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<1x16x8xf32>) -> tensor<16x8xf32>
+    return %r, %i : tensor<16x8xf32>, tensor<16x8xf32>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/complex/complex_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/complex/complex_op.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @test_complex(%arg0: tensor<2x4xf64>, %arg1: tensor<2x4xf64>) -> tensor<2x4xcomplex<f64>> {
+    %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<2x4xf64>, tensor<2x4xf64>) -> tensor<2x4xcomplex<f64>>
+    // CHECK: "ttir.reshape"(%arg0) {{.*}} -> tensor<1x2x4xf64>
+    // CHECK: "ttir.reshape"(%arg1) {{.*}} -> tensor<1x2x4xf64>
+    // CHECK: "ttir.concat"({{.*}}) {{.*}} -> tensor<2x2x4xf64>
+    // CHECK: "ttir.permute"({{.*}}) {{.*}} -> tensor<2x4x2xf64>
+    return %0 : tensor<2x4xcomplex<f64>>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/complex/imag_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/complex/imag_op.mlir
@@ -1,0 +1,16 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @test_imag(%arg0: tensor<2x4xcomplex<f64>>) -> tensor<2x4xf64> {
+    %0 = "stablehlo.imag"(%arg0) : (tensor<2x4xcomplex<f64>>) -> tensor<2x4xf64>
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: {permutation = array<i64: 2, 0, 1>}
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [1 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [2 : i32, 2 : i32, 4 : i32]
+    // CHECK: "ttir.reshape"({{.*}}) {{.*}} -> tensor<2x4xf64>
+    return %0 : tensor<2x4xf64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/complex/real_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/complex/real_op.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @test_real(%arg0: tensor<2x4xcomplex<f64>>) -> tensor<2x4xf64> {
+    %0 = "stablehlo.real"(%arg0) : (tensor<2x4xcomplex<f64>>) -> tensor<2x4xf64>
+    // CHECK: "ttir.permute"(%arg0) {{.*}} -> tensor<2x2x4xf64>
+    // CHECK: "ttir.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 2 : i32, 4 : i32]
+    // CHECK: "ttir.reshape"({{.*}}) {{.*}} -> tensor<2x4xf64>
+    return %0 : tensor<2x4xf64>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex.mlir
@@ -1,0 +1,74 @@
+// RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+    func.func @test_complex(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>)
+    -> (tensor<2x4xcomplex<f32>>) {
+        // CHECK: stablehlo.reshape
+        // CHECK-SAME: (tensor<2x4xf32>) -> tensor<1x2x4xf32>
+        // CHECK: stablehlo.reshape
+        // CHECK-SAME: (tensor<2x4xf32>) -> tensor<1x2x4xf32>
+        // CHECK: stablehlo.concatenate
+        // CHECK-SAME: (tensor<1x2x4xf32>, tensor<1x2x4xf32>) -> tensor<2x2x4xf32>
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x2x4xf32>) -> tensor<2x4x2xf32>
+        %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<2x4xf32>, tensor<2x4xf32>) -> tensor<2x4xcomplex<f32>>
+        return %0 : tensor<2x4xcomplex<f32>>
+    }
+    func.func @test_real(%arg0: tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32> {
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<2x2x4xf32>
+        // CHECK: stablehlo.slice
+        // CHECK-SAME: [0:1, 0:2, 0:4]
+        // CHECK: stablehlo.reshape
+        // CHECK-SAME: (tensor<1x2x4xf32>) -> tensor<2x4xf32>
+        %0 = "stablehlo.real"(%arg0) : (tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32>
+        return %0 : tensor<2x4xf32>
+    }
+    func.func @test_imag(%arg0: tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32> {
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<2x2x4xf32>
+        // CHECK: stablehlo.slice
+        // CHECK-SAME: [1:2, 0:2, 0:4]
+        // CHECK: stablehlo.reshape
+        // CHECK-SAME: (tensor<1x2x4xf32>) -> tensor<2x4xf32>
+        %0 = "stablehlo.imag"(%arg0) : (tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32>
+        return %0 : tensor<2x4xf32>
+    }
+    func.func @test_complex_chain(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>)
+    -> (tensor<2x4xf32>, tensor<2x4xf32>) {
+        // CHECK: stablehlo.reshape
+        // CHECK: stablehlo.reshape
+        // CHECK: stablehlo.concatenate
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x2x4xf32>) -> tensor<2x4x2xf32>
+        %0 = "stablehlo.complex"(%arg0, %arg1) : (tensor<2x4xf32>, tensor<2x4xf32>) -> tensor<2x4xcomplex<f32>>
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<2x2x4xf32>
+        // CHECK: stablehlo.slice
+        // CHECK: stablehlo.reshape
+        %1 = "stablehlo.real"(%0) : (tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32>
+        // CHECK: stablehlo.transpose
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<2x2x4xf32>
+        // CHECK: stablehlo.slice
+        // CHECK: stablehlo.reshape
+        %2 = "stablehlo.imag"(%0) : (tensor<2x4xcomplex<f32>>) -> tensor<2x4xf32>
+        return %1, %2 : tensor<2x4xf32>, tensor<2x4xf32>
+    }
+    func.func @test_complex_broadcast_in_dim(%arg0: tensor<2x4xcomplex<f32>>) -> tensor<3x2x4xcomplex<f32>> {
+        // CHECK: stablehlo.broadcast_in_dim
+        // CHECK-SAME: dims = [1, 2, 3]
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<3x2x4x2xf32>
+        %0 = "stablehlo.broadcast_in_dim"(%arg0) {
+            broadcast_dimensions = array<i64: 1, 2>
+        } : (tensor<2x4xcomplex<f32>>) -> tensor<3x2x4xcomplex<f32>>
+        return %0 : tensor<3x2x4xcomplex<f32>>
+    }
+
+    func.func @test_complex_reshape(%arg0: tensor<2x4xcomplex<f32>>) -> tensor<8xcomplex<f32>> {
+        // CHECK: stablehlo.reshape
+        // CHECK-SAME: (tensor<2x4x2xf32>) -> tensor<8x2xf32>
+        %0 = "stablehlo.reshape"(%arg0) : (tensor<2x4xcomplex<f32>>) -> tensor<8xcomplex<f32>>
+        return %0 : tensor<8xcomplex<f32>>
+    }
+}

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/deepseek_v3_2_rope.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/deepseek_v3_2_rope.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion %s
+
+func.func @main(%arg0: tensor<16x8xcomplex<f32>>, %arg1: tensor<2x16x4x16xbf16>) -> tensor<2x16x4x16xbf16> {
+  %0 = stablehlo.convert %arg1 : (tensor<2x16x4x16xbf16>) -> tensor<2x16x4x16xf32>
+  %1 = stablehlo.reshape %0 : (tensor<2x16x4x16xf32>) -> tensor<2x16x4x8x2xf32>
+  %2 = stablehlo.slice %1 [0:2, 0:16, 0:4, 0:8, 0:1] : (tensor<2x16x4x8x2xf32>) -> tensor<2x16x4x8x1xf32>
+  %3 = stablehlo.reshape %2 : (tensor<2x16x4x8x1xf32>) -> tensor<2x16x4x8xf32>
+  %4 = stablehlo.slice %1 [0:2, 0:16, 0:4, 0:8, 1:2] : (tensor<2x16x4x8x2xf32>) -> tensor<2x16x4x8x1xf32>
+  %5 = stablehlo.reshape %4 : (tensor<2x16x4x8x1xf32>) -> tensor<2x16x4x8xf32>
+  %6 = stablehlo.complex %3, %5 : tensor<2x16x4x8xcomplex<f32>>
+  %7 = stablehlo.reshape %arg0 : (tensor<16x8xcomplex<f32>>) -> tensor<1x16x8xcomplex<f32>>
+  %8 = stablehlo.reshape %7 : (tensor<1x16x8xcomplex<f32>>) -> tensor<16x8xcomplex<f32>>
+  %9 = stablehlo.broadcast_in_dim %8, dims = [1, 3] : (tensor<16x8xcomplex<f32>>) -> tensor<2x16x4x8xcomplex<f32>>
+  %10 = stablehlo.multiply %6, %9 : tensor<2x16x4x8xcomplex<f32>>
+  %11 = stablehlo.real %10 : (tensor<2x16x4x8xcomplex<f32>>) -> tensor<2x16x4x8xf32>
+  %12 = stablehlo.reshape %11 : (tensor<2x16x4x8xf32>) -> tensor<2x16x4x8x1xf32>
+  %13 = stablehlo.imag %10 : (tensor<2x16x4x8xcomplex<f32>>) -> tensor<2x16x4x8xf32>
+  %14 = stablehlo.reshape %13 : (tensor<2x16x4x8xf32>) -> tensor<2x16x4x8x1xf32>
+  %15 = stablehlo.concatenate %12, %14, dim = 4 : (tensor<2x16x4x8x1xf32>, tensor<2x16x4x8x1xf32>) -> tensor<2x16x4x8x2xf32>
+  %16 = stablehlo.reshape %15 : (tensor<2x16x4x8x2xf32>) -> tensor<2x16x4x16xf32>
+  %17 = stablehlo.convert %16 : (tensor<2x16x4x16xf32>) -> tensor<2x16x4x16xbf16>
+  return %17 : tensor<2x16x4x16xbf16>
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3060)

### Problem description
Our compiler does not have complex data type and complex operation support ([stablehlo.complex](https://openxla.org/stablehlo/spec#complex), [stablehlo.real](https://openxla.org/stablehlo/spec#real), [stablehlo.imag](https://openxla.org/stablehlo/spec#imag)) 

### What's changed
Complex values are stored in memory as real and imaginary interleaved: [re0, im0, re1, im1, ...] Therefore, they can be unpacked with a trailing dim 2. For example: tensor<1x3xcomplex<f32>> → tensor<1x3x2xf32>

Adding a trailing dim of 2 will result in performance degradation due to tilize/ untilize. Therefore, in conversion patterns, we need to include a transpose/ permute to move the trailing dim to 0th dim. For example: tensor<1x3x2xf32> --> tensor<2x1x3xf32>

If we add support for the following stablehlo complex ops, we would rewrite other standard ops with complex data type: [stablehlo.complex](https://openxla.org/stablehlo/spec#complex), [stablehlo.real](https://openxla.org/stablehlo/spec#real), [stablehlo.imag](https://openxla.org/stablehlo/spec#imag)

We can cover conversion in stablehlo to ttir pipeline with two passes:
- StablehloComplexMathExpander: Currently, I wrote a temp patch for mult op since that's what we're seeing in Deepseek v3.2 RoPE. However, I intend to make upstream changes in stablehlo: https://github.com/openxla/stablehlo/issues/2913 
- StableHLOComplexDataTypeConversionPass: This pass replaces complex values with their unpacked versions, rewrites reshape and broadcast_in_dim ops with the unpacked complex values, and rewrites stablehlo.complex, stablehlo.real, stablehlo.imag ops using existing ops.
    - stablehlo.complex:
        - reshape/ unsqueeze real and imaginary to add a prepending dim 1: tensor<3xf32> --> tensor<1x3xf32>
        - concatenate along dim 0: tensor<1x3xf32>, tensor<1x3xf32> --> tensor<2x3xf32>
        - transpose: tensor<2x3xf32> --> tensor<3x2xf32>
    - stablehlo.real/ imag:
        - transpose: tensor<3x2xf32> --> tensor<2x3xf32>
        - slice along dim 0: tensor<2x3xf32> --> tensor<1x3xf32>
        - reshape/ squeeze: tensor<1x3xf32> --> tensor<3xf32>
