### PR TITLE
[runtime] use dynamic trace region

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -13,13 +13,8 @@ namespace tt::constants {
 // This reserves a region of L1 memory for L1_SMALL buffers used by convs.
 constexpr static std::size_t L1_SMALL_SIZE = 1 << 16;
 
-// Used only in unittests:
-// todo(arminaleTT): look into dynamically adjusting this
-// getOpRuntime() uses trace capture to run and measure the runtime of an op.
-// This requires the device to be opened with sufficient trace region size.
-// This number is currently set based on manual testing of supported ops to
-// accommodate the highest required trace buffer size (2004992B)
-static constexpr size_t opModelDefaultTraceRegionSize = 6000000;
+// Use dynamic trace region (size = 0).
+static constexpr size_t opModelDefaultTraceRegionSize = 0;
 
 } // namespace tt::constants
 

--- a/runtime/lib/ttnn/operations/trace/begin_trace_capture.cpp
+++ b/runtime/lib/ttnn/operations/trace/begin_trace_capture.cpp
@@ -17,11 +17,6 @@ void run(const ::tt::target::ttnn::BeginTraceCaptureOp *op,
   LOG_ASSERT(meshDevice.get_program_cache().is_enabled(),
              "Program cache must be enabled");
 
-  LOG_ASSERT(meshDevice.allocator()
-                     ->get_statistics(::ttnn::BufferType::TRACE)
-                     .total_allocatable_size_bytes > 0,
-             "Trace region size must be greater than 0");
-
   ::ttnn::MeshTraceId traceId =
       ::ttnn::operations::trace::begin_trace_capture(&meshDevice, ttnnCqId);
   ::ttnn::Tensor traceIdTensor =

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -183,10 +183,6 @@ void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
 
   LOG_ASSERT(meshDevice.get_program_cache().is_enabled(),
              "Program cache must be enabled");
-  LOG_ASSERT(meshDevice.allocator()
-                     ->get_statistics(::ttnn::BufferType::TRACE)
-                     .total_allocatable_size_bytes > 0,
-             "Trace region size must be greater than 0");
 
   auto traceCache =
       deviceHandle.getTraceCache()

--- a/runtime/lib/ttnn/operations/trace/end_trace_capture.cpp
+++ b/runtime/lib/ttnn/operations/trace/end_trace_capture.cpp
@@ -18,10 +18,6 @@ void run(const ::tt::target::ttnn::EndTraceCaptureOp *op,
 
   LOG_ASSERT(meshDevice.get_program_cache().is_enabled(),
              "Program cache must be enabled");
-  LOG_ASSERT(meshDevice.allocator()
-                     ->get_statistics(::ttnn::BufferType::TRACE)
-                     .total_allocatable_size_bytes > 0,
-             "Trace region size must be greater than 0");
 
   const ::ttnn::Tensor &traceIdTensor =
       context.getTensorPool().getTTNNTensorAndValidate(op->trace_id());

--- a/runtime/test/ttnn/python/n150/test_trace.py
+++ b/runtime/test/ttnn/python/n150/test_trace.py
@@ -24,7 +24,10 @@ FLATBUFFER_BASE_PATH = (
 
 
 @pytest.mark.parametrize("num_loops", [5])
-def test_trace_matmul_multiply_no_consteval(helper: Helper, request, num_loops):
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_trace_matmul_multiply_no_consteval(
+    helper: Helper, request, num_loops, trace_region_size
+):
     binary_path = os.path.join(
         FLATBUFFER_BASE_PATH, "matmul_multiply_no_consteval.mlir.tmp.ttnn"
     )
@@ -44,7 +47,9 @@ def test_trace_matmul_multiply_no_consteval(helper: Helper, request, num_loops):
     debug_stats = ttrt.runtime.DebugStats.get()
 
     with DeviceContext(
-        mesh_shape=[1, 1], enable_program_cache=True, trace_region_size=80000
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
     ) as device:
 
         for i in range(num_loops):
@@ -65,7 +70,10 @@ def test_trace_matmul_multiply_no_consteval(helper: Helper, request, num_loops):
 
 
 @pytest.mark.parametrize("num_loops", [5])
-def test_trace_matmul_multiply_with_consteval(helper: Helper, request, num_loops):
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_trace_matmul_multiply_with_consteval(
+    helper: Helper, request, num_loops, trace_region_size
+):
     binary_path = os.path.join(
         FLATBUFFER_BASE_PATH, "matmul_multiply_consteval.mlir.tmp.ttnn"
     )
@@ -83,7 +91,9 @@ def test_trace_matmul_multiply_with_consteval(helper: Helper, request, num_loops
     debug_stats = ttrt.runtime.DebugStats.get()
 
     with DeviceContext(
-        mesh_shape=[1, 1], enable_program_cache=True, trace_region_size=80000
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
     ) as device:
 
         inputs_runtime_with_layout, golden, _ = test_runner.get_inputs_and_golden(
@@ -148,7 +158,8 @@ def mnist_linear_logits_golden(inputs):
 
 
 @pytest.mark.parametrize("num_loops", [16])
-def test_mnist_linear_logits(helper: Helper, request, num_loops):
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_mnist_linear_logits(helper: Helper, request, num_loops, trace_region_size):
     binary_path = os.path.join(
         FLATBUFFER_BASE_PATH, "mnist_linear_logits.mlir.tmp.ttnn"
     )
@@ -169,7 +180,9 @@ def test_mnist_linear_logits(helper: Helper, request, num_loops):
     output_torch = get_torch_output_container(test_runner.program)
 
     with DeviceContext(
-        mesh_shape=[1, 1], enable_program_cache=True, trace_region_size=80000
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
     ) as device:
 
         inputs_runtime_with_layout, golden, _ = test_runner.get_inputs_and_golden(

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -76,8 +76,8 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15;     // 32kB
-  static constexpr std::size_t traceRegionSize = 1 << 20; // 1MB
+  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -76,8 +76,8 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15;     // 32kB
-  static constexpr std::size_t traceRegionSize = 1 << 20; // 1MB
+  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -90,8 +90,8 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
-  static constexpr std::size_t l1SmallSize = 1 << 15;     // 32kB
-  static constexpr std::size_t traceRegionSize = 1 << 20; // 1MB
+  static constexpr std::size_t l1SmallSize = 1 << 15; // 32kB
+  static constexpr std::size_t traceRegionSize = 0;
 
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.


### PR DESCRIPTION
Recently, `tt-metal` introduced support for dynamic trace region - this means we are no longer required to pre-allocate memory for `trace` (tenstorrent/tt-metal#36999).

Changing default values for trace region size to 0, so that we are using dynamic trace region by default.

The assertions which check that we have pre-allocated trace region are now removed - since they don't make sense anymore.

Users can still override this behaviour by specifying wanted trace region size when opening the device.

Closes #7425