### PR TITLE
Builder: re-raise the exception after the wrapper change

### DIFF
--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -648,6 +648,7 @@ def pytest_runtest_call(item: pytest.Item):
     Extract runtime information from tests that actually execute.
 
     This includes failure classification and error reporting during the call phase.
+    Exceptions are re-raised so tests fail normally while still recording metadata.
 
     Runtime report data includes:
     - failure_stage: Categorizes where in the compilation pipeline the test failed
@@ -678,6 +679,7 @@ def pytest_runtest_call(item: pytest.Item):
                 f"Unknown failure detected! Please address this or correctly throw a `TTBuilder*` exception instead if this is a compilation issue, runtime error, or golden mismatch. Exception: {exc}:{type(exc)}"
             )
         failure_stage = TTBUILDER_EXCEPTIONS[exc_name]
+        raise
     finally:
         _safe_add_property(item, "failure_stage", failure_stage)
 

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -263,6 +263,9 @@ def test_matmul_1d_shapes(
     request,
     device,
 ):
+    if dtype == torch.float32 and shape in ((32768, 32, 32), (32, 32, 32768)):
+        pytest.xfail(reason="Too large for f32.")
+
     lhs = (
         shape[0],
         shape[1],

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1550,7 +1550,13 @@ def test_topk(
         ),
     ],
 )
-@pytest.mark.parametrize("target", ["ttnn", "ttmetal"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ttnn",
+        "ttmetal" | Marks(pytest.mark.xfail(reason="Unimplemented ttir.embedding")),
+    ],
+)
 def test_unique_ops(
     inputs_shapes: List[Shape],
     inputs_dtypes: List[torch.dtype],
@@ -1805,7 +1811,7 @@ def test_gather(
 )
 @pytest.mark.parametrize(
     "target",
-    ["ttnn", "ttmetal"],
+    ["ttnn", "ttmetal" | Marks(pytest.mark.xfail(reason="Unhoisted ttir.zeros"))],
 )
 def test_hoisted_gather(
     input_shape: Shape,

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
@@ -341,7 +341,7 @@ def leaky_relu(
     return builder.leaky_relu(in0, parameter, unit_attrs=unit_attrs)
 
 
-unary_ops_with_float_param = [leaky_relu]
+unary_ops_with_float_param = [leaky_relu | SkipIf("ttmetal")]
 
 
 @pytest.mark.parametrize("shape", [(64, 128)], ids=shape_str)


### PR DESCRIPTION
### What's changed
The wrapper update in #7401 consumed the exception (unlike the old hookwrapper), must re-raise to avoid false passings.