### PR TITLE
[D2M] Change d2m.emptyOp Traits to Avoid Incorrect Elimination by CSE Pass

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -389,7 +389,8 @@ def D2M_GenericOp
 
 def D2M_EmptyOp
     : D2M_Op<
-          "empty", [Pure, DeclareOpInterfaceMethods<
+          "empty", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                    DeclareOpInterfaceMethods<
                         BufferizableOpInterface,
                         ["bufferizesToMemoryRead", "bufferizesToMemoryWrite",
                          "bufferize", "getAliasingValues", "getBufferType"]>]> {

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -107,6 +107,18 @@ void d2m::EmptyOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
 }
 
 //===----------------------------------------------------------------------===//
+// EmptyOp Memory Effects
+//===----------------------------------------------------------------------===//
+
+void d2m::EmptyOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Allocate::get(),
+                       getOperation()->getResult(0),
+                       SideEffects::DefaultResource::get());
+}
+
+//===----------------------------------------------------------------------===//
 // EmptyOp Bufferization Interface Implementation
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Dialect/D2M/bufferization/empty_cse.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/empty_cse.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --cse %s | FileCheck %s
+
+// CHECK-LABEL: func.func @two_empty_ops_not_merged
+// CHECK: d2m.empty
+// CHECK: d2m.empty
+func.func @two_empty_ops_not_merged() -> (tensor<2x4x!ttcore.tile<32x32, f32>>, tensor<2x4x!ttcore.tile<32x32, f32>>) {
+  %0 = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>>
+  %1 = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>>
+  return %0, %1 : tensor<2x4x!ttcore.tile<32x32, f32>>, tensor<2x4x!ttcore.tile<32x32, f32>>
+}

--- a/test/ttmlir/Dialect/D2M/bufferization/memory_effects.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/memory_effects.mlir
@@ -52,3 +52,17 @@ func.func @to_layout_memref(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttc
   "d2m.to_layout"(%arg0, %alloc) : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
 }
+
+// CHECK-LABEL: func.func @unused_empty_removed
+// CHECK-NOT: d2m.empty
+func.func @unused_empty_removed(%arg0: tensor<2x4x!ttcore.tile<32x32, f32>>) -> tensor<2x4x!ttcore.tile<32x32, f32>> {
+  %0 = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>>
+  return %arg0 : tensor<2x4x!ttcore.tile<32x32, f32>>
+}
+
+// CHECK-LABEL: func.func @used_empty_kept
+// CHECK: d2m.empty
+func.func @used_empty_kept() -> tensor<2x4x!ttcore.tile<32x32, f32>> {
+  %0 = d2m.empty() : tensor<2x4x!ttcore.tile<32x32, f32>>
+  return %0 : tensor<2x4x!ttcore.tile<32x32, f32>>
+}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7433

### Problem description
In #7144 the d2m.emptyOp was changed from having a `MemoryEffects<[MemAlloc]>` trait to having a `Pure` trait. This fixed the issue of the emptyOp not being canonicalized when it was unused. However, this also led the CSE pass to combine d2m.emptyOps when their types were identical, turning two tensor allocations into one. This is incorrect.

### What's changed
- Changed the trait on d2m.emptyOp from `Pure` to `MemoryEffectsOpInterface`. 
  - The previous `MemoryEffects<[MemAlloc]>` declares a side effect that is not associated with any value; thus it cannot be eliminated. With this implementation of `getEffects`, we tie the side effect to the result of the empty op
- Add lit tests to verify both canonicalization and CSE behaviour

### Checklist
- [X] New/Existing tests provide coverage for changes
