### PR TITLE
[stablehlo] Add Conv2d builder convenience API + tests

### DIFF
--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -1786,6 +1786,56 @@ def test_convolution(
 @pytest.mark.parametrize(
     "shapes,stride,padding,dilation,groups",
     [
+        ([(1, 32, 16, 16), (64, 32, 3, 3)], [1, 1], [1, 1], [1, 1], 1),
+        ([(1, 32, 16, 16), (32, 1, 3, 3)], [2, 2], [1, 1], [1, 1], 32),
+    ],
+    ids=["conv2d_basic", "conv2d_depthwise"],
+)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_conv2d(
+    shapes: List[Shape],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
+    groups: int,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    """Test StableHLOBuilder.conv2d convenience API (NCHW/OIHW)."""
+
+    def module(builder: StableHLOBuilder):
+        @builder.func(shapes, [dtype] * len(shapes))
+        def conv2d(
+            in0: Operand,
+            weight: Operand,
+            builder: StableHLOBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.conv2d(
+                in0,
+                weight,
+                stride=stride,
+                padding=padding,
+                dilation=dilation,
+                groups=groups,
+            )
+
+    compile_and_execute_shlo(
+        module,
+        test_base=request.node.name,
+        target=target,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes,stride,padding,dilation,groups",
+    [
         # Depthwise convolution (groups = input_channels)
         (
             [(1, 32, 28, 28), (32, 1, 3, 3)],

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -6980,6 +6980,91 @@ class StableHLOBuilder(Builder):
 
         return reduce_window_module, reduce_window_builder
 
+    def conv2d(
+        self,
+        in0: Operand,
+        weight: Operand,
+        stride: Union[int, List[int]],
+        padding: Union[int, List[int]],
+        dilation: Union[int, List[int]],
+        groups: int = 1,
+        batch_group_count: int = 1,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        """
+        Convenience wrapper around ``stablehlo.convolution`` for 2D convolution in NCHW/OIHW layout.
+
+        Parameters
+        ----------
+        in0 : Operand
+            Input tensor in NCHW format.
+        weight : Operand
+            Weight tensor in OIHW format.
+        stride : Union[int, List[int]]
+            Convolution stride. Integer applies to both spatial dimensions.
+        padding : Union[int, List[int]]
+            Padding. Integer applies symmetric padding, list supports [h, w] or [top, bottom, left, right].
+        dilation : Union[int, List[int]]
+            Kernel dilation. Integer applies to both spatial dimensions.
+        groups : int
+            Number of groups for grouped convolution.
+        batch_group_count : int
+            StableHLO batch_group_count attribute.
+        output_type : Optional[torch.dtype]
+            Optional output dtype.
+        loc : Optional[str]
+            Optional source location.
+        unit_attrs : Optional[List[str]]
+            Optional list of unit attributes.
+        """
+
+        def _to_2d_list(value: Union[int, List[int]]) -> List[int]:
+            if isinstance(value, int):
+                return [value, value]
+            if len(value) == 1:
+                return [value[0], value[0]]
+            if len(value) == 2:
+                return [value[0], value[1]]
+            raise ValueError(f"Expected int or list of len 1/2, got {value}")
+
+        stride_2d = _to_2d_list(stride)
+        dilation_2d = _to_2d_list(dilation)
+
+        if isinstance(padding, int):
+            padding_4d = [padding, padding, padding, padding]
+        elif len(padding) == 2:
+            padding_4d = [padding[0], padding[0], padding[1], padding[1]]
+        elif len(padding) == 4:
+            # [top, bottom, left, right] -> [top, bottom, left, right]
+            padding_4d = list(padding)
+        else:
+            raise ValueError(f"Expected padding as int or list of len 2/4, got {padding}")
+
+        return self.convolution(
+            in0,
+            weight,
+            window_strides=stride_2d,
+            padding=padding_4d,
+            lhs_dilation=[1, 1],
+            rhs_dilation=dilation_2d,
+            input_batch_dimension=0,
+            input_feature_dimension=1,
+            input_spatial_dimensions=[2, 3],
+            kernel_output_feature_dimension=0,
+            kernel_input_feature_dimension=1,
+            kernel_spatial_dimensions=[2, 3],
+            output_batch_dimension=0,
+            output_feature_dimension=1,
+            output_spatial_dimensions=[2, 3],
+            feature_group_count=groups,
+            batch_group_count=batch_group_count,
+            output_type=output_type,
+            loc=loc,
+            unit_attrs=unit_attrs,
+        )
+
     ############### stablehlo.ConvolutionOp ###############
 
     @tag(stablehlo.ConvolutionOp)


### PR DESCRIPTION
## Summary
- add StableHLOBuilder.conv2d convenience API for 2D convolution in NCHW/OIHW layout
- normalize stride/padding/dilation inputs and delegate to existing stablehlo.convolution builder path
- add golden test coverage in test/python/golden/test_stablehlo_ops.py for basic and depthwise conv2d cases

## Testing
- pytest -q test/python/golden/test_stablehlo_ops.py -k "test_conv2d or test_convolution_groups_dilation" -> failed: ModuleNotFoundError: No module named ttnn
- retry once: PYTHONPATH=python pytest -q test/python/golden/test_stablehlo_ops.py -k "test_conv2d" -> failed: ModuleNotFoundError: No module named ttnn

Fixes #4869