### PR TITLE
Set system sfpi to off by default, except for ci and wheels

### DIFF
--- a/.github/workflows/call-build-release.yml
+++ b/.github/workflows/call-build-release.yml
@@ -121,6 +121,7 @@ jobs:
           -DTTMLIR_ENABLE_STABLEHLO=ON \
           -DTTMLIR_ENABLE_OPMODEL=${{ matrix.build.enable_op_model }} \
           -DTTMLIR_ENABLE_ALCHEMIST_WHEEL=${{ matrix.build.enable_alchemist_whl }} \
+          -DTT_USE_SYSTEM_SFPI=ON \
           -DTT_RUNTIME_DEBUG=${{ matrix.build.enable_runtime_debug }} \
           -S ${{ steps.strings.outputs.work-dir }}
 

--- a/.github/workflows/call-lint.yml
+++ b/.github/workflows/call-lint.yml
@@ -54,6 +54,7 @@ jobs:
         -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
         -DTTMLIR_ENABLE_STABLEHLO=ON \
         -DTTMLIR_ENABLE_OPMODEL=ON \
+        -DTT_USE_SYSTEM_SFPI=ON \
         -S ${{ steps.strings.outputs.work-dir }}
 
     - name: Lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(TTMLIR_ENABLE_TOOLS "Enable building core tools (ttmlir-opt, ttmlir-lsp-s
 option(TTMLIR_ENABLE_ALCHEMIST "Enable tt-alchemist lib" ON)
 option(TTMLIR_ENABLE_ALCHEMIST_WHEEL "Enable tt-alchemist wheel" OFF)  # Expensive to build
 option(CODE_COVERAGE "Enable coverage reporting" OFF)
-option(TT_USE_SYSTEM_SFPI "Use system path for SFPI. SFPI is used to compile firmware." ON)
+option(TT_USE_SYSTEM_SFPI "Use system path for SFPI. SFPI is used to compile firmware." OFF)
 
 if (TTMLIR_ENABLE_RUNTIME)
   option(TT_RUNTIME_ENABLE_TTNN "Enable TTNN Runtime (requires TTMLIR_ENABLE_RUNTIME)" ON)

--- a/python/setup.py
+++ b/python/setup.py
@@ -82,6 +82,7 @@ class CMakeBuild(build_ext):
                 "-DCMAKE_CXX_COMPILER=clang++",
                 "-DTTMLIR_ENABLE_TESTS=OFF",
                 "-DTTMLIR_ENABLE_TOOLS=OFF",
+                "-DTT_USE_SYSTEM_SFPI=ON",
                 "-DTTMLIR_ENABLE_TTNN_JIT=OFF",  # Disable ttnn-jit to avoid circular dependency
             ]
 

--- a/tools/pykernel/setup.py
+++ b/tools/pykernel/setup.py
@@ -70,6 +70,7 @@ class CMakeBuild(build_ext):
             "-DTTMLIR_ENABLE_STABLEHLO=OFF",
             "-DTTMLIR_ENABLE_OPMODEL=OFF",
             "-DTTMLIR_ENABLE_EXPLORER=OFF",
+            "-DTT_USE_SYSTEM_SFPI=ON",
         ]
 
         # Set source

--- a/tools/ttnn-jit/setup.py
+++ b/tools/ttnn-jit/setup.py
@@ -126,6 +126,7 @@ class CMakeBuild(build_ext):
                 "-DTTMLIR_ENABLE_OPMODEL=OFF",
                 "-DTTMLIR_ENABLE_TESTS=OFF",
                 "-DTTMLIR_ENABLE_ALCHEMIST=OFF",
+                "-DTT_USE_SYSTEM_SFPI=ON",
             ]
             cmake_args.extend(["-S", str(source_dir)])
             print(f"Running CMake configure: {' '.join(cmake_args)}")


### PR DESCRIPTION
### Ticket
slack

### Problem description
Set system sfpi to off by default for dev environment.

### What's changed
For CI/wheels make sure system sfpi is set to ON.

### Checklist
- [ ] New/Existing tests provide coverage for changes
- wheel build run: https://github.com/tenstorrent/tt-mlir/actions/runs/22960197324
(manually checked sfpi is system)
