### PR TITLE
[Optimizer] Enable scatterOp layout workaround

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -672,6 +672,6 @@ private:
 const std::set<mlir::StringRef>
     TTNNWorkarounds::TTNNWorkarounds::enabledOpsForWorkaroundWithOptimizer = {
         ttnn::WhereOp::getOperationName(), ttnn::FullOp::getOperationName(),
-        ttnn::EmbeddingOp::getOperationName()};
-
+        ttnn::EmbeddingOp::getOperationName(),
+        ttnn::ScatterOp::getOperationName()};
 } // namespace mlir::tt::ttnn


### PR DESCRIPTION
### Summary
This is the second part of fixing GPT OSS benchmark test in XLA with `optimization_level=1`. When running the test with the fix from #7325, the run hangs on a seemingly unproblematic `FillPad` op. Enabling the scatter workaround from `optimization_level=0` makes the benchmark complete successfully. The connection between these ops is unclear (they are not in the same data pipeline), also it happens on a seemingly random layer event though they all get the same change(one scatter op each layer); the current suspicion is a memory or synchronization issue. Root cause is hard to isolate right now, so this whitelist is the only viable solution at present.

### Checklist
- [x] Final part of fix for benchmark gpt_oss to work with optimization_level=1
