### PR TITLE
Fix MorehCumSumOp missing memory config in flatbuffer translation

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -629,9 +629,7 @@ createOp(FlatbufferObjectCache &cache, MorehCumSumOp op) {
                                             /*local_shape*/ std::nullopt);
 
   auto coreRangeSet = getTensorValueCoreRangeSet(cache, outputType);
-  auto memoryConfig = op.getMemoryConfig()
-                          ? toFlatbuffer(cache, op.getMemoryConfig().value())
-                          : 0;
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 
   return ::tt::target::ttnn::CreateMorehCumSumOp(*cache.fbb, in, output,
                                                  op.getDim(), memoryConfig);


### PR DESCRIPTION
MorehCumSumOp was falling back to no memory config (0) when the op lacked an explicit memory_config attribute, instead of deriving it from the result tensor type. Use getMemoryConfigIfNeeded() like other ops.

