### PR TITLE
TTIR creation ops: add optional dtype for arange/zeros/ones

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -4909,6 +4909,8 @@ def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {
     - `end` (Integer): The end value of the sequence (exclusive).
     - `step` (Integer): The step size between values in the sequence.
     - `arange_dimension` (Integer): The dimension along which to generate the sequence.
+    - `dtype` (Type, optional): Element type override. If specified, must
+      match the result tensor element type.
 
     Output:
     - `result` (Tensor): The generated tensor containing the sequence.
@@ -4917,7 +4919,8 @@ def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {
   let arguments = (ins SI64Attr:$start,
                        SI64Attr:$end,
                        SI64Attr:$step,
-                       I64Attr:$arange_dimension);
+                       I64Attr:$arange_dimension,
+                       OptionalAttr<TypeAttr>:$dtype);
 
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;
@@ -5032,6 +5035,8 @@ class TTIR_NamedFullOp<string mnemonic, list<Trait> traits = []> :
 
     Attributes:
     - `shape` (Array of Integer): The shape of the tensor to create.
+    - `dtype` (Type, optional): Element type override. If specified, must
+      match the result tensor element type.
 
     Output:
     - `result` (Tensor): The created tensor with the specified shape.
@@ -5041,7 +5046,8 @@ class TTIR_NamedFullOp<string mnemonic, list<Trait> traits = []> :
     by providing common argument and result definitions.
   }];
 
-  let arguments = (ins DenseI32ArrayAttr:$shape);
+  let arguments = (ins DenseI32ArrayAttr:$shape,
+                       OptionalAttr<TypeAttr>:$dtype);
 
   let results = (outs AnyRankedTensor:$result);
 }
@@ -5081,6 +5087,7 @@ def TTIR_ZerosOp : TTIR_NamedFullOp<"zeros"> {
     This operation is useful for initializing tensors before filling them with computed values or as a
     starting point for accumulation operations.
   }];
+  let hasVerifier = 1;
 }
 
 def TTIR_OnesOp : TTIR_NamedFullOp<"ones"> {
@@ -5118,6 +5125,7 @@ def TTIR_OnesOp : TTIR_NamedFullOp<"ones"> {
     This operation is useful for initializing tensors before scaling them or as a starting point for
     operations that require tensors filled with ones, such as creating masks or constant multipliers.
   }];
+  let hasVerifier = 1;
 }
 
 def TTIR_EmptyOp : TTIR_CreationOp<"empty", [TTCore_NonCacheableTrait]> {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -821,10 +821,12 @@ public:
     FloatAttr momentumAttr = rewriter.getF32FloatAttr(1.0f);
 
     auto runningMean = rewriter.create<ttir::ZerosOp>(
-        loc, meanType, llvm::to_vector_of<int32_t>(meanType.getShape()));
+        loc, meanType, llvm::to_vector_of<int32_t>(meanType.getShape()),
+        meanType.getElementType());
     auto runningVariance = rewriter.create<ttir::OnesOp>(
         loc, varianceType,
-        llvm::to_vector_of<int32_t>(varianceType.getShape()));
+        llvm::to_vector_of<int32_t>(varianceType.getShape()),
+        varianceType.getElementType());
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::BatchNormTrainingOp>(
         srcOp, TypeRange{outputType, meanType, varianceType},
@@ -4406,7 +4408,7 @@ public:
         this->getTypeConverter()->convertType(srcOp.getResult().getType()));
     rewriter.replaceOpWithNewOp<ttir::ArangeOp>(
         srcOp, outputType, 0, outputType.getDimSize(adaptor.getIotaDimension()),
-        1, adaptor.getIotaDimension());
+        1, adaptor.getIotaDimension(), outputType.getElementType());
 
     // Dynamic Iota has an output_shape attribute but the output shape is
     // already known by the result type This is to remove the operand that
@@ -5431,7 +5433,8 @@ public:
     // idx[i,j].
     auto rowOffsets = rewriter.create<ttir::ArangeOp>(
         loc, indices2DType, /*start=*/0, /*end=*/total,
-        /*step=*/dSort, /*arange_dimension=*/0);
+        /*step=*/dSort, /*arange_dimension=*/0,
+        indices2DType.getElementType());
     Value flatIndices =
         rewriter.create<ttir::AddOp>(loc, indices2DType, rowOffsets, indices2D);
 

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1305,7 +1305,8 @@ public:
         rewriter
             .create<ttir::ArangeOp>( // perform arange on the last dimension to
                                      // match how ttnn behaves
-                op.getLoc(), arangeOutputType, start, end, step, 0)
+                op.getLoc(), arangeOutputType, start, end, step, 0,
+                outputType.getElementType())
             .getResult();
 
     std::vector<int64_t> outputShape = arangeOutputType.getShape().vec();

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -127,8 +127,11 @@ public:
 
     // Get data type, tensor layout, device and memory config
     //
+    Type resultElementType =
+        mlir::cast<RankedTensorType>(op.getResult().getType()).getElementType();
+    Type dtypeType = adaptor.getDtype() ? adaptor.getDtype() : resultElementType;
     ttcore::DataTypeAttr dTypeAttr = ttcore::DataTypeAttr::get(
-        rewriter.getContext(), layoutAttr.getDataType());
+        rewriter.getContext(), ttcore::elementTypeToDataType(dtypeType));
     ttnn::BufferType bufferType = layoutAttr.getBufferType();
     ttnn::LayoutAttr tensorLayoutAttr =
         ttnn::LayoutAttr::get(op.getContext(), layoutAttr.getLayout());
@@ -2637,8 +2640,10 @@ public:
     ttnn::TTNNLayoutAttr ttnnLayoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
 
+    Type dtypeType = adaptor.getDtype() ? adaptor.getDtype()
+                                        : outputType.getElementType();
     ttcore::DataTypeAttr dtypeAttr = rewriter.getAttr<ttcore::DataTypeAttr>(
-        ttcore::elementTypeToDataType(outputType.getElementType()));
+        ttcore::elementTypeToDataType(dtypeType));
 
     mlir::Value device =
         ttnnLayoutAttr.isDeviceBufferType()

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -618,7 +618,31 @@ void mlir::tt::ttir::ClampTensorOp::getCanonicalizationPatterns(
 // ArangeOp
 //===----------------------------------------------------------------------===//
 
+namespace {
+template <typename OpT>
+::mlir::LogicalResult verifyCreationOpDtype(OpT op) {
+  Type dtype = op.getDtype();
+  if (!dtype) {
+    return success();
+  }
+
+  Type outputType = op.getResult().getType().getElementType();
+  if (dtype != outputType) {
+    return op.emitOpError() << "dtype does not match with output tensor type "
+                               "[dtype = '"
+                            << dtype << "', output tensor type = '" << outputType
+                            << "'].";
+  }
+
+  return success();
+}
+} // namespace
+
 ::mlir::LogicalResult mlir::tt::ttir::ArangeOp::verify() {
+  if (failed(verifyCreationOpDtype(*this))) {
+    return failure();
+  }
+
   int64_t start = getStart();
   int64_t end = getEnd();
   int64_t step = getStep();
@@ -643,6 +667,18 @@ void mlir::tt::ttir::ClampTensorOp::getCanonicalizationPatterns(
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ZerosOp / OnesOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::ZerosOp::verify() {
+  return verifyCreationOpDtype(*this);
+}
+
+::mlir::LogicalResult mlir::tt::ttir::OnesOp::verify() {
+  return verifyCreationOpDtype(*this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/creation/creation_dtype_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/creation/creation_dtype_negative.mlir
@@ -1,0 +1,27 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+module {
+  func.func @zeros_dtype_mismatch() -> tensor<4x4xbf16> {
+    // CHECK: error: 'ttir.zeros' op dtype does not match with output tensor type [dtype = 'f32', output tensor type = 'bf16'].
+    %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>, dtype = f32}> : () -> tensor<4x4xbf16>
+    return %0 : tensor<4x4xbf16>
+  }
+}
+
+// -----
+module {
+  func.func @ones_dtype_mismatch() -> tensor<4x4xbf16> {
+    // CHECK: error: 'ttir.ones' op dtype does not match with output tensor type [dtype = 'f32', output tensor type = 'bf16'].
+    %0 = "ttir.ones"() <{shape = array<i32: 4, 4>, dtype = f32}> : () -> tensor<4x4xbf16>
+    return %0 : tensor<4x4xbf16>
+  }
+}
+
+// -----
+module {
+  func.func @arange_dtype_mismatch() -> tensor<8xbf16> {
+    // CHECK: error: 'ttir.arange' op dtype does not match with output tensor type [dtype = 'f32', output tensor type = 'bf16'].
+    %0 = "ttir.arange"() <{start = 0 : si64, end = 8 : si64, step = 1 : si64, arange_dimension = 0 : i64, dtype = f32}> : () -> tensor<8xbf16>
+    return %0 : tensor<8xbf16>
+  }
+}

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -1502,6 +1502,7 @@ class TTIRBuilder(Builder):
             end_attr,
             step_attr,
             arange_dimension_attr,
+            mlir_output_type,
             loc=loc,
         )
         new_op_result = op.result
@@ -1537,6 +1538,11 @@ class TTIRBuilder(Builder):
         end_attr = old_op.end
         step_attr = old_op.step
         arange_dimension_attr = old_op.arange_dimension
+        dtype_attr = (
+            old_op.dtype
+            if old_op.dtype is not None
+            else old_op.result.type.element_type
+        )
 
         new_op = ttir_op(
             result,
@@ -1544,6 +1550,7 @@ class TTIRBuilder(Builder):
             end_attr,
             step_attr,
             arange_dimension_attr,
+            dtype_attr,
             loc=old_op.location,
         )
         new_op_result = new_op.result
@@ -1557,7 +1564,7 @@ class TTIRBuilder(Builder):
             step_attr,
             arange_dimension_attr,
             mesh_shape_attr,
-            old_op.result.type.element_type,
+            dtype_attr,
         )
         self._set_golden_tensor(new_op_result, golden_output)
 
@@ -1590,6 +1597,11 @@ class TTIRBuilder(Builder):
                     end_attr = old_op.end
                     step_attr = old_op.step
                     arange_dimension_attr = old_op.arange_dimension
+                    dtype_attr = (
+                        old_op.dtype
+                        if old_op.dtype is not None
+                        else old_op.result.type.element_type
+                    )
                     result = old_op.result.type
 
                     new_op = ttir_op(
@@ -1598,6 +1610,7 @@ class TTIRBuilder(Builder):
                         end_attr,
                         step_attr,
                         arange_dimension_attr,
+                        dtype_attr,
                         loc=old_op.location,
                     )
                     new_op_result = new_op.result
@@ -1952,6 +1965,7 @@ class TTIRBuilder(Builder):
         op = ttir_op(
             result,
             shape_attr,
+            mlir_output_type,
             loc=loc,
         )
         op_result = op.result
@@ -1978,10 +1992,16 @@ class TTIRBuilder(Builder):
         ttir_op = self.get_opview_from_parser(TTIRBuilder.ones_parser)
         result = old_op.result.type
         shape_attr = old_op.shape
+        dtype_attr = (
+            old_op.dtype
+            if old_op.dtype is not None
+            else old_op.result.type.element_type
+        )
 
         new_op = ttir_op(
             result,
             shape_attr,
+            dtype_attr,
             loc=old_op.location,
         )
         new_op_result = new_op.result
@@ -2019,8 +2039,15 @@ class TTIRBuilder(Builder):
                 @func.func(*op_input_types, name="ones_module")
                 def decorated_func():
                     result = old_op.result.type
+                    dtype_attr = (
+                        old_op.dtype
+                        if old_op.dtype is not None
+                        else old_op.result.type.element_type
+                    )
 
-                    new_op = ttir_op(result, old_op.shape, loc=old_op.location)
+                    new_op = ttir_op(
+                        result, old_op.shape, dtype_attr, loc=old_op.location
+                    )
                     new_op_result = new_op.result
 
                     old_op_result = self._get_golden_tensor(old_op.result)
@@ -2060,6 +2087,7 @@ class TTIRBuilder(Builder):
         op = ttir_op(
             result,
             shape_attr,
+            mlir_output_type,
             loc=loc,
         )
         op_result = op.result
@@ -2086,10 +2114,16 @@ class TTIRBuilder(Builder):
         ttir_op = self.get_opview_from_parser(TTIRBuilder.zeros_parser)
         result = old_op.result.type
         shape_attr = old_op.shape
+        dtype_attr = (
+            old_op.dtype
+            if old_op.dtype is not None
+            else old_op.result.type.element_type
+        )
 
         new_op = ttir_op(
             result,
             shape_attr,
+            dtype_attr,
             loc=old_op.location,
         )
         new_op_result = new_op.result
@@ -2127,10 +2161,16 @@ class TTIRBuilder(Builder):
                 @func.func(*op_input_types, name="zeros_module")
                 def decorated_func():
                     result = old_op.result.type
+                    dtype_attr = (
+                        old_op.dtype
+                        if old_op.dtype is not None
+                        else old_op.result.type.element_type
+                    )
 
                     new_op = ttir_op(
                         result,
                         old_op.shape,
+                        dtype_attr,
                         loc=old_op.location,
                     )
                     new_op_result = new_op.result


### PR DESCRIPTION
## Summary
This PR adds an optional `dtype` attribute to TTIR creation ops:
- `ttir.arange`
- `ttir.zeros`
- `ttir.ones`

and wires it through verification + lowering + builder paths.

## What changed
- ODS:
  - `ArangeOp` now accepts `OptionalAttr<TypeAttr>:$dtype`
  - `TTIR_NamedFullOp` now accepts `OptionalAttr<TypeAttr>:$dtype` (covers both `ones` and `zeros`)
- Verifiers:
  - Added dtype/result-element-type consistency verification for `ArangeOp`, `ZerosOp`, `OnesOp`
- Lowering:
  - TTIR->TTNN conversion now uses op `dtype` when present (falls back to result element type otherwise)
  - Updated StableHLO->TTIR and TTIR decomposition sites that construct `arange/zeros/ones` to pass dtype explicitly
- Builder:
  - Updated TTIR Python builder generation/parse/split flows for `arange/zeros/ones` to preserve dtype
- Tests:
  - Added negative verifier tests for dtype mismatch:
    - `test/ttmlir/Dialect/TTIR/creation/creation_dtype_negative.mlir`

## Validation
- `python3 -m py_compile tools/builder/ttir/ttir_builder.py`

Related to #2094
