### PR TITLE
Add mesh shapes for upcoming quad BH lb, dual t3k

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h
@@ -18,19 +18,24 @@ inline constexpr llvm::StringRef kDefaultMeshName = "mesh";
 inline constexpr llvm::StringRef kTTShardingConstraintTargetName =
     "tt.sharding_constraint";
 
-inline const llvm::SmallVector<llvm::SmallVector<int64_t, 2>, 7>
-    SupportedMeshes = {{{1, 1},
-                        {1, 2},
-                        {1, 4},
-                        {1, 8},
-                        {2, 4},
-                        {1, 32},
-                        {4, 8},
-                        {4, 16},
-                        {4, 32},
-                        {8, 4},
-                        {8, 8},
-                        {8, 16}}};
+inline const llvm::SmallVector<llvm::SmallVector<int64_t, 2>> SupportedMeshes =
+    {{{1, 1},
+      {1, 2},
+      {1, 4},
+      {1, 8},
+      {1, 16},
+      {1, 32},
+      {1, 64},
+      {2, 2},
+      {2, 4},
+      {2, 8},
+      {4, 4},
+      {4, 8},
+      {4, 16},
+      {4, 32},
+      {8, 4},
+      {8, 8},
+      {8, 16}}};
 
 // Check if the meshMap is valid.
 // todo: https://github.com/tenstorrent/tt-mlir/issues/4668


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3127?issue=tenstorrent%7Ctt-xla%7C3583

### Problem description
We can only open a 1x16 mesh over the dual t3k.
We also need 4x4 to support upcoming dual BH LB cluster in CI.

### What's changed
Add 1x16, 1x,64, 2x2 2x8 and 4x4 to supported mesh shapes.

### Checklist
- [ ] New/Existing tests provide coverage for changes
