### PR TITLE
Add perf credentials to the collect data job

### DIFF
--- a/.github/workflows/workflow-run-collect-data.yml
+++ b/.github/workflows/workflow-run-collect-data.yml
@@ -28,4 +28,6 @@ jobs:
           sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
           sftp_optest_host: ${{ secrets.SFTP_OP_TEST_WRITER_HOSTNAME }}
           sftp_optest_user: ${{ secrets.SFTP_OP_TEST_WRITER_USERNAME }}
+          sftp_perf_host: ${{ secrets.SFTP_PERF_WRITER_HOSTNAME }}
+          sftp_perf_user: ${{ secrets.SFTP_PERF_WRITER_USERNAME }}
           ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
/

### Problem description
tt-mlir can't send perf reports to superset.

### What's changed
Pass perf credentials to the collect data job.

### Checklist
- [ ] New/Existing tests provide coverage for changes
