### PR TITLE
[Optimizer] Remove unused tensorL1UsageCap pass-level options

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -325,10 +325,6 @@ def TTNNOperationValidationAndFallback: Pass<"ttnn-operation-validation-and-fall
     to find working configurations.
   }];
   let options = [
-    Option<"tensorL1UsageCap",
-           "tensor-l1-usage-cap",
-           "float", /*default=*/"1.0",
-           "Limit L1 memory usage to this fraction of available space (0.0-1.0)">,
     Option<"maxFallbackAttempts",
            "max-fallback-attempts",
            "uint32_t", /*default=*/"10000",
@@ -349,13 +345,6 @@ def TTNNRowMajorLayoutPropagation : Pass<"ttnn-rm-layout-propagation", "::mlir::
 
     This pass should run before the optimizer to provide better initial layout hints.
   }];
-
-  let options = [
-    Option<"tensorL1UsageCap",
-           "tensor-l1-usage-cap",
-           "float", /*default=*/"1.0",
-           "Limit L1 memory usage to this fraction of available space (0.0-1.0)">
-  ];
 }
 
 def TTNNEmitPyWorkarounds: Pass<"ttnn-emitpy-workarounds", "::mlir::ModuleOp"> {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -108,7 +108,6 @@ void createTTNNPipelineAnalysisPasses(
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
 
     ttnn::TTNNOperationValidationAndFallbackOptions validationOptions;
-    validationOptions.tensorL1UsageCap = options.tensorL1UsageCap;
     validationOptions.maxFallbackAttempts = options.maxFallbackAttempts;
 
     pm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
@@ -47,10 +47,6 @@ public:
   using impl::TTNNRowMajorLayoutPropagationBase<
       TTNNRowMajorLayoutPropagation>::TTNNRowMajorLayoutPropagationBase;
 
-  TTNNRowMajorLayoutPropagation(TTNNRowMajorLayoutPropagationOptions options)
-      : impl::TTNNRowMajorLayoutPropagationBase<TTNNRowMajorLayoutPropagation>(
-            std::move(options)) {}
-
   void runOnOperation() final {
 #ifndef TTMLIR_ENABLE_OPMODEL
     llvm::llvm_unreachable_internal(


### PR DESCRIPTION
### Summary
Remove `tensorL1UsageCap` option from TTNNOperationValidationAndFallback and TTNNRowMajorLayoutPropagation  pass definitions in `Passes.td`. These passes read the value from the module attribute (set by DevicePassesWrapper) via `utils::getTensorL1UsageCap()`, so the pass-level options were redundant and unused.

### Checklist
- [ ] New/Existing tests provide coverage for changes
