### PR TITLE
Expand `getOperandShardingAttr` to resolve sharding through collective ops

### DIFF
--- a/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/ShardyUtils.cpp
@@ -378,6 +378,7 @@ getOutShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
 // 1) func.func entry-block arg attrs
 // 2) sdy.manual_computation region arg per-value attrs
 // 3) OpResult per-value attrs
+// 4) OpResult inherent "out_sharding" property (e.g. all_gather)
 // Falls back to full replicate if none found.
 mlir::sdy::TensorShardingAttr
 getOperandShardingAttr(const mlir::OpOperand &operand,
@@ -416,6 +417,10 @@ getOperandShardingAttr(const mlir::OpOperand &operand,
         unsigned i = (resNo < shardings.size()) ? resNo : 0u; // broadcast-safe
         result = shardings[i];
       }
+    } else if (auto outSharding =
+                   mlir::dyn_cast_or_null<mlir::sdy::TensorShardingAttr>(
+                       owner->getAttr("out_sharding"))) {
+      result = outSharding;
     }
   }
 

--- a/test/ttmlir/Dialect/StableHLO/global_to_local_shape/ccl_out_sharding.mlir
+++ b/test/ttmlir/Dialect/StableHLO/global_to_local_shape/ccl_out_sharding.mlir
@@ -1,0 +1,22 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --split-input-file --update-global-to-local-shapes -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Test that out_sharding from all_gather is used to determine local shapes
+// for downstream ops (e.g. slice indices).
+module @SyncTensorsGraph.6 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @main(%arg0: tensor<32x2880x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {"_axis_1"}, {}]>, ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<16x720x2880xbf16>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<i64> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<i64>>, ttcore.shard_status = #ttcore.shard_status<presharded>}, tensor<2880x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_1", ?}, {?}]>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<720x2880xbf16>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) {
+    %0:2 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{"_axis_0"}, {"_axis_1"}, {}]>] out_shardings=[<@mesh, []>, <@mesh, [{"_axis_1", ?}, {?}]>] manual_axes={} (%arg1: tensor<32x2880x2880xbf16>) {
+      // CHECK: stablehlo.slice
+      // CHECK-SAME: [0:1, 0:720, 0:2880]
+      %c = stablehlo.constant dense<0> : tensor<i64>
+      %1 = sdy.all_gather [{"_axis_0"}, {}, {}] %arg1 out_sharding=<@mesh, [{}, {"_axis_1"}, {}]> : tensor<32x2880x2880xbf16>
+      %2 = stablehlo.slice %1 [0:1, 0:2880, 0:2880] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{?}, {"_axis_1", ?}, {?}]>]>} : (tensor<32x2880x2880xbf16>) -> tensor<1x2880x2880xbf16>
+      %3 = stablehlo.reshape %2 {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{"_axis_1", ?}, {?}]>]>} : (tensor<1x2880x2880xbf16>) -> tensor<2880x2880xbf16>
+      sdy.return %c, %3 : tensor<i64>, tensor<2880x2880xbf16>
+    } : (tensor<32x2880x2880xbf16>) -> (tensor<i64>, tensor<2880x2880xbf16>)
+    return %0#0, %0#1 : tensor<i64>, tensor<2880x2880xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket


### Problem description
The `getOperandShardingAttr` fails to resolve the output sharding of shardy collective ops (e.g. `sdy.all_gather`)

These ops store their output sharding as an inherent attribute (`out_sharding`) in the op's Properties struct, not as a generic `sdy.sharding` discardable attribute. The function only checked for the latter, so it fell through to the default fully-replicated sharding.

This caused `UpdateGlobalToLocalShapes` to leave slice indices at global sizes when the slice operand came from a collective op which resulted in error `limit index 2880 is larger than dimension size 720 in dimension 1` (for the test written in this PR).

The pattern arises in MoE models where expert weights are sharded on two mesh axes (experts + hidden dim). Selecting a single expert triggers an `all_gather` on the expert axis, but the hidden dim remains sharded. The subsequent slice's
limits were not updated to reflect the local (sharded) hidden dim size.

### What's changed
Added check for `out_sharding` attribute as the last fallback.

### Checklist
- [ ] New/Existing tests provide coverage for changes
