### PR TITLE
Revert "Fix ttrt run output readback for multi-device presharded outp…

### DIFF
--- a/test/ttmlir/Silicon/StableHLO/n300/sdy_presharded.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n300/sdy_presharded.mlir
@@ -1,7 +1,6 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-pipeline="mesh-shape=1,2 result-presharded=0" --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,2" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
-// RUN: ttrt run %t.ttnn
 
 module {
   sdy.mesh @mesh = <["x"=1, "batch"=2]>

--- a/tools/ttrt/common/run.py
+++ b/tools/ttrt/common/run.py
@@ -826,32 +826,21 @@ class Run:
                                 start_get_output = time.perf_counter_ns()
                                 output_host = ttrt.runtime.to_host(
                                     runtime_output_tensor, untilize=True
-                                )
-                                if (
-                                    len(program.output_tensors[i]) > 1
-                                    and bin.extension != ".ttm"
-                                ):
-                                    output_shards = ttrt.runtime.get_device_tensors(
-                                        outputs[i]
-                                    )
-                                    for shard_idx in range(len(output_host)):
-                                        ttrt.runtime.memcpy(
-                                            output_shards[shard_idx],
-                                            output_host[shard_idx],
-                                        )
-                                else:
-                                    combined_output_tensor = output_host[0]
-                                    if bin.extension != ".ttm":
-                                        combined_output_tensor = ttrt.runtime.create_multi_device_host_tensor_from_shards(
-                                            [output_host[0]], {}, (1, 1)
-                                        )
-                                    ttrt.runtime.memcpy(
-                                        outputs[i],
-                                        combined_output_tensor,
-                                    )
+                                )[0]
                                 end_get_output = time.perf_counter_ns()
                                 e2e_duration_nanoseconds_output += (
                                     end_get_output - start_get_output
+                                )
+
+                                combined_output_tensor = output_host
+                                if bin.extension != ".ttm":
+                                    combined_output_tensor = ttrt.runtime.create_multi_device_host_tensor_from_shards(
+                                        [output_host], {}, (1, 1)
+                                    )
+
+                                ttrt.runtime.memcpy(
+                                    outputs[i],
+                                    combined_output_tensor,
                                 )
                                 ttrt.runtime.deallocate_tensor(
                                     runtime_output_tensor, force=True


### PR DESCRIPTION
…uts (#7399)"

This reverts commit 1de2d7cf07e52be600b54f219d344eaae4d3fe53.

### Ticket
#7461

### Problem description
The original commit (#7399) modified the output readback path in `tools/ttrt/common/run.py` to handle presharded multi-device outputs. However, it introduced a regression that causes `ttrt run` to fail on all multichip models in the device perf nightly