### PR TITLE
Update .gitignore to allow for Claude skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@ third_party/ttnn-python
 .DS_STORE
 .vscode/*
 .cache
-.claude/*
-!.claude/skills/
+.claude/settings.local.json
 *pycache*
 *.egg-info
 cluster_descriptor.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,3 @@ targets tt-metal.
   set the environment variable `SYSTEM_DESC_PATH=$(pwd)/ttrt-artifacts/system_desc.ttsys`.
 - `ttrt run ...`: Runs a compiler generated flatbuffer on silicon.  Can either
   point to a flatbuffer file or a directory containing flatbuffers.
-
-# Claude skills
-- project level skills live in `.claude/skills` dir
-- personal skills should live in `.claude/skills-local` dir


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Whole of `.claude/` was git ignored, not allowing for claude skills to be added.

### What's changed
Add rule to exclude `.claude/skills/` from `.gitignore`.

Personal (local) claude skills should be put in `.claude/skills-local/`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
