### PR TITLE
Add macro guards around flatbuffers-specific code

### DIFF
--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -14,7 +14,6 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
-#include <fstream>
 #endif
 
 #include "mlir/IR/Builders.h"
@@ -28,6 +27,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <fstream>
 #include <numeric>
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.cpp.inc"
@@ -282,9 +282,8 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
     MLIRContext *context, StringRef path,
     llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
 #ifdef TTMLIR_NO_FLATBUFFERS
-  diagFn() << "loading system descriptor from file requires flatbuffers "
-              "support (disabled by TTMLIR_NO_FLATBUFFERS)";
-  return failure();
+  return diagFn() << "loading system descriptor from file requires flatbuffers "
+                     "support (disabled by TTMLIR_NO_FLATBUFFERS)";
 #else
   if (path.empty()) {
     diagFn() << "system desc path must not be empty";
@@ -309,9 +308,9 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
     MLIRContext *context, void *systemDesc,
     llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
 #ifdef TTMLIR_NO_FLATBUFFERS
-  diagFn() << "loading system descriptor from buffer requires flatbuffers "
-              "support (disabled by TTMLIR_NO_FLATBUFFERS)";
-  return failure();
+  return diagFn()
+         << "loading system descriptor from buffer requires flatbuffers "
+            "support (disabled by TTMLIR_NO_FLATBUFFERS)";
 #else
   // Read relevant information from binary
   const auto *binarySystemDescRoot =


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Downstream consumers that build a minimal subset of tt-mlir (e.g., TTKernel, TTCore dialects) do not need flatbuffers, but `TTCoreOpsTypes.cpp` unconditionally includes flatbuffer-generated headers and depends on flatbuffer deserialization code, creating a transitive (false) dependency.

### What's changed
Guard flatbuffer includes and the bodies of `SystemDescAttr::getFromPath` / `getFromBuffer` behind `#ifndef TTMLIR_NO_FLATBUFFERS`. When the macro is defined, the methods return a diagnostic error instead. No change to the public API or tt-mlir's build behavior.

### Checklist
- [x] New/Existing tests provide coverage for changes
