### PR TITLE
Speedup docker image build

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -30,7 +30,6 @@ apt-get install -y -qq \
     doxygen \
     graphviz \
     libyaml-cpp-dev \
-    libboost-all-dev \
     curl \
     jq \
     sudo \
@@ -45,6 +44,9 @@ apt-get install -y -qq python3.12 python3.12-dev python3.12-venv
 wget -q https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_DEPENDENCIES_COMMIT}/{install_dependencies.sh,tt_metal/sfpi-info.sh,tt_metal/sfpi-version}
 chmod u+x sfpi-info.sh
 bash install_dependencies.sh --docker
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 # ANCHOR_END: developer_dependencies
 EOT
 
@@ -52,7 +54,11 @@ EOT
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod u+x llvm.sh && \
     ./llvm.sh 17 && \
-    apt install -y libc++-17-dev libc++abi-17-dev && \
+    apt-get update && \
+    apt-get install -y libc++-17-dev libc++abi-17-dev && \
+    rm llvm.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/bin/clang-17 /usr/bin/clang && \
     ln -s /usr/bin/clang++-17 /usr/bin/clang++ && \
     ln -s /usr/bin/clangd-17 /usr/bin/clangd
@@ -62,21 +68,11 @@ RUN python3.12 -m pip install --no-cache-dir --break-system-packages cmake \
     sphinx \
     sphinx-markdown-builder
 
-# Install Googletest
-RUN git clone https://github.com/google/googletest.git -b release-1.12.1 && \
-    cd googletest && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DBUILD_GMOCK=OFF && \
-    make && \
-    make install && \
-    cd ../.. && \
-    rm -rf googletest
-
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt update \
-    && apt install -y gh \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/* \
     && gh --version

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -1,30 +1,16 @@
 ARG FROM_TAG=latest
 
 # Multi-stage build to optimize for both base and ci images
-# This stage handles the expensive GDB build that can be shared
-FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-24-04:${FROM_TAG} AS gdb-builder
+# This stage creates a shared install script
+FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-24-04:${FROM_TAG} AS ird-builder
 SHELL ["/bin/bash", "-c"]
 
 # Set environment variables for build stage
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install build dependencies for GDB
-RUN apt-get install -y libmpfr-dev
-
-# Build GDB 16.3 (this is the expensive part we want to cache)
-RUN wget https://mirror.csclub.uwaterloo.ca/gnu/gdb/gdb-16.3.tar.gz && \
-    # wget https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.gz && \
-    # use specific mirror because of CIv2 runner white listing issues
-    tar -xzf gdb-16.3.tar.gz && \
-    cd gdb-16.3 && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    cd .. && \
-    rm -rf gdb-16.3 gdb-16.3.tar.gz
-
 RUN echo " \
   apt-get update && apt-get install -y \
+    gdb \
     ssh \
     sudo \
     wget \
@@ -33,6 +19,7 @@ RUN echo " \
     tmux \
     psmisc \
     bash-completion \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*" > _install.sh && chmod +x _install.sh
 
 # Base image stage
@@ -45,16 +32,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 
 # Copy and run the install script
-COPY --from=gdb-builder /_install.sh /_install.sh
+COPY --from=ird-builder /_install.sh /_install.sh
 RUN /_install.sh && rm /_install.sh
 
 # Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
     chmod -R 777 $TTMLIR_TOOLCHAIN_DIR
-
-# Copy the pre-built GDB from the builder stage
-COPY --from=gdb-builder /usr/local /usr/local
-RUN gdb --version
 
 # CI image stage
 ARG FROM_TAG=latest
@@ -66,13 +49,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 
 # Copy and run the install script
-COPY --from=gdb-builder /_install.sh /_install.sh
+COPY --from=ird-builder /_install.sh /_install.sh
 RUN /_install.sh && rm /_install.sh
 
 # Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
     chmod -R 777 $TTMLIR_TOOLCHAIN_DIR
-
-# Copy the pre-built GDB from the builder stage
-COPY --from=gdb-builder /usr/local /usr/local
-RUN gdb --version

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -3,16 +3,24 @@ if (NOT TTMLIR_ENABLE_RUNTIME OR (NOT TT_RUNTIME_ENABLE_TTNN AND NOT TT_RUNTIME_
 endif()
 
 enable_testing()
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-FetchContent_MakeAvailable(googletest)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  target_compile_options(gtest PRIVATE -Wno-covered-switch-default)
+# Prefer system-installed GTest with FetchContent fallback
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  message(STATUS "System GTest not found, fetching from source")
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  )
+  FetchContent_MakeAvailable(googletest)
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(gtest PRIVATE -Wno-covered-switch-default)
+  endif()
+else()
+  message(STATUS "Using system GTest")
 endif()
 
 include(GoogleTest)

--- a/tools/explorer/Dockerfile.explorer
+++ b/tools/explorer/Dockerfile.explorer
@@ -39,7 +39,6 @@ apt-get install -y \
     graphviz \
     jq \
     lcov \
-    libboost-all-dev \
     libcapstone-dev \
     libgtest-dev \
     libhwloc-dev \


### PR DESCRIPTION
### What's changed
- Remove the slow GDB build and just use the apt version, according to survey almost no one uses it and the one in u2404 is recent enough (v15).
- Follow what's done by other docker files and clean apt cache and index in the main docker file to reduce image size.
- Consolidate the three gtest installations: remove outdated manual docker build, tell runtime test to fallback to its own build only if it's not found in the system (u2404 comes with gtest 1.14).
- Remove the unused Boost dependency, tt-metal downloads its own anyway.