### PR TITLE
Builder: promote bf16 MM to f32 to avoid slow fallback path

### DIFF
--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -254,7 +254,7 @@ def test_matmul_ttnn_shapes_double_buffered(
     ],
     ids=shape_str,
 )
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_matmul_1d_shapes(
     shape: tuple[int, ...],

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -84,6 +84,9 @@ class GoldenMapTensor:
         for name in _MUTATING_METHOD_NAMES
     }
 
+    # Torch matmul functions that are too slow on CPUs w/o hardware bf16 support.
+    _BF16_UPCAST_MM_FUNCS = frozenset({torch.matmul, torch.mm, torch.bmm, torch.einsum})
+
     # ----- Methods -----
 
     def __init__(self, shard_map: Dict[int, torch.Tensor], mesh_shape: Tuple[int, int]):
@@ -255,6 +258,28 @@ class GoldenMapTensor:
             if isinstance(obj, dict):
                 return {kk: _take(v, k) for kk, v in obj.items()}
             return obj
+
+        # Transparently upcast bf16 matmul to f32 and cast back so it uses the fast BLAS backend.
+        if func in cls._BF16_UPCAST_MM_FUNCS and any(
+            st.dtype == torch.bfloat16 for st in st_inputs
+        ):
+            _orig_func = func
+            # Torch promotes mixed-precision matmuls (bf16 @ f32 -> f32), so we only downcast if there's no f32.
+            has_f32_input = any(st.dtype == torch.float32 for st in st_inputs)
+
+            print(f"Upcasting bf16 matmul to f32 for {_orig_func.__name__}")
+
+            def func(*a, **kw):
+                a = tuple(
+                    x.float()
+                    if isinstance(x, torch.Tensor) and x.dtype == torch.bfloat16
+                    else x
+                    for x in a
+                )
+                result = _orig_func(*a, **kw)
+                if not has_f32_input:
+                    return result.to(torch.bfloat16)
+                return result
 
         # Apply func shard-wise.
         out_shards = {k: func(*_take(args, k), **_take(kwargs, k)) for k in keys}


### PR DESCRIPTION
### Problem description
The CPU in our CI runners does not have AVX-512 support and so torch bf16 matmul will skip MKL and fallback to its extremely slow single-threaded internal implementation ([reference](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cpu/BlasKernel.cpp)).
As we add more tests that involve matmul, they will take a very large amount of time in the CI.

### How to solve it
Intercept bf16 matmul in builder, and transparently dispatch it to faster alternatives.
Option 1: the JAX team provides the [ml_dtypes](https://github.com/jax-ml/ml_dtypes) numpy plugin that provides bf16 matmul kernels for numpy.
Option 2: simply upcast bf16 tensors to f32, pass them to torch matmul, and downcast the result if none of the input was f32 (torch auto-promotes `bf16 @ f32 -> f32`).

In test script [bf16-matmul-perf-pcc.py](https://github.com/user-attachments/files/26000231/bf16-matmul-perf-pcc.py), the performance & accuracy of these two approaches are compared against torch-native bf16 matmul on EPYC 7352.

```
NumPy 2.1.2, ml_dtypes 0.5.4, PyTorch 2.9.1+cpu
CPU threads: torch.get_num_threads() = 12
Warmup: 2, Iterations: N=512: 300, N=1024: 30, N=2048: 3

Approach             N   Time(ms)     GFLOPS
--------------------------------------------
torch bf16         512     205.92       1.30
torch f32 cast     512       0.44     615.55
numpy bf16         512       1.09     246.97
torch bf16        1024    3161.72       0.68
torch f32 cast    1024       3.05     703.13
numpy bf16        1024      13.35     160.91
torch bf16        2048   63016.58       0.27
torch f32 cast    2048      22.92     749.49
numpy bf16        2048      35.40     485.36


=== Summary: GFLOPS by approach ===

    N |      torch bf16  torch f32 cast      numpy bf16
-------------------------------------------------------
  512 |            1.30          615.55          246.97
 1024 |            0.68          703.13          160.91
 2048 |            0.27          749.49          485.36


=== Correctness: PCC vs torch native bf16 (reference) ===

    N | torch f32 cast     numpy bf16
----------------------------------------
  512 |     1.00000000     0.99999863
 1024 |     1.00000000     0.99999862
 2048 |     1.00000000     0.99999863
```

The results showed that the upcast approach is both faster & perfectly accurate, which makes sense considering how similar the binary representation of bf16 & f32 are, and how optimized MKL is.

Running `test/python/golden/test_metal_matmul.py` before and after the change (w/ hot kernel cache):
**21min 4s -> 1min 10s**

TTNN builder bf16 matmul tests in `test_ttnn_ops.py` also enjoy this speedup and can serve as a cross-validation.