### PR TITLE
[ttrt] Add fabric config option for ttrt perf

### DIFF
--- a/.github/test_scripts/ttrt.sh
+++ b/.github/test_scripts/ttrt.sh
@@ -14,6 +14,6 @@ echo "Running TTRT tests"
 # to test directory names (e.g. n300-llmbox runner uses the llmbox test directory)
 TTRT_TEST_PATH=$(eval echo "$2")
 TTRT_TEST_PATH="${TTRT_TEST_PATH//n300-llmbox/llmbox}"
-ttrt "$1" "$BUILD_DIR/test/ttmlir/$TTRT_TEST_PATH" $3
+ttrt "$1" "$BUILD_DIR/test/ttmlir/$TTRT_TEST_PATH" "${@:3}"
 cp ${1}_results.json ${TTRT_REPORT_PATH} || true
 cp ttrt_report.xml $TEST_REPORT_PATH || true

--- a/tools/ttrt/common/perf.py
+++ b/tools/ttrt/common/perf.py
@@ -141,6 +141,13 @@ class Perf:
             help="Enable benchmark mode with warmup and e2e time measurements (automatically enables program cache)",
         )
         Perf.register_arg(
+            name="--fabric-config",
+            type=str,
+            default="fabric_1d",
+            choices=None,
+            help="Select fabric topology: disabled, fabric_1d, fabric_1d_ring, fabric_2d, fabric_2d_torus_x, fabric_2d_torus_y, fabric_2d_torus_xy or custom (case-insensitive, default: fabric_1d)",
+        )
+        Perf.register_arg(
             name="binary",
             type=str,
             default="",
@@ -437,6 +444,11 @@ class Perf:
 
                     if self["--benchmark"]:
                         command_options += " --benchmark "
+
+                    if self["--fabric-config"] is not None:
+                        command_options += (
+                            f" --fabric-config {self['--fabric-config']} "
+                        )
 
                     if self["--ignore-version"]:
                         command_options += " --ignore-version "


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/7378)

### Problem description
`ttrt perf` is not working for ring ops on galaxy as it uses `ttrt run` without fabric config set to ring.

### What's changed
Added `--fabric-config` option for `ttrt perf`.

For profiling llama 70b on galaxy, use `ttrt perf --fabric-config fabric_1d_ring`.

Once this is merged and uplifted in tt-xla, it should be used in perf benchmark, like on [this branch.](https://github.com/tenstorrent/tt-xla/compare/mvasiljevic/add_perf_fabric_config)

### Checklist
- [ ] New/Existing tests provide coverage for changes
