### PR TITLE
[D2M] [WIP]use proper stream dst for stream_layout's cb

### DIFF
--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -177,11 +177,16 @@ public:
         args.push_back(operand);
       }
 
-      // Use hoisted CB if one exists for this operand, otherwise the
-      // operand itself (or view input) is both the buffer and the CB.
+      // Use hoisted CB if one exists for this operand.  Otherwise the
+      // buffer itself is the CB.  For streams/views we must unwrap to
+      // the underlying buffer so the stream_layout/view_layout op
+      // doesn't stay alive in the output IR.
       auto it = hoistedCBMap.find(i);
       if (it != hoistedCBMap.end()) {
         cbs.push_back(it->second);
+      } else if (auto stream = mlir::dyn_cast_if_present<d2m::StreamLayoutOp>(
+                     operand.getDefiningOp())) {
+        cbs.push_back(stream.getInput());
       } else if (auto view = mlir::dyn_cast_if_present<d2m::ViewLayoutOp>(
                      operand.getDefiningOp())) {
         cbs.push_back(view.getInput());

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -127,32 +127,29 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     SymbolTable symbolTable(op->getParentOfType<ModuleOp>());
 
-    // Phase 1: Scan additional args to build a map from I/O operand index
+    // Scan additional args to build a map from I/O operand index
     // to its hoisted CB, and collect other additional args separately.
     unsigned ioSize = op.getInputsAndOutputs().size();
     DenseMap<unsigned, Value> hoistedCBMap;
     llvm::SmallVector<Value> extraArgs;
-    llvm::SmallVector<Value> extraCBs;
-    llvm::SmallVector<int64_t> extraCBPorts;
-    int64_t cbPort = static_cast<int64_t>(ioSize);
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operand = adaptor.getOperands()[ioSize + i];
       if (mlir::isa<ttmetal::GlobalSemaphoreType>(operand.getType())) {
         extraArgs.push_back(operand);
       } else if (mlir::isa<MemRefType>(operand.getType())) {
         // Hoisted CB buffer (already converted to CreateBufferOp by
-        // MemrefAllocRewriter).  If it backs a regular operand, record
-        // the mapping; otherwise collect as an extra CB entry.
-        if (auto cbForOp =
-                operand.getDefiningOp()
-                    ? operand.getDefiningOp()->getAttrOfType<IntegerAttr>(
-                          "d2m.cb_for_operand")
-                    : IntegerAttr()) {
-          hoistedCBMap[static_cast<unsigned>(cbForOp.getInt())] = operand;
-        } else {
-          extraCBs.push_back(operand);
-          extraCBPorts.push_back(cbPort++);
+        // MemrefAllocRewriter).  Must be tagged with the I/O operand
+        // index it backs.
+        auto cbForOp =
+            operand.getDefiningOp()
+                ? operand.getDefiningOp()->getAttrOfType<IntegerAttr>(
+                      "d2m.cb_for_operand")
+                : IntegerAttr();
+        if (!cbForOp) {
+          op.emitOpError("memref additional arg missing d2m.cb_for_operand");
+          return failure();
         }
+        hoistedCBMap[static_cast<unsigned>(cbForOp.getInt())] = operand;
       } else {
         op.emitOpError(
             "unexpected operand type in d2m.generic's additionalArgs: ")
@@ -161,7 +158,7 @@ public:
       }
     }
 
-    // Phase 2: Process I/O operands, using hoisted CBs where available.
+    // Process I/O operands, using hoisted CBs where available.
     llvm::SmallVector<Value> args;
     llvm::SmallVector<Value> cbs;
     llvm::SmallVector<int64_t> cbPorts;
@@ -195,10 +192,8 @@ public:
       cbPorts.push_back(static_cast<int64_t>(i));
     }
 
-    // Append non-I/O additional args and CBs.
+    // Append non-I/O additional args (semaphores).
     args.append(extraArgs);
-    cbs.append(extraCBs);
-    cbPorts.append(extraCBPorts);
 
     ArrayAttr threads = op.getThreads();
     auto physicalGridShape = op.getPhysicalGridShape();

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -127,56 +127,31 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     SymbolTable symbolTable(op->getParentOfType<ModuleOp>());
 
-    llvm::SmallVector<Value> remappedBuffers;
-    llvm::SmallVector<Value> cbs;
-    llvm::SmallVector<int64_t> cbPorts;
-    llvm::SmallVector<Value> args;
-    int64_t cbPort = 0;
-    for (unsigned i = 0; i < op.getInputsAndOutputs().size(); ++i) {
-      auto operand = adaptor.getOperands()[i];
-
-      if (auto stream = mlir::dyn_cast_if_present<d2m::StreamLayoutOp>(
-              operand.getDefiningOp());
-          stream) {
-        args.push_back(stream.getInput());
-        remappedBuffers.push_back(rewriter.getRemappedValue(stream.getInput()));
-        cbs.push_back(rewriter.getRemappedValue(stream.getInput()));
-      } else if (auto view = mlir::dyn_cast_if_present<d2m::ViewLayoutOp>(
-                     operand.getDefiningOp());
-                 view) {
-        args.push_back(view.getInput());
-        remappedBuffers.push_back(rewriter.getRemappedValue(view.getInput()));
-        cbs.push_back(view.getInput());
-      } else {
-        args.push_back(operand);
-        remappedBuffers.push_back(rewriter.getRemappedValue(operand));
-        cbs.push_back(operand);
-      }
-
-      cbPorts.push_back(cbPort++);
-    }
-
-    // Add additional args.
+    // Phase 1: Scan additional args to build a map from I/O operand index
+    // to its hoisted CB, and collect other additional args separately.
     unsigned ioSize = op.getInputsAndOutputs().size();
+    DenseMap<unsigned, Value> hoistedCBMap;
+    llvm::SmallVector<Value> extraArgs;
+    llvm::SmallVector<Value> extraCBs;
+    llvm::SmallVector<int64_t> extraCBPorts;
+    int64_t cbPort = static_cast<int64_t>(ioSize);
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operand = adaptor.getOperands()[ioSize + i];
       if (mlir::isa<ttmetal::GlobalSemaphoreType>(operand.getType())) {
-        args.push_back(operand);
+        extraArgs.push_back(operand);
       } else if (mlir::isa<MemRefType>(operand.getType())) {
         // Hoisted CB buffer (already converted to CreateBufferOp by
-        // MemrefAllocRewriter).  If it backs a regular operand, override
-        // that operand's CB; otherwise add as a new CB entry.
+        // MemrefAllocRewriter).  If it backs a regular operand, record
+        // the mapping; otherwise collect as an extra CB entry.
         if (auto cbForOp =
                 operand.getDefiningOp()
                     ? operand.getDefiningOp()->getAttrOfType<IntegerAttr>(
                           "d2m.cb_for_operand")
                     : IntegerAttr()) {
-          unsigned idx = static_cast<unsigned>(cbForOp.getInt());
-          assert(idx < cbs.size() && "d2m.cb_for_operand out of range");
-          cbs[idx] = operand;
+          hoistedCBMap[static_cast<unsigned>(cbForOp.getInt())] = operand;
         } else {
-          cbs.push_back(operand);
-          cbPorts.push_back(cbPort++);
+          extraCBs.push_back(operand);
+          extraCBPorts.push_back(cbPort++);
         }
       } else {
         op.emitOpError(
@@ -185,6 +160,45 @@ public:
         return failure();
       }
     }
+
+    // Phase 2: Process I/O operands, using hoisted CBs where available.
+    llvm::SmallVector<Value> args;
+    llvm::SmallVector<Value> cbs;
+    llvm::SmallVector<int64_t> cbPorts;
+    for (unsigned i = 0; i < ioSize; ++i) {
+      auto operand = adaptor.getOperands()[i];
+
+      if (auto stream = mlir::dyn_cast_if_present<d2m::StreamLayoutOp>(
+              operand.getDefiningOp());
+          stream) {
+        args.push_back(stream.getInput());
+      } else if (auto view = mlir::dyn_cast_if_present<d2m::ViewLayoutOp>(
+                     operand.getDefiningOp());
+                 view) {
+        args.push_back(view.getInput());
+      } else {
+        args.push_back(operand);
+      }
+
+      // Use hoisted CB if one exists for this operand, otherwise the
+      // operand itself (or view input) is both the buffer and the CB.
+      auto it = hoistedCBMap.find(i);
+      if (it != hoistedCBMap.end()) {
+        cbs.push_back(it->second);
+      } else if (auto view = mlir::dyn_cast_if_present<d2m::ViewLayoutOp>(
+                     operand.getDefiningOp())) {
+        cbs.push_back(view.getInput());
+      } else {
+        cbs.push_back(operand);
+      }
+
+      cbPorts.push_back(static_cast<int64_t>(i));
+    }
+
+    // Append non-I/O additional args and CBs.
+    args.append(extraArgs);
+    cbs.append(extraCBs);
+    cbPorts.append(extraCBPorts);
 
     ArrayAttr threads = op.getThreads();
     auto physicalGridShape = op.getPhysicalGridShape();

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -133,7 +133,7 @@ static RankedTensorType convertMemrefToTTNNTensor(MLIRContext *ctx,
 namespace {
 
 // Helper struct to extract and return both IO and CB from a d2m.generic
-// operand.
+// operand.  The CB field is only meaningful when no hoisted CB overrides it.
 struct IOAndCB {
   Value io;
   Value cb;
@@ -464,21 +464,9 @@ public:
             ctx, ttnn::CoreCoordAttr::get(ctx, 0, 0),
             ttnn::CoreCoordAttr::get(ctx, endCoreRange[0], endCoreRange[1])));
 
-    llvm::SmallVector<Value> ios(ioSize);
-    llvm::SmallVector<Value> cbs(ioSize);
-    llvm::SmallVector<Value> adaptorInputsAndOutputs(
-        adaptor.getOperands().begin(), adaptor.getOperands().begin() +
-                                           adaptor.getInputs().size() +
-                                           adaptor.getOutputs().size());
-    for (auto [i, orig, converted] :
-         llvm::enumerate(op.getInputsAndOutputs(), adaptorInputsAndOutputs)) {
-      auto [io, cb] = extractIOAndCBFromGenericOperand(orig, converted);
-      ios[i] = io;
-      cbs[i] = cb;
-    }
-
-    // Process additionalArgs: semaphores/tensors go to the GenericOp,
-    // hoisted CB allocs override the corresponding CB descriptor.
+    // Scan additional args to build a map from I/O operand index
+    // to its hoisted CB, and collect other additional args separately.
+    DenseMap<unsigned, Value> hoistedCBMap;
     llvm::SmallVector<Value> additionalArgs;
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operand = adaptor.getOperands()[ioSize + i];
@@ -488,18 +476,17 @@ public:
       // *original* operand because MemrefAllocRewriter may have already
       // converted the alloc to a ttnn.empty (tensor type).  Use the
       // original memref for CB descriptor derivation.
-      if (auto cbForOp =
-              origOperand.getDefiningOp()
-                  ? origOperand.getDefiningOp()->getAttrOfType<IntegerAttr>(
-                        "d2m.cb_for_operand")
-                  : IntegerAttr()) {
-        unsigned idx = static_cast<unsigned>(cbForOp.getInt());
-        TT_assertv(idx < cbs.size(), "d2m.cb_for_operand out of range");
-        cbs[idx] = origOperand;
-        continue;
-      }
-      if (mlir::isa<MemRefType>(operand.getType())) {
-        cbs.push_back(operand);
+      if (mlir::isa<MemRefType>(origOperand.getType())) {
+        auto cbForOp =
+            origOperand.getDefiningOp()
+                ? origOperand.getDefiningOp()->getAttrOfType<IntegerAttr>(
+                      "d2m.cb_for_operand")
+                : IntegerAttr();
+        if (!cbForOp) {
+          op.emitOpError("memref additional arg missing d2m.cb_for_operand");
+          return failure();
+        }
+        hoistedCBMap[static_cast<unsigned>(cbForOp.getInt())] = origOperand;
       } else if (mlir::isa<ttnn::GlobalSemaphoreType>(operand.getType())) {
         additionalArgs.push_back(operand);
       } else if (mlir::isa<RankedTensorType>(operand.getType())) {
@@ -510,6 +497,23 @@ public:
             << operand.getType();
         return failure();
       }
+    }
+
+    // Process I/O operands, using hoisted CBs where available.
+    llvm::SmallVector<Value> ios(ioSize);
+    llvm::SmallVector<Value> cbs(ioSize);
+    llvm::SmallVector<Value> adaptorInputsAndOutputs(
+        adaptor.getOperands().begin(), adaptor.getOperands().begin() +
+                                           adaptor.getInputs().size() +
+                                           adaptor.getOutputs().size());
+    for (auto [i, orig, converted] :
+         llvm::enumerate(op.getInputsAndOutputs(), adaptorInputsAndOutputs)) {
+      auto [io, cb] = extractIOAndCBFromGenericOperand(orig, converted);
+      ios[i] = io;
+      // Use hoisted CB if one exists for this operand, otherwise use
+      // the CB derived from the operand itself.
+      auto it = hoistedCBMap.find(i);
+      cbs[i] = it != hoistedCBMap.end() ? it->second : cb;
     }
 
     // Create CB descriptors.

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -167,6 +167,13 @@ struct MemrefValueContext {
 
 using OperandDefChain = llvm::SmallVector<Operation *, 4>;
 
+struct OperandDefChainAnalysis {
+  Value root;
+  MemRefType type;
+  bool containsStreamLayout = false;
+  bool containsViewLayout = false;
+};
+
 struct OperandContext {
   // Link to the operand in the incoming IR.
   OpOperand *operand = nullptr;
@@ -186,6 +193,8 @@ struct OperandContext {
   bool isOutput = false;
   // `true` if this operand already has a stream in the incoming IR.
   bool hasStream = false;
+  // `true` if this operand's defining chain contains a `d2m.view_layout`.
+  bool hasViewLayout = false;
   // To be able to plan possible pressure on L1, this precomputes
   // the type of the stream buffer this operand would have.
   MemRefType bufferType;
@@ -207,9 +216,6 @@ struct GenericOpContext {
   OperandContextList operands;
   // Pre-computed block factors for the modified op.
   SmallVector<int64_t> reblockedFactors;
-  // Generic ops in "DMA-only" form currently operate in alias mode
-  // and do not use operand streams.
-  bool isDMAOnly = false;
   // Generic ops in "explicit datamovement" form have no static
   // iteration space (indexing maps, etc) information.
   bool isExplicitDatamovement = false;
@@ -623,7 +629,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       // a planner-assigned L1 address and will be stamped with
       // CBLayoutAttr.
       if (genericIt != analysis.generics.end() &&
-          !genericIt->second.isDMAOnly &&
           !genericIt->second.isExplicitDatamovement) {
         for (Region &region : genericOp->getRegions()) {
           for (const OperandContext &operandCtx : genericIt->second.operands) {
@@ -651,14 +656,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
               continue;
             }
             auto memrefType = allocOp.getType();
-            // Inner allocs may lack a memory space before remapping;
-            // ensure they are registered as L1 so the planner can
-            // assign them an address.
-            if (!memrefType.getMemorySpace()) {
-              memrefType = MemRefType::get(memrefType.getShape(),
-                                           memrefType.getElementType(),
-                                           memrefType.getLayout(), L1Attr);
-            }
             MemrefValueContext &ctx = addMemrefValueContext(
                 rewriter, analysis, allocOp.getResult(), memrefType, device);
             ctx.live = {genericSeqPos, genericSeqPos};
@@ -712,11 +709,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                                          d2m::GenericOp genericOp) {
     GenericOpContext &genericCtx = analysis.generics[genericOp];
 
-    // Detect generic ops in "DMA-only" form: they must not
-    // insert operand streams and therefore have no associated memory
-    // allocation needs.
-    genericCtx.isDMAOnly = genericOp.isDMAOnlyForm();
-
     // Detect generic ops in "explicit datamovement" form: they do not have
     // iteration space (indexing maps, etc) information and can't be analyzed
     // by this pass. However, a `GenericOpContext` entry must still be created
@@ -728,9 +720,9 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
   // Internal helper used by `analyzeGenericOps()` to create analysis entries
   // for each operand of `genericOp`.
-  void createOperandContexts(FuncAnalysisData &analysis,
-                             d2m::GenericOp genericOp,
-                             GenericOpContext &genericCtx) {
+  LogicalResult createOperandContexts(FuncAnalysisData &analysis,
+                                      d2m::GenericOp genericOp,
+                                      GenericOpContext &genericCtx) {
     [[maybe_unused]] AsOperandPrinter asOperand{genericOp->getParentOp()};
     [[maybe_unused]] ttcore::DeviceAttr device =
         ttcore::lookupDevice(genericOp);
@@ -836,12 +828,22 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       // `operandCtx.defChain` and updates this memref's slot in
       // `analysis.memrefs`.
 
-      MemRefType memrefType = nullptr;
-      std::tie(operandCtx.root, memrefType, operandCtx.hasStream) =
-          analyzeOperandDefChain(genericOp, operand.get(), operandCtx.defChain);
+      FailureOr<OperandDefChainAnalysis> operandDefChainAnalysis =
+          analyzeOperandDefChain(genericOp, operand.get(),
+                                 static_cast<int32_t>(operandIndex),
+                                 operandCtx.defChain);
+      if (failed(operandDefChainAnalysis)) {
+        return failure();
+      }
+      operandCtx.root = operandDefChainAnalysis->root;
+      MemRefType memrefType = operandDefChainAnalysis->type;
+      operandCtx.hasStream = operandDefChainAnalysis->containsStreamLayout;
+      operandCtx.hasViewLayout = operandDefChainAnalysis->containsViewLayout;
       TT_ALLOC_DEBUG(
-          "\tadding memref value ctx: root {}, memref type {}, has stream: {}",
-          asOperand(operandCtx.root), memrefType, operandCtx.hasStream);
+          "\tadding memref value ctx: root {}, memref type {}, has stream: {}, "
+          "has view layout: {}",
+          asOperand(operandCtx.root), memrefType, operandCtx.hasStream,
+          operandCtx.hasViewLayout);
 
       Value operandValue = operandCtx.operand->get();
 
@@ -938,6 +940,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         }
       }
     }
+
+    return success();
   }
 
   /// Populate `analysis.generics`:
@@ -968,17 +972,25 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     MLIRContext *ctx = &getContext();
     IRRewriter rewriter(ctx);
 
-    [[maybe_unused]] int32_t genericsInDMAOnlyForm = 0;
     [[maybe_unused]] int32_t genericsInExplicitDatamovementForm = 0;
 
-    funcBody.walk([&](d2m::GenericOp genericOp) {
-      GenericOpContext &genericCtx = createGenericContext(analysis, genericOp);
+    if (funcBody
+            .walk([&](d2m::GenericOp genericOp) -> WalkResult {
+              GenericOpContext &genericCtx =
+                  createGenericContext(analysis, genericOp);
 
-      genericsInDMAOnlyForm += genericCtx.isDMAOnly;
-      genericsInExplicitDatamovementForm += genericCtx.isExplicitDatamovement;
+              genericsInExplicitDatamovementForm +=
+                  genericCtx.isExplicitDatamovement;
 
-      createOperandContexts(analysis, genericOp, genericCtx);
-    });
+              if (failed(
+                      createOperandContexts(analysis, genericOp, genericCtx))) {
+                return WalkResult::interrupt();
+              }
+              return WalkResult::advance();
+            })
+            .wasInterrupted()) {
+      return failure();
+    }
 
     if (TT_DEBUG_ENABLED()) {
       for ([[maybe_unused]] auto &[value, valueCtx] : analysis.memrefs) {
@@ -993,9 +1005,9 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       };
     }
 
-    TT_ALLOC_DEBUG("collected {} generic op context(s) ({} DMA-only, {} "
+    TT_ALLOC_DEBUG("collected {} generic op context(s) ({} "
                    "explicit datamovement)",
-                   analysis.generics.size(), genericsInDMAOnlyForm,
+                   analysis.generics.size(),
                    genericsInExplicitDatamovementForm);
 
     return success();
@@ -1026,8 +1038,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     Planner::Problem &problem = analysis.problem(MemorySpace::DeviceL1);
 
     for (auto &[memref, memrefCtx] : analysis.memrefs) {
+      // Inner allocs (inside generic regions) are always L1 even if the
+      // memref type lacks a memory space (e.g. from bufferized tensor.empty).
       const MemorySpace memspace =
-          ttcore::getMemorySpace(memrefCtx.type, MemorySpace::System);
+          memrefCtx.isInsideGeneric
+              ? MemorySpace::DeviceL1
+              : ttcore::getMemorySpace(memrefCtx.type, MemorySpace::System);
       if (!ttcore::isDeviceMemorySpace(memspace)) {
         continue;
       }
@@ -1169,7 +1185,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       const auto &memInfo = memSpaces[ordinal(MemorySpace::DeviceDRAM)];
 
       for (auto &[memref, memrefCtx] : analysis.memrefs) {
-        if (!isDeviceMemorySpace(memrefCtx.type, MemorySpace::System)) {
+        if (!memrefCtx.isInsideGeneric &&
+            !isDeviceMemorySpace(memrefCtx.type, MemorySpace::System)) {
           continue;
         }
 
@@ -1229,7 +1246,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     IRRewriter rewriter(funcOp->getContext());
 
     for (auto &[memref, memrefCtx] : analysis.memrefs) {
-      if (!isDeviceMemorySpace(memrefCtx.type, MemorySpace::System)) {
+      if (!memrefCtx.isInsideGeneric &&
+          !isDeviceMemorySpace(memrefCtx.type, MemorySpace::System)) {
         continue;
       }
       memref::AllocOp allocOp = memref.getDefiningOp<memref::AllocOp>();
@@ -1267,10 +1285,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
     llvm::DenseSet<Operation *> visited;
     for (const auto &[genericOp, genericCtx] : analysis.generics) {
-      if (genericCtx.isDMAOnly) {
-        // Generics in "DMA only" form do not use streams.
-        continue;
-      }
       if (genericCtx.isExplicitDatamovement) {
         // Generics in "explicit datamovement" form manage their own
         // streams which should already be present in the incoming IR.
@@ -1380,14 +1394,23 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         TT_debug(memrefIt2 != analysis.memrefs.end());
         const MemorySpace operandMemSpace = *memrefIt2->second.remappedMemSpace;
 
-        // Get the CB argument type for this operand
+        // Get the CB argument type for this operand. Some generics do not have
+        // an in-region get_cb/alloc yet at this point, so fall back to the
+        // analyzed stream buffer type when needed.
         TT_assert(!genericOp->getRegions().empty());
         Region &region = genericOp->getRegions().front();
         TT_assert(region.hasOneBlock());
         Value operandAlloc =
             d2m::GenericOp::getOperandAlloc(region, operandIndex);
-        TT_assert(operandAlloc);
-        Type cbUnderlyingType = operandAlloc.getType();
+        Type cbUnderlyingType;
+        if (operandAlloc) {
+          cbUnderlyingType = operandAlloc.getType();
+        } else {
+          cbUnderlyingType = operandCtx.bufferType;
+        }
+        if (!cbUnderlyingType) {
+          continue;
+        }
         // Unwrap CBType to get the underlying memref/tensor type.
         if (auto cbType = mlir::dyn_cast<d2m::CBType>(cbUnderlyingType)) {
           cbUnderlyingType = cbType.getUnderlying();
@@ -1748,8 +1771,9 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       return true;
     }
 
+    // DMA-only generics are expected to stream all operands.
     if (genericOp.isDMAOnlyForm()) {
-      return false;
+      return true;
     }
 
     // Non-trivial views need a stream to represent the implied data movement.
@@ -1946,13 +1970,15 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   ///  the actual type of this Value or the type it is being cast to by a ttnn
   ///  bridge cast).
   ///
-  static std::tuple<Value, MemRefType, bool>
+  static FailureOr<OperandDefChainAnalysis>
   analyzeOperandDefChain(d2m::GenericOp genericOp, Value operand,
+                         int32_t operandIndex,
                          SmallVector<Operation *, 4> &chain) {
     [[maybe_unused]] AsOperandPrinter asOperand{genericOp->getParentOp()};
 
+    OperandDefChainAnalysis analysis;
     MemRefType type = nullptr;
-    bool containsStream = false;
+    bool previousWasViewLayout = false;
 
     Value value = operand;
     Operation *definingOp = value.getDefiningOp();
@@ -1960,13 +1986,13 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     while (definingOp != nullptr) {
       chain.emplace_back(definingOp);
 
-      if (auto op = llvm::dyn_cast<memref::AllocOp>(definingOp)) {
+      if (auto op = mlir::dyn_cast<memref::AllocOp>(definingOp)) {
         if (type == nullptr) {
           type = mlir::cast<MemRefType>(op->getResultTypes().front());
         }
         break;
       }
-      if (auto op = llvm::dyn_cast<ttir::TTNNMetalLayoutCastOp>(definingOp)) {
+      if (auto op = mlir::dyn_cast<ttir::TTNNMetalLayoutCastOp>(definingOp)) {
         value = op.getInput();
         if (type == nullptr) {
           type = mlir::cast<MemRefType>(op->getResultTypes().front());
@@ -1974,14 +2000,22 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
         break;
       }
 
-      if (auto op = llvm::dyn_cast<d2m::ViewLayoutOp>(definingOp)) {
+      if (auto op = mlir::dyn_cast<d2m::ViewLayoutOp>(definingOp)) {
+        TT_assertv(!previousWasViewLayout,
+                   "operand #{} has a defining chain with back-to-back "
+                   "d2m.view_layout ops",
+                   operandIndex);
+        analysis.containsViewLayout = true;
+        previousWasViewLayout = true;
         value = op.getInput();
-      } else if (auto op = llvm::dyn_cast<d2m::StreamLayoutOp>(definingOp)) {
+      } else if (auto op = mlir::dyn_cast<d2m::StreamLayoutOp>(definingOp)) {
         value = op.getInput();
-        containsStream = true;
+        analysis.containsStreamLayout = true;
+        previousWasViewLayout = false;
       } else if (auto op =
-                     llvm::dyn_cast<d2m::CreateGlobalSemaphoreOp>(definingOp)) {
+                     mlir::dyn_cast<d2m::CreateGlobalSemaphoreOp>(definingOp)) {
         value = op.getInput();
+        previousWasViewLayout = false;
       } else {
         TT_assertv(false,
                    "unexpected op '{}' in the def chain for operand '{}'",
@@ -1999,7 +2033,9 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       type = mlir::cast<MemRefType>(arg.getType());
     }
 
-    return {value, type, containsStream};
+    analysis.root = value;
+    analysis.type = type;
+    return analysis;
   }
 
   // Factor out defaults passed into DeviceAttr::getMemrefSizeBytes()

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -651,6 +651,14 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
               continue;
             }
             auto memrefType = allocOp.getType();
+            // Inner allocs may lack a memory space before remapping;
+            // ensure they are registered as L1 so the planner can
+            // assign them an address.
+            if (!memrefType.getMemorySpace()) {
+              memrefType = MemRefType::get(memrefType.getShape(),
+                                           memrefType.getElementType(),
+                                           memrefType.getLayout(), L1Attr);
+            }
             MemrefValueContext &ctx = addMemrefValueContext(
                 rewriter, analysis, allocOp.getResult(), memrefType, device);
             ctx.live = {genericSeqPos, genericSeqPos};

--- a/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
+++ b/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
@@ -232,6 +232,12 @@ public:
         continue;
       }
 
+      // Skip allocs that were hoisted outside the generic by HoistCBAllocs.
+      // These are real CB buffers managed via the additional-args mechanism.
+      if (allocOp->getParentRegion() != remoteLoad->getParentRegion()) {
+        continue;
+      }
+
       // Find the last use of the alloc result or remote_load result BEFORE we
       // modify the IR
       Block *block = allocOp->getBlock();
@@ -325,6 +331,11 @@ public:
         remoteStore.emitWarning(
             "could not find memref.alloc for local buffer operand, skipping "
             "conversion");
+        continue;
+      }
+
+      // Skip allocs hoisted outside the generic by HoistCBAllocs.
+      if (allocOp->getParentRegion() != remoteStore->getParentRegion()) {
         continue;
       }
 

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
@@ -4,15 +4,12 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
-#include "ttmlir/Asserts.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/PatternMatch.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
-#include "ttmlir/Utils.h"
-
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/PatternMatch.h"
+#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 
@@ -22,15 +19,18 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Helper function to check if an operand is remote (i.e., comes from a view op
-// such as view_layout or stream_layout).
-static bool isRemoteOperand(Value operand, Operation *op) {
-  Operation *defOp = operand.getDefiningOp();
-  if (!defOp) {
-    return false;
+static LogicalResult verifyGenericOperand(Operation *op, Value memrefOperand) {
+  GenericOp generic = op->getParentOfType<GenericOp>();
+  if (!generic) {
+    return op->emitError("must be nested in d2m.generic");
   }
-  // Remote operands are those that come from ops implementing ViewOpInterface
-  return mlir::isa<ViewOpInterface>(defOp);
+
+  if (!llvm::is_contained(generic.getInputsAndOutputs(), memrefOperand)) {
+    return op->emitError(
+        "must access a d2m.generic input/output operand as its memref operand");
+  }
+
+  return success();
 }
 
 // Helper function to find the ReserveOp that produces a given value,
@@ -60,141 +60,95 @@ static ReserveOp findReserveOp(Value value) {
   return nullptr;
 }
 
-// Recognize and simplify the load-store idiom where a remote_load and
-// remote_store share the same local buffer:
-//   %buffer = memref.alloc()
-//   %loaded = remote_load %buffer %input[indices]
-//   %result = remote_store %output[indices] %buffer
-// One of the operands is always a local CB, so this load-store pair can
-// always be simplified to either a load or a store to a local CB, eliminating
-// the other op and avoiding a redundant copy.
-static void simplifyLoadStorePairs(ModuleOp moduleOp, IRRewriter &rewriter,
-                                   CBCache &cache, PortCounter &portCounters) {
-  SmallVector<std::pair<RemoteLoadOp, RemoteStoreOp>> loadStorePairsToSimplify;
-  moduleOp->walk([&](GenericOp generic) {
-    // Collect all candidate load-store pairs in the generic region
-    generic->walk([&](RemoteStoreOp storeOp) {
-      if (!storeOp.isImplicitForm()) {
-        return;
-      }
-      Value localBuffer = storeOp.getLocalBuffer();
-      if (!localBuffer) {
-        return;
-      }
-
-      // Find a RemoteLoadOp that uses the same localBuffer
-      RemoteLoadOp matchingLoadOp = nullptr;
-      for (Operation *user : localBuffer.getUsers()) {
-        if (auto loadOp = mlir::dyn_cast<RemoteLoadOp>(user)) {
-          if (loadOp.isImplicitForm() &&
-              loadOp.getLocalBuffer() == localBuffer) {
-            matchingLoadOp = loadOp;
-            break;
-          }
-        }
-      }
-
-      if (!matchingLoadOp) {
-        return;
-      }
-
-      // Found a load-store pair sharing the same localBuffer
-      loadStorePairsToSimplify.push_back({matchingLoadOp, storeOp});
-    });
-  });
-
-  // Simplify each load-store pair
-  for (auto [loadOp, storeOp] : loadStorePairsToSimplify) {
-    Location loc = loadOp.getLoc();
-    GenericOp generic = loadOp->getParentOfType<GenericOp>();
-    if (!generic) {
+// Replace only uses owned by operations in the given block. This avoids
+// rewriting enclosing d2m.generic operands to values defined inside the region.
+static void replaceUsesInBlock(Value from, Value to, Block *block,
+                               Operation *excludedUser = nullptr) {
+  SmallVector<OpOperand *> usesToReplace;
+  for (OpOperand &use : from.getUses()) {
+    Operation *owner = use.getOwner();
+    if (owner == excludedUser || owner->getBlock() != block) {
       continue;
     }
-
-    // Determine which operand is remote (has a view/stream layout)
-    // In dma-only form, one operand typically has a view transformation
-    Value loadMemref = loadOp.getMemref();
-    Value storeMemref = storeOp.getMemref();
-
-    // Find operand indices (verification guarantees these exist)
-    auto opOperands = generic->getOpOperands();
-    auto *loadOperandIt = llvm::find_if(opOperands, [&](OpOperand &opOperand) {
-      return opOperand.get() == loadMemref;
-    });
-    auto *storeOperandIt = llvm::find_if(opOperands, [&](OpOperand &opOperand) {
-      return opOperand.get() == storeMemref;
-    });
-    TT_assert((loadOperandIt != opOperands.end() &&
-               storeOperandIt != opOperands.end()));
-    TT_assert(generic.getNumRegions() == 1u);
-
-    // Get CB values for the input and output operands.
-    Value inputCB = findAssociatedCB(loadOp.getOperation(), loadMemref,
-                                     rewriter, cache, portCounters);
-    Value outputCB = findAssociatedCB(storeOp.getOperation(), storeMemref,
-                                      rewriter, cache, portCounters);
-    TT_assert((inputCB && outputCB));
-
-    rewriter.setInsertionPoint(loadOp);
-
-    // Case A: Load from remote (input has view layout) -> load into output CB
-    // Case B: Store to remote (output has view layout) -> store from input CB
-    bool isRemoteLoad = isRemoteOperand(loadMemref, loadOp.getOperation());
-    bool isRemoteStore = isRemoteOperand(storeMemref, storeOp.getOperation());
-
-    TT_assert(!(isRemoteLoad && isRemoteStore));
-    // When neither operand is remote (e.g., L1-to-L1 layout conversions in
-    // TTNN mode where operands come from TTNNMetalLayoutCastOp rather than
-    // ViewOpInterface), both the load and store are needed — skip
-    // simplification.
-    if (!isRemoteLoad && !isRemoteStore) {
-      continue;
-    }
-    if (!isRemoteStore) {
-      // Create the explicit CB form of remote_load (no localBuffer, has CB
-      // operand)
-      rewriter.create<RemoteLoadOp>(loc, loadMemref, loadOp.getIndices(),
-                                    outputCB, loadOp.getMcastStartIndex(),
-                                    loadOp.getMcastShape());
-    } else {
-      rewriter.create<RemoteStoreOp>(loc, storeMemref, loadOp.getIndices(),
-                                     inputCB);
-    }
-
-    // Get the shared localBuffer before erasing operations
-    Value localBuffer = loadOp.getLocalBuffer();
-    memref::AllocOp allocToErase = nullptr;
-    if (localBuffer) {
-      allocToErase = mlir::dyn_cast_if_present<memref::AllocOp>(
-          localBuffer.getDefiningOp());
-    }
-
-    // Erase the original load and store operations
-    rewriter.eraseOp(storeOp);
-    rewriter.eraseOp(loadOp);
-
-    // Erase the shared alloc if it's now unused
-    if (allocToErase && allocToErase->use_empty()) {
-      rewriter.eraseOp(allocToErase);
-    }
+    usesToReplace.push_back(&use);
+  }
+  for (OpOperand *use : usesToReplace) {
+    use->set(to);
   }
 }
 
+// Find the first remote_store in reserveOp's block that consumes the same CB
+// and appears after reserveOp.
+static RemoteStoreOp getFirstFollowingRemoteStoreForCb(ReserveOp reserveOp,
+                                                       Value cb) {
+  if (!reserveOp || !cb) {
+    return nullptr;
+  }
+
+  for (Operation *op = reserveOp->getNextNode(); op; op = op->getNextNode()) {
+    auto remoteStore = mlir::dyn_cast<RemoteStoreOp>(op);
+    if (remoteStore && remoteStore.getCb() == cb) {
+      return remoteStore;
+    }
+  }
+
+  return nullptr;
+}
+
 // Structure to hold information needed for push/pop insertion
+struct PendingPopInfo {
+  Value cb;
+  Location loc;
+  Block *insertionBlock;
+};
+
 struct PushPopInfo {
-  SmallVector<std::pair<Value, Location>> cbsNeedingPop;
+  SmallVector<PendingPopInfo> popsNeedingInsertion;
   SmallVector<std::pair<ReserveOp, Value>> reserveOpsNeedingPush;
 };
 
+// Validate shared local-buffer forwarding legality between an implicit
+// remote_load and implicit remote_store users. If forwarding is legal, returns
+// the unique store user that can be folded into the forward-able pair path.
+static LogicalResult getLegalForwardableStore(RemoteLoadOp remoteLoad,
+                                              Value localBuffer,
+                                              RemoteStoreOp &forwardableStore) {
+  forwardableStore = nullptr;
+  if (!localBuffer) {
+    return success();
+  }
+
+  forwardableStore = utils::findForwardableStore(remoteLoad);
+  if (forwardableStore) {
+    if (remoteLoad.isMcast()) {
+      return remoteLoad.emitOpError(
+          "multicast d2m.remote_load cannot be forwarded to d2m.remote_store");
+    }
+    return success();
+  }
+
+  // findForwardableStore returned null. If any implicit store users of the
+  // local buffer exist, the pattern is illegal at this point in the pipeline.
+  for (Operation *user : localBuffer.getUsers()) {
+    auto storeUser = mlir::dyn_cast<RemoteStoreOp>(user);
+    if (!storeUser || !storeUser.isImplicitForm() ||
+        storeUser.getLocalBuffer() != localBuffer) {
+      continue;
+    }
+    return remoteLoad.emitOpError("local buffer shared between "
+                                  "d2m.remote_load and d2m.remote_store must "
+                                  "form an exclusive forward-able pair");
+  }
+
+  return success();
+}
+
 // Pass A: Convert all remote_load and remote_store into explicit CB form.
 // Returns information needed for push/pop insertion.
-static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
-                                           IRRewriter &rewriter, CBCache &cache,
-                                           PortCounter &portCounters) {
-  PushPopInfo info;
-
-  // Pre-process generics with load-store idiom
-  simplifyLoadStorePairs(moduleOp, rewriter, cache, portCounters);
+static LogicalResult convertToExplicitCBForm(ModuleOp moduleOp,
+                                             IRRewriter &rewriter,
+                                             PushPopInfo &info, CBCache &cache,
+                                             PortCounter &portCounters) {
 
   // Transform RemoteLoadOp (implicit form -> explicit CB form)
   SmallVector<RemoteLoadOp> remoteLoadsToConvert;
@@ -209,30 +163,63 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
   for (RemoteLoadOp remoteLoad : remoteLoadsToConvert) {
     Location loc = remoteLoad.getLoc();
     Value memref = remoteLoad.getMemref();
+
+    if (failed(verifyGenericOperand(remoteLoad.getOperation(), memref))) {
+      return failure();
+    }
+
     Value assocCb = remoteLoad.isImplicitForm()
                         ? findAssociatedCB(remoteLoad.getOperation(), memref,
                                            rewriter, cache, portCounters)
                         : remoteLoad.getCb();
 
     if (!assocCb) {
-      remoteLoad.emitWarning("could not find associated CB block argument, "
-                             "skipping conversion");
-      continue;
+      remoteLoad.emitError(
+          "could not find associated CB block argument for memref operand");
+      return failure();
     }
 
     // Get the local buffer (destination) from implicit form remote_load
     // Downstream operations may reference this buffer directly
     Value localBuffer = remoteLoad.getLocalBuffer();
-    // Only erase allocs that live inside the generic (local working buffers).
-    // Hoisted CB allocs live outside as additionalArgs and must not be erased.
-    GenericOp generic = remoteLoad->getParentOfType<GenericOp>();
     memref::AllocOp allocToErase = nullptr;
-    if (localBuffer) {
+    RemoteStoreOp forwardableStore = nullptr;
+    // Check if the local buffer is a hoisted CB (defined outside the
+    // generic by HoistCBAllocs, passed via additionalArgs).  These are
+    // real CB buffers that legitimately share between load and store —
+    // skip forwarding validation and alloc erasure.
+    bool isHoistedCB = localBuffer && localBuffer.getDefiningOp() &&
+                       localBuffer.getDefiningOp()->getParentRegion() !=
+                           remoteLoad->getParentRegion();
+    if (localBuffer && !isHoistedCB) {
       if (auto allocOp = mlir::dyn_cast_if_present<memref::AllocOp>(
               localBuffer.getDefiningOp())) {
-        if (generic && generic->isAncestor(allocOp)) {
-          allocToErase = allocOp;
+        allocToErase = allocOp;
+      }
+      if (failed(getLegalForwardableStore(remoteLoad, localBuffer,
+                                          forwardableStore))) {
+        return failure();
+      }
+    }
+
+    Value loadTargetCb = assocCb;
+    bool eraseForwardableStoreWithoutReplacement = false;
+    if (forwardableStore) {
+      Value storeMemref = forwardableStore.getMemref();
+      bool storeMemrefIsStreamBacked =
+          mlir::isa_and_nonnull<StreamLayoutOp>(storeMemref.getDefiningOp());
+      if (!storeMemrefIsStreamBacked) {
+        // If the forwardable store targets a local generic operand (no stream),
+        // load directly into that output operand's CB and drop the store.
+        loadTargetCb =
+            findAssociatedCB(forwardableStore.getOperation(), storeMemref,
+                             rewriter, cache, portCounters);
+        if (!loadTargetCb) {
+          forwardableStore.emitError(
+              "could not find associated CB for forwarded memref operand");
+          return failure();
         }
+        eraseForwardableStoreWithoutReplacement = true;
       }
     }
 
@@ -240,11 +227,44 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
 
     // Create the explicit CB form of remote_load (no localBuffer, no result,
     // has CB operand) d2m.remote_load %memref[indices] into %cb
-    rewriter.create<RemoteLoadOp>(loc, memref, remoteLoad.getIndices(), assocCb,
-                                  remoteLoad.getMcastStartIndex(),
-                                  remoteLoad.getMcastShape());
+    auto explicitRemoteLoad = rewriter.create<RemoteLoadOp>(
+        loc, memref, remoteLoad.getIndices(), loadTargetCb,
+        remoteLoad.getMcastStartIndex(), remoteLoad.getMcastShape());
 
-    // Create wait operation to produce the result value
+    // Forward-able pair:
+    //   remote_load %buf %in[...]
+    //   remote_store %out[...] %buf
+    // Lower both to the same CB without introducing reserve/push.
+    //
+    // When the store remains as an explicit remote_store that consumes the same
+    // CB as the load, wait/pop stay implicit in that store path and must not be
+    // materialized here. If the store folds away entirely (e.g. the forwarded
+    // destination is a local generic operand), the remote_load becomes the lone
+    // consumer and we must still materialize wait/pop.
+    if (forwardableStore) {
+      rewriter.setInsertionPointAfter(explicitRemoteLoad);
+      if (eraseForwardableStoreWithoutReplacement) {
+        auto waitOp = rewriter.create<WaitOp>(loc, loadTargetCb);
+        if (remoteLoad.getResult()) {
+          replaceUsesInBlock(remoteLoad.getResult(), waitOp.getResult(),
+                             remoteLoad->getBlock(), remoteLoad.getOperation());
+        }
+        info.popsNeedingInsertion.push_back(
+            {loadTargetCb, loc, remoteLoad->getBlock()});
+      } else {
+        rewriter.create<RemoteStoreOp>(
+            forwardableStore.getLoc(), forwardableStore.getMemref(),
+            forwardableStore.getIndices(), loadTargetCb);
+      }
+      rewriter.eraseOp(forwardableStore);
+      rewriter.eraseOp(remoteLoad);
+      if (allocToErase) {
+        rewriter.eraseOp(allocToErase);
+      }
+      continue;
+    }
+
+    // Create wait operation to produce the result value.
     // %in = d2m.wait %cb
     auto waitOp = rewriter.create<WaitOp>(loc, assocCb);
 
@@ -275,29 +295,28 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
       }
     }
 
-    // Replace uses of the local buffer with the wait result.
-    // Only replace uses inside the generic's regions — the local buffer may
-    // be an additionalArg (hoisted CB alloc) whose operand on the generic op
-    // itself must not be touched.
+    // Replace all uses of the local buffer with the wait result
+    // This is important because downstream operations may reference the
+    // localBuffer directly (e.g., remote_store using the alloc result)
     if (localBuffer) {
-      rewriter.replaceUsesWithIf(
-          localBuffer, waitOp.getResult(), [&](OpOperand &use) {
-            return generic && generic->isProperAncestor(use.getOwner());
-          });
+      replaceUsesInBlock(localBuffer, waitOp.getResult(),
+                         remoteLoad->getBlock(), remoteLoad.getOperation());
     }
 
     // Replace all uses of remote_load result with wait result
     if (remoteLoad.getResult()) {
-      rewriter.replaceAllUsesWith(remoteLoad.getResult(), waitOp.getResult());
+      replaceUsesInBlock(remoteLoad.getResult(), waitOp.getResult(),
+                         remoteLoad->getBlock(), remoteLoad.getOperation());
     }
 
     // Track CB that needs pop insertion (deferred to Pass B)
-    info.cbsNeedingPop.push_back({assocCb, loc});
+    info.popsNeedingInsertion.push_back({assocCb, loc, remoteLoad->getBlock()});
 
     // Erase the original remote_load operation
     rewriter.eraseOp(remoteLoad);
 
-    if (allocToErase) {
+    // Erase the memref.alloc if it was the local buffer source
+    if (allocToErase && allocToErase->use_empty()) {
       rewriter.eraseOp(allocToErase);
     }
   }
@@ -356,11 +375,12 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     rewriter.eraseOp(allocOp);
   }
 
-  // Transform RemoteStoreOp: convert implicit form to explicit CB form, and
-  // ensure explicit form stores (e.g., created by simplifyLoadStorePairs) get
-  // reserve/push inserted for CB synchronization.
+  // Transform RemoteStoreOp (implicit form -> explicit CB form)
   SmallVector<RemoteStoreOp> remoteStoresToConvert;
   moduleOp->walk([&](RemoteStoreOp remoteStore) {
+    if (!remoteStore.isImplicitForm()) {
+      return;
+    }
     remoteStoresToConvert.push_back(remoteStore);
   });
 
@@ -377,6 +397,10 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     Value localBuffer = remoteStore.getLocalBuffer();
     Value assocCb;
 
+    if (failed(verifyGenericOperand(remoteStore.getOperation(), memref))) {
+      return failure();
+    }
+
     if (remoteStore.isImplicitForm()) {
       // Implicit form: find the CB by tracing back from the local buffer.
       // First try to find a ReserveOp in the chain.
@@ -389,8 +413,6 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
         // WaitOp result. Extract the CB from the WaitOp.
         assocCb = waitOp.getCb();
       } else {
-        // The localBuffer may be a hoisted additionalArg (external alloc).
-        // Find the CB via the store's memref operand instead.
         assocCb = findAssociatedCB(remoteStore.getOperation(), memref, rewriter,
                                    cache, portCounters);
         if (!assocCb) {
@@ -408,24 +430,20 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
                                      assocCb);
 
       // Track the reserve op for push insertion (avoid duplicates).
+      // When the CB was found through a WaitOp (non-simplified load-store
+      // pair), there is no ReserveOp — the load already populated the CB.
+      // We only need a pop after consuming the data.
       if (reserveOp && cbsWithReserveOps.insert(assocCb).second) {
         info.reserveOpsNeedingPush.push_back({reserveOp, assocCb});
       } else if (!reserveOp && cbsWithReserveOps.insert(assocCb).second) {
-        // No existing reserve (e.g. hoisted additionalArg output).
-        // Create right after the get_cb so it dominates all uses.
         OpBuilder::InsertionGuard reserveGuard(rewriter);
         rewriter.setInsertionPointAfterValue(assocCb);
         auto newReserve = rewriter.create<ReserveOp>(loc, assocCb);
         info.reserveOpsNeedingPush.push_back({newReserve, assocCb});
-        // Replace uses of the old localBuffer with the reserve result
-        // inside the generic only.
         if (localBuffer) {
-          GenericOp storeGeneric = remoteStore->getParentOfType<GenericOp>();
-          rewriter.replaceUsesWithIf(
-              localBuffer, newReserve.getResult(), [&](OpOperand &use) {
-                return storeGeneric &&
-                       storeGeneric->isProperAncestor(use.getOwner());
-              });
+          replaceUsesInBlock(localBuffer, newReserve.getResult(),
+                             remoteStore->getBlock(),
+                             remoteStore.getOperation());
         }
       }
 
@@ -449,67 +467,48 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     }
   }
 
-  return info;
+  return success();
 }
 
 // Pass B: Insert push and pop operations
-static void insertPushAndPopOps(ModuleOp moduleOp, IRRewriter &rewriter,
-                                PushPopInfo &info) {
-  // Insert pop ops for remote_load conversions.
-  // Insert the pop in the same block as the corresponding WaitOp so that
-  // D2MCBOpRewriter::hasExplicitRelease (which only checks the same block)
-  // finds it and does not auto-insert a duplicate pop.
-  for (auto &[assocCb, loc] : info.cbsNeedingPop) {
-    // Find the WaitOp that uses this CB.
-    WaitOp waitOp = nullptr;
-    for (auto *user : assocCb.getUsers()) {
-      if (auto w = dyn_cast<WaitOp>(user)) {
-        waitOp = w;
-        break;
-      }
-    }
-    if (!waitOp) {
+static void insertPushAndPopOps(IRRewriter &rewriter, PushPopInfo &info) {
+  // Insert pop ops for remote_load conversions
+  for (const PendingPopInfo &pendingPop : info.popsNeedingInsertion) {
+    Block *insertionBlock = pendingPop.insertionBlock;
+    if (!insertionBlock) {
       continue;
     }
 
-    Block *waitBlock = waitOp->getBlock();
-    // Insert before the terminator (e.g., scf.yield) to avoid placing
-    // ops after it, which would violate block structure invariants.
-    if (waitBlock->mightHaveTerminator()) {
-      rewriter.setInsertionPoint(waitBlock->getTerminator());
+    if (!insertionBlock->empty() &&
+        insertionBlock->back().hasTrait<OpTrait::IsTerminator>()) {
+      rewriter.setInsertionPoint(&insertionBlock->back());
     } else {
-      rewriter.setInsertionPointToEnd(waitBlock);
+      rewriter.setInsertionPointToEnd(insertionBlock);
     }
-    rewriter.create<PopOp>(loc, assocCb);
+    rewriter.create<PopOp>(pendingPop.loc, pendingPop.cb);
   }
 
   // Insert push ops for each reserve op
   for (auto &[reserveOp, assocCb] : info.reserveOpsNeedingPush) {
     Location loc = reserveOp.getLoc();
-
-    GenericOp generic = reserveOp->getParentOfType<GenericOp>();
-    Region *genericRegion = nullptr;
-    if (generic.getNumRegions() == 1) {
-      genericRegion = &generic.getRegion(0);
-    } else {
-      genericRegion = ttmlir::utils::getRegionWithParentOfType<GenericOp>(
-          reserveOp.getOperation());
+    Block *insertionBlock = reserveOp->getBlock();
+    if (!insertionBlock) {
+      reserveOp.emitWarning("could not find block for push insertion");
+      continue;
     }
 
-    if (genericRegion && !genericRegion->empty()) {
-      Block *topLevelBlock = &genericRegion->front();
-      // Insert before the terminator (YieldOp)
-      if (!topLevelBlock->empty() &&
-          topLevelBlock->back().hasTrait<OpTrait::IsTerminator>()) {
-        rewriter.setInsertionPoint(&topLevelBlock->back());
-      } else {
-        rewriter.setInsertionPointToEnd(topLevelBlock);
-      }
-      rewriter.create<PushOp>(loc, assocCb);
+    // Push must be in the same region as reserve/compute and before the store
+    // that consumes this CB.
+    if (RemoteStoreOp store =
+            getFirstFollowingRemoteStoreForCb(reserveOp, assocCb)) {
+      rewriter.setInsertionPoint(store);
+    } else if (!insertionBlock->empty() &&
+               insertionBlock->back().hasTrait<OpTrait::IsTerminator>()) {
+      rewriter.setInsertionPoint(&insertionBlock->back());
     } else {
-      reserveOp.emitWarning(
-          "could not find top-level region block for push insertion");
+      rewriter.setInsertionPointToEnd(insertionBlock);
     }
+    rewriter.create<PushOp>(loc, assocCb);
   }
 }
 
@@ -524,15 +523,19 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
+    PushPopInfo info;
     CBCache cbCache;
     PortCounter portCounters;
 
     // Pass A: Convert all remote_load and remote_store into explicit CB form
-    PushPopInfo info =
-        convertToExplicitCBForm(moduleOp, rewriter, cbCache, portCounters);
+    if (failed(convertToExplicitCBForm(moduleOp, rewriter, info, cbCache,
+                                       portCounters))) {
+      signalPassFailure();
+      return;
+    }
 
     // Pass B: Insert push and pop operations
-    insertPushAndPopOps(moduleOp, rewriter, info);
+    insertPushAndPopOps(rewriter, info);
   }
 };
 } // namespace


### PR DESCRIPTION
### Ticket
NA

### Problem description
In flatbuffer serialization for ttmetal, the new handling of streamLayoutOps is not correct--we insert the input to the stream as a placeholder "cb" and then overwrite it later.  This is not logically correct and is causing some problems in Brett's branch.

### What's changed
We ought to first map the hoisted allocs to their operands, and then when processing operands look up any hoisted allocs and use those as CB's for the non-aliased case (and use the operands themselves as CBs for the aliased case).  There seems to be a couple of bugs in Allocate.cpp with inserting streams properly as well.

### Checklist
- [ ] New/Existing tests provide coverage for changes
