### PR TITLE
[d2m] L1 scratchpad dynamic sizing

### DIFF
--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/DstRegisterAnalysis.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
@@ -21,8 +22,9 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-// Fixed scratch buffer size in bytes.
-constexpr size_t kScratchSizeBytes = 128 * 1024; // 128KB
+// Fallback scratch buffer size in bytes, used as an upper bound, and when the
+// DST packing analysis does not produce results for a given generic.
+constexpr size_t kFallbackScratchSizeBytes = 128 * 1024; // 128KB
 
 // Get the tile type from a memref type, if it has one.
 static ttcore::TileType getTileType(MemRefType memrefType) {
@@ -44,17 +46,48 @@ static MemRefType findTiledInputType(GenericOp genericOp) {
   return MemRefType();
 }
 
-// Check if a d2m.generic needs a scratch buffer. Scratch is needed when the
-// region contains more than one linalg.generic, which means elementwise fusion
-// produced a multi-op kernel whose intermediate results must be spilled to L1.
-static bool needsScratch(GenericOp genericOp) {
+// Count the number of linalg.generic ops in the first region of a
+// d2m.generic. A count greater than one indicates a fused kernel whose
+// intermediate results may need to be spilled to a scratch buffer.
+static unsigned countLinalgGenerics(GenericOp genericOp) {
   if (genericOp.getNumRegions() == 0) {
-    return false;
+    return 0;
   }
 
   unsigned linalgCount = 0;
   genericOp.getRegion(0).walk([&](linalg::GenericOp) { ++linalgCount; });
-  return linalgCount > 1;
+  return linalgCount;
+}
+
+// Compute the number of scratch tiles needed for a d2m.generic. Returns
+// min(linalgCount * numTilesPerResult, kFallbackScratchSizeBytes /
+// tileSizeBytes) when the DST packing analysis produces results for this
+// generic, otherwise falls back to kFallbackScratchSizeBytes / tileSizeBytes.
+static size_t
+computeScratchNumTiles(GenericOp genericOp, unsigned linalgCount,
+                       ttcore::TileType tileType,
+                       const utils::DstRegisterAnalysis &dstAnalysis) {
+  const size_t tileSizeBytes = tileType.getSizeBytes();
+  const size_t fallbackNumTiles =
+      std::max<size_t>(kFallbackScratchSizeBytes / tileSizeBytes, 1);
+
+  const utils::DSTPackingInfo *packingInfo = dstAnalysis.lookup(genericOp);
+  if (!packingInfo) {
+    return fallbackNumTiles;
+  }
+  const utils::DSTPackingRegionInfo *regionInfo =
+      packingInfo->lookup(&genericOp.getRegion(0));
+  if (!regionInfo) {
+    return fallbackNumTiles;
+  }
+
+  const size_t analysisNumTiles =
+      static_cast<size_t>(linalgCount) *
+      static_cast<size_t>(regionInfo->numTilesPerResult);
+  if (analysisNumTiles == 0) {
+    return fallbackNumTiles;
+  }
+  return std::min(analysisNumTiles, fallbackNumTiles);
 }
 
 // Transfer d2m.blocking_map attributes from inner linalg ops (set during
@@ -85,7 +118,8 @@ static void transferBlockingMaps(GenericOp genericOp) {
 // Add a scratch buffer inside a single d2m.generic op's region
 // (post-bufferization). Creates a memref.alloc + scratch_init at the start of
 // the region body.
-static void addScratchToGeneric(GenericOp genericOp) {
+static void addScratchToGeneric(GenericOp genericOp,
+                                const utils::DstRegisterAnalysis &dstAnalysis) {
   // Skip if not in compute-only form.
   if (!genericOp.isComputeOnlyForm()) {
     return;
@@ -94,7 +128,8 @@ static void addScratchToGeneric(GenericOp genericOp) {
   // Only add scratch to fused generics with multiple linalg.generic ops,
   // which indicates elementwise fusion produced a multi-op kernel whose
   // intermediate results must be spilled to L1.
-  if (!needsScratch(genericOp)) {
+  unsigned linalgCount = countLinalgGenerics(genericOp);
+  if (linalgCount <= 1) {
     return;
   }
 
@@ -106,12 +141,9 @@ static void addScratchToGeneric(GenericOp genericOp) {
 
   ttcore::TileType tileType = getTileType(refMemRefType);
 
-  // Calculate number of tiles that fit in the scratch buffer.
-  size_t tileSizeBytes = tileType.getSizeBytes();
-  size_t numTiles = kScratchSizeBytes / tileSizeBytes;
-  if (numTiles == 0) {
-    numTiles = 1; // At least one tile.
-  }
+  // Calculate number of scratch tiles using the DST packing analysis.
+  size_t numTiles =
+      computeScratchNumTiles(genericOp, linalgCount, tileType, dstAnalysis);
 
   // Build scratch shard shape: [1, numTiles].
   SmallVector<int64_t> scratchShardShape = {1, static_cast<int64_t>(numTiles)};
@@ -143,14 +175,17 @@ class D2MInsertScratchBuffers
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    // Collect generics.
+    // Run DST packing analysis on the module to compute per-generic scratch
+    // size estimates.
+    utils::DstRegisterAnalysis dstAnalysis(moduleOp);
+
     SmallVector<GenericOp> genericsToProcess;
     moduleOp.walk(
         [&](GenericOp genericOp) { genericsToProcess.push_back(genericOp); });
 
     for (GenericOp genericOp : genericsToProcess) {
       transferBlockingMaps(genericOp);
-      addScratchToGeneric(genericOp);
+      addScratchToGeneric(genericOp, dstAnalysis);
     }
   }
 };

--- a/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
@@ -10,12 +10,12 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 // Two tile_add ops in a fused generic → scratch_init should be inserted.
-// Verify: memref.alloc + scratch_init inside region.
+// Verify: memref.alloc sized by DST packing analysis + scratch_init inside region.
 
 // CHECK-LABEL: func.func @two_adds_gets_scratch
 // CHECK: d2m.generic
 // CHECK: ins(%{{.*}}, %{{.*}} :
-// CHECK: memref.alloc() : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
+// CHECK: memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<32768x4096, 1>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled
@@ -63,7 +63,7 @@ func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
 
 // CHECK-LABEL: func.func @add_and_mul_gets_scratch
 // CHECK: d2m.generic
-// CHECK: memref.alloc() : memref<1x32x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<131072x4096, 1>, #l1>
+// CHECK: memref.alloc() : memref<1x8x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<32768x4096, 1>, #l1>
 // CHECK-NEXT: d2m.scratch_init
 func.func @add_and_mul_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   %out = memref.alloc() : !memref_tiled


### PR DESCRIPTION
### Problem description
Current scratch size per generic is hardcoded to 128K. This wastes L1 on small fused kernels when the analysis can prove a tighter bound.

### What's changed
Use `DstRegisterAnalysis` to compute a per-generic scratch size as `linalgCount * numTilesPerResult` tiles, capped at the existing 128 KB upper bound.

