### PR TITLE
Add TTNN concat/reshape hang workarounds

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPPADDIMREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPPADDIMREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// When a ConcatOp is in TILE_LAYOUT and any input's concat-dimension size
+// is not tile-aligned (i.e. not a multiple of 32), the runtime takes the
+// untilize_rm_retilize_concat path. That path calls untilize_with_unpadding
+// with extremely small NOC writes (e.g. 2-4 bytes per element), which hangs
+// on multi-device meshes.
+//
+// This narrowed pattern only applies when the final input is the only operand
+// whose concat dimension is not tile-aligned. In that case, padding the tail
+// input to a multiple of 32, concatenating, and trimming the trailing suffix
+// preserves semantics while bypassing the problematic untilize path.
+class ConcatOpPadDimRewritePattern
+    : public mlir::OpRewritePattern<ttnn::ConcatOp> {
+public:
+  using mlir::OpRewritePattern<ttnn::ConcatOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(ttnn::ConcatOp op,
+                                      PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_CONCATOPPADDIMREWRITEPATTERN_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_RESHAPENARROWTILEDREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_RESHAPENARROWTILEDREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// When a ReshapeOp is in TILE_LAYOUT and the output's last dimension is
+// not tile-aligned (< 32), the tiled reshape kernel generates many tiny
+// L1-to-L1 segment copies (e.g. 4 bytes each for INT32).  On multi-device
+// meshes this can hang the device command queue.
+//
+// This pattern decomposes the problematic reshape into:
+//   1. ttnn.to_layout  TILE -> ROW_MAJOR   (untilize)
+//   2. ttnn.reshape    in ROW_MAJOR         (metadata / lightweight copy)
+//   3. ttnn.to_layout  ROW_MAJOR -> TILE    (tilize)
+//
+// The ROW_MAJOR reshape path is far better tested and avoids the tiled
+// reshape kernel entirely.
+class ReshapeNarrowTiledRewritePattern
+    : public mlir::OpRewritePattern<ttnn::ReshapeOp> {
+public:
+  using mlir::OpRewritePattern<ttnn::ReshapeOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(ttnn::ReshapeOp op,
+                                      PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_RESHAPENARROWTILEDREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
         Workarounds/Decomposition/ArgMaxOpDimRewritePattern.cpp
         Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
+        Workarounds/Decomposition/ConcatOpPadDimRewritePattern.cpp
         Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
         Workarounds/Decomposition/PointToPointOpRewritePattern.cpp
         Workarounds/Decomposition/SplitQueryKeyValueAndSplitHeadsOpRewritePattern.cpp
@@ -57,6 +58,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/Conv3dPadOutputChannelsRewritePattern.cpp
         Workarounds/Decomposition/Conv3dDepthPaddingRewritePattern.cpp
         Workarounds/Decomposition/PadHighDimRewritePattern.cpp
+        Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.cpp
         Workarounds/TTNNWorkaroundsPatterns.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+static constexpr int64_t kTileSize = ttnn::TILE_WIDTH;
+// NOC DMA minimum transfer size (bytes). Writes smaller than this hang the
+// untilize_with_unpadding kernel. See tt_cluster.cpp min_dma_size_bytes.
+static constexpr unsigned kNocMinWriteBytes = 32;
+
+static int64_t roundUpToTile(int64_t val) {
+  return ((val + kTileSize - 1) / kTileSize) * kTileSize;
+}
+
+LogicalResult
+ConcatOpPadDimRewritePattern::matchAndRewrite(ttnn::ConcatOp op,
+                                              PatternRewriter &rewriter) const {
+  int32_t dim = op.getDim();
+  auto inputs = op.getInputs();
+
+  if (inputs.empty()) {
+    return failure();
+  }
+
+  RankedTensorType firstInputType =
+      mlir::cast<RankedTensorType>(inputs[0].getType());
+  int64_t rank = firstInputType.getRank();
+  if (rank == 0) {
+    return failure();
+  }
+  int64_t normalizedDim = dim >= 0 ? dim : dim + rank;
+
+  if (normalizedDim < 0 || normalizedDim >= rank) {
+    return failure();
+  }
+
+  // Only apply when all inputs (and the result) have tiled TTNNLayoutAttr.
+  for (auto input : inputs) {
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    auto inputLayoutAttr =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+    if (!inputLayoutAttr || !inputLayoutAttr.isTiled()) {
+      return failure();
+    }
+  }
+  auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
+  auto resultLayoutAttr =
+      mlir::dyn_cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
+  if (!resultLayoutAttr || !resultLayoutAttr.isTiled()) {
+    return failure();
+  }
+
+  // The current pad+concat+slice decomposition is only semantics-preserving
+  // when the logical output can be recovered with a single suffix trim.
+  // That requires every non-final input to already be tile-aligned on the
+  // concat dimension; only the last input may need padding.
+  bool lastInputUnaligned = false;
+  for (size_t inputIndex = 0; inputIndex < inputs.size(); ++inputIndex) {
+    auto input = inputs[inputIndex];
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    if (inputType.getRank() == 0 || inputType.getRank() != rank) {
+      return failure();
+    }
+    int64_t dimSize = inputType.getShape()[normalizedDim];
+    bool inputUnaligned = (dimSize % kTileSize) != 0;
+    if (inputIndex + 1 == inputs.size()) {
+      lastInputUnaligned = inputUnaligned;
+    } else if (inputUnaligned) {
+      return failure();
+    }
+  }
+
+  if (!lastInputUnaligned) {
+    return failure();
+  }
+
+  // The untilize_rm_retilize path calls untilize_with_unpadding on each
+  // input. That kernel hangs when the last-dim partial-tile segment is
+  // smaller than the NOC minimum DMA size (32 bytes). Only apply the
+  // pad workaround when at least one input would produce such small writes.
+  bool hasSmallNocWrite = false;
+  for (auto input : inputs) {
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    if (inputType.getRank() == 0 || inputType.getRank() != rank) {
+      return failure();
+    }
+    int64_t lastDim = inputType.getShape()[inputType.getRank() - 1];
+    int64_t partialWidth = lastDim % kTileSize;
+    if (partialWidth == 0) {
+      continue;
+    }
+    mlir::Type elemType = inputType.getElementType();
+    if (!mlir::isa<ttcore::TileType>(elemType) && !elemType.isIntOrFloat()) {
+      continue;
+    }
+    uint64_t elementSizeBytes = ttcore::getElementSizeBytes(elemType);
+    if (elementSizeBytes == 0) {
+      continue;
+    }
+    unsigned segmentBytes = static_cast<unsigned>(partialWidth) *
+                            static_cast<unsigned>(elementSizeBytes);
+    if (segmentBytes < kNocMinWriteBytes) {
+      hasSmallNocWrite = true;
+      break;
+    }
+  }
+
+  if (!hasSmallNocWrite) {
+    return failure();
+  }
+
+  // Pad each input along the concat dimension to a tile-aligned size.
+  SmallVector<Value> paddedInputs;
+  int64_t totalPaddedDimSize = 0;
+
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto inputValue = mlir::cast<mlir::TypedValue<RankedTensorType>>(inputs[i]);
+    auto inputType = inputValue.getType();
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    int64_t dimSize = inputShape[normalizedDim];
+    int64_t paddedDimSize = roundUpToTile(dimSize);
+
+    totalPaddedDimSize += paddedDimSize;
+
+    if (dimSize == paddedDimSize) {
+      paddedInputs.push_back(inputValue);
+      continue;
+    }
+
+    // Build padding array: [front_0, back_0, front_1, back_1, ...]
+    SmallVector<int32_t> padding(rank * 2, 0);
+    padding[normalizedDim * 2 + 1] =
+        static_cast<int32_t>(paddedDimSize - dimSize);
+
+    auto padOp = ttir_to_ttnn::utils::generatePad(
+        inputValue, padding, rewriter,
+        ttmlir::utils::appendLocationSuffix(op.getLoc(),
+                                            "_pad_input_" + std::to_string(i)));
+
+    paddedInputs.push_back(padOp.getResult());
+  }
+
+  // Compute the padded output shape.
+  SmallVector<int64_t> paddedOutputShape(firstInputType.getShape());
+  paddedOutputShape[normalizedDim] = totalPaddedDimSize;
+
+  RankedTensorType paddedOutputType =
+      ttnn::utils::RankedTensorTypeFactory::create(
+          mlir::cast<RankedTensorType>(op.getResult().getType()),
+          paddedOutputShape);
+
+  // Create the new concat with padded inputs.
+  auto newConcatOp = rewriter.create<ttnn::ConcatOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_padded_concat"),
+      paddedOutputType, paddedInputs, op.getDimAttr(),
+      op.getMemoryConfigAttr());
+
+  // Slice the result back to the original output shape.
+  RankedTensorType originalOutputType = op.getResult().getType();
+  ArrayRef<int64_t> originalOutputShape = originalOutputType.getShape();
+
+  SmallVector<int32_t> begins(rank, 0);
+  SmallVector<int32_t> ends(originalOutputShape.begin(),
+                            originalOutputShape.end());
+  SmallVector<int32_t> steps(rank, 1);
+
+  auto sliceOp = rewriter.create<ttnn::SliceStaticOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_unpad_slice"),
+      originalOutputType, newConcatOp.getResult(),
+      rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
+      rewriter.getI32ArrayAttr(steps));
+
+  rewriter.replaceOp(op, sliceOp.getResult());
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+static constexpr int64_t kTileWidth = ttnn::TILE_WIDTH;
+// NOC DMA minimum transfer size (bytes). Writes smaller than this hang the
+// tiled reshape kernel. See tt_cluster.cpp min_dma_size_bytes.
+static constexpr unsigned kNocMinWriteBytes = 32;
+
+LogicalResult ReshapeNarrowTiledRewritePattern::matchAndRewrite(
+    ttnn::ReshapeOp op, PatternRewriter &rewriter) const {
+  auto inputValue =
+      mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput());
+  RankedTensorType inputType = inputValue.getType();
+  RankedTensorType outputType = op.getResult().getType();
+
+  auto inputLayoutAttr =
+      mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  if (!inputLayoutAttr || !inputLayoutAttr.isTiled()) {
+    return failure();
+  }
+
+  auto outputLayoutAttr =
+      mlir::dyn_cast<TTNNLayoutAttr>(outputType.getEncoding());
+  if (!outputLayoutAttr || !outputLayoutAttr.isTiled()) {
+    return failure();
+  }
+
+  int64_t inputRank = inputType.getRank();
+  int64_t outputRank = outputType.getRank();
+  if (inputRank == 0 || outputRank == 0) {
+    return failure();
+  }
+
+  int64_t outputLastDim = outputType.getShape()[outputRank - 1];
+  int64_t partialWidth = outputLastDim % kTileWidth;
+
+  if (partialWidth == 0) {
+    return failure();
+  }
+
+  mlir::Type elemType = inputType.getElementType();
+  if (!mlir::isa<ttcore::TileType>(elemType) && !elemType.isIntOrFloat()) {
+    return failure();
+  }
+  uint64_t elementSizeBytes = ttcore::getElementSizeBytes(elemType);
+  if (elementSizeBytes == 0) {
+    return failure();
+  }
+  unsigned segmentBytes = static_cast<unsigned>(partialWidth) *
+                          static_cast<unsigned>(elementSizeBytes);
+
+  // Only decompose when the partial-tile-column segment is smaller than
+  // the NOC minimum DMA size.  Larger segments are safe in the tiled
+  // reshape kernel.
+  if (segmentBytes >= kNocMinWriteBytes) {
+    return failure();
+  }
+
+  // Skip reshapes the runtime handles as views: when the last dim and the
+  // second-to-last dim are unchanged (or both tile-aligned), the tiled
+  // reshape kernel is never invoked.
+  int64_t inputLastDim = inputType.getShape()[inputRank - 1];
+  if (inputLastDim == outputLastDim) {
+    if (inputRank >= 2 && outputRank >= 2) {
+      int64_t inputSecondLast = inputType.getShape()[inputRank - 2];
+      int64_t outputSecondLast = outputType.getShape()[outputRank - 2];
+      if (inputSecondLast == outputSecondLast ||
+          (inputSecondLast % kTileWidth == 0 &&
+           outputSecondLast % kTileWidth == 0)) {
+        return failure();
+      }
+    }
+  }
+
+  // Convert the input from tiled layout to row-major layout.
+  auto toRMOp = utils::createToLayoutOp(
+      op.getOperation(), inputValue, rewriter, Layout::RowMajor,
+      inputLayoutAttr.getBufferType(), inputLayoutAttr.getMemLayout(),
+      inputLayoutAttr.getDataType(), "_reshape_wa_to_rm");
+
+  // Perform the reshape in row-major layout.
+  auto rmInputResult =
+      mlir::cast<mlir::TypedValue<RankedTensorType>>(toRMOp.getResult());
+  RankedTensorType rmOutputType = utils::RankedTensorTypeFactory::create(
+      rmInputResult.getType(), outputType.getShape());
+
+  auto reshapeOp = rewriter.create<ttnn::ReshapeOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape_wa_rm"),
+      rmOutputType, rmInputResult, op.getShapeAttr(),
+      /*memory_config=*/nullptr);
+
+  // Convert the reshaped result back to tiled layout.
+  auto toTileOp = utils::createToLayoutOp(
+      op.getOperation(),
+      mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapeOp.getResult()),
+      rewriter, Layout::Tile, outputLayoutAttr.getBufferType(),
+      outputLayoutAttr.getMemLayout(), outputLayoutAttr.getDataType(),
+      "_reshape_wa_to_tile");
+
+  rewriter.replaceOp(op, toTileOp.getResult());
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpDimRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpPadDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dEnableKernelStrideFoldingRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h"
@@ -32,6 +33,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RMSNormConfigRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterConfigRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceScatterOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RotaryEmbeddingOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadTileDimsRewritePattern.h"
@@ -614,6 +616,11 @@ public:
               DistributedRMSNormWidthShardInputRewritePattern,
           workarounds::decomposition::ReduceScatterConfigRewritePattern>(
           &getContext());
+
+      patterns
+          .add<workarounds::decomposition::ConcatOpPadDimRewritePattern,
+               workarounds::decomposition::ReshapeNarrowTiledRewritePattern>(
+              &getContext());
       patterns.add<workarounds::decomposition::LinearOpRewritePattern>(
           &getContext(), /*benefit=*/2);
       patterns

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/reshape.h"
-#include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 
 #include "tt/runtime/detail/ttnn/utils.h"

--- a/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_test_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_test_positive.mlir
@@ -2,12 +2,28 @@
 // RUN: FileCheck %s --input-file=%t
 module @jit_batch_norm {
   func.func public @test_batch_norm(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>, %arg4: tensor<2xf32>) -> tensor<2x2x2x2xf32> {
-    // CHECK: [[VAL0:%[0-9]+]] = "ttnn.reshape"(%arg3)
-    // CHECK: [[VAL1:%[0-9]+]] = "ttnn.reshape"(%arg4)
-    // CHECK: [[VAL2:%[0-9]+]] = "ttnn.reshape"(%arg1)
-    // CHECK: [[VAL3:%[0-9]+]] = "ttnn.reshape"(%arg2)
+    // CHECK: [[ARG3_RM:%[0-9]+]] = "ttnn.to_layout"(%arg3)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL0_RM:%[0-9]+]] = "ttnn.reshape"([[ARG3_RM]])
+    // CHECK: [[VAL0:%[0-9]+]] = "ttnn.to_layout"([[VAL0_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG4_RM:%[0-9]+]] = "ttnn.to_layout"(%arg4)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL1_RM:%[0-9]+]] = "ttnn.reshape"([[ARG4_RM]])
+    // CHECK: [[VAL1:%[0-9]+]] = "ttnn.to_layout"([[VAL1_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG1_RM:%[0-9]+]] = "ttnn.to_layout"(%arg1)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL2_RM:%[0-9]+]] = "ttnn.reshape"([[ARG1_RM]])
+    // CHECK: [[VAL2:%[0-9]+]] = "ttnn.to_layout"([[VAL2_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG2_RM:%[0-9]+]] = "ttnn.to_layout"(%arg2)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL3_RM:%[0-9]+]] = "ttnn.reshape"([[ARG2_RM]])
+    // CHECK: [[VAL3:%[0-9]+]] = "ttnn.to_layout"([[VAL3_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
     %1 = "ttir.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) <{dimension = 1 : i32, epsilon = 0.000000e+00 : f32}> : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<2x2x2x2xf32>
-    // CHECK: [[VAL4:%[0-9]+]] = "ttnn.batch_norm_inference"(%arg0, [[VAL0]], [[VAL1]], [[VAL2]], [[VAL3]]) <{{{.*}}epsilon = 0.000000e+00 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1>}> : (tensor<2x2x2x2xf32, #ttnn_layout>, tensor<1x2x1x1xf32, #ttnn_layout2>, tensor<1x2x1x1xf32, #ttnn_layout2>, tensor<1x2x1x1xf32, #ttnn_layout2>, tensor<1x2x1x1xf32, #ttnn_layout2>) -> tensor<2x2x2x2xf32, #ttnn_layout>
+    // CHECK: [[VAL4:%[0-9]+]] = "ttnn.batch_norm_inference"(%arg0, [[VAL0]], [[VAL1]], [[VAL2]], [[VAL3]]) <{{{.*}}epsilon = 0.000000e+00 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1>}>
     return %1 : tensor<2x2x2x2xf32>
     // CHECK: return [[VAL4]]
   }

--- a/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_training_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/batch_norm/batch_norm_training_test.mlir
@@ -2,15 +2,29 @@
 // RUN: FileCheck %s --input-file=%t
 module @jit_batch_norm_training {
   func.func public @test_batch_norm_training(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>, %arg4: tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>) {
-    // CHECK: [[VAL0:%[0-9]+]] = "ttnn.reshape"(%arg1)
-    // CHECK: [[VAL1:%[0-9]+]] = "ttnn.reshape"(%arg2)
-    // CHECK: [[VAL2:%[0-9]+]] = "ttnn.reshape"(%arg3)
-    // CHECK: [[VAL3:%[0-9]+]] = "ttnn.reshape"(%arg4)
+    // CHECK: [[ARG1_RM:%[0-9]+]] = "ttnn.to_layout"(%arg1)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL0_RM:%[0-9]+]] = "ttnn.reshape"([[ARG1_RM]])
+    // CHECK: [[VAL0:%[0-9]+]] = "ttnn.to_layout"([[VAL0_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG2_RM:%[0-9]+]] = "ttnn.to_layout"(%arg2)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL1_RM:%[0-9]+]] = "ttnn.reshape"([[ARG2_RM]])
+    // CHECK: [[VAL1:%[0-9]+]] = "ttnn.to_layout"([[VAL1_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG3_RM:%[0-9]+]] = "ttnn.to_layout"(%arg3)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL2_RM:%[0-9]+]] = "ttnn.reshape"([[ARG3_RM]])
+    // CHECK: [[VAL2:%[0-9]+]] = "ttnn.to_layout"([[VAL2_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK: [[ARG4_RM:%[0-9]+]] = "ttnn.to_layout"(%arg4)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: [[VAL3_RM:%[0-9]+]] = "ttnn.reshape"([[ARG4_RM]])
+    // CHECK: [[VAL3:%[0-9]+]] = "ttnn.to_layout"([[VAL3_RM]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
     %3:3 = "ttir.batch_norm_training"(%arg0, %arg1, %arg2, %arg3, %arg4) <{dimension = 1 : i32, epsilon = 1.000000e-05 : f32, momentum = 1.000000e-01 : f32}> : (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> (tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>)
     // CHECK: [[RESULT:%[0-9]+]] = "ttnn.batch_norm_training"(%arg0, [[VAL2]], [[VAL3]], [[VAL0]], [[VAL1]]) <{{{.*}}epsilon = {{.*}}, momentum = {{.*}}, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1>}>
-    // CHECK: [[VAL4:%[0-9]+]] = "ttnn.reshape"([[VAL2]])
-    // CHECK: [[VAL5:%[0-9]+]] = "ttnn.reshape"([[VAL3]])
     return %3#0, %3#1, %3#2 : tensor<2x2x2x2xf32>, tensor<2xf32>, tensor<2xf32>
-    // CHECK: return [[RESULT]], [[VAL4]], [[VAL5]]
+    // CHECK: return [[RESULT]], %arg3, %arg4
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_pad_dim_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_pad_dim_workaround.mlir
@@ -1,0 +1,65 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Unit tests for ConcatOpPadDimRewritePattern.
+// The pattern pads the last (unaligned) concat input to tile boundary, then
+// slices the result back to the original shape. It fires when a partial-tile
+// column would produce a NOC DMA write < 32 bytes.
+
+module {
+  // Test 1: Workaround SHOULD apply - last input unaligned with small NOC write
+  // bf16 element = 2 bytes.  last-dim 8 => partial 8 elements => 16 bytes < 32.
+  // Two inputs: first is tile-aligned (size 32), last is unaligned (size 8).
+  func.func @concat_pad_dim_should_apply(
+      %arg0: tensor<32x32xbf16>,
+      %arg1: tensor<32x8xbf16>
+  ) -> tensor<32x40xbf16> {
+    // CHECK-LABEL: func.func @concat_pad_dim_should_apply
+    // CHECK: "ttnn.pad"
+    // CHECK: "ttnn.concat"
+    // CHECK: "ttnn.slice_static"
+    %0 = "ttnn.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x32xbf16>, tensor<32x8xbf16>) -> tensor<32x40xbf16>
+    return %0 : tensor<32x40xbf16>
+  }
+
+  // Test 2: Workaround should NOT apply - all inputs are tile-aligned
+  func.func @concat_pad_dim_all_aligned(
+      %arg0: tensor<32x32xbf16>,
+      %arg1: tensor<32x32xbf16>
+  ) -> tensor<32x64xbf16> {
+    // CHECK-LABEL: func.func @concat_pad_dim_all_aligned
+    // CHECK: "ttnn.concat"
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice_static"
+    %0 = "ttnn.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x64xbf16>
+    return %0 : tensor<32x64xbf16>
+  }
+
+  // Test 3: Workaround should NOT apply - non-final input is unaligned
+  // (both inputs unaligned; pattern refuses to rewrite)
+  func.func @concat_pad_dim_non_final_unaligned(
+      %arg0: tensor<32x8xbf16>,
+      %arg1: tensor<32x8xbf16>
+  ) -> tensor<32x16xbf16> {
+    // CHECK-LABEL: func.func @concat_pad_dim_non_final_unaligned
+    // CHECK: "ttnn.concat"
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice_static"
+    %0 = "ttnn.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x8xbf16>, tensor<32x8xbf16>) -> tensor<32x16xbf16>
+    return %0 : tensor<32x16xbf16>
+  }
+
+  // Test 4: Workaround should NOT apply - partial width is large enough
+  // (f32 element = 4 bytes, last-dim 16 => partial 16 elems => 64 bytes >= 32)
+  func.func @concat_pad_dim_large_partial_width(
+      %arg0: tensor<32x32xf32>,
+      %arg1: tensor<32x16xf32>
+  ) -> tensor<32x48xf32> {
+    // CHECK-LABEL: func.func @concat_pad_dim_large_partial_width
+    // CHECK: "ttnn.concat"
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice_static"
+    %0 = "ttnn.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x32xf32>, tensor<32x16xf32>) -> tensor<32x48xf32>
+    return %0 : tensor<32x48xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
@@ -5,11 +5,9 @@
 module {
   func.func public @test_conv3d_f32_to_bf16(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.conv3d"
+    // CHECK: [[INPUT_BF16:%[0-9]+]] = "ttnn.to_layout"(%{{[0-9]+}}) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>
+    // CHECK: [[WEIGHT_BF16:%[0-9]+]] = "ttnn.to_layout"(%{{[0-9]+}}) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>
+    // CHECK: "ttnn.conv3d"([[INPUT_BF16]], [[WEIGHT_BF16]], %{{[0-9]+}})
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{
               stride = array<i32: 1, 1, 1>,
@@ -22,13 +20,10 @@ module {
 
   func.func public @test_conv3d_f32_to_bf16_with_bias(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>, %arg2: tensor<1x1x1x1x16xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16_with_bias
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.conv3d"
+    // CHECK: [[INPUT_BF16:%[0-9]+]] = "ttnn.to_layout"(%{{[0-9]+}}) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>
+    // CHECK: [[WEIGHT_BF16:%[0-9]+]] = "ttnn.to_layout"(%{{[0-9]+}}) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>
+    // CHECK: [[BIAS_BF16:%[0-9]+]] = "ttnn.to_layout"(%{{[0-9]+}}) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>
+    // CHECK: "ttnn.conv3d"([[INPUT_BF16]], [[WEIGHT_BF16]], [[BIAS_BF16]], %{{[0-9]+}})
     %0 = "ttir.conv3d"(%arg0, %arg1, %arg2)
             <{
               stride = array<i32: 1, 1, 1>,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reshape_narrow_tiled_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reshape_narrow_tiled_workaround.mlir
@@ -1,0 +1,65 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Unit tests for ReshapeNarrowTiledRewritePattern.
+// The pattern decomposes a tiled reshape into TILE->RM + reshape + RM->TILE
+// when the output last-dim partial tile would produce a NOC DMA write < 32
+// bytes.
+
+module {
+  // Test 1: Workaround SHOULD apply.
+  // bf16 (2 bytes), output last-dim 8 => partial 8 elems => 16 bytes < 32.
+  // Input 32x32 -> Output 128x8: last dim changes, small partial tile.
+  func.func @reshape_narrow_should_apply(
+      %arg0: tensor<32x32xbf16>
+  ) -> tensor<128x8xbf16> {
+    // CHECK-LABEL: func.func @reshape_narrow_should_apply
+    // Step 1: to_layout TILE -> ROW_MAJOR
+    // CHECK: "ttnn.to_layout"
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // Step 2: reshape in ROW_MAJOR
+    // CHECK: "ttnn.reshape"
+    // Step 3: to_layout ROW_MAJOR -> TILE
+    // CHECK: "ttnn.to_layout"
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    %0 = "ttnn.reshape"(%arg0) <{shape = [128 : i32, 8 : i32]}> : (tensor<32x32xbf16>) -> tensor<128x8xbf16>
+    return %0 : tensor<128x8xbf16>
+  }
+
+  // Test 2: Workaround should NOT apply - output last dim is tile-aligned.
+  // 32x32 -> 16x64: last dim 64 is tile-aligned, no partial tile.
+  func.func @reshape_narrow_aligned_output(
+      %arg0: tensor<32x32xbf16>
+  ) -> tensor<16x64xbf16> {
+    // CHECK-LABEL: func.func @reshape_narrow_aligned_output
+    // CHECK: "ttnn.reshape"
+    // CHECK-NOT: layout = #ttnn.layout<row_major>
+    %0 = "ttnn.reshape"(%arg0) <{shape = [16 : i32, 64 : i32]}> : (tensor<32x32xbf16>) -> tensor<16x64xbf16>
+    return %0 : tensor<16x64xbf16>
+  }
+
+  // Test 3: Workaround should NOT apply - segment bytes >= 32.
+  // f32 (4 bytes), output last-dim 16 => partial 16 elems => 64 bytes >= 32.
+  func.func @reshape_narrow_large_segment(
+      %arg0: tensor<32x32xf32>
+  ) -> tensor<64x16xf32> {
+    // CHECK-LABEL: func.func @reshape_narrow_large_segment
+    // CHECK: "ttnn.reshape"
+    // CHECK-NOT: layout = #ttnn.layout<row_major>
+    %0 = "ttnn.reshape"(%arg0) <{shape = [64 : i32, 16 : i32]}> : (tensor<32x32xf32>) -> tensor<64x16xf32>
+    return %0 : tensor<64x16xf32>
+  }
+
+  // Test 4: Workaround should NOT apply - view reshape (last dim unchanged).
+  // 1x32x8 -> 32x8: last dim stays 8 (same), second-to-last also same => view.
+  func.func @reshape_narrow_view_skip(
+      %arg0: tensor<1x32x8xbf16>
+  ) -> tensor<32x8xbf16> {
+    // CHECK-LABEL: func.func @reshape_narrow_view_skip
+    // CHECK: "ttnn.reshape"
+    // The view-skip logic should prevent the pattern from applying because
+    // last dim is unchanged (8 == 8) and second-to-last is unchanged (32 == 32).
+    %0 = "ttnn.reshape"(%arg0) <{shape = [32 : i32, 8 : i32]}> : (tensor<1x32x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
@@ -11,9 +11,16 @@ module @where attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg2) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xf32, #ttnn_layout2>) -> tensor<1x1x1x1xf32, #ttnn_layout3>
     %2 = "ttnn.repeat"(%1) <{repeat_dims = #ttnn.shape<1x12x1x46>}> : (tensor<1x1x1x1xf32, #ttnn_layout3>) -> tensor<1x12x1x46xf32, #ttnn_layout1>
-    // CHECK: %[[TOLAYOUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[SCALAR_RM:.*]] = "ttnn.to_layout"(%arg2)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
-    // CHECK: "ttnn.where"(%[[TOLAYOUT]]
+    // CHECK: %[[SCALAR_RESHAPE:.*]] = "ttnn.reshape"(%[[SCALAR_RM]])
+    // CHECK: %[[SCALAR_TILE:.*]] = "ttnn.to_layout"(%[[SCALAR_RESHAPE]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+    // CHECK: %[[SCALAR_REPEAT:.*]] = "ttnn.repeat"(%[[SCALAR_TILE]])
+    // CHECK: %[[COND_REPEAT:.*]] = "ttnn.repeat"(%arg0)
+    // CHECK: %[[COND_F32:.*]] = "ttnn.to_layout"(%[[COND_REPEAT]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+    // CHECK: "ttnn.where"(%[[COND_F32]]
     // CHECK-SAME: tensor<1x12x1x46xf32
     // CHECK-SAME: tensor<1x12x1x46xf32
     // CHECK-SAME: tensor<1x12x1x46xf32

--- a/test/ttmlir/Silicon/TTNN/n150/simple_repeat.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_repeat.mlir
@@ -10,8 +10,12 @@ func.func @main0(%arg0: tensor<1x16x32xf32>, %arg1: tensor<1x1x32xf32>) -> tenso
 }
 
 func.func public @main1(%arg0: tensor<1xf32>, %arg1: tensor<512x512xf32>) -> (tensor<512x512xf32>) {
-  // CHECK: %{{[0-9]+}} = "ttnn.reshape"(%arg0)
-  // CHECK: %{{[0-9]+}} = "ttnn.repeat"(%{{[0-9]+}})
+  // CHECK: %[[ARG0_RM:.*]] = "ttnn.to_layout"(%arg0)
+  // CHECK-SAME: layout = #ttnn.layout<row_major>
+  // CHECK: %[[RESHAPE_RM:.*]] = "ttnn.reshape"(%[[ARG0_RM]])
+  // CHECK: %[[RESHAPE_TILE:.*]] = "ttnn.to_layout"(%[[RESHAPE_RM]])
+  // CHECK-SAME: layout = #ttnn.layout<tile>
+  // CHECK: %[[REPEAT0:.*]] = "ttnn.repeat"(%[[RESHAPE_TILE]])
   %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 1 : i32]}> : (tensor<1xf32>) -> tensor<1x1xf32>
   %3 = "ttir.broadcast"(%1) <{broadcast_dimensions = array<i64 : 512, 512>}> : (tensor<1x1xf32>) -> tensor<512x512xf32>
   %5 = "ttir.maximum"(%3, %arg1) : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
@@ -30,8 +34,18 @@ func.func @main2(%arg0: tensor<1x23x40x1xf32>, %arg1: tensor<128xf32>) -> tensor
 }
 
 func.func @main3(%arg0: tensor<6x2xf32>) -> tensor<2400x2xf32> {
-  // CHECK: %{{[0-9]+}} = "ttnn.repeat"
+  // CHECK: %[[ARG0_RM:.*]] = "ttnn.to_layout"(%arg0)
+  // CHECK-SAME: layout = #ttnn.layout<row_major>
+  // CHECK: %[[INPUT_RESHAPE:.*]] = "ttnn.reshape"(%[[ARG0_RM]])
+  // CHECK: %[[INPUT_TILE:.*]] = "ttnn.to_layout"(%[[INPUT_RESHAPE]])
+  // CHECK-SAME: layout = #ttnn.layout<tile>
+  // CHECK: %[[REPEAT:.*]] = "ttnn.repeat"(%[[INPUT_TILE]])
   // CHECK-SAME: repeat_dims = #ttnn.shape<400x1x1x1>
+  // CHECK: %[[REPEAT_RM:.*]] = "ttnn.to_layout"(%[[REPEAT]])
+  // CHECK-SAME: layout = #ttnn.layout<row_major>
+  // CHECK: %[[OUTPUT_RESHAPE:.*]] = "ttnn.reshape"(%[[REPEAT_RM]])
+  // CHECK: %[[OUTPUT_TILE:.*]] = "ttnn.to_layout"(%[[OUTPUT_RESHAPE]])
+  // CHECK-SAME: layout = #ttnn.layout<tile>
   %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 6 : i32, 2 : i32]}> : (tensor<6x2xf32>) -> tensor<1x6x2xf32>
   %3 = "ttir.reshape"(%1) <{shape = [1 : i32, 6 : i32, 1 : i32, 2 : i32]}> : (tensor<1x6x2xf32>) -> tensor<1x6x1x2xf32>
   %5 = "ttir.broadcast"(%3) <{broadcast_dimensions = array<i64 : 400, 1, 1, 1>}> : (tensor<1x6x1x2xf32>) -> tensor<400x6x1x2xf32>


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Multi-chip GPT-OSS TP could hang when tiled concat/reshape hit partial-tile tails that produced sub-32B NOC writes. It's indeterministic.

### What's changed
Add TTNN workaround patterns that only rewrite the unsafe cases: narrow tiled reshapes are routed through row-major, and concat pad/slice is restricted to the semantics-safe case where only the final operand is unaligned.

### Checklist
- [ ] New/Existing tests provide coverage for changes
