### PR TITLE
Adding workaround for all gather op for 1d tensors

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLGATHEROPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLGATHEROPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// AllGatherOp in TTNN currently does not support 1d tensors.
+// As a temporary workaround, we insert reshape ops front and back
+// to make the tensor at least two dimensional.
+// Metal issue: https://github.com/tenstorrent/tt-metal/issues/40107
+class TTNNAllGatherWorkarounds : public OpRewritePattern<ttnn::AllGatherOp> {
+public:
+  using OpRewritePattern<ttnn::AllGatherOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::AllGatherOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_ALLGATHEROPREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNTraceHoistTransform.cpp
         TTNNUniqueLocs.cpp
         TTNNWeightDtypeConversion.cpp
+        Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.cpp
         Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+LogicalResult
+TTNNAllGatherWorkarounds::matchAndRewrite(ttnn::AllGatherOp op,
+                                          PatternRewriter &rewriter) const {
+  RankedTensorType inputType = op.getInput().getType();
+  int64_t rank = inputType.getRank();
+
+  // Only apply workaround for 1D tensors. 0D tensors (scalars) have no valid
+  // gather dimension and are rejected by AllGatherOp verification.
+  if (rank != 1) {
+    return failure();
+  }
+
+  RankedTensorType outputType = op.getResult().getType();
+  SmallVector<int64_t> originalShape(inputType.getShape());
+  SmallVector<int64_t> outputShape(outputType.getShape());
+  int32_t originalGatherDim = op.getAllGatherDim();
+
+  // Create padded shape by adding a leading dimension of size 1
+  SmallVector<int64_t> paddedInputShape = {1};
+  paddedInputShape.append(originalShape.begin(), originalShape.end());
+
+  // Create padded output shape
+  SmallVector<int64_t> paddedOutputShape = {1};
+  paddedOutputShape.append(outputShape.begin(), outputShape.end());
+
+  // Normalize negative gather dimension before adjusting for padding.
+  // E.g. for a 1D input, dim=-1 should map to dim=0, then become 1 after
+  // padding with a leading dimension.
+  int32_t normalizedGatherDim =
+      originalGatherDim < 0 ? originalGatherDim + rank : originalGatherDim;
+  int32_t adjustedGatherDim = normalizedGatherDim + 1;
+
+  // Create reshape to 2D
+  SmallVector<int32_t> paddedShapeI32(paddedInputShape.begin(),
+                                      paddedInputShape.end());
+  RankedTensorType reshapeInputType =
+      ttnn::utils::RankedTensorTypeFactory::create(inputType, paddedInputShape);
+  auto reshapeInput = rewriter.create<ttnn::ReshapeOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape_to_2d"),
+      reshapeInputType, op.getInput(), rewriter.getI32ArrayAttr(paddedShapeI32),
+      ttnn::MemoryConfigAttr());
+
+  // Create 2D output tensor type
+  RankedTensorType paddedOutputType =
+      ttnn::utils::RankedTensorTypeFactory::create(outputType,
+                                                   paddedOutputShape);
+
+  // Create the all gather operation on 2D tensors with adjusted gather_dim
+  auto allGather2D = rewriter.create<ttnn::AllGatherOp>(
+      ttmlir::utils::appendLocationSuffix(op.getLoc(), "_all_gather_2d"),
+      paddedOutputType, reshapeInput.getResult(), adjustedGatherDim,
+      op.getClusterAxis(), op.getSubDeviceIdAttr(), op.getMemoryConfigAttr(),
+      op.getNumLinksAttr(), op.getTopologyAttr());
+
+  // Reshape back to original dimensionality
+  SmallVector<int32_t> outputShapeI32(outputShape.begin(), outputShape.end());
+  rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
+      op, outputType, allGather2D.getResult(),
+      rewriter.getI32ArrayAttr(outputShapeI32), ttnn::MemoryConfigAttr());
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/AllGatherOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatenateHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dEnableKernelStrideFoldingRewritePattern.h"
@@ -579,6 +580,7 @@ public:
       RewritePatternSet patterns(&getContext());
       patterns.add<
           TTNNAllReduceWorkarounds,
+          workarounds::decomposition::TTNNAllGatherWorkarounds,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,
           workarounds::decomposition::CumSumOpDimRewritePattern,

--- a/test/python/golden/ttir_ops/ccl/test_all_gather.py
+++ b/test/python/golden/ttir_ops/ccl/test_all_gather.py
@@ -104,3 +104,76 @@ def test_all_gather(
         mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
         **get_request_kwargs(request),
     )
+
+
+@pytest.mark.parametrize("test_size", [32, 64, 128])
+@pytest.mark.parametrize(
+    "mesh_shape",
+    [(1, 2), (1, 4), (1, 8), (2, 1), (4, 1), (8, 1)],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("all_gather_dim", [0, -1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_all_gather_1d(
+    test_size: int,
+    mesh_shape: Tuple[int, int],
+    cluster_axis: int,
+    all_gather_dim: int,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("all_gather across 1 device is meaningless")
+
+    # The runtime mesh_shard cannot handle 1D tensors with a 2D mesh (the
+    # ShardToFull composer requires unique dims, but a 1D tensor only has dim 0).
+    # Work around this by sharding a 2D (1, N) tensor, reshaping to 1D before
+    # all_gather (which exercises the compiler's 1D reshape workaround), then
+    # reshaping back to 2D to unshard.
+    shard_dims = [0, 1]
+    shard_shape_2d = make_shard_shape(2, shard_dims, mesh_shape)
+
+    full_input_shape = [1 * mesh_shape[0], test_size * mesh_shape[1]]
+    shard_test_shape_1d = [test_size]
+    gathered_shape_2d = [1 * mesh_shape[0], test_size * mesh_shape[1]]
+
+    def module(builder: TTIRBuilder):
+        @builder.func([full_input_shape], [dtype])
+        def all_gather(in0: Operand, builder: TTIRBuilder):
+            in_shard = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+            # Reshape to 1D to exercise the all_gather 1D workaround.
+            in_1d = builder.reshape(in_shard, shape=shard_test_shape_1d)
+
+            all_gather0 = builder.all_gather(
+                in_1d,
+                all_gather_dim=all_gather_dim,
+                cluster_axis=cluster_axis,
+            )
+
+            # Reshape back to 2D so mesh_shard can unshard.
+            out_2d = builder.reshape(all_gather0, shape=gathered_shape_2d)
+
+            return builder.mesh_shard(
+                out_2d,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape_2d,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        **get_request_kwargs(request),
+    )

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_gather_1d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/all_gather_1d_workaround.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// Unit tests for all_gather 1D tensor reshape workaround
+
+// Verify that 1D tensor all_gather is decomposed into reshape(2D) -> all_gather -> reshape(1D)
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0) -> (d0, 0), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_out = #ttnn.ttnn_layout<(d0) -> (d0, 0), <1x1>, memref<4x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module attributes {} {
+  // CHECK-LABEL: all_gather_1d_reshape_workaround
+  func.func @all_gather_1d_reshape_workaround(%arg0: tensor<32xbf16, #ttnn_layout>) -> tensor<128xbf16, #ttnn_layout_out> {
+    // CHECK: %[[RESHAPE_IN:.*]] = "ttnn.reshape"(%arg0)
+    // CHECK-SAME: shape = [1 : i32, 32 : i32]
+    // CHECK: %[[AG:.*]] = "ttnn.all_gather"(%[[RESHAPE_IN]])
+    // CHECK-SAME: all_gather_dim = 1 : si32
+    // CHECK: "ttnn.reshape"(%[[AG]])
+    // CHECK-SAME: shape = [128 : i32]
+    %0 = "ttnn.all_gather"(%arg0) <{all_gather_dim = 0 : si32, cluster_axis = 1 : ui32}> : (tensor<32xbf16, #ttnn_layout>) -> tensor<128xbf16, #ttnn_layout_out>
+    return %0 : tensor<128xbf16, #ttnn_layout_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
@@ -16,6 +16,23 @@ module attributes {} {
 
 // -----
 
+// Verify 1D tensor all_gather is decomposed with reshape workaround
+module attributes {} {
+  // CHECK-LABEL: all_gather_reshape_1d
+  func.func @all_gather_reshape_1d(%arg0: tensor<32xbf16>) -> tensor<128xbf16> {
+    %0 = "ttir.all_gather"(%arg0) <{all_gather_dim = 0 : si32, cluster_axis = 1 : ui32}> : (tensor<32xbf16>) -> tensor<128xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 32 : i32]
+    // CHECK: "ttnn.all_gather"
+    // CHECK-SAME: all_gather_dim = 1 : si32
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    return %0 : tensor<128xbf16>
+  }
+}
+
+// -----
+
 // Verify op folding for single mesh device communication
 module attributes {} {
   // CHECK-LABEL: all_gather_positive_folding


### PR DESCRIPTION
### Ticket
N/A

### Problem description
After removing https://github.com/tenstorrent/tt-mlir/pull/7489, the tt-xla uplift started failing on:
https://github.com/tenstorrent/tt-xla/actions/runs/23194900645/job/67403179028?pr=3690

### What's changed
Added a workaround to reshape input from 1d to 2d and back to 1d after all gather.

Opened issue on Metal for 1d all gather input support:
https://github.com/tenstorrent/tt-metal/issues/40107

### Checklist
- [x] New/Existing tests provide coverage for changes
