### PR TITLE
Move HW-specific MoE restriction from frontend to MLIR

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1621,6 +1621,7 @@ def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine"> {
                          I64Attr:$num_devices,
                          I64Attr:$cluster_axis,
                          I64Attr:$num_experts_per_tok,
+                         DefaultValuedAttr<I64Attr, "1">:$output_shard_dim,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
     let results = (outs AnyRankedTensor:$result);

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MOEWORKAROUNDSREWRITEPATTERNS_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MOEWORKAROUNDSREWRITEPATTERNS_H
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Populate all MoE-specific decomposition workarounds.
+//
+// This is the single entry point for MoE hardware workarounds, including:
+// - all_to_all_dispatch input-rank canonicalization to [B, 1, S, H]
+// - all_to_all_combine input-layout canonicalization to [E, BD, S, H]
+// - moe_expert_token_remap topk-rank canonicalization
+// - sparse_matmul tile-dimension reshaping/decomposition
+// - all_to_all_combine decode shard-dim runtime workaround
+void populateMoeWorkaroundPatterns(RewritePatternSet &patterns);
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_MOEWORKAROUNDSREWRITEPATTERNS_H

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -99,6 +99,7 @@ table AllToAllCombineOp {
   num_devices: uint32;
   cluster_axis: uint32;
   num_experts_per_tok: uint32;
+  output_shard_dim: uint32 = 1;
   memory_config: tt.target.ttnn.MemoryConfig;
 }
 

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7062,6 +7062,10 @@ public:
             srcOp, "num_devices must be a valid integer.");
       }
     }
+    if (numDevices <= 0) {
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "num_devices must be positive.");
+    }
 
     // Parse cluster_axis attribute
     auto clusterAxisStringAttr =
@@ -7215,6 +7219,9 @@ public:
     Value inputTensor = adaptor.getOperands()[0];
     Value expertMetadata = adaptor.getOperands()[1];
     Value expertMapping = adaptor.getOperands()[2];
+    auto mappingInputType = cast<RankedTensorType>(expertMapping.getType());
+    auto mappingShape = mappingInputType.getShape();
+    int64_t totalDevices = mappingShape[3];
 
     RankedTensorType outputType = cast<RankedTensorType>(
         getTypeConverter()->convertType(srcOp.getResult(0).getType()));
@@ -7234,8 +7241,6 @@ public:
     // subsets.
     // mapping shape: [1, 1, E_total, D_total] where D_total = total devices.
     // nonClusterSize = D_total / dispatch_devices = devices on the other axis.
-    auto mappingType = cast<RankedTensorType>(expertMapping.getType());
-    int64_t totalDevices = mappingType.getShape()[3];
     int64_t nonClusterSize =
         totalDevices / std::max(numDevices, static_cast<int64_t>(1));
     if (nonClusterSize > 1 && numDevices > 1) {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1414,18 +1414,20 @@ public:
   LogicalResult
   matchAndRewrite(ttir::SparseMatmulOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Convert nnz to IntegerAttr
+    // Simple 1:1 TTIR -> TTNN conversion.
+    // Tiling for untiled inputs (M < 32) is handled by
+    // SparseMatmulTileDimsRewritePattern in the TTNN workarounds pass.
+    auto a = mlir::cast<TypedValue<RankedTensorType>>(adaptor.getA());
+    auto b = mlir::cast<TypedValue<RankedTensorType>>(adaptor.getB());
+
     mlir::IntegerAttr nnzAttr = nullptr;
     if (auto nnz = op.getNnz()) {
       nnzAttr = rewriter.getI64IntegerAttr(*nnz);
     }
 
-    // Generate program config from tensor shapes and device grid
-    auto aType = mlir::cast<RankedTensorType>(adaptor.getA().getType());
-    auto bType = mlir::cast<RankedTensorType>(adaptor.getB().getType());
     auto deviceAttr = ttcore::lookupDevice(op);
     auto programConfigAttr = createSparseMatmulProgramConfigAttr(
-        rewriter.getContext(), aType, bType, deviceAttr);
+        rewriter.getContext(), a.getType(), b.getType(), deviceAttr);
 
     rewriter.replaceOpWithNewOp<ttnn::SparseMatmulOp>(
         op, this->getTypeConverter()->convertType(op.getType()), adaptor.getA(),
@@ -1473,11 +1475,27 @@ public:
   LogicalResult
   matchAndRewrite(ttir::AllToAllCombineOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto outputType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+    auto inputType = cast<RankedTensorType>(adaptor.getInputTensor().getType());
+    auto inputShape = inputType.getShape();
+
+    // Auto-detect output_shard_dim from input tensor shape.
+    // input_tensor: [E_local, BD, S, H] (default, shard_dim=1)
+    // For decode (S=1), use shard_dim=2 to avoid tile waste on S dimension.
+    // inputShape[2] is the S dimension in [E, BD, S, H] layout.
+    int64_t outputShardDim = (inputShape.size() >= 4 && inputShape[2] == 1)
+                                 ? 2  // decode mode
+                                 : 1; // prefill mode
+
+    // NOTE: runtime decode workaround (output_shard_dim=2 -> 1+reshape) is
+    // handled in TTNN MoE decomposition workarounds.
+
     rewriter.replaceOpWithNewOp<ttnn::AllToAllCombineOp>(
-        op, this->getTypeConverter()->convertType(op.getResult().getType()),
-        adaptor.getInputTensor(), adaptor.getExpertMetadata(),
+        op, outputType, adaptor.getInputTensor(), adaptor.getExpertMetadata(),
         adaptor.getExpertMapping(), op.getNumDevicesAttr(),
         op.getClusterAxisAttr(), op.getNumExpertsPerTokAttr(),
+        rewriter.getI64IntegerAttr(outputShardDim),
         /*memory_config=*/nullptr);
     return success();
   }

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -428,9 +428,19 @@ getSparseMatmulShardingRule(mlir::stablehlo::CustomCallOp op) {
     inputAExpertDim = mlir::sdy::kNullDim; // replicate
     outputExpertDim = 3;
   } else if (isInputASparse && !isInputBSparse) {
-    // Mode: [A,E,M,K] @ [1,E,K,N] -> [A,E,M,N]
-    inputAExpertDim = 1;
-    outputExpertDim = 1;
+    // Canonical: [A,E,M,K] @ [1,E,K,N] -> [A,E,M,N]  (E at dim 1)
+    // MoE form:  [BD,S,E,K] @ [1,E,K,N] -> [BD,S,E,N] (E at dim 2)
+    // The frontend should canonicalize to the first form, but detect
+    // dynamically in case the reshape was skipped.
+    auto aShape = inputAType.getShape();
+    if (aShape.size() >= 3 && aShape[2] == numExperts &&
+        aShape[1] != numExperts) {
+      inputAExpertDim = 2;
+      outputExpertDim = 2;
+    } else {
+      inputAExpertDim = 1;
+      outputExpertDim = 1;
+    }
   } else if (isInputASparse && isInputBSparse) {
     // Mode: [1,E,M,K] @ [1,E,K,N] -> [1,E,M,N]
     inputAExpertDim = 1;
@@ -534,7 +544,10 @@ getSparseMatmulShardingRule(mlir::stablehlo::CustomCallOp op) {
 // Shardy from propagating any sharding through the op. Without isBlocked,
 // Shardy would insert unnecessary all_gather/AllSlice pairs.
 //
-// Operands: [0] input [B,S,1,H], [1] indices [B,S,1,K], [2] mapping [1,1,E,D]
+// Operands:
+//   [0] input   [B,S,H] or [B,S,1,H] or [B,1,S,H]
+//   [1] indices [B*S,K] or [B,S,K] or [B,S,1,K] or [B,1,S,K]
+//   [2] mapping [1,1,E,D]
 // Results:  [0] dispatched [1,B*D,S,H], [1] metadata [1,B*D,S,K]
 //
 // Note: torch-xla may emit the custom_call with either:
@@ -557,21 +570,16 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
   auto mappingType =
       llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
 
-  if (!inputType || inputType.getRank() != 4 || !indicesType ||
-      indicesType.getRank() != 4 || !mappingType ||
+  if (!inputType || !indicesType || !mappingType ||
+      (inputType.getRank() != 3 && inputType.getRank() != 4) ||
+      (indicesType.getRank() != 2 && indicesType.getRank() != 3 &&
+       indicesType.getRank() != 4) ||
       mappingType.getRank() != 4) {
     op.getOperation()->emitWarning()
-        << "all_to_all_dispatch: all operands must be 4D";
+        << "all_to_all_dispatch: expected input rank 3/4, indices rank 2/3/4,"
+        << " mapping rank 4";
     return mlir::sdy::OpShardingRuleAttr();
   }
-
-  // Extract dimension sizes
-  int64_t bDim = inputType.getShape()[0];   // B
-  int64_t sDim = inputType.getShape()[1];   // S
-  int64_t hDim = inputType.getShape()[3];   // H
-  int64_t kDim = indicesType.getShape()[3]; // K
-  int64_t eDim = mappingType.getShape()[2]; // E
-  int64_t dDim = mappingType.getShape()[3]; // D
 
   // Resolve result types: handle both variadic (2 results) and tuple (1 result)
   SmallVector<Type> resultTypes;
@@ -599,6 +607,81 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
     return mlir::sdy::OpShardingRuleAttr();
   }
 
+  if (resultTypes.size() != 2) {
+    op.getOperation()->emitWarning()
+        << "all_to_all_dispatch: expected exactly 2 result tensors";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto dispatchedType = llvm::dyn_cast<RankedTensorType>(resultTypes[0]);
+  auto metadataOutType = llvm::dyn_cast<RankedTensorType>(resultTypes[1]);
+  if (!dispatchedType || !metadataOutType || dispatchedType.getRank() != 4 ||
+      metadataOutType.getRank() != 4) {
+    op.getOperation()->emitWarning()
+        << "all_to_all_dispatch: both results must be rank-4 tensors";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // Infer dimension positions from the input tensor layout.
+  int64_t inputBDim = 0;
+  int64_t inputSDim = mlir::sdy::kNullDim;
+  int64_t inputHDim = mlir::sdy::kNullDim;
+
+  int64_t outputS = dispatchedType.getShape()[2];
+  if (inputType.getRank() == 3) {
+    // [B, S, H]
+    inputSDim = 1;
+    inputHDim = 2;
+  } else {
+    // [B, S, 1, H] or [B, 1, S, H]
+    auto inShape = inputType.getShape();
+    inputHDim = 3;
+    if (inShape[2] == outputS || inShape[1] == 1) {
+      inputSDim = 2;
+    } else if (inShape[1] == outputS || inShape[2] == 1) {
+      inputSDim = 1;
+    } else {
+      // Conservatively default to [B,1,S,H] style.
+      inputSDim = 2;
+    }
+  }
+
+  int64_t indicesBDim = mlir::sdy::kNullDim;
+  int64_t indicesSDim = mlir::sdy::kNullDim;
+  int64_t indicesKDim = mlir::sdy::kNullDim;
+  int64_t indicesFlatBSDim = mlir::sdy::kNullDim;
+
+  if (indicesType.getRank() == 2) {
+    // [B*S, K]
+    indicesFlatBSDim = 0;
+    indicesKDim = 1;
+  } else if (indicesType.getRank() == 3) {
+    // [B, S, K]
+    indicesBDim = 0;
+    indicesSDim = 1;
+    indicesKDim = 2;
+  } else {
+    // [B, S, 1, K] or [B, 1, S, K]
+    auto idxShape = indicesType.getShape();
+    indicesBDim = 0;
+    indicesKDim = 3;
+    if (idxShape[2] == outputS || idxShape[1] == 1) {
+      indicesSDim = 2;
+    } else if (idxShape[1] == outputS || idxShape[2] == 1) {
+      indicesSDim = 1;
+    } else {
+      indicesSDim = 2;
+    }
+  }
+
+  // Extract dimension sizes.
+  int64_t bDim = inputType.getShape()[inputBDim];
+  int64_t sDim = inputType.getShape()[inputSDim];
+  int64_t hDim = inputType.getShape()[inputHDim];
+  int64_t kDim = indicesType.getShape()[indicesKDim];
+  int64_t eDim = mappingType.getShape()[2];
+  int64_t dDim = mappingType.getShape()[3];
+
   // Use explicit type-range constructor to bypass TupleType cast issue
   // Result 0: dispatched [1, B*D, S, H]
   // Result 1: metadata [1, B*D, S, K]
@@ -608,30 +691,40 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
 
   // B factor: input[0]=dim0, input[1]=dim0, input[2]=kNull,
   //           result[0]=kNull (B is absorbed into B*D), result[1]=kNull
-  builder.addFactor({0, 0, mlir::sdy::kNullDim},
+  builder.addFactor({inputBDim, indicesBDim, mlir::sdy::kNullDim},
                     {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, bDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
-  // S factor: input[0]=dim1, input[1]=dim1, input[2]=kNull,
+  // S factor: input[0]=S, input[1]=S (if present), input[2]=kNull,
   //           result[0]=dim2, result[1]=dim2
-  builder.addFactor({1, 1, mlir::sdy::kNullDim}, {2, 2}, sDim,
+  builder.addFactor({inputSDim, indicesSDim, mlir::sdy::kNullDim}, {2, 2}, sDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
-  // H factor: input[0]=dim3, input[1]=kNull, input[2]=kNull,
+  // H factor: input[0]=H, input[1]=kNull, input[2]=kNull,
   //           result[0]=dim3, result[1]=kNull
-  builder.addFactor({3, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+  builder.addFactor({inputHDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
                     {3, mlir::sdy::kNullDim}, hDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
-  // K factor: input[0]=kNull, input[1]=dim3, input[2]=kNull,
+  // K factor: input[0]=kNull, input[1]=K, input[2]=kNull,
   //           result[0]=kNull, result[1]=dim3
-  builder.addFactor({mlir::sdy::kNullDim, 3, mlir::sdy::kNullDim},
+  builder.addFactor({mlir::sdy::kNullDim, indicesKDim, mlir::sdy::kNullDim},
                     {mlir::sdy::kNullDim, 3}, kDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
+
+  // Flattened [B*S, K] indices format: block sharding on flattened token dim.
+  if (indicesFlatBSDim != mlir::sdy::kNullDim) {
+    int64_t bsDim = indicesType.getShape()[indicesFlatBSDim];
+    builder.addFactor(
+        {mlir::sdy::kNullDim, indicesFlatBSDim, mlir::sdy::kNullDim},
+        {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, bsDim,
+        mlir::sdy::FactorType::kNeedReplication,
+        /*isBlocked=*/true);
+  }
 
   // E factor: input[0]=kNull, input[1]=kNull, input[2]=dim2,
   //           result[0]=kNull, result[1]=kNull
@@ -660,9 +753,11 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
 //
 // H, BD, S, K: kNeedReplication with isBlocked (no sharding propagation).
 //
-// Operands: [0] expert_out [E,B*D,S,H], [1] metadata [1,B*D,S,K],
+// Operands:
+//   [0] expert_out [E,B*D,S,H] or [B*D,S,E,H]
+//   [1] metadata [1,B*D,S,K],
 //           [2] mapping [1,1,E_total,D]
-// Results:  [0] combined [K,B,S,H]
+// Results:  [0] combined [K,B,S,H] (or [K,S,B,H] when output_shard_dim=2)
 static mlir::sdy::OpShardingRuleAttr
 getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
   if (op.getNumOperands() != 3) {
@@ -692,13 +787,53 @@ getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
     return mlir::sdy::OpShardingRuleAttr();
   }
 
+  // Parse output_shard_dim (default 1) to map BD/S to result dimensions.
+  int64_t outputShardDim = 1;
+  if (auto frontendAttrs = mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+          op->getDiscardableAttr("mhlo.frontend_attributes"))) {
+    if (auto strAttr =
+            frontendAttrs.getAs<mlir::StringAttr>("output_shard_dim")) {
+      if (strAttr.getValue().getAsInteger(10, outputShardDim)) {
+        op.getOperation()->emitWarning()
+            << "all_to_all_combine: output_shard_dim must be an integer";
+        return mlir::sdy::OpShardingRuleAttr();
+      }
+    }
+  }
+  if (outputShardDim != 1 && outputShardDim != 2) {
+    op.getOperation()->emitWarning()
+        << "all_to_all_combine: output_shard_dim must be 1 or 2";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // Detect whether expert_out is canonical [E,BD,S,H] or pre-canonicalization
+  // [BD,S,E,H] before StableHLO->TTIR canonicalization.
+  auto expertOutShape = expertOutType.getShape();
+  int64_t eTotalDim = mappingType.getShape()[2];
+  int64_t dDim = mappingType.getShape()[3];
+  int64_t eLocalDim = mlir::sdy::kNullDim;
+  if (dDim > 1 && eTotalDim > 0 && (eTotalDim % dDim) == 0) {
+    eLocalDim = eTotalDim / dDim;
+  }
+
+  bool looksLikeBdseh =
+      (expertOutShape[2] == eTotalDim) ||
+      (eLocalDim != mlir::sdy::kNullDim && expertOutShape[2] == eLocalDim);
+
+  int64_t expertOutEDim = looksLikeBdseh ? 2 : 0;
+  int64_t expertOutBDDim = looksLikeBdseh ? 0 : 1;
+  int64_t expertOutSDim = looksLikeBdseh ? 1 : 2;
+  int64_t expertOutHDim = 3;
+
+  int64_t resultBDDim = (outputShardDim == 1) ? 1 : 2;
+  int64_t resultSDim = (outputShardDim == 1) ? 2 : 1;
+
   // Extract dimension sizes
-  int64_t eDim = expertOutType.getShape()[0];  // E (global expert count)
-  int64_t bdDim = expertOutType.getShape()[1]; // B*D
-  int64_t sDim = expertOutType.getShape()[2];  // S
-  int64_t hDim = expertOutType.getShape()[3];  // H
-  int64_t kDim = metadataType.getShape()[3];   // K
-  int64_t dDim = mappingType.getShape()[3];    // D (num dispatch devices)
+  int64_t eDim = expertOutType.getShape()[expertOutEDim];
+  int64_t bdDim = expertOutType.getShape()[expertOutBDDim];
+  int64_t sDim = expertOutType.getShape()[expertOutSDim];
+  int64_t hDim = expertOutType.getShape()[expertOutHDim];
+  int64_t kDim = metadataType.getShape()[3];
 
   mlir::sdy::OpShardingRuleBuilder builder(op);
 
@@ -708,13 +843,12 @@ getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
   // Using kReduction here causes Shardy to insert all_reduce on BOTH axes
   // (kPassThrough with kNullDim in the result also triggers reduce), which
   // corrupts the combine output by summing unrelated batches.
-  builder.addFactor({0, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+  builder.addFactor({expertOutEDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
                     {mlir::sdy::kNullDim}, eDim,
                     mlir::sdy::FactorType::kPassThrough);
 
   // E factor (mapping): mapping dim 2 is the global expert count and must
   // stay replicated — combine reads it to determine expert-to-device routing.
-  int64_t eTotalDim = mappingType.getShape()[2];
   builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim, 2},
                     {mlir::sdy::kNullDim}, eTotalDim,
                     mlir::sdy::FactorType::kNeedReplication,
@@ -722,8 +856,8 @@ getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
 
   // H factor: kNeedReplication with isBlocked.
   // H is replicated through combine (not sharded on any axis).
-  builder.addFactor({3, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, {3}, hDim,
-                    mlir::sdy::FactorType::kNeedReplication,
+  builder.addFactor({expertOutHDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                    {3}, hDim, mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
   // K factor: expertOut=kNull, metadata[1]=dim3, mapping=kNull, result=dim0
@@ -732,13 +866,13 @@ getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
                     /*isBlocked=*/true);
 
   // S factor: expertOut[0]=dim2, metadata[1]=dim2, mapping=kNull, result=dim2
-  builder.addFactor({2, 2, mlir::sdy::kNullDim}, {2}, sDim,
+  builder.addFactor({expertOutSDim, 2, mlir::sdy::kNullDim}, {resultSDim}, sDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
   // BD factor: expertOut[0]=dim1, metadata[1]=dim1, mapping=kNull, result=dim1
-  builder.addFactor({1, 1, mlir::sdy::kNullDim}, {1}, bdDim,
-                    mlir::sdy::FactorType::kNeedReplication,
+  builder.addFactor({expertOutBDDim, 1, mlir::sdy::kNullDim}, {resultBDDim},
+                    bdDim, mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
   // D factor: expertOut=kNull, metadata=kNull, mapping[2]=dim3, result=kNull
@@ -776,8 +910,11 @@ struct StablehloShardingModel
 // outputs use global E shape, and UpdateGlobalToLocalShapes divides E by
 // the compound mesh factor to produce E_local on each device.
 //
-// Operands: [0] topk [D,B,S,E], [1] mapping [1,1,E,D], [2] metadata [D,B,S,K]
-// Results:  [0] mapping_out [1,B,S,E], [1] reduced [1,1,ceil(BS/R),E]
+// Operands:
+//   [0] topk [D,B,S,E] or [1,BD,S,E] or [B,S,E] or [B*S,E]
+//   [1] mapping [1,1,E,D]
+//   [2] metadata [D_or_1,BD,S,K]
+// Results:  [0] mapping_out [1,BD,S,E], [1] reduced [1,1,ceil(BS/R),E]
 static mlir::sdy::OpShardingRuleAttr
 getMoeExpertTokenRemapShardingRule(mlir::stablehlo::CustomCallOp op) {
   if (op.getNumOperands() != 3) {
@@ -793,11 +930,13 @@ getMoeExpertTokenRemapShardingRule(mlir::stablehlo::CustomCallOp op) {
   auto metadataType =
       llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
 
-  if (!topkType || topkType.getRank() != 4 || !mappingInputType ||
-      mappingInputType.getRank() != 4 || !metadataType ||
-      metadataType.getRank() != 4) {
+  if (!topkType || !mappingInputType || !metadataType ||
+      (topkType.getRank() != 2 && topkType.getRank() != 3 &&
+       topkType.getRank() != 4) ||
+      mappingInputType.getRank() != 4 || metadataType.getRank() != 4) {
     op.getOperation()->emitWarning()
-        << "moe_expert_token_remap: all operands must be 4D";
+        << "moe_expert_token_remap: expected topk rank 2/3/4 and mapping/"
+        << "metadata rank 4";
     return mlir::sdy::OpShardingRuleAttr();
   }
 
@@ -820,36 +959,85 @@ getMoeExpertTokenRemapShardingRule(mlir::stablehlo::CustomCallOp op) {
     return mlir::sdy::OpShardingRuleAttr();
   }
 
-  int64_t dDim = topkType.getShape()[0];
-  int64_t bDim = topkType.getShape()[1];
-  int64_t sDim = topkType.getShape()[2];
-  int64_t eDim = topkType.getShape()[3];
+  // Resolve non-canonical topk layouts (rank 2 or 3).
+  int64_t topkDDim = mlir::sdy::kNullDim;
+  int64_t topkBDDim = mlir::sdy::kNullDim;
+  int64_t topkSDim = mlir::sdy::kNullDim;
+  int64_t topkEDim = mlir::sdy::kNullDim;
+  int64_t topkFlatBSDim = mlir::sdy::kNullDim;
+
+  auto topkShape = topkType.getShape();
+  auto metadataShape = metadataType.getShape();
+  if (topkType.getRank() == 2) {
+    // [B*S, E]
+    topkFlatBSDim = 0;
+    topkEDim = 1;
+  } else if (topkType.getRank() == 3) {
+    // [B, S, E]
+    topkBDDim = 0;
+    topkSDim = 1;
+    topkEDim = 2;
+  } else {
+    // [D, B, S, E] or [1, BD, S, E]
+    topkEDim = 3;
+    topkSDim = 2;
+    topkBDDim = 1;
+    if (topkShape[0] > 1 && topkShape[0] == metadataShape[0]) {
+      topkDDim = 0;
+    }
+  }
+
+  if (topkSDim != mlir::sdy::kNullDim &&
+      topkShape[topkSDim] != metadataShape[2]) {
+    topkSDim = mlir::sdy::kNullDim;
+  }
+  if (topkBDDim != mlir::sdy::kNullDim &&
+      topkShape[topkBDDim] != metadataShape[1]) {
+    topkBDDim = mlir::sdy::kNullDim;
+  }
+
+  int64_t metadataDDim = (metadataShape[0] > 1) ? 0 : mlir::sdy::kNullDim;
+
+  int64_t dDim = mappingInputType.getShape()[3];
+  int64_t bdDim = metadataType.getShape()[1];
+  int64_t sDim = metadataType.getShape()[2];
+  int64_t eDim = topkType.getShape()[topkEDim];
   int64_t kDim = metadataType.getShape()[3];
 
   mlir::sdy::OpShardingRuleBuilder builder(op.getOperandTypes(),
                                            TypeRange(resultTypes),
                                            op.getContext(), std::nullopt);
 
-  // D factor: topk[0], mapping_in=kNull, metadata[0],
+  // D factor: topk[D] (if present), mapping_in[3], metadata[0] (if present),
   //           mapping_out=kNull, reduced=kNull
-  builder.addFactor({0, mlir::sdy::kNullDim, 0},
+  builder.addFactor({topkDDim, 3, metadataDDim},
                     {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, dDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
-  // B factor: topk[1], mapping_in=kNull, metadata[1],
+  // BD factor: topk[BD] (if present), mapping_in=kNull, metadata[1],
   //           mapping_out[1], reduced=kNull
-  builder.addFactor({1, mlir::sdy::kNullDim, 1}, {1, mlir::sdy::kNullDim}, bDim,
+  builder.addFactor({topkBDDim, mlir::sdy::kNullDim, 1},
+                    {1, mlir::sdy::kNullDim}, bdDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
-  // S factor: topk[2], mapping_in=kNull, metadata[2],
+  // S factor: topk[S] (if present), mapping_in=kNull, metadata[2],
   //           mapping_out[2], reduced=kNull
-  builder.addFactor({2, mlir::sdy::kNullDim, 2}, {2, mlir::sdy::kNullDim}, sDim,
+  builder.addFactor({topkSDim, mlir::sdy::kNullDim, 2},
+                    {2, mlir::sdy::kNullDim}, sDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
+  // Flattened [B*S, E] topk format: block sharding on flattened token dim.
+  if (topkFlatBSDim != mlir::sdy::kNullDim) {
+    int64_t bsDim = topkType.getShape()[topkFlatBSDim];
+    builder.addFactor({topkFlatBSDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                      {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, bsDim,
+                      mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
   // E factor (replicated inputs): topk[3] and mapping_in[2] must keep E_global.
   // The kernel needs the full expert-to-device table and all expert routing
   // weights to perform global-to-local remapping internally.
-  builder.addFactor({3, 2, mlir::sdy::kNullDim},
+  builder.addFactor({topkEDim, 2, mlir::sdy::kNullDim},
                     {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, eDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5956,12 +5956,16 @@ mlir::tt::ttir::PagedScaledDotProductAttentionDecodeOp::verify() {
   ::mlir::RankedTensorType dispatchedType = getDispatched().getType();
   ::mlir::RankedTensorType metadataType = getMetadata().getType();
 
-  // All tensors must be 4D
-  if (inputType.getRank() != 4) {
-    return emitOpError("input_tensor must be a 4D tensor [B, S, 1, H]");
+  // input_tensor accepts rank 3 or 4; the workaround canonicalizes to rank 4.
+  //   [B, S, H] or [B, 1, S, H]
+  if (inputType.getRank() != 3 && inputType.getRank() != 4) {
+    return emitOpError(
+        "input_tensor must be rank 3 or 4 ([B, S, H] or [B, 1, S, H])");
   }
-  if (indicesType.getRank() != 4) {
-    return emitOpError("expert_indices must be a 4D tensor [B, S, 1, K]");
+  if (indicesType.getRank() != 2 && indicesType.getRank() != 3 &&
+      indicesType.getRank() != 4) {
+    return emitOpError("expert_indices must be rank 2, 3, or 4 "
+                       "([B*S, K], [B, S, K], or [B, 1, S, K])");
   }
   if (mappingType.getRank() != 4) {
     return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
@@ -6041,8 +6045,9 @@ mlir::tt::ttir::PagedScaledDotProductAttentionDecodeOp::verify() {
   ::mlir::RankedTensorType mappingOutputType = getMapping().getType();
   ::mlir::RankedTensorType reducedType = getReduced().getType();
 
-  if (topkType.getRank() != 4) {
-    return emitOpError("topk_tensor must be a 4D tensor [D, B, S, E]");
+  if (topkType.getRank() != 2 && topkType.getRank() != 3 &&
+      topkType.getRank() != 4) {
+    return emitOpError("topk_tensor must be rank 2, 3, or 4");
   }
   if (mappingInputType.getRank() != 4) {
     return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2623,12 +2623,16 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
   ::mlir::RankedTensorType dispatchedType = getDispatched().getType();
   ::mlir::RankedTensorType metadataType = getMetadata().getType();
 
-  // All tensors must be 4D
-  if (inputType.getRank() != 4) {
-    return emitOpError("input_tensor must be a 4D tensor [B, S, 1, H]");
+  // input_tensor accepts rank 3 or 4; the workaround canonicalizes to rank 4.
+  //   [B, S, H] or [B, 1, S, H]
+  if (inputType.getRank() != 3 && inputType.getRank() != 4) {
+    return emitOpError(
+        "input_tensor must be rank 3 or 4 ([B, S, H] or [B, 1, S, H])");
   }
-  if (indicesType.getRank() != 4) {
-    return emitOpError("expert_indices must be a 4D tensor [B, S, 1, K]");
+  if (indicesType.getRank() != 2 && indicesType.getRank() != 3 &&
+      indicesType.getRank() != 4) {
+    return emitOpError("expert_indices must be rank 2, 3, or 4 "
+                       "([B*S, K], [B, S, K], or [B, 1, S, K])");
   }
   if (mappingType.getRank() != 4) {
     return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
@@ -2694,6 +2698,13 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     return emitOpError("num_experts_per_tok must be positive");
   }
 
+  // Verify output_shard_dim is 1 or 2.
+  int64_t outputShardDim = getOutputShardDim();
+  if (outputShardDim != 1 && outputShardDim != 2) {
+    return emitOpError("output_shard_dim must be 1 or 2, got ")
+           << outputShardDim;
+  }
+
   return success();
 }
 
@@ -2708,8 +2719,9 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
   ::mlir::RankedTensorType mappingOutputType = getMapping().getType();
   ::mlir::RankedTensorType reducedType = getReduced().getType();
 
-  if (topkType.getRank() != 4) {
-    return emitOpError("topk_tensor must be a 4D tensor [D, B, S, E]");
+  if (topkType.getRank() != 2 && topkType.getRank() != 3 &&
+      topkType.getRank() != 4) {
+    return emitOpError("topk_tensor must be rank 2, 3, or 4");
   }
   if (mappingInputType.getRank() != 4) {
     return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -53,6 +53,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/Conv3dPadOutputChannelsRewritePattern.cpp
         Workarounds/Decomposition/Conv3dDepthPaddingRewritePattern.cpp
         Workarounds/Decomposition/PadHighDimRewritePattern.cpp
+        Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.cpp
         Workarounds/TTNNWorkaroundsPatterns.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.cpp
@@ -1,0 +1,1365 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+namespace {
+
+static Value createReshape(PatternRewriter &rewriter, Location loc, Value input,
+                           llvm::ArrayRef<int64_t> outputShape,
+                           StringRef suffix) {
+  auto inputType = cast<RankedTensorType>(input.getType());
+  RankedTensorType outputType =
+      ttnn::utils::RankedTensorTypeFactory::create(inputType, outputShape);
+  SmallVector<int32_t> shapeI32(outputShape.begin(), outputShape.end());
+  return rewriter
+      .create<ttnn::ReshapeOp>(
+          ttmlir::utils::appendLocationSuffix(loc, suffix), outputType, input,
+          rewriter.getI32ArrayAttr(shapeI32), ttnn::MemoryConfigAttr())
+      .getResult();
+}
+
+static ttcore::TileSizeAttr
+getPreferredTileSize(ttcore::ChipDescAttr chipDesc) {
+  llvm::ArrayRef<ttcore::TileSizeAttr> supported =
+      chipDesc.getSupportedTileSizes();
+  if (supported.empty()) {
+    return {};
+  }
+
+  auto betterTile = [](ttcore::TileSizeAttr lhs, ttcore::TileSizeAttr rhs) {
+    int64_t lhsArea = lhs.getY() * lhs.getX();
+    int64_t rhsArea = rhs.getY() * rhs.getX();
+    if (lhsArea != rhsArea) {
+      return lhsArea < rhsArea;
+    }
+    if (lhs.getY() != rhs.getY()) {
+      return lhs.getY() < rhs.getY();
+    }
+    return lhs.getX() < rhs.getX();
+  };
+
+  ttcore::TileSizeAttr preferred = supported.front();
+  for (ttcore::TileSizeAttr tile : supported.drop_front()) {
+    if (betterTile(preferred, tile)) {
+      preferred = tile;
+    }
+  }
+  return preferred;
+}
+
+class SparseMatmulTileDimsRewritePattern
+    : public OpRewritePattern<ttnn::SparseMatmulOp> {
+public:
+  using OpRewritePattern<ttnn::SparseMatmulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::SparseMatmulOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+// Generate a default program config for sparse_matmul based on tiled shapes.
+static ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr
+createProgramConfig(MLIRContext *ctx, RankedTensorType aType,
+                    RankedTensorType bType, ttcore::DeviceAttr deviceAttr,
+                    int64_t tileH, int64_t tileW) {
+  auto gridShape = deviceAttr.getWorkerGrid().getShape();
+  int64_t coreY = gridShape[0];
+  int64_t coreX = gridShape[1];
+
+  auto aShape = aType.getShape();
+  auto bShape = bType.getShape();
+
+  int64_t M = aShape[aShape.size() - 2];
+  int64_t N = bShape[bShape.size() - 1];
+  int64_t NTiles = (N + tileW - 1) / tileW;
+
+  int64_t usedCoreX = std::min(coreX, NTiles);
+  while (usedCoreX > 1) {
+    int64_t pcn = (NTiles + usedCoreX - 1) / usedCoreX;
+    if ((NTiles + pcn - 1) / pcn == usedCoreX) {
+      break;
+    }
+    --usedCoreX;
+  }
+
+  int64_t perCoreM = std::max(static_cast<int64_t>(1), M / tileH);
+  int64_t perCoreN =
+      std::max(static_cast<int64_t>(1), (NTiles + usedCoreX - 1) / usedCoreX);
+
+  auto gridAttr = ttnn::CoreCoordAttr::get(ctx, usedCoreX, coreY);
+  auto hopCoresAttr = ttnn::CoreRangeSetAttr::get(ctx, {});
+
+  return ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr::get(
+      ctx, gridAttr,
+      /*in0_block_w=*/1, /*out_subblock_h=*/1, /*out_subblock_w=*/1,
+      /*out_block_h=*/1, /*out_block_w=*/1,
+      /*per_core_m=*/static_cast<uint64_t>(perCoreM),
+      /*per_core_n=*/static_cast<uint64_t>(perCoreN),
+      /*fuse_batch=*/false, /*fused_activation=*/nullptr,
+      /*mcast_in0=*/true, /*gather_in0=*/false,
+      /*hop_cores=*/hopCoresAttr, /*num_global_cb_receivers=*/0,
+      /*untilize_out=*/false);
+}
+
+template <typename OpTy>
+static OpTy getSingleUserOfType(Value value) {
+  SmallVector<Operation *> users;
+  for (Operation *user : value.getUsers()) {
+    if (mlir::isa<ttnn::DeallocateOp>(user)) {
+      continue;
+    }
+    users.push_back(user);
+  }
+
+  if (users.size() != 1) {
+    return nullptr;
+  }
+  return mlir::dyn_cast<OpTy>(users.front());
+}
+
+// Return the unique user of the requested type while tolerating other
+// non-Deallocate users. This is useful for already-tiled MoE chains where the
+// legacy path may keep extra users alive, but we still want to rewrite the
+// matching sparse_matmul->activation->sparse_matmul subgraph.
+template <typename OpTy>
+static OpTy getUniqueUserOfType(Value value) {
+  OpTy found;
+  for (Operation *user : value.getUsers()) {
+    if (mlir::isa<ttnn::DeallocateOp>(user)) {
+      continue;
+    }
+    auto op = mlir::dyn_cast<OpTy>(user);
+    if (!op) {
+      continue;
+    }
+    if (found) {
+      return nullptr;
+    }
+    found = op;
+  }
+  return found;
+}
+
+static bool isPermutation(ttnn::PermuteOp permuteOp,
+                          llvm::ArrayRef<int64_t> expected) {
+  if (!permuteOp) {
+    return false;
+  }
+  auto perm = permuteOp.getPermutation();
+  if (perm.size() != expected.size()) {
+    return false;
+  }
+  return llvm::equal(perm, expected);
+}
+
+static Value cloneLikeWithNewOperands(PatternRewriter &rewriter, Operation *op,
+                                      llvm::ArrayRef<Value> operands,
+                                      Type resultType) {
+  OperationState state(op->getLoc(), op->getName().getStringRef());
+  state.addOperands(operands);
+  state.addTypes(resultType);
+  state.addAttributes(op->getAttrs());
+  return rewriter.create(state)->getResult(0);
+}
+
+static bool isPointwiseRankPreservingOp(Operation *op) {
+  if (!mlir::isa<ttnn::AddOp, ttnn::MultiplyOp, ttnn::ClampScalarOp,
+                 ttnn::SigmoidOp, ttnn::SiluOp>(op)) {
+    return false;
+  }
+  if (op->getNumResults() != 1) {
+    return false;
+  }
+  auto resultType = mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType) {
+    return false;
+  }
+  for (Value operand : op->getOperands()) {
+    auto operandType = mlir::dyn_cast<RankedTensorType>(operand.getType());
+    if (operandType && operandType.getRank() == resultType.getRank()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Walk forward through pointwise rank-preserving ops, recording the shortest
+// distance to each reachable op. The reachable value set is used to determine
+// whether a candidate common op directly merges both slice branches.
+static DenseMap<Operation *, int64_t>
+collectForwardPointwiseDistances(Value start, DenseSet<Value> &reachable) {
+  DenseMap<Operation *, int64_t> opDistance;
+  DenseMap<Value, int64_t> valueDistance;
+  SmallVector<Value> worklist = {start};
+  valueDistance[start] = 0;
+
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    int64_t distance = valueDistance.lookup(v);
+    reachable.insert(v);
+
+    for (Operation *user : v.getUsers()) {
+      if (mlir::isa<ttnn::DeallocateOp>(user) ||
+          !isPointwiseRankPreservingOp(user)) {
+        continue;
+      }
+
+      int64_t newDistance = distance + 1;
+      auto opIt = opDistance.find(user);
+      if (opIt != opDistance.end() && opIt->second <= newDistance) {
+        continue;
+      }
+      opDistance[user] = newDistance;
+
+      for (Value result : user->getResults()) {
+        auto valueIt = valueDistance.find(result);
+        if (valueIt != valueDistance.end() && valueIt->second <= newDistance) {
+          continue;
+        }
+        valueDistance[result] = newDistance;
+        worklist.push_back(result);
+      }
+    }
+  }
+
+  return opDistance;
+}
+
+// Find the nearest common pointwise rank-preserving op reachable from both
+// slices. Prefer an op that directly consumes one value from each branch when
+// available, otherwise fall back to the earliest common pointwise user.
+static Operation *
+findNearestCommonPointwiseUser(MutableArrayRef<ttnn::SliceStaticOp> slices) {
+  if (slices.size() != 2) {
+    return nullptr;
+  }
+  DenseSet<Value> reach0, reach1;
+  auto dist0 = collectForwardPointwiseDistances(slices[0].getResult(), reach0);
+  auto dist1 = collectForwardPointwiseDistances(slices[1].getResult(), reach1);
+
+  Operation *bestDirectMerge = nullptr;
+  int64_t bestDirectMaxDist = 0;
+  int64_t bestDirectSumDist = 0;
+  Operation *bestCommon = nullptr;
+  int64_t bestCommonMaxDist = 0;
+  int64_t bestCommonSumDist = 0;
+
+  for (const auto &it : dist0) {
+    Operation *op = it.first;
+    int64_t distFrom0 = it.second;
+    auto dist1It = dist1.find(op);
+    if (dist1It == dist1.end()) {
+      continue;
+    }
+    int64_t distFrom1 = dist1It->second;
+    int64_t maxDist = std::max(distFrom0, distFrom1);
+    int64_t sumDist = distFrom0 + distFrom1;
+
+    bool has0OnlyOperand = false;
+    bool has1OnlyOperand = false;
+    for (Value operand : op->getOperands()) {
+      bool from0 = reach0.count(operand);
+      bool from1 = reach1.count(operand);
+      has0OnlyOperand |= from0 && !from1;
+      has1OnlyOperand |= from1 && !from0;
+    }
+    bool directlyMergesBranches = has0OnlyOperand && has1OnlyOperand;
+
+    auto isBetterCandidate = [&](Operation *bestOp, int64_t bestMaxDist,
+                                 int64_t bestSumDist) {
+      return !bestOp || maxDist < bestMaxDist ||
+             (maxDist == bestMaxDist && sumDist < bestSumDist);
+    };
+
+    if (directlyMergesBranches) {
+      if (isBetterCandidate(bestDirectMerge, bestDirectMaxDist,
+                            bestDirectSumDist)) {
+        bestDirectMerge = op;
+        bestDirectMaxDist = maxDist;
+        bestDirectSumDist = sumDist;
+      }
+    } else if (isBetterCandidate(bestCommon, bestCommonMaxDist,
+                                 bestCommonSumDist)) {
+      bestCommon = op;
+      bestCommonMaxDist = maxDist;
+      bestCommonSumDist = sumDist;
+    }
+  }
+
+  return bestDirectMerge ? bestDirectMerge : bestCommon;
+}
+
+// Collect all ops between the slices and finalCommonOp (exclusive of both
+// slices and finalCommonOp) and return them in topological order.
+static SmallVector<Operation *>
+collectActivationSubgraph(MutableArrayRef<ttnn::SliceStaticOp> slices,
+                          Operation *finalCommonOp) {
+  DenseSet<Operation *> subgraphOps;
+  SmallVector<Value> worklist;
+  for (auto slice : slices) {
+    worklist.push_back(slice.getResult());
+  }
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    for (Operation *user : v.getUsers()) {
+      if (mlir::isa<ttnn::DeallocateOp>(user)) {
+        continue;
+      }
+      if (user == finalCommonOp) {
+        continue;
+      }
+      if (!isPointwiseRankPreservingOp(user)) {
+        continue;
+      }
+      if (subgraphOps.insert(user).second) {
+        for (Value result : user->getResults()) {
+          worklist.push_back(result);
+        }
+      }
+    }
+  }
+
+  SmallVector<Operation *> topoOrder;
+  DenseSet<Operation *> sorted;
+  bool progress = true;
+  while (progress && sorted.size() < subgraphOps.size()) {
+    progress = false;
+    for (Operation *op : subgraphOps) {
+      if (sorted.count(op)) {
+        continue;
+      }
+      bool ready = true;
+      for (Value operand : op->getOperands()) {
+        Operation *def = operand.getDefiningOp();
+        if (def && subgraphOps.count(def) && !sorted.count(def)) {
+          ready = false;
+          break;
+        }
+      }
+      if (ready) {
+        topoOrder.push_back(op);
+        sorted.insert(op);
+        progress = true;
+      }
+    }
+  }
+  return topoOrder;
+}
+
+// Clone all ops from slices through finalCommonOp with new shapes, returning
+// the new finalCommonOp value. The shape mapping replaces the old flattened
+// [BD*dimB*M, E, 1, X] layout with an M-preserving [dimA*dimB, E, M, X].
+static Value cloneActivationChainWithNewShapes(
+    MutableArrayRef<ttnn::SliceStaticOp> slices, Value newPreSliceInput,
+    int64_t dimA, int64_t dimB, int64_t E, int64_t M, int64_t expandedN,
+    SmallVector<Operation *> &topoOrder, Operation *finalCommonOp,
+    PatternRewriter &rewriter) {
+
+  auto preSliceInputType =
+      mlir::cast<RankedTensorType>(newPreSliceInput.getType());
+  int64_t reducedN = expandedN / 2;
+  SmallVector<int64_t> actShape = {dimA * dimB, E, M, reducedN};
+  auto sliceOutType =
+      ttnn::utils::RankedTensorTypeFactory::create(preSliceInputType, actShape);
+
+  auto makeNewType = [&](RankedTensorType oldType) -> RankedTensorType {
+    return ttnn::utils::RankedTensorTypeFactory::create(
+        oldType, {dimA * dimB, E, M, oldType.getShape()[3]});
+  };
+
+  DenseMap<Value, Value> valueMapping;
+
+  for (auto slice : slices) {
+    auto beginsOpt =
+        ttmlir::utils::getIntegerVector<int64_t>(slice.getBegins());
+    if (!beginsOpt) {
+      llvm::consumeError(beginsOpt.takeError());
+      continue;
+    }
+    int32_t startN = static_cast<int32_t>((*beginsOpt)[3]);
+    SmallVector<int32_t> begins = {0, 0, 0, startN};
+    SmallVector<int32_t> ends = {static_cast<int32_t>(dimA * dimB),
+                                 static_cast<int32_t>(E),
+                                 static_cast<int32_t>(M),
+                                 static_cast<int32_t>(expandedN)};
+    SmallVector<int32_t> steps = {1, 1, 1, 2};
+    Value newSlice =
+        rewriter
+            .create<ttnn::SliceStaticOp>(
+                slice.getLoc(), sliceOutType, newPreSliceInput,
+                rewriter.getI32ArrayAttr(begins),
+                rewriter.getI32ArrayAttr(ends),
+                rewriter.getI32ArrayAttr(steps))
+            .getResult();
+    valueMapping[slice.getResult()] = newSlice;
+  }
+
+  for (Operation *op : topoOrder) {
+    SmallVector<Value> newOperands;
+    for (Value operand : op->getOperands()) {
+      auto it = valueMapping.find(operand);
+      newOperands.push_back(it != valueMapping.end() ? it->second : operand);
+    }
+    auto oldType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    Value newResult =
+        cloneLikeWithNewOperands(rewriter, op, newOperands, makeNewType(oldType));
+    valueMapping[op->getResult(0)] = newResult;
+  }
+
+  // Clone finalCommonOp separately (not in topoOrder).
+  SmallVector<Value> finalOpOperands;
+  for (Value operand : finalCommonOp->getOperands()) {
+    auto it = valueMapping.find(operand);
+    finalOpOperands.push_back(it != valueMapping.end() ? it->second : operand);
+  }
+  auto finalOpOldType =
+      mlir::cast<RankedTensorType>(finalCommonOp->getResult(0).getType());
+  return cloneLikeWithNewOperands(rewriter, finalCommonOp, finalOpOperands,
+                                  makeNewType(finalOpOldType));
+}
+
+// Build the common M-preserving pre-slice tensor from the tiled gate-up sparse
+// output. Accepts either [dimA, dimB, E, M, N] or [dimA, dimB, 1, E, M, N] and
+// produces [dimA*dimB, E, M, N] ready for slicing. Keep this chain minimal so
+// the resulting graph stays close to the old frontend-modeled path from main.
+static Value buildMPreservingPreSliceChain(Value tiledGateUpResult, Value bias,
+                                           Operation *origAdd, int64_t dimA,
+                                           int64_t dimB, int64_t E, int64_t M,
+                                           int64_t expandedN,
+                                           PatternRewriter &rewriter,
+                                           Location loc) {
+  auto preSliceReshape = ttir_to_ttnn::utils::generateReshape(
+      cast<TypedValue<RankedTensorType>>(tiledGateUpResult),
+      {dimA * dimB, E, M, expandedN},
+      rewriter, loc);
+
+  return cloneLikeWithNewOperands(rewriter, origAdd,
+                                  {preSliceReshape.getResult(), bias},
+                                  preSliceReshape.getType());
+}
+
+// Verify that the two slices have step=2 on the last dimension and that their
+// begins differ only in the last element (0 vs 1).
+static bool verifyHalfSlices(MutableArrayRef<ttnn::SliceStaticOp> slices) {
+  if (slices.size() != 2) {
+    return false;
+  }
+  for (auto slice : slices) {
+    auto beginsOpt =
+        ttmlir::utils::getIntegerVector<int64_t>(slice.getBegins());
+    auto stepsOpt = ttmlir::utils::getIntegerVector<int64_t>(slice.getStep());
+    if (!beginsOpt) {
+      llvm::consumeError(beginsOpt.takeError());
+      if (stepsOpt) {
+        (void)*stepsOpt;
+      } else {
+        llvm::consumeError(stepsOpt.takeError());
+      }
+      return false;
+    }
+    if (!stepsOpt) {
+      llvm::consumeError(stepsOpt.takeError());
+      return false;
+    }
+    auto &begins = *beginsOpt;
+    auto &steps = *stepsOpt;
+    if (begins.size() != 4 || steps.size() != 4 || steps[3] != 2) {
+      return false;
+    }
+    if (begins[3] != 0 && begins[3] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Rewrite already-tiled gate-up activation chain from flattened layout:
+//
+//   sparse -> reshape(5D) -> permute -> reshape(flat) -> add -> activation
+//   -> reshape -> permute
+//
+// to an M-preserving layout:
+//
+//   sparse -> reshape(5D) -> reshape(4D) -> add(4D) -> activation
+//
+// Handles both clamp-based and standard SwiGLU activation patterns by using
+// generic graph traversal to find the nearest common pointwise merge op.
+static LogicalResult
+rewriteAlreadyTiledGateUpActivationChain(ttnn::SparseMatmulOp srcOp,
+                                         PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard guard(rewriter);
+
+  auto gateUpReshape = getUniqueUserOfType<ttnn::ReshapeOp>(srcOp.getResult());
+  if (!gateUpReshape) {
+    return failure();
+  }
+
+  auto gateUpShape = gateUpReshape.getType().getShape();
+  if (gateUpShape.size() != 5) {
+    return failure();
+  }
+
+  auto preFlattenPermute =
+      getUniqueUserOfType<ttnn::PermuteOp>(gateUpReshape.getResult());
+  if (!isPermutation(preFlattenPermute, {0, 1, 3, 2, 4})) {
+    return failure();
+  }
+
+  auto flattened =
+      getUniqueUserOfType<ttnn::ReshapeOp>(preFlattenPermute.getResult());
+  if (!flattened) {
+    return failure();
+  }
+
+  auto flattenedShape = flattened.getType().getShape();
+  if (flattenedShape.size() != 4 || flattenedShape[2] != 1) {
+    return failure();
+  }
+
+  auto preActAdd = getUniqueUserOfType<ttnn::AddOp>(flattened.getResult());
+  if (!preActAdd) {
+    return failure();
+  }
+
+  SmallVector<ttnn::SliceStaticOp> preActSlices;
+  for (Operation *user : preActAdd.getResult().getUsers()) {
+    if (mlir::isa<ttnn::DeallocateOp>(user)) {
+      continue;
+    }
+    auto slice = mlir::dyn_cast<ttnn::SliceStaticOp>(user);
+    if (!slice) {
+      continue;
+    }
+    preActSlices.push_back(slice);
+  }
+  if (!verifyHalfSlices(preActSlices)) {
+    return failure();
+  }
+
+  Operation *finalMergeOp = findNearestCommonPointwiseUser(preActSlices);
+  if (!finalMergeOp) {
+    return failure();
+  }
+
+  auto finalReshape =
+      getUniqueUserOfType<ttnn::ReshapeOp>(finalMergeOp->getResult(0));
+  auto finalPermute =
+      finalReshape
+          ? getUniqueUserOfType<ttnn::PermuteOp>(finalReshape.getResult())
+          : nullptr;
+  if (!finalReshape || !isPermutation(finalPermute, {0, 2, 1, 3})) {
+    return failure();
+  }
+
+  auto finalType = mlir::cast<RankedTensorType>(finalPermute.getType());
+  auto finalShape = finalType.getShape();
+  if (finalShape.size() != 4) {
+    return failure();
+  }
+
+  int64_t dimA = gateUpShape[0];
+  int64_t dimB = gateUpShape[1];
+  int64_t E = gateUpShape[2];
+  int64_t M = gateUpShape[3];
+  int64_t expandedN = gateUpShape[4];
+  int64_t reducedN = finalShape[3];
+
+  if (finalShape[0] != dimA * dimB || finalShape[1] != E ||
+      finalShape[2] != M) {
+    return failure();
+  }
+  if (expandedN != reducedN * 2) {
+    return failure();
+  }
+  if (flattenedShape[1] != E) {
+    return failure();
+  }
+
+  Value addBias = preActAdd.getLhs() == flattened.getResult()
+                      ? preActAdd.getRhs()
+                      : preActAdd.getLhs();
+  auto addBiasType = mlir::cast<RankedTensorType>(addBias.getType());
+  auto addBiasShape = addBiasType.getShape();
+  if (addBiasShape.size() != 4 || addBiasShape[0] != 1 ||
+      addBiasShape[1] != E || addBiasShape[2] != 1 ||
+      addBiasShape[3] != expandedN) {
+    return failure();
+  }
+
+  // Validate activation subgraph BEFORE creating any new ops to avoid
+  // dangling ops on failure.
+  auto topoOrder = collectActivationSubgraph(preActSlices, finalMergeOp);
+  for (Operation *op : topoOrder) {
+    auto type = mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!type || type.getShape().size() != 4) {
+      return failure();
+    }
+  }
+
+  rewriter.setInsertionPoint(preActAdd);
+  auto loc = srcOp.getLoc();
+
+  Value preSliceInput = buildMPreservingPreSliceChain(
+      srcOp.getResult(), addBias, preActAdd.getOperation(), dimA, dimB,
+      E, M, expandedN, rewriter, loc);
+
+  Value newFinalMerge = cloneActivationChainWithNewShapes(
+      preActSlices, preSliceInput, dimA, dimB, E, M, expandedN, topoOrder,
+      finalMergeOp, rewriter);
+
+  rewriter.replaceOp(finalPermute, newFinalMerge);
+  return success();
+}
+
+// Erase an op and all its DeallocateOp users from the IR.
+// Returns false if the op still has non-DeallocateOp users (skip erasure).
+static bool eraseOpAndDeallocates(PatternRewriter &rewriter, Operation *op) {
+  for (Value result : op->getResults()) {
+    for (Operation *user : result.getUsers()) {
+      if (!mlir::isa<ttnn::DeallocateOp>(user)) {
+        return false;
+      }
+    }
+  }
+  for (Value result : op->getResults()) {
+    for (Operation *user : llvm::make_early_inc_range(result.getUsers())) {
+      rewriter.eraseOp(user);
+    }
+  }
+  rewriter.eraseOp(op);
+  return true;
+}
+
+// Rewrite the gate-up chain for the untiled case. Instead of creating an
+// untile chain and hoping the already-tiled rewriter matches later, this
+// directly walks the original 4D chain:
+//
+//   srcOp -> reshape [BD,S,E,N] -> add(bias) -> slices -> activation
+//   -> finalMergeOp -> reshape -> ...
+//
+// and rewrites it using the tiled sparse_matmul result.
+static LogicalResult
+rewriteUntiledGateUpChain(ttnn::SparseMatmulOp origSrcOp,
+                          Value tiledSparseResult, int64_t dimA, int64_t dimB,
+                          int64_t E, int64_t M, int64_t expandedN,
+                          PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard guard(rewriter);
+
+  auto origReshape =
+      getSingleUserOfType<ttnn::ReshapeOp>(origSrcOp.getResult());
+  if (!origReshape) {
+    return failure();
+  }
+  auto origReshapeShape = origReshape.getType().getShape();
+  if (origReshapeShape.size() != 4) {
+    return failure();
+  }
+
+  int64_t BD = origReshapeShape[0];
+  int64_t S = origReshapeShape[1];
+  if (origReshapeShape[2] != E || origReshapeShape[3] != expandedN) {
+    return failure();
+  }
+  if (BD * S != dimA * dimB * M) {
+    return failure();
+  }
+
+  auto origAdd = getSingleUserOfType<ttnn::AddOp>(origReshape.getResult());
+  if (!origAdd) {
+    return failure();
+  }
+
+  Value origBias = origAdd.getLhs() == origReshape.getResult()
+                       ? origAdd.getRhs()
+                       : origAdd.getLhs();
+  if (origAdd.getLhs() != origReshape.getResult() &&
+      origAdd.getRhs() != origReshape.getResult()) {
+    return failure();
+  }
+
+  auto biasType = mlir::cast<RankedTensorType>(origBias.getType());
+  auto biasShape = biasType.getShape();
+  if (biasShape.size() != 4) {
+    return failure();
+  }
+
+  SmallVector<ttnn::SliceStaticOp> origSlices;
+  for (Operation *user : origAdd.getResult().getUsers()) {
+    if (mlir::isa<ttnn::DeallocateOp>(user)) {
+      continue;
+    }
+    auto slice = mlir::dyn_cast<ttnn::SliceStaticOp>(user);
+    if (!slice) {
+      return failure();
+    }
+    origSlices.push_back(slice);
+  }
+  if (!verifyHalfSlices(origSlices)) {
+    return failure();
+  }
+
+  Operation *finalMergeOp = findNearestCommonPointwiseUser(origSlices);
+  if (!finalMergeOp) {
+    return failure();
+  }
+
+  int64_t reducedN = expandedN / 2;
+  auto finalMergeType =
+      mlir::cast<RankedTensorType>(finalMergeOp->getResult(0).getType());
+  auto finalMergeShape = finalMergeType.getShape();
+  if (finalMergeShape.size() != 4 || finalMergeShape[0] != BD ||
+      finalMergeShape[1] != S || finalMergeShape[2] != E ||
+      finalMergeShape[3] != reducedN) {
+    return failure();
+  }
+
+  auto topoOrder = collectActivationSubgraph(origSlices, finalMergeOp);
+  for (Operation *op : topoOrder) {
+    auto type = mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!type || type.getShape().size() != 4) {
+      return failure();
+    }
+  }
+
+  rewriter.setInsertionPoint(origAdd);
+  auto loc = origSrcOp.getLoc();
+
+  Value preSliceInput = buildMPreservingPreSliceChain(
+      tiledSparseResult, origBias, origAdd.getOperation(), dimA, dimB, E, M,
+      expandedN, rewriter, loc);
+
+  Value newFinalMergeVal = cloneActivationChainWithNewShapes(
+      origSlices, preSliceInput, dimA, dimB, E, M, expandedN, topoOrder,
+      finalMergeOp, rewriter);
+
+  // Back-permute: [dimA*dimB, E, M, reducedN] -> [BD, S, E, reducedN]
+  auto backPermute = ttir_to_ttnn::utils::generatePermute(
+      cast<TypedValue<RankedTensorType>>(newFinalMergeVal), {0, 2, 1, 3},
+      rewriter, loc);
+
+  rewriter.replaceOp(finalMergeOp, backPermute.getResult());
+
+  // Clean up the dead original chain in reverse topological order.
+  for (auto it = topoOrder.rbegin(); it != topoOrder.rend(); ++it) {
+    eraseOpAndDeallocates(rewriter, *it);
+  }
+  for (auto slice : origSlices) {
+    eraseOpAndDeallocates(rewriter, slice.getOperation());
+  }
+  eraseOpAndDeallocates(rewriter, origAdd.getOperation());
+  eraseOpAndDeallocates(rewriter, origReshape.getOperation());
+
+  return success();
+}
+
+// Rewrite already-tiled down-projection post-sparse chain:
+//
+//   sparse -> permute -> reshape(flatten) -> add -> reshape -> permute
+//
+// to:
+//
+//   sparse -> add -> reshape -> permute -> reshape
+//
+// This keeps the expert axis resident through the add and removes two
+// expensive layout transforms around the down-projection path.
+static LogicalResult
+rewriteAlreadyTiledDownProjectionPostSparseChain(ttnn::SparseMatmulOp srcOp,
+                                                 PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard guard(rewriter);
+
+  auto srcType = cast<RankedTensorType>(srcOp.getResult().getType());
+  if (srcType.getRank() != 4) {
+    return failure();
+  }
+  auto srcShape = srcType.getShape();
+  int64_t TSrc = srcShape[0];
+  int64_t EDown = srcShape[1];
+  int64_t MDown = srcShape[2];
+  int64_t HDown = srcShape[3];
+  if (TSrc <= 0 || EDown <= 0 || MDown <= 0 || HDown <= 0) {
+    return failure();
+  }
+
+  auto downPermute = getSingleUserOfType<ttnn::PermuteOp>(srcOp.getResult());
+  if (!isPermutation(downPermute, {0, 2, 1, 3})) {
+    return failure();
+  }
+
+  auto downFlatten =
+      getSingleUserOfType<ttnn::ReshapeOp>(downPermute.getResult());
+  if (!downFlatten) {
+    return failure();
+  }
+
+  auto downAdd = getSingleUserOfType<ttnn::AddOp>(downFlatten.getResult());
+  if (!downAdd) {
+    return failure();
+  }
+  Value bias = downAdd.getLhs() == downFlatten.getResult()   ? downAdd.getRhs()
+               : downAdd.getRhs() == downFlatten.getResult() ? downAdd.getLhs()
+                                                             : Value();
+  if (!bias) {
+    return failure();
+  }
+
+  auto downReshaped = getSingleUserOfType<ttnn::ReshapeOp>(downAdd.getResult());
+  auto downPermuteBack =
+      downReshaped
+          ? getSingleUserOfType<ttnn::PermuteOp>(downReshaped.getResult())
+          : nullptr;
+  if (!downReshaped || !isPermutation(downPermuteBack, {2, 0, 1, 3})) {
+    return failure();
+  }
+
+  auto downFlattenType = cast<RankedTensorType>(downFlatten.getType());
+  auto downReshapedType = cast<RankedTensorType>(downReshaped.getType());
+  auto downPermuteBackType = cast<RankedTensorType>(downPermuteBack.getType());
+  if (downFlattenType.getRank() != 4 || downReshapedType.getRank() != 4 ||
+      downPermuteBackType.getRank() != 4) {
+    return failure();
+  }
+  auto downFlattenShape = downFlattenType.getShape();
+  auto downReshapedShape = downReshapedType.getShape();
+  auto downPermuteBackShape = downPermuteBackType.getShape();
+
+  int64_t TDown = downReshapedShape[0];
+  int64_t SDown = downReshapedShape[1];
+  int64_t EReshaped = downReshapedShape[2];
+  int64_t HReshaped = downReshapedShape[3];
+
+  auto hasExpectedBiasShape = [&](Value maybeBias) {
+    auto biasType = dyn_cast<RankedTensorType>(maybeBias.getType());
+    if (!biasType || biasType.getRank() != 4) {
+      return false;
+    }
+    auto biasShape = biasType.getShape();
+    return biasShape[0] == 1 && biasShape[1] == EDown && biasShape[2] == 1 &&
+           biasShape[3] == HDown;
+  };
+
+  if (TDown <= 0 || MDown <= 0 || EDown != EReshaped || HDown != HReshaped ||
+      SDown <= 0 || SDown % MDown != 0 || !hasExpectedBiasShape(bias) ||
+      downFlattenShape[0] != TSrc * MDown || downFlattenShape[1] != EDown ||
+      downFlattenShape[2] != 1 || downFlattenShape[3] != HDown) {
+    return failure();
+  }
+
+  int64_t groupedS = SDown / MDown;
+  if (TSrc != TDown * groupedS || downPermuteBackShape[0] != EDown ||
+      downPermuteBackShape[1] != TDown || downPermuteBackShape[2] != SDown ||
+      downPermuteBackShape[3] != HDown) {
+    return failure();
+  }
+
+  rewriter.setInsertionPoint(downAdd);
+
+  Value newDownAdd = cloneLikeWithNewOperands(
+      rewriter, downAdd.getOperation(), {srcOp.getResult(), bias}, srcType);
+
+  auto grouped = ttir_to_ttnn::utils::generateReshape(
+      cast<TypedValue<RankedTensorType>>(newDownAdd),
+      {TDown, groupedS, EDown, MDown, HDown}, rewriter, srcOp.getLoc());
+  auto regroupPermute = ttir_to_ttnn::utils::generatePermute(
+      cast<TypedValue<RankedTensorType>>(grouped.getResult()), {2, 0, 1, 3, 4},
+      rewriter, srcOp.getLoc());
+  auto regroupReshape = ttir_to_ttnn::utils::generateReshape(
+      cast<TypedValue<RankedTensorType>>(regroupPermute.getResult()),
+      {EDown, TDown, SDown, HDown}, rewriter, srcOp.getLoc());
+
+  rewriter.replaceOp(downPermuteBack, regroupReshape.getResult());
+  return success();
+}
+
+LogicalResult SparseMatmulTileDimsRewritePattern::matchAndRewrite(
+    ttnn::SparseMatmulOp srcOp, PatternRewriter &rewriter) const {
+
+  auto a = srcOp.getA();
+  auto b = srcOp.getB();
+  auto sparsity = srcOp.getSparsity();
+
+  auto aType = mlir::cast<RankedTensorType>(a.getType());
+  auto bType = mlir::cast<RankedTensorType>(b.getType());
+  auto spType = mlir::cast<RankedTensorType>(sparsity.getType());
+  auto aShape = aType.getShape();
+  int64_t mDim = aShape[aShape.size() - 2];
+
+  bool isASparse = srcOp.getIsInputASparse();
+  bool isBSparse = srcOp.getIsInputBSparse();
+  auto loc = srcOp.getLoc();
+  auto chipDesc = ttcore::getOpChipDescAttr(srcOp);
+  auto preferredTile = getPreferredTileSize(chipDesc);
+  if (!preferredTile) {
+    srcOp.emitError("chip description has no supported tile sizes");
+    return failure();
+  }
+  int64_t tileHeight = preferredTile.getY();
+  int64_t tileWidth = preferredTile.getX();
+  if (tileHeight <= 0 || tileWidth <= 0) {
+    srcOp.emitError("preferred tile size must be positive");
+    return failure();
+  }
+
+  if (!isASparse && isBSparse) {
+    if (mDim == tileHeight) {
+      // Handle already-tiled gate-up subgraph where the preceding graph
+      // flattened [dimA, dimB, M] to [dimA*dimB*M, E, 1] before SwiGLU.
+      // Rewrite to keep the M axis through elementwise activation.
+      return rewriteAlreadyTiledGateUpActivationChain(srcOp, rewriter);
+    }
+
+    if (mDim > tileHeight) {
+      return failure();
+    }
+
+    // Gate-up: A=[BD, S, 1, H], sparsity=[1, 1, BD*S/M, E]
+    auto bShape = bType.getShape();
+    auto spShape = spType.getShape();
+
+    int64_t BD = aShape[0];
+    int64_t S = aShape[1];
+    int64_t H = aShape[3];
+    int64_t E = spShape[3];
+    int64_t N = bShape[3];
+    int64_t reducedTokens = spShape[2];
+    int64_t M = (BD * S) / reducedTokens;
+
+    bool splitSeq = (S % M == 0) && (S >= M);
+    bool splitBd = (BD % M == 0) && (BD >= M);
+    if (!splitSeq && !splitBd) {
+      return srcOp.emitError("Neither seq_len (")
+             << S << ") nor BD (" << BD << ") is divisible by tile size " << M;
+    }
+
+    int64_t dimA = splitSeq ? BD : BD / M;
+    int64_t dimB = splitSeq ? S / M : S;
+
+    // Tile A: [BD, S, 1, H] -> [dimA, dimB, M, H]
+    Value tiledA;
+    if (splitSeq) {
+      tiledA = ttir_to_ttnn::utils::generateReshape(a, {BD, S / M, M, H},
+                                                    rewriter, loc)
+                   .getResult();
+    } else {
+      auto reshaped = ttir_to_ttnn::utils::generateReshape(a, {BD / M, M, S, H},
+                                                           rewriter, loc);
+      tiledA = ttir_to_ttnn::utils::generatePermute(
+                   cast<TypedValue<RankedTensorType>>(reshaped.getResult()),
+                   {0, 2, 1, 3}, rewriter, loc)
+                   .getResult();
+    }
+
+    // Tile sparsity: [1, 1, BD*S/M, E] -> [dimA, dimB, 1, E]
+    auto tiledSparsity = ttir_to_ttnn::utils::generateReshape(
+        sparsity, {dimA, dimB, 1, E}, rewriter, loc);
+
+    // Create tiled sparse_matmul
+    auto tiledATyped = cast<TypedValue<RankedTensorType>>(tiledA);
+    auto deviceAttr = ttcore::lookupDevice(srcOp);
+    auto programConfigAttr =
+        createProgramConfig(rewriter.getContext(), tiledATyped.getType(), bType,
+                            deviceAttr, tileHeight, tileWidth);
+
+    llvm::SmallVector<int64_t> tiledOutShape = {dimA, dimB, 1, E, M, N};
+    auto tiledOutType = ttnn::utils::RankedTensorTypeFactory::create(
+        tiledATyped.getType(), tiledOutShape);
+
+    mlir::IntegerAttr nnzAttr = nullptr;
+    if (auto nnz = srcOp.getNnz()) {
+      nnzAttr = rewriter.getI64IntegerAttr(*nnz);
+    }
+
+    auto tiledResult = rewriter.create<ttnn::SparseMatmulOp>(
+        loc, tiledOutType, tiledATyped, b,
+        cast<TypedValue<RankedTensorType>>(tiledSparsity.getResult()),
+        srcOp.getIsInputASparse(), srcOp.getIsInputBSparse(), nnzAttr,
+        programConfigAttr, /*memory_config=*/nullptr, /*dtype=*/nullptr,
+        /*compute_config=*/nullptr);
+
+    // Try to rewrite the entire gate-up chain (add + activation) directly,
+    // avoiding the intermediate untile chain that the already-tiled rewriter
+    // cannot match due to different chain shapes.
+    if (succeeded(rewriteUntiledGateUpChain(srcOp, tiledResult.getResult(),
+                                            dimA, dimB, E, M, N, rewriter))) {
+      eraseOpAndDeallocates(rewriter, srcOp);
+      return success();
+    }
+
+    // Fallback: untile output while preserving the legacy gate-up factoring.
+    auto squeezed = ttir_to_ttnn::utils::generateReshape(
+        cast<TypedValue<RankedTensorType>>(tiledResult.getResult()),
+        {dimA, dimB, E, M, N}, rewriter, loc);
+
+    auto legacyPermuted = ttir_to_ttnn::utils::generatePermute(
+        cast<TypedValue<RankedTensorType>>(squeezed.getResult()),
+        {0, 1, 3, 2, 4}, rewriter, loc);
+
+    auto legacyGateUp = ttir_to_ttnn::utils::generateReshape(
+        cast<TypedValue<RankedTensorType>>(legacyPermuted.getResult()),
+        {BD, S, E, N}, rewriter, loc);
+
+    auto untiled = ttir_to_ttnn::utils::generateReshape(
+        cast<TypedValue<RankedTensorType>>(legacyGateUp.getResult()),
+        {BD, S, 1, E, 1, N}, rewriter, loc);
+
+    rewriter.replaceOp(srcOp, untiled.getResult());
+    return success();
+
+  } else if (isASparse && !isBSparse) {
+    if (mDim == tileHeight) {
+      return rewriteAlreadyTiledDownProjectionPostSparseChain(srcOp, rewriter);
+    }
+
+    if (mDim > tileHeight) {
+      return failure();
+    }
+
+    // Down: A=[BD*S, E, 1, inter], sparsity=[1, 1, BD*S/M, E]
+    auto bShape = bType.getShape();
+    auto spShape = spType.getShape();
+
+    int64_t totalTokens = aShape[0];
+    int64_t E = aShape[1];
+    int64_t inter = aShape[3];
+    int64_t H = bShape[3];
+    int64_t reducedTokens = spShape[2];
+    int64_t M = totalTokens / reducedTokens;
+
+    // Tile A: [BD*S, E, 1, inter] -> [BD*S/M, E, M, inter]
+    auto reshaped = ttir_to_ttnn::utils::generateReshape(
+        a, {totalTokens / M, M, E, inter}, rewriter, loc);
+    auto tiledA = ttir_to_ttnn::utils::generatePermute(
+        cast<TypedValue<RankedTensorType>>(reshaped.getResult()), {0, 2, 1, 3},
+        rewriter, loc);
+
+    auto tiledATyped = cast<TypedValue<RankedTensorType>>(tiledA.getResult());
+    auto deviceAttr = ttcore::lookupDevice(srcOp);
+    auto programConfigAttr =
+        createProgramConfig(rewriter.getContext(), tiledATyped.getType(), bType,
+                            deviceAttr, tileHeight, tileWidth);
+
+    llvm::SmallVector<int64_t> tiledOutShape = {totalTokens / M, E, M, H};
+    auto tiledOutType = ttnn::utils::RankedTensorTypeFactory::create(
+        tiledATyped.getType(), tiledOutShape);
+
+    mlir::IntegerAttr nnzAttr = nullptr;
+    if (auto nnz = srcOp.getNnz()) {
+      nnzAttr = rewriter.getI64IntegerAttr(*nnz);
+    }
+
+    auto tiledResult = rewriter.create<ttnn::SparseMatmulOp>(
+        loc, tiledOutType, tiledATyped, b, sparsity, srcOp.getIsInputASparse(),
+        srcOp.getIsInputBSparse(), nnzAttr, programConfigAttr,
+        /*memory_config=*/nullptr, /*dtype=*/nullptr,
+        /*compute_config=*/nullptr);
+
+    // Untile output: [BD*S/M, E, M, H] -> [BD*S, E, 1, H]
+    auto permuted = ttir_to_ttnn::utils::generatePermute(
+        cast<TypedValue<RankedTensorType>>(tiledResult.getResult()),
+        {0, 2, 1, 3}, rewriter, loc);
+
+    auto untiled = ttir_to_ttnn::utils::generateReshape(
+        cast<TypedValue<RankedTensorType>>(permuted.getResult()),
+        {totalTokens, E, 1, H}, rewriter, loc);
+
+    rewriter.replaceOp(srcOp, untiled.getResult());
+    return success();
+  }
+
+  // Not an untiled case we handle — leave as-is.
+  return failure();
+}
+
+class MoeAllToAllDispatchCanonicalizeInputsRewritePattern
+    : public OpRewritePattern<ttnn::AllToAllDispatchOp> {
+public:
+  using OpRewritePattern<ttnn::AllToAllDispatchOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::AllToAllDispatchOp op,
+                                PatternRewriter &rewriter) const override {
+    Value inputTensor = op.getInputTensor();
+    Value expertIndices = op.getExpertIndices();
+    auto inputType = cast<RankedTensorType>(inputTensor.getType());
+    auto indicesType = cast<RankedTensorType>(expertIndices.getType());
+
+    if (inputType.getRank() == 4 && indicesType.getRank() == 4) {
+      return failure();
+    }
+
+    bool modified = false;
+    if (inputType.getRank() == 3) {
+      auto shape = inputType.getShape();
+      if (shape[0] <= 0 || shape[1] <= 0 || shape[2] <= 0) {
+        return failure();
+      }
+      inputTensor =
+          createReshape(rewriter, op.getLoc(), inputTensor,
+                        {shape[0], 1, shape[1], shape[2]}, "_input_4d");
+      inputType = cast<RankedTensorType>(inputTensor.getType());
+      modified = true;
+    }
+
+    int64_t B = inputType.getShape()[0];
+    int64_t S = inputType.getShape()[2];
+    if (indicesType.getRank() == 2) {
+      int64_t K = indicesType.getShape()[1];
+      if (B <= 0 || S <= 0 || K <= 0) {
+        return failure();
+      }
+      expertIndices = createReshape(rewriter, op.getLoc(), expertIndices,
+                                    {B, 1, S, K}, "_expert_indices_4d");
+      modified = true;
+    } else if (indicesType.getRank() == 3) {
+      auto shape = indicesType.getShape();
+      if (shape[0] <= 0 || shape[1] <= 0 || shape[2] <= 0) {
+        return failure();
+      }
+      expertIndices = createReshape(rewriter, op.getLoc(), expertIndices,
+                                    {shape[0], 1, shape[1], shape[2]},
+                                    "_expert_indices_4d");
+      modified = true;
+    }
+
+    if (!modified) {
+      return failure();
+    }
+
+    auto newOp = rewriter.create<ttnn::AllToAllDispatchOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_moe_workaround"),
+        cast<RankedTensorType>(op.getDispatched().getType()),
+        cast<RankedTensorType>(op.getMetadata().getType()), inputTensor,
+        expertIndices, op.getExpertMapping(), op.getNumDevicesAttr(),
+        op.getClusterAxisAttr(), op.getMemoryConfigAttr());
+
+    rewriter.replaceOp(op, {newOp.getDispatched(), newOp.getMetadata()});
+    return success();
+  }
+};
+
+class MoeAllToAllCombineCanonicalizeInputLayoutRewritePattern
+    : public OpRewritePattern<ttnn::AllToAllCombineOp> {
+public:
+  using OpRewritePattern<ttnn::AllToAllCombineOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::AllToAllCombineOp op,
+                                PatternRewriter &rewriter) const override {
+    auto inputType = cast<RankedTensorType>(op.getInputTensor().getType());
+    auto metadataType =
+        cast<RankedTensorType>(op.getExpertMetadata().getType());
+    auto mappingType = cast<RankedTensorType>(op.getExpertMapping().getType());
+    if (inputType.getRank() != 4 || metadataType.getRank() != 4 ||
+        mappingType.getRank() != 4) {
+      return failure();
+    }
+
+    auto inputShape = inputType.getShape();
+    auto metadataShape = metadataType.getShape();
+    auto mappingShape = mappingType.getShape();
+
+    int64_t metadataBD = metadataShape[1];
+    int64_t metadataS = metadataShape[2];
+    int64_t eGlobal = mappingShape[2];
+    int64_t totalDevices = mappingShape[3];
+    int64_t maybeE = inputShape[2];
+
+    int64_t eLocal = -1;
+    if (totalDevices > 0 && eGlobal > 0 && eGlobal % totalDevices == 0) {
+      eLocal = eGlobal / totalDevices;
+    }
+    bool expertDimMatches =
+        (maybeE == eGlobal) || (eLocal > 0 && maybeE == eLocal);
+    bool looksLikeBdseh = (inputShape[0] == metadataBD) &&
+                          (inputShape[1] == metadataS) && expertDimMatches;
+    if (!looksLikeBdseh) {
+      return failure();
+    }
+
+    DenseI64ArrayAttr permutation = rewriter.getDenseI64ArrayAttr({2, 0, 1, 3});
+    RankedTensorType permutedType =
+        ttnn::utils::RankedTensorTypeFactory::create(
+            inputType,
+            {inputShape[2], inputShape[0], inputShape[1], inputShape[3]});
+
+    auto permute = rewriter.create<ttnn::PermuteOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_to_ebdsh"),
+        permutedType, op.getInputTensor(), permutation,
+        ttnn::MemoryConfigAttr(), FloatAttr());
+
+    auto newOp = rewriter.create<ttnn::AllToAllCombineOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_moe_workaround"),
+        cast<RankedTensorType>(op.getResult().getType()), permute.getResult(),
+        op.getExpertMetadata(), op.getExpertMapping(), op.getNumDevicesAttr(),
+        op.getClusterAxisAttr(), op.getNumExpertsPerTokAttr(),
+        op.getOutputShardDimAttr(), op.getMemoryConfigAttr());
+
+    rewriter.replaceOp(op, newOp.getResult());
+    return success();
+  }
+};
+
+class MoeExpertTokenRemapCanonicalizeTopkRewritePattern
+    : public OpRewritePattern<ttnn::MoeExpertTokenRemapOp> {
+public:
+  using OpRewritePattern<ttnn::MoeExpertTokenRemapOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::MoeExpertTokenRemapOp op,
+                                PatternRewriter &rewriter) const override {
+    Value topkTensor = op.getTopkTensor();
+    auto topkType = cast<RankedTensorType>(topkTensor.getType());
+    if (topkType.getRank() != 2 && topkType.getRank() != 3) {
+      return failure();
+    }
+
+    auto metadataType =
+        cast<RankedTensorType>(op.getExpertMetadata().getType());
+    if (metadataType.getRank() != 4) {
+      return failure();
+    }
+    int64_t BD = metadataType.getShape()[1];
+    int64_t S = metadataType.getShape()[2];
+    if (BD <= 0 || S <= 0) {
+      return failure();
+    }
+
+    auto repeatAlongDim0 = [&](Value value, int64_t repeats,
+                               StringRef suffix) -> FailureOr<Value> {
+      if (repeats <= 1) {
+        return value;
+      }
+      auto valueType = cast<RankedTensorType>(value.getType());
+      auto outShape = llvm::SmallVector<int64_t>(valueType.getShape().begin(),
+                                                 valueType.getShape().end());
+      if (outShape[0] <= 0) {
+        return failure();
+      }
+      outShape[0] *= repeats;
+      auto outType =
+          ttnn::utils::RankedTensorTypeFactory::create(valueType, outShape);
+      SmallVector<Value> repeatedInputs(repeats, value);
+      return rewriter
+          .create<ttnn::ConcatOp>(
+              ttmlir::utils::appendLocationSuffix(op.getLoc(), suffix), outType,
+              repeatedInputs, /*dim=*/0, ttnn::MemoryConfigAttr())
+          .getResult();
+    };
+
+    if (topkType.getRank() == 2) {
+      int64_t BS = topkType.getShape()[0];
+      int64_t E = topkType.getShape()[1];
+      if (BS <= 0 || E <= 0 || BS % S != 0) {
+        return failure();
+      }
+      int64_t B = BS / S;
+      if (B <= 0 || BD % B != 0) {
+        return failure();
+      }
+      int64_t repeats = BD / B;
+
+      topkTensor = createReshape(rewriter, op.getLoc(), topkTensor, {B, S, E},
+                                 "_topk_3d");
+      FailureOr<Value> repeated =
+          repeatAlongDim0(topkTensor, repeats, "_topk_repeat_dim0");
+      if (failed(repeated)) {
+        return failure();
+      }
+      topkTensor = *repeated;
+      topkTensor = createReshape(rewriter, op.getLoc(), topkTensor,
+                                 {1, BD, S, E}, "_topk_4d");
+    } else {
+      int64_t B = topkType.getShape()[0];
+      int64_t STopk = topkType.getShape()[1];
+      int64_t E = topkType.getShape()[2];
+      if (B <= 0 || STopk <= 0 || E <= 0 || BD % B != 0) {
+        return failure();
+      }
+      int64_t repeats = BD / B;
+      FailureOr<Value> repeated =
+          repeatAlongDim0(topkTensor, repeats, "_topk_repeat_dim0");
+      if (failed(repeated)) {
+        return failure();
+      }
+      topkTensor = *repeated;
+      topkTensor = createReshape(rewriter, op.getLoc(), topkTensor,
+                                 {1, BD, STopk, E}, "_topk_4d");
+    }
+
+    auto newOp = rewriter.create<ttnn::MoeExpertTokenRemapOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_moe_workaround"),
+        cast<RankedTensorType>(op.getMapping().getType()),
+        cast<RankedTensorType>(op.getReduced().getType()), topkTensor,
+        op.getExpertMapping(), op.getExpertMetadata(),
+        op.getReductionSizeAttr(), op.getMemoryConfigAttr());
+    rewriter.replaceOp(op, {newOp.getMapping(), newOp.getReduced()});
+    return success();
+  }
+};
+
+// Runtime workaround for decode-style all_to_all_combine:
+// output_shard_dim=2 with result shape [K, B, 1, H] can fail in runtime.
+// Rewrite to output_shard_dim=1 with an intermediate [K, 1, B, H] output,
+// then reshape back to the original result type.
+class MoeAllToAllCombineDecodeShardDimRewritePattern
+    : public OpRewritePattern<ttnn::AllToAllCombineOp> {
+public:
+  using OpRewritePattern<ttnn::AllToAllCombineOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::AllToAllCombineOp op,
+                                PatternRewriter &rewriter) const override {
+    RankedTensorType outputType = op.getResult().getType();
+    ArrayRef<int64_t> outputShape = outputType.getShape();
+
+    if (op.getOutputShardDim() != 2 || outputType.getRank() != 4 ||
+        outputShape[2] != 1) {
+      return failure();
+    }
+
+    RankedTensorType workaroundType = RankedTensorType::get(
+        {outputShape[0], outputShape[2], outputShape[1], outputShape[3]},
+        outputType.getElementType(), outputType.getEncoding());
+
+    auto combineOp = rewriter.create<ttnn::AllToAllCombineOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(), "_moe_workaround"),
+        workaroundType, op.getInputTensor(), op.getExpertMetadata(),
+        op.getExpertMapping(), op.getNumDevicesAttr(), op.getClusterAxisAttr(),
+        op.getNumExpertsPerTokAttr(),
+        rewriter.getI64IntegerAttr(/*output_shard_dim=*/1),
+        op.getMemoryConfigAttr());
+
+    SmallVector<int32_t> reshapeShape;
+    reshapeShape.reserve(outputShape.size());
+    for (int64_t dim : outputShape) {
+      reshapeShape.push_back(static_cast<int32_t>(dim));
+    }
+
+    rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
+        op, outputType, combineOp.getResult(),
+        rewriter.getI32ArrayAttr(reshapeShape), op.getMemoryConfigAttr());
+    return success();
+  }
+};
+
+} // namespace
+
+void populateMoeWorkaroundPatterns(RewritePatternSet &patterns) {
+  patterns.add<SparseMatmulTileDimsRewritePattern,
+               MoeAllToAllDispatchCanonicalizeInputsRewritePattern,
+               MoeAllToAllCombineCanonicalizeInputLayoutRewritePattern,
+               MoeExpertTokenRemapCanonicalizeTopkRewritePattern,
+               MoeAllToAllCombineDecodeShardDimRewritePattern>(
+      patterns.getContext());
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -24,6 +24,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ExplicateOperandBroadcastsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MoeWorkaroundsRewritePatterns.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PadHighDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.h"
@@ -570,6 +571,10 @@ public:
   void runOnOperation() final {
     if (decompositionWorkaroundsEnabled) {
       RewritePatternSet patterns(&getContext());
+
+      // Keep all MoE hardware workarounds bundled and registered together.
+      workarounds::decomposition::populateMoeWorkaroundPatterns(patterns);
+
       patterns.add<
           TTNNAllReduceWorkarounds,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1208,7 +1208,8 @@ createOp(FlatbufferObjectCache &cache, AllToAllCombineOp op) {
       *cache.fbb, inputTensor, expertMetadata, expertMapping, output,
       static_cast<uint32_t>(op.getNumDevices()),
       static_cast<uint32_t>(op.getClusterAxis()),
-      static_cast<uint32_t>(op.getNumExpertsPerTok()), memoryConfig);
+      static_cast<uint32_t>(op.getNumExpertsPerTok()),
+      static_cast<uint32_t>(op.getOutputShardDim()), memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::MoeExpertTokenRemapOp>

--- a/runtime/lib/ttnn/operations/ccl/all_to_all_combine.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_to_all_combine.cpp
@@ -27,6 +27,9 @@ void run(const ::tt::target::ttnn::AllToAllCombineOp *op,
   std::optional<uint32_t> axis =
       std::make_optional<uint32_t>(op->cluster_axis());
 
+  std::optional<uint32_t> outputShardDim =
+      std::make_optional<uint32_t>(op->output_shard_dim());
+
   ::ttnn::Tensor output =
       ::ttnn::all_to_all_combine(input, expertMapping, expertMetadata,
                                  /*locally_reduced=*/false,
@@ -34,7 +37,7 @@ void run(const ::tt::target::ttnn::AllToAllCombineOp *op,
                                  /*topology=*/std::nullopt,
                                  /*memory_config=*/memoryConfig,
                                  /*axis=*/axis,
-                                 /*output_shard_dim=*/std::nullopt,
+                                 /*output_shard_dim=*/outputShardDim,
                                  /*subdevice_id=*/std::nullopt,
                                  /*optional_output_tensor=*/std::nullopt);
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/sparse_moe_ops.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/sparse_moe_ops.mlir
@@ -83,6 +83,48 @@ module @sparse_moe_ops attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repli
     } : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>, tensor<1x2x128x32xbf16>, tensor<1x4x2880x5760xbf16>, tensor<1x4x2880x2880xbf16>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
+
+  // Rank-3 inputs:
+  // [B, S, H] + [B*S, K] are preserved in TTIR and canonicalized in TTIR->TTNN.
+  func.func public @dispatch_rank3_inputs(
+    %activations_3d: tensor<1x128x2880xbf16>,
+    %indices_2d: tensor<128x4xi64>,
+    %expert_mapping: tensor<1x1x32x8xi64>
+  ) -> tensor<1x2x128x2880xbf16> {
+    %dispatch:2 = stablehlo.custom_call @tt.all_to_all_dispatch(%activations_3d, %indices_2d, %expert_mapping) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {cluster_axis = "0", num_devices = "2"}
+    } : (tensor<1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %dispatch#0 : tensor<1x2x128x2880xbf16>
+  }
+
+  // Non-canonical combine input layout:
+  // [BD, S, E, H] is preserved in TTIR and canonicalized to [E, BD, S, H] in TTIR->TTNN.
+  func.func public @combine_bdseh_input_layout(
+    %combine_input_bdseh: tensor<2x128x4x2880xbf16>,
+    %metadata: tensor<1x2x128x4xi64>,
+    %expert_mapping: tensor<1x1x32x8xi64>
+  ) -> tensor<4x1x128x2880xbf16> {
+    %combine = stablehlo.custom_call @tt.all_to_all_combine(%combine_input_bdseh, %metadata, %expert_mapping) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {cluster_axis = "0", num_devices = "2", num_experts_per_tok = "4"}
+    } : (tensor<2x128x4x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    return %combine : tensor<4x1x128x2880xbf16>
+  }
+
+  // Rank-2 topk input:
+  // [B*S, E] is preserved in TTIR and canonicalized to rank 4 in TTIR->TTNN.
+  func.func public @remap_topk_rank2(
+    %topk_2d: tensor<128x32xbf16>,
+    %expert_mapping: tensor<1x1x32x8xi64>,
+    %metadata: tensor<1x2x128x4xi64>
+  ) -> tensor<1x2x128x32xbf16> {
+    %remap:2 = stablehlo.custom_call @tt.moe_expert_token_remap(%topk_2d, %expert_mapping, %metadata) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {num_devices = "2", reduction_size = "32"}
+    } : (tensor<128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xbf16>)
+    return %remap#0 : tensor<1x2x128x32xbf16>
+  }
 }
 
 // CHECK: "ttir.all_to_all_dispatch"
@@ -104,3 +146,12 @@ module @sparse_moe_ops attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repli
 // CHECK-SAME: cluster_axis = 0
 // CHECK-SAME: num_devices = 2
 // CHECK-SAME: num_experts_per_tok = 4
+
+// CHECK-LABEL: func.func public @dispatch_rank3_inputs
+// CHECK: "ttir.all_to_all_dispatch"
+
+// CHECK-LABEL: func.func public @combine_bdseh_input_layout
+// CHECK: "ttir.all_to_all_combine"
+
+// CHECK-LABEL: func.func public @remap_topk_rank2
+// CHECK: "ttir.moe_expert_token_remap"

--- a/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
@@ -24,6 +24,24 @@ module attributes {} {
 
 // -----
 
+// Verify rank-3 dispatch inputs are canonicalized to rank 4 by MoE workarounds.
+module attributes {} {
+  func.func @all_to_all_dispatch_rank3(
+    %activations: tensor<1x128x2880xbf16>,
+    %indices: tensor<128x4xi64>,
+    %expert_mapping: tensor<1x1x32x8xi64>
+  ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
+    %dispatched, %metadata = "ttir.all_to_all_dispatch"(%activations, %indices, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
+  }
+}
+// CHECK-LABEL: @all_to_all_dispatch_rank3
+// CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 1 : i32, 128 : i32, 2880 : i32]}>
+// CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 1 : i32, 128 : i32, 4 : i32]}>
+// CHECK: "ttnn.all_to_all_dispatch"
+
+// -----
+
 // Verify lowering of ttir.moe_expert_token_remap to ttnn.moe_expert_token_remap
 module attributes {} {
   func.func @moe_expert_token_remap(
@@ -38,6 +56,25 @@ module attributes {} {
 // CHECK-LABEL: @moe_expert_token_remap
 // CHECK: "ttnn.moe_expert_token_remap"
 // CHECK-SAME: reduction_size = 32
+
+// -----
+
+// Verify rank-2 topk inputs are canonicalized to rank 4 by MoE workarounds.
+module attributes {} {
+  func.func @moe_expert_token_remap_topk_rank2(
+    %topk_weights: tensor<128x32xbf16>,
+    %expert_mapping: tensor<1x1x32x8xi64>,
+    %metadata: tensor<1x2x128x4xi64>
+  ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
+    %mapping, %reduced = "ttir.moe_expert_token_remap"(%topk_weights, %expert_mapping, %metadata) <{reduction_size = 32 : i64}> : (tensor<128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
+  }
+}
+// CHECK-LABEL: @moe_expert_token_remap_topk_rank2
+// CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 128 : i32, 32 : i32]}>
+// CHECK: "ttnn.concat"(%{{.*}}, %{{.*}})
+// CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 2 : i32, 128 : i32, 32 : i32]}>
+// CHECK: "ttnn.moe_expert_token_remap"
 
 // -----
 
@@ -93,3 +130,21 @@ module attributes {} {
 // CHECK-SAME: cluster_axis = 0
 // CHECK-SAME: num_devices = 2
 // CHECK-SAME: num_experts_per_tok = 4
+
+// -----
+
+// Verify combine input layout [BD, S, E, H] is canonicalized
+// to HW-required [E, BD, S, H] by MoE workarounds.
+module attributes {} {
+  func.func @all_to_all_combine_bdseh_input_layout(
+    %input: tensor<2x128x4x2880xbf16>,
+    %metadata: tensor<1x2x128x4xi64>,
+    %expert_mapping: tensor<1x1x32x8xi64>
+  ) -> tensor<4x1x128x2880xbf16> {
+    %result = "ttir.all_to_all_combine"(%input, %metadata, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}> : (tensor<2x128x4x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    return %result : tensor<4x1x128x2880xbf16>
+  }
+}
+// CHECK-LABEL: @all_to_all_combine_bdseh_input_layout
+// CHECK: "ttnn.permute"(%{{.*}}) <{permutation = array<i64: 2, 0, 1, 3>}>
+// CHECK: "ttnn.all_to_all_combine"

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/sparse_moe_ops.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/sparse_moe_ops.mlir
@@ -86,3 +86,51 @@ module @Remap_BlocksD attributes {mhlo.cross_program_prefetches = [], mhlo.front
     return %0#0, %0#1 : tensor<1x1x32x8xbf16>, tensor<1x1x1x8xbf16>
   }
 }
+
+// -----
+
+// =====================================================================
+// all_to_all_dispatch: rank-3 input path [B,S,H] + [B*S,K]
+// =====================================================================
+// Input is rank-3 [B,S,H] and sharded on H (dim 2). Dispatch rule should still
+// block H sharding and force all_gather before the custom call.
+module @Dispatch_Rank3Input attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "input"}, %arg1: tensor<32x4xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "indices"}, %arg2: tensor<1x1x8x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "mapping"}) -> (tensor<1x2x32x128xbf16>, tensor<1x2x32x4xbf16>) {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.all_to_all_dispatch
+    %0:2 = stablehlo.custom_call @tt.all_to_all_dispatch(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2"}} : (tensor<1x32x128xbf16>, tensor<32x4xbf16>, tensor<1x1x8x2xbf16>) -> (tensor<1x2x32x128xbf16>, tensor<1x2x32x4xbf16>)
+    return %0#0, %0#1 : tensor<1x2x32x128xbf16>, tensor<1x2x32x4xbf16>
+  }
+}
+
+// -----
+
+// =====================================================================
+// all_to_all_combine: [BD,S,E,H] input layout (non-canonical)
+// =====================================================================
+// Input is [BD,S,E,H] instead of canonical [E,BD,S,H]. Combine rule should
+// still block H sharding and insert all_gather before custom call.
+module @Combine_BdsehInput attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2x32x4x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,1,1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "expert_output"}, %arg1: tensor<1x2x32x4xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "metadata"}, %arg2: tensor<1x1x8x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "mapping"}) -> tensor<4x1x32x128xbf16> {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.all_to_all_combine
+    %0 = stablehlo.custom_call @tt.all_to_all_combine(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2", num_experts_per_tok = "4"}} : (tensor<2x32x4x128xbf16>, tensor<1x2x32x4xbf16>, tensor<1x1x8x2xbf16>) -> tensor<4x1x32x128xbf16>
+    return %0 : tensor<4x1x32x128xbf16>
+  }
+}
+
+// -----
+
+// =====================================================================
+// moe_expert_token_remap: rank-2 topk input [B*S, E]
+// =====================================================================
+// topk input is rank-2 and sharded on E (dim 1). Input E factor is blocked,
+// so all_gather must still be inserted before the custom call.
+module @Remap_Topk2DInput attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<32x8xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "topk"}, %arg1: tensor<1x1x8x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "mapping"}, %arg2: tensor<1x2x32x4xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "metadata"}) -> (tensor<1x2x32x8xbf16>, tensor<1x1x2x8xbf16>) {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.moe_expert_token_remap
+    %0:2 = stablehlo.custom_call @tt.moe_expert_token_remap(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {num_devices = "2", reduction_size = "32"}} : (tensor<32x8xbf16>, tensor<1x1x8x2xbf16>, tensor<1x2x32x4xbf16>) -> (tensor<1x2x32x8xbf16>, tensor<1x1x2x8xbf16>)
+    return %0#0, %0#1 : tensor<1x2x32x8xbf16>, tensor<1x1x2x8xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
@@ -4,25 +4,25 @@
 
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 
-// input_tensor must be 4D
+// input_tensor must be rank 3 or 4
 module attributes {} {
   func.func @dispatch_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
     %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op input_tensor must be a 4D tensor
+// CHECK: error: 'ttir.all_to_all_dispatch' op input_tensor must be rank 3 or 4
 
 // -----
 
-// expert_indices must be 4D
+// expert_indices must be rank 2, 3, or 4
 module attributes {} {
-  func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+  func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<512xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
+    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<512xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op expert_indices must be a 4D tensor
+// CHECK: error: 'ttir.all_to_all_dispatch' op expert_indices must be rank 2, 3, or 4
 
 // -----
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/moe_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/moe_workaround.mlir
@@ -1,0 +1,200 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --canonicalize %s | FileCheck %s
+
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test bundled MoE workarounds.
+// Non-canonical rank/layout forms should be canonicalized to HW-required
+// shapes here, not in conversion patterns.
+// Decode-like all_to_all_combine with output_shard_dim=2 and S=1 should be
+// rewritten to output_shard_dim=1 + reshape back to the original result shape.
+// Gate-up sparse_matmul activation chains should also be rewritten here to
+// preserve the M dimension through the pointwise subgraph.
+
+module @test_moe_workaround attributes {} {
+
+  func.func public @all_to_all_dispatch_rank3(
+    %input: tensor<64x128x7168xbf16>,
+    %indices: tensor<8192x8xi64>,
+    %mapping: tensor<1x1x256x8xi64>
+  ) -> (tensor<1x64x128x7168xbf16>, tensor<1x64x128x8xi64>) {
+    // CHECK-LABEL: func.func public @all_to_all_dispatch_rank3
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [64 : i32, 1 : i32, 128 : i32, 7168 : i32]}>
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [64 : i32, 1 : i32, 128 : i32, 8 : i32]}>
+    // CHECK: "ttnn.all_to_all_dispatch"(%{{.*}}, %{{.*}}, %{{.*}})
+    %dispatched, %metadata = "ttnn.all_to_all_dispatch"(%input, %indices, %mapping) <{
+      cluster_axis = 0 : i64,
+      num_devices = 2 : i64
+    }> : (tensor<64x128x7168xbf16>, tensor<8192x8xi64>, tensor<1x1x256x8xi64>) -> (tensor<1x64x128x7168xbf16>, tensor<1x64x128x8xi64>)
+    return %dispatched, %metadata : tensor<1x64x128x7168xbf16>, tensor<1x64x128x8xi64>
+  }
+
+  func.func public @all_to_all_combine_layout_bdseh(
+    %input: tensor<64x128x32x7168xbf16>,
+    %metadata: tensor<1x64x128x8xi64>,
+    %mapping: tensor<1x1x256x8xi64>
+  ) -> tensor<8x8x128x7168xbf16> {
+    // CHECK-LABEL: func.func public @all_to_all_combine_layout_bdseh
+    // CHECK: "ttnn.permute"(%{{.*}}) <{permutation = array<i64: 2, 0, 1, 3>}>
+    // CHECK: "ttnn.all_to_all_combine"(%{{.*}}, %{{.*}}, %{{.*}})
+    %result = "ttnn.all_to_all_combine"(%input, %metadata, %mapping) <{
+      cluster_axis = 0 : i64,
+      num_devices = 8 : i64,
+      num_experts_per_tok = 8 : i64,
+      output_shard_dim = 1 : i64
+    }> : (tensor<64x128x32x7168xbf16>, tensor<1x64x128x8xi64>, tensor<1x1x256x8xi64>) -> tensor<8x8x128x7168xbf16>
+    return %result : tensor<8x8x128x7168xbf16>
+  }
+
+  func.func public @moe_expert_token_remap_topk_rank2(
+    %topk: tensor<1024x8xbf16>,
+    %mapping: tensor<1x1x256x8xi64>,
+    %metadata: tensor<1x64x128x8xi64>
+  ) -> (tensor<1x64x128x8xbf16>, tensor<1x1x8x8xbf16>) {
+    // CHECK-LABEL: func.func public @moe_expert_token_remap_topk_rank2
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [8 : i32, 128 : i32, 8 : i32]}>
+    // CHECK: "ttnn.concat"(%{{.*}}
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 64 : i32, 128 : i32, 8 : i32]}>
+    // CHECK: "ttnn.moe_expert_token_remap"(%{{.*}}, %{{.*}}, %{{.*}})
+    %mapping_out, %reduced = "ttnn.moe_expert_token_remap"(%topk, %mapping, %metadata) <{
+      reduction_size = 8 : i64
+    }> : (tensor<1024x8xbf16>, tensor<1x1x256x8xi64>, tensor<1x64x128x8xi64>) -> (tensor<1x64x128x8xbf16>, tensor<1x1x8x8xbf16>)
+    return %mapping_out, %reduced : tensor<1x64x128x8xbf16>, tensor<1x1x8x8xbf16>
+  }
+
+  func.func public @all_to_all_combine_decode(
+    %input: tensor<8x64x1x7168xbf16>,
+    %metadata: tensor<1x64x1x8xi64>,
+    %mapping: tensor<1x1x256x8xi64>
+  ) -> tensor<8x8x1x7168xbf16> {
+    // CHECK-LABEL: func.func public @all_to_all_combine_decode
+    // CHECK: "ttnn.all_to_all_combine"
+    // CHECK-SAME: output_shard_dim = 1
+    // CHECK-SAME: -> tensor<8x1x8x7168xbf16
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [8 : i32, 8 : i32, 1 : i32, 7168 : i32]}>
+    %result = "ttnn.all_to_all_combine"(%input, %metadata, %mapping) <{
+      cluster_axis = 0 : i64,
+      num_devices = 2 : i64,
+      num_experts_per_tok = 8 : i64,
+      output_shard_dim = 2 : i64
+    }> : (tensor<8x64x1x7168xbf16>, tensor<1x64x1x8xi64>, tensor<1x1x256x8xi64>) -> tensor<8x8x1x7168xbf16>
+    return %result : tensor<8x8x1x7168xbf16>
+  }
+
+  // Already tiled gate-up chain with a non-multiply merge op.
+  // This exercises the generic nearest-common-pointwise-user rewrite.
+  func.func public @sparse_matmul_already_tiled_gate_up_add_merge(
+    %input: tensor<2x4x32x2880xbf16>,
+    %weight: tensor<1x1x2880x5760xbf16>,
+    %sparsity: tensor<2x4x1x1xbf16>,
+    %up_bias: tensor<1x1x1x5760xbf16>
+  ) -> tensor<8x1x32x2880xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_already_tiled_gate_up_add_merge
+    // CHECK-NOT: tensor<256x1x1x5760xbf16
+    // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%{{.*}}) <{shape = [8 : i32, 1 : i32, 32 : i32, 5760 : i32]}>
+    // CHECK: %[[PRE:.*]] = "ttnn.add"(%[[RESHAPE]], %{{.*}}) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<8x1x32x5760xbf16>, tensor<1x1x1x5760xbf16>) -> tensor<8x1x32x5760xbf16>
+    // CHECK-DAG: %[[GATE:.*]] = "ttnn.slice_static"(%[[PRE]]) <{begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32], ends = [8 : i32, 1 : i32, 32 : i32, 5760 : i32], step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}>
+    // CHECK-DAG: %[[VALUE:.*]] = "ttnn.slice_static"(%[[PRE]]) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [8 : i32, 1 : i32, 32 : i32, 5760 : i32], step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}>
+    // CHECK-DAG: %[[GATE_SILU:.*]] = "ttnn.silu"(%[[GATE]]) : (tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    // CHECK-DAG: %[[VALUE_SIGMOID:.*]] = "ttnn.sigmoid"(%[[VALUE]]) : (tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    // CHECK: "ttnn.add"(%[[GATE_SILU]], %[[VALUE_SIGMOID]]) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<8x1x32x2880xbf16>, tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    %sm = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<2x4x32x2880xbf16>, tensor<1x1x2880x5760xbf16>, tensor<2x4x1x1xbf16>) -> tensor<2x4x1x1x32x5760xbf16>
+
+    %r0 = "ttnn.reshape"(%sm) <{shape = [2 : i32, 4 : i32, 1 : i32, 32 : i32, 5760 : i32]}>
+      : (tensor<2x4x1x1x32x5760xbf16>) -> tensor<2x4x1x32x5760xbf16>
+    %p0 = "ttnn.permute"(%r0) <{permutation = array<i64: 0, 1, 3, 2, 4>}>
+      : (tensor<2x4x1x32x5760xbf16>) -> tensor<2x4x32x1x5760xbf16>
+    %flat = "ttnn.reshape"(%p0) <{shape = [256 : i32, 1 : i32, 1 : i32, 5760 : i32]}>
+      : (tensor<2x4x32x1x5760xbf16>) -> tensor<256x1x1x5760xbf16>
+
+    %pre = "ttnn.add"(%flat, %up_bias) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x5760xbf16>, tensor<1x1x1x5760xbf16>) -> tensor<256x1x1x5760xbf16>
+
+    %gate = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32],
+      ends = [256 : i32, 1 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<256x1x1x5760xbf16>) -> tensor<256x1x1x2880xbf16>
+    %gate_silu = "ttnn.silu"(%gate)
+      : (tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+
+    %value = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32],
+      ends = [256 : i32, 1 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<256x1x1x5760xbf16>) -> tensor<256x1x1x2880xbf16>
+    %value_sigmoid = "ttnn.sigmoid"(%value)
+      : (tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+
+    %out = "ttnn.add"(%gate_silu, %value_sigmoid) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x2880xbf16>, tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+    %r1 = "ttnn.reshape"(%out) <{shape = [8 : i32, 32 : i32, 1 : i32, 2880 : i32]}>
+      : (tensor<256x1x1x2880xbf16>) -> tensor<8x32x1x2880xbf16>
+    %p1 = "ttnn.permute"(%r1) <{permutation = array<i64: 0, 2, 1, 3>}>
+      : (tensor<8x32x1x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    return %p1 : tensor<8x1x32x2880xbf16>
+  }
+
+  // Untiled gate-up chain should be rewritten directly from the tiled sparse
+  // output instead of going through the legacy [BD, S, E, N] activation path.
+  func.func public @sparse_matmul_gate_up_untiled_add_merge(
+    %input: tensor<2x128x1x2880xbf16>,
+    %weight: tensor<1x1x2880x5760xbf16>,
+    %sparsity: tensor<1x1x8x1xbf16>,
+    %up_bias: tensor<1x1x1x5760xbf16>
+  ) -> tensor<8x1x32x2880xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_gate_up_untiled_add_merge
+    // CHECK: "ttnn.sparse_matmul"
+    // CHECK-SAME: tensor<2x4x32x2880xbf16
+    // CHECK-SAME: tensor<1x1x2880x5760xbf16
+    // CHECK-SAME: tensor<2x4x1x1xbf16
+    // CHECK-SAME: -> tensor<2x4x1x1x32x5760xbf16
+    // CHECK-NOT: tensor<2x128x1x5760xbf16
+    // CHECK: %[[PRE:.*]] = "ttnn.add"(%{{.*}}, %{{.*}}) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<8x1x32x5760xbf16>, tensor<1x1x1x5760xbf16>) -> tensor<8x1x32x5760xbf16>
+    // CHECK-DAG: %[[UGATE:.*]] = "ttnn.slice_static"(%[[PRE]]) <{begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32], ends = [8 : i32, 1 : i32, 32 : i32, 5760 : i32], step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}>
+    // CHECK-DAG: %[[UVALUE:.*]] = "ttnn.slice_static"(%[[PRE]]) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [8 : i32, 1 : i32, 32 : i32, 5760 : i32], step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}>
+    // CHECK-DAG: %[[UGATE_SILU:.*]] = "ttnn.silu"(%[[UGATE]]) : (tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    // CHECK-DAG: %[[UVALUE_SIGMOID:.*]] = "ttnn.sigmoid"(%[[UVALUE]]) : (tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    // CHECK: %[[UMERGE:.*]] = "ttnn.add"(%[[UGATE_SILU]], %[[UVALUE_SIGMOID]]) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<8x1x32x2880xbf16>, tensor<8x1x32x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    // CHECK: "ttnn.permute"(%[[UMERGE]]) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x1x32x2880xbf16>) -> tensor<8x32x1x2880xbf16>
+    %sm = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<2x128x1x2880xbf16>, tensor<1x1x2880x5760xbf16>, tensor<1x1x8x1xbf16>) -> tensor<2x128x1x1x1x5760xbf16>
+
+    %r0 = "ttnn.reshape"(%sm) <{shape = [2 : i32, 128 : i32, 1 : i32, 5760 : i32]}>
+      : (tensor<2x128x1x1x1x5760xbf16>) -> tensor<2x128x1x5760xbf16>
+    %pre = "ttnn.add"(%r0, %up_bias) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<2x128x1x5760xbf16>, tensor<1x1x1x5760xbf16>) -> tensor<2x128x1x5760xbf16>
+
+    %gate = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32],
+      ends = [2 : i32, 128 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<2x128x1x5760xbf16>) -> tensor<2x128x1x2880xbf16>
+    %gate_silu = "ttnn.silu"(%gate)
+      : (tensor<2x128x1x2880xbf16>) -> tensor<2x128x1x2880xbf16>
+
+    %value = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32],
+      ends = [2 : i32, 128 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<2x128x1x5760xbf16>) -> tensor<2x128x1x2880xbf16>
+    %value_sigmoid = "ttnn.sigmoid"(%value)
+      : (tensor<2x128x1x2880xbf16>) -> tensor<2x128x1x2880xbf16>
+
+    %out = "ttnn.add"(%gate_silu, %value_sigmoid) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<2x128x1x2880xbf16>, tensor<2x128x1x2880xbf16>) -> tensor<2x128x1x2880xbf16>
+    %r1 = "ttnn.reshape"(%out) <{shape = [8 : i32, 32 : i32, 1 : i32, 2880 : i32]}>
+      : (tensor<2x128x1x2880xbf16>) -> tensor<8x32x1x2880xbf16>
+    %p1 = "ttnn.permute"(%r1) <{permutation = array<i64: 0, 2, 1, 3>}>
+      : (tensor<8x32x1x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    return %p1 : tensor<8x1x32x2880xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_tile_dims_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_tile_dims_workaround.mlir
@@ -1,0 +1,141 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-layout --ttnn-workaround --canonicalize %s | FileCheck %s
+
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test sparse_matmul tile dims workaround.
+// When input A has M=1 (untiled), the workaround should insert
+// reshape/permute to tile to M=32 and untile the output.
+
+module @test_sparse_matmul_tile_dims attributes {} {
+
+  // Gate-up: untiled input [BD=2, S=128, M=1, H=2880]
+  // Workaround should tile to [BD=2, S/M=4, M=32, H=2880]
+  func.func public @sparse_matmul_gate_up_untiled(
+    %input: tensor<2x128x1x2880xbf16>,
+    %weight: tensor<1x4x2880x5760xbf16>,
+    %sparsity: tensor<1x1x8x4xbf16>
+  ) -> tensor<2x128x1x4x1x5760xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_gate_up_untiled
+    // Verify tiled sparse_matmul with M=32
+    // CHECK: "ttnn.sparse_matmul"
+    // CHECK-SAME: tensor<2x4x32x2880xbf16
+    // CHECK-SAME: tensor<1x4x2880x5760xbf16
+    // CHECK-SAME: tensor<2x4x1x4xbf16
+    // CHECK-SAME: -> tensor<2x4x1x4x32x5760xbf16
+    // Verify legacy gate-up factoring is preserved before re-expanding.
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [2 : i32, 4 : i32, 4 : i32, 32 : i32, 5760 : i32]}>
+    // CHECK: "ttnn.permute"(%{{.*}}) <{permutation = array<i64: 0, 1, 3, 2, 4>}>
+    // CHECK: "ttnn.reshape"(%{{.*}}) <{shape = [2 : i32, 128 : i32, 1 : i32, 4 : i32, 1 : i32, 5760 : i32]}>
+    %result = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<2x128x1x2880xbf16>, tensor<1x4x2880x5760xbf16>, tensor<1x1x8x4xbf16>) -> tensor<2x128x1x4x1x5760xbf16>
+    return %result : tensor<2x128x1x4x1x5760xbf16>
+  }
+
+  // Down: untiled input [BD*S=256, E=4, M=1, inter=2880]
+  // Workaround should tile to [BD*S/M=8, E=4, M=32, inter=2880]
+  func.func public @sparse_matmul_down_untiled(
+    %input: tensor<256x4x1x2880xbf16>,
+    %weight: tensor<1x4x2880x2880xbf16>,
+    %sparsity: tensor<1x1x8x4xbf16>
+  ) -> tensor<256x4x1x2880xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_down_untiled
+    // Verify tiled sparse_matmul with M=32
+    // CHECK: "ttnn.sparse_matmul"
+    // CHECK-SAME: tensor<8x4x32x2880xbf16
+    // CHECK-SAME: tensor<1x4x2880x2880xbf16
+    // CHECK-SAME: -> tensor<8x4x32x2880xbf16
+    %result = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = true,
+      is_input_b_sparse = false,
+      nnz = 0 : i64
+    }> : (tensor<256x4x1x2880xbf16>, tensor<1x4x2880x2880xbf16>, tensor<1x1x8x4xbf16>) -> tensor<256x4x1x2880xbf16>
+    return %result : tensor<256x4x1x2880xbf16>
+  }
+
+  // Already tiled: M=32, workaround should NOT apply
+  func.func public @sparse_matmul_already_tiled(
+    %input: tensor<2x4x32x2880xbf16>,
+    %weight: tensor<1x4x2880x5760xbf16>,
+    %sparsity: tensor<2x4x1x4xbf16>
+  ) -> tensor<2x4x1x4x32x5760xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_already_tiled
+    // CHECK: "ttnn.sparse_matmul"
+    // CHECK-SAME: tensor<2x4x32x2880xbf16
+    // No extra reshape/permute should be inserted
+    %result = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<2x4x32x2880xbf16>, tensor<1x4x2880x5760xbf16>, tensor<2x4x1x4xbf16>) -> tensor<2x4x1x4x32x5760xbf16>
+    return %result : tensor<2x4x1x4x32x5760xbf16>
+  }
+
+  // Already tiled gate-up + flattened SwiGLU chain:
+  // rewrite should restore M-preserving activation layout.
+  func.func public @sparse_matmul_already_tiled_gate_up_activation(
+    %input: tensor<2x4x32x2880xbf16>,
+    %weight: tensor<1x1x2880x5760xbf16>,
+    %sparsity: tensor<2x4x1x1xbf16>,
+    %up_bias: tensor<1x1x1x5760xbf16>,
+    %scalar_bias: tensor<1x1x1x1xbf16>,
+    %scalar_mul: tensor<1x1x1x1xbf16>
+  ) -> tensor<8x1x32x2880xbf16> {
+    // CHECK-LABEL: func.func public @sparse_matmul_already_tiled_gate_up_activation
+    // CHECK-NOT: tensor<256x1x1x5760xbf16
+    // CHECK: "ttnn.add"(%{{.*}}, %{{.*}}) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<2x4x1x32x5760xbf16
+    // CHECK: "ttnn.permute"(%{{.*}}) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x32x1x5760xbf16
+    // CHECK: "ttnn.slice_static"(%{{.*}}) <{begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32], ends = [8 : i32, 1 : i32, 32 : i32, 5760 : i32], step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}>
+    %sm = "ttnn.sparse_matmul"(%input, %weight, %sparsity) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<2x4x32x2880xbf16>, tensor<1x1x2880x5760xbf16>, tensor<2x4x1x1xbf16>) -> tensor<2x4x1x1x32x5760xbf16>
+
+    %r0 = "ttnn.reshape"(%sm) <{shape = [2 : i32, 4 : i32, 1 : i32, 32 : i32, 5760 : i32]}>
+      : (tensor<2x4x1x1x32x5760xbf16>) -> tensor<2x4x1x32x5760xbf16>
+    %p0 = "ttnn.permute"(%r0) <{permutation = array<i64: 0, 1, 3, 2, 4>}>
+      : (tensor<2x4x1x32x5760xbf16>) -> tensor<2x4x32x1x5760xbf16>
+    %flat = "ttnn.reshape"(%p0) <{shape = [256 : i32, 1 : i32, 1 : i32, 5760 : i32]}>
+      : (tensor<2x4x32x1x5760xbf16>) -> tensor<256x1x1x5760xbf16>
+
+    %pre = "ttnn.add"(%flat, %up_bias) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x5760xbf16>, tensor<1x1x1x5760xbf16>) -> tensor<256x1x1x5760xbf16>
+
+    %gate = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 1 : i32],
+      ends = [256 : i32, 1 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<256x1x1x5760xbf16>) -> tensor<256x1x1x2880xbf16>
+    %gate_clamped = "ttnn.clamp_scalar"(%gate) <{max = 7.000000e+00 : f32, min = -7.000000e+00 : f32}>
+      : (tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+    %gate_added = "ttnn.add"(%gate_clamped, %scalar_bias) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x2880xbf16>, tensor<1x1x1x1xbf16>) -> tensor<256x1x1x2880xbf16>
+
+    %value = "ttnn.slice_static"(%pre) <{
+      begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32],
+      ends = [256 : i32, 1 : i32, 1 : i32, 5760 : i32],
+      step = [1 : i32, 1 : i32, 1 : i32, 2 : i32]
+    }> : (tensor<256x1x1x5760xbf16>) -> tensor<256x1x1x2880xbf16>
+    %value_clamped = "ttnn.clamp_scalar"(%value) <{max = 7.000000e+00 : f32, min = 0xFF800000 : f32}>
+      : (tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+    %value_scaled = "ttnn.multiply"(%value_clamped, %scalar_mul) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x2880xbf16>, tensor<1x1x1x1xbf16>) -> tensor<256x1x1x2880xbf16>
+    %value_sigmoid = "ttnn.sigmoid"(%value_scaled)
+      : (tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+    %value_gated = "ttnn.multiply"(%value_clamped, %value_sigmoid) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x2880xbf16>, tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+
+    %out = "ttnn.multiply"(%gate_added, %value_gated) <{dtype = #ttcore.supportedDataTypes<bf16>}>
+      : (tensor<256x1x1x2880xbf16>, tensor<256x1x1x2880xbf16>) -> tensor<256x1x1x2880xbf16>
+    %r1 = "ttnn.reshape"(%out) <{shape = [8 : i32, 32 : i32, 1 : i32, 2880 : i32]}>
+      : (tensor<256x1x1x2880xbf16>) -> tensor<8x32x1x2880xbf16>
+    %p1 = "ttnn.permute"(%r1) <{permutation = array<i64: 0, 2, 1, 3>}>
+      : (tensor<8x32x1x2880xbf16>) -> tensor<8x1x32x2880xbf16>
+    return %p1 : tensor<8x1x32x2880xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
@@ -4,25 +4,25 @@
 
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 
-// input_tensor must be 4D
+// input_tensor must be rank 3 or 4
 module attributes {} {
   func.func @dispatch_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
     %0, %1 = "ttnn.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttnn.all_to_all_dispatch' op input_tensor must be a 4D tensor
+// CHECK: error: 'ttnn.all_to_all_dispatch' op input_tensor must be rank 3 or 4
 
 // -----
 
-// expert_indices must be 4D
+// expert_indices must be rank 2, 3, or 4
 module attributes {} {
-  func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttnn.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+  func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<512xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
+    %0, %1 = "ttnn.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<512xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttnn.all_to_all_dispatch' op expert_indices must be a 4D tensor
+// CHECK: error: 'ttnn.all_to_all_dispatch' op expert_indices must be rank 2, 3, or 4
 
 // -----
 

--- a/test/ttmlir/Dialect/TTNN/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
@@ -23,3 +23,14 @@ module attributes {} {
   }
 }
 // CHECK: error: 'ttnn.moe_expert_token_remap' op expert_metadata must be a 4D tensor
+
+// -----
+
+// topk_tensor must be rank 2, 3, or 4
+module attributes {} {
+  func.func @remap_topk_rank(%topk: tensor<256xbf16>, %mapping: tensor<1x1x32x8xi64>, %meta: tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
+    %0, %1 = "ttnn.moe_expert_token_remap"(%topk, %mapping, %meta) <{reduction_size = 32 : i64}> : (tensor<256xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    return %0, %1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
+  }
+}
+// CHECK: error: 'ttnn.moe_expert_token_remap' op topk_tensor must be rank 2, 3, or 4


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3667)

### Problem description
The current Sparse MoE implementation in ttnn has specific shape restrictions. This shape restriction is reflected in frontend (e.g. tt-xla), which is not necessarily revealed to users.

### What's changed
To keep the frontend (tt-xla) hardware-agnostic, this restriction has been moved to the MLIR level as a workaround pattern.

### Checklist
- [ ] New/Existing tests provide coverage for changes
