### PR TITLE
D2M: support NoC-unfriendly slice ops

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -46,8 +46,14 @@ enum OutputDimensions { OUTPUT_BATCH = 0, OUTPUT_SEQ = 1, OUTPUT_HIDDEN = 2 };
 
 template <typename T>
 T alignUp(const T val, const T alignment) {
-  assert(alignment > 0);
+  assert(val >= 0 && alignment > 0);
   return ((val + alignment - 1) / alignment) * alignment;
+}
+
+template <typename T>
+T alignDown(const T val, const T alignment) {
+  assert(val >= 0 && alignment > 0);
+  return val - (val % alignment);
 }
 
 template <typename Iter>

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -25,7 +25,6 @@
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
@@ -2386,6 +2385,164 @@ concatenateHeadsLogicalInfo(ttir::ConcatenateHeadsOp op) {
   return {map, canBeTilized};
 }
 
+class D2MSliceStaticOpNoCConstraintsRewriter
+    : public OpConversionPattern<ttir::SliceStaticOp> {
+public:
+  D2MSliceStaticOpNoCConstraintsRewriter(const TypeConverter &typeConverter,
+                                         mlir::MLIRContext *ctx)
+      : OpConversionPattern<ttir::SliceStaticOp>(typeConverter, ctx,
+                                                 /*benefit=*/10) {}
+
+  LogicalResult
+  matchAndRewrite(ttir::SliceStaticOp op, ttir::SliceStaticOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // This is also the minimum NoC transfer size in bytes.
+    const int32_t nocAlignmentL1 =
+        ttcore::getOpChipDescAttr(op).getNocL1AddressAlignBytes();
+
+    auto begins = extractFromIntegerArrayAttr<int32_t>(op.getBegins());
+    auto ends = extractFromIntegerArrayAttr<int32_t>(op.getEnds());
+    auto step = extractFromIntegerArrayAttr<int32_t>(op.getStep());
+
+    auto inType = mlir::cast<RankedTensorType>(op.getInput().getType());
+    auto inShape = inType.getShape();
+    auto outType = mlir::cast<RankedTensorType>(op.getResult().getType());
+    auto outShape = outType.getShape();
+
+    const int32_t rank = static_cast<int32_t>(inType.getRank());
+    assert(rank >= 2);
+
+    const int32_t elementBytes =
+        std::max(1, static_cast<int32_t>(inType.getElementTypeBitWidth()) / 8);
+
+    assert((nocAlignmentL1 != 0) && (nocAlignmentL1 % elementBytes == 0));
+    const int32_t alignToElements = nocAlignmentL1 / elementBytes;
+
+    // Assume all shards in L1 already start at aligned addresses.
+    const bool isAlignedWidth = begins[rank - 1] % alignToElements == 0;
+    const bool isAlignedHeight = begins[rank - 2] % alignToElements == 0;
+    const bool notStridedWidth = step[rank - 1] == 1;
+    const bool notStridedHeight = step[rank - 2] == 1;
+
+    const bool isNoCFriendlyWidth = isAlignedWidth && notStridedWidth;
+    const bool isNoCFriendlyHeight = isAlignedHeight && notStridedHeight;
+
+    if (isNoCFriendlyWidth) {
+      return failure();
+    }
+
+    // Height <-> Width transpose indices.
+    SmallVector<int64_t> hwTransposeIdx(rank);
+    std::iota(hwTransposeIdx.begin(), hwTransposeIdx.end(), 0);
+    std::swap(hwTransposeIdx[rank - 1], hwTransposeIdx[rank - 2]);
+
+    auto loc = op.getLoc();
+
+    if (isNoCFriendlyHeight) {
+      // Transpose - Slice - Transpose.
+
+      auto transposedInShape =
+          ttmlir::utils::applyPermutation(inShape, hwTransposeIdx);
+      auto transposedInType = RankedTensorType::get(
+          transposedInShape, inType.getElementType(), inType.getEncoding());
+
+      auto preTranspose = rewriter.create<ttir::PermuteOp>(
+          loc, transposedInType, op.getInput(), hwTransposeIdx);
+
+      // Transpose the slice spec.
+      std::swap(begins[rank - 1], begins[rank - 2]);
+      std::swap(ends[rank - 1], ends[rank - 2]);
+      std::swap(step[rank - 1], step[rank - 2]);
+
+      auto transposedOutShape =
+          ttmlir::utils::applyPermutation(outShape, hwTransposeIdx);
+      auto transposedOutType = RankedTensorType::get(
+          transposedOutShape, outType.getElementType(), outType.getEncoding());
+
+      auto transposedSliceOp = rewriter.create<ttir::SliceStaticOp>(
+          loc, transposedOutType, preTranspose.getResult(),
+          rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
+          rewriter.getI32ArrayAttr(step));
+
+      auto postTranspose = rewriter.create<ttir::PermuteOp>(
+          loc, outType, transposedSliceOp.getResult(), hwTransposeIdx);
+
+      rewriter.replaceOp(op, postTranspose.getResult());
+    } else {
+      // Slice(crop width) - Transpose - Slice(height only) - Transpose.
+
+      // Slice all other dims as instructed, and do a NoC-friendly width crop.
+      SmallVector<int32_t> cropWidthBegins(begins);
+      SmallVector<int32_t> cropWidthEnds(ends);
+      SmallVector<int32_t> cropWidthStep(step);
+      cropWidthBegins[rank - 1] =
+          ttmlir::utils::alignDown(cropWidthBegins[rank - 1], alignToElements);
+      cropWidthEnds[rank - 1] = std::min(
+          static_cast<int32_t>(inShape[rank - 1]),
+          ttmlir::utils::alignUp(cropWidthEnds[rank - 1], alignToElements));
+      cropWidthStep[rank - 1] = 1;
+
+      SmallVector<int64_t> cropWidthOutShape(outShape);
+      cropWidthOutShape[rank - 1] =
+          cropWidthEnds[rank - 1] - cropWidthBegins[rank - 1];
+      auto cropWidthOutType = RankedTensorType::get(
+          cropWidthOutShape, outType.getElementType(), outType.getEncoding());
+
+      auto cropWidthSliceOp = rewriter.create<ttir::SliceStaticOp>(
+          loc, cropWidthOutType, op.getInput(),
+          rewriter.getI32ArrayAttr(cropWidthBegins),
+          rewriter.getI32ArrayAttr(cropWidthEnds),
+          rewriter.getI32ArrayAttr(cropWidthStep));
+
+      auto transposedCropWidthShape = ttmlir::utils::applyPermutation(
+          cropWidthOutType.getShape(), hwTransposeIdx);
+      auto transposedCropWidthType = RankedTensorType::get(
+          transposedCropWidthShape, outType.getElementType(),
+          outType.getEncoding());
+
+      auto preTranspose = rewriter.create<ttir::PermuteOp>(
+          loc, transposedCropWidthType, cropWidthSliceOp.getResult(),
+          hwTransposeIdx);
+
+      // Construct the height only slice spec.
+      SmallVector<int32_t> heightSliceBegins(rank, 0);
+      SmallVector<int32_t> heightSliceEnds(outShape);
+      SmallVector<int32_t> heightSliceStep(rank, 1);
+      // This is the amount we aligned down, trim it.
+      heightSliceBegins[rank - 1] =
+          begins[rank - 1] - cropWidthBegins[rank - 1];
+      // The end is still that far away, just from a new begin.
+      heightSliceEnds[rank - 1] =
+          heightSliceBegins[rank - 1] + (ends[rank - 1] - begins[rank - 1]);
+      // Restore the original step.
+      heightSliceStep[rank - 1] = step[rank - 1];
+
+      // Transpose to finish the height slice spec.
+      std::swap(heightSliceBegins[rank - 1], heightSliceBegins[rank - 2]);
+      std::swap(heightSliceEnds[rank - 1], heightSliceEnds[rank - 2]);
+      std::swap(heightSliceStep[rank - 1], heightSliceStep[rank - 2]);
+
+      auto transposedOutShape =
+          ttmlir::utils::applyPermutation(outShape, hwTransposeIdx);
+      auto transposedOutType = RankedTensorType::get(
+          transposedOutShape, outType.getElementType(), outType.getEncoding());
+
+      auto heightSliceOp = rewriter.create<ttir::SliceStaticOp>(
+          loc, transposedOutType, preTranspose.getResult(),
+          rewriter.getI32ArrayAttr(heightSliceBegins),
+          rewriter.getI32ArrayAttr(heightSliceEnds),
+          rewriter.getI32ArrayAttr(heightSliceStep));
+
+      auto postTranspose = rewriter.create<ttir::PermuteOp>(
+          loc, outType, heightSliceOp.getResult(), hwTransposeIdx);
+
+      rewriter.replaceOp(op, postTranspose.getResult());
+    }
+
+    return success();
+  }
+};
+
 } // namespace mlir::tt
 
 namespace mlir::tt {
@@ -2460,6 +2617,8 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MTensorManipulationOpRewriter<ttir::PermuteOp, permuteLogicalInfo>
   >(typeConverter, ctx, defaultInputMemSpace, defaultOutputMemSpace, ttnnMode, collapseTensors, enableMulticastInference);
 
+  // High-priority rewriter for SliceStatic ops that violate NoC constraints.
+  patterns.add<D2MSliceStaticOpNoCConstraintsRewriter>(typeConverter, ctx);
 
   // ToLayout 1:1 conversion.
   patterns.add<D2MToLayoutOpRewriter>(typeConverter, ctx, ttnnMode);

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -1017,7 +1017,11 @@ public:
           // shapes don't divide evenly into tiles. Decompose via scalar space:
           // untilize → map in scalar space → tilize back.
 
-          // Untilize to scalar space while preserving the current grid.
+          // Untilize to scalar space (preserve current layout properties).
+          // Do not reblock/collapse virtual-grid shape at this stage:
+          // format-conversion generic requires matching shard structure between
+          // input and output, and scalar-space mapping is handled in the next
+          // step.
           Type scalarType = getScalarType(currentInfo.type.getElementType());
           auto untilizedType = typeBuilder.modifyDeviceType(
               currentInfo.type, *currentInfo.layout, targetGridShape,

--- a/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
+++ b/lib/Dialect/D2M/Transforms/MaterializeViewReturns.cpp
@@ -113,17 +113,15 @@ public:
     ModuleOp module = getOperation();
     OpBuilder builder(&getContext());
 
-    // Process each function in the module to find unmaterialized view returns.
+    // Process each function in the module to find unmaterialized views.
     module.walk([&](func::FuncOp funcOp) {
+      // Case 1: Direct view return (should not happen with proper pipelines).
       funcOp.walk([&](func::ReturnOp returnOp) {
         builder.setInsertionPoint(returnOp);
 
         // Inspect each return operand to determine if it needs materialization.
         for (OpOperand &opOperand : returnOp->getOpOperands()) {
           Operation *definingOp = opOperand.get().getDefiningOp();
-
-          // Case 1: Direct view return (should not happen with proper
-          // pipelines).
           if (isViewOp(definingOp)) {
             // Insert a generic op to materialize the view before returning.
             // This ensures the tensor transformation represented by the view
@@ -131,30 +129,30 @@ public:
             Value materialized =
                 materializeView(builder, returnOp.getLoc(), opOperand.get());
             opOperand.set(materialized);
-            continue;
           }
+        }
+      });
 
-          // Case 2: View consumed by device-to-host ToHostOp before return.
-          // Pattern: %view = view_layout ... -> %host = to_host %view ->
-          // return %host. We need to materialize the view BEFORE the
-          // device-to-host transfer.
-          auto toLayoutOp =
-              mlir::dyn_cast_if_present<d2m::ToLayoutOp>(definingOp);
-          bool isToHostOp = mlir::isa_and_nonnull<d2m::ToHostOp>(definingOp) ||
-                            (toLayoutOp && toLayoutOp.isDeviceToHost());
-          if (isToHostOp) {
-            Value toHostInput = definingOp->getOperand(0);
-            Operation *inputDefiningOp = toHostInput.getDefiningOp();
+      // Case 2: View consumed by ToHostOp (or ToLayoutOp that is
+      // device-to-host). This can happen before the return, or in the middle of
+      // the function for the return-to-host-then-fetch-back pattern.
+      // Materialize the view BEFORE the device-to-host transfer.
+      funcOp.walk([&](Operation *op) {
+        auto toLayoutOp = mlir::dyn_cast_if_present<d2m::ToLayoutOp>(op);
+        bool isToHostOp = mlir::isa_and_nonnull<d2m::ToHostOp>(op) ||
+                          (toLayoutOp && toLayoutOp.isDeviceToHost());
 
-            if (isViewOp(inputDefiningOp)) {
-              // Materialize the view before the device-to-host transfer.
-              builder.setInsertionPoint(definingOp);
-              Value materialized =
-                  materializeView(builder, definingOp->getLoc(), toHostInput);
+        if (isToHostOp) {
+          Value toHostInput = op->getOperand(0);
+          Operation *inputDefiningOp = toHostInput.getDefiningOp();
 
-              // Update the ToHostOp to use the materialized value.
-              definingOp->setOperand(0, materialized);
-            }
+          if (isViewOp(inputDefiningOp)) {
+            // Materialize the view before the device-to-host transfer.
+            builder.setInsertionPoint(op);
+            Value materialized =
+                materializeView(builder, op->getLoc(), toHostInput);
+            // Update the ToHostOp to use the materialized value.
+            op->setOperand(0, materialized);
           }
         }
       });

--- a/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
@@ -121,6 +121,8 @@ public:
       updateConstantValueAttr(constantOp);
     } else if (auto arangeOp = dyn_cast<ttir::ArangeOp>(newOp)) {
       updateArangeDimension(arangeOp);
+    } else if (auto sliceOp = dyn_cast<ttir::SliceStaticOp>(newOp)) {
+      updateSliceStaticAttrs(sliceOp);
     }
 
     rewriter.replaceOp(op, newOp->getResults());
@@ -178,6 +180,50 @@ private:
 
     OpBuilder builder(reshapeOp.getContext());
     reshapeOp.setShapeAttr(builder.getI32ArrayAttr(expandShape(currentShape)));
+  }
+
+  static void updateSliceStaticAttrs(ttir::SliceStaticOp sliceOp) {
+    auto resultType = dyn_cast<RankedTensorType>(sliceOp.getResult().getType());
+    auto inputType = dyn_cast<RankedTensorType>(sliceOp.getInput().getType());
+    if (!resultType || !inputType) {
+      return;
+    }
+
+    ArrayAttr beginsAttr = sliceOp.getBeginsAttr();
+    ArrayAttr endsAttr = sliceOp.getEndsAttr();
+    ArrayAttr stepAttr = sliceOp.getStepAttr();
+
+    // Check if attributes already match the expanded rank
+    if (static_cast<int64_t>(beginsAttr.size()) == inputType.getRank()) {
+      return;
+    }
+
+    // Extract current attribute values
+    SmallVector<int32_t> begins, ends, step;
+    for (Attribute attr : beginsAttr) {
+      begins.push_back(cast<IntegerAttr>(attr).getInt());
+    }
+    for (Attribute attr : endsAttr) {
+      ends.push_back(cast<IntegerAttr>(attr).getInt());
+    }
+    for (Attribute attr : stepAttr) {
+      step.push_back(cast<IntegerAttr>(attr).getInt());
+    }
+
+    // Prepend values for new leading dimensions
+    int64_t numDimsToAdd = inputType.getRank() - begins.size();
+    SmallVector<int32_t> newBegins(numDimsToAdd, 0);
+    SmallVector<int32_t> newEnds(numDimsToAdd, 1);
+    SmallVector<int32_t> newStep(numDimsToAdd, 1);
+
+    newBegins.append(begins.begin(), begins.end());
+    newEnds.append(ends.begin(), ends.end());
+    newStep.append(step.begin(), step.end());
+
+    OpBuilder builder(sliceOp.getContext());
+    sliceOp.setBeginsAttr(builder.getI32ArrayAttr(newBegins));
+    sliceOp.setEndsAttr(builder.getI32ArrayAttr(newEnds));
+    sliceOp.setStepAttr(builder.getI32ArrayAttr(newStep));
   }
 };
 

--- a/test/python/golden/test_metal_tms.py
+++ b/test/python/golden/test_metal_tms.py
@@ -35,6 +35,37 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
 @pytest.mark.parametrize(
     "shape, permutation",
     [
+        # 2d transpose
+        [(32, 128 * 500), [1, 0]],
+        pytest.param(
+            (32, 128 * 501),
+            [1, 0],
+            marks=pytest.mark.skip_config(
+                ["n150"],
+                ["n300"],
+                reason="L1 memory usage exceeds capacity #7559",
+            ),
+        ),
+        pytest.param(
+            (32, 128 * 800),
+            [1, 0],
+            marks=pytest.mark.skip_config(
+                ["n150"],
+                ["n300"],
+                reason="L1 memory usage exceeds capacity #7559",
+            ),
+        ),
+        pytest.param(
+            (32, 128 * 801),
+            [1, 0],
+            marks=pytest.mark.skip_config(
+                ["n150"],
+                ["n300"],
+                ["p150"],
+                ["p300"],
+                reason="L1 memory usage exceeds capacity #7559",
+            ),
+        ),
         # 3d inner permutes
         [(3, 32, 32), [0, 2, 1]],
         [(3, 32, 64), [0, 2, 1]],

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -371,6 +371,11 @@ def test_cpu_hoistable_reshape_op(
         ((4, 5, 32, 64), [1, 2, 0, 0], [3, 4, 32, 64], [1, 1, 1, 1]),
         ((8, 6, 64, 32), [2, 1, 0, 0], [6, 5, 64, 32], [1, 1, 1, 1]),
         ((2, 4, 3, 32, 64), [0, 1, 1, 0, 0], [2, 3, 2, 32, 64], [1, 1, 1, 1, 1]),
+        # Simple 1D
+        ((64,), [0], [32], None),
+        # Strided 1D
+        ((70,), [3], [62], [7]),
+        ((2048,), [0], [2048], [3]),
         # Simple 2D
         ((64, 64), [0, 0], [32, 32], None),
         # Crop 2D
@@ -379,7 +384,17 @@ def test_cpu_hoistable_reshape_op(
         ((192, 64), [2, 0], [192, 64], [3, 1]),
         ((64, 192), [0, 2], [64, 192], [1, 3]),
         # Sample large 2D tensors
-        ((32, 131072), [0, 3], [32, 128 * 991], [2, 991]),
+        pytest.param(
+            (32, 131072),
+            [0, 3],
+            [32, 128 * 991],
+            [2, 991],
+            marks=pytest.mark.skip_config(
+                ["ttmetal", "p150"],
+                ["ttmetal", "p300"],
+                reason="L1 memory usage exceeds capacity #7559",
+            ),
+        ),
         ((131072, 32), [5, 1], [128 * 997, 32], [997, 2]),
         ((1024, 1024), [3, 2], [64 * 11, 64 * 13], [11, 13]),
         # Simple 3D
@@ -410,31 +425,24 @@ def test_cpu_hoistable_reshape_op(
         ((3, 20, 14, 64, 64), [1, 5, 6, 31, 32], [2, 6, 7, 32, 33], None),
     ],
 )
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitpy"])
 def test_slice(
     shape: Shape,
     begins: List[int],
     ends: List[int],
     step: List[int],
+    dtype: torch.dtype,
     target: str,
     request,
     device,
 ):
     def module(builder: TTIRBuilder):
-        @builder.func([shape], [torch.float32])
+        @builder.func([shape], [dtype])
         def slice_wrapper(
             in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
         ):
             return builder.slice(in0, begins, ends, step, unit_attrs=unit_attrs)
-
-    # NoC alignment is at least 16B => must align to 4 floats.
-    special_dma = (begins[-1] % 4 != 0) or (step is not None and step[-1] != 1)
-    if target == "ttmetal" and special_dma:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Unaligned and/or strided DMA in the last dim #6475", run=True
-            )
-        )
 
     compile_and_execute_ttir(
         module,

--- a/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
@@ -294,6 +294,33 @@ module {
     // CHECK: %[[DEVICE_TENSOR:.*]] = d2m.to_layout %arg0
     // CHECK: d2m.view_layout %[[DEVICE_TENSOR]]
     // CHECK: d2m.generic
+    %0 = "ttir.slice_static"(%arg0) <{begins = [16 : i32, 0 : i32], ends = [48 : i32, 32 : i32], step = [1 : i32, 1 : i32]}> : (tensor<96x96xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+
+  // CHECK-LABEL: func @named_slice_static_w_unaligned
+  func.func @named_slice_static_w_unaligned(%arg0: tensor<96x96xf32>) -> tensor<32x32xf32> {
+    // Use the transpose-slice-transpose strategy.
+    // CHECK-NOT: slice
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.generic
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.generic
+    %0 = "ttir.slice_static"(%arg0) <{begins = [32 : i32, 1 : i32], ends = [64 : i32, 64 : i32], step = [1 : i32, 2 : i32]}> : (tensor<96x96xf32>) -> tensor<32x32xf32>
+    return %0 : tensor<32x32xf32>
+  }
+
+  // CHECK-LABEL: func @named_slice_static_hw_unaligned
+  func.func @named_slice_static_hw_unaligned(%arg0: tensor<96x96xf32>) -> tensor<32x32xf32> {
+    // Use the slice-transpose-slice-transpose strategy.
+    // CHECK-NOT: slice
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.generic
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.view_layout
+    // CHECK: d2m.generic
     %0 = "ttir.slice_static"(%arg0) <{begins = [1 : i32, 0 : i32], ends = [96 : i32, 64 : i32], step = [3 : i32, 2 : i32]}> : (tensor<96x96xf32>) -> tensor<32x32xf32>
     return %0 : tensor<32x32xf32>
   }

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -256,3 +256,17 @@ func.func @test_uncollapsed_indivisible_bounce_grid(%arg0: tensor<1x5x1x19x32x32
   %1 = d2m.to_layout %arg0, %0 : tensor<1x5x1x19x32x32xbf16, #layout_indivisible_bounce_grid> into tensor<19x160x32xbf16> -> tensor<19x160x32xbf16>
   return %1 : tensor<19x160x32xbf16>
 }
+
+// Complex tiled mapping on an uncollapsed (>2D) grid should not collapse the intermediate untilized tensor to 2D.
+// The format conversion generic requires matching shard structure on input/output.
+#layout_tm_src = #ttcore.metal_layout<logical_shape = 5x1024x64, dim_alignments = 1x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#layout_tm_dst = #ttcore.metal_layout<logical_shape = 5x1024x64, dim_alignments = 1x256x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+func.func @complex_tiled_mapping_preserves_untilize_shape(%arg0: tensor<1x1x1x5x32x2x!ttcore.tile<32x32, f32>, #layout_tm_src>) -> tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst> {
+  // CHECK-LABEL: @complex_tiled_mapping_preserves_untilize_shape
+  // CHECK: d2m.tile_untilize_block
+  // CHECK-SAME: (tensor<5x32x2x!ttcore.tile<32x32, f32>>, tensor<5x1024x64xf32>) -> tensor<5x1024x64xf32>
+  %0 = d2m.empty() : tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst>
+  %1 = d2m.to_layout %arg0, %0 : tensor<1x1x1x5x32x2x!ttcore.tile<32x32, f32>, #layout_tm_src> into tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst> -> tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst>
+  return %1 : tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst>
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
@@ -292,3 +292,16 @@ func.func @implicit_broadcast_1d_3d(%arg0: tensor<64xf32>, %arg1: tensor<2x32x64
   %0 = "ttir.add"(%arg0, %arg1) : (tensor<64xf32>, tensor<2x32x64xf32>) -> tensor<2x32x64xf32>
   return %0 : tensor<2x32x64xf32>
 }
+
+// =============================================================================
+// Test 16: Slice - 1D input
+// =============================================================================
+
+// CHECK-LABEL: func.func @slice_static_1d
+// CHECK-SAME: (%arg0: tensor<1x128xf32>) -> tensor<1x64xf32>
+// CHECK: %[[SLICE:.*]] = "ttir.slice_static"(%arg0) <{begins = [0 : i32, 1 : i32], ends = [1 : i32, 128 : i32], step = [1 : i32, 2 : i32]}> : (tensor<1x128xf32>) -> tensor<1x64xf32>
+// CHECK: return %[[SLICE]] : tensor<1x64xf32>
+func.func @slice_static_1d(%arg0: tensor<128xf32>) -> tensor<64xf32> {
+  %0 = "ttir.slice_static"(%arg0) <{begins = [1 : i32], ends = [128 : i32], step = [2 : i32]}> : (tensor<128xf32>) -> tensor<64xf32>
+  return %0 : tensor<64xf32>
+}


### PR DESCRIPTION
### Ticket
Related-To: #6475

### Problem description
D2M slice op isn't working correctly if:
- The width slice start at a non-NoC-aligned address
- The width step/stride isn't 1 (violates minimal NoC transfer size requirement)

### What's changed
- Add 1D -> 2D support for the slice op in the rank normalization pass
- Add a high-priority rewriter in `TTIRToD2M` that:
  - If the width slice is NoC-unfriendly but not the height dim, do Transpose-Slice-Transpose
  - If both width & height are NoC-unfriendly, do Slice(crop width)-Transpose-Slice(height only)-Transpose
 - Teach `MaterializeViewReturns` to also recognize `view -> to_host` that doesn't immediately return
 - Add detailed comment in `LowerToLayout` about why a virtual grid reblocking shouldn't happen 

### Caveats
- The intermediate results are written to the host, and immediately fetched back
- This is subject to the permute op's limitation when dealing with tall/wide tensors #7559

### Checklist
- [x] New/Existing tests provide coverage for changes
