### PR TITLE
Complex Math Expander Patch Integration

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -5,6 +5,6 @@
 
 # Calculate hash from the following files. This hash is used to tag the docker images.
 # Any change in these files will result in a new docker image build
-DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/ttnn-requirements.txt env/patches/shardy.patch env/patches/shardy_mpmd_pybinds.patch test/python/requirements.txt env/install-tt-triage.sh"
+DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci .github/Dockerfile.ird .github/Dockerfile.cibuildwheel env/CMakeLists.txt env/init_venv.sh env/build-requirements.txt env/ttnn-requirements.txt env/patches/shardy.patch env/patches/shardy_mpmd_pybinds.patch env/patches/stablehlo-complex-mul-expander.patch test/python/requirements.txt env/install-tt-triage.sh"
 DOCKERFILE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES | sha256sum | cut -d ' ' -f 1)
 echo dt-$DOCKERFILE_HASH

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/deepseek_v3_2_rope.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/deepseek_v3_2_rope.mlir
@@ -1,4 +1,5 @@
 // RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion %s
+// REQUIRES: stablehlo
 
 func.func @main(%arg0: tensor<16x8xcomplex<f32>>, %arg1: tensor<2x16x4x16xbf16>) -> tensor<2x16x4x16xbf16> {
   %0 = stablehlo.convert %arg1 : (tensor<2x16x4x16xbf16>) -> tensor<2x16x4x16xf32>


### PR DESCRIPTION
### Ticket
None

### Problem description
1- `test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/deepseek_v3_2_rope.mlir` was missing `REQUIRES: stablehlo` - therefore it wasn't running nightly
2-  `env/patches/stablehlo-complex-mul-expander.patch` was not applied to the toolchain and had to be manually applied

### What's changed
1- Added stablehlo requirement
2- Added patch to `.github/get-docker-tag.sh` so it regenerates the toolchain when edited. 