### PR TITLE
[ttnn-jit] update doc

### DIFF
--- a/docs/src/ttnn-jit.md
+++ b/docs/src/ttnn-jit.md
@@ -82,7 +82,7 @@ This demo is available [here](../../test/ttnn-jit/demo/test_cosh.py).
 | `enable_cache` | `bool` | `False` | Enables caching for compiled JIT graphs. |
 | `math_fidelity` | `ttnn.MathFidelity` | `ttnn.MathFidelity.HiFi4` | Sets the math fidelity setting for the JIT graph. |
 | `debug` | `bool` | `False` | Enables debug prints during compilation and execution. |
-| `compile_only` | `bool` | `False` | Only compile runtime without execution. The resulting flatbuffer and kernel source files will be dumped to `generated/jit`. |
+| `compile_only` | `bool` | `False` | Only compile runtime without execution. The resulting flatbuffer and kernel source files will be dumped to `generated/ttnn-jit/<func_name>`. |
 | `memory_config` | `ttnn.MemoryConfig` | `None` | Output memory configuration for the JIT function. If specified, the output tensor will use this exact layout. If unspecified, a maximally L1 block sharded layout will be used as default. |
 | `fallback` | `bool` | `False` | When enabled, falls back to running the original function eagerly through TTNN if JIT compilation or execution fails. Cannot be used together with `compile_only`. |
 
@@ -149,15 +149,20 @@ The output is a valid MLIR module in the TTIR dialect. The previous `cosh` [exam
 ```mlir
 module {
   func.func @cosh(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
-    %0 = ttir.exp %arg0 : tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
-    %1 = ttir.neg %arg0 : tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
-    %2 = ttir.exp %1 : tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
-    %3 = ttir.add %0, %2 : tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
-    %4 = ttir.multiply %3, 0.5 : tensor<32x32xbf16, #ttnn_layout>, f32 -> tensor<32x32xbf16, #ttnn_layout>
-    return %4 : tensor<32x32xbf16, #ttnn_layout>
+    %0 = "ttir.exp"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16>
+    %1 = "ttir.neg"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16>
+    %2 = "ttir.exp"(%1) : (tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %3 = "ttir.add"(%0, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %cst = "ttir.full"() <{shape = array<i32: 32, 32>, fill_value = 5.000000e-01 : f32}> : () -> tensor<32x32xf32>
+    %4 = "ttir.multiply"(%3, %cst) : (tensor<32x32xbf16>, tensor<32x32xf32>) -> tensor<32x32xbf16>
+    %5 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+    %6 = ttir.to_layout %4, %5 : tensor<32x32xbf16> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+    return %6 : tensor<32x32xbf16, #ttnn_layout>
   }
 }
 ```
+
+Only function arguments and the final return value carry a `#ttnn_layout` encoding that specifies the exact tensor layout (sharding, memory space, grid). Intermediate results are left as bare tensor types; the D2M GridSelection pass infers optimal layouts for these during compilation.
 
 ### Step 2: D2M Compilation Pipeline
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`ttnn-jit` doc was out of date.

### What's changed
Updates the `ttnn-jit` doc with the most relevant commits. See the [doc](https://github.com/tenstorrent/tt-mlir/blob/sgholami/jit-doc-update/docs/src/ttnn-jit.md).

### List of relevant commits
#### Frontend Overhaul
54d2e063d3 - [D2M][TTNN-JIT] Add Tracing Frontend for IR Generation (#6484)
70a40f7b22 - [D2M][TTNN-JIT] Remove AST and Graph Capture Frontends from TTNN-JIT (#6624)
aa43448ba6 - [D2M][TTNN-JIT][Tracing] fix type hint issue (#7347)
fa84a18f63 - [ttnn.jit] frontend fixes for bh grid (#7306)

#### New Operation Support
2873f3e7af - [D2M][TTNN-JIT][Tracing] Add JIT support for some tensor manipulation (TM) operations (#6698)
e3e8956e8e - [D2M][TTNN-JIT][Tracing] Add JIT support for more tensor manipulation (TM) operations (#6900)
ff2d7e2f71 - [ttnn.jit] Add ttnn.clamp support for ttnn.jit (#7214)
6a5251b3af - [D2M][ttnn-jit] Support CCLs through jit (#7345)

#### Memory & Layout
9ec32e52aa - [ttnn.jit] Add Optional Output Memory Layout Selection Passed from TTNN JIT Decorator (#6819)
c7b8bd7784 - [ttnn.jit] Set the default Output Tensor Layout to Maximally L1 Block Sharded Output Layout (#6875)
2b3a37866f - [ttnn.jit] Add ND Sharding Support in JIT Frontend, JIT D2M Pipeline and Runtime (#6559)
94bf181808 - [ttnn.jit][D2M] Add Support for DRAM Interleaved as Output Memory Config (#7391)
a7f92be191 - Integrate Metal Allocator with TTNN-JIT for D2M Memory Management (#6795)
6460bda81f - [ttnn.jit] Infer Intermediate Layouts in D2M GridSelection Pass (#7144)

#### Matmul Fixes
92abcaec77 - [ttnn.jit] Fix Matmul Tracing and Re-Enable Matmul Tests in ttnn.jit (#7420)

#### Infrastructure
3d424043db - D2M: auto detect ETH dispatch availability (#7146)
5d90bfef65 - [D2M][ttnn-jit] Nightly perf collection for Superset (#7495)

#### Fallback Mode (in-flight)
65226a1158 - [ttnn-jit] add fallback mode to ttnn-jit
1f9f12f121 - fix comments, disallow compile_only and fallback mode to be used together

### Checklist
- [X] New/Existing tests provide coverage for changes
