### PR TITLE
[TTIR] Generalize matmul canonicalization to absorb leading dim merge/split reshapes

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3692,46 +3692,102 @@ void mlir::tt::ttir::LinearOp::getCanonicalizationPatterns(
 }
 // ANCHOR_END: adding_an_op_matmul_ttir_verify
 
-// Returns true if `longer` is `shorter` with leading size-1 dimensions
-// prepended.
-static bool isLeadingOnesToShorter(llvm::ArrayRef<int64_t> longer,
-                                   llvm::ArrayRef<int64_t> shorter) {
-  if (longer.size() <= shorter.size()) {
-    return false;
+// Returns the number of leading input dimensions that are merged into the
+// first output dimension. Returns 0 if the reshape is not a leading dimension
+// merge.
+//
+// A leading merge reshapes [d0, d1, ..., dk, t0, t1, ...] ->
+//                          [d0*d1*...*dk, t0, t1, ...]
+// where the trailing dimensions are preserved exactly.
+static size_t getLeadingMergeCount(mlir::tt::ttir::ReshapeOp reshapeOp) {
+  auto inShape = reshapeOp.getInput().getType().getShape();
+  auto outShape = reshapeOp.getType().getShape();
+
+  // Must reduce rank by at least 1.
+  if (outShape.size() >= inShape.size()) {
+    return 0;
   }
 
-  size_t rankDiff = longer.size() - shorter.size();
-  return llvm::all_of(longer.take_front(rankDiff),
-                      [](int64_t dim) { return dim == 1; }) &&
-         longer.drop_front(rankDiff) == shorter;
+  size_t rankDiff = inShape.size() - outShape.size();
+  size_t numMerged = rankDiff + 1;
+
+  // Trailing dims must match exactly.
+  if (inShape.drop_front(numMerged) != outShape.drop_front(1)) {
+    return 0;
+  }
+
+  // Product of merged leading dims must equal the output's first dim.
+  int64_t product = 1;
+  for (size_t i = 0; i < numMerged; ++i) {
+    if (inShape[i] <= 0) {
+      return 0;
+    }
+    product *= inShape[i];
+  }
+
+  if (product != outShape[0]) {
+    return 0;
+  }
+
+  return numMerged;
 }
 
-// Returns true if the reshape removes leading size-1 dimensions.
-//   input:  [1, ..., 1, d0, d1, ..., dk]  (N leading 1s)
-//   output: [d0, d1, ..., dk]
-static bool isLeadingSqueeze(mlir::tt::ttir::ReshapeOp reshapeOp) {
-  return isLeadingOnesToShorter(reshapeOp.getInput().getType().getShape(),
-                                reshapeOp.getType().getShape());
-}
-
-// Returns true if the reshape adds leading size-1 dimensions.
-//   input:  [d0, d1, ..., dk]
-//   output: [1, ..., 1, d0, d1, ..., dk]  (N leading 1s)
-static bool isLeadingUnsqueeze(mlir::tt::ttir::ReshapeOp reshapeOp) {
-  return isLeadingOnesToShorter(reshapeOp.getType().getShape(),
-                                reshapeOp.getInput().getType().getShape());
-}
-
-// MatmulOp canonicalization: absorb leading squeeze/unsqueeze reshapes.
+// Returns the leading dimensions that a single input dimension is split into,
+// or an empty vector if the reshape is not a leading dimension split.
 //
-// Matches patterns like:
-//   %a = ttir.reshape [1,B,M,K] -> [B,M,K]
-//   %b = ttir.reshape [1,B,K,N] -> [B,K,N]
-//   %r = ttir.matmul (%a, %b) -> [B,M,N]
-//   %o = ttir.reshape %r -> [1,B,M,N]
+// A leading split reshapes [P, t0, t1, ...] -> [d0, d1, ..., dk, t0, t1, ...]
+// where P == d0*d1*...*dk and the trailing dimensions are preserved.
+static llvm::SmallVector<int64_t>
+getLeadingSplitDims(mlir::tt::ttir::ReshapeOp reshapeOp) {
+  auto inShape = reshapeOp.getInput().getType().getShape();
+  auto outShape = reshapeOp.getType().getShape();
+
+  // Must increase rank by at least 1.
+  if (inShape.size() >= outShape.size()) {
+    return {};
+  }
+
+  size_t rankDiff = outShape.size() - inShape.size();
+  size_t numSplit = rankDiff + 1;
+
+  // Trailing dims must match exactly.
+  if (inShape.drop_front(1) != outShape.drop_front(numSplit)) {
+    return {};
+  }
+
+  // Product of split dims must equal the input's first dim.
+  int64_t product = 1;
+  llvm::SmallVector<int64_t> splitDims;
+  for (size_t i = 0; i < numSplit; ++i) {
+    if (outShape[i] <= 0) {
+      return {};
+    }
+    product *= outShape[i];
+    splitDims.push_back(outShape[i]);
+  }
+
+  if (product != inShape[0]) {
+    return {};
+  }
+
+  return splitDims;
+}
+
+// MatmulOp canonicalization: absorb leading dimension merge/split reshapes.
 //
-// And replaces with:
-//   %o = matmul %a_orig, %b_orig -> [1,B,M,N]
+// Matches patterns where both matmul inputs have leading dimensions merged
+// into a single batch dimension, and the output splits that dimension back.
+// This covers both the leading-1 squeeze/unsqueeze case (e.g. [1,B,M,K] ->
+// [B,M,K]) and the general batch-merge case (e.g. [B,H,M,K] -> [B*H,M,K]).
+//
+// Example:
+//   %a = ttir.reshape [D0,D1,M,K] -> [D0*D1,M,K]
+//   %b = ttir.reshape [D0,D1,K,N] -> [D0*D1,K,N]
+//   %r = ttir.matmul (%a, %b) -> [D0*D1,M,N]
+//   %o = ttir.reshape %r -> [D0,D1,M,N]
+//
+// Becomes:
+//   %o = matmul %a_orig, %b_orig -> [D0,D1,M,N]
 //
 void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
@@ -3740,72 +3796,67 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
       return mlir::failure();
     }
 
-    auto unsqueezeOp =
+    auto splitOp =
         mlir::dyn_cast<ttir::ReshapeOp>(*op.getResult().getUsers().begin());
-    if (!unsqueezeOp) {
+    if (!splitOp) {
       return mlir::failure();
     }
 
-    if (!isLeadingUnsqueeze(unsqueezeOp)) {
+    auto splitDims = getLeadingSplitDims(splitOp);
+    if (splitDims.empty()) {
       return mlir::failure();
     }
 
-    mlir::Value inputA = op.getA();
-    mlir::Value inputB = op.getB();
-    mlir::Value newA = inputA;
-    mlir::Value newB = inputB;
-
-    auto squeezeA = inputA.getDefiningOp<ttir::ReshapeOp>();
-    auto squeezeB = inputB.getDefiningOp<ttir::ReshapeOp>();
-
-    bool isSqueezedA = squeezeA && isLeadingSqueeze(squeezeA);
-    bool isSqueezedB = squeezeB && isLeadingSqueeze(squeezeB);
-
-    if (!isSqueezedA && !isSqueezedB) {
+    // Both inputs must be leading dimension merges.
+    auto mergeA = op.getA().getDefiningOp<ttir::ReshapeOp>();
+    auto mergeB = op.getB().getDefiningOp<ttir::ReshapeOp>();
+    if (!mergeA || !mergeB) {
       return mlir::failure();
     }
 
-    if (isSqueezedA) {
-      newA = squeezeA.getInput();
+    size_t mergeCountA = getLeadingMergeCount(mergeA);
+    size_t mergeCountB = getLeadingMergeCount(mergeB);
+    if (mergeCountA == 0 || mergeCountB == 0) {
+      return mlir::failure();
     }
-    if (isSqueezedB) {
-      newB = squeezeB.getInput();
+
+    // The merged leading dims must be identical in both inputs.
+    auto aInShape = mergeA.getInput().getType().getShape();
+    auto bInShape = mergeB.getInput().getType().getShape();
+    auto aLeading = aInShape.take_front(mergeCountA);
+    auto bLeading = bInShape.take_front(mergeCountB);
+    if (aLeading != bLeading) {
+      return mlir::failure();
     }
+
+    // The split dims in the output must match the merged leading dims.
+    if (llvm::SmallVector<int64_t>(aLeading.begin(), aLeading.end()) !=
+        splitDims) {
+      return mlir::failure();
+    }
+
+    mlir::Value newA = mergeA.getInput();
+    mlir::Value newB = mergeB.getInput();
 
     auto newAType = mlir::cast<mlir::RankedTensorType>(newA.getType());
     auto newBType = mlir::cast<mlir::RankedTensorType>(newB.getType());
 
-    // Bail out if either matmul input is 1D. Un-squeezing would flip it to 2D,
-    // changing matmul semantics (1D inputs have special prepend/append-1
-    // behavior that affects which dimensions are inner vs outer).
-    if (mlir::cast<mlir::RankedTensorType>(inputA.getType()).getRank() < 2 ||
-        mlir::cast<mlir::RankedTensorType>(inputB.getType()).getRank() < 2) {
-      return mlir::failure();
-    }
-
-    // Bail out if the transformed inputs would have different ranks.
-    // When only one input had a leading squeeze, absorbing it promotes that
-    // input to a higher rank while the other stays unchanged, producing a
-    // matmul with mismatched input ranks (e.g. rank 3 vs rank 4) that TTNN
-    // rejects at runtime.
+    // Bail out if the restored inputs would have different ranks.
     if (newAType.getRank() != newBType.getRank()) {
       return mlir::failure();
     }
 
-    // For same-rank >= 2D inputs, verify the rank matches the unsqueeze output.
-    // The inner dims and batch values are guaranteed compatible by the existing
-    // valid matmul (squeeze only removes leading 1s).
-    if (newAType.getRank() != unsqueezeOp.getType().getRank()) {
+    // Verify the new input rank matches the split output rank.
+    if (newAType.getRank() != splitOp.getType().getRank()) {
       return mlir::failure();
     }
 
-    auto newResultType =
-        mlir::RankedTensorType::get(unsqueezeOp.getType().getShape(),
-                                    unsqueezeOp.getType().getElementType(),
-                                    unsqueezeOp.getType().getEncoding());
+    auto newResultType = mlir::RankedTensorType::get(
+        splitOp.getType().getShape(), splitOp.getType().getElementType(),
+        splitOp.getType().getEncoding());
 
-    rewriter.replaceOpWithNewOp<ttir::MatmulOp>(unsqueezeOp, newResultType,
-                                                newA, newB, op.getTransposeA(),
+    rewriter.replaceOpWithNewOp<ttir::MatmulOp>(splitOp, newResultType, newA,
+                                                newB, op.getTransposeA(),
                                                 op.getTransposeB());
 
     return mlir::success();

--- a/test/ttmlir/Dialect/TTIR/canonicalize/matmul_leading_dim_merge_canonicalize.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/matmul_leading_dim_merge_canonicalize.mlir
@@ -1,0 +1,114 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // Both inputs merged, output split -- pattern fires.
+  // This is the SDPA pattern: [batch, heads, S, D] -> [batch*heads, S, D]
+  func.func @matmul_both_merged(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<32x32x64x128xf32>) -> tensor<32x32x18x128xf32> {
+    // CHECK-LABEL: @matmul_both_merged
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: -> tensor<32x32x18x128xf32>
+    // CHECK-NOT: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 64 : i32, 128 : i32]}> : (tensor<32x32x64x128xf32>) -> tensor<1024x64x128xf32>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 32 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<32x32x18x128xf32>
+    return %3 : tensor<32x32x18x128xf32>
+  }
+
+  // Transpose attributes are preserved -- pattern fires.
+  func.func @matmul_merged_with_transpose(%arg0: tensor<32x32x64x18xf32>, %arg1: tensor<32x32x128x64xf32>) -> tensor<32x32x18x128xf32> {
+    // CHECK-LABEL: @matmul_merged_with_transpose
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: transpose_a = true
+    // CHECK-SAME: transpose_b = true
+    // CHECK-SAME: -> tensor<32x32x18x128xf32>
+    // CHECK-NOT: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 64 : i32, 18 : i32]}> : (tensor<32x32x64x18xf32>) -> tensor<1024x64x18xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 128 : i32, 64 : i32]}> : (tensor<32x32x128x64xf32>) -> tensor<1024x128x64xf32>
+    %2 = "ttir.matmul"(%0, %1) <{transpose_a = true, transpose_b = true}> : (tensor<1024x64x18xf32>, tensor<1024x128x64xf32>) -> tensor<1024x18x128xf32>
+    %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 32 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<32x32x18x128xf32>
+    return %3 : tensor<32x32x18x128xf32>
+  }
+
+  // Three leading dims merged -- pattern fires.
+  func.func @matmul_three_dims_merged(%arg0: tensor<4x8x16x64x32xbf16>, %arg1: tensor<4x8x16x32x64xbf16>) -> tensor<4x8x16x64x64xbf16> {
+    // CHECK-LABEL: @matmul_three_dims_merged
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: -> tensor<4x8x16x64x64xbf16>
+    // CHECK-NOT: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [512 : i32, 64 : i32, 32 : i32]}> : (tensor<4x8x16x64x32xbf16>) -> tensor<512x64x32xbf16>
+    %1 = "ttir.reshape"(%arg1) <{shape = [512 : i32, 32 : i32, 64 : i32]}> : (tensor<4x8x16x32x64xbf16>) -> tensor<512x32x64xbf16>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<512x64x32xbf16>, tensor<512x32x64xbf16>) -> tensor<512x64x64xbf16>
+    %3 = "ttir.reshape"(%2) <{shape = [4 : i32, 8 : i32, 16 : i32, 64 : i32, 64 : i32]}> : (tensor<512x64x64xbf16>) -> tensor<4x8x16x64x64xbf16>
+    return %3 : tensor<4x8x16x64x64xbf16>
+  }
+
+  // Only one input merged -- pattern does not fire.
+  func.func @matmul_one_input_merged(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<1024x64x128xf32>) -> tensor<32x32x18x128xf32> {
+    // CHECK-LABEL: @matmul_one_input_merged
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.matmul"
+    // CHECK: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.matmul"(%0, %arg1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 32 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<32x32x18x128xf32>
+    return %2 : tensor<32x32x18x128xf32>
+  }
+
+  // Leading dims don't match between A and B -- pattern does not fire.
+  func.func @matmul_mismatched_leading_dims(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<64x16x64x128xf32>) -> tensor<32x32x18x128xf32> {
+    // CHECK-LABEL: @matmul_mismatched_leading_dims
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.matmul"
+    // CHECK: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 64 : i32, 128 : i32]}> : (tensor<64x16x64x128xf32>) -> tensor<1024x64x128xf32>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 32 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<32x32x18x128xf32>
+    return %3 : tensor<32x32x18x128xf32>
+  }
+
+  // Split dims don't match merge dims -- pattern does not fire.
+  func.func @matmul_mismatched_split(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<32x32x64x128xf32>) -> tensor<64x16x18x128xf32> {
+    // CHECK-LABEL: @matmul_mismatched_split
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.matmul"
+    // CHECK: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 64 : i32, 128 : i32]}> : (tensor<32x32x64x128xf32>) -> tensor<1024x64x128xf32>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    %3 = "ttir.reshape"(%2) <{shape = [64 : i32, 16 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<64x16x18x128xf32>
+    return %3 : tensor<64x16x18x128xf32>
+  }
+
+  // Matmul result has multiple uses -- pattern does not fire.
+  func.func @matmul_merged_multi_use(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<32x32x64x128xf32>) -> (tensor<32x32x18x128xf32>, tensor<1024x18x128xf32>) {
+    // CHECK-LABEL: @matmul_merged_multi_use
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.matmul"
+    // CHECK: "ttir.reshape"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 64 : i32, 128 : i32]}> : (tensor<32x32x64x128xf32>) -> tensor<1024x64x128xf32>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 32 : i32, 18 : i32, 128 : i32]}> : (tensor<1024x18x128xf32>) -> tensor<32x32x18x128xf32>
+    return %3, %2 : tensor<32x32x18x128xf32>, tensor<1024x18x128xf32>
+  }
+
+  // No output reshape -- pattern does not fire.
+  func.func @matmul_merged_no_split(%arg0: tensor<32x32x18x64xf32>, %arg1: tensor<32x32x64x128xf32>) -> tensor<1024x18x128xf32> {
+    // CHECK-LABEL: @matmul_merged_no_split
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.matmul"
+    %0 = "ttir.reshape"(%arg0) <{shape = [1024 : i32, 18 : i32, 64 : i32]}> : (tensor<32x32x18x64xf32>) -> tensor<1024x18x64xf32>
+    %1 = "ttir.reshape"(%arg1) <{shape = [1024 : i32, 64 : i32, 128 : i32]}> : (tensor<32x32x64x128xf32>) -> tensor<1024x64x128xf32>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<1024x18x64xf32>, tensor<1024x64x128xf32>) -> tensor<1024x18x128xf32>
+    return %2 : tensor<1024x18x128xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/matmul_squeeze_unsqueeze_canonicalize.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/matmul_squeeze_unsqueeze_canonicalize.mlir
@@ -15,7 +15,7 @@ module {
     return %3 : tensor<1x5x64x64xbf16>
   }
 
-  // Only input A squeezed -- pattern does not fire (rank mismatch).
+  // Only input A squeezed -- pattern does not fire (both inputs must be merged).
   func.func @matmul_one_input_squeezed(%arg0: tensor<1x64x128xbf16>, %arg1: tensor<128x32xbf16>) -> tensor<1x64x32xbf16> {
     // CHECK-LABEL: @matmul_one_input_squeezed
     // CHECK: "ttir.reshape"
@@ -27,7 +27,7 @@ module {
     return %2 : tensor<1x64x32xbf16>
   }
 
-  // Only input B squeezed -- pattern does not fire (rank mismatch).
+  // Only input B squeezed -- pattern does not fire (both inputs must be merged).
   func.func @matmul_one_input_b_squeezed(%arg0: tensor<64x128xbf16>, %arg1: tensor<1x128x32xbf16>) -> tensor<1x64x32xbf16> {
     // CHECK-LABEL: @matmul_one_input_b_squeezed
     // CHECK: "ttir.reshape"
@@ -39,8 +39,8 @@ module {
     return %2 : tensor<1x64x32xbf16>
   }
 
-  // Only one input squeezed, batch dim > 1 -- pattern does not fire (rank
-  // mismatch would produce mixed-rank matmul that TTNN rejects).
+  // Only one input squeezed -- pattern does not fire (both inputs must be
+  // merged).
   func.func @matmul_one_input_squeezed_batch_gt1(%arg0: tensor<1x12x577x64xbf16>, %arg1: tensor<12x577x577xbf16>) -> tensor<1x12x577x64xbf16> {
     // CHECK-LABEL: @matmul_one_input_squeezed_batch_gt1
     // CHECK: "ttir.reshape"
@@ -91,7 +91,8 @@ module {
     return %3 : tensor<1x5x64x64xbf16>
   }
 
-  // Non-leading squeeze (middle dim) -- pattern does not fire.
+  // Non-leading squeeze (middle dim) -- pattern does not fire (only one input
+  // merged).
   func.func @matmul_non_leading_squeeze(%arg0: tensor<5x1x64x32xbf16>, %arg1: tensor<5x32x64xbf16>) -> tensor<5x1x64x64xbf16> {
     // CHECK-LABEL: @matmul_non_leading_squeeze
     // CHECK: "ttir.reshape"
@@ -117,8 +118,8 @@ module {
     return %3 : tensor<1x1x5x64x64xbf16>
   }
 
-    // One original matmul operand is 1D after squeeze. Pattern must not fire
-  // because un-squeezing would change 1D matmul semantics.
+  // One original matmul operand is 1D after squeeze -- pattern does not fire
+  // (only one input merged).
   func.func @matmul_rank1_operand_no_rewrite(%arg0: tensor<64x32xbf16>, %arg1: tensor<1x32xbf16>) -> tensor<1x64xbf16> {
     // CHECK-LABEL: @matmul_rank1_operand_no_rewrite
     // CHECK: "ttir.reshape"
@@ -130,8 +131,7 @@ module {
     return %2 : tensor<1x64xbf16>
   }
 
-  // Leading unsqueeze cannot be absorbed when batch-prefix broadcast would
-  // drop the added leading-1 dimension. Pattern must not fire.
+  // Only one input merged with broadcast prefix -- pattern does not fire.
   func.func @matmul_non_absorbable_broadcast_prefix(%arg0: tensor<1x5x64x32xbf16>, %arg1: tensor<7x5x32x64xbf16>) -> tensor<1x7x5x64x64xbf16> {
     // CHECK-LABEL: @matmul_non_absorbable_broadcast_prefix
     // CHECK: "ttir.reshape"


### PR DESCRIPTION
## Summary
- Generalizes the TTIR matmul canonicalization to absorb leading dimension merge/split reshapes around matmul ops (e.g., `[32,32,S,D] → [1024,S,D]`), not just leading size-1 squeeze/unsqueeze
- Unifies the old leading-1 squeeze/unsqueeze pattern and the new general merge pattern into a single canonicalization, since the former is a strict subset of the latter
- Enables downstream SDPA fusing to match 4D `[B,H,S,D]` attention patterns from XLA/JAX that were previously hidden behind 3D batch matmuls

## Context
XLA/JAX emits `dot_general` with batch and head dimensions already merged before the attention matmuls. This produced an IR like:
```
%a = reshape [32,32,S,D] → [1024,S,D]
%b = reshape [32,32,D,S] → [1024,D,S]
%r = matmul(%a, %b)      → [1024,S,S]
%o = reshape %r           → [32,32,S,S]
```
The SDPA fusing pattern requires 4D tensors and couldn't look through these reshapes. This canonicalization absorbs them into the matmul, restoring the 4D form so SDPA fusing matches.

## Test plan
- [x] All 23 existing TTIR canonicalization tests pass (including updated squeeze/unsqueeze tests)
- [x] New test file with 8 cases covering general merge (positive) and edge cases (negative)
- [x] Verified SDPA fuses on a real XLA-generated LLaMA decode IR (`ttnn.scaled_dot_product_attention_decode` appears in output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)