### PR TITLE
d2m: complex mapping fix for LowerToLayout

### DIFF
--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -381,8 +381,7 @@ public:
   // The ViewLayoutOp represents the transformation as an affine map, and the
   // DMA generic materializes the data movement for L1→L1 transformations.
   static Value lowerMappingChange(PatternRewriter &rewriter, Value input,
-                                  Value output, Location loc,
-                                  ArrayRef<int64_t> targetGridShape) {
+                                  Value output, Location loc) {
     auto inputInfo = TensorInfo::from(input);
     auto outputInfo = TensorInfo::from(output);
 
@@ -633,6 +632,9 @@ public:
     bool outputTiled = ttcore::isTiled(outputType);
     assert(inputTiled != outputTiled &&
            "one of input or output must be tiled for now");
+    assert(TensorInfo::from(input).getGridShape() ==
+               TensorInfo::from(output).getGridShape() &&
+           "format conversion generic requires matching input/output grids");
 
     return rewriter
         .create<GenericOp>(
@@ -1015,17 +1017,14 @@ public:
           // shapes don't divide evenly into tiles. Decompose via scalar space:
           // untilize → map in scalar space → tilize back.
 
-          // Untilize to scalar space (preserve current layout properties).
-          // Reblock virtual grid shape here to align with earlier splitting
-          // phases that use reblocked intermediates to bounce virtual grid
-          // shapes from host to device.
+          // Untilize to scalar space while preserving the current grid.
           Type scalarType = getScalarType(currentInfo.type.getElementType());
           auto untilizedType = typeBuilder.modifyDeviceType(
               currentInfo.type, *currentInfo.layout, targetGridShape,
               currentRemapping.value_or(AffineMap()),
               ttcore::MemorySpace::DeviceL1,
               /*newTensorGrid=*/{}, scalarType,
-              /*newTileShape=*/{}, /* reblockVirtualGridShapes */ true);
+              /*newTileShape=*/{}, /*reblockVirtualGridShapes=*/false);
           auto untilizedEmpty = createEmpty(untilizedType);
           currentValue = lowerFormatConversionGeneric(
               rewriter, currentValue, untilizedEmpty, op.getLoc());
@@ -1048,9 +1047,8 @@ public:
           auto scalarTargetType = RankedTensorType::get(
               scalarTargetDeviceShape, scalarType, scalarTargetLayout);
           auto scalarTargetEmpty = createEmpty(scalarTargetType);
-          currentValue =
-              lowerMappingChange(rewriter, currentValue, scalarTargetEmpty,
-                                 op.getLoc(), targetGridShape);
+          currentValue = lowerMappingChange(rewriter, currentValue,
+                                            scalarTargetEmpty, op.getLoc());
           currentInfo = TensorInfo::from(currentValue);
 
           // Tilize back to match target format.
@@ -1085,9 +1083,8 @@ public:
 
           auto intermediateEmpty = createEmpty(intermediateType);
 
-          currentValue =
-              lowerMappingChange(rewriter, currentValue, intermediateEmpty,
-                                 op.getLoc(), targetGridShape);
+          currentValue = lowerMappingChange(rewriter, currentValue,
+                                            intermediateEmpty, op.getLoc());
           currentInfo = TensorInfo::from(currentValue);
         }
       }
@@ -1115,9 +1112,8 @@ public:
             /*newTensorGrid=*/{}, /*newElementType=*/{},
             /*newTileShape=*/{}, /*reblockVirtualGridShapes=*/true);
         auto reblockedEmpty = createEmpty(reblocked);
-        currentValue =
-            lowerMappingChange(rewriter, currentValue, reblockedEmpty,
-                               op.getLoc(), targetGridShape);
+        currentValue = lowerMappingChange(rewriter, currentValue,
+                                          reblockedEmpty, op.getLoc());
         currentInfo = TensorInfo::from(currentValue);
       }
     }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_complex_tilized_mapping.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_to_layout_complex_tilized_mapping.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-lower-to-layout -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#src = #ttcore.metal_layout<logical_shape = 32x5120, dim_alignments = 32x256, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#dst = #ttcore.metal_layout<logical_shape = 32x5120, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+
+// CHECK-LABEL: func.func @preserve_virtual_grid_during_untilize
+// CHECK: %[[SRC:.*]] = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x40x1x4x!ttcore.tile<32x32, f32>, #{{.*}}>
+// CHECK: %[[SCALAR:.*]] = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x40x32x128xf32, #{{.*}}>
+// CHECK: %[[UNTILIZED:.*]] = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x40
+// CHECK: ins(%[[SRC]] : tensor<1x40x1x4x!ttcore.tile<32x32, f32>, #{{.*}}>)
+// CHECK: outs(%[[SCALAR]] : tensor<1x40x32x128xf32, #{{.*}}>)
+// CHECK: d2m.tile_untilize_block
+// CHECK-NOT: tensor<1x8x32x640xf32
+func.func @preserve_virtual_grid_during_untilize() -> tensor<1x1x1x160x!ttcore.tile<32x32, f32>, #dst> {
+  %src_tensor = d2m.empty() {virtualGridForwardMapping = affine_map<(d0, d1, d2, d3) -> ((d1 floordiv 8) mod 5, d1 mod 8, d2, d3)>, virtualGridInverseMapping = affine_map<(d0, d1) -> (0, 0, (d1 + d0 * 8) mod 40)>} : tensor<1x40x1x4x!ttcore.tile<32x32, f32>, #src>
+  %dst_tensor = d2m.empty() : tensor<1x1x1x160x!ttcore.tile<32x32, f32>, #dst>
+  %result = d2m.to_layout %src_tensor, %dst_tensor : tensor<1x40x1x4x!ttcore.tile<32x32, f32>, #src> into tensor<1x1x1x160x!ttcore.tile<32x32, f32>, #dst> -> tensor<1x1x1x160x!ttcore.tile<32x32, f32>, #dst>
+  return %result : tensor<1x1x1x160x!ttcore.tile<32x32, f32>, #dst>
+}


### PR DESCRIPTION
- Do not use a bounce grid when a complex mapping is detected in LowerToLayout. Instead, untilize on the same grid. 
- Added lit test
