### PR TITLE
Fix tt-xla regression: guard reshape workaround against L1 overflow

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReshapeNarrowTiledRewritePattern.cpp
@@ -22,8 +22,11 @@ static constexpr int64_t kTileWidth = ttnn::TILE_WIDTH;
 // tiled reshape kernel. See tt_cluster.cpp min_dma_size_bytes.
 static constexpr unsigned kNocMinWriteBytes = 32;
 // The RM fallback allocates circular buffers proportional to the larger row-
-// major stick. Keep a safety margin relative to usable L1 so wide sticks do
-// not overflow per-core memory.
+// major stick. In reshape_rm_program_factory.cpp, cb_src0 is sized from
+// num_pages * max(old_stick_size, new_stick_size). This pass does not model
+// the exact per-core num_pages split, so keep a conservative safety margin
+// relative to usable L1. If reshape_rm CB sizing changes materially, revisit
+// this divisor.
 static constexpr uint64_t kMaxRMFallbackStickUsableL1Divisor = 4;
 
 LogicalResult ReshapeNarrowTiledRewritePattern::matchAndRewrite(
@@ -51,6 +54,7 @@ LogicalResult ReshapeNarrowTiledRewritePattern::matchAndRewrite(
     return failure();
   }
 
+  int64_t inputLastDim = inputType.getShape()[inputRank - 1];
   int64_t outputLastDim = outputType.getShape()[outputRank - 1];
   int64_t partialWidth = outputLastDim % kTileWidth;
 
@@ -76,7 +80,6 @@ LogicalResult ReshapeNarrowTiledRewritePattern::matchAndRewrite(
     return failure();
   }
 
-  int64_t inputLastDim = inputType.getShape()[inputRank - 1];
   uint64_t inputStickBytes =
       static_cast<uint64_t>(inputLastDim) * elementSizeBytes;
   uint64_t outputStickBytes =

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reshape_narrow_tiled_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reshape_narrow_tiled_workaround.mlir
@@ -50,7 +50,19 @@ module {
     return %0 : tensor<64x16xf32>
   }
 
-  // Test 4: Workaround should NOT apply - view reshape (last dim unchanged).
+  // Test 4: Workaround should NOT apply - RM fallback stick exceeds the
+  // usable-L1-derived guard even though the partial-tile DMA condition matches.
+  func.func @reshape_narrow_large_stick_skip(
+      %arg0: tensor<32x262144xbf16>
+  ) -> tensor<1048576x8xbf16> {
+    // CHECK-LABEL: func.func @reshape_narrow_large_stick_skip
+    // CHECK: "ttnn.reshape"
+    // CHECK-NOT: layout = #ttnn.layout<row_major>
+    %0 = "ttnn.reshape"(%arg0) <{shape = [1048576 : i32, 8 : i32]}> : (tensor<32x262144xbf16>) -> tensor<1048576x8xbf16>
+    return %0 : tensor<1048576x8xbf16>
+  }
+
+  // Test 5: Workaround should NOT apply - view reshape (last dim unchanged).
   // 1x32x8 -> 32x8: last dim stays 8 (same), second-to-last also same => view.
   func.func @reshape_narrow_view_skip(
       %arg0: tensor<1x32x8xbf16>


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3845)

### Problem description
The global reshape workaround can route large partial-tile reshapes through the row-major fallback, which may exceed usable per-core L1 and fail at runtime in tt-xla.

### What's changed
Add a device-aware guard based on usable L1 size so these reshapes stay on the original tiled path while preserving the workaround for smaller safe cases.


### Checklist
- [ ] New/Existing tests provide coverage for changes
