### PR TITLE
[ttnn-jit] Enable reduction tests

### DIFF
--- a/test/ttnn-jit/nightly/test_reduction.py
+++ b/test/ttnn-jit/nightly/test_reduction.py
@@ -12,7 +12,7 @@ from utils import (
 )
 
 
-L1_REDUCTION_SHAPES = [
+REDUCTION_SHAPES = [
     # (shape, max_grid, dim)
     # 1x1 grid
     ((32, 32), (0, 0), 1),
@@ -33,57 +33,31 @@ L1_REDUCTION_SHAPES = [
     ((1024, 1024), (0, 7), 1),
 ]
 
-DRAM_REDUCTION_SHAPES = [(shape, dim) for shape, _, dim in L1_REDUCTION_SHAPES]
-
 REDUCTION_OPS = [
-    ("max", ttnn.max),
-    ("sum", ttnn.sum),
-    ("mean", ttnn.mean),
-    ("min", ttnn.min),
+    ttnn.max,
+    ttnn.sum,
+    ttnn.mean,
+    ttnn.min,
 ]
 
 
-# ------------------------------------------------------------
-# L1 reduction tests (max, sum)
-# ------------------------------------------------------------
-@pytest.mark.parametrize("shape, max_grid, dim", L1_REDUCTION_SHAPES)
-@pytest.mark.parametrize("op_name, op_func", REDUCTION_OPS)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.skip(
-    reason="Reduction ops are not currently supported in ttnn-jit: Issue #5446"
-)
-def test_reductions_l1(device, shape, max_grid, dim, op_name, op_func, dtype):
-    """Test reduction operations (max, sum) with L1 block-sharded config."""
+@pytest.mark.parametrize("shape, max_grid, dim", REDUCTION_SHAPES)
+@pytest.mark.parametrize("op", REDUCTION_OPS)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_reductions(device, shape, max_grid, dim, op, dtype, buffer_type):
+    """Test reduction operations (max, sum) with L1 or DRAM config."""
 
     def reduction_func(input_tensor):
-        return op_func(input_tensor, dim=dim, keepdim=True)
+        return op(input_tensor, dim=dim, keepdim=True)
 
-    run_op_test(
-        device,
-        shape,
-        max_grid,
-        dtype,
-        reduction_func,
-        num_inputs=1,
-        buffer_type=ttnn.BufferType.L1,
-        shard_strategy=ttnn.ShardStrategy.BLOCK,
+    if op in [ttnn.mean, ttnn.min]:
+        pytest.skip(reason="Mean and Min are not currently supported in D2M")
+
+    shard_strategy = (
+        ttnn.ShardStrategy.BLOCK if buffer_type == ttnn.BufferType.L1 else None
     )
 
-
-# ------------------------------------------------------------
-# DRAM reduction tests (max, sum)
-# ------------------------------------------------------------
-@pytest.mark.parametrize("shape, dim", DRAM_REDUCTION_SHAPES)
-@pytest.mark.parametrize("op_name, op_func", REDUCTION_OPS)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.skip(reason="DRAM reduction ops are not currently supported")
-def test_reductions_dram(device, shape, dim, op_name, op_func, dtype):
-    """Test reduction operations (max, sum) with DRAM config."""
-
-    def reduction_func(input_tensor):
-        return op_func(input_tensor, dim=dim, keepdim=True)
-
-    max_grid = (0, 0)
     run_op_test(
         device,
         shape,
@@ -91,5 +65,7 @@ def test_reductions_dram(device, shape, dim, op_name, op_func, dtype):
         dtype,
         reduction_func,
         num_inputs=1,
-        buffer_type=ttnn.BufferType.DRAM,
+        buffer_type=buffer_type,
+        shard_strategy=shard_strategy,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )

--- a/test/ttnn-jit/test_reduction_smoketest.py
+++ b/test/ttnn-jit/test_reduction_smoketest.py
@@ -12,7 +12,7 @@ from utils import (
 )
 
 
-L1_REDUCTION_SHAPES = [
+REDUCTION_SHAPES = [
     # (shape, max_grid, dim)
     ((32, 32), (0, 0), 1),
     ((128, 128), (0, 0), 0),
@@ -23,73 +23,31 @@ L1_REDUCTION_SHAPES = [
     ((1024, 1024), (0, 7), 1),
 ]
 
-DRAM_REDUCTION_SHAPES = [(shape, dim) for shape, _, dim in L1_REDUCTION_SHAPES]
-
 REDUCTION_OPS = [
-    ("max", ttnn.max),
-    ("sum", ttnn.sum),
-    ("mean", ttnn.mean),
-    ("min", ttnn.min),
+    ttnn.max,
+    ttnn.sum,
+    ttnn.mean,
+    ttnn.min,
 ]
 
 
-# ------------------------------------------------------------
-# L1 reduction tests (max, sum)
-# ------------------------------------------------------------
-@pytest.mark.parametrize(
-    "shape, max_grid, dim",
-    L1_REDUCTION_SHAPES,
-    ids=[f"{shape}_grid{grid}_dim{dim}" for shape, grid, dim in L1_REDUCTION_SHAPES],
-)
-@pytest.mark.parametrize("op_name, op_func", REDUCTION_OPS)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float32, torch.bfloat16],
-    ids=["f32", "bf16"],
-)
-@pytest.mark.skip(
-    reason="Reduction ops are not currently supported in ttnn-jit: Issue #6623"
-)
-def test_reductions_l1(device, shape, max_grid, dim, op_name, op_func, dtype):
-    """Test reduction operations (max, sum) with L1 block-sharded config."""
+@pytest.mark.parametrize("shape, max_grid, dim", REDUCTION_SHAPES)
+@pytest.mark.parametrize("op", REDUCTION_OPS)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_reductions(device, shape, max_grid, dim, op, dtype, buffer_type):
+    """Test reduction operations (max, sum) with L1 or DRAM config."""
 
     def reduction_func(input_tensor):
-        return op_func(input_tensor, dim=dim, keepdim=True)
+        return op(input_tensor, dim=dim, keepdim=True)
 
-    run_op_test(
-        device,
-        shape,
-        max_grid,
-        dtype,
-        reduction_func,
-        num_inputs=1,
-        buffer_type=ttnn.BufferType.L1,
-        shard_strategy=ttnn.ShardStrategy.BLOCK,
+    if op in [ttnn.mean, ttnn.min]:
+        pytest.skip(reason="Mean and Min are not currently supported in D2M")
+
+    shard_strategy = (
+        ttnn.ShardStrategy.BLOCK if buffer_type == ttnn.BufferType.L1 else None
     )
 
-
-# ------------------------------------------------------------
-# DRAM reduction tests (max, sum)
-# ------------------------------------------------------------
-@pytest.mark.parametrize(
-    "shape, dim",
-    DRAM_REDUCTION_SHAPES,
-    ids=[f"{shape}_dim{dim}" for shape, dim in DRAM_REDUCTION_SHAPES],
-)
-@pytest.mark.parametrize("op_name, op_func", REDUCTION_OPS)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float32, torch.bfloat16],
-    ids=["f32", "bf16"],
-)
-@pytest.mark.skip(reason="DRAM reduction ops are not currently supported: Issue #6623")
-def test_reductions_dram(device, shape, dim, op_name, op_func, dtype):
-    """Test reduction operations (max, sum) with DRAM config."""
-
-    def reduction_func(input_tensor):
-        return op_func(input_tensor, dim=dim, keepdim=True)
-
-    max_grid = (0, 0)
     run_op_test(
         device,
         shape,
@@ -97,5 +55,7 @@ def test_reductions_dram(device, shape, dim, op_name, op_func, dtype):
         dtype,
         reduction_func,
         num_inputs=1,
-        buffer_type=ttnn.BufferType.DRAM,
+        buffer_type=buffer_type,
+        shard_strategy=shard_strategy,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6623

### Problem description
Reduction tests were all being skipped in `ttnn-jit`.

### What's changed
This PR:
- Enables all reduction tests for `ttnn.sum` and `ttnn.max` (Note that D2M does not support `ttnn.min` and `ttnn.mean` atm).
   - 60 out of 120 tests are enabled in `test_reduction`,
   - 56 out of 112 tests are enabled in `test_reduction_smoketest`.
- Refactors `test/ttnn-jit/nightly/test_reduction.py` and `test/ttnn-jit/test_reduction_smoketest.py`,

### Checklist
- [X] New/Existing tests provide coverage for changes
