### PR TITLE
Add const-eval pass before optimizer passes

### DIFF
--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -339,6 +339,16 @@ void createTTIRToTTNNDevicePipeline(
       devicePm.addPass(tt::ttnn::createTTNND2MFusing());
     }
 
+    // Const-eval pass which should pick up any const-evalable ops created in
+    // TTNN workarounds, weight dtype conversion, or any TTNN pass after the
+    // first const-eval pass.
+    //
+    // Without this pass, optimizer might L1-shard certain ops which would get
+    // const-evaled in the later const-eval pass.
+    if (options.enableConstEval) {
+      devicePm.addPass(transforms::createConstEvalHoistTransform());
+    }
+
     createTTNNPipelineAnalysisPasses(devicePm, options);
 
     if (options.enableD2MFusing) {


### PR DESCRIPTION
### Ticket
#7540

### Problem description
Passes that run between the first const-eval pass and the optimizer (e.g. TTNN workarounds, weight dtype conversion) can generate new const-evalable ops. Without an intervening const-eval pass, these ops reach the optimizer, which may assign them L1-sharded layouts. When the later (post-optimizer) const-eval pass then hoists these ops into const-eval functions, the L1-sharding decisions become invalid - the optimizer assumed they would run in the forward function where L1 space is available, but there are no such guarantees inside const-eval functions, due to different ordering of operations, and different memory footprints of intermediate results.

More generally, ops in const-eval functions should not operate on L1-sharded operands, as this is fragile and not expected by the optimizer.

> **Note:** Consecutive const-eval passes perform `UndoConstEval` before re-running. This is fragile and should be reconsidered as part of #7463.

### What's changed
Added a const-eval pass immediately before the optimizer so that any newly created const-evalable ops are hoisted *before* the optimizer makes layout decisions about them. This prevents the optimizer from assigning L1-sharded layouts to ops that will ultimately be const-evaled.

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Branch:** [`xla-validate/7602`](https://github.com/tenstorrent/tt-mlir/tree/xla-validate/7602)
**Base (uplifted):** `60a7e71`

| Test Suite | Run | Status |
|------------|-----|--------|
| mlir-uplift-qualification | [Run #23566350220](https://github.com/tenstorrent/tt-xla/actions/runs/23566350220) | ✅ passed |

<!-- /xla-validate -->
