### PR TITLE
[runtime] fix basic multi-graph trace scenario

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/types/trace_cache.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/trace_cache.h
@@ -13,12 +13,32 @@ namespace tt::runtime::ttnn {
 
 struct TraceData {
   ::ttnn::MeshTraceId traceId;
-  // Input tensor buffers to write the input tensors to
+  /// Input tensor buffers to write the input tensors to.
   std::vector<::tt::runtime::Tensor> inputTensors;
-  // Output tensor buffers to write the output tensors to
+  /// Output tensor buffers to write the output tensors to.
   std::vector<::tt::runtime::Tensor> outputTensors;
+  /// Trace cache generation id at capture time - used to detect stale traces.
+  uint64_t generationId = 0;
 };
 
+/// Cache for storing captured traces.
+///
+/// The captured traces are stored by a two-level key:
+/// - the first level key identifies the main program (binary id + main program
+/// index)
+/// - the second level key identifies the capture and execute program IDs for
+/// the trace.
+///
+/// The cache also maintains a generation id to allow detection of stale traces.
+/// Traces are inherently unsafe to reuse after certain operations (e.g. after a
+/// new graph is captured). This is because the old trace may overwrite memory
+/// allocated for the new graph - those allocations were not present at
+/// the time of the capture, the captured graph could have used that memory for
+/// its intermediate buffers.
+///
+/// To handle those cases, the cache provides the generation id - which should
+/// be incremented by runtime whenever it performs an operation that may
+/// invalidate existing traces.
 class TraceCache {
 public:
   TraceCache(std::shared_ptr<::ttnn::MeshDevice> meshDevice)
@@ -36,16 +56,24 @@ public:
                  const CaptureExecuteProgramKey &captureExecuteKey);
   void insert(const MainProgramKey &key,
               const CaptureExecuteProgramKey &captureExecuteKey,
-              const TraceData &traceData);
+              TraceData traceData);
   void erase(const MainProgramKey &key);
   void erase(const MainProgramKey &key,
              const CaptureExecuteProgramKey &captureExecuteKey);
+
+  uint64_t getGenerationId() const { return generationId; }
+
+  /// Increments the generation id.
+  /// Should be called by runtime whenever it performs an operation that may
+  /// invalidate existing traces (e.g. when a new graph is captured).
+  void incrementGeneration() { generationId++; }
 
 private:
   std::weak_ptr<::ttnn::MeshDevice> meshDevice;
   std::unordered_map<MainProgramKey,
                      std::unordered_map<CaptureExecuteProgramKey, TraceData>>
       cache;
+  uint64_t generationId = 0;
 };
 } // namespace tt::runtime::ttnn
 

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/program_executor.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/types/trace_cache.h"
 #include "tt/runtime/detail/ttnn/types/types.h"
 #include "tt/runtime/detail/ttnn/utils.h"
@@ -113,10 +114,11 @@ static void runTraceProgramAndCaptureTrace(
   }
 
   TraceData traceData{.traceId = meshTraceId,
-                      .inputTensors = inputSlots,
-                      .outputTensors = outputSlots};
+                      .inputTensors = std::move(inputSlots),
+                      .outputTensors = std::move(outputSlots),
+                      .generationId = traceCache.getGenerationId()};
   auto [mainProgramKey, captureExecuteKey] = getTraceCacheKeys(op, context);
-  traceCache.insert(mainProgramKey, captureExecuteKey, traceData);
+  traceCache.insert(mainProgramKey, captureExecuteKey, std::move(traceData));
 }
 
 static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
@@ -193,6 +195,7 @@ void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
 
   if (!traceCache->contains(mainProgramKey, captureExecuteKey)) {
     LOG_DEBUG("Trace cache miss, running program and capturing trace");
+    traceCache->incrementGeneration();
     runTraceProgramAndCaptureTrace(op, context, *traceCache);
     debug::Stats::get().incrementStat("TraceCacheMiss");
     debug::Stats::get().incrementStat("CapturedTrace");
@@ -201,6 +204,28 @@ void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
 
   TraceData *traceData = traceCache->get(mainProgramKey, captureExecuteKey);
   LOG_ASSERT(traceData, "TraceData must be populated in TraceCache");
+
+  // Check if the trace is stale by comparing the generation id of the trace
+  // with the current generation id of the cache.
+  //
+  // If the trace is stale, that means that we have new allocations on the
+  // device since the trace was captured, so we need to re-capture it again.
+  // Otherwise, we would possibly be overwriting new allocations when replaying
+  // (executing) the stale trace.
+  if (traceData->generationId < traceCache->getGenerationId()) {
+    LOG_DEBUG("Trace is stale (captured at gen ", traceData->generationId,
+              ", current gen ", traceCache->getGenerationId(),
+              "), invalidating and recapturing");
+
+    // Remove the stale trace from the cache and recapture it.
+    traceCache->erase(mainProgramKey, captureExecuteKey);
+    runTraceProgramAndCaptureTrace(op, context, *traceCache);
+
+    debug::Stats::get().incrementStat("TraceCacheMiss");
+    debug::Stats::get().incrementStat("TraceStaleRecapture");
+    return;
+  }
+
   LOG_DEBUG("Trace cache hit, executing trace directly");
   executeTrace(op, context, *traceData);
   debug::Stats::get().incrementStat("ExecutedTrace");

--- a/runtime/lib/ttnn/types/trace_cache.cpp
+++ b/runtime/lib/ttnn/types/trace_cache.cpp
@@ -34,8 +34,8 @@ TraceData *TraceCache::get(const MainProgramKey &key,
 
 void TraceCache::insert(const MainProgramKey &key,
                         const CaptureExecuteProgramKey &captureExecuteKey,
-                        const TraceData &traceData) {
-  cache[key][captureExecuteKey] = traceData;
+                        TraceData traceData) {
+  cache[key][captureExecuteKey] = std::move(traceData);
 }
 
 void TraceCache::erase(const MainProgramKey &key) {

--- a/runtime/test/ttnn/python/n150/test_trace.py
+++ b/runtime/test/ttnn/python/n150/test_trace.py
@@ -4,10 +4,11 @@
 
 import time
 import pytest
-import torch.nn.functional as F
+import os
+import torch
 import ttrt
 import ttrt.runtime
-from ttrt.common.util import *
+from ttrt.common.util import Binary, FileManager, Logger
 from ..utils import (
     TT_MLIR_HOME,
     Helper,
@@ -64,6 +65,104 @@ def test_trace_matmul_multiply_no_consteval(
             assert debug_stats.get_stat("TraceCacheMiss") == 1
             assert debug_stats.get_stat("CapturedTrace") == 1
             assert debug_stats.get_stat("ExecutedTrace") == i
+
+    ttrt.runtime.DebugStats.get().clear()
+    helper.teardown()
+
+
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_trace_memory_overwrite_multi_graph(helper: Helper, request, trace_region_size):
+    """
+    This test verifies that the two traced graphs do not overwrite each other's memory.
+    Device allocations, after a trace is captured, are (in general) not safe - there are no guarantees that the
+    newly allocated memory does not overlap with memory used by the previously captured trace. If the overlap
+    happens then the trace replay may corrupt the newly allocated memory (e.g. by writing its intermediates to it).
+
+    We handle this case in runtime by tracking all of the captures - whenever we have a new capture, we bump
+    trace cache generation id. Then, when we want to replay a cached trace, we check the generation id of the cached trace
+    against the current generation id of the cache. In case of mismatch, we re-capture & re-cache the trace to ensure that
+    we won't overlap with any of the new allocations that happened since the last time we captured the trace.
+    """
+    binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "matmul_multiply_consteval.mlir.tmp.ttnn"
+    )
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+    helper.initialize(request.node.name, binary_path)
+    helper.check_constraints()
+
+    first_bin_config = ProgramTestConfig(
+        name="first_graph",
+        expected_num_inputs=3,
+        compute_golden=None,
+        description="Graph whose trace replay can corrupt victim memory",
+    )
+    first_bin_runner = ProgramTestRunner(first_bin_config, helper.binary, 0)
+
+    victim_binary = Binary(Logger(), FileManager(Logger()), binary_path)
+    victim_config = ProgramTestConfig(
+        name="victim",
+        expected_num_inputs=3,
+        compute_golden=lambda inputs: ((inputs[0] @ inputs[1]) * inputs[2]),
+        description="Graph whose parameters can get corrupted by trace replay",
+    )
+    victim_runner = ProgramTestRunner(victim_config, victim_binary, 0)
+
+    debug_stats = ttrt.runtime.DebugStats.get()
+
+    with DeviceContext(
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
+    ) as device:
+
+        # Execute & capture the first graph.
+        (
+            pressure_inputs,
+            _,
+            _pressure_inputs_torch,
+        ) = first_bin_runner.get_inputs_and_golden(device)
+        first_bin_runner.run_program(device, pressure_inputs)
+
+        # Run the first graph few times - confirm that we're actually executing the trace.
+        for i in range(3):
+            first_bin_runner.run_program(device, pressure_inputs)
+            assert debug_stats.get_stat("TraceCacheMiss") == 1
+            assert debug_stats.get_stat("ExecutedTrace") == i + 1
+
+        # Reset the stats.
+        debug_stats.clear()
+
+        # Now enters the second graph.
+        # These inputs are allocated after we've captured the first trace.
+        # Hence, they are vulnerable to getting overwritten if we would naively
+        # replay the first trace.
+        (
+            victim_inputs,
+            victim_golden,
+            _victim_inputs_torch,
+        ) = victim_runner.get_inputs_and_golden(device)
+
+        # Capture victim trace, golden check should pass.
+        victim_runner.run_program_and_compare_golden(
+            device, victim_inputs, victim_golden
+        )
+
+        # Replay both traces in a loop, verifying that the outputs of the victim graph
+        # stay correct - i.e. we do NOT overwrite any of the input tensors of the victim
+        # graph.
+        loop_count = 32
+        for i in range(loop_count):
+            first_bin_runner.run_program(device, pressure_inputs)
+            victim_runner.run_program_and_compare_golden(
+                device, victim_inputs, victim_golden
+            )
+
+        # The first graph should have been recaptured once.
+        assert debug_stats.get_stat("TraceStaleRecapture") == 1
+        # We have two misses, one for the initial capture of the victim graph and one for the re-capture of the first graph.
+        assert debug_stats.get_stat("TraceCacheMiss") == 2
+        # We should hit the cache for both graphs each time we run the loop, except for the first recapture.
+        assert debug_stats.get_stat("ExecutedTrace") == 2 * loop_count - 1
 
     ttrt.runtime.DebugStats.get().clear()
     helper.teardown()


### PR DESCRIPTION
Current implementation of `trace` is very unsafe when executing multiple graphs - there exist no mechanism to protect the user from one trace overwriting input buffers of another graph (traced or not).

When we capture a trace, all operations captured are replayed exactly on the next execution of the trace - including all memory allocations/reads & writes. Consider the following (slightly simplified) sequence of events:
- all inputs for the graph A are allocated on the device, let's say that we fill the memory space on device up to address 0x100 (simplified)
- we capture the graph A - during capture various intermediate tensors are allocated for individual operations inside of the graph - up to the address 0x200
- during the capture we will deallocate all of the allocated intermediates, freeing up the memory, so again (after the capture is completed) everything after address 0x100 is free
- next graph comes, and we allocate its inputs on the device - these inputs cause the memory up to 0x200 to be filled - and we execute the graph
- now we execute the graph A again, the trace is replayed.

After the above sequence, the graph B's inputs now contain garbage values, since they were overwritten by the trace replay of graph A - because graph A used address range 0x100-0x200 for its intermediates, while graph B used the same range for its inputs.

To prevent this, cached trace invalidation mechanism is implemented. With this change, we will invalidate all existing cached traces after we capture a new graph. Invalidated traces will be recaptured on-demand - when the graph which has an invalidated entry is submitted for execution. This works because everything that needs to be persisted (weight tensors, any program config tensors, etc.) is already allocated, so when recapturing the intermediates of the graph won't be able to use that space - hence no overwrites on future trace replay.

In this change we ONLY cover the basic scenario, which assumes all graphs that will be executed are traced graphs and there are no persistent device tensor allocations outside of the captured graphs (which could be overwritten).

Other scenarios include:
- user allocates and holds on to a tensor on device (while there are existing captured traces)
- user executes a new non-traced graph
- user clears the program cache - while there are existing captured traces.

Covering these scenarios will be done in the future.

Regression e2e test is added - the test verifies that executing two traced graphs does not overwrite any of the weight tensors.

Closes #7608
Parent issue #7607