### PR TITLE
Add full builder API support for ttir.update_cache

### DIFF
--- a/test/python/golden/mlir_snippets/ttir/ttir_update_cache.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_update_cache.mlir
@@ -1,0 +1,9 @@
+// Note: Cache dim 2 (sequence length) must be >= 256 because the test
+// infrastructure generates random indices in [0, 256) via torch.randint.
+// Constraints: input dim 0 must be 1, and dims 1/3 must match cache dims 1/3.
+module {
+  func.func @update_cache(%arg0: tensor<1x16x256x64xf32>, %arg1: tensor<1x16x1x64xf32>, %arg2: tensor<1xi32>) -> tensor<1x16x256x64xf32> {
+    %1 = "ttir.update_cache"(%arg0, %arg1, %arg2) {batch_offset = 0 : i32} : (tensor<1x16x256x64xf32>, tensor<1x16x1x64xf32>, tensor<1xi32>) -> tensor<1x16x256x64xf32>
+    return %1 : tensor<1x16x256x64xf32>
+  }
+}

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -985,30 +985,6 @@ def test_fill_cache(shapes: List[Shape], request, device):
     )
 
 
-@pytest.mark.xfail(reason="run error")
-@pytest.mark.parametrize(
-    "shapes", [[(1, 32, 64, 512), (1, 32, 1, 512), (1,)]], ids=shapes_list_str
-)
-@pytest.mark.parametrize("dtypes", [[torch.float32, torch.float32, torch.int32]])
-def test_update_cache(shapes: List[Shape], dtypes: List[torch.dtype], request, device):
-    def module(builder: TTIRBuilder):
-        @builder.func(shapes, dtypes)
-        def update_cache(
-            in0: Operand,
-            in1: Operand,
-            in2: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            return builder.update_cache(in0, in1, in2, unit_attrs=unit_attrs)
-
-    compile_and_execute_ttir(
-        module,
-        **get_request_kwargs(request),
-        device=device,
-    )
-
-
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("scale", [0.1])
 @pytest.mark.parametrize("zero_point", [0])

--- a/test/python/golden/ttir_ops/kv_cache/test_kv_cache.py
+++ b/test/python/golden/ttir_ops/kv_cache/test_kv_cache.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from typing import List, Optional
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from test_utils import shapes_list_str
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize(
+    "shapes", [[(1, 32, 64, 512), (1, 32, 1, 512), (1,)]], ids=shapes_list_str
+)
+@pytest.mark.parametrize("dtypes", [[torch.float32, torch.float32, torch.int32]])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy"])
+def test_update_cache(
+    shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
+):
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def update_cache(
+            in0: Operand,
+            in1: Operand,
+            in2: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            # Provide a valid index within the cache sequence dimension
+            cache_seq_len = shapes[0][2]
+            update_index = torch.randint(0, cache_seq_len, shapes[2], dtype=torch.int32)
+            builder.set_goldens(inputs={in2: update_index})
+            return builder.update_cache(in0, in1, in2, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -11227,14 +11227,17 @@ class TTIRBuilder(Builder):
             unit_attrs=unit_attrs,
         )
 
+    @tag(ttir.UpdateCacheOp)
     def update_cache(
         self,
         in0: Operand,
         in1: Operand,
         in2: Operand,
         batch_offset: int = 0,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
-    ) -> OpView:
+    ) -> OpResult:
         """
         Creates ``ttir.update_cache``.
 
@@ -11244,57 +11247,177 @@ class TTIRBuilder(Builder):
         starting at a specified batch offset. This operation is typically used in
         sequence models to maintain and update cached states.
 
-        .. code-block:: mlir
-
-            // Update cache with new values at batch offset 1
-            %result = ttir.update_cache(%new_values, %old_cache, %mask, batch_offset = 1) \
-                : tensor<2x3xf32>, tensor<4x3xf32>, tensor<2xi1> -> tensor<4x3xf32>
-            // New values tensor:
-            // [[1.0, 2.0, 3.0],
-            //  [4.0, 5.0, 6.0]]
-            // Old cache tensor:
-            // [[0.1, 0.2, 0.3],
-            //  [0.4, 0.5, 0.6],
-            //  [0.7, 0.8, 0.9],
-            //  [1.0, 1.1, 1.2]]
-            // Mask tensor:
-            // [true, false]  // Only update first new value
-            // Output tensor:
-            // [[0.1, 0.2, 0.3],
-            //  [1.0, 2.0, 3.0],  // Updated with first new value
-            //  [0.7, 0.8, 0.9],  // Kept old value due to mask
-            //  [1.0, 1.1, 1.2]]
-
         Parameters
         ----------
         in0 : Operand
-            New values to update cache with
-        in1 : Operand
             Cache tensor to be updated
+        in1 : Operand
+            Input tensor containing new values
         in2 : Operand
-            Mask tensor indicating which values to update
+            Update index tensor
         batch_offset : int, optional
             Starting position in batch dimension (default: 0)
+        output_type : Optional[torch.dtype], optional
+            Output tensor dtype
+        loc : Optional[str], optional
+            Location name for the op
         unit_attrs : *Optional[List[str]]*, optional
             Optional list of unit attributes
 
         Returns
         -------
-        (*OpView*)
+        (*OpResult*)
             The updated cache tensor
         """
-        return self._op_proxy(
-            ttir.UpdateCacheOp,
-            [in0, in1, in2],
-            ttir_kwargs={"batch_offset": batch_offset},
-            organize_ttir_args=lambda i, o: (o, i[0], i[1], i[2]),
-            organize_golden_args=lambda i: (
-                self._get_golden_tensor(i[0]),
-                self._get_golden_tensor(i[1]),
-                self._get_golden_tensor(i[2]),
-            ),
-            unit_attrs=unit_attrs,
+        ttir_op = self.get_opview_from_method(TTIRBuilder.update_cache)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        batch_offset_attr = IntegerAttr.get(IntegerType.get_signless(32), batch_offset)
+
+        input_cache = self._get_golden_tensor(in0)
+        input_update = self._get_golden_tensor(in1)
+        input_index = self._get_golden_tensor(in2)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(
+            input_cache,
+            input_update,
+            input_index,
+            batch_offset_attr,
+            mlir_output_type,
         )
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttir_op(
+            result,
+            in0,
+            in1,
+            in2,
+            batch_offset_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttir.UpdateCacheOp)
+    def update_cache_parser(
+        self,
+        old_op: ttir.UpdateCacheOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.update_cache_parser)
+
+        cache = global_dict[old_op.cache]
+        input = global_dict[old_op.input]
+        update_index = global_dict[old_op.update_index]
+        result = old_op.result.type
+        batch_offset_attr = old_op.batch_offset
+
+        new_op = ttir_op(
+            result,
+            cache,
+            input,
+            update_index,
+            batch_offset_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input_cache = self._get_golden_tensor(cache)
+        input_update = self._get_golden_tensor(input)
+        input_index = self._get_golden_tensor(update_index)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(
+            input_cache,
+            input_update,
+            input_index,
+            batch_offset_attr,
+            result.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.UpdateCacheOp)
+    def update_cache_split(
+        self,
+        old_op: ttir.UpdateCacheOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(TTIRBuilder.update_cache_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            update_cache_module = Module.create()
+            update_cache_builder = TTIRBuilder(old_ctx, old_loc)
+            op_input_types = [
+                old_op.cache.type,
+                old_op.input.type,
+                old_op.update_index.type,
+            ]
+
+            with InsertionPoint(update_cache_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="update_cache_module")
+                def decorated_func(*inputs):
+                    cache = inputs[0]
+                    input = inputs[1]
+                    update_index = inputs[2]
+                    result = old_op.result.type
+                    batch_offset_attr = old_op.batch_offset
+
+                    new_op = ttir_op(
+                        result,
+                        cache,
+                        input,
+                        update_index,
+                        batch_offset_attr,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    input_cache = self._get_golden_tensor(old_op.cache)
+                    input_update = self._get_golden_tensor(old_op.input)
+                    input_index = self._get_golden_tensor(old_op.update_index)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    update_cache_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+                    update_cache_builder._set_golden_tensor(cache, input_cache)
+                    update_cache_builder._set_golden_tensor(input, input_update)
+                    update_cache_builder._set_golden_tensor(update_index, input_index)
+                    ordered_inputs.extend([cache, input, update_index])
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                update_cache_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return update_cache_module, update_cache_builder
 
     @tag(ttir.Conv2dOp)
     def conv2d(

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2642,6 +2642,8 @@ def update_cache_golden(
     cache_tensor: GoldenMapTensor,
     update_tensor: GoldenMapTensor,
     indices_tensor,
+    batch_offset=None,
+    output_type_mlir=None,
     **kwargs,
 ) -> GoldenMapTensor:
     """
@@ -2655,8 +2657,12 @@ def update_cache_golden(
         Tensor containing update data
     indices_tensor : GoldenMapTensor
         Tensor containing update indices
+    batch_offset : IntegerAttr, optional
+        Batch offset attribute (ignored in golden computation)
+    output_type_mlir : Type, optional
+        MLIR output type (ignored in golden computation)
     **kwargs : dict
-        Additional keyword arguments (batch_offset is ignored)
+        Additional keyword arguments
 
     Returns
     -------
@@ -2665,8 +2671,15 @@ def update_cache_golden(
     """
     result = cache_tensor.clone()
 
+    # indices_tensor contains the position(s) in the sequence dimension
+    # where update_tensor values should be written
+    indices = indices_tensor.shard_at(0).to(torch.long)
+    seq_len = update_tensor.shape[2]
     for device_id, shard in result.shard_map.items():
-        shard[:, :, : update_tensor.shape[2], :] = update_tensor.shard_at(device_id)
+        update_data = update_tensor.shard_at(device_id)
+        for i in range(seq_len):
+            idx = indices[i].item()
+            shard[:, :, idx, :] = update_data[:, :, i, :]
     return result
 
 


### PR DESCRIPTION
### Ticket
Closes #7244

### Summary
- Upgrade ttir.update_cache from _op_proxy to full @tag/@parse/@split decorator support in ttir_builder.py
- Fix update_cache_golden to use actual index positions from update_index tensor instead of always writing to offset 0
- Move test_update_cache from test_ttir_ops.py to test/python/golden/ttir_ops/kv_cache/test_kv_cache.py and add valid index generation via set_goldens
- Add MLIR snippet (ttir_update_cache.mlir) for automatic parse/split test discovery


### Checklist
- [x] New/Existing tests provide coverage for changes
