### PR TITLE
Refreshing the device mapping tensor in reshape op

### DIFF
--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -8,6 +8,38 @@
 
 #include "tt/runtime/detail/ttnn/utils.h"
 
+namespace {
+
+// Tiled reshape can corrupt the cached mapping_tensor's DRAM region when
+// the output has non-tile-aligned height or width.  Force the mapping tensor to
+// be recreated on every invocation for such shapes.
+bool isNonTileAligned(const std::vector<int32_t> &outputShape,
+                      const std::array<uint32_t, 2> &tileShape) {
+  if (outputShape.empty()) {
+    return true;
+  }
+  int32_t widthDim = outputShape.back();
+  int32_t heightDim = outputShape.size() > 1
+                          ? outputShape[outputShape.size() - 2]
+                          : static_cast<int32_t>(tileShape[0]);
+  if (widthDim <= 0 || heightDim <= 0) {
+    return true;
+  }
+  return (static_cast<uint32_t>(widthDim) % tileShape[1] != 0) ||
+         (static_cast<uint32_t>(heightDim) % tileShape[0] != 0);
+}
+
+::ttnn::TileReshapeMapMode
+selectReshapeMapMode(const ::ttnn::Tensor &input,
+                     const std::vector<int32_t> &outputShape) {
+  const auto &tileShape = input.tensor_spec().tile().get_tile_shape();
+  return isNonTileAligned(outputShape, tileShape)
+             ? ::ttnn::TileReshapeMapMode::RECREATE
+             : ::ttnn::TileReshapeMapMode::CACHE;
+}
+
+} // namespace
+
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -22,7 +54,11 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
                 ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
           : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
                 op->memory_config());
-  ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
+  // Workaround for NoC DMA hang.
+  // Issue : https://github.com/tenstorrent/tt-metal/issues/40612
+  auto mapMode = selectReshapeMapMode(in, shape);
+  ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig,
+                                       /*padValue=*/std::nullopt, mapMode);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/40612)

### Problem description
The tiled reshape kernel in tt-metal uses a pre-computed mapping_tensor (stored in DRAM) that describes how to copy data segments from input tiles to output tiles. When the program cache is hit, this mapping tensor is reused from the previous invocation. However, when the output shape has non-tile-aligned dimensions (height or width not a multiple of the tile size), the mapping tensor's DRAM region gets corrupted between invocations, causing a NOC DMA hang.

Root cause (observed behavior):
Partial tiles (created by non-tile-aligned height/width) produce a different mapping structure with non-standard segment offsets. When the cached program is reused, the corrupted mapping data causes the reader kernel to issue NOC reads to invalid DRAM addresses, leading to a device hang. The exact corruption mechanism is not fully understood, but it is reproducible and deterministic for a given shape.

### What's changed
At the tt-mlir runtime layer, we check if the output shape's last two dimensions (height, width) are tile-aligned. If either is not, we pass TileReshapeMapMode::RECREATE to ttnn::reshape, which forces tt-metal to recompute and reallocate the mapping tensor on every program cache hit instead of reusing the stale one.
Performance impact: Negligible. The mapping tensor is small (tens of KB) and the host-side recomputation + PCIe transfer cost is sub-millisecond.

### Checklist
- [ ] New/Existing tests provide coverage for changes
