### PR TITLE
Adding builder support for ttir.mesh_partition op

### DIFF
--- a/test/python/golden/mlir_snippets/ttir/ttir_mesh_partition.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_mesh_partition.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @mesh_partition(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+    %0 = "ttir.mesh_partition"(%arg0) <{cluster_axis = 1 : ui32, dim = 2 : si32}> : (tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
+    return %0 : tensor<4x4x128x128xf32>
+  }
+}

--- a/test/python/golden/ttir_ops/ccl/test_mesh_partition.py
+++ b/test/python/golden/ttir_ops/ccl/test_mesh_partition.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from collections import OrderedDict
+from typing import Tuple
+
+from builder.base.builder_utils import Operand, Shape
+from builder.base.builder_enums import MeshShardDirection, MeshShardType
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_and_execute_ttir
+from conftest import get_request_kwargs
+from test_utils import shape_str, make_shard_shape
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize(
+    "test_shape",
+    [
+        (2, 32, 32, 32),
+        (32, 32, 32, 32),
+        (4, 32, 32),
+        (32, 32, 32),
+        (8, 32),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("mesh_shape", [(1, 2), (1, 8), (2, 4)], ids=shape_str)
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_mesh_partition(
+    test_shape: Shape,
+    mesh_shape: Tuple[int, int],
+    dim: int,
+    cluster_axis: int,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if dim >= len(test_shape):
+        pytest.skip("dim is out of range")
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("mesh_partition across 1 device is meaningless")
+
+    num_partitions = mesh_shape[cluster_axis]
+    if test_shape[dim] % num_partitions != 0:
+        pytest.skip("dim size not divisible by number of partitions")
+
+    rank_in = len(test_shape)
+    rank_mesh = len(mesh_shape)
+
+    if rank_mesh > rank_in:
+        pytest.skip("mesh rank exceeds tensor rank")
+
+    # Take the last `rank_mesh` dims as sharded dims
+    shard_dims = list(range(rank_in - rank_mesh, rank_in))
+
+    if dim in shard_dims:
+        pytest.skip("partition dim overlaps with shard dims")
+    shard_shape = make_shard_shape(rank_in, shard_dims, mesh_shape)
+
+    full_input_shape = list(test_shape)
+    for d, factor in zip(shard_dims, mesh_shape):
+        full_input_shape[d] *= factor
+
+    def module(builder: TTIRBuilder):
+        @builder.func([full_input_shape], [dtype])
+        def mesh_partition(in0: Operand, builder: TTIRBuilder):
+            in_shard = builder.mesh_shard(
+                in0,
+                shard_direction=MeshShardDirection.FullToShard.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=shard_dims,
+            )
+
+            partitioned = builder.mesh_partition(
+                in_shard,
+                dim=dim,
+                cluster_axis=cluster_axis,
+            )
+
+            return builder.mesh_shard(
+                partitioned,
+                shard_direction=MeshShardDirection.ShardToFull.value,
+                shard_type=MeshShardType.Devices.value,
+                shard_shape=shard_shape,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        mesh_name="mesh",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+        **get_request_kwargs(request),
+    )

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -961,6 +961,149 @@ class TTIRBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    ############### ttir.MeshPartitionOp ###############
+
+    @tag(ttir.MeshPartitionOp)
+    def mesh_partition(
+        self,
+        input: Operand,
+        dim: int,
+        cluster_axis: Optional[int] = None,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttir_op = self.get_opview_from_method(TTIRBuilder.mesh_partition)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(input)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input0 = self._get_golden_tensor(input)
+        dim_attr = IntegerAttr.get(IntegerType.get_signed(32), dim)
+        if cluster_axis is not None:
+            cluster_axis_attr = IntegerAttr.get(
+                IntegerType.get_unsigned(32), cluster_axis
+            )
+        else:
+            cluster_axis_attr = None
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(
+            input0, dim_attr, cluster_axis_attr, mlir_output_type
+        )
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttir_op(
+            result,
+            input,
+            dim_attr,
+            cluster_axis=cluster_axis_attr,
+            loc=loc,
+        )
+        new_op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op_result
+
+    @parse(ttir.MeshPartitionOp)
+    def mesh_partition_parser(
+        self,
+        old_op: ttir.MeshPartitionOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.mesh_partition_parser)
+
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
+        dim_attr = old_op.dim
+        cluster_axis_attr = old_op.cluster_axis
+
+        new_op = ttir_op(
+            result,
+            in0,
+            dim_attr,
+            cluster_axis=cluster_axis_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(
+            input0,
+            dim_attr,
+            cluster_axis_attr,
+            old_op.result.type.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.MeshPartitionOp)
+    def mesh_partition_split(
+        self,
+        old_op: ttir.MeshPartitionOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(TTIRBuilder.mesh_partition_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            mesh_partition_module = Module.create()
+            mesh_partition_builder = TTIRBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(mesh_partition_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="mesh_partition_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttir_op(
+                        result,
+                        in0,
+                        old_op.dim,
+                        cluster_axis=old_op.cluster_axis,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    mesh_partition_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+                    input0 = self._get_golden_tensor(old_op.input)
+                    mesh_partition_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                mesh_partition_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return mesh_partition_module, mesh_partition_builder
+
     ############### ttir.ToLayoutOp ###############
 
     @tag(ttir.ToLayoutOp)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4615,6 +4615,32 @@ def ttir_to_layout_golden(
     return output_tensor.to(output_dtype)
 
 
+def ttir_mesh_partition_golden(
+    input: GoldenMapTensor,
+    dim_attr: IntegerAttr,
+    cluster_axis_attr,
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    dim = unpack_mlir_attr(dim_attr)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    if cluster_axis_attr is not None:
+        cluster_axis = unpack_mlir_attr(cluster_axis_attr)
+    else:
+        cluster_axis = 0
+
+    grouped_shards = input.group_by_axis(cluster_axis)
+    num_partitions = len(grouped_shards[0]) if grouped_shards else 1
+    output_shards = {}
+    for group in grouped_shards:
+        group_ids = list(group.keys())
+        for idx, device_id in enumerate(group_ids):
+            shard = group[device_id]
+            chunks = torch.chunk(shard, num_partitions, dim=dim)
+            output_shards[device_id] = chunks[idx].clone().to(output_dtype)
+    return GoldenMapTensor(output_shards, input.mesh_shape)
+
+
 def ttir_all_gather_golden(
     input: GoldenMapTensor,
     all_gather_dim_attr: IntegerAttr,
@@ -6750,6 +6776,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.UpdateCacheOp: update_cache_golden,
     # CCL (Collective Communication Library) operations
     ttir.MeshShardOp: ttir_mesh_shard_golden,
+    ttir.MeshPartitionOp: ttir_mesh_partition_golden,
     ttir.AllGatherOp: ttir_all_gather_golden,
     ttir.AllReduceOp: ttir_all_reduce_golden,
     ttir.ReduceScatterOp: ttir_reduce_scatter_golden,


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7266

### Summary
- Add full builder API support (@tag, @parse, @split) for the ttir.MeshPartitionOp in ttir_builder.py
- Implement golden function (ttir_mesh_partition_golden) in mapping.py that partitions tensor shards along a given dimension based on cluster axis position
- Add parametrized golden test (test_mesh_partition.py) covering various shapes, mesh configurations, dims, cluster axes, and dtypes (bf16/f32)
- Add MLIR snippet for ttir.mesh_partition

### Checklist
- [ ] New/Existing tests provide coverage for changes
