### PR TITLE
Enable TestMockDeviceCrash in CI

### DIFF
--- a/.github/test_scripts/op_model.sh
+++ b/.github/test_scripts/op_model.sh
@@ -9,10 +9,13 @@ echo "Running op-model test Conversion"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Conversion/TestConversion
 echo "Running op-model test Lib"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLib
-# echo "Running op-model test MockDeviceCrash"
-# $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestMockDeviceCrash
 echo "Running op-model test Interface"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Op/TestOpModelInterface
+echo "Running op-model test MockDeviceCrash"
+$BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestMockDeviceCrash
+echo "Running op-model test MockDevice"
+$BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice
+
 echo
 echo "Run Optimizer Models Perf Tests"
 llvm-lit -v --xunit-xml-output ${TEST_REPORT_PATH%_*}_models_perf_tests_${TEST_REPORT_PATH##*_} --param TTMLIR_ENABLE_OPTIMIZER_MODELS_PERF_TESTS=1 $BUILD_DIR/test/ttmlir/Silicon/TTNN/n150/optimizer/models_perf_tests


### PR DESCRIPTION
Also enable TestOpModelLibMockDevice which wasn't enabled before. 

`TestMockDeviceCrash` will remain active until fix is uplifted, then we will notice test failure. 