### PR TITLE
Add TTNN builder @split support and deallocate op

### DIFF
--- a/test/python/golden/mlir_snippets/ttnn/ttnn_deallocate.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_deallocate.mlir
@@ -1,0 +1,8 @@
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @model(%arg0: tensor<32x32xf32, #ttnn_layout>) -> () {
+    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<32x32xf32, #ttnn_layout>) -> ()
+    return
+  }
+}

--- a/test/python/golden/test_parse_split_ops.py
+++ b/test/python/golden/test_parse_split_ops.py
@@ -94,7 +94,15 @@ def test_stablehlo_parsing_splitting_ops(mlir_snippet, request, device):
     split_modules = split_mlir_file(mlir_module, builder, target="stablehlo")
 
 
+skip_split_ttnn_tests = [
+    "ttnn_all_gather.mlir",
+]
+
+
 @pytest.mark.parametrize("mlir_snippet", ttnn_mlir_snippets.keys())
 def test_ttnn_parsing_splitting_ops(mlir_snippet, request, device):
     mlir_ir_string = ttnn_mlir_snippets[mlir_snippet]
     mlir_module, builder = load_mlir_file(mlir_ir_string, target="ttnn")
+
+    if mlir_snippet not in skip_split_ttnn_tests:
+        split_modules = split_mlir_file(mlir_module, builder, target="ttnn")

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -348,6 +348,56 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.AddOp)
+    def add_split(
+        self,
+        old_op: ttnn.AddOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.add_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            add_module = Module.create()
+            add_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(add_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="add_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    add_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    add_builder._set_golden_tensor(in0, input0)
+                    add_builder._set_golden_tensor(in1, input1)
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                add_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return add_module, add_builder
+
     ############### ttnn.AbsOp ###############
 
     @tag(ttnn.AbsOp)
@@ -411,6 +461,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.AbsOp)
+    def abs_split(
+        self,
+        old_op: ttnn.AbsOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.abs_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            abs_module = Module.create()
+            abs_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(abs_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="abs_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    abs_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    abs_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                abs_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return abs_module, abs_builder
 
     ############### ttnn.CbrtOp ###############
 
@@ -476,6 +570,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.CbrtOp)
+    def cbrt_split(
+        self,
+        old_op: ttnn.CbrtOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.cbrt_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            cbrt_module = Module.create()
+            cbrt_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(cbrt_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="cbrt_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    cbrt_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    cbrt_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                cbrt_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return cbrt_module, cbrt_builder
+
     ############### ttnn.CeilOp ###############
 
     @tag(ttnn.CeilOp)
@@ -539,6 +677,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.CeilOp)
+    def ceil_split(
+        self,
+        old_op: ttnn.CeilOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.ceil_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            ceil_module = Module.create()
+            ceil_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(ceil_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="ceil_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    ceil_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    ceil_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                ceil_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return ceil_module, ceil_builder
 
     ############### ttnn.CosOp ###############
 
@@ -604,6 +786,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.CosOp)
+    def cos_split(
+        self,
+        old_op: ttnn.CosOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.cos_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            cos_module = Module.create()
+            cos_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(cos_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="cos_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    cos_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    cos_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                cos_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return cos_module, cos_builder
+
     ############### ttnn.AcosOp ###############
 
     @tag(ttnn.AcosOp)
@@ -667,6 +893,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.AcosOp)
+    def acos_split(
+        self,
+        old_op: ttnn.AcosOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.acos_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            acos_module = Module.create()
+            acos_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(acos_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="acos_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    acos_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    acos_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                acos_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return acos_module, acos_builder
 
     ############### ttnn.ErfOp ###############
 
@@ -732,6 +1001,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.ErfOp)
+    def erf_split(
+        self,
+        old_op: ttnn.ErfOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.erf_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            erf_module = Module.create()
+            erf_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(erf_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="erf_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    erf_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    erf_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                erf_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return erf_module, erf_builder
+
     ############### ttnn.ErfcOp ###############
 
     @tag(ttnn.ErfcOp)
@@ -795,6 +1108,50 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.ErfcOp)
+    def erfc_split(
+        self,
+        old_op: ttnn.ErfcOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.erfc_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            erfc_module = Module.create()
+            erfc_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(erfc_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="erfc_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    erfc_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    erfc_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                erfc_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return erfc_module, erfc_builder
 
     ############### ttnn.ExpOp ###############
 
@@ -860,6 +1217,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.ExpOp)
+    def exp_split(
+        self,
+        old_op: ttnn.ExpOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.exp_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            exp_module = Module.create()
+            exp_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(exp_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="exp_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    exp_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    exp_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                exp_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return exp_module, exp_builder
+
     ############### ttnn.FloorOp ###############
 
     @tag(ttnn.FloorOp)
@@ -923,6 +1323,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.FloorOp)
+    def floor_split(
+        self,
+        old_op: ttnn.FloorOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.floor_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            floor_module = Module.create()
+            floor_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(floor_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="floor_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    floor_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    floor_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                floor_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return floor_module, floor_builder
 
     ############### ttnn.GeluOp ###############
 
@@ -988,6 +1431,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.GeluOp)
+    def gelu_split(
+        self,
+        old_op: ttnn.GeluOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.gelu_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            gelu_module = Module.create()
+            gelu_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(gelu_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="gelu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    gelu_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    gelu_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                gelu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return gelu_module, gelu_builder
+
     ############### ttnn.IsFiniteOp ###############
 
     @tag(ttnn.IsFiniteOp)
@@ -1051,6 +1537,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.IsFiniteOp)
+    def isfinite_split(
+        self,
+        old_op: ttnn.IsFiniteOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.isfinite_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            isfinite_module = Module.create()
+            isfinite_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(isfinite_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="isfinite_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    isfinite_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    isfinite_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                isfinite_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return isfinite_module, isfinite_builder
 
     ############### ttnn.LogicalNotOp ###############
 
@@ -1116,6 +1645,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LogicalNotOp)
+    def logical_not_split(
+        self,
+        old_op: ttnn.LogicalNotOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_not_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_not_module = Module.create()
+            logical_not_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(logical_not_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_not_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_not_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    logical_not_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_not_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_not_module, logical_not_builder
+
     ############### ttnn.BitwiseNotOp ###############
 
     @tag(ttnn.BitwiseNotOp)
@@ -1179,6 +1751,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.BitwiseNotOp)
+    def bitwise_not_split(
+        self,
+        old_op: ttnn.BitwiseNotOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.bitwise_not_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            bitwise_not_module = Module.create()
+            bitwise_not_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(bitwise_not_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="bitwise_not_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    bitwise_not_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    bitwise_not_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                bitwise_not_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return bitwise_not_module, bitwise_not_builder
 
     ############### ttnn.NegOp ###############
 
@@ -1244,6 +1859,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.NegOp)
+    def neg_split(
+        self,
+        old_op: ttnn.NegOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.neg_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            neg_module = Module.create()
+            neg_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(neg_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="neg_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    neg_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    neg_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                neg_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return neg_module, neg_builder
+
     ############### ttnn.TanOp ###############
 
     @tag(ttnn.TanOp)
@@ -1307,6 +1965,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.TanOp)
+    def tan_split(
+        self,
+        old_op: ttnn.TanOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.tan_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            tan_module = Module.create()
+            tan_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(tan_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="tan_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    tan_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    tan_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                tan_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return tan_module, tan_builder
 
     ############### ttnn.AtanOp ###############
 
@@ -1372,6 +2073,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.AtanOp)
+    def atan_split(
+        self,
+        old_op: ttnn.AtanOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.atan_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            atan_module = Module.create()
+            atan_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(atan_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="atan_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    atan_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    atan_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                atan_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return atan_module, atan_builder
+
     ############### ttnn.TanhOp ###############
 
     @tag(ttnn.TanhOp)
@@ -1435,6 +2179,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.TanhOp)
+    def tanh_split(
+        self,
+        old_op: ttnn.TanhOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.tanh_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            tanh_module = Module.create()
+            tanh_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(tanh_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="tanh_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    tanh_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    tanh_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                tanh_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return tanh_module, tanh_builder
 
     ############### ttnn.ReciprocalOp ###############
 
@@ -1500,6 +2287,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.ReciprocalOp)
+    def reciprocal_split(
+        self,
+        old_op: ttnn.ReciprocalOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.reciprocal_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            reciprocal_module = Module.create()
+            reciprocal_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(reciprocal_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="reciprocal_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    reciprocal_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    reciprocal_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                reciprocal_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return reciprocal_module, reciprocal_builder
+
     ############### ttnn.ReluOp ###############
 
     @tag(ttnn.ReluOp)
@@ -1563,6 +2393,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.ReluOp)
+    def relu_split(
+        self,
+        old_op: ttnn.ReluOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.relu_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            relu_module = Module.create()
+            relu_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(relu_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="relu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    relu_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    relu_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                relu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return relu_module, relu_builder
 
     ############### ttnn.Relu6Op ###############
 
@@ -1628,6 +2501,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.Relu6Op)
+    def relu6_split(
+        self,
+        old_op: ttnn.Relu6Op,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.relu6_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            relu6_module = Module.create()
+            relu6_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(relu6_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="relu6_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    relu6_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    relu6_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                relu6_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return relu6_module, relu6_builder
+
     ############### ttnn.RsqrtOp ###############
 
     @tag(ttnn.RsqrtOp)
@@ -1691,6 +2607,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.RsqrtOp)
+    def rsqrt_split(
+        self,
+        old_op: ttnn.RsqrtOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.rsqrt_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            rsqrt_module = Module.create()
+            rsqrt_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(rsqrt_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="rsqrt_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    rsqrt_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    rsqrt_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                rsqrt_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return rsqrt_module, rsqrt_builder
 
     ############### ttnn.SigmoidOp ###############
 
@@ -1756,6 +2715,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.SigmoidOp)
+    def sigmoid_split(
+        self,
+        old_op: ttnn.SigmoidOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.sigmoid_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            sigmoid_module = Module.create()
+            sigmoid_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(sigmoid_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="sigmoid_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    sigmoid_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    sigmoid_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                sigmoid_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return sigmoid_module, sigmoid_builder
+
     ############### ttnn.SiluOp ###############
 
     @tag(ttnn.SiluOp)
@@ -1819,6 +2821,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.SiluOp)
+    def silu_split(
+        self,
+        old_op: ttnn.SiluOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.silu_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            silu_module = Module.create()
+            silu_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(silu_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="silu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    silu_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    silu_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                silu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return silu_module, silu_builder
 
     ############### ttnn.SignOp ###############
 
@@ -1884,6 +2929,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.SignOp)
+    def sign_split(
+        self,
+        old_op: ttnn.SignOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.sign_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            sign_module = Module.create()
+            sign_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(sign_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="sign_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    sign_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    sign_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                sign_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return sign_module, sign_builder
+
     ############### ttnn.SinOp ###############
 
     @tag(ttnn.SinOp)
@@ -1947,6 +3035,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.SinOp)
+    def sin_split(
+        self,
+        old_op: ttnn.SinOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.sin_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            sin_module = Module.create()
+            sin_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(sin_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="sin_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    sin_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    sin_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                sin_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return sin_module, sin_builder
 
     ############### ttnn.AsinOp ###############
 
@@ -2012,6 +3143,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.AsinOp)
+    def asin_split(
+        self,
+        old_op: ttnn.AsinOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.asin_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            asin_module = Module.create()
+            asin_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(asin_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="asin_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    asin_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    asin_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                asin_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return asin_module, asin_builder
+
     ############### ttnn.SqrtOp ###############
 
     @tag(ttnn.SqrtOp)
@@ -2076,6 +3250,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.SqrtOp)
+    def sqrt_split(
+        self,
+        old_op: ttnn.SqrtOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.sqrt_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            sqrt_module = Module.create()
+            sqrt_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(sqrt_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="sqrt_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    sqrt_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    sqrt_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                sqrt_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return sqrt_module, sqrt_builder
+
     ############### ttnn.TypecastOp ###############
 
     @tag(ttnn.TypecastOp)
@@ -2136,6 +3353,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.TypecastOp)
+    def typecast_split(
+        self,
+        old_op: ttnn.TypecastOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.typecast_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            typecast_module = Module.create()
+            typecast_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(typecast_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="typecast_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, old_op.dtype, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    typecast_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    typecast_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                typecast_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return typecast_module, typecast_builder
 
     ############### ttnn.LogOp ###############
 
@@ -2201,6 +3461,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LogOp)
+    def log_split(
+        self,
+        old_op: ttnn.LogOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.log_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            log_module = Module.create()
+            log_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(log_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="log_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    log_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    log_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                log_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return log_module, log_builder
+
     ############### ttnn.Log1pOp ###############
 
     @tag(ttnn.Log1pOp)
@@ -2265,6 +3568,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.Log1pOp)
+    def log1p_split(
+        self,
+        old_op: ttnn.Log1pOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.log1p_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            log1p_module = Module.create()
+            log1p_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(log1p_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="log1p_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    log1p_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    log1p_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                log1p_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return log1p_module, log1p_builder
+
     ############### ttnn.Expm1Op ###############
 
     @tag(ttnn.Expm1Op)
@@ -2328,6 +3674,49 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.Expm1Op)
+    def expm1_split(
+        self,
+        old_op: ttnn.Expm1Op,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.expm1_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            expm1_module = Module.create()
+            expm1_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(expm1_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="expm1_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    expm1_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    expm1_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                expm1_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return expm1_module, expm1_builder
 
     ############### ttnn.EqualOp ###############
 
@@ -2400,6 +3789,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.EqualOp)
+    def eq_split(
+        self,
+        old_op: ttnn.EqualOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.eq_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            eq_module = Module.create()
+            eq_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(eq_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="eq_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    eq_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    eq_builder._set_golden_tensor(in0, input0)
+                    eq_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                eq_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return eq_module, eq_builder
+
     ############### ttnn.NotEqualOp ###############
 
     @tag(ttnn.NotEqualOp)
@@ -2470,6 +3908,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.NotEqualOp)
+    def ne_split(
+        self,
+        old_op: ttnn.NotEqualOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.ne_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            ne_module = Module.create()
+            ne_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(ne_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="ne_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    ne_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    ne_builder._set_golden_tensor(in0, input0)
+                    ne_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                ne_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return ne_module, ne_builder
 
     ############### ttnn.GreaterEqualOp ###############
 
@@ -2542,6 +4029,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.GreaterEqualOp)
+    def ge_split(
+        self,
+        old_op: ttnn.GreaterEqualOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.ge_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            ge_module = Module.create()
+            ge_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(ge_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="ge_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    ge_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    ge_builder._set_golden_tensor(in0, input0)
+                    ge_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                ge_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return ge_module, ge_builder
+
     ############### ttnn.GreaterThanOp ###############
 
     @tag(ttnn.GreaterThanOp)
@@ -2612,6 +4148,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.GreaterThanOp)
+    def gt_split(
+        self,
+        old_op: ttnn.GreaterThanOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.gt_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            gt_module = Module.create()
+            gt_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(gt_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="gt_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    gt_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    gt_builder._set_golden_tensor(in0, input0)
+                    gt_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                gt_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return gt_module, gt_builder
 
     ############### ttnn.LessEqualOp ###############
 
@@ -2684,6 +4269,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LessEqualOp)
+    def le_split(
+        self,
+        old_op: ttnn.LessEqualOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.le_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            le_module = Module.create()
+            le_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(le_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="le_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    le_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    le_builder._set_golden_tensor(in0, input0)
+                    le_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                le_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return le_module, le_builder
+
     ############### ttnn.LessThanOp ###############
 
     @tag(ttnn.LessThanOp)
@@ -2754,6 +4388,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.LessThanOp)
+    def lt_split(
+        self,
+        old_op: ttnn.LessThanOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.lt_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            lt_module = Module.create()
+            lt_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(lt_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="lt_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    lt_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    lt_builder._set_golden_tensor(in0, input0)
+                    lt_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                lt_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return lt_module, lt_builder
 
     ############### ttnn.LogicalAndOp ###############
 
@@ -2826,6 +4509,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LogicalAndOp)
+    def logical_and_split(
+        self,
+        old_op: ttnn.LogicalAndOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_and_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_and_module = Module.create()
+            logical_and_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(logical_and_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_and_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_and_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    logical_and_builder._set_golden_tensor(in0, input0)
+                    logical_and_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_and_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_and_module, logical_and_builder
+
     ############### ttnn.LogicalLeftShiftOp ###############
 
     @tag(ttnn.LogicalLeftShiftOp)
@@ -2894,6 +4626,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.LogicalLeftShiftOp)
+    def logical_left_shift_split(
+        self,
+        old_op: ttnn.LogicalLeftShiftOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_left_shift_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_left_shift_module = Module.create()
+            logical_left_shift_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(logical_left_shift_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_left_shift_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_left_shift_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    logical_left_shift_builder._set_golden_tensor(in0, input0)
+                    logical_left_shift_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_left_shift_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_left_shift_module, logical_left_shift_builder
 
     ############### ttnn.LogicalOrOp ###############
 
@@ -2966,6 +4747,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LogicalOrOp)
+    def logical_or_split(
+        self,
+        old_op: ttnn.LogicalOrOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_or_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_or_module = Module.create()
+            logical_or_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(logical_or_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_or_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_or_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    logical_or_builder._set_golden_tensor(in0, input0)
+                    logical_or_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_or_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_or_module, logical_or_builder
+
     ############### ttnn.LogicalRightShiftOp ###############
 
     @tag(ttnn.LogicalRightShiftOp)
@@ -3036,6 +4866,57 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.LogicalRightShiftOp)
+    def logical_right_shift_split(
+        self,
+        old_op: ttnn.LogicalRightShiftOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_right_shift_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_right_shift_module = Module.create()
+            logical_right_shift_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(logical_right_shift_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_right_shift_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_right_shift_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    logical_right_shift_builder._set_golden_tensor(in0, input0)
+                    logical_right_shift_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_right_shift_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_right_shift_module, logical_right_shift_builder
 
     ############### ttnn.LogicalXorOp ###############
 
@@ -3108,6 +4989,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.LogicalXorOp)
+    def logical_xor_split(
+        self,
+        old_op: ttnn.LogicalXorOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.logical_xor_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            logical_xor_module = Module.create()
+            logical_xor_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(logical_xor_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="logical_xor_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    logical_xor_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    logical_xor_builder._set_golden_tensor(in0, input0)
+                    logical_xor_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                logical_xor_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return logical_xor_module, logical_xor_builder
+
     ############### ttnn.BitwiseAndOp ###############
 
     @tag(ttnn.BitwiseAndOp)
@@ -3177,6 +5107,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.BitwiseAndOp)
+    def bitwise_and_split(
+        self,
+        old_op: ttnn.BitwiseAndOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.bitwise_and_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            bitwise_and_module = Module.create()
+            bitwise_and_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(bitwise_and_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="bitwise_and_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    bitwise_and_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    bitwise_and_builder._set_golden_tensor(in0, input0)
+                    bitwise_and_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                bitwise_and_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return bitwise_and_module, bitwise_and_builder
 
     ############### ttnn.BitwiseOrOp ###############
 
@@ -3248,6 +5225,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.BitwiseOrOp)
+    def bitwise_or_split(
+        self,
+        old_op: ttnn.BitwiseOrOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.bitwise_or_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            bitwise_or_module = Module.create()
+            bitwise_or_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(bitwise_or_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="bitwise_or_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    bitwise_or_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    bitwise_or_builder._set_golden_tensor(in0, input0)
+                    bitwise_or_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                bitwise_or_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return bitwise_or_module, bitwise_or_builder
+
     ############### ttnn.BitwiseXorOp ###############
 
     @tag(ttnn.BitwiseXorOp)
@@ -3318,6 +5342,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.BitwiseXorOp)
+    def bitwise_xor_split(
+        self,
+        old_op: ttnn.BitwiseXorOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.bitwise_xor_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            bitwise_xor_module = Module.create()
+            bitwise_xor_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(bitwise_xor_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="bitwise_xor_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    bitwise_xor_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    bitwise_xor_builder._set_golden_tensor(in0, input0)
+                    bitwise_xor_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                bitwise_xor_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return bitwise_xor_module, bitwise_xor_builder
+
     ############### ttnn.MinimumOp ###############
 
     @tag(ttnn.MinimumOp)
@@ -3386,6 +5457,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.MinimumOp)
+    def minimum_split(
+        self,
+        old_op: ttnn.MinimumOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.minimum_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            minimum_module = Module.create()
+            minimum_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(minimum_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="minimum_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    minimum_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    minimum_builder._set_golden_tensor(in0, input0)
+                    minimum_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                minimum_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return minimum_module, minimum_builder
 
     ############### ttnn.MaximumOp ###############
 
@@ -3458,6 +5576,53 @@ class TTNNBuilder(Builder):
 
         return max_module, max_builder
 
+    @split(ttnn.MaximumOp)
+    def maximum_split(
+        self,
+        old_op: ttnn.MaximumOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.maximum_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            maximum_module = Module.create()
+            maximum_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(maximum_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="maximum_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    maximum_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    maximum_builder._set_golden_tensor(in0, input0)
+                    maximum_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                maximum_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return maximum_module, maximum_builder
+
     ############### ttnn.SubtractOp ###############
 
     @tag(ttnn.SubtractOp)
@@ -3529,6 +5694,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.SubtractOp)
+    def subtract_split(
+        self,
+        old_op: ttnn.SubtractOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.subtract_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            subtract_module = Module.create()
+            subtract_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(subtract_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="subtract_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    subtract_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    subtract_builder._set_golden_tensor(in0, input0)
+                    subtract_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                subtract_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return subtract_module, subtract_builder
+
     ############### ttnn.RemainderOp ###############
 
     @tag(ttnn.RemainderOp)
@@ -3597,6 +5811,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.RemainderOp)
+    def remainder_split(
+        self,
+        old_op: ttnn.RemainderOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.remainder_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            remainder_module = Module.create()
+            remainder_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(remainder_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="remainder_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    remainder_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    remainder_builder._set_golden_tensor(in0, input0)
+                    remainder_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                remainder_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return remainder_module, remainder_builder
 
     ############### ttnn.PowTensorOp ###############
 
@@ -3667,6 +5928,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.PowTensorOp)
+    def pow_tensor_split(
+        self,
+        old_op: ttnn.PowTensorOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.pow_tensor_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            pow_tensor_module = Module.create()
+            pow_tensor_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(pow_tensor_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="pow_tensor_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    pow_tensor_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    pow_tensor_builder._set_golden_tensor(in0, input0)
+                    pow_tensor_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                pow_tensor_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return pow_tensor_module, pow_tensor_builder
+
     ############### ttnn.Atan2Op ###############
 
     @tag(ttnn.Atan2Op)
@@ -3735,6 +6043,53 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.Atan2Op)
+    def atan2_split(
+        self,
+        old_op: ttnn.Atan2Op,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.atan2_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            atan2_module = Module.create()
+            atan2_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(atan2_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="atan2_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, in1, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    atan2_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    atan2_builder._set_golden_tensor(in0, input0)
+                    atan2_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                atan2_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return atan2_module, atan2_builder
 
     ############### ttnn.MultiplyOp ###############
 
@@ -3807,6 +6162,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.MultiplyOp)
+    def multiply_split(
+        self,
+        old_op: ttnn.MultiplyOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.multiply_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            multiply_module = Module.create()
+            multiply_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(multiply_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="multiply_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    multiply_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    multiply_builder._set_golden_tensor(in0, input0)
+                    multiply_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                multiply_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return multiply_module, multiply_builder
+
     ############### ttnn.DivideOp ###############
 
     @tag(ttnn.DivideOp)
@@ -3877,6 +6281,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.DivideOp)
+    def divide_split(
+        self,
+        old_op: ttnn.DivideOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.divide_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            divide_module = Module.create()
+            divide_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.lhs.type, old_op.rhs.type]
+
+            with InsertionPoint(divide_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="divide_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result, in0, in1, loc=old_op.location, dtype=old_op.dtype
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    divide_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.lhs)
+                    input1 = self._get_golden_tensor(old_op.rhs)
+                    divide_builder._set_golden_tensor(in0, input0)
+                    divide_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                divide_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return divide_module, divide_builder
 
     ############### ttnn.ClampTensorOp ###############
 
@@ -3962,6 +6415,69 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.ClampTensorOp)
+    def clamp_tensor_split(
+        self,
+        old_op: ttnn.ClampTensorOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.clamp_tensor_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            clamp_tensor_module = Module.create()
+            clamp_tensor_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [
+                old_op.input.type,
+                old_op.min.type,
+                old_op.max.type,
+            ]
+
+            with InsertionPoint(clamp_tensor_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="clamp_tensor_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    min_tensor = inputs[1]
+                    max_tensor = inputs[2]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        min_tensor,
+                        max_tensor,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    clamp_tensor_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    input1 = self._get_golden_tensor(old_op.min)
+                    input2 = self._get_golden_tensor(old_op.max)
+                    clamp_tensor_builder._set_golden_tensor(in0, input0)
+                    clamp_tensor_builder._set_golden_tensor(min_tensor, input1)
+                    clamp_tensor_builder._set_golden_tensor(max_tensor, input2)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(min_tensor)
+                    ordered_inputs.append(max_tensor)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                clamp_tensor_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return clamp_tensor_module, clamp_tensor_builder
+
     ############### ttnn.ConcatOp ###############
 
     @tag(ttnn.ConcatOp)
@@ -4034,6 +6550,55 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.ConcatOp)
+    def concat_split(
+        self,
+        old_op: ttnn.ConcatOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.concat_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            concat_module = Module.create()
+            concat_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [inp.type for inp in old_op.inputs]
+
+            with InsertionPoint(concat_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="concat_module")
+                def decorated_func(*inputs):
+                    input_list = list(inputs)
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        input_list,
+                        dim=old_op.dim,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    concat_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    for i, old_inp in enumerate(old_op.inputs):
+                        inp_golden = self._get_golden_tensor(old_inp)
+                        concat_builder._set_golden_tensor(inputs[i], inp_golden)
+                        ordered_inputs.append(inputs[i])
+
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                concat_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return concat_module, concat_builder
 
     ############### ttnn.RepeatOp ###############
 
@@ -4109,6 +6674,54 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {}
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
+
+    @split(ttnn.RepeatOp)
+    def repeat_split(
+        self,
+        old_op: ttnn.RepeatOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.repeat_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            repeat_module = Module.create()
+            repeat_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(repeat_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="repeat_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        old_op.repeat_dims,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    repeat_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    repeat_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                repeat_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return repeat_module, repeat_builder
 
     ############### ttnn.WhereOp ###############
 
@@ -4207,6 +6820,67 @@ class TTNNBuilder(Builder):
         op_map_dictionary[old_op.result] = new_op_result
         return new_op, op_map_dictionary
 
+    @split(ttnn.WhereOp)
+    def where_split(
+        self,
+        old_op: ttnn.WhereOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.where_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            where_module = Module.create()
+            where_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [
+                old_op.first.type,
+                old_op.second.type,
+                old_op.third.type,
+            ]
+
+            with InsertionPoint(where_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="where_module")
+                def decorated_func(*inputs):
+                    first = inputs[0]
+                    second = inputs[1]
+                    third = inputs[2]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        first,
+                        second,
+                        third,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    where_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.first)
+                    input1 = self._get_golden_tensor(old_op.second)
+                    input2 = self._get_golden_tensor(old_op.third)
+                    where_builder._set_golden_tensor(first, input0)
+                    where_builder._set_golden_tensor(second, input1)
+                    where_builder._set_golden_tensor(third, input2)
+
+                    ordered_inputs.append(first)
+                    ordered_inputs.append(second)
+                    ordered_inputs.append(third)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                where_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return where_module, where_builder
+
     ############### ttnn.MatmulOp ###############
 
     @tag(ttnn.MatmulOp)
@@ -4299,6 +6973,60 @@ class TTNNBuilder(Builder):
 
         op_map_dictionary = {old_op.result: new_op_result}
         return new_op, op_map_dictionary
+
+    @split(ttnn.MatmulOp)
+    def matmul_split(
+        self,
+        old_op: ttnn.MatmulOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.matmul_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            matmul_module = Module.create()
+            matmul_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.a.type, old_op.b.type]
+
+            with InsertionPoint(matmul_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="matmul_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        in1,
+                        loc=old_op.location,
+                        transpose_a=old_op.transpose_a,
+                        transpose_b=old_op.transpose_b,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    matmul_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.a)
+                    input1 = self._get_golden_tensor(old_op.b)
+                    matmul_builder._set_golden_tensor(in0, input0)
+                    matmul_builder._set_golden_tensor(in1, input1)
+
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                matmul_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return matmul_module, matmul_builder
 
     ############### ttnn.LinearOp ###############
 
@@ -4401,6 +7129,69 @@ class TTNNBuilder(Builder):
         op_map_dictionary = {old_op.result: new_op_result}
         return new_op, op_map_dictionary
 
+    @split(ttnn.LinearOp)
+    def linear_split(
+        self,
+        old_op: ttnn.LinearOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.linear_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            linear_module = Module.create()
+            linear_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.a.type, old_op.b.type]
+            has_bias = old_op.bias is not None
+            if has_bias:
+                op_input_types.append(old_op.bias.type)
+
+            with InsertionPoint(linear_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="linear_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    in1 = inputs[1]
+                    bias = inputs[2] if has_bias else None
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        in1,
+                        loc=old_op.location,
+                        bias=bias,
+                        transpose_a=old_op.transpose_a,
+                        transpose_b=old_op.transpose_b,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    linear_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.a)
+                    input1 = self._get_golden_tensor(old_op.b)
+                    linear_builder._set_golden_tensor(in0, input0)
+                    linear_builder._set_golden_tensor(in1, input1)
+                    ordered_inputs.append(in0)
+                    ordered_inputs.append(in1)
+                    if has_bias:
+                        bias_golden = self._get_golden_tensor(old_op.bias)
+                        linear_builder._set_golden_tensor(bias, bias_golden)
+                        ordered_inputs.append(bias)
+
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                linear_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return linear_module, linear_builder
+
     ############### ttnn.ClampScalarOp ###############
 
     @tag(ttnn.ClampScalarOp)
@@ -4465,6 +7256,57 @@ class TTNNBuilder(Builder):
 
         op_map_dictionary = {old_op.result: new_op_result}
         return new_op, op_map_dictionary
+
+    @split(ttnn.ClampScalarOp)
+    def clamp_scalar_split(
+        self,
+        old_op: ttnn.ClampScalarOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.clamp_scalar_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            clamp_scalar_module = Module.create()
+            clamp_scalar_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(clamp_scalar_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="clamp_scalar_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        old_op.min,
+                        old_op.max,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    clamp_scalar_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    clamp_scalar_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                clamp_scalar_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return clamp_scalar_module, clamp_scalar_builder
 
     ############### ttnn.RepeatInterleaveOp ###############
 
@@ -4532,6 +7374,57 @@ class TTNNBuilder(Builder):
 
         return new_op, {old_op.result: new_op_result}
 
+    @split(ttnn.RepeatInterleaveOp)
+    def repeat_interleave_split(
+        self,
+        old_op: ttnn.RepeatInterleaveOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.repeat_interleave_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            repeat_interleave_module = Module.create()
+            repeat_interleave_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(repeat_interleave_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="repeat_interleave_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(
+                        result,
+                        in0,
+                        old_op.repeats,
+                        old_op.dim,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    repeat_interleave_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    repeat_interleave_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                repeat_interleave_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return repeat_interleave_module, repeat_interleave_builder
+
     ############### ttnn.LeakyReluOp ###############
 
     @tag(ttnn.LeakyReluOp)
@@ -4594,6 +7487,49 @@ class TTNNBuilder(Builder):
 
         return new_op, {old_op.result: new_op_result}
 
+    @split(ttnn.LeakyReluOp)
+    def leaky_relu_split(
+        self,
+        old_op: ttnn.LeakyReluOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.leaky_relu_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            leaky_relu_module = Module.create()
+            leaky_relu_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(leaky_relu_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="leaky_relu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, old_op.parameter, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    leaky_relu_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    leaky_relu_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                leaky_relu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return leaky_relu_module, leaky_relu_builder
+
     ############### ttnn.MishOp ###############
 
     @tag(ttnn.MishOp)
@@ -4651,6 +7587,49 @@ class TTNNBuilder(Builder):
         self._set_golden_tensor(new_op_result, golden_output)
 
         return new_op, {old_op.result: new_op_result}
+
+    @split(ttnn.MishOp)
+    def mish_split(
+        self,
+        old_op: ttnn.MishOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.mish_split)
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+
+        with old_ctx, old_loc:
+            mish_module = Module.create()
+            mish_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(mish_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="mish_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+                    new_op = ttnn_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    mish_builder._set_golden_tensor(new_op_result, old_op_result)
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    mish_builder._set_golden_tensor(in0, input0)
+
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                mish_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return mish_module, mish_builder
 
     ############### ttnn.DumpTensorOp ###############
 
@@ -5033,6 +8012,90 @@ class TTNNBuilder(Builder):
         golden_output = op_golden_function(input0)
         self._set_golden_tensor(new_op_result, golden_output)
         return new_op, {old_op.result: new_op_result}
+
+    ############### ttnn.DeallocateOp ###############
+
+    @tag(ttnn.DeallocateOp)
+    def deallocate(
+        self,
+        input: Operand,
+        force: bool = False,
+        loc: Optional[str] = None,
+    ) -> None:
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.deallocate)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        ttnn_op(
+            input,
+            force=force,
+            loc=loc,
+        )
+
+        return
+
+    @parse(ttnn.DeallocateOp)
+    def deallocate_parser(
+        self,
+        old_op: ttnn.DeallocateOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(TTNNBuilder.deallocate_parser)
+        in0 = global_dict[old_op.input]
+
+        ttnn_op(
+            in0,
+            force=old_op.force,
+            loc=old_op.location,
+        )
+
+        return None, {}
+
+    @split(ttnn.DeallocateOp)
+    def deallocate_split(
+        self,
+        old_op: ttnn.DeallocateOp,
+    ) -> Tuple[Module, TTNNBuilder]:
+        ttnn_op = self.get_opview_from_split(TTNNBuilder.deallocate_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            deallocate_module = Module.create()
+            deallocate_builder = TTNNBuilder(old_ctx, old_loc)
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(deallocate_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="deallocate_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+
+                    ttnn_op(
+                        in0,
+                        force=old_op.force,
+                        loc=old_op.location,
+                    )
+
+                    input0 = self._get_golden_tensor(old_op.input)
+                    deallocate_builder._set_golden_tensor(in0, input0)
+                    ordered_inputs.append(in0)
+
+                    return
+
+                new_func_op = decorated_func.func_op
+                deallocate_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return deallocate_module, deallocate_builder
 
     # ----- Private CCL Helpers -----
 


### PR DESCRIPTION
### Ticket
Solves https://github.com/tenstorrent/tt-mlir/issues/7264

## Summary
- Add `@split` methods for all TTNN ops in `ttnn_builder.py` (~43 ops covering unary, binary, ternary, variadic, and special patterns)
- Add full builder support (`@tag`, `@parse`, `@split`) for `ttnn.deallocate` op
- Extend `test_ttnn_parsing_splitting_ops` to call `split_mlir_file` (previously only parsed)
- Add `ttnn_deallocate.mlir` test snippet
- Skip `ttnn_all_gather.mlir` in split tests (`GetDeviceOp` has no tensor inputs)

### Checklist
- [x] New/Existing tests provide coverage for changes
