### PR TITLE
Fix TTIR and/or canonicalization

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -255,6 +255,22 @@ static bool isConstantNonZero(mlir::Value value) {
   return attr && !isZeroAttr(attr);
 }
 
+// Check if the attribute represents one.
+static bool isOneAttr(mlir::Attribute attr) {
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(attr)) {
+    return floatAttr.getValue().isExactlyValue(1.0);
+  }
+  if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+    return intAttr.getValue().isOne();
+  }
+  return false;
+}
+
+static bool isConstantOne(mlir::Value value) {
+  mlir::Attribute attr = getConstantValue(value);
+  return attr && isOneAttr(attr);
+}
+
 // Helper to extract the shape of a RankedTensorType as a vector of i32.
 static llvm::SmallVector<int32_t>
 getShapeAsI32(mlir::RankedTensorType tensorType) {
@@ -265,9 +281,38 @@ getShapeAsI32(mlir::RankedTensorType tensorType) {
 // LogicalAndOp
 //===----------------------------------------------------------------------===//
 
+// Check if a value is known to be boolean-valued (exactly 0 or 1).
+// True for: i1 types, constants that are exactly 0 or 1 (looks through
+// layout ops), and results of comparison/logical ops.
+static bool isBooleanValued(mlir::Value value) {
+  auto type = mlir::cast<mlir::RankedTensorType>(value.getType());
+  if (type.getElementType().isInteger(1)) {
+    return true;
+  }
+
+  if (isConstantZero(value) || isConstantOne(value)) {
+    return true;
+  }
+
+  mlir::Operation *defOp = value.getDefiningOp();
+  if (!defOp) {
+    return false;
+  }
+
+  // Comparison and logical ops always produce 0/1.
+  return llvm::isa<mlir::tt::ttir::EqualOp, mlir::tt::ttir::NotEqualOp,
+                   mlir::tt::ttir::GreaterEqualOp,
+                   mlir::tt::ttir::GreaterThanOp, mlir::tt::ttir::LessEqualOp,
+                   mlir::tt::ttir::LessThanOp, mlir::tt::ttir::LogicalAndOp,
+                   mlir::tt::ttir::LogicalOrOp, mlir::tt::ttir::LogicalXorOp,
+                   mlir::tt::ttir::LogicalNotOp, mlir::tt::ttir::IsFiniteOp>(
+      defOp);
+}
+
 // LogicalAndOp canonicalization:
-//   and(zero, x)    -> ZerosOp        (absorbing)
-//   and(nonzero, x) -> x (i1) or OnesOp (identity, both const nonzero)
+//   and(zero, x)    -> ZerosOp   (absorbing)
+//   and(nonzero, x) -> x         (identity, when x is boolean-valued)
+//   and(nonzero, nonzero) -> OnesOp (both constant nonzero)
 void mlir::tt::ttir::LogicalAndOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
   // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -275,7 +320,6 @@ void mlir::tt::ttir::LogicalAndOp::getCanonicalizationPatterns(
       +[](mlir::tt::ttir::LogicalAndOp op, mlir::PatternRewriter &rewriter) {
         auto resultType =
             mlir::cast<mlir::RankedTensorType>(op.getResult().getType());
-        bool isI1 = resultType.getElementType().isInteger(1);
 
         // Absorbing: and(zero, x) -> 0
         if (isConstantZero(op.getLhs()) || isConstantZero(op.getRhs())) {
@@ -285,12 +329,12 @@ void mlir::tt::ttir::LogicalAndOp::getCanonicalizationPatterns(
           return mlir::success();
         }
 
-        // Identity: and(nonzero, x) -> x when x is guaranteed boolean (i1)
-        if (isConstantNonZero(op.getLhs()) && isI1) {
+        // Identity: and(nonzero, x) -> x when x is boolean-valued
+        if (isConstantNonZero(op.getLhs()) && isBooleanValued(op.getRhs())) {
           rewriter.replaceOp(op, op.getRhs());
           return mlir::success();
         }
-        if (isConstantNonZero(op.getRhs()) && isI1) {
+        if (isConstantNonZero(op.getRhs()) && isBooleanValued(op.getLhs())) {
           rewriter.replaceOp(op, op.getLhs());
           return mlir::success();
         }
@@ -313,8 +357,9 @@ void mlir::tt::ttir::LogicalAndOp::getCanonicalizationPatterns(
 //===----------------------------------------------------------------------===//
 
 // LogicalOrOp canonicalization:
-//   or(nonzero, x) -> OnesOp          (absorbing)
-//   or(zero, x)    -> x (i1) or ZerosOp (identity, both const zero)
+//   or(nonzero, x) -> OnesOp   (absorbing)
+//   or(zero, x)    -> x        (identity, when x is boolean-valued)
+//   or(zero, zero)  -> ZerosOp  (both constant zero)
 void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
   // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -322,7 +367,6 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
       +[](mlir::tt::ttir::LogicalOrOp op, mlir::PatternRewriter &rewriter) {
         auto resultType =
             mlir::cast<mlir::RankedTensorType>(op.getResult().getType());
-        bool isI1 = resultType.getElementType().isInteger(1);
 
         // Absorbing: or(nonzero, x) -> 1
         if (isConstantNonZero(op.getLhs()) || isConstantNonZero(op.getRhs())) {
@@ -332,12 +376,12 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
           return mlir::success();
         }
 
-        // Identity: or(zero, x) -> x when x is guaranteed boolean (i1)
-        if (isConstantZero(op.getLhs()) && isI1) {
+        // Identity: or(zero, x) -> x when x is boolean-valued
+        if (isConstantZero(op.getLhs()) && isBooleanValued(op.getRhs())) {
           rewriter.replaceOp(op, op.getRhs());
           return mlir::success();
         }
-        if (isConstantZero(op.getRhs()) && isI1) {
+        if (isConstantZero(op.getRhs()) && isBooleanValued(op.getLhs())) {
           rewriter.replaceOp(op, op.getLhs());
           return mlir::success();
         }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/logical_identity_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/logical_identity_fold_tests.mlir
@@ -105,54 +105,63 @@ module {
     return %1 : tensor<64x64xi32>
   }
 
-  // Identity: and(nonzero, x) -> x for i1
+  // Identity: and(nonzero, x) -> x for i1 (boolean-valued, no ne needed)
   func.func @logical_and_identity_i1(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
     %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
     // CHECK-LABEL: func.func @logical_and_identity_i1
     // CHECK-NOT: "ttir.logical_and"
+    // CHECK-NOT: "ttir.ne"
+    // CHECK: return %arg0
     %1 = "ttir.logical_and"(%ones, %arg0) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
     return %1 : tensor<64x64xi1>
   }
 
-  // Identity: and(x, nonzero) -> x for i1
+  // Identity: and(x, nonzero) -> x for i1 (boolean-valued, no ne needed)
   func.func @logical_and_identity_i1_rhs(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
     %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
     // CHECK-LABEL: func.func @logical_and_identity_i1_rhs
     // CHECK-NOT: "ttir.logical_and"
+    // CHECK-NOT: "ttir.ne"
+    // CHECK: return %arg0
     %1 = "ttir.logical_and"(%arg0, %ones) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
     return %1 : tensor<64x64xi1>
   }
 
-  // Identity: or(zero, x) -> x for i1
+  // Identity: or(zero, x) -> x for i1 (boolean-valued, no ne needed)
   func.func @logical_or_identity_i1(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
     %zero = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
     // CHECK-LABEL: func.func @logical_or_identity_i1
     // CHECK-NOT: "ttir.logical_or"
+    // CHECK-NOT: "ttir.ne"
+    // CHECK: return %arg0
     %1 = "ttir.logical_or"(%zero, %arg0) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
     return %1 : tensor<64x64xi1>
   }
 
-  // Identity: or(x, zero) -> x for i1
+  // Identity: or(x, zero) -> x for i1 (boolean-valued, no ne needed)
   func.func @logical_or_identity_i1_rhs(%arg0: tensor<64x64xi1>) -> tensor<64x64xi1> {
     %zero = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xi1>
     // CHECK-LABEL: func.func @logical_or_identity_i1_rhs
     // CHECK-NOT: "ttir.logical_or"
+    // CHECK-NOT: "ttir.ne"
+    // CHECK: return %arg0
     %1 = "ttir.logical_or"(%arg0, %zero) : (tensor<64x64xi1>, tensor<64x64xi1>) -> tensor<64x64xi1>
     return %1 : tensor<64x64xi1>
   }
 
-  // and(nonzero, one_const) -> ones(result_type) (both nonzero)
-  func.func @logical_and_nonzero_one_const(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  // and(full(5), full(1)) -> full(1) (full(1) is boolean-valued, full(5) is nonzero identity)
+  func.func @logical_and_full_one(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
     %five = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 5.000000e+00 : f32}> : () -> tensor<64x64xf32>
     %one = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
-    // CHECK-LABEL: func.func @logical_and_nonzero_one_const
+    // CHECK-LABEL: func.func @logical_and_full_one
     // CHECK-NOT: "ttir.logical_and"
-    // CHECK: "ttir.ones"
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 1.000000e+00
     %1 = "ttir.logical_and"(%five, %one) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
     return %1 : tensor<64x64xf32>
   }
 
-  // and(nonzero, nonzero_non_one) -> ones(result_type)
+  // Both constant nonzero: and(full(5), full(3)) -> ones
   func.func @logical_and_both_nonzero(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
     %five = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 5.000000e+00 : f32}> : () -> tensor<64x64xf32>
     %three = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 3.000000e+00 : f32}> : () -> tensor<64x64xf32>
@@ -163,7 +172,18 @@ module {
     return %1 : tensor<64x64xf32>
   }
 
-  // or(zero, zero) -> zeros(result_type) (both zero)
+  // Identity: and(nonzero, zeros_op) -> zeros_op (ZerosOp is boolean-valued)
+  func.func @logical_and_zeros_rhs_identity(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    %zeros = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_zeros_rhs_identity
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: "ttir.zeros"
+    %1 = "ttir.logical_and"(%ones, %zeros) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // Both constant zero: or(zero, zero) -> zeros
   func.func @logical_or_both_zero(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
     %zero1 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
     %zero2 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
@@ -176,20 +196,74 @@ module {
     return %1 : tensor<64x64xf32>
   }
 
-  // Verify identity folds are NOT applied for non-boolean dynamic inputs.
-  func.func @logical_and_no_identity_fold(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  // Identity: or(zero, ones_op) -> ones_op (OnesOp is boolean-valued)
+  func.func @logical_or_ones_rhs_identity(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zeros = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    %ones = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_ones_rhs_identity
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: "ttir.ones"
+    %1 = "ttir.logical_or"(%zeros, %ones) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // Identity: and(nonzero, ge_result) -> ge_result (comparison output is boolean)
+  func.func @logical_and_identity_cmp_output(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
     %ones = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
-    // CHECK-LABEL: func.func @logical_and_no_identity_fold
+    %cmp = "ttir.ge"(%arg0, %arg1) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_identity_cmp_output
+    // CHECK-NOT: "ttir.logical_and"
+    // CHECK: %[[CMP:.*]] = "ttir.ge"
+    // CHECK: return %[[CMP]]
+    %1 = "ttir.logical_and"(%ones, %cmp) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // Identity: or(zero, logical_and_result) -> logical_and_result (logical output is boolean)
+  func.func @logical_or_identity_logical_output(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %land = "ttir.logical_and"(%arg0, %arg1) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_or_identity_logical_output
+    // CHECK-NOT: "ttir.logical_or"
+    // CHECK: %[[LAND:.*]] = "ttir.logical_and"
+    // CHECK: return %[[LAND]]
+    %1 = "ttir.logical_or"(%zero, %land) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  // No fold: and(nonzero, dynamic_f32) stays (cannot prove x is boolean-valued)
+  func.func @logical_and_no_fold_dynamic(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %ones = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    // CHECK-LABEL: func.func @logical_and_no_fold_dynamic
     // CHECK: "ttir.logical_and"
     %1 = "ttir.logical_and"(%ones, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
     return %1 : tensor<64x64xf32>
   }
 
-  func.func @logical_or_no_identity_fold(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  // No fold: or(zero, dynamic_f32) stays (cannot prove x is boolean-valued)
+  func.func @logical_or_no_fold_dynamic(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
     %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0.000000e+00 : f32}> : () -> tensor<64x64xf32>
-    // CHECK-LABEL: func.func @logical_or_no_identity_fold
+    // CHECK-LABEL: func.func @logical_or_no_fold_dynamic
     // CHECK: "ttir.logical_or"
     %1 = "ttir.logical_or"(%zero, %arg0) : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
     return %1 : tensor<64x64xf32>
+  }
+
+  // No fold: and(nonzero, dynamic_i32) stays
+  func.func @logical_and_no_fold_dynamic_int(%arg0: tensor<64x64xi32>) -> tensor<64x64xi32> {
+    %one = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1 : i32}> : () -> tensor<64x64xi32>
+    // CHECK-LABEL: func.func @logical_and_no_fold_dynamic_int
+    // CHECK: "ttir.logical_and"
+    %1 = "ttir.logical_and"(%one, %arg0) : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi32>
+    return %1 : tensor<64x64xi32>
+  }
+
+  // No fold: or(zero, dynamic_i32) stays
+  func.func @logical_or_no_fold_dynamic_int(%arg0: tensor<64x64xi32>) -> tensor<64x64xi32> {
+    %zero = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0 : i32}> : () -> tensor<64x64xi32>
+    // CHECK-LABEL: func.func @logical_or_no_fold_dynamic_int
+    // CHECK: "ttir.logical_or"
+    %1 = "ttir.logical_or"(%zero, %arg0) : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi32>
+    return %1 : tensor<64x64xi32>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3901

### Problem description
The previous `LogicalAnd`/`LogicalOr` canonicalization only applied identity folding (`and(nonzero, x) → x`, `or(zero, x) → x`) when the result type was `i1`. After `ElementTypeNormalization` widens `i1 -> bf16`, these patterns stopped firing, leaving redundant logical ops in the graph that block further optimizations on the CPU-hoisted path.

### What's changed
Instead of checking the result element type, the canonicalizer now checks whether the non-constant operand is **boolean-valued** - i.e. produced by a comparison, logical op, or is a known 0/1 constant. This makes identity folding work regardless of the element type used to carry boolean values, which is critical for the CPU-hoisted const-eval path where these patterns appear after type normalization.


### Note
This is a somewhat-hacky approach which uses canonicalization patterns instead of native MLIR folding, but it's required now to prevent OOMs on tt-xla models. A more robust and simple approach should be delivered as part of #7354.

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Branch:** [`xla-validate/7642`](https://github.com/tenstorrent/tt-mlir/tree/xla-validate/7642)
**Base (uplifted):** `60a7e716`

| Test Suite | Run | Status |
|------------|-----|--------|
| mlir-uplift-qualification | [Run #23605106665](https://github.com/tenstorrent/tt-xla/actions/runs/23605106665) | :white_check_mark: passed |

*Last validated: 2026-03-27 UTC*
<!-- /xla-validate -->


