### PR TITLE
Enable implicit broadcasting for CPU-hoisted binary ops

### DIFF
--- a/lib/Conversion/TTIRToLinalg/EltwiseBinary.cpp
+++ b/lib/Conversion/TTIRToLinalg/EltwiseBinary.cpp
@@ -28,20 +28,21 @@ namespace mlir::tt::ttir_to_linalg {
 // implementation strategy, in order of preference:
 //
 // 1. TOSA 1:1        — Direct mapping to a single TOSA op.
-//                      Preferred when a TOSA equivalent exists.
-// 2. Named linalg    — Direct mapping to a named linalg op (e.g. linalg.mul).
-//                      Used when no TOSA equivalent exists but a named linalg
-//                      op does.
-// 3. linalg.generic + math/arith — A linalg.generic body containing a single
-//                      math or arith dialect op. Used for ops with no TOSA or
-//                      named linalg equivalent.
-// 4. Custom          — Multi-op sequences in TOSA, linalg, or arith dialects.
+//                      Preferred when a TOSA equivalent exists. TOSA ops
+//                      handle broadcasting natively.
+// 2. linalg.generic + arith/math — A linalg.generic body containing scalar
+//                      arith or math ops. Broadcasting is handled implicitly
+//                      through affine indexing maps, avoiding materialization
+//                      of intermediate broadcast buffers.
+// 3. Custom          — Multi-op sequences in TOSA, linalg, or arith dialects.
 //                      Used for compound operations (e.g. gelu_bw, remainder).
 
 //===----------------------------------------------------------------------===//
 // TOSA Binary Conversion Patterns
 //===----------------------------------------------------------------------===//
 
+// TOSA binary ops support implicit broadcasting natively, so operands are
+// passed directly without explicit broadcast materialization.
 namespace {
 template <typename TTIROpTy, typename TosaOpTy>
 class ElementwiseBinaryOpToTosaPattern : public OpConversionPattern<TTIROpTy> {
@@ -58,16 +59,8 @@ public:
           op, "result type must be a ranked tensor type");
     }
 
-    Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
-
-    auto result =
-        rewriter.create<TosaOpTy>(loc, resultType, ValueRange{lhs, rhs});
-
-    rewriter.replaceOp(op, result);
+    rewriter.replaceOpWithNewOp<TosaOpTy>(
+        op, resultType, ValueRange{adaptor.getLhs(), adaptor.getRhs()});
     return success();
   }
 };
@@ -91,18 +84,12 @@ public:
     }
 
     Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
-
     auto boolType = RankedTensorType::get(resultType.getShape(),
                                           rewriter.getIntegerType(1));
-    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, lhs, rhs);
+    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, adaptor.getLhs(),
+                                                adaptor.getRhs());
 
-    auto result = rewriter.create<tosa::CastOp>(loc, resultType, boolResult);
-
-    rewriter.replaceOp(op, result);
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, resultType, boolResult);
     return success();
   }
 };
@@ -125,19 +112,13 @@ public:
     }
 
     Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
-
     // Swapped operands: rhs, lhs.
     auto boolType = RankedTensorType::get(resultType.getShape(),
                                           rewriter.getIntegerType(1));
-    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, rhs, lhs);
+    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, adaptor.getRhs(),
+                                                adaptor.getLhs());
 
-    auto result = rewriter.create<tosa::CastOp>(loc, resultType, boolResult);
-
-    rewriter.replaceOp(op, result);
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, resultType, boolResult);
     return success();
   }
 };
@@ -160,21 +141,14 @@ public:
     }
 
     Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
-
     auto boolType = RankedTensorType::get(resultType.getShape(),
                                           rewriter.getIntegerType(1));
-    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, lhs, rhs);
-
+    auto boolResult = rewriter.create<TosaOpTy>(loc, boolType, adaptor.getLhs(),
+                                                adaptor.getRhs());
     auto notResult =
         rewriter.create<tosa::LogicalNotOp>(loc, boolType, boolResult);
 
-    auto result = rewriter.create<tosa::CastOp>(loc, resultType, notResult);
-
-    rewriter.replaceOp(op, result);
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, resultType, notResult);
     return success();
   }
 };
@@ -182,9 +156,9 @@ public:
 
 // Logical binary operations pattern (LogicalAnd, LogicalOr, LogicalXor).
 // These operations:
-// 1. Convert float inputs to boolean (non-zero = true)
-// 2. Apply the TOSA logical operation
-// 3. Convert boolean result back to float (true = 1.0, false = 0.0)
+// 1. Convert inputs to boolean (non-zero = true)
+// 2. Apply the TOSA logical operation (implicit broadcasting)
+// 3. Convert boolean result back to original type
 namespace {
 template <typename TTIROpTy, typename TosaOpTy>
 class LogicalBinaryOpToTosaPattern : public OpConversionPattern<TTIROpTy> {
@@ -202,66 +176,21 @@ public:
     }
 
     Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
 
     // Convert both inputs to boolean tensors.
-    Value boolLhs = convertToBooleanTensor(lhs, loc, rewriter);
-    Value boolRhs = convertToBooleanTensor(rhs, loc, rewriter);
+    Value boolLhs = convertToBooleanTensor(adaptor.getLhs(), loc, rewriter);
+    Value boolRhs = convertToBooleanTensor(adaptor.getRhs(), loc, rewriter);
 
-    // Get the boolean type for the intermediate result.
+    // Get the boolean type for the result.
     auto boolType = RankedTensorType::get(resultType.getShape(),
                                           rewriter.getIntegerType(1));
 
-    // Apply the logical operation to the boolean tensors.
+    // Apply the logical operation (TOSA handles broadcasting).
     auto logicalResult =
         rewriter.create<TosaOpTy>(loc, boolType, boolLhs, boolRhs);
 
-    // Convert boolean result back to original type using cast.
-    auto result = rewriter.create<tosa::CastOp>(loc, resultType, logicalResult);
-
-    rewriter.replaceOp(op, result);
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// Named Linalg Op Conversion Patterns
-//===----------------------------------------------------------------------===//
-
-namespace {
-// General elementwise conversion pattern for binary ops lowered to named linalg
-// ops. Supports implicit broadcasting via broadcastToShape.
-template <typename TTIROpTy, typename LinalgOpTy,
-          typename OpAdaptor = typename TTIROpTy::Adaptor>
-class ElementwiseBinaryOpToNamedLinalgPattern
-    : public OpConversionPattern<TTIROpTy> {
-public:
-  using OpConversionPattern<TTIROpTy>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto resultType = dyn_cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getType()));
-    if (!resultType) {
-      return rewriter.notifyMatchFailure(
-          op, "result type must be a ranked tensor type");
-    }
-
-    Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
-
-    auto output = rewriter.create<tensor::EmptyOp>(loc, resultType.getShape(),
-                                                   resultType.getElementType());
-    rewriter.replaceOpWithNewOp<LinalgOpTy>(
-        op, resultType, ValueRange{lhs, rhs}, output.getResult());
+    // Convert boolean result back to original type.
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, resultType, logicalResult);
     return success();
   }
 };
@@ -271,9 +200,34 @@ public:
 // Linalg Generic + Math/Arith Dialect Patterns
 //===----------------------------------------------------------------------===//
 
+// Build a broadcast-aware affine map for an operand. The map has as many
+// result expressions as the operand rank. Handles rank extension (fewer dims
+// than result — leading dims are dropped) and size-1 broadcasting (maps to 0).
+static AffineMap buildBroadcastAffineMap(ArrayRef<int64_t> operandShape,
+                                         ArrayRef<int64_t> resultShape,
+                                         MLIRContext *ctx) {
+  int64_t resultRank = resultShape.size();
+  int64_t operandRank = operandShape.size();
+  int64_t rankDiff = resultRank - operandRank;
+
+  // Only emit expressions for the operand's own dimensions,
+  // aligned to the trailing dimensions of the result.
+  SmallVector<AffineExpr> exprs;
+  for (int64_t i = 0; i < operandRank; ++i) {
+    int64_t resultDim = i + rankDiff;
+    if (operandShape[i] == 1 && resultShape[resultDim] != 1) {
+      exprs.push_back(getAffineConstantExpr(0, ctx));
+    } else {
+      exprs.push_back(getAffineDimExpr(resultDim, ctx));
+    }
+  }
+  return AffineMap::get(resultRank, 0, exprs, ctx);
+}
+
 // Base class for TTIR binary ops lowered via linalg.generic. Subclasses only
-// need to implement buildBody() to emit the scalar computation. Supports
-// implicit broadcasting by broadcasting both inputs to result shape.
+// need to implement buildBody() to emit the scalar computation.
+// Broadcasting is handled implicitly through affine indexing maps, avoiding
+// materialization of intermediate broadcast buffers.
 namespace {
 template <typename TTIROpTy>
 class ElementwiseBinaryOpToLinalgGenericPatternBase
@@ -292,14 +246,20 @@ public:
     }
 
     Location loc = op.getLoc();
-    Value lhs = broadcastToShape(adaptor.getLhs(), resultType.getShape(), loc,
-                                 rewriter);
-    Value rhs = broadcastToShape(adaptor.getRhs(), resultType.getShape(), loc,
-                                 rewriter);
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    auto lhsType = cast<RankedTensorType>(lhs.getType());
+    auto rhsType = cast<RankedTensorType>(rhs.getType());
 
     int64_t rank = resultType.getRank();
-    auto indexingMap =
-        AffineMap::getMultiDimIdentityMap(rank, rewriter.getContext());
+    MLIRContext *ctx = rewriter.getContext();
+
+    AffineMap lhsMap =
+        buildBroadcastAffineMap(lhsType.getShape(), resultType.getShape(), ctx);
+    AffineMap rhsMap =
+        buildBroadcastAffineMap(rhsType.getShape(), resultType.getShape(), ctx);
+    AffineMap resultMap = AffineMap::getMultiDimIdentityMap(rank, ctx);
+
     SmallVector<utils::IteratorType> iteratorTypes(
         rank, utils::IteratorType::parallel);
 
@@ -308,8 +268,8 @@ public:
 
     auto genericOp = rewriter.create<linalg::GenericOp>(
         loc, resultType, ValueRange{lhs, rhs}, ValueRange{emptyTensor},
-        SmallVector<AffineMap>{indexingMap, indexingMap, indexingMap},
-        iteratorTypes, [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
+        SmallVector<AffineMap>{lhsMap, rhsMap, resultMap}, iteratorTypes,
+        [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
           Value result = buildBody(b, nestedLoc, args, resultType);
           b.create<linalg::YieldOp>(nestedLoc, result);
         });
@@ -337,6 +297,26 @@ protected:
   Value buildBody(OpBuilder &b, Location loc, ValueRange args,
                   RankedTensorType /*resultType*/) const override {
     return b.create<MathOpTy>(loc, args[0], args[1]);
+  }
+};
+} // namespace
+
+// Template for TTIR ops that map to arith dialect ops (float/int variants).
+namespace {
+template <typename TTIROpTy, typename ArithFOpTy, typename ArithIOpTy>
+class ElementwiseBinaryOpToArithPattern
+    : public ElementwiseBinaryOpToLinalgGenericPatternBase<TTIROpTy> {
+public:
+  using ElementwiseBinaryOpToLinalgGenericPatternBase<
+      TTIROpTy>::ElementwiseBinaryOpToLinalgGenericPatternBase;
+
+protected:
+  Value buildBody(OpBuilder &b, Location loc, ValueRange args,
+                  RankedTensorType /*resultType*/) const override {
+    if (isa<FloatType>(args[0].getType())) {
+      return b.create<ArithFOpTy>(loc, args[0], args[1]);
+    }
+    return b.create<ArithIOpTy>(loc, args[0], args[1]);
   }
 };
 } // namespace
@@ -407,7 +387,8 @@ public:
 
     Location loc = op.getLoc();
 
-    // Broadcast both inputs to the result shape for implicit broadcasting.
+    // Compound patterns use resultType for all intermediate ops, so operands
+    // must be pre-broadcast to the result shape.
     grad = broadcastToShape(grad, resultType.getShape(), loc, rewriter);
     x = broadcastToShape(x, resultType.getShape(), loc, rewriter);
 
@@ -544,11 +525,12 @@ private:
 void populateTTIRToLinalgEltwiseBinaryPatterns(MLIRContext *ctx,
                                                RewritePatternSet &patterns,
                                                TypeConverter &typeConverter) {
-  // Named linalg ops (with implicit broadcasting support)
-  patterns.add<
-      ElementwiseBinaryOpToNamedLinalgPattern<ttir::MultiplyOp, linalg::MulOp>,
-      ElementwiseBinaryOpToNamedLinalgPattern<ttir::DivOp, linalg::DivOp>>(
-      typeConverter, ctx);
+  // linalg.generic + arith ops
+  patterns.add<ElementwiseBinaryOpToArithPattern<ttir::MultiplyOp,
+                                                 arith::MulFOp, arith::MulIOp>,
+               ElementwiseBinaryOpToArithPattern<ttir::DivOp, arith::DivFOp,
+                                                 arith::DivSIOp>>(typeConverter,
+                                                                  ctx);
 
   // linalg.generic + math dialect ops
   patterns.add<ElementwiseBinaryOpToMathPattern<ttir::Atan2Op, math::Atan2Op>>(

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_binary.py
@@ -796,7 +796,10 @@ hoisted_binary_shapes = [
     [(128, 128), (1, 128)],  # Broadcasting second dimension
     [(128, 128), (128, 1)],  # Broadcasting first dimension
     [(1, 32), (1, 32)],  # Small shapes
+    [(1, 32), (32, 1)],  # Both operands broadcast
+    [(1, 1), (32, 32)],  # Scalar-like broadcast
     [(128, 128, 64), (128, 1, 64)],  # 3D tensors with broadcasting
+    [(1, 1, 64), (128, 128, 64)],  # 3D both leading dims broadcast
     [(7, 41, 43, 11), (7, 41, 43, 11)],  # 4D tensors
 ]
 

--- a/test/ttmlir/Conversion/TTIRToLinalg/binary_eltwise.mlir
+++ b/test/ttmlir/Conversion/TTIRToLinalg/binary_eltwise.mlir
@@ -82,75 +82,79 @@ func.func @test_logical_right_shift(%arg0: tensor<64x128xi32>, %arg1: tensor<64x
 
 // ===--- Broadcasting ---=================================================//
 
-// TOSA op with rhs broadcast (single dim).
+// TOSA op with rhs broadcast (single dim, implicit in TOSA).
 // CHECK-LABEL: func.func @test_subtract_broadcast_rhs
 func.func @test_subtract_broadcast_rhs(%arg0: tensor<32x32xf32>, %arg1: tensor<32x1xf32>) -> tensor<32x32xf32> {
-  // CHECK: linalg.broadcast
+  // CHECK-NOT: linalg.broadcast
   // CHECK: tosa.sub
   %0 = "ttir.subtract"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x32xf32>
   return %0 : tensor<32x32xf32>
 }
 
-// Named linalg op with both operands broadcast.
+// Multiply with both operands broadcast (implicit via affine maps).
 // CHECK-LABEL: func.func @test_multiply_broadcast_both
 func.func @test_multiply_broadcast_both(%arg0: tensor<1x32xf32>, %arg1: tensor<32x1xf32>) -> tensor<32x32xf32> {
-  // CHECK: linalg.broadcast
-  // CHECK: linalg.broadcast
-  // CHECK: linalg.mul
+  // CHECK-NOT: linalg.broadcast
+  // CHECK: linalg.generic
+  // CHECK: arith.mulf
   %0 = "ttir.multiply"(%arg0, %arg1) : (tensor<1x32xf32>, tensor<32x1xf32>) -> tensor<32x32xf32>
   return %0 : tensor<32x32xf32>
 }
 
-// Rank-extending broadcast (2D -> 3D).
+// Rank-extending broadcast (2D -> 3D, implicit via affine maps).
 // CHECK-LABEL: func.func @test_multiply_broadcast_rank_extend
 func.func @test_multiply_broadcast_rank_extend(%arg0: tensor<32x1xf32>, %arg1: tensor<32x32x32xf32>) -> tensor<32x32x32xf32> {
-  // CHECK: linalg.broadcast
-  // CHECK: linalg.mul
+  // CHECK-NOT: linalg.broadcast
+  // CHECK: linalg.generic
+  // CHECK: arith.mulf
   %0 = "ttir.multiply"(%arg0, %arg1) : (tensor<32x1xf32>, tensor<32x32x32xf32>) -> tensor<32x32x32xf32>
   return %0 : tensor<32x32x32xf32>
 }
 
-// 4D broadcast with multiple singleton dims.
+// 4D broadcast with multiple singleton dims (implicit via affine maps).
 // CHECK-LABEL: func.func @test_multiply_broadcast_4d
 func.func @test_multiply_broadcast_4d(%arg0: tensor<32x1x32x1xf32>, %arg1: tensor<32x32x32x32xf32>) -> tensor<32x32x32x32xf32> {
-  // CHECK: linalg.broadcast
-  // CHECK: linalg.mul
+  // CHECK-NOT: linalg.broadcast
+  // CHECK: linalg.generic
+  // CHECK: arith.mulf
   %0 = "ttir.multiply"(%arg0, %arg1) : (tensor<32x1x32x1xf32>, tensor<32x32x32x32xf32>) -> tensor<32x32x32x32xf32>
   return %0 : tensor<32x32x32x32xf32>
 }
 
-// Scalar (0D) broadcast uses tensor.extract + linalg.fill.
+// Scalar (0D) broadcast (implicit via affine maps, no results in map).
 // CHECK-LABEL: func.func @test_multiply_broadcast_scalar
 func.func @test_multiply_broadcast_scalar(%arg0: tensor<f32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  // CHECK: tensor.extract
-  // CHECK: linalg.fill
-  // CHECK: linalg.mul
+  // CHECK-NOT: linalg.broadcast
+  // CHECK: linalg.generic
+  // CHECK: arith.mulf
   %0 = "ttir.multiply"(%arg0, %arg1) : (tensor<f32>, tensor<32x32xf32>) -> tensor<32x32xf32>
   return %0 : tensor<32x32xf32>
 }
 
-// linalg.generic op with broadcast (atan2).
+// linalg.generic op with broadcast (atan2, implicit via affine maps).
 // CHECK-LABEL: func.func @test_atan2_broadcast
 func.func @test_atan2_broadcast(%arg0: tensor<64x128xf32>, %arg1: tensor<1x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: linalg.broadcast
+  // CHECK-NOT: linalg.broadcast
   // CHECK: linalg.generic
   // CHECK: math.atan2
   %0 = "ttir.atan2"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<1x128xf32>) -> tensor<64x128xf32>
   return %0 : tensor<64x128xf32>
 }
 
-// ===--- Named Linalg Ops ---=============================================//
+// ===--- Multiply / Div via linalg.generic ---=============================//
 
 // CHECK-LABEL: func.func @test_multiply
 func.func @test_multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: linalg.mul
+  // CHECK: linalg.generic
+  // CHECK: arith.mulf
   %0 = "ttir.multiply"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %0 : tensor<64x128xf32>
 }
 
 // CHECK-LABEL: func.func @test_div
 func.func @test_div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: linalg.div
+  // CHECK: linalg.generic
+  // CHECK: arith.divf
   %0 = "ttir.div"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %0 : tensor<64x128xf32>
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3901

### Problem description
Binary ops lowered to Linalg and TOSA ops used explicit `linalg.broadcast` ops to materialize broadcast operands before computation. For large tensors with broadcasting (e.g. causal mask generation on CPU), this allocates full-size intermediate buffers unnecessarily.

### What's changed
Replaced explicit `linalg.broadcast` + named linalg ops with `linalg.generic` using broadcast-aware affine indexing maps. Size-1 dimensions map to constant index 0, so broadcasting is handled implicitly during iteration without materializing intermediate tensors. This applies to all binary ops lowered via `linalg.generic` (including `multiply` and `div`, which moved from named linalg ops to the generic pattern). 

TOSA patterns also drop their explicit broadcast calls since TOSA ops handle broadcasting natively.

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Branch:** [`xla-validate/7643`](https://github.com/tenstorrent/tt-mlir/tree/xla-validate/7643)
**Base (uplifted):** `60a7e716`

| Test Suite | Run | Status |
|------------|-----|--------|
| mlir-uplift-qualification | [Run #23555627425](https://github.com/tenstorrent/tt-xla/actions/runs/23555627425) | :white_check_mark: passed |

*Last validated: 2026-03-25 18:56 UTC*
<!-- /xla-validate -->