### PR TITLE
Implement boolean narrowing pass for CPU-hoisted ops

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -481,4 +481,18 @@ def TTIRFoldFullToScalar: Pass<"ttir-fold-full-to-scalar", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
 }
 
+def TTIRCPUBooleanNarrowing : Pass<"ttir-cpu-boolean-narrowing", "::mlir::ModuleOp"> {
+  let summary = "Narrow boolean-producing ops to i1 in the CPU module.";
+  let description = [{
+    ElementTypeNormalization converts i1 to bf16 because TT hardware
+    doesn't support boolean tensor storage. On the CPU path this is unnecessary
+    and inflates memory (e.g. a 32768x32768 causal mask becomes 4 GiB in f32
+    instead of 1 GiB in i1).
+
+    This pass runs on the CPU module before linalg lowering and narrows
+    comparison/logical ops back to i1. Typecasts are inserted at boundaries
+    where i1 values flow into non-boolean consumers.
+  }];
+}
+
 #endif

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -291,6 +291,10 @@ void createTTIRToLLVMCPUPipeline(OpPassManager &pm,
   cpuPm.addPass(mlir::createCanonicalizerPass());
   cpuPm.addPass(mlir::createCSEPass());
 
+  // Narrow boolean-producing ops back to i1. ElementTypeNormalization widens
+  // i1 → bf16 for hardware, but CPUs handle i1 natively.
+  cpuPm.addPass(ttir::createTTIRCPUBooleanNarrowing());
+
   // Lower TTIR to mix of linalg direct, TOSA (which we can subsequently lower
   // to linalg), and Tensor dialect ops.
   cpuPm.addPass(createConvertTTIRToLinalgPass());

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(EraseInverseOps)
 add_subdirectory(HoistCPUOps)
 add_mlir_dialect_library(MLIRTTIRTransforms
         Broadcast.cpp
+        CPUBooleanNarrowing.cpp
         DecomposeComplexPermute.cpp
         DecomposeComplexReshape.cpp
         GlobalDataFormatConversion.cpp

--- a/lib/Dialect/TTIR/Transforms/CPUBooleanNarrowing.cpp
+++ b/lib/Dialect/TTIR/Transforms/CPUBooleanNarrowing.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ElementTypeNormalization converts i1 → bf16 because TT hardware doesn't
+// support boolean storage. On the CPU path this is unnecessary and wastes
+// memory (e.g. a 32768×32768 causal mask: 4 GiB in f32 vs 1 GiB in i1).
+//
+// This pass narrows comparison/logical ops back to i1 in the CPU module,
+// propagating i1 through shape-transparent ops (slice, reshape, permute,
+// broadcast) and inserting typecasts only at arithmetic boundaries.
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRCPUBOOLEANNARROWING
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+// Ops through which i1 can propagate: logical ops and shape-manipulation ops
+// that preserve element values.
+static bool isBooleanTransparent(Operation *op) {
+  return isa<
+      // Logical ops (consume and produce booleans).
+      LogicalAndOp, LogicalOrOp, LogicalXorOp, LogicalNotOp,
+      // Boolean reductions.
+      ReduceAndOp, ReduceOrOp,
+      // Shape-manipulation (data-movement, values unchanged).
+      SliceStaticOp, ReshapeOp, PermuteOp, BroadcastOp, ConcatOp, RepeatOp,
+      RepeatInterleaveOp, SqueezeOp, UnsqueezeOp, ReverseOp, TransposeOp>(op);
+}
+
+class TTIRCPUBooleanNarrowing
+    : public impl::TTIRCPUBooleanNarrowingBase<TTIRCPUBooleanNarrowing> {
+public:
+  using impl::TTIRCPUBooleanNarrowingBase<
+      TTIRCPUBooleanNarrowing>::TTIRCPUBooleanNarrowingBase;
+
+  void runOnOperation() final {
+    OpBuilder builder(getOperation().getContext());
+
+    getOperation().walk([&](Operation *op) {
+      if (!isBooleanProducer(op)) {
+        return;
+      }
+      for (OpResult result : op->getResults()) {
+        if (!cast<RankedTensorType>(result.getType())
+                 .getElementType()
+                 .isInteger(1)) {
+          narrowResult(result, builder);
+        }
+      }
+    });
+  }
+
+private:
+  // Ops whose results are boolean by semantics (entry points for narrowing).
+  static bool isBooleanProducer(Operation *op) {
+    return isa<EqualOp, NotEqualOp, GreaterEqualOp, GreaterThanOp, LessEqualOp,
+               LessThanOp, LogicalAndOp, LogicalOrOp, LogicalXorOp,
+               LogicalNotOp, ReduceAndOp, ReduceOrOp>(op);
+  }
+
+  // Narrow a result to i1 and propagate through transparent ops.
+  // Insert typecasts only at non-transparent boundaries.
+  void narrowResult(OpResult result, OpBuilder &builder) {
+    auto origType = cast<RankedTensorType>(result.getType());
+    result.setType(
+        RankedTensorType::get(origType.getShape(), builder.getI1Type()));
+
+    SmallVector<OpOperand *> nonTransparentUses;
+    for (OpOperand &use : llvm::make_early_inc_range(result.getUses())) {
+      if (isBooleanTransparent(use.getOwner())) {
+        for (OpResult r : use.getOwner()->getResults()) {
+          if (!cast<RankedTensorType>(r.getType())
+                   .getElementType()
+                   .isInteger(1)) {
+            narrowResult(r, builder);
+          }
+        }
+      } else {
+        nonTransparentUses.push_back(&use);
+      }
+    }
+
+    if (!nonTransparentUses.empty()) {
+      builder.setInsertionPointAfterValue(result);
+      Value cast = builder.create<TypecastOp>(result.getLoc(), origType, result,
+                                              /*conservativeFolding=*/false);
+      for (OpOperand *use : nonTransparentUses) {
+        use->set(cast);
+      }
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttir

--- a/test/ttmlir/Dialect/TTIR/cpu_boolean_narrowing/cpu_boolean_narrowing_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/cpu_boolean_narrowing/cpu_boolean_narrowing_tests.mlir
@@ -1,0 +1,99 @@
+// RUN: ttmlir-opt -ttir-cpu-boolean-narrowing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // Comparison op narrowed to i1, typecast at return.
+  // CHECK-LABEL: func.func @ge_narrowing
+  func.func @ge_narrowing(%arg0: tensor<4x1xi32>, %arg1: tensor<1x4xi32>) -> tensor<4x4xf32> {
+    // CHECK: "ttir.ge"(%arg0, %arg1) : (tensor<4x1xi32>, tensor<1x4xi32>) -> tensor<4x4xi1>
+    // CHECK: "ttir.typecast"
+    // CHECK-SAME: (tensor<4x4xi1>) -> tensor<4x4xf32>
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x1xi32>, tensor<1x4xi32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // Boolean chain: ge → logical_and, both narrowed to i1.
+  // CHECK-LABEL: func.func @boolean_chain
+  func.func @boolean_chain(%arg0: tensor<4x1xi32>, %arg1: tensor<1x4xi32>) -> tensor<4x4xf32> {
+    // CHECK: %[[GE:.*]] = "ttir.ge"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.logical_and"(%[[GE]], %[[GE]]) : (tensor<4x4xi1>, tensor<4x4xi1>) -> tensor<4x4xi1>
+    // CHECK: "ttir.typecast"
+    // CHECK-SAME: (tensor<4x4xi1>) -> tensor<4x4xf32>
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x1xi32>, tensor<1x4xi32>) -> tensor<4x4xf32>
+    %1 = "ttir.logical_and"(%0, %0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+
+  // Mixed: ge feeds both logical_and (boolean) and add (arithmetic).
+  // CHECK-LABEL: func.func @mixed_consumers
+  func.func @mixed_consumers(%arg0: tensor<4x1xi32>, %arg1: tensor<1x4xi32>, %arg2: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+    // CHECK: %[[GE:.*]] = "ttir.ge"{{.*}} -> tensor<4x4xi1>
+    // CHECK: %[[CAST:.*]] = "ttir.typecast"(%[[GE]]){{.*}} -> tensor<4x4xf32>
+    // CHECK: "ttir.logical_and"(%[[GE]], %[[GE]]) : (tensor<4x4xi1>, tensor<4x4xi1>) -> tensor<4x4xi1>
+    // CHECK: "ttir.add"(%[[CAST]], %arg2)
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x1xi32>, tensor<1x4xi32>) -> tensor<4x4xf32>
+    %1 = "ttir.logical_and"(%0, %0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %2 = "ttir.add"(%0, %arg2) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1, %2 : tensor<4x4xf32>, tensor<4x4xf32>
+  }
+
+  // Already i1: no change.
+  // CHECK-LABEL: func.func @already_i1
+  func.func @already_i1(%arg0: tensor<4x4xi32>, %arg1: tensor<4x4xi32>) -> tensor<4x4xi1> {
+    // CHECK: "ttir.eq"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<4x4xi32>) -> tensor<4x4xi1>
+    // CHECK-NOT: "ttir.typecast"
+    %0 = "ttir.eq"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<4x4xi32>) -> tensor<4x4xi1>
+    return %0 : tensor<4x4xi1>
+  }
+
+  // All comparison ops narrow.
+  // CHECK-LABEL: func.func @all_comparisons
+  func.func @all_comparisons(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>) {
+    // CHECK: "ttir.eq"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.ne"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.gt"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.ge"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.lt"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.le"{{.*}} -> tensor<4x4xi1>
+    %0 = "ttir.eq"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %1 = "ttir.ne"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %2 = "ttir.gt"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %3 = "ttir.ge"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %4 = "ttir.lt"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %5 = "ttir.le"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0, %1, %2, %3, %4, %5 : tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>, tensor<4x4xf32>
+  }
+
+  // Logical not narrows.
+  // CHECK-LABEL: func.func @logical_not_narrowing
+  func.func @logical_not_narrowing(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK: %[[GE:.*]] = "ttir.ge"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.logical_not"(%[[GE]]) : (tensor<4x4xi1>) -> tensor<4x4xi1>
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %1 = "ttir.logical_not"(%0) : (tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+
+  // i1 propagates through slice — typecast only on the sliced result.
+  // CHECK-LABEL: func.func @slice_propagation
+  func.func @slice_propagation(%arg0: tensor<1x1x1x32768x1xi32>, %arg1: tensor<1x1x1x1x32768xi32>) -> tensor<1x1x1x4x4xf32> {
+    // CHECK: "ttir.ge"{{.*}} -> tensor<1x1x1x32768x32768xi1>
+    // CHECK: "ttir.slice_static"{{.*}} -> tensor<1x1x1x4x4xi1>
+    // CHECK: "ttir.typecast"{{.*}} (tensor<1x1x1x4x4xi1>) -> tensor<1x1x1x4x4xf32>
+    // CHECK-NOT: tensor<1x1x1x32768x32768xf32>
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<1x1x1x32768x1xi32>, tensor<1x1x1x1x32768xi32>) -> tensor<1x1x1x32768x32768xf32>
+    %1 = "ttir.slice_static"(%0) <{begins = [0:i32,0:i32,0:i32,0:i32,0:i32], ends = [1:i32,1:i32,1:i32,4:i32,4:i32], step = [1:i32,1:i32,1:i32,1:i32,1:i32]}> : (tensor<1x1x1x32768x32768xf32>) -> tensor<1x1x1x4x4xf32>
+    return %1 : tensor<1x1x1x4x4xf32>
+  }
+
+  // i1 propagates through reshape.
+  // CHECK-LABEL: func.func @reshape_propagation
+  func.func @reshape_propagation(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<16xf32> {
+    // CHECK: "ttir.ge"{{.*}} -> tensor<4x4xi1>
+    // CHECK: "ttir.reshape"{{.*}} -> tensor<16xi1>
+    // CHECK: "ttir.typecast"{{.*}} (tensor<16xi1>) -> tensor<16xf32>
+    %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    %1 = "ttir.reshape"(%0) <{shape = [16 : i32]}> : (tensor<4x4xf32>) -> tensor<16xf32>
+    return %1 : tensor<16xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3901

### Problem description
`ElementTypeNormalization` widens `i1 → bf16` because TT hardware doesn't support boolean tensor storage. On the CPU-hoisted path this is unnecessary and causes massive memory inflation - e.g. a 32768×32768 causal mask becomes ~4 GiB in f32 instead of ~1GiB in i1.

### What's changed
Added a new `TTIRCPUBooleanNarrowing` pass that runs on the CPU module before linalg lowering. It narrows comparison and logical ops back to `i1` output types and propagates `i1` through shape-transparent ops (slice, reshape, permute, broadcast, etc.). Typecasts are inserted only at boundaries where `i1` values flow into non-boolean consumers (e.g. arithmetic ops or function returns).

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Branch:** [`xla-validate/7644`](https://github.com/tenstorrent/tt-mlir/tree/xla-validate/7644)
**Base (uplifted):** `60a7e716`

| Test Suite | Run | Status |
|------------|-----|--------|
| mlir-uplift-qualification | [Run #23591902376](https://github.com/tenstorrent/tt-xla/actions/runs/23591902376) | :white_check_mark: passed |

*Last validated: 2026-03-26 12:14 UTC*
<!-- /xla-validate -->


