### PR TITLE
Add optional per-op device synchronization for debugging

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/program_executor.h
+++ b/runtime/include/tt/runtime/detail/ttnn/program_executor.h
@@ -65,6 +65,13 @@ private:
    * Dumps device profile counters if needed
    */
   void dumpPerfCountersIfNeeded();
+
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  /**
+   * Synchronizes all devices after each op when TT_RUNTIME_SYNC_AFTER_OP is set
+   */
+  void syncAfterOpIfNeeded();
+#endif
 };
 
 } // namespace tt::runtime::ttnn

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -4,6 +4,12 @@
 
 #include "tt/runtime/detail/ttnn/program_executor.h"
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+#include <cstdlib>
+
+#include <tt-metalium/distributed.hpp>
+#endif
+
 #include "operations/cache/load_cached.h"
 #include "operations/ccl/aggregate_tensor.h"
 #include "operations/ccl/all_gather.h"
@@ -181,6 +187,9 @@ void ProgramExecutor::execute() {
     runCallback(debug::Hooks::get().getPreOperatorCallback(), executableHandle,
                 op, context.get());
     runOperation(op);
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    syncAfterOpIfNeeded();
+#endif
     runCallback(debug::Hooks::get().getPostOperatorCallback(), executableHandle,
                 op, context.get());
     dumpPerfCountersIfNeeded();
@@ -612,5 +621,16 @@ void ProgramExecutor::dumpPerfCountersIfNeeded() {
   }
 #endif
 }
+
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+void ProgramExecutor::syncAfterOpIfNeeded() {
+  static const bool enabled =
+      std::getenv("TT_RUNTIME_SYNC_AFTER_OP") != nullptr;
+  if (enabled) {
+    ::tt::tt_metal::distributed::Synchronize(&context->getMeshDevice(),
+                                             std::nullopt);
+  }
+}
+#endif
 
 } // namespace tt::runtime::ttnn


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Since ops are executed asynchronously, it’s hard to identify which one is actually hanging based on the current logs alone.

### What's changed
Add syncAfterOpIfNeeded() to ProgramExecutor that synchronizes all devices after each operation when TT_RUNTIME_SYNC_AFTER_OP env var is set. Guarded behind TT_RUNTIME_DEBUG to ensure zero overhead in release builds. Useful for isolating which op causes hangs or incorrect results on device.

### Checklist
- [ ] New/Existing tests provide coverage for changes
