### PR TITLE
Add layer_norm_pre_all_gather op to TTNN dialect

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -80,6 +80,10 @@ struct IDevice;
 
 struct Tensor;
 
+namespace prim {
+struct LayerNormShardedMultiCoreProgramConfig;
+} // namespace prim
+
 namespace operations {
 namespace unary {
 struct UnaryWithParam;
@@ -245,6 +249,12 @@ struct TypeName<::ttnn::Tensor> {
 template <>
 struct TypeName<::ttnn::WormholeComputeKernelConfig> {
   inline static const std::string value = "::ttnn::WormholeComputeKernelConfig";
+};
+
+template <>
+struct TypeName<::ttnn::prim::LayerNormShardedMultiCoreProgramConfig> {
+  inline static const std::string value =
+      "::ttnn::prim::LayerNormShardedMultiCoreProgramConfig";
 };
 
 // Marker type for MatmulMultiCoreReuseMultiCast1DProgramConfig (used by
@@ -1008,6 +1018,42 @@ struct EmitCTypeConverter<::ttnn::WormholeComputeKernelConfig> {
       rso << ".dst_full_sync_en = "
           << (dstFullSyncEn.getValue() ? "true" : "false");
     }
+
+    rso << "}";
+    return buf;
+  }
+};
+
+// Specialization for LayerNormShardedMultiCoreProgramConfig
+template <>
+struct EmitCTypeConverter<
+    ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig> {
+  static std::optional<std::string> convert(mlir::Attribute attr) {
+    auto configAttr = mlir::dyn_cast_if_present<
+        ttnn::LayerNormShardedMultiCoreProgramConfigAttr>(attr);
+    if (!configAttr) {
+      return {};
+    }
+    return convert(configAttr);
+  }
+
+  static std::string
+  convert(ttnn::LayerNormShardedMultiCoreProgramConfigAttr attr) {
+    std::string buf;
+    llvm::raw_string_ostream rso(buf);
+    rso << TypeNameV<
+               ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig> << "{";
+
+    rso << ".compute_with_storage_grid_size = "
+        << EmitCTypeConverter<::ttnn::CoreCoord>::convert(
+               attr.getComputeWithStorageGridSize());
+    rso << ", .subblock_w = "
+        << EmitCTypeConverter<size_t>::convert(attr.getSubblockW());
+    rso << ", .block_h = "
+        << EmitCTypeConverter<size_t>::convert(attr.getBlockH());
+    rso << ", .block_w = "
+        << EmitCTypeConverter<size_t>::convert(attr.getBlockW());
+    rso << ", .inplace = " << (attr.getInplace() ? "true" : "false");
 
     rso << "}";
     return buf;
@@ -1850,6 +1896,11 @@ struct TTNNTarget<tt::ttcore::TopologyAttr> {
 template <>
 struct TTNNTarget<tt::ttnn::DeviceComputeKernelConfigAttr> {
   using type = ::ttnn::WormholeComputeKernelConfig;
+};
+
+template <>
+struct TTNNTarget<tt::ttnn::LayerNormShardedMultiCoreProgramConfigAttr> {
+  using type = ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig;
 };
 
 template <typename T>

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2360,6 +2360,42 @@ def TTNN_LayerNormOp : TTNN_Op<"layer_norm", [AttrSizedOperandSegments, TTNN_Mem
     let hasVerifier = 1;
 }
 
+def TTNN_LayerNormPreAllGatherOp : TTNN_Op<"layer_norm_pre_all_gather",
+    [AttrSizedOperandSegments, TTNN_DtypeOpInterface, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface]> {
+    let summary = "Layer normalization pre-all-gather op.";
+    let description = [{
+      Computes local partial statistics (Welford) for distributed layer
+      normalization on a width-sharded input tensor. Produces partial
+      statistics that should be all-gathered across devices before being
+      consumed by a post-all-gather normalization op.
+
+      Inputs:
+        - input: Input tensor (width-sharded in L1).
+        - residual_input: Optional residual tensor to add before computing
+            statistics. Must have the same shape as input.
+        - recip: Optional precomputed reciprocal tensor.
+
+      Attributes:
+        - dtype: Optional output data type. Defaults to BFloat16 in the
+            runtime if not specified.
+        - compute_config: Optional device compute kernel configuration.
+        - program_config: Optional LayerNormShardedMultiCoreProgramConfig.
+        - memory_config: Optional output memory configuration.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         Optional<AnyRankedTensor>:$residual_input,
+                         Optional<AnyRankedTensor>:$recip,
+                         OptionalAttr<TTCore_DataTypeAttr>:$dtype,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config,
+                         OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface]> {
     let summary = "Group normalization op.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -77,6 +77,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm.hpp"
 #include "ttnn/operations/normalization/layernorm/layernorm.hpp"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
 #include "ttnn/operations/normalization/rmsnorm/rmsnorm.hpp"
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
 #include "ttnn/operations/pool/upsample/upsample.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1516,6 +1516,31 @@ struct OpModel<LayerNormOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<LayerNormPreAllGatherOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> recipShape,
+      std::optional<TTNNLayoutAttr> recipLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+               std::optional<TTNNLayoutAttr> residualInputLayout,
+               std::optional<llvm::ArrayRef<int64_t>> recipShape,
+               std::optional<TTNNLayoutAttr> recipLayout,
+               std::optional<ttcore::DataType> dtype,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -80,6 +80,17 @@ table LayerNormOp {
   out: tt.target.ttnn.TensorRef;
 }
 
+table LayerNormPreAllGatherOp {
+  input: tt.target.ttnn.TensorRef;
+  residual_input: tt.target.ttnn.TensorRef;
+  recip: tt.target.ttnn.TensorRef;
+  dtype: tt.target.DataType = BFloat16;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
+  program_config: tt.target.ttnn.LayerNormShardedMultiCoreProgramConfig;
+  out: tt.target.ttnn.TensorRef;
+}
+
 table GroupNormOp {
   input: tt.target.ttnn.TensorRef;
   input_mask: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -80,6 +80,7 @@ union OpType {
   GlobalAvgPool2dOp,
   GroupNormOp,
   LayerNormOp,
+  LayerNormPreAllGatherOp,
   LinearOp,
   LoadCachedOp,
   // ANCHOR: adding_an_op_matmul_fbs_op_type

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3516,6 +3516,45 @@ public:
 };
 } // namespace
 
+// LayerNormPreAllGatherOp conversion pattern
+//
+namespace {
+class LayerNormPreAllGatherOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormPreAllGatherOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormPreAllGatherOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormPreAllGatherOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::LayerNormPreAllGatherOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    // Args must match tt-metal invoke parameter order:
+    // input, dtype, residual_input, compute_kernel_config,
+    // program_config, memory_config, recip_tensor
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDtype()),
+        emitter.emit(srcOp.getResidualInput()),
+        emitter.emit(srcOp.getComputeConfig()),
+        emitter.emit(srcOp.getProgramConfig()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
+        emitter.emit(srcOp.getRecip()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // GroupNormOp conversion pattern
 //
 namespace {
@@ -4946,8 +4985,9 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
                CumSumOpConversionPattern, BatchNormInferenceOpConversionPattern,
                BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
-               LayerNormOpConversionPattern, GroupNormOpConversionPattern>(
-      typeConverter, ctx);
+               LayerNormOpConversionPattern,
+               LayerNormPreAllGatherOpConversionPattern,
+               GroupNormOpConversionPattern>(typeConverter, ctx);
 
   // CCL ops
   //

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3847,6 +3847,45 @@ public:
 };
 } // namespace
 
+// LayerNormPreAllGatherOp conversion pattern
+//
+namespace {
+class LayerNormPreAllGatherOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormPreAllGatherOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormPreAllGatherOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormPreAllGatherOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::LayerNormPreAllGatherOp>
+        emitter(srcOp, adaptor, rewriter, this->isGoldenModeEnabled());
+
+    // Args match tt-metal invoke parameter order with named kwargs.
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDtype(), "dtype"),
+        emitter.emit(srcOp.getResidualInput(), "residual_input_tensor"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
+        emitter.emit(srcOp.getMemoryConfig() |
+                         emitter.getMemoryConfig(srcOp.getResult()),
+                     "memory_config"),
+        emitter.emit(srcOp.getRecip(), "recip_tensor"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // GroupNormOp conversion pattern
 //
 namespace {
@@ -4479,11 +4518,12 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
 
   // Normalization ops
   //
-  patterns.add<BatchNormInferenceOpConversionPattern,
-               BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
-               DistributedRMSNormOpConversionPattern,
-               LayerNormOpConversionPattern, GroupNormOpConversionPattern>(
-      typeConverter, ctx, enableGoldenMode);
+  patterns
+      .add<BatchNormInferenceOpConversionPattern,
+           BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
+           DistributedRMSNormOpConversionPattern, LayerNormOpConversionPattern,
+           LayerNormPreAllGatherOpConversionPattern,
+           GroupNormOpConversionPattern>(typeConverter, ctx, enableGoldenMode);
 
   // Transformers ops
   //

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3071,6 +3071,56 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOp
+//===----------------------------------------------------------------------===//
+::mlir::LogicalResult mlir::tt::ttnn::LayerNormPreAllGatherOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+
+  if (inputType.getRank() < 2) {
+    return emitOpError("input tensor must have rank >= 2");
+  }
+
+  // If residual_input is present, its shape must match input shape.
+  if (getResidualInput()) {
+    RankedTensorType residualType = getResidualInput().getType();
+    if (residualType.getShape() != inputType.getShape()) {
+      return emitOpError("residual_input shape must match input shape");
+    }
+  }
+
+  // Output shape must match input shape except the last dimension,
+  // which must be 2 * TILE_WIDTH (64) for the partial statistics
+  // (E(x) and E(x²)).
+  RankedTensorType outputType = getResult().getType();
+  auto inputShape = inputType.getShape();
+  auto outputShape = outputType.getShape();
+
+  if (inputType.getRank() != outputType.getRank()) {
+    return emitOpError("input and output must have the same rank");
+  }
+
+  // All dimensions except the last must match.
+  for (int64_t i = 0; i < inputType.getRank() - 1; ++i) {
+    if (inputShape[i] != outputShape[i]) {
+      return emitOpError() << "output dimension " << i << " (" << outputShape[i]
+                           << ") must match input dimension (" << inputShape[i]
+                           << ")";
+    }
+  }
+
+  // Last dimension must be 2 * TILE_WIDTH for layernorm statistics.
+  constexpr int64_t kExpectedLastDim = 2 * TILE_WIDTH;
+  if (outputShape.back() != kExpectedLastDim) {
+    return emitOpError()
+           << "output last dimension must be " << kExpectedLastDim
+           << " (2 * TILE_WIDTH) for layernorm partial statistics, got "
+           << outputShape.back();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 ::mlir::LogicalResult mlir::tt::ttnn::GroupNormOp::verify() {

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4039,6 +4039,75 @@ LayerNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+struct LayerNormPreAllGatherOptionalArgs {
+  std::optional<llvm::ArrayRef<int64_t>> residualInputShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> residualInputLayout = std::nullopt;
+  std::optional<llvm::ArrayRef<int64_t>> recipShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> recipLayout = std::nullopt;
+};
+
+static LayerNormPreAllGatherOptionalArgs
+unpackLayerNormPreAllGatherOptionalArgs(
+    const std::vector<TTNNLayoutAttr> &inputs, LayerNormPreAllGatherOp op) {
+  LayerNormPreAllGatherOptionalArgs ret;
+  // inputs[0] = input layout; optional operands follow in operand order.
+  size_t idx = 1;
+  if (op.getResidualInput()) {
+    ret.residualInputShape = op.getResidualInput().getType().getShape();
+    if (idx < inputs.size()) {
+      ret.residualInputLayout = inputs[idx++];
+    }
+  }
+  if (op.getRecip()) {
+    ret.recipShape = op.getRecip().getType().getShape();
+    if (idx < inputs.size()) {
+      ret.recipLayout = inputs[idx++];
+    }
+  }
+  return ret;
+}
+
+llvm::Expected<op_model::OpConstraints>
+LayerNormPreAllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  const auto inputShape = getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints, *this,
+      deviceGrid, inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, optionalArgs.recipShape,
+      optionalArgs.recipLayout, getDtype(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+LayerNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  const auto inputShape = getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<LayerNormPreAllGatherOp>::getOpRuntime, *this,
+      inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, optionalArgs.recipShape,
+      optionalArgs.recipLayout, getDtype(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6452,6 +6452,105 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> recipShape,
+    std::optional<TTNNLayoutAttr> recipLayout,
+    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> residualInputSpec =
+      detail::convertToOptionalTensorSpec(device, residualInputShape,
+                                          residualInputLayout);
+  std::optional<::ttnn::TensorSpec> recipSpec =
+      detail::convertToOptionalTensorSpec(device, recipShape, recipLayout);
+
+  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
+  if (dtype.has_value()) {
+    metalDtype = conversion::getDataType(dtype.value());
+  }
+
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
+        /*dtype=*/metalDtype,
+        /*residual_input_tensor=*/residualInputSpec,
+        /*compute_kernel_config=*/std::nullopt,
+        /*program_config=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*recip_tensor=*/recipSpec);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> recipShape,
+    std::optional<TTNNLayoutAttr> recipLayout,
+    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> residualInputSpec =
+      detail::convertToOptionalTensorSpec(device, residualInputShape,
+                                          residualInputLayout);
+  std::optional<::ttnn::TensorSpec> recipSpec =
+      detail::convertToOptionalTensorSpec(device, recipShape, recipLayout);
+
+  ::ttnn::DataType metalDtype = ::ttnn::DataType::BFLOAT16;
+  if (dtype.has_value()) {
+    metalDtype = conversion::getDataType(dtype.value());
+  }
+
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
+        /*dtype=*/metalDtype,
+        /*residual_input_tensor=*/residualInputSpec,
+        /*compute_kernel_config=*/std::nullopt,
+        /*program_config=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*recip_tensor=*/recipSpec);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1530,6 +1530,50 @@ createOp(FlatbufferObjectCache &cache, LayerNormOp op) {
                                                memoryConfig, output);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormPreAllGatherOp>
+createOp(FlatbufferObjectCache &cache, LayerNormPreAllGatherOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> residualInput = 0;
+  if (op.getResidualInput()) {
+    residualInput = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getResidualInput()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> recip = 0;
+  if (op.getRecip()) {
+    recip = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getRecip()));
+  }
+
+  auto output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  ::tt::target::DataType dtype = ::tt::target::DataType::BFloat16;
+  if (op.getDtype()) {
+    dtype = toFlatbuffer(cache, op.getDtype().value());
+  }
+
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
+
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
+  ::flatbuffers::Offset<
+      ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfig>
+      programConfig = 0;
+  if (op.getProgramConfig()) {
+    programConfig = toFlatbuffer(cache, op.getProgramConfig().value());
+  }
+
+  return ::tt::target::ttnn::CreateLayerNormPreAllGatherOp(
+      *cache.fbb, input, residualInput, recip, dtype, memoryConfig,
+      computeConfig.value_or(0), programConfig, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::GroupNormOp>
 createOp(FlatbufferObjectCache &cache, GroupNormOp op) {
   flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
@@ -4260,6 +4304,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto layerNormOp = dyn_cast<LayerNormOp>(op); layerNormOp) {
     return createOperation(cache, createOp(cache, layerNormOp), debugString,
                            locInfo);
+  }
+  if (auto layerNormPreAllGatherOp = dyn_cast<LayerNormPreAllGatherOp>(op);
+      layerNormPreAllGatherOp) {
+    return createOperation(cache, createOp(cache, layerNormPreAllGatherOp),
+                           debugString, locInfo);
   }
   if (auto groupNormOp = dyn_cast<GroupNormOp>(op); groupNormOp) {
     return createOperation(cache, createOp(cache, groupNormOp), debugString,

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/distributed_rms_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/group_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm_pre_all_gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/rms_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/softmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/pool2d.cpp

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/normalization/layer_norm_pre_all_gather.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
+
+namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather {
+void run(const ::tt::target::ttnn::LayerNormPreAllGatherOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
+
+  std::optional<::ttnn::Tensor> residualInput = std::nullopt;
+  if (op->residual_input()) {
+    residualInput = tensorPool.getTTNNTensorAndValidate(op->residual_input());
+  }
+
+  ::ttnn::DataType dtype =
+      ::tt::runtime::ttnn::utils::toTTNNDataType(op->dtype());
+
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
+  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig =
+      std::nullopt;
+  if (op->program_config()) {
+    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
+        op->program_config());
+  }
+
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+
+  std::optional<::ttnn::Tensor> recip = std::nullopt;
+  if (op->recip()) {
+    recip = tensorPool.getTTNNTensorAndValidate(op->recip());
+  }
+
+  ::ttnn::Tensor output = ::ttnn::layer_norm_pre_all_gather(
+      input, dtype, residualInput, computeConfig, programConfig, memoryConfig,
+      recip);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
+}
+} // namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.h
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_LAYER_NORM_PRE_ALL_GATHER_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_LAYER_NORM_PRE_ALL_GATHER_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather {
+void run(const ::tt::target::ttnn::LayerNormPreAllGatherOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::layer_norm_pre_all_gather
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -71,6 +71,7 @@
 #include "operations/normalization/distributed_rms_norm.h"
 #include "operations/normalization/group_norm.h"
 #include "operations/normalization/layer_norm.h"
+#include "operations/normalization/layer_norm_pre_all_gather.h"
 #include "operations/normalization/rms_norm.h"
 #include "operations/normalization/softmax.h"
 #include "operations/pool/pool2d.h"
@@ -369,6 +370,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::LayerNormOp: {
     return operations::layer_norm::run(op->type_as_LayerNormOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::LayerNormPreAllGatherOp: {
+    return operations::layer_norm_pre_all_gather::run(
+        op->type_as_LayerNormPreAllGatherOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::GroupNormOp: {
     return operations::group_norm::run(op->type_as_GroupNormOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1212,6 +1212,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_LayerNormOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::LayerNormPreAllGatherOp: {
+    tensorRef = opContext.type_as_LayerNormPreAllGatherOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::GroupNormOp: {
     tensorRef = opContext.type_as_GroupNormOp()->out();
     break;
@@ -1652,6 +1656,18 @@ getOpInputRefs(OpContext opContextHandle,
     }
     if (opContext.type_as_LayerNormOp()->bias()) {
       tensorRefs.push_back(opContext.type_as_LayerNormOp()->bias());
+    }
+    break;
+  }
+  case ::tt::target::ttnn::OpType::LayerNormPreAllGatherOp: {
+    tensorRefs = {opContext.type_as_LayerNormPreAllGatherOp()->input()};
+    if (opContext.type_as_LayerNormPreAllGatherOp()->residual_input()) {
+      tensorRefs.push_back(
+          opContext.type_as_LayerNormPreAllGatherOp()->residual_input());
+    }
+    if (opContext.type_as_LayerNormPreAllGatherOp()->recip()) {
+      tensorRefs.push_back(
+          opContext.type_as_LayerNormPreAllGatherOp()->recip());
     }
     break;
   }

--- a/test/python/golden/ttnn_ops/normalization/test_ttnn_normalization.py
+++ b/test/python/golden/ttnn_ops/normalization/test_ttnn_normalization.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import List, Optional
+from conftest import get_request_kwargs
+from builder.base.builder_utils import Operand, Shape
+from builder.ttnn.ttnn_builder import TTNNBuilder
+from builder.base.builder_apis import compile_and_execute_ttnn
+from test_utils import shape_str
+
+pytestmark = pytest.mark.frontend("ttnn")
+
+
+# LayerNormPreAllGather tests
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 32, 128),
+        (1, 1, 32, 512),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("has_residual", [False, True])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_layer_norm_pre_all_gather(
+    shape: Shape,
+    has_residual: bool,
+    target: str,
+    request,
+    device,
+):
+    shapes = [shape]
+    if has_residual:
+        shapes.append(shape)
+
+    def module(builder: TTNNBuilder):
+        @builder.func(shapes, [torch.bfloat16] * len(shapes))
+        def layer_norm_pre_all_gather(*inputs, unit_attrs: Optional[List[str]] = None):
+            builder = inputs[-1]
+            in0 = inputs[0]
+            residual = None
+            if has_residual and len(inputs) > 2:
+                residual = inputs[1]
+
+            return builder.layer_norm_pre_all_gather(
+                in0,
+                residual_input=residual,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )

--- a/test/ttmlir/Dialect/TTNN/layer_norm_pre_all_gather/layer_norm_pre_all_gather_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/layer_norm_pre_all_gather/layer_norm_pre_all_gather_negative.mlir
@@ -1,0 +1,28 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_small = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 16 + d1, d2, d3), <1x1>, memref<16x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_out = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK: error: 'ttnn.layer_norm_pre_all_gather' op residual_input shape must match input shape
+  func.func @forward_residual_shape_mismatch(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout>, %arg1: tensor<1x1x16x128xbf16, #ttnn_layout_small>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out> {
+    %0 = "ttnn.layer_norm_pre_all_gather"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<1x1x32x128xbf16, #ttnn_layout>, tensor<1x1x16x128xbf16, #ttnn_layout_small>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<1x1x32x64xbf16, #ttnn_layout_out>
+  }
+}
+
+// -----
+
+#dram2 = #ttnn.buffer_type<dram>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, bf16>, #dram2>, <interleaved>>
+#ttnn_layout_bad_out = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, bf16>, #dram2>, <interleaved>>
+
+module {
+  // CHECK: error: 'ttnn.layer_norm_pre_all_gather' op output last dimension must be 64 (2 * TILE_WIDTH) for layernorm partial statistics, got 32
+  func.func @forward_bad_output_shape(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout2>) -> tensor<1x1x32x32xbf16, #ttnn_layout_bad_out> {
+    %0 = "ttnn.layer_norm_pre_all_gather"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 0, 0>}> : (tensor<1x1x32x128xbf16, #ttnn_layout2>) -> tensor<1x1x32x32xbf16, #ttnn_layout_bad_out>
+    return %0 : tensor<1x1x32x32xbf16, #ttnn_layout_bad_out>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/layer_norm_pre_all_gather/simple_layer_norm_pre_all_gather.mlir
+++ b/test/ttmlir/Dialect/TTNN/layer_norm_pre_all_gather/simple_layer_norm_pre_all_gather.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_out = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // Test basic layer_norm_pre_all_gather with input only.
+  func.func @forward(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out> {
+    // CHECK: "ttnn.layer_norm_pre_all_gather"
+    %0 = "ttnn.layer_norm_pre_all_gather"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 0, 0>}> : (tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<1x1x32x64xbf16, #ttnn_layout_out>
+  }
+
+  // Test layer_norm_pre_all_gather with residual_input.
+  func.func @forward_with_residual(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout>, %arg1: tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out> {
+    // CHECK: "ttnn.layer_norm_pre_all_gather"
+    %0 = "ttnn.layer_norm_pre_all_gather"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<1x1x32x128xbf16, #ttnn_layout>, tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<1x1x32x64xbf16, #ttnn_layout_out>
+  }
+
+  // Test layer_norm_pre_all_gather with dtype attribute.
+  func.func @forward_with_dtype(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out> {
+    // CHECK: "ttnn.layer_norm_pre_all_gather"
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    %0 = "ttnn.layer_norm_pre_all_gather"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 0, 0>}> : (tensor<1x1x32x128xbf16, #ttnn_layout>) -> tensor<1x1x32x64xbf16, #ttnn_layout_out>
+    return %0 : tensor<1x1x32x64xbf16, #ttnn_layout_out>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -4633,6 +4633,131 @@ INSTANTIATE_TEST_SUITE_P(LayerNormTests, OpModelLayerNormParam,
                          layerNormTestValues);
 
 //===----------------------------------------------------------------------===//
+// LayerNormPreAllGatherOp Tests
+//===----------------------------------------------------------------------===//
+
+class OpModelLayerNormPreAllGatherParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          std::tuple<detail::TestTensor,                // input
+                     detail::TestTensor,                // output
+                     std::optional<detail::TestTensor>, // residual_input
+                     std::optional<detail::TestTensor>, // recip
+                     std::optional<ttcore::DataType>,   // dtype
+                     detail::ExpectedResult             // expected result
+                     >> {};
+
+TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
+  auto params = GetParam();
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<1>(params);
+  const auto residualOpt = std::get<2>(params);
+  const auto recipOpt = std::get<3>(params);
+  const auto dtype = std::get<4>(params);
+  const auto expectedResult = std::get<5>(params);
+  const auto expectedLegal = expectedResult.expectedLegal;
+
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  // Create optional layouts for residual_input and recip
+  std::optional<llvm::ArrayRef<int64_t>> residualInputShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> residualInputLayout = std::nullopt;
+  if (residualOpt.has_value()) {
+    const auto &[shape, layout, bufferType, virtualGrid] = residualOpt.value();
+    residualInputShape = shape;
+    residualInputLayout =
+        CreateTiledLayout(shape, bufferType, layout, virtualGrid);
+  }
+
+  std::optional<llvm::ArrayRef<int64_t>> recipShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> recipLayout = std::nullopt;
+  if (recipOpt.has_value()) {
+    const auto &[shape, layout, bufferType, virtualGrid] = recipOpt.value();
+    recipShape = shape;
+    recipLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
+  }
+
+  // Test getOpConstraints
+  auto constraintsExp =
+      op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
+          CreateWorkerGrid(), inputShape, inputLayout, residualInputShape,
+          residualInputLayout, recipShape, recipLayout, dtype, outputLayout);
+
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (constraintsExp) {
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+                outputLayoutReadBacks] = constraintsExp.get();
+    EXPECT_GE(cbSize, 0);
+    EXPECT_GE(l1PeakSize, 0);
+    EXPECT_GE(totalPeakSize, 0);
+    EXPECT_GE(outputSize, 0);
+  } else {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  // Test getOpRuntime
+  auto runtimeExp = op_model::OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
+      inputShape, inputLayout, residualInputShape, residualInputLayout,
+      recipShape, recipLayout, dtype, outputLayout);
+
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+// Test values for LayerNormPreAllGatherOp
+const auto layerNormPreAllGatherTestValues = ::testing::Values(
+    // Test case 1: Basic with input only (no optional tensors)
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        std::nullopt, std::nullopt, std::nullopt, detail::ExpectedResult{true}),
+
+    // Test case 2: With residual_input
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        std::make_optional(detail::TestTensor{{1, 1, 32, 128},
+                                              TensorMemoryLayout::Interleaved,
+                                              BufferType::DRAM}),
+        std::nullopt, std::nullopt, detail::ExpectedResult{true}),
+
+    // Test case 3: With explicit BFloat16 dtype
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 512}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        std::nullopt, std::nullopt,
+        std::make_optional(ttcore::DataType::BFloat16),
+        detail::ExpectedResult{true}),
+
+    // Test case 4: With L1 memory buffers
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::L1},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::L1},
+        std::nullopt, std::nullopt, std::nullopt,
+        detail::ExpectedResult{true}));
+
+INSTANTIATE_TEST_SUITE_P(LayerNormPreAllGatherTests,
+                         OpModelLayerNormPreAllGatherParam,
+                         layerNormPreAllGatherTestValues);
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp Tests
 //===----------------------------------------------------------------------===//
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4459,6 +4459,116 @@ TEST_F(OpModelBase, layerNormOpL1Memory) {
   }
 }
 
+TEST_F(OpModelBase, layerNormPreAllGatherOp) {
+  // Basic LayerNormPreAllGather with input only
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> outputShape = {1, 1, 32, 64};
+
+  auto input = createEmptyTensor(inputShape);
+  auto outputType = createRankedTensorType(outputShape);
+
+  LayerNormPreAllGatherOp op = builder.create<LayerNormPreAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input,
+      /*residual_input=*/nullptr, /*recip=*/nullptr,
+      /*dtype=*/nullptr, /*memory_config=*/nullptr,
+      /*compute_config=*/nullptr, /*program_config=*/nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, layerNormPreAllGatherOpWithResidual) {
+  // LayerNormPreAllGather with residual_input
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> outputShape = {1, 1, 32, 64};
+
+  auto input = createEmptyTensor(inputShape);
+  auto residualInput = createEmptyTensor(inputShape);
+  auto outputType = createRankedTensorType(outputShape);
+
+  LayerNormPreAllGatherOp op = builder.create<LayerNormPreAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input,
+      /*residual_input=*/residualInput, /*recip=*/nullptr,
+      /*dtype=*/nullptr, /*memory_config=*/nullptr,
+      /*compute_config=*/nullptr, /*program_config=*/nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, layerNormPreAllGatherOpL1Memory) {
+  // LayerNormPreAllGather with L1 memory buffers
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> outputShape = {1, 1, 32, 64};
+
+  const TTNNLayoutAttr inputLayout_L1 = CreateTiledLayout(
+      inputShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto input =
+      createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout_L1);
+  auto outputType = createRankedTensorType(outputShape, builder.getBF16Type());
+
+  LayerNormPreAllGatherOp op = builder.create<LayerNormPreAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input,
+      /*residual_input=*/nullptr, /*recip=*/nullptr,
+      /*dtype=*/nullptr, /*memory_config=*/nullptr,
+      /*compute_config=*/nullptr, /*program_config=*/nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, groupNormOp) {
   // Test case 1: Basic GroupNorm with weight and bias
   llvm::SmallVector<int64_t> inputShape = {1, 1, 64, 480};

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -5146,6 +5146,116 @@ class TTNNBuilder(Builder):
             f"shard_dims={shard_dims}, composer_dims={composer_dims}"
         )
 
+    ############### ttnn.LayerNormPreAllGatherOp ###############
+
+    @tag(ttnn.LayerNormPreAllGatherOp)
+    def layer_norm_pre_all_gather(
+        self,
+        input: Operand,
+        residual_input: Optional[Operand] = None,
+        recip: Optional[Operand] = None,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.layer_norm_pre_all_gather)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(input)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input_golden = self._get_golden_tensor(input)
+        residual_golden = (
+            self._get_golden_tensor(residual_input)
+            if residual_input is not None
+            else None
+        )
+        recip_golden = self._get_golden_tensor(recip) if recip is not None else None
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input_golden,
+            residual_golden,
+            recip_golden,
+            mlir_output_type,
+        )
+        result = self.create_ttnn_tensor(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        output_dtype = self._get_data_type_attribute(input)
+
+        op = ttnn_op(
+            result,
+            input,
+            loc=loc,
+            residual_input=residual_input,
+            recip=recip,
+            dtype=output_dtype,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttnn.LayerNormPreAllGatherOp)
+    def layer_norm_pre_all_gather_parser(
+        self,
+        old_op: ttnn.LayerNormPreAllGatherOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(
+            TTNNBuilder.layer_norm_pre_all_gather_parser
+        )
+
+        in0 = global_dict[old_op.input]
+        residual_input = (
+            global_dict[old_op.residual_input]
+            if old_op.residual_input is not None
+            else None
+        )
+        recip = global_dict[old_op.recip] if old_op.recip is not None else None
+        result = old_op.result.type
+
+        new_op = ttnn_op(
+            result,
+            in0,
+            loc=old_op.location,
+            residual_input=residual_input,
+            recip=recip,
+            dtype=old_op.dtype,
+            memory_config=old_op.memory_config,
+            compute_config=old_op.compute_config,
+            program_config=old_op.program_config,
+        )
+        new_op_result = new_op.result
+
+        input_golden = self._get_golden_tensor(in0)
+        residual_golden = (
+            self._get_golden_tensor(residual_input)
+            if residual_input is not None
+            else None
+        )
+        recip_golden = self._get_golden_tensor(recip) if recip is not None else None
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input_golden,
+            residual_golden,
+            recip_golden,
+            result.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op, {old_op.result: new_op_result}
+
     ############### ttnn.AllGatherOp ###############
 
     @tag(ttnn.AllGatherOp)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6335,6 +6335,43 @@ def ttnn_layer_norm_golden(
     ).to(output_dtype)
 
 
+def ttnn_layer_norm_pre_all_gather_golden(
+    input: GoldenMapTensor,
+    residual_input: Optional[GoldenMapTensor],
+    recip: Optional[GoldenMapTensor],
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    # `recip` is a precomputed reciprocal LUT [1/1, 1/2, ..., 1/width] used by
+    # the Welford kernel path to replace expensive divisions with multiplies.
+    # It affects *how* the device computes E(x) and E(x^2) (numerical stability
+    # and performance), but not *what* the mathematical result is. The golden
+    # reference computes the same statistics via torch.mean(), so `recip` is
+    # intentionally unused here.
+    del recip
+
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    TILE_WIDTH = 32
+
+    input_float = input.float()
+    if residual_input is not None:
+        input_float = input_float + residual_input.float()
+
+    # Compute per-row partial statistics: E(x^2) and E(x).
+    # Build output per-shard to preserve GoldenMapTensor structure.
+    def compute_stats(shard):
+        shard_float = shard.float()
+        ex2 = shard_float.square().mean(dim=-1, keepdim=True)
+        ex = shard_float.mean(dim=-1, keepdim=True)
+        output_shape = list(shard_float.shape)
+        output_shape[-1] = 2 * TILE_WIDTH
+        output = torch.zeros(output_shape, dtype=torch.float32)
+        output[..., :1] = ex2
+        output[..., TILE_WIDTH : TILE_WIDTH + 1] = ex
+        return output.to(output_dtype)
+
+    return GoldenMapTensor.apply_shardwise(input_float, compute_stats)
+
+
 def ttnn_group_norm_golden(
     input: GoldenMapTensor,
     weight: Optional[GoldenMapTensor],
@@ -6868,6 +6905,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.MatmulOp: ttnn_matmul_golden,
     ttnn.LinearOp: ttnn_linear_golden,
     ttnn.LayerNormOp: ttnn_layer_norm_golden,
+    ttnn.LayerNormPreAllGatherOp: ttnn_layer_norm_pre_all_gather_golden,
     ttnn.GroupNormOp: ttnn_group_norm_golden,
     ttnn.RMSNormOp: rms_norm_golden,
     # Tensor manipulation


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7595

### Summary
- Adds a dedicated ttnn.layer_norm_pre_all_gather op that computes local partial Welford statistics (E(x) and E(x²)) for distributed layer normalization. The output shape replaces the input's last dimension with 2 * TILE_WIDTH (64) containing the two statistics tiles.
- Full pipeline support: TableGen op definition, verifier (input/output shape validation), flatbuffer schema/emission, runtime handler, EmitC/EmitPy conversion patterns, OpModel interface, TTNN builder with golden function, and MLIR lit tests (positive + negative).

### Checklist
- [ ] New/Existing tests provide coverage for changes
