### PR TITLE
[D2M] Add explicit D2M AliasOp to replace aliased allocs

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2525,15 +2525,15 @@ def D2M_AliasOp : D2M_GenericRegionOp<"alias_buffer", [Pure]> {
     portion (grid dimensions stripped).
 
     This op is introduced by the allocator pass for operands that do not
-    require streaming. It makes explicit in the IR that no real buffer
-    allocation is needed -- the compute kernel can operate directly on the
-    input data in place.
+    require streaming. It encodes in the IR that no separate buffer
+    allocation is needed; the compute kernel operates directly on the
+    input data in place. Downstream passes convert this op into circular
+    buffer operations (reserve/push/wait/pop).
 
     ```mlir
     d2m.generic ins(%input : memref<1x1x32x32xf32, ...>) ... {
       %shard = d2m.alias_buffer %input :
           memref<1x1x32x32xf32, ...> -> memref<32x32xf32, ...>
-      // use %shard directly -- no remote_load needed
     }
     ```
   }];

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2516,36 +2516,36 @@ def D2M_ArangeBlockOp : D2M_GenericRegionComputeOp<"arange_block",
 //===----------------------------------------------------------------------===//
 
 def D2M_AliasOp : D2M_GenericRegionOp<"alias_buffer", [Pure]> {
-    let summary = "Alias a shard of an input buffer without allocation.";
-    let description = [{
-      The `alias_buffer` operation declares that a local buffer within a generic
-      region directly aliases (shares storage with) a shard of an input operand
-      rather than requiring a separate allocation. It takes a full sharded memref
-      (with grid dimensions) and returns a memref containing only the shard
-      portion (grid dimensions stripped).
+  let summary = "Alias a shard of an input buffer without allocation.";
+  let description = [{
+    The `alias_buffer` operation declares that a local buffer within a generic
+    region directly aliases (shares storage with) a shard of an input operand
+    rather than requiring a separate allocation. It takes a full sharded memref
+    (with grid dimensions) and returns a memref containing only the shard
+    portion (grid dimensions stripped).
 
-      This op is introduced by the allocator pass for operands that do not
-      require streaming. It makes explicit in the IR that no real buffer
-      allocation is needed -- the compute kernel can operate directly on the
-      input data in place.
+    This op is introduced by the allocator pass for operands that do not
+    require streaming. It makes explicit in the IR that no real buffer
+    allocation is needed -- the compute kernel can operate directly on the
+    input data in place.
 
-      ```mlir
-      d2m.generic ins(%input : memref<1x1x32x32xf32, ...>) ... {
-        %shard = d2m.alias_buffer %input :
-            memref<1x1x32x32xf32, ...> -> memref<32x32xf32, ...>
-        // use %shard directly -- no remote_load needed
-      }
-      ```
-    }];
+    ```mlir
+    d2m.generic ins(%input : memref<1x1x32x32xf32, ...>) ... {
+      %shard = d2m.alias_buffer %input :
+          memref<1x1x32x32xf32, ...> -> memref<32x32xf32, ...>
+      // use %shard directly -- no remote_load needed
+    }
+    ```
+  }];
 
-    let arguments = (ins AnyNon0RankedMemRef:$input);
-    let results = (outs AnyNon0RankedMemRef:$result);
+  let arguments = (ins AnyNon0RankedMemRef:$input);
+  let results = (outs AnyNon0RankedMemRef:$result);
 
-    let assemblyFormat = [{
-      $input attr-dict `:` type($input) `->` type($result)
-    }];
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
 
-    let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_D2M_D2MGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2510,4 +2510,42 @@ def D2M_ArangeBlockOp : D2M_GenericRegionComputeOp<"arange_block",
 
   let hasVerifier = 1;
 }
+
+//===----------------------------------------------------------------------===//
+// D2M Alias Op
+//===----------------------------------------------------------------------===//
+
+def D2M_AliasOp : D2M_GenericRegionOp<"alias_buffer", [Pure]> {
+    let summary = "Alias a shard of an input buffer without allocation.";
+    let description = [{
+      The `alias_buffer` operation declares that a local buffer within a generic
+      region directly aliases (shares storage with) a shard of an input operand
+      rather than requiring a separate allocation. It takes a full sharded memref
+      (with grid dimensions) and returns a memref containing only the shard
+      portion (grid dimensions stripped).
+
+      This op is introduced by the allocator pass for operands that do not
+      require streaming. It makes explicit in the IR that no real buffer
+      allocation is needed -- the compute kernel can operate directly on the
+      input data in place.
+
+      ```mlir
+      d2m.generic ins(%input : memref<1x1x32x32xf32, ...>) ... {
+        %shard = d2m.alias_buffer %input :
+            memref<1x1x32x32xf32, ...> -> memref<32x32xf32, ...>
+        // use %shard directly -- no remote_load needed
+      }
+      ```
+    }];
+
+    let arguments = (ins AnyNon0RankedMemRef:$input);
+    let results = (outs AnyNon0RankedMemRef:$result);
+
+    let assemblyFormat = [{
+      $input attr-dict `:` type($input) `->` type($result)
+    }];
+
+    let hasVerifier = 1;
+}
+
 #endif // TTMLIR_TTMLIR_DIALECT_D2M_D2MGENERICREGIONOPS_TD

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1916,3 +1916,46 @@ PopOp::bufferize(mlir::RewriterBase &rewriter,
                  mlir::bufferization::BufferizationState &) {
   return bufferizeCBOp(*this, rewriter, options);
 }
+
+//===----------------------------------------------------------------------===//
+// AliasOp
+//===----------------------------------------------------------------------===//
+
+mlir::LogicalResult AliasOp::verify() {
+  auto inputType = mlir::cast<MemRefType>(getInput().getType());
+  auto resultType = mlir::cast<MemRefType>(getResult().getType());
+
+  if (inputType.getElementType() != resultType.getElementType()) {
+    return emitOpError() << "element type mismatch: input has "
+                         << inputType.getElementType() << " but result has "
+                         << resultType.getElementType();
+  }
+
+  // The input must have a device layout so we can extract the shard shape.
+  auto layout =
+      mlir::dyn_cast<ttcore::DeviceLayoutInterface>(inputType.getLayout());
+  if (!layout) {
+    return emitOpError()
+           << "input memref must have a device layout (grid + shard)";
+  }
+
+  SmallVector<int64_t> expectedShardShape =
+      llvm::to_vector(layout.getShardShape(inputType));
+
+  // The result rank must be strictly less than the input rank (grid dims
+  // have been stripped).
+  if (resultType.getRank() >= inputType.getRank()) {
+    return emitOpError() << "result rank (" << resultType.getRank()
+                         << ") must be less than input rank ("
+                         << inputType.getRank()
+                         << "); alias_buffer strips grid dimensions";
+  }
+
+  if (llvm::to_vector(resultType.getShape()) != expectedShardShape) {
+    return emitOpError() << "result shape " << resultType.getShape()
+                         << " does not match expected shard shape ["
+                         << expectedShardShape << "]";
+  }
+
+  return mlir::success();
+}

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1957,5 +1957,12 @@ mlir::LogicalResult AliasOp::verify() {
                          << expectedShardShape << "]";
   }
 
+  // The result memory space must match the input's memory space since the
+  // alias shares storage.
+  if (resultType.getMemorySpace() != inputType.getMemorySpace()) {
+    return emitOpError() << "result memory space does not match input memory "
+                            "space; alias_buffer shares storage";
+  }
+
   return mlir::success();
 }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -3130,14 +3130,14 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
     return Value();
   }
 
-  // Walk the region looking for tensor.empty/memref.alloc/d2m.get_cb ops,
-  // stepping into blocking loops only. Do NOT walk into compute loops
-  // (scf.for without d2m.blocking_loop) — allocs inside those are local
-  // working buffers, not operand allocations.
+  // Walk the region looking for tensor.empty/memref.alloc/d2m.alias_buffer/
+  // d2m.get_cb ops, stepping into blocking loops only. Do NOT walk into
+  // compute loops (scf.for without d2m.blocking_loop) — allocs inside those
+  // are local working buffers, not operand allocations.
   //
   // d2m.get_cb ops are matched by operand_index when present, otherwise by
-  // their remote_load/remote_store binding. tensor.empty/memref.alloc ops are
-  // matched by positional order.
+  // their remote_load/remote_store binding. tensor.empty/memref.alloc/
+  // d2m.alias_buffer ops are matched by positional order.
   Value result;
   unsigned idx = 0;
   std::function<void(Block &)> scanBlock = [&](Block &block) {

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -3162,7 +3162,8 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
             return;
           }
         }
-      } else if (mlir::isa<mlir::tensor::EmptyOp, memref::AllocOp>(&op)) {
+      } else if (mlir::isa<mlir::tensor::EmptyOp, memref::AllocOp,
+                           d2m::AliasOp>(&op)) {
         if (idx == operandIndex) {
           result = op.getResult(0);
           return;

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1373,6 +1373,12 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                   L1memInfo, analysis.sequencing))) {
             return failure();
           }
+        } else {
+          // Operand does not require streaming -- replace the in-generic
+          // alloc with d2m.alias_buffer to make the aliasing explicit.
+          if (failed(insertAlias(rewriter, genericOp, operandCtx))) {
+            return failure();
+          }
         }
       }
 
@@ -1662,6 +1668,61 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       }
     }
     rewriter.finalizeOpModification(op);
+
+    return success();
+  }
+
+  /// Replace the in-generic alloc for a non-streamed operand with
+  /// `d2m.alias_buffer`, making it explicit that the operand's shard is used
+  /// directly without a separate allocation.
+  LogicalResult insertAlias(RewriterBase &rewriter, d2m::GenericOp genericOp,
+                            const OperandContext &operandCtx) {
+    const auto operandIndex = operandCtx.operand->getOperandNumber();
+    Value operandValue = operandCtx.operand->get();
+    auto operandMemRefType = mlir::cast<MemRefType>(operandValue.getType());
+
+    // Compute the shard shape from the operand's device layout.
+    // Skip alias insertion if the operand lacks a device layout -- this
+    // should not happen in well-formed IR but we guard against it.
+    auto layout = mlir::dyn_cast<ttcore::DeviceLayoutInterface>(
+        operandMemRefType.getLayout());
+    if (!layout) {
+      return success();
+    }
+    SmallVector<int64_t> shardShape =
+        llvm::to_vector(layout.getShardShape(operandMemRefType));
+
+    Type elementType = operandMemRefType.getElementType();
+    auto resultType =
+        MemRefType::get(shardShape, elementType, /*layout=*/nullptr,
+                        operandMemRefType.getMemorySpace());
+
+    rewriter.startOpModification(genericOp);
+    {
+      for (Region &region : genericOp->getRegions()) {
+        TT_assert(region.hasOneBlock());
+
+        Value oldAlloc = d2m::GenericOp::getOperandAlloc(region, operandIndex);
+        if (!oldAlloc || !oldAlloc.getDefiningOp()) {
+          continue;
+        }
+
+        // Only replace plain memref.allocs; skip get_cb ops and others.
+        if (!mlir::isa<memref::AllocOp>(oldAlloc.getDefiningOp())) {
+          continue;
+        }
+
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(oldAlloc.getDefiningOp());
+
+        auto aliasOp = rewriter.create<d2m::AliasOp>(oldAlloc.getLoc(),
+                                                     resultType, operandValue);
+
+        rewriter.replaceAllUsesWith(oldAlloc, aliasOp.getResult());
+        rewriter.eraseOp(oldAlloc.getDefiningOp());
+      }
+    }
+    rewriter.finalizeOpModification(genericOp);
 
     return success();
   }

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1707,10 +1707,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
           continue;
         }
 
-        // Only replace plain memref.allocs; skip get_cb ops and others.
-        if (!mlir::isa<memref::AllocOp>(oldAlloc.getDefiningOp())) {
-          continue;
-        }
+        TT_assert(mlir::isa<memref::AllocOp>(oldAlloc.getDefiningOp()));
 
         OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(oldAlloc.getDefiningOp());

--- a/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
+++ b/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
@@ -156,7 +156,7 @@ static Operation *findBufferOp(Value value) {
     return nullptr;
   }
 
-  // Direct case: value is produced by memref.alloc or d2m.alias_buffer
+  // Direct case: value is produced by memref.alloc or d2m.alias_buffer.
   if (mlir::isa<memref::AllocOp, d2m::AliasOp>(definingOp)) {
     return definingOp;
   }
@@ -236,7 +236,7 @@ public:
         continue;
       }
 
-      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer)
+      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer).
       Operation *bufferOp = findBufferOp(localBuffer);
       if (!bufferOp) {
         remoteLoad.emitWarning(
@@ -246,8 +246,8 @@ public:
       }
       Value bufferResult = bufferOp->getResult(0);
 
-      // Find the last use of the buffer result or remote_load result BEFORE we
-      // modify the IR
+      // Find the last use of the buffer result or remote_load result before
+      // modifying the IR.
       Block *block = bufferOp->getBlock();
       Operation *lastUseOfAlloc = findLastUse(bufferResult, block);
       Operation *lastUseOfRemoteLoad =
@@ -328,7 +328,7 @@ public:
         continue;
       }
 
-      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer)
+      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer).
       Operation *bufferOp = findBufferOp(localBuffer);
 
       if (!bufferOp) {

--- a/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
+++ b/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
@@ -143,10 +143,10 @@ static Operation *findLastUse(Value value, Block *block) {
   return lastUse;
 }
 
-// Helper function to find the memref.alloc operation that produces a given
-// value, potentially through a chain of operations. Returns the alloc op if
-// found, null otherwise.
-static memref::AllocOp findAllocOp(Value value) {
+// Helper function to find the buffer-producing operation (memref.alloc or
+// d2m.alias_buffer) that produces a given value, potentially through a chain
+// of operations. Returns the op if found, null otherwise.
+static Operation *findBufferOp(Value value) {
   if (!value) {
     return nullptr;
   }
@@ -156,16 +156,16 @@ static memref::AllocOp findAllocOp(Value value) {
     return nullptr;
   }
 
-  // Direct case: value is directly produced by memref.alloc
-  if (auto allocOp = mlir::dyn_cast<memref::AllocOp>(definingOp)) {
-    return allocOp;
+  // Direct case: value is produced by memref.alloc or d2m.alias_buffer
+  if (mlir::isa<memref::AllocOp, d2m::AliasOp>(definingOp)) {
+    return definingOp;
   }
 
   // Trace through operations that might pass the buffer through
   // (e.g., view-like ops, cast ops, etc.)
   for (Value operand : definingOp->getOperands()) {
-    if (auto allocOp = findAllocOp(operand)) {
-      return allocOp;
+    if (auto *bufOp = findBufferOp(operand)) {
+      return bufOp;
     }
   }
 
@@ -236,19 +236,20 @@ public:
         continue;
       }
 
-      // Find the memref.alloc that produces the local buffer
-      memref::AllocOp allocOp = findAllocOp(localBuffer);
-      if (!allocOp) {
+      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer)
+      Operation *bufferOp = findBufferOp(localBuffer);
+      if (!bufferOp) {
         remoteLoad.emitWarning(
-            "could not find memref.alloc for local buffer operand, skipping "
+            "could not find buffer op for local buffer operand, skipping "
             "conversion");
         continue;
       }
+      Value bufferResult = bufferOp->getResult(0);
 
-      // Find the last use of the alloc result or remote_load result BEFORE we
+      // Find the last use of the buffer result or remote_load result BEFORE we
       // modify the IR
-      Block *block = allocOp->getBlock();
-      Operation *lastUseOfAlloc = findLastUse(allocOp.getResult(), block);
+      Block *block = bufferOp->getBlock();
+      Operation *lastUseOfAlloc = findLastUse(bufferResult, block);
       Operation *lastUseOfRemoteLoad =
           findLastUse(remoteLoad.getResult(), block);
 
@@ -270,18 +271,18 @@ public:
       }
 
       {
-        // Insert reserve, push, and wait where the alloc was, so they
+        // Insert reserve, push, and wait where the buffer op was, so they
         // dominate all uses of the buffer (including view operations like
         // collapse_shape that may occur before the remote_load).
-        rewriter.setInsertionPoint(allocOp);
+        rewriter.setInsertionPoint(bufferOp);
 
         rewriter.create<ReserveOp>(loc, assocCb);
         rewriter.create<PushOp>(loc, assocCb);
         auto waitOp = rewriter.create<WaitOp>(loc, assocCb);
 
-        rewriter.replaceAllUsesWith(allocOp.getResult(), waitOp.getResult());
+        rewriter.replaceAllUsesWith(bufferResult, waitOp.getResult());
         rewriter.replaceAllUsesWith(remoteLoad.getResult(), waitOp.getResult());
-        rewriter.eraseOp(allocOp);
+        rewriter.eraseOp(bufferOp);
 
         // Insert pop after the last use
         if (lastUse) {
@@ -327,21 +328,22 @@ public:
         continue;
       }
 
-      // Find the memref.alloc that produces the local buffer being stored
-      memref::AllocOp allocOp = findAllocOp(localBuffer);
+      // Find the buffer-producing op (memref.alloc or d2m.alias_buffer)
+      Operation *bufferOp = findBufferOp(localBuffer);
 
-      if (!allocOp) {
+      if (!bufferOp) {
         remoteStore.emitWarning(
-            "could not find memref.alloc for local buffer operand, skipping "
+            "could not find buffer op for local buffer operand, skipping "
             "conversion");
         continue;
       }
 
-      // Replace memref.alloc with reserve
-      rewriter.setInsertionPoint(allocOp);
+      // Replace buffer op with reserve
+      rewriter.setInsertionPoint(bufferOp);
       auto reserveOp = rewriter.create<ReserveOp>(loc, assocCb);
-      rewriter.replaceAllUsesWith(allocOp.getResult(), reserveOp.getResult());
-      rewriter.eraseOp(allocOp);
+      rewriter.replaceAllUsesWith(bufferOp->getResult(0),
+                                  reserveOp.getResult());
+      rewriter.eraseOp(bufferOp);
 
       // At remote_store location, insert: push, wait, pop
       rewriter.setInsertionPoint(remoteStore);

--- a/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
+++ b/lib/Dialect/D2M/Transforms/ConvertLocalLoadStoreOpsToAliasedCBs.cpp
@@ -338,7 +338,7 @@ public:
         continue;
       }
 
-      // Replace buffer op with reserve
+      // Replace the buffer op with a reserve op.
       rewriter.setInsertionPoint(bufferOp);
       auto reserveOp = rewriter.create<ReserveOp>(loc, assocCb);
       rewriter.replaceAllUsesWith(bufferOp->getResult(0),

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -1037,6 +1037,10 @@ public:
           return cb;
         }
         return nullptr;
+      } else if (mlir::isa<d2m::AliasOp>(definingOp)) {
+        // AliasOp represents a direct buffer alias (no CB indirection).
+        // Return the alias result as the buffer value.
+        return memref;
       }
     }
     if (mlir::isa<BlockArgument>(memref)) {

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -1013,8 +1013,8 @@ public:
     return {copyInfos, dstIntermediates};
   }
 
-  // Look through subview/wait/reserve to find the associated CB or
-  // tensor.empty/memref.alloc value for a given memref.
+  // Look through subview/wait/reserve to find the associated CB,
+  // tensor.empty/memref.alloc, or d2m.alias_buffer value for a given memref.
   static Value lookThroughSubView(Value memref) {
     if (!memref) {
       return nullptr;

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
@@ -176,7 +176,7 @@ static void simplifyLoadStorePairs(ModuleOp moduleOp, IRRewriter &rewriter,
     Operation *bufferToErase = nullptr;
     if (localBuffer) {
       Operation *defOp = localBuffer.getDefiningOp();
-      if (defOp && mlir::isa<memref::AllocOp, d2m::AliasOp>(defOp)) {
+      if (mlir::isa_and_nonnull<memref::AllocOp, d2m::AliasOp>(defOp)) {
         bufferToErase = defOp;
       }
     }
@@ -242,7 +242,7 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     Operation *bufferToErase = nullptr;
     if (localBuffer) {
       Operation *defOp = localBuffer.getDefiningOp();
-      if (defOp && mlir::isa<memref::AllocOp, d2m::AliasOp>(defOp)) {
+      if (mlir::isa_and_nonnull<memref::AllocOp, d2m::AliasOp>(defOp)) {
         if (generic && generic->isAncestor(defOp)) {
           bufferToErase = defOp;
         }

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
@@ -173,19 +173,21 @@ static void simplifyLoadStorePairs(ModuleOp moduleOp, IRRewriter &rewriter,
 
     // Get the shared localBuffer before erasing operations
     Value localBuffer = loadOp.getLocalBuffer();
-    memref::AllocOp allocToErase = nullptr;
+    Operation *bufferToErase = nullptr;
     if (localBuffer) {
-      allocToErase = mlir::dyn_cast_if_present<memref::AllocOp>(
-          localBuffer.getDefiningOp());
+      Operation *defOp = localBuffer.getDefiningOp();
+      if (defOp && mlir::isa<memref::AllocOp, d2m::AliasOp>(defOp)) {
+        bufferToErase = defOp;
+      }
     }
 
     // Erase the original load and store operations
     rewriter.eraseOp(storeOp);
     rewriter.eraseOp(loadOp);
 
-    // Erase the shared alloc if it's now unused
-    if (allocToErase && allocToErase->use_empty()) {
-      rewriter.eraseOp(allocToErase);
+    // Erase the shared buffer op if it's now unused
+    if (bufferToErase && bufferToErase->use_empty()) {
+      rewriter.eraseOp(bufferToErase);
     }
   }
 }
@@ -233,15 +235,16 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     // Get the local buffer (destination) from implicit form remote_load
     // Downstream operations may reference this buffer directly
     Value localBuffer = remoteLoad.getLocalBuffer();
-    // Only erase allocs that live inside the generic (local working buffers).
-    // Hoisted CB allocs live outside as additionalArgs and must not be erased.
+    // Only erase buffer ops that live inside the generic (local working
+    // buffers). Hoisted CB allocs live outside as additionalArgs and must
+    // not be erased.
     GenericOp generic = remoteLoad->getParentOfType<GenericOp>();
-    memref::AllocOp allocToErase = nullptr;
+    Operation *bufferToErase = nullptr;
     if (localBuffer) {
-      if (auto allocOp = mlir::dyn_cast_if_present<memref::AllocOp>(
-              localBuffer.getDefiningOp())) {
-        if (generic && generic->isAncestor(allocOp)) {
-          allocToErase = allocOp;
+      Operation *defOp = localBuffer.getDefiningOp();
+      if (defOp && mlir::isa<memref::AllocOp, d2m::AliasOp>(defOp)) {
+        if (generic && generic->isAncestor(defOp)) {
+          bufferToErase = defOp;
         }
       }
     }
@@ -307,8 +310,8 @@ static PushPopInfo convertToExplicitCBForm(ModuleOp moduleOp,
     // Erase the original remote_load operation
     rewriter.eraseOp(remoteLoad);
 
-    if (allocToErase) {
-      rewriter.eraseOp(allocToErase);
+    if (bufferToErase) {
+      rewriter.eraseOp(bufferToErase);
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToExplicitCBForm.cpp
@@ -185,7 +185,7 @@ static void simplifyLoadStorePairs(ModuleOp moduleOp, IRRewriter &rewriter,
     rewriter.eraseOp(storeOp);
     rewriter.eraseOp(loadOp);
 
-    // Erase the shared buffer op if it's now unused
+    // Erase the shared buffer op if it's now unused.
     if (bufferToErase && bufferToErase->use_empty()) {
       rewriter.eraseOp(bufferToErase);
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer.mlir
@@ -1,0 +1,45 @@
+// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=stream-insert-policy=infer test-buffer-size-policy=max" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that the allocator replaces in-generic allocs with d2m.alias_buffer
+// for operands that do not require streaming (L1, all-parallel, no broadcast).
+
+#l1 = #ttcore.memory_space<l1>
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+module {
+
+  // An eltwise generic with L1 inputs and all-parallel identity maps.
+  // The inputs should get alias_buffer instead of streams.
+  // CHECK-LABEL: func @test_alias_buffer_eltwise
+  func.func @test_alias_buffer_eltwise() {
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %b = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    // CHECK: d2m.generic
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a, %b : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)  {
+    ^unified0:
+      %bf0 = d2m.get_block_factor(0) : index
+      %bf1 = d2m.get_block_factor(1) : index
+      affine.for %i = 0 to %bf0 {
+        affine.for %j = 0 to %bf1 {
+          %buf_a = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          %buf_b = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          %buf_r = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          // Use a compute op so the generic is not classified as DMA-only.
+          %cst = arith.constant 0.0 : f32
+          %tile = "d2m.tile_fill"(%cst) : (f32) -> !ttcore.tile<32x32, f32>
+          // CHECK: d2m.alias_buffer %{{.*}} : memref<{{.*}}> -> memref<1x1x!ttcore.tile<32x32, f32>,
+          // CHECK: d2m.alias_buffer %{{.*}} : memref<{{.*}}> -> memref<1x1x!ttcore.tile<32x32, f32>,
+          // CHECK-NOT: d2m.alias_buffer
+        } {d2m.blocking_loop = 1}
+      } {d2m.blocking_loop = 0}
+    }
+    return
+  }
+
+} // module

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
@@ -65,3 +65,26 @@ module {
     return
   }
 }
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+#dram = #ttcore.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// CHECK: error: 'd2m.alias_buffer' op result memory space does not match input memory space
+module {
+  func.func @alias_buffer_memspace_mismatch() {
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^unified0:
+      // Result memory space (DRAM) does not match input memory space (L1).
+      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #dram>
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
@@ -1,0 +1,89 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Verify that the alias_buffer verifier rejects malformed ops.
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// CHECK: error: 'd2m.alias_buffer' op element type mismatch
+module {
+  func.func @alias_buffer_element_type_mismatch() {
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^unified0:
+      // Element type mismatch: input is tile<32x32, f32>, result is bf16.
+      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1xbf16, #l1>
+    }
+    return
+  }
+}
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// CHECK: error: 'd2m.alias_buffer' op result rank (4) must be less than input rank (4)
+module {
+  func.func @alias_buffer_rank_not_reduced() {
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^unified0:
+      // Result rank equals input rank -- should be strictly less.
+      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+}
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// CHECK: error: 'd2m.alias_buffer' op result shape (2, 2) does not match expected shard shape
+module {
+  func.func @alias_buffer_wrong_shard_shape() {
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^unified0:
+      // Result shape 2x2 does not match expected shard shape 1x1.
+      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+}
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+
+// CHECK: error: 'd2m.alias_buffer' op input memref must have a device layout (grid + shard)
+module {
+  func.func @alias_buffer_no_device_layout() {
+    // Input has no device layout (plain memref).
+    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1>
+    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1>)
+        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^unified0:
+      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    }
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_alias_buffer_negative.mlir
@@ -50,7 +50,7 @@ module {
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #ttcore.iterator_type<parallel>
 
-// CHECK: error: 'd2m.alias_buffer' op result shape (2, 2) does not match expected shard shape
+// CHECK: error: 'd2m.alias_buffer' op result shape 2, 2 does not match expected shard shape
 module {
   func.func @alias_buffer_wrong_shard_shape() {
     %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
@@ -61,28 +61,6 @@ module {
     ^unified0:
       // Result shape 2x2 does not match expected shard shape 1x1.
       %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-    }
-    return
-  }
-}
-
-// -----
-
-#l1 = #ttcore.memory_space<l1>
-#map = affine_map<(d0, d1) -> (d0, d1)>
-#parallel = #ttcore.iterator_type<parallel>
-
-// CHECK: error: 'd2m.alias_buffer' op input memref must have a device layout (grid + shard)
-module {
-  func.func @alias_buffer_no_device_layout() {
-    // Input has no device layout (plain memref).
-    %a = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1>
-    %r = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
-    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
-        ins(%a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1>)
-        outs(%r : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
-    ^unified0:
-      %alias = d2m.alias_buffer %a : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Currently in D2M, post bufferization memref.alloc is used both to alloc actual CB allocs which we need for streaming/scratch AND for placeholder alias buffers which should not be allocated space and eventually get folded away.  We want a way to differentiate these two cases.

### What's changed
Introduce a d2m.alias_buffer op which represent stripping grid dims off a global sharded alloc to get the underlying shard as a local buffer without actual allocation.

### Checklist
- [ ] New/Existing tests provide coverage for changes
