### PR TITLE
Fix MishOp emitC conversion to use correct unary pattern (#7654)

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4818,7 +4818,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
            EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::Relu6Op>,
            EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::HardsigmoidOp>,
            EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::SiluOp>,
-           EltwiseUnaryOpConversionPattern<mlir::tt::ttnn::MishOp>,
+           EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+               mlir::tt::ttnn::MishOp>,
            ElementwiseUnaryWithFloatParameterOpConversionPattern<
                mlir::tt::ttnn::LeakyReluOp>,
            EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<

--- a/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
+++ b/test/python/golden/ttir_ops/eltwise/test_ttir_unary.py
@@ -298,9 +298,6 @@ def test_unary_ops(
     ]:
         pytest.skip("int32 unary op is not supported yet for this operation")
 
-    if target == "emitc" and test_fn in [mish]:
-        pytest.skip("https://github.com/tenstorrent/tt-mlir/issues/7654")
-
     def module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
         def unary_op(


### PR DESCRIPTION
### Ticket
Closes #7654

### Summary
- Fix MishOp emitC compilation by using EltwiseUnaryWithFastAndApproximateModeOpConversionPattern instead of EltwiseUnaryOpConversionPattern, since ttnn::mish requires a fast_and_approximate_mode bool parameter
- Remove the emitC skip for mish in the unary golden test

### Checklist
- [x] New/Existing tests provide coverage for changes
