### PR TITLE
Fix python_runner nanobind build and install paths

### DIFF
--- a/tools/tt-alchemist/csrc/python_runner/CMakeLists.txt
+++ b/tools/tt-alchemist/csrc/python_runner/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 set(PYTHON_RUNNER_LIBRARY_NAME tt-alchemist-python-runner)
 
+include(GNUInstallDirs)
+
 # We embed CPython (Py_Initialize, etc.), so request the "embed" development
 # target. nanobind additionally expects FindPython-provided variables/targets.
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
@@ -68,11 +70,11 @@ set_target_properties(${PYTHON_RUNNER_LIBRARY_NAME} PROPERTIES
 )
 
 install(FILES $<TARGET_FILE:${PYTHON_RUNNER_LIBRARY_NAME}>
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT SharedLib
 )
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python_runner.hpp
-  DESTINATION include/tools/tt-alchemist/python_runner
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tools/tt-alchemist/python_runner
   COMPONENT SharedLib
 )


### PR DESCRIPTION
This PR fixes the `tt-alchemist-python-runner` `CMake` build configuration (added in https://github.com/tenstorrent/tt-mlir/commit/d103b754574f232fa08599c4044ff083ff60649e) by renaming the internal nanobind static library target from nanobind-static to nanobind-static-python-runner to avoid name collisions with other nanobind consumers in the project, moving it to a PUBLIC link dependency so downstream targets can access nanobind headers, suppressing nanobind-originating warnings (e.g., `-Wno-cast-qual, -Wno-zero-length-array`) that are promoted to errors by the repo's and replacing hardcoded lib and include install destinations with the standard GNUInstallDirs variables (`${CMAKE_INSTALL_LIBDIR}, ${CMAKE_INSTALL_INCLUDEDIR}`) for improved portability across platforms.

Needed to unblock tt-xla uplift.