### PR TITLE
[D2M] Add support for scalar argument types and refactor argument lowering + packing

### DIFF
--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -14,7 +14,8 @@ extern "C" {
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx,
                                                     MlirType memrefType);
 
-MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelSemaphoreTypeGet(MlirContext ctx);
+MLIR_CAPI_EXPORTED MlirType
+ttmlirTTKernelLocalSemaphoreTypeGet(MlirContext ctx);
 
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelNocAddrTypeGet(MlirContext ctx);
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1661,7 +1661,7 @@ class D2M_SemaphoreUpdateOp<string mnemonic> : D2M_GenericRegionOp<mnemonic,
       ```
     }];
 
-    let arguments = (ins AnyTypeOf<[D2M_Semaphore, D2M_GlobalSemaphore]>:$semaphore, Index:$value,
+    let arguments = (ins AnyTypeOf<[D2M_LocalSemaphore, D2M_GlobalSemaphore]>:$semaphore, Index:$value,
                          Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
 
     let assemblyFormat = [{ $semaphore `,` $value (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` type($semaphore) }];
@@ -1696,7 +1696,7 @@ def D2M_SemaphoreWaitOp : D2M_GenericRegionOp<"semaphore_wait", [MemoryEffects<[
       ```
     }];
 
-    let arguments = (ins AnyTypeOf<[D2M_Semaphore, D2M_GlobalSemaphore]>:$semaphore, Index:$value, Optional<Index>:$resetValue);
+    let arguments = (ins AnyTypeOf<[D2M_LocalSemaphore, D2M_GlobalSemaphore]>:$semaphore, Index:$value, Optional<Index>:$resetValue);
 
     let assemblyFormat = [{ $semaphore `,` $value (`reset` $resetValue^)? attr-dict `:` type($semaphore) }];
 
@@ -2328,58 +2328,37 @@ def D2M_GetCBOp : D2M_GenericRegionOp<"get_cb", [Pure]> {
     }];
 
     let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$port,
-                         OptionalAttr<I64Attr>:$operand_index);
+                         OptionalAttr<I64Attr>:$operand_index,
+                         OptionalAttr<D2M_ResolutionStageAttr>:$resolution_stage);
     let results = (outs D2M_CB:$result);
 
-    let assemblyFormat = [{ `(` $port `)` (`operand_index` `=` $operand_index^)? attr-dict `:` type($result) }];
+    let assemblyFormat = [{ `(` $port `)` (`operand_index` `=` $operand_index^)? (`resolution_stage` `=` $resolution_stage^)? attr-dict `:` type($result) }];
 }
 
-def D2M_GetGlobalOperandOp : D2M_GenericRegionOp<"get_global_operand", [Pure]> {
-    let summary = "Get global operand op.";
+def D2M_GetArgOp : D2M_GenericRegionOp<"get_arg", [Pure]> {
+    let summary = "Get a generic argument for the given operand index.";
     let description = [{
-      Access the global, aka parent generic op, operand at the specified index.
+      Obtain a handle for the specified operand index. The result type determines
+      how the argument is interpreted: a memref type indicates a buffer address,
+      a local/global semaphore type indicates a semaphore, and any scalar type
+      (integer or float) indicates a scalar value.
 
-      The following forms are all equivalent, but the latter forms are required
-      when moving generic regions to top level func ops in the module.
+      Used to reference additional arguments passed to the parent generic op
+      from within a thread region or a standalone kernel function.
+
       ```mlir
-      d2m.generic (%arg0, %arg1, %arg2) {
-        ^datamovement(%cb0, %cb1, %cb2)
-          %i = d2m.iter_index(0) : index
-          %j = d2m.iter_index(1) : index
-          d2m.remote_load %arg1[%i, %j] into %cb1 // Capture %arg1 from parent scope
-      }
-      ```
-
-      And:
-      ```mlir
-      d2m.generic (%arg0, %arg1, %arg2) {
-        ^datamovement(%cb0, %cb1, %cb2)
-          %operand_arg1 = d2m.get_global_operand 1
-          %i = d2m.iter_index(0) : index
-          %j = d2m.iter_index(1) : index
-          d2m.remote_load %operand_arg1[%i, %j] into %cb0
-      }
-      ```
-
-      And:
-      ```mlir
-      func.func @main(...) {
-        d2m.generic (%arg0, %arg1, %arg2) { kernel_symbols = [@dm0] }
-      }
-
-      func.func private @dm0(%cb0, %cb1, %cb2) {
-        %operand_arg1 = d2m.get_global_operand 1
-        %i = d2m.iter_index(0) : index
-        %j = d2m.iter_index(1) : index
-        d2m.remote_load %operand_arg1[%i, %j] into %cb0
-      }
+      %buf   = d2m.get_arg operand_index = 0 : memref<...>
+      %lsem  = d2m.get_arg operand_index = 3 : !d2m.local_semaphore
+      %gsem  = d2m.get_arg operand_index = 4 : !d2m.global_semaphore
+      %val   = d2m.get_arg operand_index = 5 : ui32
       ```
     }];
 
-    let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$operand_index);
+    let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$operand_index,
+                         OptionalAttr<D2M_ResolutionStageAttr>:$resolution_stage);
     let results = (outs AnyType:$result);
 
-    let assemblyFormat = [{ `(` $operand_index `)` attr-dict `:` type($result) }];
+    let assemblyFormat = [{ `operand_index` `=` $operand_index (`resolution_stage` `=` $resolution_stage^)? attr-dict `:` type($result) }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -2505,4 +2484,25 @@ def D2M_ArangeBlockOp : D2M_GenericRegionComputeOp<"arange_block",
 
   let hasVerifier = 1;
 }
+
+def D2M_PrintArg : D2M_GenericRegionOp<"print_arg", [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "Print a kernel argument";
+    let description = [{
+        This op prints a value with an optional label prefix. Supports
+        semaphores, CBs, and scalar types (i1, ui8, si8, ui16, si16, ui32,
+        si32, f16, bf16, f32, index).
+        Example:
+        ```
+        d2m.print_arg "my label" %arg0 : !d2m.local_semaphore
+        d2m.print_arg "My value is: " %arg0 : ui32
+        d2m.print_arg %arg0 : f32
+        ```
+    }];
+
+    let arguments = (ins OptionalAttr<StrAttr>:$fmt,
+                        AnyTypeOf<[D2M_LocalSemaphore, D2M_CB, D2M_GlobalSemaphore,
+                                   AnyInteger, AnyFloat, Index]>:$value);
+    let assemblyFormat = "($fmt^)? $value attr-dict `:` type($value)";
+}
+
 #endif // TTMLIR_TTMLIR_DIALECT_D2M_D2MGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOps.td
@@ -512,6 +512,18 @@ def D2M_ResetGlobalSemaphoreOp : D2M_Op<"reset_global_semaphore"> {
   let assemblyFormat = [{ `(` $semaphore `)` attr-dict `:` type($semaphore) }];
 }
 
+def D2M_CreateLocalSemaphoreOp : D2M_Op<"create_local_semaphore"> {
+  let summary = "Create local semaphore op.";
+
+  let description = [{
+    This operation is purely a representational op. It creates a local semaphore in the core range specific within the generic op in which it is consumed.
+  }];
+
+  let arguments = (ins UI32Attr:$initialValue);
+  let results = (outs D2M_LocalSemaphore:$result);
+  let assemblyFormat = "prop-dict attr-dict `->` type($result)";
+}
+
 def D2M_FullOp
     : D2M_Op<"full", [Pure, DeclareOpInterfaceMethods<
                                 BufferizableOpInterface,

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
@@ -14,6 +14,8 @@ def D2M_ReduceDimAttr : EnumAttr<D2M_Dialect, D2M_ReduceDim, "reduce_dim">;
 
 def D2M_TileBcastTypeAttr : EnumAttr<D2M_Dialect, D2M_TileBcastType, "tile_bcast_type">;
 
+def D2M_ResolutionStageAttr : EnumAttr<D2M_Dialect, D2M_ResolutionStage, "resolution_stage">;
+
 def D2M_ThreadAttr : AttrDef<D2M_Dialect, "Thread", [], "::mlir::Attribute"> {
   let mnemonic = "thread";
   let summary = "Thread information for a generic op.";

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsEnums.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsEnums.td
@@ -67,4 +67,18 @@ def D2M_ThreadType : I32EnumAttr<"ThreadType", "D2M ThreadType", [
   let cppNamespace = "::mlir::tt::d2m";
 }
 
+// D2M ResolutionStage indicates whether a get_* op argument is resolved at
+// compile time (passed as a compile-time arg) or at runtime (passed as a
+// runtime arg).
+def D2M_ResolutionStageCompile : I32EnumAttrCase<"Compile", 0, "compile">;
+def D2M_ResolutionStageRuntime : I32EnumAttrCase<"Runtime", 1, "runtime">;
+
+def D2M_ResolutionStage : I32EnumAttr<"ResolutionStage", "D2M ResolutionStage", [
+  D2M_ResolutionStageCompile,
+  D2M_ResolutionStageRuntime
+]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::d2m";
+}
+
 #endif // TTMLIR_D2M_DIALECT_D2M_IR_D2MOPSENUMS_TD

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsTypes.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsTypes.td
@@ -21,9 +21,14 @@ def D2M_MemTx : D2M_Type<"MemTx", "mem_tx"> {
     let description = "Memory transaction returned by dma op, used to wait for completion.";
 }
 
-def D2M_Semaphore : D2M_Type<"Semaphore", "semaphore"> {
-    let summary = "D2M semaphore type.";
-    let description = "Semaphore primitive type used with semaphore ops to synchronize cores.";
+def D2M_LocalSemaphore : D2M_Type<"LocalSemaphore", "local_semaphore"> {
+    let summary = "D2M local semaphore type.";
+    let description = "Local semaphore primitive type used with semaphore ops to synchronize cores.";
+}
+
+def D2M_GlobalSemaphore : D2M_Type<"GlobalSemaphore", "global_semaphore"> {
+    let summary = "D2M global semaphore type.";
+    let description = "Global semaphore type used with semaphore wait/set ops to synchronize cores.";
 }
 
 def D2M_CB : D2M_Type<"CB", "cb", [ShapedTypeInterface, Bufferization_TensorLikeTypeInterface, Bufferization_BufferLikeTypeInterface]> {
@@ -100,11 +105,6 @@ def D2M_CB : D2M_Type<"CB", "cb", [ShapedTypeInterface, Bufferization_TensorLike
                        getShape() == shapedType.getShape());
       }
     }];
-}
-
-def D2M_GlobalSemaphore : D2M_Type<"GlobalSemaphore", "global_semaphore"> {
-    let summary = "D2M global semaphore type.";
-    let description = "Global semaphore type used with semaphore wait/set ops to synchronize cores.";
 }
 
 #endif  // TTMLIR_D2M_DIALECT_D2M_IR_D2MOPSTYPES_TD

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -937,6 +937,15 @@ def D2MConvertLocalLoadStoreOpsToAliasedCBs : Pass<"d2m-convert-local-load-store
   let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
 }
 
+def D2MNormalizeThreadArgs : Pass<"normalize-thread-args", "::mlir::ModuleOp"> {
+  let summary = "This pass normalizes thread arguments.";
+  let description = [{
+    This pass normalizes thread arguments by capturing d2m.get_cb ops and
+    additional arguments into the thread block argument list.
+  }];
+  let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
+}
+
 def D2MLowerScratchAllocate : Pass<"d2m-lower-scratch-allocate", "::mlir::ModuleOp"> {
   let summary = "Lower d2m.scratch_allocate ops to memref.subview of the scratch buffer.";
   let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -2760,7 +2760,7 @@ def TTKernel_GetNocAddrOp : TTKernel_Op<"get_noc_addr"> {
       GetNocAddr api including core coordinates
     }];
 
-    let arguments = (ins IndexLike:$x, IndexLike:$y, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$l1Address);
+    let arguments = (ins IndexLike:$x, IndexLike:$y, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$l1Address);
     let results = (outs TTKernel_NocAddr:$nocAddr);
 
     let assemblyFormat = [{
@@ -3029,7 +3029,7 @@ def TTKernel_GetSemaphoreOp : TTKernel_Op<"get_semaphore"> {
     }];
 
     let arguments = (ins IndexLike:$semaphore);
-    let results = (outs TTKernel_Semaphore:$sem_addr);
+    let results = (outs TTKernel_LocalSemaphore:$sem_addr);
 
     let assemblyFormat = [{
       `(` $semaphore `)` attr-dict `:` functional-type(operands, results)
@@ -3118,7 +3118,7 @@ def TTKernel_NocSemaphoreSetMulticastOp : TTKernel_Op<"noc_semaphore_set_multica
       *noc_semaphore_set_multicast_loopback_src* can be used.
     }];
 
-    let arguments = (ins AnyTypeOf<[TTKernel_L1Addr, TTKernel_Semaphore]>:$src_local_l1_addr,
+    let arguments = (ins AnyTypeOf<[TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$src_local_l1_addr,
                          TTKernel_NocAddr:$dst_noc_addr_multicast,
                          I32:$num_dests,
                          OptionalAttr<BoolAttr>:$linked,
@@ -3147,7 +3147,7 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
       regular non multicast operations such as *noc_async_write* in this case.
     }];
 
-    let arguments = (ins AnyTypeOf<[TTKernel_L1Addr, TTKernel_Semaphore]>:$src_local_l1_addr,
+    let arguments = (ins AnyTypeOf<[TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$src_local_l1_addr,
                          TTKernel_NocAddr:$dst_noc_addr_multicast,
                          I32:$num_dests,
                          OptionalAttr<BoolAttr>:$linked);
@@ -3161,7 +3161,7 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
 // TTKernel Compile and runtime arguments operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_ArgResultType : AnyTypeOf<[I32, TTKernel_CB, TTKernel_L1Addr]>;
+def TTKernel_ArgResultType : AnyTypeOf<[I32, TTKernel_CB, TTKernel_L1Addr, TTKernel_Scalar, TTKernel_LocalSemaphore, TTKernel_GlobalSemaphore]>;
 
 def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val", [Pure]> {
     let summary = "Get runtime arg value.";
@@ -3220,7 +3220,7 @@ def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<volatile tt_l1_ptr ui
       Cast specified addr to L1 pointer.
     }];
 
-    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$addr);
+    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore, TTKernel_GlobalSemaphore]>:$addr);
 
     let results = (outs TTKernel_L1AddrPtr:$l1_ptr);
 
@@ -3514,7 +3514,7 @@ def TTKernel_GetNocMulticastAddrOp : TTKernel_Op<"get_noc_multicast_addr"> {
     Default tt-metal get_noc_multicast_addr
   }];
 
-  let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$addr, Optional<I8>:$noc);
+  let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$addr, Optional<I8>:$noc);
   let results = (outs TTKernel_NocAddr:$mcastNocAddr);
 
     let assemblyFormat = [{
@@ -3528,7 +3528,7 @@ def TTKernel_ExperimentalGetNocMulticastAddrOp : TTKernel_Op<"experimental::get_
     Default tt-metal get_noc_multicast_addr, but flips mcast start and end coordinates on NOC1.
   }];
 
-  let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$addr, Optional<I8>:$noc);
+  let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_LocalSemaphore]>:$addr, Optional<I8>:$noc);
   let results = (outs TTKernel_NocAddr:$mcastNocAddr);
 
     let assemblyFormat = [{
@@ -3876,6 +3876,17 @@ def TTKernel_DPrintOp : TTKernel_Op<"dprint", [MemoryEffects<[MemRead, MemWrite]
         return build(odsBuilder, odsState, StringRef(fmt), ValueRange{std::forward<Args>(argv)...});
       }
     }];
+}
+
+def TTKernel_ReinterpretCastOp : TTKernel_Op<"reinterpret_cast", [Pure]> {
+    let summary = "Reinterpret cast a scalar to another scalar type";
+    let description = [{
+        Reinterprets the bits of a scalar value as another scalar type.
+    }];
+
+    let arguments = (ins TTKernel_Scalar:$input);
+    let results = (outs TTKernel_Scalar:$result);
+    let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `to` qualified(type($result))";
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -66,17 +66,19 @@ def TTKernel_BcastType : I32EnumAttr<"BcastType", "TTKernel Broadcast Types",
 
 def TTKernel_ArgTypeCBPort : I32EnumAttrCase<"CBPort", 0, "cb_port">;
 def TTKernel_ArgTypeBufferAddress : I32EnumAttrCase<"BufferAddress", 1, "buffer_address">;
-def TTKernel_ArgTypeSemaphore : I32EnumAttrCase<"Semaphore", 2, "semaphore">;
+def TTKernel_ArgTypeLocalSemaphore : I32EnumAttrCase<"LocalSemaphore", 2, "local_semaphore">;
 def TTKernel_ArgTypeNamedArgument : I32EnumAttrCase<"NamedArgument", 3, "named_argument">;
 def TTKernel_ArgTypeGlobalSemaphore : I32EnumAttrCase<"GlobalSemaphore", 4, "global_semaphore">;
+def TTKernel_ArgTypeScalar : I32EnumAttrCase<"Scalar", 5, "scalar">;
 
 def TTKernel_ArgType : I32EnumAttr<"ArgType", "TTKernel Argument Types",
                          [
                            TTKernel_ArgTypeCBPort,
                            TTKernel_ArgTypeBufferAddress,
-                           TTKernel_ArgTypeSemaphore,
+                           TTKernel_ArgTypeLocalSemaphore,
                            TTKernel_ArgTypeNamedArgument,
-                           TTKernel_ArgTypeGlobalSemaphore
+                           TTKernel_ArgTypeGlobalSemaphore,
+                           TTKernel_ArgTypeScalar
                          ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -38,9 +38,21 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
     }];
 }
 
-def TTKernel_Semaphore : TTKernel_Type<"Semaphore", "semaphore"> {
-  let summary = "TTKernel semaphore";
-  let description = "Semaphore type in TTKernel dialect";
+def TTKernel_LocalSemaphore : TTKernel_Type<"LocalSemaphore", "local_semaphore"> {
+  let summary = "TTKernel local semaphore";
+  let description = "Local Semaphore type in TTKernel dialect";
+}
+
+def TTKernel_GlobalSemaphore : TTKernel_Type<"GlobalSemaphore", "global_semaphore"> {
+  let summary = "TTKernel global semaphore";
+  let description = "Global Semaphore type in TTKernel dialect";
+}
+
+def TTKernel_Scalar : TTKernel_Type<"Scalar", "scalar"> {
+  let summary = "TTKernel scalar";
+  let description = "Scalar type in TTKernel dialect";
+  let parameters = (ins "Type":$value);
+  let assemblyFormat = "`<` $value `>`";
 }
 
 def TTKernel_NocAddr : TTKernel_Type<"NocAddr", "noc_addr"> {
@@ -132,22 +144,27 @@ def TTKernel_ArgAttr : TTKernel_Attr<"Arg", "arg"> {
   let summary = "Kernel argument.";
   let description = [{
   }];
-  let parameters = (ins "ArgType":$arg_type, "size_t":$operand_index,
+  let parameters = (ins "ArgType":$arg_type, "int64_t":$operand_index,
                         DefaultValuedParameter<"bool", "true">:$is_uniform,
-                        DefaultValuedParameter<"StringAttr", "StringAttr::get($_ctxt, \"\")">:$argument_name);
+                        DefaultValuedParameter<"StringAttr", "StringAttr::get($_ctxt, \"\")">:$argument_name,
+                        DefaultValuedParameter<"int64_t", "-1">:$port);
   let assemblyFormat = "`<` struct(params) `>`";
 
   let extraClassDeclaration = [{
-    static ArgAttr get(::mlir::MLIRContext *context, ArgType argType, size_t index) {
-      return ArgAttr::get(context, argType, index, true, StringAttr::get(context, ""));
+    static ArgAttr get(::mlir::MLIRContext *context, ArgType argType, int64_t index) {
+      return ArgAttr::get(context, argType, index, true, StringAttr::get(context, ""), -1);
+    }
+
+    static ArgAttr getCBPort(::mlir::MLIRContext *context, int64_t operandIndex, int64_t port) {
+      return ArgAttr::get(context, ArgType::CBPort, operandIndex, true, StringAttr::get(context, ""), port);
     }
 
     static ArgAttr get(::mlir::MLIRContext *context, ArgType argType, size_t index, bool isUniform) {
-      return ArgAttr::get(context, argType, index, isUniform, StringAttr::get(context, ""));
+      return ArgAttr::get(context, argType, index, isUniform, StringAttr::get(context, ""), -1);
     }
 
     static ArgAttr get(::mlir::MLIRContext *context, StringAttr argumentName) {
-      return ArgAttr::get(context, ArgType::NamedArgument, 0, true, argumentName);
+      return ArgAttr::get(context, ArgType::NamedArgument, 0, true, argumentName, -1);
     }
   }];
 }

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -93,6 +93,16 @@ def TTMetal_ResetGlobalSemaphoreOp : TTMetal_Op<"reset_global_semaphore", [Memor
     let arguments = (ins TTMetal_GlobalSemaphore:$semaphore, UI32Attr:$value);
 }
 
+def TTMetal_CreateLocalSemaphoreOp : TTMetal_Op<"create_local_semaphore", [MemoryEffects<[MemAlloc]>]> {
+    let summary = "Create local semaphore op.";
+    let description = [{
+      Create local semaphore operation
+    }];
+
+    let arguments = (ins OptionalAttr<UI32Attr>:$initial_value);
+    let results = (outs TTMetal_LocalSemaphore:$result);
+}
+
 def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer", [MemoryEffects<[MemFree]>]> {
     let summary = "Deallocate buffer op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.td
@@ -24,4 +24,9 @@ def TTMetal_GlobalSemaphore : TTMetal_Type<"GlobalSemaphore", "global_semaphore"
   let description = "Global semaphore type in TTMetal dialect";
 }
 
+def TTMetal_LocalSemaphore : TTMetal_Type<"LocalSemaphore", "local_semaphore"> {
+  let summary = "TTMetal local semaphore";
+  let description = "Local semaphore type in TTMetal dialect";
+}
+
 #endif  // TTMLIR_TTMLIR_DIALECT_TTMETAL_TTMETALOPSTYPES_TD

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -996,6 +996,16 @@ def TTNN_KernelArgGlobalSemaphoreAttr : TTNN_Attr<"KernelArgGlobalSemaphore", "k
   let assemblyFormat = "`<` $global_semaphore_index `>`";
 }
 
+def TTNN_KernelArgScalarAttr : TTNN_Attr<"KernelArgScalar", "kernel_arg_scalar"> {
+  let summary = "Scalar argument";
+  let description = [{
+    TTNN generic kernel argument for scalar values.
+  }];
+
+  let parameters = (ins "size_t":$scalar_index);
+  let assemblyFormat = "`<` $scalar_index `>`";
+}
+
 def TTNN_CoreRuntimeArgsAttr : TTNN_Attr<"CoreRuntimeArgs", "core_runtime_args"> {
   let summary = "Per-core runtime arguments";
   let description = [{

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -31,6 +31,10 @@ table ResetGlobalSemaphoreCommand {
   value: uint32;
 }
 
+table CreateLocalSemaphoreCommand {
+  ref: LocalSemaphoreRef;
+}
+
 table EnqueueWriteBufferCommand {
   src: BufferRef;
   dst: BufferRef;
@@ -95,6 +99,7 @@ union CommandType {
   DeallocateBufferCommand,
   CreateGlobalSemaphoreCommand,
   ResetGlobalSemaphoreCommand,
+  CreateLocalSemaphoreCommand,
   EnqueueRecordEventCommand,
   EnqueueWaitForEventCommand,
   EventSynchronizeCommand,

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -61,16 +61,15 @@ union Kernel {
 }
 
 table KernelArgCBPort {
-  operand_idx: uint32;
+  operand_idx: int32;
 }
 
 table KernelArgBufferAddress {
-  operand_idx: uint32;
+  operand_idx: int32;
 }
 
-table KernelArgSemaphore {
-  initial_value: uint32;
-  core_type: CoreType;
+table KernelArgLocalSemaphore {
+  operand_idx: int32;
 }
 
 table KernelArgNamedArgument {
@@ -79,15 +78,20 @@ table KernelArgNamedArgument {
 }
 
 table KernelArgGlobalSemaphore {
-  operand_idx: uint32;
+  operand_idx: int32;
+}
+
+table KernelArgScalar {
+  operand_idx: int32;
 }
 
 union KernelArgType {
   KernelArgCBPort,
   KernelArgBufferAddress,
-  KernelArgSemaphore,
+  KernelArgLocalSemaphore,
   KernelArgNamedArgument,
   KernelArgGlobalSemaphore,
+  KernelArgScalar,
 }
 
 table KernelArg {

--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -72,9 +72,15 @@ table GlobalSemaphoreRef {
   address: uint64;
 }
 
+table LocalSemaphoreRef {
+  global_id: uint32;
+  initial_value: uint32;
+}
+
 union ArgRef {
   BufferRef,
-  GlobalSemaphoreRef
+  GlobalSemaphoreRef,
+  LocalSemaphoreRef,
 }
 
 table CBRef {

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -14,8 +14,8 @@ MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, MlirType memrefType) {
   return wrap(CBType::get(mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }
 
-MlirType ttmlirTTKernelSemaphoreTypeGet(MlirContext ctx) {
-  return wrap(SemaphoreType::get(unwrap(ctx)));
+MlirType ttmlirTTKernelLocalSemaphoreTypeGet(MlirContext ctx) {
+  return wrap(LocalSemaphoreType::get(unwrap(ctx)));
 }
 
 MlirType ttmlirTTKernelNocAddrTypeGet(MlirContext ctx) {

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1861,54 +1861,107 @@ public:
 } // namespace
 
 namespace {
-class D2MGetGlobalOperandRewriter
-    : public OpConversionPattern<d2m::GetGlobalOperandOp> {
+class D2MGetArgRewriter : public OpConversionPattern<d2m::GetArgOp> {
 public:
-  D2MGetGlobalOperandRewriter(TypeConverter &typeConverter,
-                              MLIRContext *context, bool ttnnMode)
-      : OpConversionPattern<d2m::GetGlobalOperandOp>(typeConverter, context),
-        ttnnMode(ttnnMode) {}
+  using OpConversionPattern<d2m::GetArgOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(d2m::GetGlobalOperandOp op,
-                  d2m::GetGlobalOperandOpAdaptor adaptor,
+  matchAndRewrite(d2m::GetArgOp op, d2m::GetArgOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    MLIRContext *ctx = rewriter.getContext();
+    Type resultType = op.getResult().getType();
+    int64_t operandIndex = op.getOperandIndex();
+
+    auto evalTimeAttr = op.getResolutionStageAttr();
+    bool isRuntime = evalTimeAttr &&
+                     evalTimeAttr.getValue() == d2m::ResolutionStage::Runtime;
+
     func::FuncOp entry = op->getParentOfType<func::FuncOp>();
-    ArgAttr arg;
     size_t argIndex;
-    Type arg_result_type;
 
-    if (mlir::isa<MemRefType>(op.getResult().getType())) {
-      arg = rewriter.getAttr<ArgAttr>(ArgType::BufferAddress,
-                                      op.getOperandIndex());
-      arg_result_type = rewriter.getI32Type();
-    } else if (mlir::isa<d2m::GlobalSemaphoreType>(op.getResult().getType())) {
-      arg = rewriter.getAttr<ArgAttr>(ArgType::GlobalSemaphore,
-                                      op.getOperandIndex());
-      arg_result_type = ttkernel::L1AddrType::get(rewriter.getContext());
+    if (mlir::isa<MemRefType>(resultType)) {
+      // Buffer address: resolve to i32 containing the device address.
+      ArgAttr arg =
+          rewriter.getAttr<ArgAttr>(ArgType::BufferAddress, operandIndex);
+      if (isRuntime) {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
+            op, rewriter.getI32Type(), index(rewriter, op->getLoc(), argIndex));
+      } else {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
+            op, rewriter.getI32Type(), argIndex);
+      }
+    } else if (mlir::isa<d2m::GlobalSemaphoreType>(resultType)) {
+      // Global semaphore: resolve to the converted semaphore type.
+      Type semType = getTypeConverter()->convertType(resultType);
+      ArgAttr arg =
+          rewriter.getAttr<ArgAttr>(ArgType::GlobalSemaphore, operandIndex);
+      if (isRuntime) {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
+            op, semType, index(rewriter, op->getLoc(), argIndex));
+      } else {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
+            op, semType, static_cast<int32_t>(argIndex));
+      }
+    } else if (mlir::isa<d2m::LocalSemaphoreType>(resultType)) {
+      // Local semaphore: resolve to the converted semaphore type.
+      Type semType = getTypeConverter()->convertType(resultType);
+      ArgAttr arg =
+          rewriter.getAttr<ArgAttr>(ArgType::LocalSemaphore, operandIndex);
+      if (isRuntime) {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
+            op, semType, index(rewriter, op->getLoc(), argIndex));
+      } else {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
+        });
+        rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
+            op, semType, static_cast<int32_t>(argIndex));
+      }
     } else {
-      llvm_unreachable("unexpected arg type to GetGlobalOperandOp");
-    }
-
-    if (ttnnMode) {
-      rewriter.modifyOpInPlace(entry, [&]() {
-        argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
-      });
-      rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
-          op, arg_result_type, index(rewriter, op->getLoc(), argIndex));
-
-    } else {
-      rewriter.modifyOpInPlace(entry, [&]() {
-        argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
-      });
-      rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
-          op, arg_result_type, argIndex);
+      // Scalar: CT args are always passed as ui32; other types are cast.
+      Type ui32Type = IntegerType::get(ctx, 32, IntegerType::Unsigned);
+      Type ui32ScalarType = ttkernel::ScalarType::get(ctx, ui32Type);
+      ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::Scalar, operandIndex);
+      Value argVal;
+      if (isRuntime) {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendRuntimeArg(entry, arg);
+        });
+        argVal = rewriter.create<ttkernel::GetCommonArgValOp>(
+            op.getLoc(), ui32ScalarType,
+            index(rewriter, op->getLoc(), argIndex));
+      } else {
+        rewriter.modifyOpInPlace(entry, [&]() {
+          argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg);
+        });
+        argVal = rewriter.create<ttkernel::GetCompileArgValOp>(
+            op.getLoc(), ui32ScalarType, static_cast<int32_t>(argIndex));
+      }
+      if (resultType == ui32Type) {
+        rewriter.replaceOp(op, argVal);
+      } else {
+        Type targetScalarType = ttkernel::ScalarType::get(ctx, resultType);
+        rewriter.replaceOpWithNewOp<ttkernel::ReinterpretCastOp>(
+            op, targetScalarType, argVal);
+      }
     }
     return success();
   }
-
-private:
-  bool ttnnMode;
 };
 
 class D2MGetCBRewriter : public OpConversionPattern<d2m::GetCBOp> {
@@ -1920,27 +1973,42 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     Type cbType = getTypeConverter()->convertType(op.getResult().getType());
 
-    assert(op.getOperandIndex() &&
-           "d2m.get_cb must have an operand_index by the time it reaches "
-           "D2MToTTKernel lowering");
-    int64_t operandIndex = *op.getOperandIndex();
+    // if no operand index exists, set to -1. This will be used for scratchpad
+    // CBs.
+    int64_t operandIndex = -1;
+    if (op.getOperandIndex()) {
+      operandIndex = op.getOperandIndex().value();
+    }
+    int64_t port = op.getPort();
 
     // Append a CBPort entry to the parent function's ArgSpec so that
     // D2MToTTNN can generate the corresponding cb_buffer_index in the
     // kernel descriptor's ct_args.  The operand index tells the runtime
     // which operand's buffer to associate with this CB.
     func::FuncOp entry = op->getParentOfType<func::FuncOp>();
-    ArgAttr cbArg = rewriter.getAttr<ArgAttr>(ArgType::CBPort, operandIndex);
-    size_t ctArgIndex;
-    rewriter.modifyOpInPlace(entry, [&]() {
-      ctArgIndex = ArgSpecAttr::appendCompileTimeArg(entry, cbArg);
-    });
+    ArgAttr cbArg =
+        ArgAttr::getCBPort(rewriter.getContext(), operandIndex, port);
+    size_t argIndex;
 
-    // Emit a get_compile_time_arg_val that reads the port from ct_args at
-    // runtime. This allows the spatial op to remap CB ports per grid range
-    // by overriding compile-time arguments.
-    rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
-        op, cbType, static_cast<int32_t>(ctArgIndex));
+    auto evalTimeAttr = op.getResolutionStageAttr();
+    bool isRuntime = evalTimeAttr &&
+                     evalTimeAttr.getValue() == d2m::ResolutionStage::Runtime;
+    if (isRuntime) {
+      rewriter.modifyOpInPlace(entry, [&]() {
+        argIndex = ArgSpecAttr::appendRuntimeArg(entry, cbArg);
+      });
+      rewriter.replaceOpWithNewOp<ttkernel::GetCommonArgValOp>(
+          op, cbType, index(rewriter, op->getLoc(), argIndex));
+    } else {
+      rewriter.modifyOpInPlace(entry, [&]() {
+        argIndex = ArgSpecAttr::appendCompileTimeArg(entry, cbArg);
+      });
+      // Emit a get_compile_time_arg_val that reads the port from ct_args at
+      // runtime. This allows the spatial op to remap CB ports per grid range
+      // by overriding compile-time arguments.
+      rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
+          op, cbType, static_cast<int32_t>(argIndex));
+    }
     return success();
   }
 };
@@ -1978,6 +2046,7 @@ public:
 } // namespace
 
 namespace {
+// Rewrites kernel func::FuncOp signatures from D2M to TTKernel ABI.
 class D2MKernelFunctionArgsRewriter : public OpConversionPattern<func::FuncOp> {
 public:
   using OpConversionPattern<func::FuncOp>::OpConversionPattern;
@@ -2000,6 +2069,8 @@ public:
     }
   }
 
+  // Replace D2M-specific function attributes with their TTKernel equivalents
+  // and record the compile-time argument specification on the function.
   static void convertFunctionAttrs(Builder &builder, func::FuncOp op,
                                    ArrayRef<ArgAttr> rtArgs,
                                    ArrayRef<ArgAttr> ctArgs) {
@@ -2023,50 +2094,6 @@ public:
     SmallVector<ArgAttr> rtArgSpecVector;
     SmallVector<ArgAttr> ctArgSpecVector;
 
-    // Zero-input functions: just convert attrs and set function type.
-    // The D2MGetCBRewriter will append CB entries to the ArgSpec as it
-    // processes get_cb ops within the function body.
-    if (op.getFunctionType().getNumInputs() == 0) {
-      rewriter.modifyOpInPlace(op, [&]() {
-        op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
-        convertFunctionAttrs(rewriter, op, rtArgSpecVector, ctArgSpecVector);
-      });
-      return success();
-    }
-
-    Block *block = &op.getCallableRegion()->front();
-    auto blockArgs = block->getArguments();
-    assert(!blockArgs.empty());
-
-    size_t currentSemaphoreIndex = 0;
-    TypeConverter::SignatureConversion signatureConverter(op.getNumArguments());
-    OpBuilder::InsertionGuard funcInsertionGuard(rewriter);
-    rewriter.setInsertionPointToStart(block);
-    // Block arguments are semaphores only. CB args have been replaced by
-    // d2m.get_cb ops, which are lowered by D2MGetCBRewriter.
-    for (auto arg : blockArgs) {
-      Type argType = getTypeConverter()->convertType(arg.getType());
-      if (mlir::isa<SemaphoreType>(argType)) {
-        if (getTTKernelThreadType(op) != ThreadType::Noc) {
-          continue;
-        }
-        size_t ctArgIndex = ctArgSpecVector.size();
-        auto semaphoreIndex = rewriter.create<GetCompileArgValOp>(
-            op.getLoc(), rewriter.getI32Type(),
-            rewriter.getI32IntegerAttr(ctArgIndex));
-        auto semaphore =
-            rewriter.create<GetSemaphoreOp>(op.getLoc(), semaphoreIndex);
-        signatureConverter.remapInput(arg.getArgNumber(),
-                                      semaphore.getResult());
-        ctArgSpecVector.push_back(rewriter.getAttr<ArgAttr>(
-            ArgType::Semaphore, currentSemaphoreIndex++));
-      } else {
-        llvm_unreachable("unexpected block argument type");
-      }
-    }
-
-    rewriter.applySignatureConversion(block, signatureConverter,
-                                      getTypeConverter());
     rewriter.modifyOpInPlace(op, [&]() {
       op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
       convertFunctionAttrs(rewriter, op, rtArgSpecVector, ctArgSpecVector);
@@ -2181,6 +2208,23 @@ public:
 };
 } // namespace
 
+namespace {
+class D2MPrintArgOpRewriter : public OpConversionPattern<d2m::PrintArg> {
+public:
+  using OpConversionPattern<d2m::PrintArg>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::PrintArg op, d2m::PrintArgAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    std::string fmt =
+        op.getFmt() ? (op.getFmt()->str() + ": {}") : "Printing arg: {}";
+    rewriter.replaceOpWithNewOp<ttkernel::DPrintOp>(op, fmt.c_str(),
+                                                    adaptor.getValue());
+    return success();
+  }
+};
+} // namespace
+
 } // namespace mlir::tt::ttkernel
 
 namespace mlir::tt {
@@ -2282,11 +2326,13 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MSemaphoreUpdateRewriter<d2m::SemaphoreIncOp>,
                ttkernel::D2MSemaphoreWaitRewriter>(typeConverter, ctx);
 
-  patterns.add<ttkernel::D2MGetGlobalOperandRewriter>(typeConverter, ctx,
-                                                      ttnnMode);
+  patterns.add<ttkernel::D2MGetArgRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &associatedDMAWaits, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &associatedDMAWaits, &cbProducerConsumer);
+
+  // Debug op patterns.
+  patterns.add<ttkernel::D2MPrintArgOpRewriter>(typeConverter, ctx);
 
   // This is needed to lower affine apply ops that may be generated when
   // `d2m.core_index` is used with a `phys_to_virt_map`.

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -75,6 +75,7 @@ struct ConvertD2MToTTKernel
     target.addLegalOp<d2m::GenericOp>();
     target.addLegalOp<d2m::EmptyOp>();
     target.addLegalOp<d2m::MeshShardOp>();
+    target.addLegalOp<d2m::CreateLocalSemaphoreOp>();
     target.addLegalOp<d2m::CreateGlobalSemaphoreOp>();
     target.addLegalOp<d2m::ResetGlobalSemaphoreOp>();
     target.addLegalOp<d2m::SpatialOp>();
@@ -134,11 +135,11 @@ struct ConvertD2MToTTKernel
     typeConverter.addConversion([](d2m::CBType cb) -> Type {
       return ttkernel::CBType::get(cb.getUnderlyingAs<MemRefType>());
     });
-    typeConverter.addConversion([](d2m::SemaphoreType semaphore) {
-      return ttkernel::SemaphoreType::get(semaphore.getContext());
+    typeConverter.addConversion([](d2m::LocalSemaphoreType semaphore) {
+      return ttkernel::LocalSemaphoreType::get(semaphore.getContext());
     });
     typeConverter.addConversion([](d2m::GlobalSemaphoreType globalSemaphore) {
-      return ttkernel::L1AddrType::get(globalSemaphore.getContext());
+      return ttkernel::GlobalSemaphoreType::get(globalSemaphore.getContext());
     });
 
     d2m::AssociatedDMAWaits associatedDMAWaits =

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -20,6 +20,16 @@
 
 namespace mlir::tt::ttmetal {
 
+// Returns true if `type` is one of the supported scalar underlying types:
+// bool (i1), ui8, si8, ui16, si16, ui32, si32, f16, bf16, f32, or index.
+static bool isSupportedScalarType(Type type) {
+  if (auto intTy = mlir::dyn_cast<IntegerType>(type)) {
+    unsigned w = intTy.getWidth();
+    return w == 1 || w == 8 || w == 16 || w == 32;
+  }
+  return mlir::isa<Float32Type, Float16Type, BFloat16Type, IndexType>(type);
+}
+
 namespace {
 
 // Returns true if the kernel function contains an op of type OpT.
@@ -155,6 +165,10 @@ public:
     for (unsigned i = 0; i < op.getAdditionalArgs().size(); ++i) {
       auto operand = adaptor.getOperands()[ioSize + i];
       if (mlir::isa<ttmetal::GlobalSemaphoreType>(operand.getType())) {
+        args.push_back(operand);
+      } else if (mlir::isa<ttmetal::LocalSemaphoreType>(operand.getType())) {
+        args.push_back(operand);
+      } else if (isSupportedScalarType(operand.getType())) {
         args.push_back(operand);
       } else if (mlir::isa<MemRefType>(operand.getType())) {
         // Hoisted CB buffer (already converted to CreateBufferOp by
@@ -368,6 +382,24 @@ public:
 } // namespace
 
 namespace {
+class D2MCreateLocalSemaphoreRewriter
+    : public OpConversionPattern<d2m::CreateLocalSemaphoreOp> {
+public:
+  using OpConversionPattern<d2m::CreateLocalSemaphoreOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::CreateLocalSemaphoreOp op,
+                  d2m::CreateLocalSemaphoreOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<ttmetal::CreateLocalSemaphoreOp>(
+        op, ttmetal::LocalSemaphoreType::get(rewriter.getContext()),
+        adaptor.getInitialValueAttr());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class D2MCreateGlobalSemaphoreRewriter
     : public OpConversionPattern<d2m::CreateGlobalSemaphoreOp> {
 public:
@@ -429,6 +461,7 @@ void populateD2MToTTMetalPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<ttmetal::MemrefAllocRewriter, ttmetal::MemrefDeallocRewriter,
                ttmetal::D2MToDeviceRewriter, ttmetal::D2MToHostRewriter,
                ttmetal::D2MMeshShardRewriter,
+               ttmetal::D2MCreateLocalSemaphoreRewriter,
                ttmetal::D2MCreateGlobalSemaphoreRewriter,
                ttmetal::D2MResetGlobalSemaphoreRewriter>(ctx);
   patterns.add<ttmetal::D2MGenericRewriter>(ctx, mathFidelity);

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -155,7 +155,7 @@ static mlir::Attribute convertKernelArg(Builder &builder,
     return builder.getAttr<ttnn::KernelArgCBBufferIndexAttr>(
         arg.getOperandIndex());
   }
-  case ttkernel::ArgType::Semaphore: {
+  case ttkernel::ArgType::LocalSemaphore: {
     return builder.getAttr<ttnn::KernelArgSemaphoreAtAttr>(
         arg.getOperandIndex());
   }
@@ -166,6 +166,9 @@ static mlir::Attribute convertKernelArg(Builder &builder,
   case ttkernel::ArgType::GlobalSemaphore: {
     return builder.getAttr<ttnn::KernelArgGlobalSemaphoreAttr>(
         arg.getOperandIndex());
+  }
+  case ttkernel::ArgType::Scalar: {
+    return builder.getAttr<ttnn::KernelArgScalarAttr>(arg.getOperandIndex());
   }
   }
   llvm_unreachable("Invalid ArgType");
@@ -192,7 +195,7 @@ createSemaphoreDescriptors(Builder &builder, const ArrayAttr &threads,
     }
 
     for (auto ctArg : kernelSpec.getCtArgs()) {
-      if (ctArg.getArgType() == ttkernel::ArgType::Semaphore) {
+      if (ctArg.getArgType() == ttkernel::ArgType::LocalSemaphore) {
         seenSemaphoreIndices.insert(ctArg.getOperandIndex());
       }
     }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -118,6 +118,32 @@ datatypeToDataformatEnumValueOpaqueAttr(Builder &builder,
 }
 
 // Type converter used for TTKernel/TTMetal conversions:
+static std::string scalarUnderlyingToCppType(Type underlying) {
+  if (auto intTy = mlir::dyn_cast<IntegerType>(underlying)) {
+    bool isSigned = !intTy.isUnsigned();
+    switch (intTy.getWidth()) {
+    case 1:
+      return "bool";
+    case 8:
+      return isSigned ? "int8_t" : "uint8_t";
+    case 16:
+      return isSigned ? "int16_t" : "uint16_t";
+    case 32:
+      return isSigned ? "int32_t" : "uint32_t";
+    }
+  }
+  if (mlir::isa<Float32Type>(underlying)) {
+    return "float";
+  }
+  if (mlir::isa<Float16Type>(underlying)) {
+    return "float16";
+  }
+  if (mlir::isa<BFloat16Type>(underlying)) {
+    return "bfloat16";
+  }
+  llvm_unreachable("unsupported scalar underlying type");
+}
+
 namespace {
 class TTKernelToEmitCTypeConverter : public TypeConverter {
 public:
@@ -131,8 +157,8 @@ public:
     addConversion([ctx](mlir::tt::ttkernel::CBType type) -> Type {
       return Builder(ctx).getType<emitc::OpaqueType>("::tt::CB");
     });
-    addConversion([ctx](mlir::tt::ttkernel::SemaphoreType type) -> Type {
-      // Convert semaphore to an address type. (i32)
+    addConversion([ctx](mlir::tt::ttkernel::LocalSemaphoreType type) -> Type {
+      // Convert local semaphore to an address type. (i32)
       return Builder(ctx).getI32Type();
     });
     addConversion([ctx](mlir::tt::ttkernel::L1AddrType type) -> Type {
@@ -167,6 +193,10 @@ public:
           return emitc::OpaqueType::get(
               ctx, "experimental::FabricConnectionManager");
         });
+    addConversion([ctx](mlir::tt::ttkernel::ScalarType type) -> Type {
+      return emitc::OpaqueType::get(ctx,
+                                    scalarUnderlyingToCppType(type.getValue()));
+    });
   }
 };
 } // namespace
@@ -508,6 +538,31 @@ public:
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, TypeRange(), "ttmlir::dprint", nullptr, nullptr, vargs);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTKernelReinterpretCastOpRewriter
+    : public OpConversionPattern<ttkernel::ReinterpretCastOp> {
+public:
+  using OpConversionPattern<ttkernel::ReinterpretCastOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttkernel::ReinterpretCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto resultScalarType =
+        mlir::cast<ttkernel::ScalarType>(op.getResult().getType());
+    Type resultUnderlying = resultScalarType.getValue();
+    std::string cppType = scalarUnderlyingToCppType(resultUnderlying);
+    Type emitcType = emitc::OpaqueType::get(rewriter.getContext(), cppType);
+
+    auto templateArgs = rewriter.getArrayAttr(
+        {emitc::OpaqueAttr::get(rewriter.getContext(), cppType)});
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, emitcType, "static_cast", templateArgs, nullptr,
+        adaptor.getInput());
     return success();
   }
 };
@@ -1100,6 +1155,7 @@ public:
 
     patterns.add<
         TTKernelToEmitCGetCompileArgValRewriter, TTKernelToEmitCDPrintRewriter,
+        TTKernelReinterpretCastOpRewriter,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosBaseOp>,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosSizeOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetArgValOp>,

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1933,9 +1933,10 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
     // Block arguments may only be semaphore type.
     // Semaphore block args are added by PreallocateMcastSemaphores.
     for (BlockArgument arg : region.getArguments()) {
-      if (!mlir::isa<d2m::SemaphoreType>(arg.getType())) {
-        return emitOpError(
-            "region block arguments must be of 'semaphore' type");
+      if (!mlir::isa<d2m::CBType, d2m::LocalSemaphoreType,
+                     d2m::GlobalSemaphoreType>(arg.getType())) {
+        return emitOpError("all regions must either be cb, local semaphore, "
+                           "global semaphore or scalar block argument type");
       }
 
       if (arg.getType() !=
@@ -2794,10 +2795,18 @@ std::optional<SmallVector<int64_t>> d2m::GenericOp::computeGridDimConstraints(
 
 void d2m::GenericOp::getAsmBlockArgumentNames(
     Region &region, function_ref<void(Value, StringRef)> setNameFn) {
-  int semIndex = 0;
+  int cbIndex = 0;
+  int localSemIndex = 0;
+  int globalSemIndex = 0;
   for (BlockArgument arg : region.getArguments()) {
-    if (mlir::isa<SemaphoreType>(arg.getType())) {
-      setNameFn(arg, "sem" + std::to_string(semIndex++));
+    if (mlir::isa<CBType>(arg.getType())) {
+      setNameFn(arg, "cb" + std::to_string(cbIndex++));
+    } else if (mlir::isa<LocalSemaphoreType>(arg.getType())) {
+      setNameFn(arg, "lsem" + std::to_string(localSemIndex++));
+    } else if (mlir::isa<GlobalSemaphoreType>(arg.getType())) {
+      setNameFn(arg, "gsem" + std::to_string(globalSemIndex++));
+    } else {
+      llvm_unreachable("Unexpected region argument type");
     }
   }
 }

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_dialect_library(MLIRD2MTransforms
         LowerLoadStoreOpsToExplicitCBForm.cpp
         ExpandDMAReadCompositeView.cpp
         ConvertLocalLoadStoreOpsToAliasedCBs.cpp
+        NormalizeThreadArgs.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/D2M/Transforms/GenericRegionsToFuncs.cpp
@@ -4,78 +4,14 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
-#include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
 #include "ttmlir/FunctionTypes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Rewrite/FrozenRewritePatternSet.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MGENERICREGIONSTOFUNCS
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
-
-static std::optional<unsigned> getCapturedOperandIndex(GenericOp op,
-                                                       Value operand) {
-  for (OpOperand &opOperand : op->getOpOperands()) {
-    if (opOperand.get() == operand) {
-      return opOperand.getOperandNumber();
-    }
-  }
-  return std::nullopt;
-}
-
-static void rewriteOperand(OpBuilder &builder, DMAOpInterface dma,
-                           OpOperand &dmaOperand, unsigned operandIndex) {
-  MemRefType memref = mlir::cast<MemRefType>(dmaOperand.get().getType());
-  AffineMap affineMapView = builder.getMultiDimIdentityMap(memref.getRank());
-  if (dmaOperand.get().getDefiningOp()) {
-    std::tie(memref, affineMapView) =
-        applyViews(dmaOperand.get().getDefiningOp());
-  }
-  Operation *globalOperand =
-      builder.create<GetGlobalOperandOp>(dma.getLoc(), memref, operandIndex);
-  dmaOperand.set(globalOperand->getResult(0));
-}
-
-static void rewriteCapturedDMAOperands(OpBuilder &builder, GenericOp generic,
-                                       DMAOpInterface dma) {
-
-  auto srcIndex = getCapturedOperandIndex(generic, dma.getSrc());
-  auto dstIndex = getCapturedOperandIndex(generic, dma.getDst());
-
-  builder.setInsertionPoint(dma);
-  if (srcIndex) {
-    rewriteOperand(builder, dma, dma.getSrcMutable(), *srcIndex);
-  }
-
-  if (dstIndex) {
-    rewriteOperand(builder, dma, dma.getDstMutable(), *dstIndex);
-  }
-}
-
-static void rewriteAdditionalArgOperands(OpBuilder &builder,
-                                         GenericOp generic) {
-  //  Get all uses of additional arg
-  //  operands that are not the generic operation itself.
-  for (auto [idx, operand] : llvm::enumerate(generic.getAdditionalArgs())) {
-    unsigned capturedOperandIndex = *getCapturedOperandIndex(generic, operand);
-    for (OpOperand &use : llvm::make_early_inc_range(operand.getUses())) {
-      if (use.getOwner() != generic.getOperation() &&
-          generic->isAncestor(use.getOwner())) {
-        builder.setInsertionPoint(use.getOwner());
-        //  And insert a get_global_operand op where the generic operand is being used.
-        auto globalOperand = builder.create<GetGlobalOperandOp>(
-            use.getOwner()->getLoc(), operand.getType(), capturedOperandIndex);
-        use.set(globalOperand.getResult());
-      }
-    }
-  }
-}
 
 namespace {
 class D2MGenericRegionsToFuncs
@@ -89,11 +25,6 @@ public:
     OpBuilder builder(&getContext());
     int unique = 0;
     moduleOp->walk([&](GenericOp generic) {
-      generic.walk([&](DMAOpInterface dma) {
-        rewriteCapturedDMAOperands(builder, generic, dma);
-      });
-      rewriteAdditionalArgOperands(builder, generic);
-
       SmallVector<Attribute> threads;
       auto origThreads = generic.getThreadsAttr().getValue();
       for (Region &region : generic.getRegions()) {

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -20,11 +20,10 @@ namespace mlir::tt::d2m {
 constexpr StringRef kPreallocatedSemaphoresAttr = "preallocated_semaphores";
 
 // Helper to get pre-allocated semaphores for a multicast RemoteLoadOp.
-// Returns a pair of (receiversReady, senderFinished) semaphores.
-// Asserts if the semaphores were not pre-allocated by
-// D2MPreallocateMcastSemaphores.
-static std::pair<BlockArgument, BlockArgument>
-getPreallocatedSemaphores(Operation *op) {
+// Returns a pair of (receiversReady, senderFinished) Values from the parent
+// GenericOp's additionalArgs. Indices stored in preallocated_semaphores are
+// additionalArgs indices (set by D2MPreallocateMcastSemaphores).
+static std::pair<Value, Value> getPreallocatedSemaphores(Operation *op) {
   auto arrayAttr = op->getAttrOfType<ArrayAttr>(kPreallocatedSemaphoresAttr);
   TT_assertv(arrayAttr,
              "Multicast RemoteLoadOp must have preallocated_semaphores "
@@ -36,26 +35,17 @@ getPreallocatedSemaphores(Operation *op) {
   auto genericOp = op->getParentOfType<GenericOp>();
   TT_assertv(genericOp, "RemoteLoadOp must be inside a GenericOp");
 
-  // Find which region contains this operation.
-  Region *parentRegion = op->getParentRegion();
-  while (parentRegion && parentRegion->getParentOp() != genericOp) {
-    parentRegion = parentRegion->getParentOp()->getParentRegion();
-  }
-  TT_assertv(parentRegion, "Failed to find parent region for RemoteLoadOp");
-  TT_assertv(!parentRegion->empty(), "Parent region is empty");
-
-  Block &block = parentRegion->front();
-
   unsigned receiversReadyIdx = mlir::cast<IntegerAttr>(arrayAttr[0]).getInt();
   unsigned senderFinishedIdx = mlir::cast<IntegerAttr>(arrayAttr[1]).getInt();
 
-  TT_assertv(receiversReadyIdx < block.getNumArguments(),
+  auto additionalArgs = genericOp.getAdditionalArgs();
+  TT_assertv(receiversReadyIdx < additionalArgs.size(),
              "Pre-allocated receiversReady semaphore index is out of bounds");
-  TT_assertv(senderFinishedIdx < block.getNumArguments(),
+  TT_assertv(senderFinishedIdx < additionalArgs.size(),
              "Pre-allocated senderFinished semaphore index is out of bounds");
 
-  return std::make_pair(block.getArgument(receiversReadyIdx),
-                        block.getArgument(senderFinishedIdx));
+  return std::make_pair(additionalArgs[receiversReadyIdx],
+                        additionalArgs[senderFinishedIdx]);
 }
 
 namespace {
@@ -98,8 +88,8 @@ public:
     // Get pre-allocated semaphores for synchronization.
     // These must have been set by D2MPreallocateMcastSemaphores pass.
     auto preallocatedSems = getPreallocatedSemaphores(remoteLoad);
-    BlockArgument receiversReadySemaphore = preallocatedSems.first;
-    BlockArgument senderFinishedSemaphore = preallocatedSems.second;
+    Value receiversReadySemaphore = preallocatedSems.first;
+    Value senderFinishedSemaphore = preallocatedSems.second;
 
     // Number of receivers is mcastVolume - 1 (excluding sender itself).
     // The sender waits for this many semaphore increments before multicasting.

--- a/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
+++ b/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.h"
+#include "ttmlir/FunctionTypes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MNORMALIZETHREADARGS
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+namespace {
+
+// Returns true if `type` is one of the supported scalar underlying types:
+// bool (i1), ui8, si8, ui16, si16, ui32, si32, f16, bf16, f32, or index.
+static bool isSupportedScalarType(Type type) {
+  if (auto intTy = mlir::dyn_cast<IntegerType>(type)) {
+    unsigned w = intTy.getWidth();
+    return w == 1 || w == 8 || w == 16 || w == 32;
+  }
+  return mlir::isa<Float32Type, Float16Type, BFloat16Type, IndexType>(type);
+}
+
+// Inserts a get_arg op for a single DMA operand that directly references a
+// generic's ins/outs operand, replacing the direct reference with the result.
+static void rewriteOperand(IRRewriter &rewriter, DMAOpInterface dma,
+                           OpOperand &dmaOperand, unsigned operandIndex) {
+  MemRefType memref = mlir::cast<MemRefType>(dmaOperand.get().getType());
+  if (dmaOperand.get().getDefiningOp()) {
+    std::tie(memref, std::ignore) =
+        applyViews(dmaOperand.get().getDefiningOp());
+  }
+  rewriter.setInsertionPoint(dma);
+  Operation *buf = rewriter.create<GetArgOp>(
+      dma.getLoc(), memref, operandIndex,
+      ResolutionStageAttr::get(rewriter.getContext(),
+                               ResolutionStage::Compile));
+  dmaOperand.set(buf->getResult(0));
+}
+
+// For each DMA op inside a generic, if its src or dst directly references one
+// of the generic's ins/outs operands, replace it with a get_arg op.
+static std::optional<unsigned> getCapturedOperandIndex(GenericOp generic,
+                                                       Value operand) {
+  for (OpOperand &opOperand : generic->getOpOperands()) {
+    if (opOperand.get() == operand) {
+      return opOperand.getOperandNumber();
+    }
+  }
+  return std::nullopt;
+}
+
+static void rewriteCapturedDMAOperands(IRRewriter &rewriter, GenericOp generic,
+                                       DMAOpInterface dma) {
+  auto srcIndex = getCapturedOperandIndex(generic, dma.getSrc());
+  auto dstIndex = getCapturedOperandIndex(generic, dma.getDst());
+
+  if (srcIndex) {
+    rewriteOperand(rewriter, dma, dma.getSrcMutable(), *srcIndex);
+  }
+  if (dstIndex) {
+    rewriteOperand(rewriter, dma, dma.getDstMutable(), *dstIndex);
+  }
+}
+
+// This pass normalizes thread arguments by inserting d2m.get_arg ops inside
+// each thread block, and replacing all in-region uses of those args with the
+// op results. d2m.get_cb ops are left untouched.
+// operand_index for the inserted ops matches the arg's position in the
+// generic's combined operand list (ins + outs + additionalArgs).
+class D2MNormalizeThreadArgs
+    : public impl::D2MNormalizeThreadArgsBase<D2MNormalizeThreadArgs> {
+public:
+  using impl::D2MNormalizeThreadArgsBase<
+      D2MNormalizeThreadArgs>::D2MNormalizeThreadArgsBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    // Fill in resolution_stage = compile on any existing get_* ops that don't
+    // already have the attribute set.
+    auto compileAttr =
+        ResolutionStageAttr::get(&getContext(), ResolutionStage::Compile);
+    moduleOp->walk([&](Operation *op) {
+      TypeSwitch<Operation *>(op)
+          .Case<GetCBOp>([&](GetCBOp cbOp) {
+            if (!cbOp.getResolutionStageAttr()) {
+              rewriter.modifyOpInPlace(
+                  cbOp, [&]() { cbOp.setResolutionStageAttr(compileAttr); });
+            }
+          })
+          .Case<GetArgOp>([&](GetArgOp argOp) {
+            if (!argOp.getResolutionStageAttr()) {
+              rewriter.modifyOpInPlace(
+                  argOp, [&]() { argOp.setResolutionStageAttr(compileAttr); });
+            }
+          });
+    });
+
+    moduleOp->walk([&](GenericOp generic) {
+      // Rewrite DMA ops that directly capture ins/outs operands.
+      generic.walk([&](DMAOpInterface dma) {
+        rewriteCapturedDMAOperands(rewriter, generic, dma);
+      });
+
+      int64_t baseIndex = static_cast<int64_t>(generic.getInputs().size() +
+                                               generic.getOutputs().size());
+
+      // Memref additional args (hoisted CBs) are placed in the enqueue_program
+      // cbs list, not the args list. Track how many precede the current arg so
+      // semaphore/scalar operandIndices reflect their actual position in args.
+      int64_t numPrecedingCBArgs = 0;
+
+      for (auto [i, arg] : llvm::enumerate(generic.getAdditionalArgs())) {
+        Type argType = arg.getType();
+        // Memref additional args use the full D2M position (baseIndex + i).
+        // Non-memref args (semaphores, scalars) use the effective args-list
+        // position, excluding preceding CB memrefs that won't appear in args.
+        int64_t operandIndex =
+            mlir::isa<MemRefType>(argType)
+                ? baseIndex + static_cast<int64_t>(i)
+                : baseIndex + static_cast<int64_t>(i) - numPrecedingCBArgs;
+
+        if (mlir::isa<MemRefType>(argType)) {
+          // Buffer additional args: insert get_arg before each in-region use.
+          for (OpOperand &use : llvm::make_early_inc_range(arg.getUses())) {
+            if (use.getOwner() == generic.getOperation()) {
+              continue;
+            }
+            if (!generic->isAncestor(use.getOwner())) {
+              continue;
+            }
+            rewriter.setInsertionPoint(use.getOwner());
+            auto buf = rewriter.create<GetArgOp>(
+                use.getOwner()->getLoc(), argType, operandIndex,
+                ResolutionStageAttr::get(&getContext(),
+                                         ResolutionStage::Compile));
+            use.set(buf.getResult());
+          }
+          numPrecedingCBArgs++;
+          continue;
+        }
+
+        assert((isSupportedScalarType(argType) ||
+                mlir::isa<d2m::LocalSemaphoreType>(argType) ||
+                mlir::isa<d2m::GlobalSemaphoreType>(argType)) &&
+               "Additional argument type must be a supported scalar, "
+               "semaphore, or buffer type");
+
+        for (auto &region : generic.getRegions()) {
+          // Skip this region if the arg is not used anywhere inside it.
+          bool usedInRegion = llvm::any_of(arg.getUses(), [&](OpOperand &use) {
+            Block *ownerBlock = use.getOwner()->getBlock();
+            return ownerBlock &&
+                   region.findAncestorBlockInRegion(*ownerBlock) != nullptr;
+          });
+          if (!usedInRegion) {
+            continue;
+          }
+
+          for (auto &block : region) {
+            rewriter.setInsertionPointToStart(&block);
+
+            auto compileTimeAttr = ResolutionStageAttr::get(
+                &getContext(), ResolutionStage::Compile);
+            Value replacement = rewriter.create<GetArgOp>(
+                arg.getLoc(), argType, operandIndex, compileTimeAttr);
+            rewriter.setInsertionPointAfter(replacement.getDefiningOp());
+
+            rewriter.replaceUsesWithIf(arg, replacement, [&](OpOperand &use) {
+              Block *ownerBlock = use.getOwner()->getBlock();
+              return ownerBlock &&
+                     region.findAncestorBlockInRegion(*ownerBlock) != nullptr;
+            });
+          }
+        }
+      }
+    });
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
+++ b/lib/Dialect/D2M/Transforms/PreallocateMcastSemaphores.cpp
@@ -89,34 +89,32 @@ public:
     // - senderFinishedSemaphore
 
     Location loc = generic.getLoc();
-    SemaphoreType semType = rewriter.getType<SemaphoreType>();
+    LocalSemaphoreType semType = rewriter.getType<LocalSemaphoreType>();
 
-    // Track the starting index of semaphores for each RemoteLoadOp.
-    // We'll store these indices as attributes on the ops.
+    // Track the additionalArgs index of semaphores for each RemoteLoadOp.
     SmallVector<std::pair<RemoteLoadOp, SmallVector<unsigned>>>
         loadToSemIndices;
 
+    // Insert create_local_semaphore ops before the generic op.
+    rewriter.setInsertionPoint(generic);
+
     for (RemoteLoadOp load : allMcastLoads) {
-      SmallVector<unsigned> semIndices;
+      // Record the index in additionalArgs before appending.
+      unsigned baseAdditionalIdx = generic.getAdditionalArgs().size();
+      SmallVector<unsigned> semIndices = {baseAdditionalIdx,
+                                          baseAdditionalIdx + 1};
 
-      // Add 2 semaphore arguments to each region.
-      for (Region &region : generic->getRegions()) {
-        if (region.empty()) {
-          continue;
-        }
-        Block &block = region.front();
+      // Create the two local semaphores (receiversReady, senderFinished).
+      auto recvReady = rewriter.create<CreateLocalSemaphoreOp>(
+          loc, semType, rewriter.getUI32IntegerAttr(0));
+      auto senderFinished = rewriter.create<CreateLocalSemaphoreOp>(
+          loc, semType, rewriter.getUI32IntegerAttr(0));
 
-        // Record the index before adding (same index in all regions).
-        if (semIndices.empty()) {
-          unsigned baseIdx = block.getNumArguments();
-          semIndices.push_back(baseIdx);     // receiversReady index
-          semIndices.push_back(baseIdx + 1); // senderFinished index
-        }
-
-        // Add the semaphore arguments.
-        block.addArgument(semType, loc);
-        block.addArgument(semType, loc);
-      }
+      // Append them to the generic op's additionalArgs.
+      // NormalizeThreadArgs will later add block args for these
+      // and replace uses of the CreateLocalSemaphoreOp results in regions.
+      generic.getAdditionalArgsMutable().append(
+          ValueRange{recvReady.getResult(), senderFinished.getResult()});
 
       loadToSemIndices.push_back({load, semIndices});
     }

--- a/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitUnifiedThread.cpp
@@ -70,7 +70,7 @@ public:
     IRMapping computeMapping;
     for (unsigned i = 0; i < originalBlock->getNumArguments(); ++i) {
       BlockArgument origArg = originalBlock->getArgument(i);
-      assert(mlir::isa<d2m::SemaphoreType>(origArg.getType()) &&
+      assert(mlir::isa<d2m::LocalSemaphoreType>(origArg.getType()) &&
              "region block arguments must be of semaphore type");
       auto dmArg =
           datamovementBlock->addArgument(origArg.getType(), generic.getLoc());

--- a/lib/Dialect/D2M/Utils/CBUtils.cpp
+++ b/lib/Dialect/D2M/Utils/CBUtils.cpp
@@ -95,7 +95,9 @@ Value getOrCreateCB(GenericOp generic, Region &region, unsigned operandIndex,
   rewriter.setInsertionPointToStart(&region.front());
   auto getCBOp = rewriter.create<GetCBOp>(
       generic.getLoc(), cbType, port,
-      rewriter.getI64IntegerAttr(static_cast<int64_t>(operandIndex)));
+      rewriter.getI64IntegerAttr(static_cast<int64_t>(operandIndex)),
+      ResolutionStageAttr::get(rewriter.getContext(),
+                               ResolutionStage::Compile));
 
   Value result = getCBOp.getResult();
   cache[key] = result;

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -237,6 +237,12 @@ void createTTIRToTTMetalMiddleendPipeline(
   pm.addPass(d2m::createD2MExpandDMAReadCompositeView());
   pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm());
 
+  // Normalize thread arguments: promote d2m.get_cb ops and any remaining
+  // additional arguments into the thread block argument list so that the
+  // D2MToTTKernel lowering pass can uniformly treat all arguments.
+  pm.addPass(d2m::createD2MNormalizeThreadArgs());
+
+  pm.addPass(createCanonicalizerPassWithOptions(options));
   createOptimizationPasses(pm, options);
 
   pm.addPass(d2m::createD2MGenericRegionsToFuncs());

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -552,12 +552,31 @@ bufferValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
                         ttcore::SystemDescAttr systemDesc, uint64_t address) {
   auto device = ttcore::lookupDevice(value.getParentBlock()->getParentOp());
   assert(device);
-  auto memrefType = mlir::cast<MemRefType>(value.getType());
 
-  std::optional<AffineMap> virtualGridInverseMapping;
-  if (auto createBufferOp = value.getDefiningOp<ttmetal::CreateBufferOp>()) {
-    if (auto mapAttr = createBufferOp.getVirtualGridInverseMappingAttr()) {
-      virtualGridInverseMapping = mapAttr.getValue();
+  if (mlir::isa<MemRefType>(value.getType())) {
+    auto memrefType = mlir::cast<MemRefType>(value.getType());
+
+    std::optional<AffineMap> virtualGridInverseMapping;
+    if (auto createBufferOp = value.getDefiningOp<ttmetal::CreateBufferOp>()) {
+      if (auto mapAttr = createBufferOp.getVirtualGridInverseMappingAttr()) {
+        virtualGridInverseMapping = mapAttr.getValue();
+      }
+
+      // Hoisted CB buffers carry CBLayoutAttr (shard-only shape).
+      // Reconstruct a full [grid..shard..] + ShardLayoutAttr memref type so
+      // we fall through to the existing memrefTypeToFlatbuffer path, which
+      // already handles N-D grids, CB configs, and worker grid overrides.
+      if (auto cbLayout =
+              mlir::dyn_cast<ttcore::CBLayoutAttr>(memrefType.getLayout())) {
+        auto shardShape = memrefType.getShape();
+        SmallVector<int64_t> fullShape(shardShape.size(), 1);
+        fullShape.append(shardShape.begin(), shardShape.end());
+        auto shardLayoutAttr = ttcore::ShardLayoutAttr::get(
+            shardShape, memrefType.getElementType(), cbLayout.getBuffers());
+        memrefType =
+            MemRefType::get(fullShape, memrefType.getElementType(),
+                            shardLayoutAttr, memrefType.getMemorySpace());
+      }
     }
 
     // Hoisted CB buffers carry CBLayoutAttr (per-core local shape).
@@ -575,39 +594,75 @@ bufferValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
           MemRefType::get(fullShape, memrefType.getElementType(),
                           shardLayoutAttr, memrefType.getMemorySpace());
     }
+    auto bufferDesc =
+        cache.getOrCreate(memrefType, memrefTypeToFlatbuffer, device,
+                          systemDesc, virtualGridInverseMapping);
+    return target::metal::CreateBufferRef(*cache.fbb, cache.nextGlobalId(),
+                                          address, bufferDesc);
+  } else {
+    auto elementType = value.getType();
+    ttcore::DataType dtype = ttcore::elementTypeToDataType(elementType);
+    target::Dim2d elementShape(1, 1);
+    std::vector<int32_t> shape = {};
+    std::vector<int32_t> hostStrides = {};
+    std::vector<int32_t> stride = {};
+    int32_t hostVolume = 0;
+    auto bufferDetail =
+        target::metal::CreateSystemBufferDirect(*cache.fbb, &stride).Union();
+
+    auto bufferDesc = target::metal::CreateBufferDescDirect(
+        *cache.fbb, &shape, &hostStrides, hostVolume,
+        toFlatbuffer(cache, dtype), &elementShape,
+        target::metal::BufferDetail::SystemBuffer, bufferDetail, nullptr);
+
+    return target::metal::CreateBufferRef(*cache.fbb, cache.nextGlobalId(),
+                                          address, bufferDesc);
   }
 
-  auto bufferDesc =
-      cache.getOrCreate(memrefType, memrefTypeToFlatbuffer, device, systemDesc,
-                        virtualGridInverseMapping);
-  return target::metal::CreateBufferRef(*cache.fbb, cache.nextGlobalId(),
-                                        address, bufferDesc);
+  llvm_unreachable("Unsupported value type for buffer reference");
 }
 
 static flatbuffers::Offset<target::metal::TensorRef>
 tensorValueToFlatbuffer(FlatbufferObjectCache &cache, Value value) {
   auto device = ttcore::lookupDevice(value.getParentBlock()->getParentOp());
   assert(device);
-  auto memref = mlir::cast<MemRefType>(value.getType());
 
-  Type elementType = memref.getElementType();
-  assert(!mlir::isa<ttcore::TileType>(elementType));
-  ttcore::DataType dtype = ttcore::elementTypeToDataType(elementType);
+  if (mlir::isa<MemRefType>(value.getType())) {
+    auto memref = mlir::cast<MemRefType>(value.getType());
+    Type elementType = memref.getElementType();
+    assert(!mlir::isa<ttcore::TileType>(elementType));
+    ttcore::DataType dtype = ttcore::elementTypeToDataType(elementType);
 
-  assert(!mlir::isa<ttcore::DeviceLayoutInterface>(memref.getLayout()));
-  std::vector<int32_t> shape =
-      ttmlir::utils::castContainer<std::vector<int32_t>>(memref.getShape());
-  std::vector<int32_t> meshShape;
-  int32_t elementSize = getElementSizeBytes(dtype);
-  std::uint64_t size =
-      ttmlir::utils::volume(mlir::ArrayRef<int32_t>(shape), elementSize);
+    assert(!mlir::isa<ttcore::DeviceLayoutInterface>(memref.getLayout()));
+    std::vector<int32_t> shape =
+        ttmlir::utils::castContainer<std::vector<int32_t>>(memref.getShape());
+    std::vector<int32_t> meshShape;
+    int32_t elementSize = getElementSizeBytes(dtype);
+    std::uint64_t size =
+        ttmlir::utils::volume(mlir::ArrayRef<int32_t>(shape), elementSize);
 
-  auto memoryDesc =
-      target::metal::CreateMemoryDesc(*cache.fbb, toFlatbuffer(cache, dtype));
-  auto layoutDesc = target::metal::CreateLayoutDesc(*cache.fbb, memoryDesc);
-  auto tensorDesc = target::metal::CreateTensorDescDirect(
-      *cache.fbb, &shape, &meshShape, layoutDesc);
-  return target::metal::CreateTensorRef(*cache.fbb, size, tensorDesc);
+    auto memoryDesc =
+        target::metal::CreateMemoryDesc(*cache.fbb, toFlatbuffer(cache, dtype));
+    auto layoutDesc = target::metal::CreateLayoutDesc(*cache.fbb, memoryDesc);
+    auto tensorDesc = target::metal::CreateTensorDescDirect(
+        *cache.fbb, &shape, &meshShape, layoutDesc);
+    return target::metal::CreateTensorRef(*cache.fbb, size, tensorDesc);
+  } else {
+    std::uint64_t size = 0;
+    std::vector<int32_t> shape = {};
+    std::vector<int32_t> meshShape = {};
+    Type elementType = value.getType();
+    ttcore::DataType dtype = ttcore::elementTypeToDataType(elementType);
+    auto memoryDesc =
+        target::metal::CreateMemoryDesc(*cache.fbb, toFlatbuffer(cache, dtype));
+    auto layoutDesc = target::metal::CreateLayoutDesc(*cache.fbb, memoryDesc);
+    auto tensorDesc = target::metal::CreateTensorDescDirect(
+        *cache.fbb, &shape, &meshShape, layoutDesc);
+
+    return target::metal::CreateTensorRef(*cache.fbb, size, tensorDesc);
+  }
+
+  llvm_unreachable("Unsupported value type for tensor reference");
 }
 
 static flatbuffers::Offset<target::metal::GlobalSemaphoreRef>
@@ -615,6 +670,13 @@ globalSemaphoreValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
                                  uint64_t address) {
   return target::metal::CreateGlobalSemaphoreRef(*cache.fbb,
                                                  cache.nextGlobalId(), address);
+}
+
+static flatbuffers::Offset<target::metal::LocalSemaphoreRef>
+localSemaphoreValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
+                                uint32_t initialValue) {
+  return target::metal::CreateLocalSemaphoreRef(
+      *cache.fbb, cache.nextGlobalId(), initialValue);
 }
 
 static flatbuffers::Offset<target::metal::KernelArg>
@@ -636,9 +698,11 @@ toFlatbuffer(FlatbufferObjectCache &cache, KernelArgAttr kernelArg) {
               .Union();
     break;
   }
-  case ttkernel::ArgType::Semaphore: {
-    argType = target::metal::KernelArgType::KernelArgSemaphore;
-    arg = target::metal::CreateKernelArgSemaphore(*cache.fbb).Union();
+  case ttkernel::ArgType::LocalSemaphore: {
+    argType = target::metal::KernelArgType::KernelArgLocalSemaphore;
+    arg = target::metal::CreateKernelArgLocalSemaphore(
+              *cache.fbb, kernelArg.getOperandIndex())
+              .Union();
     break;
   }
   case ttkernel::ArgType::NamedArgument: {
@@ -650,6 +714,13 @@ toFlatbuffer(FlatbufferObjectCache &cache, KernelArgAttr kernelArg) {
     argType = target::metal::KernelArgType::KernelArgGlobalSemaphore;
     arg = target::metal::CreateKernelArgGlobalSemaphore(
               *cache.fbb, kernelArg.getOperandIndex())
+              .Union();
+    break;
+  }
+  case ttkernel::ArgType::Scalar: {
+    argType = target::metal::KernelArgType::KernelArgScalar;
+    arg = target::metal::CreateKernelArgScalar(*cache.fbb,
+                                               kernelArg.getOperandIndex())
               .Union();
     break;
   }
@@ -795,6 +866,16 @@ memrefGlobalOpToFlatbufferByteVector(FlatbufferObjectCache &cache,
   return data;
 }
 
+// Returns true if `type` is one of the supported scalar underlying types:
+// bool (i1), ui8, si8, ui16, si16, ui32, si32, f16, bf16, f32, or index.
+static bool isSupportedScalarType(Type type) {
+  if (auto intTy = mlir::dyn_cast<IntegerType>(type)) {
+    unsigned w = intTy.getWidth();
+    return w == 1 || w == 8 || w == 16 || w == 32;
+  }
+  return mlir::isa<Float32Type, Float16Type, BFloat16Type, IndexType>(type);
+}
+
 std::shared_ptr<void> translateTTMetalToFlatbuffer(
     Operation *op,
     const std::unordered_map<std::string,
@@ -865,6 +946,11 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
 
     cqBuilder.inputs.reserve(entry.getBody().getArguments().size());
     for (auto &input : entry.getBody().getArguments()) {
+      if (!mlir::isa<MemRefType>(input.getType()) &&
+          !isSupportedScalarType(input.getType())) {
+        llvm::report_fatal_error(
+            "Only memref inputs are supported in entry functions");
+      }
       cqBuilder.inputs.push_back(
           cache.getOrCreate(input, bufferValueToFlatbuffer, systemDesc, 0));
       tensorInputs.push_back(tensorValueToFlatbuffer(cache, input));
@@ -893,6 +979,15 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
             argTypes.push_back(target::metal::ArgRef::GlobalSemaphoreRef);
             args.push_back(
                 cache.at<target::metal::GlobalSemaphoreRef>(arg).Union());
+          } else if (mlir::isa<LocalSemaphoreType>(arg.getType())) {
+            argTypes.push_back(target::metal::ArgRef::LocalSemaphoreRef);
+            args.push_back(
+                cache.at<target::metal::LocalSemaphoreRef>(arg).Union());
+          } else if (isSupportedScalarType(arg.getType())) {
+            argTypes.push_back(target::metal::ArgRef::BufferRef);
+            args.push_back(cache.at<target::metal::BufferRef>(arg).Union());
+          } else {
+            llvm::report_fatal_error("Unsupported kernel argument type");
           }
         }
 
@@ -1057,6 +1152,19 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
                 meshShardType, meshShardDirection,
                 cache.fbb->CreateVector<int64_t>(meshShardOp.getShardShape()),
                 cache.fbb->CreateVector<int64_t>(meshShardOp.getShardDims())),
+            op);
+      } else if (auto createLocalSemaphoreOp =
+                     dyn_cast_if_present<tt::ttmetal::CreateLocalSemaphoreOp>(
+                         op);
+                 createLocalSemaphoreOp) {
+        uint32_t initialValue = createLocalSemaphoreOp.getInitialValue()
+                                    ? *createLocalSemaphoreOp.getInitialValue()
+                                    : 0;
+        cqBuilder.appendCommand(
+            target::metal::CreateCreateLocalSemaphoreCommand(
+                fbb, cache.getOrCreate(createLocalSemaphoreOp.getResult(),
+                                       localSemaphoreValueToFlatbuffer,
+                                       initialValue)),
             op);
       } else if (auto createGlobalSemaphoreOp =
                      dyn_cast_if_present<tt::ttmetal::CreateGlobalSemaphoreOp>(

--- a/python/D2MModule.cpp
+++ b/python/D2MModule.cpp
@@ -35,9 +35,9 @@ void populateD2MModule(nb::module_ &m) {
                      threadType));
       });
 
-  tt_type_class<tt::d2m::SemaphoreType>(m, "SemaphoreType")
+  tt_type_class<tt::d2m::LocalSemaphoreType>(m, "LocalSemaphoreType")
       .def_static("get", [](MlirContext ctx) {
-        return wrap(tt::d2m::SemaphoreType::get(unwrap(ctx)));
+        return wrap(tt::d2m::LocalSemaphoreType::get(unwrap(ctx)));
       });
 
   tt_type_class<tt::d2m::CBType>(m, "CBType")

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -22,8 +22,8 @@ void populateTTKernelModule(nb::module_ &m) {
         return mlir::cast<tt::ttkernel::CBType>(unwrap(ty));
       });
 
-  tt_type_class<tt::ttkernel::SemaphoreType>(m, "SemaphoreType")
-      .def_static("get", &ttmlirTTKernelSemaphoreTypeGet);
+  tt_type_class<tt::ttkernel::LocalSemaphoreType>(m, "LocalSemaphoreType")
+      .def_static("get", &ttmlirTTKernelLocalSemaphoreTypeGet);
 
   tt_type_class<tt::ttkernel::NocAddrType>(m, "NocAddrType")
       .def_static("get", &ttmlirTTKernelNocAddrTypeGet);

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -24,34 +24,59 @@ template <bool isCompileTime>
 std::vector<std::uint32_t> processKernelArgs(
     const flatbuffers::Vector<flatbuffers::Offset<target::metal::KernelArg>>
         *args,
-    const flatbuffers::Vector<target::metal::ArgRef> *argRefsType,
     const flatbuffers::Vector<flatbuffers::Offset<void>> *argRefs,
+    const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::CBRef>>
+        *cbs,
+    const std::unordered_map<std::uint32_t, Tensor> &hostBuffers,
     const std::unordered_map<
         std::uint32_t, std::shared_ptr<distributed::MeshBuffer>> &meshBuffers,
     const std::unordered_map<std::uint32_t, tt_metal::GlobalSemaphore>
-        &global_semaphores_cache,
-    const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::CBRef>>
-        *cbs,
+        &globalSemaphoresCache,
+    const std::unordered_map<std::uint32_t, std::uint32_t>
+        &localSemaphoresCache,
     const DeviceAddressValidator &deviceAddressValidator,
     std::function<std::uint32_t(std::uint32_t)> createSemaphoreFn) {
+
+  // Goal of this function is to convert the kernel args into a vector of
+  // uint32_t. This vector will be passed to the kernel at runtime.
   std::vector<std::uint32_t> argsVec;
   if (args == nullptr || args->size() == 0) {
     return argsVec;
   }
+
+  // Iterate through all args and process them based on their type.
   argsVec.reserve(args->size());
   for (const auto *kernelArg : *args) {
+
     switch (kernelArg->arg_type()) {
+
+    // For CB arg, we want the port number.
     case target::metal::KernelArgType::KernelArgCBPort: {
       const auto *arg = kernelArg->arg_as_KernelArgCBPort();
-      LOG_ASSERT(arg->operand_idx() < cbs->size(), "invalid operand ",
-                 arg->operand_idx());
-      argsVec.push_back(cbs->Get(arg->operand_idx())->port());
+      auto operand_idx = arg->operand_idx();
+
+      // CB operand index can be:
+      // -1: signify scratchpad CB
+      // >=0: index into the enqueue program command cb list
+      LOG_ASSERT(operand_idx >= -1,
+                 "Invalid operand index for CB arg: ", operand_idx);
+
+      if (operand_idx == -1) {
+        // We need to update this to support scratch pad CBs.
+        LOG_ASSERT(false, "Runtime currently does not support scratchpad CBs.");
+      } else {
+        LOG_ASSERT(operand_idx < static_cast<int32_t>(cbs->size()),
+                   "Invalid operand index: ", operand_idx);
+        argsVec.push_back(cbs->Get(operand_idx)->port());
+      }
+
       break;
     }
+
+    // For buffer address arg, we want the device address. We also need to
+    // validate that the buffer is still alive.
     case target::metal::KernelArgType::KernelArgBufferAddress: {
       const auto *arg = kernelArg->arg_as_KernelArgBufferAddress();
-      LOG_ASSERT(argRefsType->Get(arg->operand_idx()) ==
-                 target::metal::ArgRef::BufferRef);
       const target::metal::BufferRef *buffer =
           reinterpret_cast<const target::metal::BufferRef *>(
               argRefs->Get(arg->operand_idx()));
@@ -69,37 +94,82 @@ std::vector<std::uint32_t> processKernelArgs(
                                                metalBuffer->buffer_type()));
       break;
     }
-    case target::metal::KernelArgType::KernelArgSemaphore: {
+
+    // For local semaphore arg, look up the LocalSemaphoreRef via operand_idx to
+    // get the initial_value, then create a new semaphore with that value.
+    case target::metal::KernelArgType::KernelArgLocalSemaphore: {
       LOG_ASSERT(createSemaphoreFn, "createSemaphoreFn is not set");
-      const auto *arg = kernelArg->arg_as_KernelArgSemaphore();
-      argsVec.push_back(createSemaphoreFn(arg->initial_value()));
+      const auto *arg = kernelArg->arg_as_KernelArgLocalSemaphore();
+      const tt::target::metal::LocalSemaphoreRef *local_sem_ref =
+          reinterpret_cast<const target::metal::LocalSemaphoreRef *>(
+              argRefs->Get(arg->operand_idx()));
+      LOG_ASSERT(localSemaphoresCache.find(local_sem_ref->global_id()) !=
+                     localSemaphoresCache.end(),
+                 "Local semaphore id referenced by rt args is no longer alive "
+                 "or was never created ",
+                 logger::Buffer(local_sem_ref->global_id()));
+      argsVec.push_back(createSemaphoreFn(
+          localSemaphoresCache.at(local_sem_ref->global_id())));
+
       break;
     }
+
+    // For named argument, we just need to pass the value specified in the arg.
     case target::metal::KernelArgType::KernelArgNamedArgument: {
       const auto *arg = kernelArg->arg_as_KernelArgNamedArgument();
       argsVec.push_back(arg->value());
       break;
     }
+
+    // For global semaphore arg, we need to look up the global semaphore cache
+    // with the global id specified in the arg, validate that it's still alive,
+    // and pass its address to the kernel.
     case target::metal::KernelArgType::KernelArgGlobalSemaphore: {
       const auto *arg = kernelArg->arg_as_KernelArgGlobalSemaphore();
-      LOG_ASSERT(argRefsType->Get(arg->operand_idx()) ==
-                 target::metal::ArgRef::GlobalSemaphoreRef);
       const tt::target::metal::GlobalSemaphoreRef *global_semaphore_operand =
           reinterpret_cast<const target::metal::GlobalSemaphoreRef *>(
               argRefs->Get(arg->operand_idx()));
       LOG_ASSERT(
-          global_semaphores_cache.find(global_semaphore_operand->global_id()) !=
-              global_semaphores_cache.end(),
+          globalSemaphoresCache.find(global_semaphore_operand->global_id()) !=
+              globalSemaphoresCache.end(),
           "Global semaphore id referenced by rt args is no longer alive or was "
           "never created ",
           logger::Buffer(global_semaphore_operand->global_id()));
 
       argsVec.push_back(deviceAddressValidator(
-          global_semaphores_cache.at(global_semaphore_operand->global_id())
+          globalSemaphoresCache.at(global_semaphore_operand->global_id())
               .address(),
           target::BufferType::L1));
       break;
     }
+
+    // For scalar arg, we look up the scalar value from the global index and
+    // pass it to the kernel.
+    case target::metal::KernelArgType::KernelArgScalar: {
+      const auto *arg = kernelArg->arg_as_KernelArgScalar();
+      const tt::target::metal::BufferRef *buffer =
+          reinterpret_cast<const target::metal::BufferRef *>(
+              argRefs->Get(arg->operand_idx()));
+      LOG_ASSERT(hostBuffers.find(buffer->global_id()) != hostBuffers.end(),
+                 "Scalar id is no longer alive or was never created ",
+                 logger::Buffer(buffer->global_id()));
+      const Tensor &scalarTensor = hostBuffers.at(buffer->global_id());
+      LOG_ASSERT(scalarTensor.data != nullptr,
+                 "Scalar tensor data is null for global id ",
+                 buffer->global_id());
+
+      // Get the scalar value and cast it to uint32_t. We also need to validate
+      // that the scalar value can fit into uint32_t.
+      uint32_t scalarValue = 0;
+      std::memcpy(&scalarValue, scalarTensor.data.get(), sizeof(uint32_t));
+      LOG_ASSERT(scalarValue <= std::numeric_limits<uint32_t>::max(),
+                 "Scalar value ", scalarValue,
+                 " cannot fit into uint32_t for global id ",
+                 buffer->global_id());
+      argsVec.push_back(scalarValue);
+      break;
+    }
+
     case target::metal::KernelArgType::NONE:
       LOG_FATAL("Unsupported runtime arg type");
     }

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -31,6 +31,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <iostream>
+
 namespace tt::runtime::ttmetal {
 
 namespace target = ::tt::target;
@@ -70,20 +72,44 @@ private:
   void execute(const target::metal::MeshShardCommand *command);
   void execute(const target::metal::CreateGlobalSemaphoreCommand *command);
   void execute(const target::metal::ResetGlobalSemaphoreCommand *command);
+  void execute(const target::metal::CreateLocalSemaphoreCommand *command);
 
   std::uint64_t getUniqueProgramRuntimeId() { return nextProgramRuntimeId++; }
 
 private:
+  // Reference to the device.
   distributed::MeshDevice *meshDevice;
+
+  // Events for synchronizing before executing the first command.
   std::vector<std::shared_ptr<distributed::MeshEvent>> initMeshEvents;
+
+  // Buffers that live on the host. Indexed by global_id.
+  std::unordered_map<std::uint32_t, Tensor> hostBuffers;
+
+  // Buffers that live on the mesh. Indexed by global_id. They are created by
+  // ttmetal.create_buffer().
   std::unordered_map<std::uint32_t, std::shared_ptr<distributed::MeshBuffer>>
       meshBuffers;
+
+  // Global semaphores. Indexed by global_id. They are created by
+  // ttmetal.create_global_semaphore().
   std::unordered_map<std::uint32_t, tt_metal::GlobalSemaphore>
       global_semaphores;
-  std::unordered_map<std::uint32_t, Tensor> hostBuffers;
+
+  // Local semaphores. Indexed by global_id. We only store their initial value
+  // here and lookup during their creation.
+  std::unordered_map<std::uint32_t, std::uint32_t> local_semaphores;
+
+  // Mesh events created by EnqueueRecordEventCommand. Used by
+  // EnqueueWaitForEventCommand and EventSynchronizeCommand. Indexed by
+  // global_id.
   std::unordered_map<std::uint32_t, std::shared_ptr<distributed::MeshEvent>>
       meshEvents;
+
+  // Output tensors to be returned.
   std::vector<Tensor> outputs;
+
+  // Other state data structures for executing commands.
   distributed::MeshCommandQueue *mcq;
   bool blockingCQ;
   const char *currentProgramName;
@@ -102,51 +128,60 @@ MCQExecutor::MCQExecutor(
     : meshDevice(meshDevice), blockingCQ(blockingCQ),
       deviceAddressValidator(meshDevice->get_devices().at(0)),
       dylibManager(std::move(dylibManager)) {
-  initMeshEvents.reserve(inputs.size());
 
+  // Walk through the program inputs and populate hostBuffers and meshBuffers.
+  // We need to keep track of them because later commands may reference them by
+  // their global_id.
   std::uint32_t inputIndex = 0;
   for (const Tensor &input : inputs) {
     const target::metal::BufferRef *ref = programInputs->Get(inputIndex++);
     std::visit(utils::overloaded{
                    [&](const TensorDesc &) {
                      auto [_, inserted] =
-                         hostBuffers.try_emplace(ref->global_id(), input);
+                         this->hostBuffers.try_emplace(ref->global_id(), input);
                      LOG_ASSERT(inserted);
+                     std::cout << "tensordesc" << std::endl;
                    },
                    [&](const HostBuffer &hostBuffer) {
                      auto [_, inserted] =
-                         hostBuffers.try_emplace(ref->global_id(), input);
+                         this->hostBuffers.try_emplace(ref->global_id(), input);
                      LOG_ASSERT(inserted);
+                     std::cout << "host buffer" << std::endl;
                    },
                    [&](const DistributedHostBuffer &distributedHostBuffer) {
                      auto [_, inserted] =
-                         hostBuffers.try_emplace(ref->global_id(), input);
+                         this->hostBuffers.try_emplace(ref->global_id(), input);
                      LOG_ASSERT(inserted);
+                     std::cout << "distributed host buffer" << std::endl;
                    },
                    [&](const MeshBuffer &meshBuffer) {
-                     auto [_, inserted] =
-                         meshBuffers.try_emplace(ref->global_id(), meshBuffer);
+                     auto [_, inserted] = this->meshBuffers.try_emplace(
+                         ref->global_id(), meshBuffer);
                      LOG_ASSERT(inserted);
+                     std::cout << "mesh buffer" << std::endl;
                    },
                },
                input.as<MetalTensor>(DeviceRuntime::TTMetal));
 
+    // If the input has an associated mesh event, we need to synchronize on it
+    // before executing any command.
+    this->initMeshEvents.reserve(inputs.size());
     auto meshEvent =
         input.event.asSharedPtr<distributed::MeshEvent>(DeviceRuntime::TTMetal);
     if (meshEvent) {
-      initMeshEvents.push_back(meshEvent);
+      this->initMeshEvents.push_back(meshEvent);
     }
   }
 }
 
 void MCQExecutor::execute(const target::metal::CommandQueue *commandQueue) {
-  currentProgramName = commandQueue->name()->c_str();
-  mcq = &meshDevice->mesh_command_queue(commandQueue->queue_id());
+  this->currentProgramName = commandQueue->name()->c_str();
+  this->mcq = &meshDevice->mesh_command_queue(commandQueue->queue_id());
 
   for (const auto &mesh_event : initMeshEvents) {
     distributed::EventSynchronize(*mesh_event);
   }
-  initMeshEvents.clear();
+  this->initMeshEvents.clear();
 
   for (const target::metal::Command *command : *commandQueue->commands()) {
     LOG_TRACE(logger::LogRuntimeTTMetalCommand,
@@ -223,6 +258,10 @@ void MCQExecutor::execute(const target::metal::Command *command) {
     execute(command->type_as_ResetGlobalSemaphoreCommand());
     break;
   }
+  case target::metal::CommandType::CreateLocalSemaphoreCommand: {
+    execute(command->type_as_CreateLocalSemaphoreCommand());
+    break;
+  }
   case target::metal::CommandType::NONE: {
     LOG_FATAL("Unsupported CommandType::NONE");
     break;
@@ -231,10 +270,12 @@ void MCQExecutor::execute(const target::metal::Command *command) {
 }
 
 void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
+  // Get buffer description from the command.
   LOG_ASSERT(command->dst()->address() == 0);
   const auto *bufferDesc = command->dst()->desc();
   LOG_ASSERT(bufferDesc->shape()->size() > 0);
 
+  // Create a TensorDesc from the buffer description.
   TensorDesc desc = createTensorDescFromBufferDesc(bufferDesc);
   const size_t size = desc.sizeBytes();
 
@@ -243,14 +284,19 @@ void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
   if (!data) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");
   }
+
+  // If the command has initial data, copy it to the allocated memory. We assume
+  // the size of the initial data matches the buffer size.
   if (command->data() != nullptr) {
     assert(command->data()->size() == size);
     std::memcpy(data.get(), command->data()->data(), size);
   }
 
+  // Add the allocated buffer to hostBuffers. Use global id as the key so that
+  // later commands can reference it.
   auto meshShape = meshDevice->shape();
   if (meshShape.mesh_size() == 1 || !bufferDesc->mesh()) {
-    auto [_, inserted] = hostBuffers.try_emplace(
+    auto [_, inserted] = this->hostBuffers.try_emplace(
         command->dst()->global_id(),
         std::static_pointer_cast<void>(std::make_shared<MetalTensor>(desc)),
         data, DeviceRuntime::TTMetal);
@@ -266,7 +312,7 @@ void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
       distributedHostBufferPtr->emplace_shard(
           coord, [&buffer = *hostBuffer]() { return buffer; });
     }
-    auto [_, inserted] = hostBuffers.try_emplace(
+    auto [_, inserted] = this->hostBuffers.try_emplace(
         command->dst()->global_id(),
         std::static_pointer_cast<void>(
             std::make_shared<MetalTensor>(distributedHostBufferPtr)),
@@ -277,25 +323,29 @@ void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
 
 void MCQExecutor::execute(const target::metal::ReturnCommand *command) {
   auto meshEvent = std::make_shared<distributed::MeshEvent>(
-      mcq->enqueue_record_event_to_host());
+      this->mcq->enqueue_record_event_to_host());
 
-  LOG_ASSERT(outputs.empty(),
+  LOG_ASSERT(this->outputs.empty(),
              "Unexpected outputs, multiple returns not supported");
-  outputs.reserve(command->results()->size());
+  this->outputs.reserve(command->results()->size());
+
+  // For each result, check if it's a mesh buffer or a host buffer, and
+  // construct the corresponding output Tensor. We identify them by looking up
+  // their global_id in meshBuffers and hostBuffers.
   for (const auto *result : *command->results()) {
-    auto meshBufferIter = meshBuffers.find(result->global_id());
+    auto meshBufferIter = this->meshBuffers.find(result->global_id());
     bool meshBufferFound = meshBufferIter != meshBuffers.end();
-    auto hostBufferIter = hostBuffers.find(result->global_id());
+    auto hostBufferIter = this->hostBuffers.find(result->global_id());
     bool hostBufferFound = hostBufferIter != hostBuffers.end();
     LOG_ASSERT(meshBufferFound != hostBufferFound);
     if (meshBufferFound) {
-      outputs.emplace_back(
+      this->outputs.emplace_back(
           std::static_pointer_cast<void>(meshBufferIter->second), nullptr,
           DeviceRuntime::TTMetal, std::static_pointer_cast<void>(meshEvent));
     } else {
-      outputs.emplace_back(hostBufferIter->second);
-      outputs.back().event = Event(std::static_pointer_cast<void>(meshEvent),
-                                   DeviceRuntime::TTMetal);
+      this->outputs.emplace_back(hostBufferIter->second);
+      this->outputs.back().event = Event(
+          std::static_pointer_cast<void>(meshEvent), DeviceRuntime::TTMetal);
     }
   }
 }
@@ -303,29 +353,39 @@ void MCQExecutor::execute(const target::metal::ReturnCommand *command) {
 void MCQExecutor::execute(
     const target::metal::CreateGlobalSemaphoreCommand *command) {
   ZoneScopedN("CreateGlobalSemaphoreCommand");
-  LOG_ASSERT(global_semaphores.find(command->ref()->global_id()) ==
-                 global_semaphores.end(),
+  LOG_ASSERT(this->global_semaphores.find(command->ref()->global_id()) ==
+                 this->global_semaphores.end(),
              "Global semaphore with id ", command->ref()->global_id(),
              " already exists.");
   auto global_semaphore = tt::tt_metal::experimental::CreateGlobalSemaphore(
-      meshDevice, common::toCoreRangeSet(command->core_range_set()),
+      this->meshDevice, common::toCoreRangeSet(command->core_range_set()),
       command->initial_value(), tt_metal::BufferType::L1,
       deviceAddressValidator(command->ref()->address(),
                              target::BufferType::L1));
   LOG_ASSERT(global_semaphore.address() == command->ref()->address());
-  global_semaphores.emplace(command->ref()->global_id(),
-                            std::move(global_semaphore));
+  this->global_semaphores.emplace(command->ref()->global_id(),
+                                  std::move(global_semaphore));
 }
 
 void MCQExecutor::execute(
     const target::metal::ResetGlobalSemaphoreCommand *command) {
   ZoneScopedN("ResetGlobalSemaphoreCommand");
-  LOG_ASSERT(global_semaphores.find(command->ref()->global_id()) !=
-                 global_semaphores.end(),
+  LOG_ASSERT(this->global_semaphores.find(command->ref()->global_id()) !=
+                 this->global_semaphores.end(),
              "Global semaphore with id ", command->ref()->global_id(),
              " does not exist.");
-  global_semaphores.at(command->ref()->global_id())
+  this->global_semaphores.at(command->ref()->global_id())
       .reset_semaphore_value(command->value());
+}
+
+void MCQExecutor::execute(
+    const target::metal::CreateLocalSemaphoreCommand *command) {
+  LOG_ASSERT(this->local_semaphores.find(command->ref()->global_id()) ==
+                 this->local_semaphores.end(),
+             "Local semaphore with id ", command->ref()->global_id(),
+             " already exists.");
+  this->local_semaphores.emplace(command->ref()->global_id(),
+                                 command->ref()->initial_value());
 }
 
 void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
@@ -336,8 +396,16 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
 
   auto meshWorkload = distributed::MeshWorkload();
   auto deviceRange = distributed::MeshCoordinateRange(meshDevice->shape());
+
+  // Iterate through all devices. For each device:
+  // 1. Create a tt_metal::Program.
+  // 2. Create kernels for each program.
+  // 3. Create circular buffers for each CBRef in the program.
+  // 4. Add fabric config args to kernels that need them.
   for (auto deviceCoord : deviceRange) {
     tt_metal::Program program = tt_metal::CreateProgram();
+
+    // Iterate through all kernels in program.
     for (const target::metal::KernelConfig *kernelConfig :
          *command->program()->kernels()) {
       const target::metal::KernelSource *kernelSource =
@@ -348,25 +416,37 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
 
       tt::tt_metal::CoreRangeSet coreRangeSet =
           common::toCoreRangeSet(kernelConfig->core_range_set());
-
       auto createSemaphore = [&](std::uint32_t initialValue) -> std::uint32_t {
         return tt_metal::CreateSemaphore(program, coreRangeSet, initialValue);
       };
 
+      // Generate compile time args.
+      std::vector<uint32_t> compileArgs = processCompileArgs(
+          kernelConfig->args()->ct_args(), command->arg_refs(), command->cbs(),
+          this->hostBuffers, this->meshBuffers, this->global_semaphores,
+          this->local_semaphores, this->deviceAddressValidator,
+          createSemaphore);
+
+      // Generate kernel config.
+      auto generatedKernelConfig =
+          createKernelConfig(kernelConfig, compileArgs);
+
+      // Generate kernel handle.
       tt_metal::KernelHandle handle = createKernel(
-          program, kernelSourceString, coreRangeSet,
-          createKernelConfig(kernelConfig, command->arg_refs_type(),
-                             command->arg_refs(), meshBuffers,
-                             global_semaphores, command->cbs(),
-                             deviceAddressValidator, createSemaphore),
-          currentProgramName, debugInfo, kernelConfig->debug_info()->c_str(),
+          program, kernelSourceString, coreRangeSet, generatedKernelConfig,
+          this->currentProgramName, debugInfo,
+          kernelConfig->debug_info()->c_str(),
           kernelConfig->loc() ? kernelConfig->loc()->c_str() : nullptr);
 
+      // Generate runtime args.
       std::vector<uint32_t> rtArgsVec = processRuntimeArgs(
-          kernelConfig->args()->rt_args(), command->arg_refs_type(),
-          command->arg_refs(), meshBuffers, global_semaphores, command->cbs(),
-          deviceAddressValidator, createSemaphore);
+          kernelConfig->args()->rt_args(), command->arg_refs(), command->cbs(),
+          this->hostBuffers, this->meshBuffers, this->global_semaphores,
+          this->local_semaphores, this->deviceAddressValidator,
+          createSemaphore);
 
+      // If the kernel has fabric connection config and it's NocConfig, we need
+      // to append fabric config args and set them for each core.
       if (command->fabric_connection_config() &&
           kernelConfig->type_type() ==
               target::metal::KernelConfigType::NocConfig &&
@@ -374,7 +454,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
               kernelConfig->type_as_NocConfig()->noc_index()) {
         auto fabricConfigArgs = common::appendFabricConfigArgs(
             command->fabric_connection_config(), kernelConfig, program, handle,
-            deviceCoord, meshDevice, rtArgsVec, coreRangeSet);
+            deviceCoord, this->meshDevice, rtArgsVec, coreRangeSet);
 
         for (auto core : tt::tt_metal::corerange_to_cores(coreRangeSet)) {
           tt_metal::SetRuntimeArgs(program, handle, core,
@@ -385,6 +465,8 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       }
     }
 
+    // Iterate through all CBRefs in program and create circular buffers for
+    // them.
     for (const target::metal::CBRef *cbRef : *command->cbs()) {
       const target::metal::BufferDesc *bufferDesc = cbRef->buffer_ref()->desc();
       LOG_ASSERT(bufferDesc->buffer_detail_type() ==
@@ -397,7 +479,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
               !metalBuffer->circular_buffer_config()) &&
              "Interleaved buffer configs should not have a CB config");
 
-      // skip init if CircularBufferConfig is not present
+      // Skip init if CircularBufferConfig is not present.
       if (!metalBuffer->circular_buffer_config()) {
         continue;
       }
@@ -405,12 +487,12 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       tt::tt_metal::CoreRangeSet coreRangeSet = common::toCoreRangeSet(
           metalBuffer->circular_buffer_config()->core_range_set());
       tt_metal::CircularBufferConfig config =
-          createCircularBufferConfig(cbRef, meshBuffers);
+          createCircularBufferConfig(cbRef, this->meshBuffers);
       tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
     }
 
-    // fabric connected cores all have separate runtime args so we add a
-    // separate program for each device
+    // Fabric connected cores all have separate runtime args so we add a
+    // separate program for each device.
     if (command->fabric_connection_config()) {
       meshWorkload.add_program(distributed::MeshCoordinateRange(deviceCoord),
                                std::move(program));
@@ -434,7 +516,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
     }
   }
 
-  distributed::EnqueueMeshWorkload(*mcq, meshWorkload, blockingCQ);
+  distributed::EnqueueMeshWorkload(*this->mcq, meshWorkload, this->blockingCQ);
 
   if (perf::Env::get().enablePerfTrace) {
     ::tt::tt_metal::ReadMeshDeviceProfilerResults(*meshDevice);
@@ -445,67 +527,69 @@ void MCQExecutor::execute(
     const target::metal::EnqueueWriteBufferCommand *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
 
-  auto input = hostBuffers.at(command->src()->global_id());
-  auto meshBuffer = meshBuffers.at(command->dst()->global_id());
+  auto input = this->hostBuffers.at(command->src()->global_id());
+  auto meshBuffer = this->meshBuffers.at(command->dst()->global_id());
   checkHostTensorSizeMatchWithMeshBufferSize(input, meshBuffer);
-  writeHostTensorToMeshBuffer(mcq, input, meshBuffer, blockingCQ);
+  writeHostTensorToMeshBuffer(this->mcq, input, meshBuffer, this->blockingCQ);
 }
 
 void MCQExecutor::execute(
     const target::metal::EnqueueReadBufferCommand *command) {
   ZoneScopedN("EnqueueReadBufferCommand");
 
-  auto meshBuffer = meshBuffers.at(command->src()->global_id());
-  auto output = hostBuffers.at(command->dst()->global_id());
+  auto meshBuffer = this->meshBuffers.at(command->src()->global_id());
+  auto output = this->hostBuffers.at(command->dst()->global_id());
   checkHostTensorSizeMatchWithMeshBufferSize(output, meshBuffer);
-  readHostTensorFromMeshBuffer(mcq, meshBuffer, output, blockingCQ);
+  readHostTensorFromMeshBuffer(this->mcq, meshBuffer, output, this->blockingCQ);
 }
 
 void MCQExecutor::execute(const target::metal::CreateBufferCommand *command) {
   ZoneScopedN("CreateBufferCommand");
-  if (meshBuffers.find(command->ref()->global_id()) == meshBuffers.end()) {
-    meshBuffers[command->ref()->global_id()] = createMeshBufferFromBufferRef(
-        meshDevice, command->ref(), deviceAddressValidator);
+  if (this->meshBuffers.find(command->ref()->global_id()) ==
+      this->meshBuffers.end()) {
+    this->meshBuffers[command->ref()->global_id()] =
+        createMeshBufferFromBufferRef(this->meshDevice, command->ref(),
+                                      this->deviceAddressValidator);
   }
 }
 
 void MCQExecutor::execute(
     const target::metal::DeallocateBufferCommand *command) {
   ZoneScopedN("DeallocateBufferCommand");
-  auto meshBufferIter = meshBuffers.find(command->ref()->global_id());
-  LOG_ASSERT(meshBufferIter != meshBuffers.end(), "Buffer not allocated");
+  auto meshBufferIter = this->meshBuffers.find(command->ref()->global_id());
+  LOG_ASSERT(meshBufferIter != this->meshBuffers.end(), "Buffer not allocated");
   LOG_ASSERT(meshBufferIter->second != nullptr, "Buffer already deallocated");
   auto meshBuffer = meshBufferIter->second;
   meshBuffer->deallocate();
-  meshBuffers.erase(meshBufferIter);
+  this->meshBuffers.erase(meshBufferIter);
 }
 
 void MCQExecutor::execute(
     const target::metal::EnqueueRecordEventCommand *command) {
   ZoneScopedN("EnqueueRecordEventCommand");
-  meshEvents[command->ref()->global_id()] =
+  this->meshEvents[command->ref()->global_id()] =
       std::make_shared<distributed::MeshEvent>(mcq->enqueue_record_event());
 }
 
 void MCQExecutor::execute(
     const target::metal::EnqueueWaitForEventCommand *command) {
   ZoneScopedN("EnqueueWaitForEventCommand");
-  auto mesh_event = meshEvents.at(command->ref()->global_id());
-  mcq->enqueue_wait_for_event(*mesh_event);
+  auto mesh_event = this->meshEvents.at(command->ref()->global_id());
+  this->mcq->enqueue_wait_for_event(*mesh_event);
 }
 
 void MCQExecutor::execute(
     const target::metal::EventSynchronizeCommand *command) {
   ZoneScopedN("EventSynchronizeCommand");
-  auto mesh_event = meshEvents.at(command->ref()->global_id());
+  auto mesh_event = this->meshEvents.at(command->ref()->global_id());
   distributed::EventSynchronize(*mesh_event);
 }
 
 void MCQExecutor::execute(const target::metal::MemrefCopyCommand *command) {
-  auto srcIt = hostBuffers.find(command->src()->global_id());
-  LOG_ASSERT(srcIt != hostBuffers.end());
-  auto dstIt = hostBuffers.find(command->dst()->global_id());
-  LOG_ASSERT(dstIt != hostBuffers.end());
+  auto srcIt = this->hostBuffers.find(command->src()->global_id());
+  LOG_ASSERT(srcIt != this->hostBuffers.end());
+  auto dstIt = this->hostBuffers.find(command->dst()->global_id());
+  LOG_ASSERT(dstIt != this->hostBuffers.end());
   ttmetal::memcpy(
       dstIt->second, createTensorDescFromBufferDesc(command->dst()->desc()),
       srcIt->second, createTensorDescFromBufferDesc(command->src()->desc()));
@@ -553,7 +637,7 @@ void MCQExecutor::execute(const target::metal::CpuCommand *command) {
 
 void MCQExecutor::execute(const target::metal::FinishCommand *) {
   ZoneScopedN("FinishCommand");
-  distributed::Finish(*mcq);
+  distributed::Finish(*this->mcq);
 }
 
 void MCQExecutor::execute(const target::metal::MeshShardCommand *command) {

--- a/runtime/lib/ttmetal/kernels.cpp
+++ b/runtime/lib/ttmetal/kernels.cpp
@@ -106,21 +106,9 @@ tt_metal::KernelHandle createKernel(
 }
 
 std::variant<tt_metal::DataMovementConfig, tt_metal::ComputeConfig>
-createKernelConfig(
-    const target::metal::KernelConfig *kernelConfig,
-    const flatbuffers::Vector<target::metal::ArgRef> *argRefsType,
-    const flatbuffers::Vector<flatbuffers::Offset<void>> *argRefs,
-    const std::unordered_map<
-        std::uint32_t, std::shared_ptr<distributed::MeshBuffer>> &meshBuffers,
-    const std::unordered_map<std::uint32_t, tt_metal::GlobalSemaphore>
-        &global_semaphores_cache,
-    const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::CBRef>>
-        *cbs,
-    const DeviceAddressValidator &deviceAddressValidator,
-    std::function<std::uint32_t(std::uint32_t)> createSemaphoreFn) {
-  std::vector<uint32_t> compileArgs = processCompileArgs(
-      kernelConfig->args()->ct_args(), argRefsType, argRefs, meshBuffers,
-      global_semaphores_cache, cbs, deviceAddressValidator, createSemaphoreFn);
+createKernelConfig(const target::metal::KernelConfig *kernelConfig,
+                   std::vector<uint32_t> compileArgs) {
+
   switch (kernelConfig->type_type()) {
   case target::metal::KernelConfigType::NocConfig: {
     switch (kernelConfig->type_as_NocConfig()->noc_index()) {
@@ -132,6 +120,7 @@ createKernelConfig(
     }
     }
   }
+
   case target::metal::KernelConfigType::EthernetConfig: {
     // EthernetConfig has been removed from Metal public API (commit cfc4c40).
     // Ethernet functionality should now use fabric APIs instead.

--- a/runtime/lib/ttmetal/kernels.h
+++ b/runtime/lib/ttmetal/kernels.h
@@ -36,18 +36,8 @@ tt_metal::KernelHandle createKernel(
     const char *kernelDebugInfo, const char *kernelLoc);
 
 std::variant<tt_metal::DataMovementConfig, tt_metal::ComputeConfig>
-createKernelConfig(
-    const target::metal::KernelConfig *kernelConfig,
-    const flatbuffers::Vector<target::metal::ArgRef> *argRefsType,
-    const flatbuffers::Vector<flatbuffers::Offset<void>> *argRefs,
-    const std::unordered_map<
-        std::uint32_t, std::shared_ptr<distributed::MeshBuffer>> &meshBuffers,
-    const std::unordered_map<std::uint32_t, tt_metal::GlobalSemaphore>
-        &global_semaphores_cache,
-    const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::CBRef>>
-        *cbs,
-    const DeviceAddressValidator &deviceAddressValidator,
-    std::function<std::uint32_t(std::uint32_t)> createSemaphoreFn);
+createKernelConfig(const target::metal::KernelConfig *kernelConfig,
+                   std::vector<uint32_t> compileArgs);
 
 } // namespace tt::runtime::ttmetal
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -165,6 +165,7 @@ def test_div(shape: Shape, dtype: torch.dtype, target: str, request, device):
         **get_request_kwargs(request),
         target=target,
         device=device,
+        print_ir=True,
     )
 
 

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -2,9 +2,9 @@
 
 module {
   // Local semaphore_set
-  func.func private @local_set(%sem0: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @local_set(%sem0: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %c1 = arith.constant 1 : index
-    d2m.semaphore_set %sem0, %c1 : !d2m.semaphore
+    d2m.semaphore_set %sem0, %c1 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%[[SEM]])
@@ -13,11 +13,11 @@ module {
   }
 
   // Remote single-core semaphore_inc
-  func.func private @remote_inc(%sem0: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @remote_inc(%sem0: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %c1 = arith.constant 1 : index
     %y  = arith.constant 2 : index
     %x  = arith.constant 3 : index
-    d2m.semaphore_inc %sem0, %c1, core[%y, %x] : !d2m.semaphore
+    d2m.semaphore_inc %sem0, %c1, core[%y, %x] : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[NOC:[0-9]+]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[SEM]])
@@ -26,13 +26,13 @@ module {
   }
 
   // Remote multicast semaphore_set
-  func.func private @mcast_set(%sem0: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @mcast_set(%sem0: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %c7 = arith.constant 7 : index
     %y  = arith.constant 4 : index
     %x  = arith.constant 5 : index
     %h  = arith.constant 2 : index
     %w  = arith.constant 3 : index
-    d2m.semaphore_set %sem0, %c7, core[%y, %x] mcast[%h, %w] : !d2m.semaphore
+    d2m.semaphore_set %sem0, %c7, core[%y, %x] mcast[%h, %w] : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[MADDR:[0-9]+]] = ttkernel.experimental::get_noc_multicast_addr({{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SEM]])
@@ -43,9 +43,9 @@ module {
   }
 
   // semaphore_wait without reset
-  func.func private @wait_no_reset(%sem0: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @wait_no_reset(%sem0: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %c2 = arith.constant 2 : index
-    d2m.semaphore_wait %sem0, %c2 : !d2m.semaphore
+    d2m.semaphore_wait %sem0, %c2 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%[[SEM]])
@@ -54,10 +54,10 @@ module {
   }
 
   // semaphore_wait with reset
-  func.func private @wait_with_reset(%sem0: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @wait_with_reset(%sem0: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %c2 = arith.constant 2 : index
     %c0 = arith.constant 0 : index
-    d2m.semaphore_wait %sem0, %c2 reset %c0 : !d2m.semaphore
+    d2m.semaphore_wait %sem0, %c2 reset %c0 : !d2m.local_semaphore
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[PTR:[0-9]+]] = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%[[SEM]])

--- a/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/generic_lowering.mlir
@@ -8,28 +8,28 @@ module {
     %view = d2m.view_layout %arg0 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x8x24x!ttcore.tile<32x32, f32>, #ttcore.shard<98304x4096, 1>, #l1_> -> memref<8x8x1x3x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_>
     %view_1 = d2m.view_layout %arg1 remapping = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> : memref<1x1x24x32x!ttcore.tile<32x32, f32>, #ttcore.shard<131072x4096, 1>, #l1_> -> memref<8x8x3x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_>
     // CHECK: "ttmetal.enqueue_program"
-    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<semaphore[0]>, <semaphore[1]>, <semaphore[2]>, <semaphore[3]>, <cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<semaphore[0]>, <semaphore[1]>, <semaphore[2]>, <semaphore[3]>, <cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, true, false, false, [default]>]
+    // CHECK-SAME: {{.*}}cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<local_semaphore[0]>, <local_semaphore[1]>, <local_semaphore[2]>, <local_semaphore[3]>, <cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc0>, #ttmetal.noc_config<@datamovement_kernel1, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<local_semaphore[0]>, <local_semaphore[1]>, <local_semaphore[2]>, <local_semaphore[3]>, <cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc1>, #ttmetal.compute_config<@compute_kernel2, #ttmetal.core_range<0x0, 8x8>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, true, false, false, [default]>]
     d2m.generic {block_factors = [], grid = #ttcore.grid<8x8>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @datamovement_kernel0>, #d2m.thread<datamovement, @datamovement_kernel1>, #d2m.thread<compute, @compute_kernel2>]}
         ins(%view, %view_1 : memref<8x8x1x3x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_>, memref<8x8x3x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1_>)
         outs(%alloc : memref<8x8x1x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>)
     return %alloc  : memref<8x8x1x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
   }
 
-  func.func private @datamovement_kernel0(%arg3: !d2m.semaphore, %arg4: !d2m.semaphore, %arg5: !d2m.semaphore, %arg6: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @datamovement_kernel0(%arg3: !d2m.local_semaphore, %arg4: !d2m.local_semaphore, %arg5: !d2m.local_semaphore, %arg6: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %cb0 = d2m.get_cb(0) operand_index = 0 : !d2m.cb<memref<1x3x!ttcore.tile<32x32, f32>, #l1_>>
     %cb1 = d2m.get_cb(1) operand_index = 1 : !d2m.cb<memref<3x4x!ttcore.tile<32x32, f32>, #l1_>>
     %cb2 = d2m.get_cb(2) operand_index = 2 : !d2m.cb<memref<1x4x!ttcore.tile<32x32, f32>, #l1_>>
     return
   }
 
-  func.func private @datamovement_kernel1(%arg3: !d2m.semaphore, %arg4: !d2m.semaphore, %arg5: !d2m.semaphore, %arg6: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
+  func.func private @datamovement_kernel1(%arg3: !d2m.local_semaphore, %arg4: !d2m.local_semaphore, %arg5: !d2m.local_semaphore, %arg6: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<datamovement>} {
     %cb0 = d2m.get_cb(0) operand_index = 0 : !d2m.cb<memref<1x3x!ttcore.tile<32x32, f32>, #l1_>>
     %cb1 = d2m.get_cb(1) operand_index = 1 : !d2m.cb<memref<3x4x!ttcore.tile<32x32, f32>, #l1_>>
     %cb2 = d2m.get_cb(2) operand_index = 2 : !d2m.cb<memref<1x4x!ttcore.tile<32x32, f32>, #l1_>>
     return
   }
 
-  func.func private @compute_kernel2(%arg3: !d2m.semaphore, %arg4: !d2m.semaphore, %arg5: !d2m.semaphore, %arg6: !d2m.semaphore) attributes {d2m.thread = #d2m.thread<compute>} {
+  func.func private @compute_kernel2(%arg3: !d2m.local_semaphore, %arg4: !d2m.local_semaphore, %arg5: !d2m.local_semaphore, %arg6: !d2m.local_semaphore) attributes {d2m.thread = #d2m.thread<compute>} {
     %cb0 = d2m.get_cb(0) operand_index = 0 : !d2m.cb<memref<1x3x!ttcore.tile<32x32, f32>, #l1_>>
     %cb1 = d2m.get_cb(1) operand_index = 1 : !d2m.cb<memref<3x4x!ttcore.tile<32x32, f32>, #l1_>>
     %cb2 = d2m.get_cb(2) operand_index = 2 : !d2m.cb<memref<1x4x!ttcore.tile<32x32, f32>, #l1_>>

--- a/test/ttmlir/Dialect/D2M/Transforms/preallocate_mcast_semaphores.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/preallocate_mcast_semaphores.mlir
@@ -15,9 +15,9 @@ module {
 
     // CHECK: d2m.generic
     // Semaphores should be added to both regions (2 per multicast load)
-    // CHECK: ^{{.*}}(%[[SEM0:.*]]: !d2m.semaphore, %[[SEM1:.*]]: !d2m.semaphore):
+    // CHECK: ^{{.*}}(%[[SEM0:.*]]: !d2m.local_semaphore, %[[SEM1:.*]]: !d2m.local_semaphore):
     // CHECK: d2m.remote_load {{.*}} {preallocated_semaphores = [0, 1]}
-    // CHECK: ^{{.*}}(%{{.*}}: !d2m.semaphore, %{{.*}}: !d2m.semaphore):
+    // CHECK: ^{{.*}}(%{{.*}}: !d2m.local_semaphore, %{{.*}}: !d2m.local_semaphore):
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #reduction], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
         ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
         outs(%alloc : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)  {
@@ -103,7 +103,7 @@ module {
 
     // CHECK: d2m.generic
     // 2 multicast loads = 4 semaphores (2 per load)
-    // CHECK: ^{{.*}}(%{{.*}}: !d2m.semaphore, %{{.*}}: !d2m.semaphore, %{{.*}}: !d2m.semaphore, %{{.*}}: !d2m.semaphore):
+    // CHECK: ^{{.*}}(%{{.*}}: !d2m.local_semaphore, %{{.*}}: !d2m.local_semaphore, %{{.*}}: !d2m.local_semaphore, %{{.*}}: !d2m.local_semaphore):
     // First load gets indices [0, 1]
     // CHECK: d2m.remote_load{{.*}}into %{{.*}} {preallocated_semaphores = [0, 1]}
     // Second load gets indices [2, 3]
@@ -156,7 +156,7 @@ module {
 
     // CHECK: d2m.generic
     // Only 1 multicast load = 2 semaphores
-    // CHECK: ^{{.*}}(%{{.*}}: !d2m.semaphore, %{{.*}}: !d2m.semaphore):
+    // CHECK: ^{{.*}}(%{{.*}}: !d2m.local_semaphore, %{{.*}}: !d2m.local_semaphore):
     // Only the multicast load gets the attribute
     // CHECK: d2m.remote_load{{.*}}into %{{.*}} {preallocated_semaphores = [0, 1]}
     // Non-multicast load does NOT get the attribute
@@ -209,7 +209,7 @@ module {
     // CHECK: d2m.generic
     // No remote loads = no semaphores added
     // No block args (no CBs, no semaphores)
-    // CHECK-NOT: !d2m.semaphore
+    // CHECK-NOT: !d2m.local_semaphore
     d2m.generic {block_factors = [], grid = #ttcore.grid<2x4>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
         ins(%arg0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
         outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)  {

--- a/test/ttmlir/Dialect/D2M/Transforms/schedule_dma.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/schedule_dma.mlir
@@ -417,7 +417,7 @@ module {
     d2m.generic {block_factors = [], grid = #ttcore.grid<2x4>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
         ins(%arg0, %arg1 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
         outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)  {
-    ^datamovement0(%sem0: !d2m.semaphore):
+    ^datamovement0(%sem0: !d2m.local_semaphore):
         %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
         %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
         %cb2 = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
@@ -438,13 +438,13 @@ module {
         scf.for %arg3 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg2 : index
           %1 = arith.addi %core1, %arg3 : index
-          d2m.semaphore_wait %sem0, %c1: !d2m.semaphore
+          d2m.semaphore_wait %sem0, %c1: !d2m.local_semaphore
           d2m.remote_load %arg0[%0, %1] into %cb0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
           d2m.remote_load %arg1[%0, %1] into %cb1 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }, {
-    ^compute0(%sem0: !d2m.semaphore):
+    ^compute0(%sem0: !d2m.local_semaphore):
       %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %cb2 = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
@@ -57,7 +57,7 @@ module attributes {ttcore.system_desc = #system_desc} {
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
         ins(%stream : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
         outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
-    ^unified0(%sem0: !d2m.semaphore):
+    ^unified0(%sem0: !d2m.local_semaphore):
       %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %c0 = arith.constant 0 : index
@@ -69,7 +69,7 @@ module attributes {ttcore.system_desc = #system_desc} {
           %0 = arith.addi %core0, %arg1 : index
           %1 = arith.addi %core1, %arg2 : index
           d2m.remote_load %stream[%0, %1] into %cb0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
-          d2m.semaphore_wait %sem0, %c1 : !d2m.semaphore
+          d2m.semaphore_wait %sem0, %c1 : !d2m.local_semaphore
           %2 = d2m.wait %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%2 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%2 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
@@ -111,14 +111,14 @@ module attributes {ttcore.system_desc = #system_desc} {
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
         ins(%arg0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>)
         outs(%alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
-    ^unified0(%sem0: !d2m.semaphore):
+    ^unified0(%sem0: !d2m.local_semaphore):
       %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       scf.for %arg1 = %c0 to %c1 step %c1 {
         scf.for %arg2 = %c0 to %c1 step %c1 {
-          d2m.semaphore_wait %sem0, %c1 : !d2m.semaphore
+          d2m.semaphore_wait %sem0, %c1 : !d2m.local_semaphore
           %0 = d2m.wait %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%0 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):

--- a/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/d2m_to_ttkernel_argument_lowering.mlir
@@ -1,0 +1,261 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --convert-d2m-to-ttkernel %s | FileCheck %s
+// Test for lowering kernel arguments from D2M dialect to TTKernel dialect
+
+// Test for lowering aliased cb types.
+#l1 = #ttcore.memory_space<l1>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0, port = 0>, <arg_type = cb_port, operand_index = 1, port = 1>]>
+// CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+// CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1024, f32>
+func.func private @cb_lowering() attributes {d2m.thread = #d2m.thread<compute>, tt.function_type = "kernel"} {
+  %arg0 = d2m.get_cb(0) operand_index = 0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %arg1 = d2m.get_cb(1) operand_index = 1 : <memref<32x32xf32, #l1>>
+  %0 = d2m.reserve %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  d2m.push %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %1 = d2m.wait %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  %2 = d2m.reserve %arg1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  %3 = "d2m.tile_untilize_block"(%1, %2) : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<32x32xf32, #l1>) -> memref<32x32xf32, #l1>
+  d2m.pop %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  d2m.push %arg1 : <memref<32x32xf32, #l1>>
+  %4 = d2m.wait %arg1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  d2m.pop %arg1 : <memref<32x32xf32, #l1>>
+  return
+}
+
+// -----
+
+// Test for loweing scratchpad cb types.
+#l1 = #ttcore.memory_space<l1>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0, port = 0>, <arg_type = cb_port, operand_index = -1, port = 1>]>
+// CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+// CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1024, f32>
+func.func private @cb_lowering() attributes {d2m.thread = #d2m.thread<compute>, tt.function_type = "kernel"} {
+  %arg0 = d2m.get_cb(0) operand_index = 0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %arg1 = d2m.get_cb(1) : <memref<32x32xf32, #l1>>
+  %0 = d2m.reserve %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  d2m.push %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %1 = d2m.wait %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  %2 = d2m.reserve %arg1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  %3 = "d2m.tile_untilize_block"(%1, %2) : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<32x32xf32, #l1>) -> memref<32x32xf32, #l1>
+  d2m.pop %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  d2m.push %arg1 : <memref<32x32xf32, #l1>>
+  %4 = d2m.wait %arg1 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  d2m.pop %arg1 : <memref<32x32xf32, #l1>>
+  return
+}
+
+// -----
+
+// Test for lowering scalar types.
+#l1 = #ttcore.memory_space<l1>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0, port = 0>, <arg_type = cb_port, operand_index = 1, port = 1>, <arg_type = scalar, operand_index = 2>]>
+// CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, f32>
+// CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+// CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.scalar<ui32>
+func.func private @scalar_lowering() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+  %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<32x32xf32, #l1>>
+  %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %scalar = d2m.get_arg operand_index = 2 : ui32
+  %0 = d2m.reserve %cb0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  d2m.push %cb0 : <memref<32x32xf32, #l1>>
+  %1 = d2m.wait %cb0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+  %2 = d2m.reserve %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  %3 = "d2m.tile_tilize_block"(%1, %2) : (memref<32x32xf32, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  d2m.pop %cb0 : <memref<32x32xf32, #l1>>
+  d2m.push %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %5 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  d2m.pop %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  return
+}
+
+// -----
+
+// Test for lowering global semaphore types.
+#l1 = #ttcore.memory_space<l1>
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1, port = 1>, <arg_type = global_semaphore, operand_index = 3>, <arg_type = buffer_address, operand_index = 1>]>
+func.func private @datamovement_kernel1() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+  // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<4, !ttcore.tile<32x32, f32>>
+  // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.global_semaphore
+  %arg1 = d2m.get_cb(1) operand_index = 1 : !d2m.cb<memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+  %arg3 = d2m.get_arg operand_index = 3 : !d2m.global_semaphore
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  scf.for %arg4 = %c0 to %c2 step %c1 {
+    scf.for %arg5 = %c0 to %c2 step %c1 {
+      %0 = d2m.wait %arg1 : <memref<2x2x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      // CHECK: %3 = ttkernel.get_compile_time_arg_val(2) : () -> i32
+      %1 = d2m.get_arg operand_index = 1 : memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+      %tx = d2m.dma_write %0[%c0], %1[%arg4, %arg5, %c0], <4> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+      d2m.pop %arg1 : <memref<2x2x!ttcore.tile<32x32, f32>, #l1>>
+    }
+  }
+  // CHECK: %2 = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%1) : (!ttkernel.global_semaphore) -> !ttkernel.l1_addr_ptr
+  d2m.semaphore_wait %arg3, %c1 : !d2m.global_semaphore
+  return
+}
+
+// -----
+
+// Test for lowering local semaphore types.
+#l1 = #ttcore.memory_space<l1>
+#map1 = affine_map<() -> ()>
+
+// CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0, port = 0>, <arg_type = local_semaphore, operand_index = 5>, <arg_type = local_semaphore, operand_index = 6>, <arg_type = buffer_address, operand_index = 0>]>
+func.func private @datamovement_kernel4() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+  // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+  // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.local_semaphore
+  // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.local_semaphore
+  %arg0 = d2m.get_cb(0) operand_index = 0 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  %arg5 = d2m.get_arg operand_index = 5 : !d2m.local_semaphore
+  %arg6 = d2m.get_arg operand_index = 6 : !d2m.local_semaphore
+  %c4 = arith.constant 4 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c7 = arith.constant 7 : index
+  %core0 = d2m.core_index(0) {phys_to_virt_map = #map1} : index
+  %core1 = d2m.core_index(1) {phys_to_virt_map = #map1} : index
+  %0 = arith.cmpi eq, %core1, %c0 : index
+  scf.for %arg7 = %c0 to %c4 step %c1 {
+    %1 = d2m.reserve %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    scf.if %0 {
+      // CHECK: %8 = ttkernel.get_compile_time_arg_val(3) : () -> i32
+      %2 = d2m.get_arg operand_index = 0 : memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+      %tx = d2m.dma_read %2[%core0, %arg7, %c0], %1[%c0], <1> : (memref<8x4x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+      // CHECK: %18 = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%1) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      d2m.semaphore_wait %arg5, %c7 reset %c0 : !d2m.local_semaphore
+      %tx_0 = d2m.dma_write %1[%c0], %1[%c0] core[%core0, %c0] mcast[%c1, %c8], <1> : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx_0
+      // CHECK: %45 = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%2) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      d2m.semaphore_set %arg6, %c1, core[%core0, %c0] mcast[%c1, %c8] : !d2m.local_semaphore
+    } else {
+      d2m.semaphore_inc %arg5, %c1, core[%core0, %c0] : !d2m.local_semaphore
+      // CHECK: %11 = ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>(%2) : (!ttkernel.local_semaphore) -> !ttkernel.l1_addr_ptr
+      d2m.semaphore_wait %arg6, %c1 reset %c0 : !d2m.local_semaphore
+    }
+    d2m.push %arg0 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+  } {d2m.blocking_loop = 0 : i64}
+  return
+}
+
+// -----
+
+// Test for lowering scalar types used as kernel arguments.
+#l1 = #ttcore.memory_space<l1>
+module {
+  func.func @test(%arg0: i32, %arg1: si32, %arg2: ui16, %arg3: si16, %arg4: ui8, %arg5: si8, %arg6: i1, %arg7: f32, %arg8: bf16, %arg9: f16) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @datamovement0>]}
+        ins(%alloc_0 : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        additionalArgs(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9 : i32, si32, ui16, si16, ui8, si8, i1, f32, bf16, f16)
+
+    return
+  }
+  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0, port = 0>, <arg_type = cb_port, operand_index = 1, port = 1>, <arg_type = scalar, operand_index = 2>, <arg_type = scalar, operand_index = 3>, <arg_type = scalar, operand_index = 4>, <arg_type = scalar, operand_index = 5>, <arg_type = scalar, operand_index = 6>, <arg_type = scalar, operand_index = 7>, <arg_type = scalar, operand_index = 8>, <arg_type = scalar, operand_index = 9>, <arg_type = scalar, operand_index = 10>, <arg_type = scalar, operand_index = 11>]>
+  func.func private @datamovement0() attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"} {
+    // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<1024, f32>
+    // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<1, !ttcore.tile<32x32, f32>>
+    // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %3 = ttkernel.reinterpret_cast %2 : !ttkernel.scalar<ui32> to !ttkernel.scalar<i32>
+    // CHECK: %4 = ttkernel.get_compile_time_arg_val(3) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %5 = ttkernel.reinterpret_cast %4 : !ttkernel.scalar<ui32> to !ttkernel.scalar<si32>
+    // CHECK: %6 = ttkernel.get_compile_time_arg_val(4) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %7 = ttkernel.reinterpret_cast %6 : !ttkernel.scalar<ui32> to !ttkernel.scalar<ui16>
+    // CHECK: %8 = ttkernel.get_compile_time_arg_val(5) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %9 = ttkernel.reinterpret_cast %8 : !ttkernel.scalar<ui32> to !ttkernel.scalar<si16>
+    // CHECK: %10 = ttkernel.get_compile_time_arg_val(6) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %11 = ttkernel.reinterpret_cast %10 : !ttkernel.scalar<ui32> to !ttkernel.scalar<ui8>
+    // CHECK: %12 = ttkernel.get_compile_time_arg_val(7) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %13 = ttkernel.reinterpret_cast %12 : !ttkernel.scalar<ui32> to !ttkernel.scalar<si8>
+    // CHECK: %14 = ttkernel.get_compile_time_arg_val(8) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %15 = ttkernel.reinterpret_cast %14 : !ttkernel.scalar<ui32> to !ttkernel.scalar<i1>
+    // CHECK: %16 = ttkernel.get_compile_time_arg_val(9) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %17 = ttkernel.reinterpret_cast %16 : !ttkernel.scalar<ui32> to !ttkernel.scalar<f32>
+    // CHECK: %18 = ttkernel.get_compile_time_arg_val(10) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %19 = ttkernel.reinterpret_cast %18 : !ttkernel.scalar<ui32> to !ttkernel.scalar<bf16>
+    // CHECK: %20 = ttkernel.get_compile_time_arg_val(11) : () -> !ttkernel.scalar<ui32>
+    // CHECK: %21 = ttkernel.reinterpret_cast %20 : !ttkernel.scalar<ui32> to !ttkernel.scalar<f16>
+    %arg0 = d2m.get_cb(0) operand_index = 0 : !d2m.cb<memref<32x32xf32, #l1>>
+    %arg1 = d2m.get_cb(1) operand_index = 1 : !d2m.cb<memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    %arg2 = d2m.get_arg operand_index = 2 : i32
+    %arg3 = d2m.get_arg operand_index = 3 : si32
+    %arg4 = d2m.get_arg operand_index = 4 : ui16
+    %arg5 = d2m.get_arg operand_index = 5 : si16
+    %arg6 = d2m.get_arg operand_index = 6 : ui8
+    %arg7 = d2m.get_arg operand_index = 7 : si8
+    %arg8 = d2m.get_arg operand_index = 8 : i1
+    %arg9 = d2m.get_arg operand_index = 9 : f32
+    %arg10 = d2m.get_arg operand_index = 10 : bf16
+    %arg11 = d2m.get_arg operand_index = 11 : f16
+    %10 = d2m.reserve %arg0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+    d2m.push %arg0 : <memref<32x32xf32, #l1>>
+    %11 = d2m.wait %arg0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+    %12 = d2m.reserve %arg1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    %13 = "d2m.tile_tilize_block"(%11, %12) : (memref<32x32xf32, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    d2m.pop %arg0 : <memref<32x32xf32, #l1>>
+    d2m.push %arg1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    %14 = d2m.wait %arg1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    d2m.pop %arg1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    return
+  }
+}
+
+// -----
+
+// Test for lowering d2m.get_arg (buffer) used as kernel argument.
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, %arg1: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>) -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1> {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+    %view = d2m.view_layout %arg0 remapping = #map : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>]}
+        ins(%view, %arg1 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
+        outs(%alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
+     {
+      // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+      %0 = d2m.get_cb(0) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %2 = d2m.get_cb(2) resolution_stage =  compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %3 = d2m.reserve %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      // CHECK: %3 = ttkernel.get_compile_time_arg_val(3) : () -> i32
+      %4 = d2m.get_arg operand_index = 0 resolution_stage =  compile : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+      %tx = d2m.dma_read %4[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+      d2m.push %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return %alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+  }
+}
+
+// -----
+
+// Test for lowering d2m.get_arg (buffer) as a runtime arg.
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  // CHECK: ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = -1, port = 0>, <arg_type = cb_port, operand_index = -1, port = 1>, <arg_type = cb_port, operand_index = -1, port = 2>]>
+  func.func @runtime_arg_test() {
+    // CHECK: %0 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: %1 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: %2 = ttkernel.get_compile_time_arg_val(2) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    %0 = d2m.get_cb(0) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %1 = d2m.get_cb(1) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %2 = d2m.get_cb(2) resolution_stage = compile : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    %3 = d2m.reserve %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+    %c0 = arith.constant 0 : index
+    // CHECK: %3 = ttkernel.get_common_arg_val(%c0_0) : (index) -> i32
+    %4 = d2m.get_arg operand_index = 0 resolution_stage = runtime : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+    %tx = d2m.dma_read %4[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+    d2m.dma_wait %tx
+    d2m.push %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    return
+  }
+}

--- a/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args.mlir
+++ b/test/ttmlir/Dialect/D2M/arguments/normalize_thread_args.mlir
@@ -1,0 +1,258 @@
+// RUN: ttmlir-opt --split-input-file --normalize-thread-args %s | FileCheck %s
+// Test for capturing additional arguments into threads
+
+// Test for capturing aliased cb types.
+#l1 = #ttcore.memory_space<l1>
+module {
+  func.func @test(%arg0: index) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%alloc_0 : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+     {
+    ^unified0():
+      // CHECK: %0 = d2m.get_cb(0) operand_index = 0 resolution_stage =  compile : <memref<32x32xf32, #l1>>
+      // CHECK: %1 = d2m.get_cb(1) operand_index = 1 resolution_stage =  compile : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<32x32xf32, #l1>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1 step %arg0 {
+
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Test for capturing scratchpad cb types.
+#l1 = #ttcore.memory_space<l1>
+module {
+  func.func @test(%arg0: index) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%alloc_0 : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+     {
+    ^unified0():
+      // CHECK: %0 = d2m.get_cb(0) operand_index = 0 resolution_stage =  compile : <memref<32x32xf32, #l1>>
+      // CHECK: %1 = d2m.get_cb(1) resolution_stage =  compile : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<32x32xf32, #l1>>
+      %cb1 = d2m.get_cb(1) : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1 step %arg0 {
+
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Test for capturing global semaphore types.
+#layout = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout1 = #ttcore.metal_layout<logical_shape = 8x8, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  func.func @generic_with_global_semaphore(%arg0: tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>) -> tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout> {
+    %0 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+    %1 = d2m.empty() : tensor<8x8x1x1xui32, #layout1>
+    %2 = d2m.create_global_semaphore(%1) {value = 0 : ui32} : tensor<8x8x1x1xui32, #layout1> -> !d2m.global_semaphore
+    %3 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+    %4 = d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%arg0 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)
+        outs(%3 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)
+        additionalArgs(%2 : !d2m.global_semaphore)
+     {
+    // CHECK: %5 = d2m.get_arg operand_index = 2 resolution_stage =  compile : !d2m.global_semaphore
+    ^unified0():
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <tensor<1x1x!ttcore.tile<32x32, f32>>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <tensor<1x1x!ttcore.tile<32x32, f32>>>
+      %c1 = arith.constant 1 : index
+      d2m.semaphore_wait %2, %c1 : !d2m.global_semaphore
+      d2m.yield %3 : (tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>)
+    } : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+    d2m.reset_global_semaphore(%2) {value = 0 : ui32} : !d2m.global_semaphore
+    return %4 : tensor<1x1x1x1x!ttcore.tile<32x32, f32>, #layout>
+  }
+}
+
+// -----
+
+// Test for capturing local semaphore types.
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<() -> ()>
+
+module {
+  func.func @test() {
+    %alloc_in = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_out = memref.alloc() {address = 5120 : i64, alignment = 16 : i64} : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %0 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %1 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %2 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    %3 = d2m.create_local_semaphore <{initialValue = 0 : ui32}> -> !d2m.local_semaphore
+    d2m.generic {block_factors = [], grid = #ttcore.grid<8x8>, indexing_maps = [], iterator_types = [],
+                 threads = [#d2m.thread<datamovement>, #d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%alloc_in : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%alloc_out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        additionalArgs(%0, %1, %2, %3 : !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore, !d2m.local_semaphore)
+    {
+    // CHECK: %4 = d2m.get_arg operand_index = 3 resolution_stage = compile : !d2m.local_semaphore
+    // CHECK: %5 = d2m.get_arg operand_index = 2 resolution_stage = compile : !d2m.local_semaphore
+    ^datamovement0():
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
+      %c7 = arith.constant 7 : index
+      %c8 = arith.constant 8 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %core0 = d2m.core_index(0) {phys_to_virt_map = #map} : index
+      %isSender = arith.cmpi eq, %core0, %c0 : index
+      scf.if %isSender {
+        d2m.semaphore_wait %0, %c7 reset %c0 : !d2m.local_semaphore
+        d2m.semaphore_set %1, %c1, core[%core0, %c0] mcast[%c1, %c8] : !d2m.local_semaphore
+      } else {
+        %core0_r = d2m.core_index(0) {phys_to_virt_map = #map} : index
+        d2m.semaphore_inc %0, %c1, core[%core0_r, %c0] : !d2m.local_semaphore
+        d2m.semaphore_wait %1, %c1 reset %c0 : !d2m.local_semaphore
+      }
+    }, {
+    // CHECK: %4 = d2m.get_arg operand_index = 5 resolution_stage = compile : !d2m.local_semaphore
+    // CHECK: %5 = d2m.get_arg operand_index = 4 resolution_stage = compile : !d2m.local_semaphore
+    ^datamovement1():
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>>
+      %c7 = arith.constant 7 : index
+      %c8 = arith.constant 8 : index
+      %c1 = arith.constant 1 : index
+      %c0 = arith.constant 0 : index
+      %core1 = d2m.core_index(1) {phys_to_virt_map = #map} : index
+      %isSender = arith.cmpi eq, %core1, %c0 : index
+      scf.if %isSender {
+        d2m.semaphore_wait %2, %c7 reset %c0 : !d2m.local_semaphore
+        d2m.semaphore_set %3, %c1, core[%c0, %core1] mcast[%c8, %c1] : !d2m.local_semaphore
+      } else {
+        %core1_r = d2m.core_index(1) {phys_to_virt_map = #map} : index
+        d2m.semaphore_inc %2, %c1, core[%c0, %core1_r] : !d2m.local_semaphore
+        d2m.semaphore_wait %3, %c1 reset %c0 : !d2m.local_semaphore
+      }
+    }, {
+    ^compute0():
+    }
+    return
+  }
+}
+
+// -----
+
+// Test for capturing scalar types.
+#l1 = #ttcore.memory_space<l1>
+module {
+  func.func @test(%arg0: index) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%alloc_0 : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        additionalArgs(%arg0 : index)
+     {
+    // CHECK: %0 = d2m.get_arg operand_index = 2 resolution_stage = compile : index
+    ^unified0():
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<32x32xf32, #l1>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg2 = %c0 to %c1 step %arg0 {
+
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Test for inserting multiple dtype scalar values.
+#l1 = #ttcore.memory_space<l1>
+module {
+  func.func @test(%arg0: i32, %arg1: si32, %arg2: ui16, %arg3: si16, %arg4: ui8, %arg5: si8, %arg6: i1, %arg7: f32, %arg8: bf16, %arg9: f16) {
+    %alloc = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %alloc_0 = memref.alloc() {address = 107808 : i64, alignment = 16 : i64} : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<unified>]}
+        ins(%alloc_0 : memref<1x1x32x32xf32, #ttcore.shard<32x4, 1>, #l1>)
+        outs(%alloc : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        additionalArgs(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9 : i32, si32, ui16, si16, ui8, si8, i1, f32, bf16, f16)
+     {
+    ^unified0():
+      // CHECK: %0 = d2m.get_arg operand_index = 11 resolution_stage =  compile : f16
+      // CHECK: %1 = d2m.get_arg operand_index = 10 resolution_stage =  compile : bf16
+      // CHECK: %2 = d2m.get_arg operand_index = 9 resolution_stage =  compile : f32
+      // CHECK: %3 = d2m.get_arg operand_index = 8 resolution_stage =  compile : i1
+      // CHECK: %4 = d2m.get_arg operand_index = 7 resolution_stage =  compile : si8
+      // CHECK: %5 = d2m.get_arg operand_index = 6 resolution_stage =  compile : ui8
+      // CHECK: %6 = d2m.get_arg operand_index = 5 resolution_stage =  compile : si16
+      // CHECK: %7 = d2m.get_arg operand_index = 4 resolution_stage =  compile : ui16
+      // CHECK: %8 = d2m.get_arg operand_index = 3 resolution_stage =  compile : si32
+      // CHECK: %9 = d2m.get_arg operand_index = 2 resolution_stage =  compile : i32
+      // unrealized_conversion_cast are inserted to force the argument to not be canonicalized away
+      %temp0 = builtin.unrealized_conversion_cast %arg0 : i32 to i32
+      %temp1 = builtin.unrealized_conversion_cast %arg1 : si32 to si32
+      %temp2 = builtin.unrealized_conversion_cast %arg2 : ui16 to ui16
+      %temp3 = builtin.unrealized_conversion_cast %arg3 : si16 to si16
+      %temp4 = builtin.unrealized_conversion_cast %arg4 : ui8 to ui8
+      %temp5 = builtin.unrealized_conversion_cast %arg5 : si8 to si8
+      %temp6 = builtin.unrealized_conversion_cast %arg6 : i1 to i1
+      %temp7 = builtin.unrealized_conversion_cast %arg7 : f32 to f32
+      %temp8 = builtin.unrealized_conversion_cast %arg8 : bf16 to bf16
+      %temp9 = builtin.unrealized_conversion_cast %arg9 : f16 to f16
+      %cb0 = d2m.get_cb(0) operand_index = 0 : <memref<32x32xf32, #l1>>
+      %cb1 = d2m.get_cb(1) operand_index = 1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %0 = d2m.reserve %cb0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+      d2m.push %cb0 : <memref<32x32xf32, #l1>>
+      %1 = d2m.wait %cb0 : <memref<32x32xf32, #l1>> -> memref<32x32xf32, #l1>
+      %2 = d2m.reserve %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %3 = "d2m.tile_tilize_block"(%1, %2) : (memref<32x32xf32, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.pop %cb0 : <memref<32x32xf32, #l1>>
+      d2m.push %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+      %4 = d2m.wait %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      d2m.pop %cb1 : <memref<1x1x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test for capturing buffer address arguments.
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>, %arg1: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>) -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1> {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+    %view = d2m.view_layout %arg0 remapping = #map : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%view, %arg1 : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
+        outs(%alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>)
+     {
+      %0 = d2m.get_cb(0) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %1 = d2m.get_cb(1) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %2 = d2m.get_cb(2) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %3 = d2m.wait %1 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      // CHECK: %4 = d2m.get_arg operand_index = 0 resolution_stage = compile : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+      %tx = d2m.dma_read %view[%c0, %c0, %c0], %3[%c0], <1> : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> !d2m.mem_tx
+      d2m.dma_wait %tx
+    }, {
+      %0 = d2m.get_cb(0) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %1 = d2m.get_cb(1) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %2 = d2m.get_cb(2) : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+    }
+    return %alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_negative.mlir
@@ -29,7 +29,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<
 func.func @matmul(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096,1>, #l1_>) -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096,1>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096,1>, #l1_>
   "d2m.generic"(%arg0, %alloc) <{block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>], operandSegmentSizes = array<i32: 1, 1, 0>}> ({
-  ^bb0(%sem0: !d2m.semaphore):
+  ^bb0(%sem0: !d2m.local_semaphore):
   %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
   %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
   }, {

--- a/test/ttmlir/Dialect/D2M/generic/generic_pure_tensor_multi_region.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_pure_tensor_multi_region.mlir
@@ -23,7 +23,7 @@ func.func @pure_tensor_multiple_regions(%arg0: tensor<64x128xf32>, %arg1: tensor
   }
   ins(%arg0, %arg1 : tensor<64x128xf32>, tensor<64x128xf32>)
   outs(%0 : tensor<64x128xf32>) {
-  ^datamovement0(%sem0: !d2m.semaphore, %sem1: !d2m.semaphore, %sem2: !d2m.semaphore, %sem3: !d2m.semaphore):
+  ^datamovement0(%sem0: !d2m.local_semaphore, %sem1: !d2m.local_semaphore, %sem2: !d2m.local_semaphore, %sem3: !d2m.local_semaphore):
     %cb_in0 = d2m.get_cb(0) : !d2m.cb<tensor<64x128xf32>>
     %cb_in1 = d2m.get_cb(1) : !d2m.cb<tensor<64x128xf32>>
     %cb_out = d2m.get_cb(2) : !d2m.cb<tensor<64x128xf32>>
@@ -36,7 +36,7 @@ func.func @pure_tensor_multiple_regions(%arg0: tensor<64x128xf32>, %arg1: tensor
     %result = tensor.insert %val into %out[%c0, %c0] : tensor<64x128xf32>
     d2m.yield %result : (tensor<64x128xf32>)
   }, {
-  ^datamovement1(%sem0_2: !d2m.semaphore, %sem1_2: !d2m.semaphore, %sem2_2: !d2m.semaphore, %sem3_2: !d2m.semaphore):
+  ^datamovement1(%sem0_2: !d2m.local_semaphore, %sem1_2: !d2m.local_semaphore, %sem2_2: !d2m.local_semaphore, %sem3_2: !d2m.local_semaphore):
     %cb_in0_2 = d2m.get_cb(0) : !d2m.cb<tensor<64x128xf32>>
     %cb_in1_2 = d2m.get_cb(1) : !d2m.cb<tensor<64x128xf32>>
     %cb_out_2 = d2m.get_cb(2) : !d2m.cb<tensor<64x128xf32>>
@@ -49,7 +49,7 @@ func.func @pure_tensor_multiple_regions(%arg0: tensor<64x128xf32>, %arg1: tensor
     %result_2 = tensor.insert %val_2 into %out_2[%c0_2, %c0_2] : tensor<64x128xf32>
     d2m.yield %result_2 : (tensor<64x128xf32>)
   }, {
-  ^compute0(%sem0_3: !d2m.semaphore, %sem1_3: !d2m.semaphore, %sem2_3: !d2m.semaphore, %sem3_3: !d2m.semaphore):
+  ^compute0(%sem0_3: !d2m.local_semaphore, %sem1_3: !d2m.local_semaphore, %sem2_3: !d2m.local_semaphore, %sem3_3: !d2m.local_semaphore):
     %cb_in0_3 = d2m.get_cb(0) : !d2m.cb<tensor<64x128xf32>>
     %cb_in1_3 = d2m.get_cb(1) : !d2m.cb<tensor<64x128xf32>>
     %cb_out_3 = d2m.get_cb(2) : !d2m.cb<tensor<64x128xf32>>

--- a/test/ttmlir/Dialect/D2M/generic/generic_regions_to_funcs.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_regions_to_funcs.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --d2m-generic-regions-to-funcs -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --normalize-thread-args --d2m-generic-regions-to-funcs -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 #l1_ = #ttcore.memory_space<l1>
@@ -39,5 +39,5 @@ func.func @add(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0
   return %alloc : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<0x0, 1>, #l1_>
 }
 // CHECK: func.func private @datamovement_kernel0{{.*}} attributes {d2m.thread = #d2m.thread<datamovement>, tt.function_type = "kernel"}
-// CHECK: d2m.get_global_operand(0)
+// CHECK: d2m.get_arg operand_index = 0
 // CHECK: func.func private @compute_kernel1{{.*}} attributes {d2m.thread = #d2m.thread<compute>, tt.function_type = "kernel"}


### PR DESCRIPTION
Ticket: https://github.com/tenstorrent/tt-mlir/issues/7184

This PR supports scalar arguments lowering and cleans up other argument representation and packing.

Most notably:

- rename "Semaphore" to "LocalSemaphore" to distinguish between local and global semaphores
- clean up arguments allowed to be inserted in kernel (cb, global_semaphore, local_semaphore, scalar, buffer_address)
- introduce new d2m.get_arg op to reference where an arg came from in original operand list
- introduce "resolution_stage" to distinguish whether an argument should be packed as compile time or runtime arg
- introduce d2m.print_arg op to print any argument in a kernel
- new pass `normalize-thread-args` to normalize all thread arguments before ttkernel lowering
- support lowering scalar values into kernel arguments
- tight packing of kernel arguments (only ones used in the kernel are packed)