### PR TITLE
Add layer_norm_post_all_gather op in TTNN dialect

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2412,6 +2412,44 @@ def TTNN_LayerNormPreAllGatherOp : TTNN_Op<"layer_norm_pre_all_gather",
     let hasVerifier = 1;
 }
 
+def TTNN_LayerNormPostAllGatherOp : TTNN_Op<"layer_norm_post_all_gather",
+    [AttrSizedOperandSegments, TTNN_DtypeOpInterface, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface]> {
+    let summary = "Layer normalization post-all-gather op.";
+    let description = [{
+      Applies normalization using gathered statistics from a distributed
+      layer normalization pipeline. Takes the original input tensor and
+      the all-gathered partial statistics, computes the final normalized
+      output, and optionally scales by weight and shifts by bias.
+
+      Inputs:
+        - input: Original input tensor.
+        - stats: All-gathered statistics tensor from pre-all-gather phase.
+        - weight: Optional scale (gamma) tensor.
+        - bias: Optional shift (beta) tensor.
+
+      Attributes:
+        - epsilon: Small constant for numerical stability (default 1e-12).
+        - dtype: Optional output data type.
+        - compute_config: Optional device compute kernel configuration.
+        - program_config: Optional LayerNormShardedMultiCoreProgramConfig.
+        - memory_config: Optional output memory configuration.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$stats,
+                         Optional<AnyRankedTensor>:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         DefaultValuedAttr<F32Attr, "1e-12">:$epsilon,
+                         OptionalAttr<TTCore_DataTypeAttr>:$dtype,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config,
+                         OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface]> {
     let summary = "Group normalization op.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -77,6 +77,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm.hpp"
 #include "ttnn/operations/normalization/layernorm/layernorm.hpp"
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
 #include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
 #include "ttnn/operations/normalization/rmsnorm/rmsnorm.hpp"
 #include "ttnn/operations/normalization/softmax/softmax.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1547,6 +1547,32 @@ struct OpModel<LayerNormPreAllGatherOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<LayerNormPostAllGatherOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+      TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> statsShape,
+      TTNNLayoutAttr statsLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+               std::optional<llvm::ArrayRef<int64_t>> weightShape,
+               std::optional<TTNNLayoutAttr> weightLayout,
+               std::optional<llvm::ArrayRef<int64_t>> biasShape,
+               std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -91,6 +91,19 @@ table LayerNormPreAllGatherOp {
   out: tt.target.ttnn.TensorRef;
 }
 
+table LayerNormPostAllGatherOp {
+  input: tt.target.ttnn.TensorRef;
+  stats: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  epsilon: float = 1e-12;
+  dtype: tt.target.DataType = null;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
+  program_config: tt.target.ttnn.LayerNormShardedMultiCoreProgramConfig;
+  out: tt.target.ttnn.TensorRef;
+}
+
 table GroupNormOp {
   input: tt.target.ttnn.TensorRef;
   input_mask: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -81,6 +81,7 @@ union OpType {
   GroupNormOp,
   LayerNormOp,
   LayerNormPreAllGatherOp,
+  LayerNormPostAllGatherOp,
   LinearOp,
   LoadCachedOp,
   // ANCHOR: adding_an_op_matmul_fbs_op_type

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3555,6 +3555,45 @@ public:
 };
 } // namespace
 
+// LayerNormPostAllGatherOp conversion pattern
+//
+namespace {
+class LayerNormPostAllGatherOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormPostAllGatherOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormPostAllGatherOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormPostAllGatherOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::LayerNormPostAllGatherOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getStats()),
+        emitter.emit(srcOp.getEpsilon()),
+        emitter.emit(srcOp.getWeight()),
+        emitter.emit(srcOp.getBias()),
+        emitter.emit(srcOp.getMemoryConfig()) |
+            emitter.getMemoryConfig(srcOp.getResult()),
+        emitter.emit(srcOp.getComputeConfig()),
+        emitter.emit(srcOp.getProgramConfig()),
+        emitter.emit(srcOp.getDtype()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // GroupNormOp conversion pattern
 //
 namespace {
@@ -4984,13 +5023,14 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Other ops
   //
-  patterns.add<SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
-               DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
-               CumSumOpConversionPattern, BatchNormInferenceOpConversionPattern,
-               BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
-               LayerNormOpConversionPattern,
-               LayerNormPreAllGatherOpConversionPattern,
-               GroupNormOpConversionPattern>(typeConverter, ctx);
+  patterns.add<
+      SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
+      DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
+      CumSumOpConversionPattern, BatchNormInferenceOpConversionPattern,
+      BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
+      LayerNormOpConversionPattern, LayerNormPreAllGatherOpConversionPattern,
+      LayerNormPostAllGatherOpConversionPattern, GroupNormOpConversionPattern>(
+      typeConverter, ctx);
 
   // CCL ops
   //

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3860,6 +3860,46 @@ public:
 };
 } // namespace
 
+// LayerNormPostAllGatherOp conversion pattern
+//
+namespace {
+class LayerNormPostAllGatherOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormPostAllGatherOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormPostAllGatherOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormPostAllGatherOp srcOp,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::LayerNormPostAllGatherOp>
+        emitter(srcOp, adaptor, rewriter, this->isGoldenModeEnabled());
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getStats(), "stats"),
+        emitter.emit(srcOp.getEpsilon(), "epsilon"),
+        emitter.emit(srcOp.getWeight(), "weight"),
+        emitter.emit(srcOp.getBias(), "bias"),
+        emitter.emit(srcOp.getMemoryConfig() |
+                         emitter.getMemoryConfig(srcOp.getResult()),
+                     "memory_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
+        emitter.emit(srcOp.getDtype(), "dtype"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // GroupNormOp conversion pattern
 //
 namespace {
@@ -4499,6 +4539,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
            DistributedRMSNormOpConversionPattern, LayerNormOpConversionPattern,
            LayerNormPreAllGatherOpConversionPattern,
+           LayerNormPostAllGatherOpConversionPattern,
            GroupNormOpConversionPattern>(typeConverter, ctx, enableGoldenMode);
 
   // Transformers ops

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3121,6 +3121,52 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOp
+//===----------------------------------------------------------------------===//
+::mlir::LogicalResult mlir::tt::ttnn::LayerNormPostAllGatherOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType statsType = getStats().getType();
+  RankedTensorType outputType = getResult().getType();
+
+  // Input must have rank >= 2.
+  if (inputType.getRank() < 2) {
+    return emitOpError("input must have rank >= 2");
+  }
+
+  // Stats must have rank >= 2.
+  if (statsType.getRank() < 2) {
+    return emitOpError("stats must have rank >= 2");
+  }
+
+  // Output shape must match input shape.
+  if (inputType.getShape() != outputType.getShape()) {
+    return emitOpError("input and output must have the same shape");
+  }
+
+  // Verify weight tensor shape if present.
+  if (getWeight()) {
+    RankedTensorType weightType = getWeight().getType();
+    int64_t lastDimSize = inputType.getShape().back();
+    if (weightType.getRank() != 1 || weightType.getShape()[0] != lastDimSize) {
+      return emitOpError("weight tensor must be 1D with size matching the last "
+                         "dimension of input");
+    }
+  }
+
+  // Verify bias tensor shape if present.
+  if (getBias()) {
+    RankedTensorType biasType = getBias().getType();
+    int64_t lastDimSize = inputType.getShape().back();
+    if (biasType.getRank() != 1 || biasType.getShape()[0] != lastDimSize) {
+      return emitOpError("bias tensor must be 1D with size matching the last "
+                         "dimension of input");
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 ::mlir::LogicalResult mlir::tt::ttnn::GroupNormOp::verify() {

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4140,6 +4140,77 @@ LayerNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+struct LayerNormPostAllGatherOptionalArgs {
+  std::optional<llvm::ArrayRef<int64_t>> weightShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> weightLayout = std::nullopt;
+  std::optional<llvm::ArrayRef<int64_t>> biasShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> biasLayout = std::nullopt;
+};
+
+static LayerNormPostAllGatherOptionalArgs
+unpackLayerNormPostAllGatherOptionalArgs(
+    const std::vector<TTNNLayoutAttr> &inputs, LayerNormPostAllGatherOp op) {
+  LayerNormPostAllGatherOptionalArgs ret;
+  // inputs[0] = input, inputs[1] = stats; optional operands follow.
+  size_t idx = 2;
+  if (op.getWeight()) {
+    ret.weightShape = op.getWeight().getType().getShape();
+    if (idx < inputs.size()) {
+      ret.weightLayout = inputs[idx++];
+    }
+  }
+  if (op.getBias()) {
+    ret.biasShape = op.getBias().getType().getShape();
+    if (idx < inputs.size()) {
+      ret.biasLayout = inputs[idx++];
+    }
+  }
+  return ret;
+}
+
+llvm::Expected<op_model::OpConstraints>
+LayerNormPostAllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto statsShape = getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
+
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints, *this,
+      deviceGrid, inputShape, inputs[0], statsShape, inputs[1],
+      optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  const auto inputShape = getInput().getType().getShape();
+  const auto statsShape = getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<LayerNormPostAllGatherOp>::getOpRuntime, *this,
+      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6557,6 +6557,107 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> statsShape,
+    TTNNLayoutAttr statsLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  auto statsSpecExp =
+      detail::convertToTensorSpec(device, statsShape, statsLayout);
+  if (!statsSpecExp) {
+    return statsSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> weightSpec =
+      detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
+  std::optional<::ttnn::TensorSpec> biasSpec =
+      detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
+
+  auto query = [=]() {
+    return QUERY_OP_CONSTRAINTS(::ttnn::layer_norm_post_all_gather, device,
+                                inputSpec, statsSpec, epsilon.convertToFloat(),
+                                weightSpec, biasSpec,
+                                detail::getNullableMemoryConfig(outputLayout),
+                                /*compute_kernel_config=*/std::nullopt,
+                                /*program_config=*/std::nullopt,
+                                /*dtype=*/std::nullopt);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+                                     query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  auto statsSpecExp =
+      detail::convertToTensorSpec(device, statsShape, statsLayout);
+  if (!statsSpecExp) {
+    return statsSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
+
+  std::optional<::ttnn::TensorSpec> weightSpec =
+      detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
+  std::optional<::ttnn::TensorSpec> biasSpec =
+      detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
+
+  auto query = [=]() {
+    return QUERY_OP_RUNTIME(::ttnn::layer_norm_post_all_gather, device,
+                            inputSpec, statsSpec, epsilon.convertToFloat(),
+                            weightSpec, biasSpec,
+                            detail::getNullableMemoryConfig(outputLayout),
+                            /*compute_kernel_config=*/std::nullopt,
+                            /*program_config=*/std::nullopt,
+                            /*dtype=*/std::nullopt);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1574,6 +1574,51 @@ createOp(FlatbufferObjectCache &cache, LayerNormPreAllGatherOp op) {
       computeConfig.value_or(0), programConfig, output);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormPostAllGatherOp>
+createOp(FlatbufferObjectCache &cache, LayerNormPostAllGatherOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+
+  auto stats = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getStats()));
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> weight = 0;
+  if (op.getWeight()) {
+    weight = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getWeight()));
+  }
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> bias = 0;
+  if (op.getBias()) {
+    bias = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getBias()));
+  }
+
+  auto output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
+
+  std::optional<
+      ::flatbuffers::Offset<::tt::target::ttnn::DeviceComputeKernelConfig>>
+      computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
+  ::flatbuffers::Offset<
+      ::tt::target::ttnn::LayerNormShardedMultiCoreProgramConfig>
+      programConfig = 0;
+  if (op.getProgramConfig()) {
+    programConfig = toFlatbuffer(cache, op.getProgramConfig().value());
+  }
+
+  ::flatbuffers::Optional<::tt::target::DataType> dtype =
+      toFlatbuffer(cache, op.getDtype());
+
+  return ::tt::target::ttnn::CreateLayerNormPostAllGatherOp(
+      *cache.fbb, input, stats, weight, bias, op.getEpsilon().convertToFloat(),
+      dtype, memoryConfig, computeConfig.value_or(0), programConfig, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::GroupNormOp>
 createOp(FlatbufferObjectCache &cache, GroupNormOp op) {
   flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
@@ -4316,6 +4361,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto layerNormPreAllGatherOp = dyn_cast<LayerNormPreAllGatherOp>(op);
       layerNormPreAllGatherOp) {
     return createOperation(cache, createOp(cache, layerNormPreAllGatherOp),
+                           debugString, locInfo);
+  }
+  if (auto layerNormPostAllGatherOp = dyn_cast<LayerNormPostAllGatherOp>(op);
+      layerNormPostAllGatherOp) {
+    return createOperation(cache, createOp(cache, layerNormPostAllGatherOp),
                            debugString, locInfo);
   }
   if (auto groupNormOp = dyn_cast<GroupNormOp>(op); groupNormOp) {

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -78,6 +78,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/group_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm_pre_all_gather.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm_post_all_gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/rms_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/softmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/pool2d.cpp

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/normalization/layer_norm_post_all_gather.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+#include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
+
+namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather {
+void run(const ::tt::target::ttnn::LayerNormPostAllGatherOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
+  ::ttnn::Tensor &stats = tensorPool.getTTNNTensorAndValidate(op->stats());
+
+  float epsilon = op->epsilon();
+
+  std::optional<::ttnn::Tensor> weight = std::nullopt;
+  if (op->weight()) {
+    weight = tensorPool.getTTNNTensorAndValidate(op->weight());
+  }
+
+  std::optional<::ttnn::Tensor> bias = std::nullopt;
+  if (op->bias()) {
+    bias = tensorPool.getTTNNTensorAndValidate(op->bias());
+  }
+
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
+  std::optional<::ttnn::prim::LayerNormProgramConfig> programConfig =
+      std::nullopt;
+  if (op->program_config()) {
+    programConfig = utils::createLayerNormShardedMultiCoreProgramConfig(
+        op->program_config());
+  }
+
+  std::optional<::ttnn::DataType> dtype = std::nullopt;
+  if (op->dtype()) {
+    dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*op->dtype());
+  }
+
+  ::ttnn::Tensor output = ::ttnn::layer_norm_post_all_gather(
+      input, stats, epsilon, weight, bias, memoryConfig, computeConfig,
+      programConfig, dtype);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
+}
+} // namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.h
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_post_all_gather.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_LAYER_NORM_POST_ALL_GATHER_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_NORMALIZATION_LAYER_NORM_POST_ALL_GATHER_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather {
+void run(const ::tt::target::ttnn::LayerNormPostAllGatherOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::layer_norm_post_all_gather
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -71,6 +71,7 @@
 #include "operations/normalization/distributed_rms_norm.h"
 #include "operations/normalization/group_norm.h"
 #include "operations/normalization/layer_norm.h"
+#include "operations/normalization/layer_norm_post_all_gather.h"
 #include "operations/normalization/layer_norm_pre_all_gather.h"
 #include "operations/normalization/rms_norm.h"
 #include "operations/normalization/softmax.h"
@@ -374,6 +375,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::LayerNormPreAllGatherOp: {
     return operations::layer_norm_pre_all_gather::run(
         op->type_as_LayerNormPreAllGatherOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::LayerNormPostAllGatherOp: {
+    return operations::layer_norm_post_all_gather::run(
+        op->type_as_LayerNormPostAllGatherOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::GroupNormOp: {
     return operations::group_norm::run(op->type_as_GroupNormOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1216,6 +1216,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_LayerNormPreAllGatherOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::LayerNormPostAllGatherOp: {
+    tensorRef = opContext.type_as_LayerNormPostAllGatherOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::GroupNormOp: {
     tensorRef = opContext.type_as_GroupNormOp()->out();
     break;
@@ -1668,6 +1672,19 @@ getOpInputRefs(OpContext opContextHandle,
     if (opContext.type_as_LayerNormPreAllGatherOp()->recip()) {
       tensorRefs.push_back(
           opContext.type_as_LayerNormPreAllGatherOp()->recip());
+    }
+    break;
+  }
+  case ::tt::target::ttnn::OpType::LayerNormPostAllGatherOp: {
+    tensorRefs = {opContext.type_as_LayerNormPostAllGatherOp()->input(),
+                  opContext.type_as_LayerNormPostAllGatherOp()->stats()};
+    if (opContext.type_as_LayerNormPostAllGatherOp()->weight()) {
+      tensorRefs.push_back(
+          opContext.type_as_LayerNormPostAllGatherOp()->weight());
+    }
+    if (opContext.type_as_LayerNormPostAllGatherOp()->bias()) {
+      tensorRefs.push_back(
+          opContext.type_as_LayerNormPostAllGatherOp()->bias());
     }
     break;
   }

--- a/test/python/golden/ttnn_ops/normalization/test_ttnn_normalization.py
+++ b/test/python/golden/ttnn_ops/normalization/test_ttnn_normalization.py
@@ -11,7 +11,33 @@ from builder.ttnn.ttnn_builder import TTNNBuilder
 from builder.base.builder_apis import compile_and_execute_ttnn
 from test_utils import shape_str
 
+from golden.mapping import GoldenMapTensor
+
 pytestmark = pytest.mark.frontend("ttnn")
+
+TILE_WIDTH = 32
+
+
+def build_stats_golden(input_golden: GoldenMapTensor) -> GoldenMapTensor:
+    """Build a valid stats tensor from the input, matching tt-metal's expected format.
+
+    For single-device layernorm the stats tensor is 2 tiles wide (64 elements):
+      tile 0 [0:32]:  sum(x^2) at position 0, zeros elsewhere
+      tile 1 [32:64]: sum(x) at position 32, zeros elsewhere
+    """
+
+    def compute_stats(shard):
+        shard_float = shard.float()
+        sum_x = shard_float.sum(dim=-1, keepdim=True)
+        sum_x2 = shard_float.pow(2).sum(dim=-1, keepdim=True)
+        output_shape = list(shard_float.shape)
+        output_shape[-1] = 2 * TILE_WIDTH
+        stats = torch.zeros(output_shape, dtype=shard.dtype)
+        stats[..., :1] = sum_x2
+        stats[..., TILE_WIDTH : TILE_WIDTH + 1] = sum_x
+        return stats
+
+    return GoldenMapTensor.apply_shardwise(input_golden, compute_stats)
 
 
 # LayerNormPreAllGather tests
@@ -26,7 +52,7 @@ pytestmark = pytest.mark.frontend("ttnn")
     ids=shape_str,
 )
 @pytest.mark.parametrize("has_residual", [False, True])
-@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
 def test_layer_norm_pre_all_gather(
     shape: Shape,
     has_residual: bool,
@@ -50,6 +76,71 @@ def test_layer_norm_pre_all_gather(
             return builder.layer_norm_pre_all_gather(
                 in0,
                 residual_input=residual,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttnn(
+        module,
+        **get_request_kwargs(request),
+        device=device,
+        target=target,
+    )
+
+
+# LayerNormPostAllGather tests
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 32, 128),
+        (1, 1, 32, 512),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize("has_weight_bias", [False, True])
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_layer_norm_post_all_gather(
+    shape: Shape,
+    has_weight_bias: bool,
+    target: str,
+    request,
+    device,
+):
+    # Stats tensor shape: same leading dims as input, last dim = 2 * TILE_WIDTH (64)
+    stats_shape = shape[:-1] + (64,)
+    shapes = [shape, stats_shape]
+    dtypes = [torch.bfloat16, torch.bfloat16]
+
+    if has_weight_bias:
+        weight_shape = (shape[-1],)
+        shapes.append(weight_shape)
+        shapes.append(weight_shape)
+        dtypes.extend([torch.bfloat16, torch.bfloat16])
+
+    def module(builder: TTNNBuilder):
+        @builder.func(shapes, dtypes)
+        def layer_norm_post_all_gather(*inputs, unit_attrs: Optional[List[str]] = None):
+            builder = inputs[-1]
+            in0 = inputs[0]
+            stats = inputs[1]
+            weight = None
+            bias = None
+            if has_weight_bias and len(inputs) > 3:
+                weight = inputs[2]
+                bias = inputs[3]
+
+            # Override the random stats golden with valid statistics
+            # derived from the input tensor, matching tt-metal's format.
+            input_golden = builder._get_golden_tensor(in0)
+            stats_golden = build_stats_golden(input_golden)
+            builder._set_golden_tensor(stats, stats_golden)
+
+            return builder.layer_norm_post_all_gather(
+                in0,
+                stats,
+                weight=weight,
+                bias=bias,
                 unit_attrs=unit_attrs,
             )
 

--- a/test/ttmlir/Dialect/TTNN/layer_norm_post_all_gather/layer_norm_post_all_gather_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/layer_norm_post_all_gather/layer_norm_post_all_gather_negative.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt %s 2>&1 | FileCheck %s
+
+module {
+  // CHECK: error: 'ttnn.layer_norm_post_all_gather' op input and output must have the same shape
+  func.func @bad_output_shape(%arg0: tensor<1x1x32x128xbf16>, %arg1: tensor<1x1x32x64xbf16>) -> tensor<1x1x32x64xbf16> {
+    %0 = "ttnn.layer_norm_post_all_gather"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<1x1x32x128xbf16>, tensor<1x1x32x64xbf16>) -> tensor<1x1x32x64xbf16>
+    return %0 : tensor<1x1x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/layer_norm_post_all_gather/simple_layer_norm_post_all_gather.mlir
+++ b/test/ttmlir/Dialect/TTNN/layer_norm_post_all_gather/simple_layer_norm_post_all_gather.mlir
@@ -1,0 +1,24 @@
+// RUN: ttmlir-opt %s | FileCheck %s
+
+module {
+  // Test basic layer_norm_post_all_gather with input and stats only
+  func.func @forward(%arg0: tensor<1x1x32x128xbf16>, %arg1: tensor<1x1x32x64xbf16>) -> tensor<1x1x32x128xbf16> {
+    // CHECK: "ttnn.layer_norm_post_all_gather"
+    %0 = "ttnn.layer_norm_post_all_gather"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<1x1x32x128xbf16>, tensor<1x1x32x64xbf16>) -> tensor<1x1x32x128xbf16>
+    return %0 : tensor<1x1x32x128xbf16>
+  }
+
+  // Test layer_norm_post_all_gather with weight and bias
+  func.func @forward_with_weight_bias(%arg0: tensor<1x1x32x128xbf16>, %arg1: tensor<1x1x32x64xbf16>, %arg2: tensor<128xbf16>, %arg3: tensor<128xbf16>) -> tensor<1x1x32x128xbf16> {
+    // CHECK: "ttnn.layer_norm_post_all_gather"
+    %0 = "ttnn.layer_norm_post_all_gather"(%arg0, %arg1, %arg2, %arg3) <{epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 1>}> : (tensor<1x1x32x128xbf16>, tensor<1x1x32x64xbf16>, tensor<128xbf16>, tensor<128xbf16>) -> tensor<1x1x32x128xbf16>
+    return %0 : tensor<1x1x32x128xbf16>
+  }
+
+  // Test layer_norm_post_all_gather with dtype attribute
+  func.func @forward_with_dtype(%arg0: tensor<1x1x32x128xbf16>, %arg1: tensor<1x1x32x64xbf16>) -> tensor<1x1x32x128xbf16> {
+    // CHECK: "ttnn.layer_norm_post_all_gather"
+    %0 = "ttnn.layer_norm_post_all_gather"(%arg0, %arg1) <{epsilon = 1.000000e-12 : f32, dtype = #ttcore.supportedDataTypes<bf16>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<1x1x32x128xbf16>, tensor<1x1x32x64xbf16>) -> tensor<1x1x32x128xbf16>
+    return %0 : tensor<1x1x32x128xbf16>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -4768,6 +4768,132 @@ INSTANTIATE_TEST_SUITE_P(LayerNormPreAllGatherTests,
                          layerNormPreAllGatherTestValues);
 
 //===----------------------------------------------------------------------===//
+// LayerNormPostAllGatherOp Tests
+//===----------------------------------------------------------------------===//
+
+class OpModelLayerNormPostAllGatherParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          std::tuple<detail::TestTensor,                // input
+                     detail::TestTensor,                // stats
+                     detail::TestTensor,                // output
+                     std::optional<detail::TestTensor>, // weight
+                     std::optional<detail::TestTensor>, // bias
+                     float,                             // epsilon
+                     detail::ExpectedResult             // expected result
+                     >> {};
+
+TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
+  auto params = GetParam();
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+  const auto [statsShape, statsTensorLayout, statsBufferType,
+              statsVirtualGrid] = std::get<1>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<2>(params);
+  const auto weightOpt = std::get<3>(params);
+  const auto biasOpt = std::get<4>(params);
+  const auto epsilon = llvm::APFloat(std::get<5>(params));
+  const auto expectedResult = std::get<6>(params);
+  const auto expectedLegal = expectedResult.expectedLegal;
+
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+  const TTNNLayoutAttr statsLayout = CreateTiledLayout(
+      statsShape, statsBufferType, statsTensorLayout, statsVirtualGrid);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  std::optional<llvm::ArrayRef<int64_t>> weightShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> weightLayout = std::nullopt;
+  if (weightOpt.has_value()) {
+    const auto &[shape, layout, bufferType, virtualGrid] = weightOpt.value();
+    weightShape = shape;
+    weightLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
+  }
+
+  std::optional<llvm::ArrayRef<int64_t>> biasShape = std::nullopt;
+  std::optional<TTNNLayoutAttr> biasLayout = std::nullopt;
+  if (biasOpt.has_value()) {
+    const auto &[shape, layout, bufferType, virtualGrid] = biasOpt.value();
+    biasShape = shape;
+    biasLayout = CreateTiledLayout(shape, bufferType, layout, virtualGrid);
+  }
+
+  auto constraintsExp =
+      op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
+          CreateWorkerGrid(), inputShape, inputLayout, statsShape, statsLayout,
+          weightShape, weightLayout, biasShape, biasLayout, epsilon,
+          outputLayout);
+
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (constraintsExp) {
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+                outputLayoutReadBacks] = constraintsExp.get();
+    EXPECT_GE(cbSize, 0);
+    EXPECT_GE(l1PeakSize, 0);
+    EXPECT_GE(totalPeakSize, 0);
+    EXPECT_GE(outputSize, 0);
+  } else {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = op_model::OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
+      inputShape, inputLayout, statsShape, statsLayout, weightShape,
+      weightLayout, biasShape, biasLayout, epsilon, outputLayout);
+
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+const auto layerNormPostAllGatherTestValues = ::testing::Values(
+    // Test case 1: Basic with input and stats only
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        std::nullopt, std::nullopt, 1e-12f, detail::ExpectedResult{true}),
+
+    // Test case 2: With weight and bias
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+        std::make_optional(detail::TestTensor{
+            {128}, TensorMemoryLayout::Interleaved, BufferType::DRAM}),
+        std::make_optional(detail::TestTensor{
+            {128}, TensorMemoryLayout::Interleaved, BufferType::DRAM}),
+        1e-12f, detail::ExpectedResult{true}),
+
+    // Test case 3: With L1 memory buffers
+    std::make_tuple(
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::L1},
+        detail::TestTensor{
+            {1, 1, 32, 64}, TensorMemoryLayout::Interleaved, BufferType::L1},
+        detail::TestTensor{
+            {1, 1, 32, 128}, TensorMemoryLayout::Interleaved, BufferType::L1},
+        std::make_optional(detail::TestTensor{
+            {128}, TensorMemoryLayout::Interleaved, BufferType::L1}),
+        std::make_optional(detail::TestTensor{
+            {128}, TensorMemoryLayout::Interleaved, BufferType::L1}),
+        1e-12f, detail::ExpectedResult{true}));
+
+INSTANTIATE_TEST_SUITE_P(LayerNormPostAllGatherTests,
+                         OpModelLayerNormPostAllGatherParam,
+                         layerNormPostAllGatherTestValues);
+
+//===----------------------------------------------------------------------===//
 // GroupNormOp Tests
 //===----------------------------------------------------------------------===//
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4583,6 +4583,133 @@ TEST_F(OpModelBase, layerNormPreAllGatherOpL1Memory) {
   }
 }
 
+TEST_F(OpModelBase, layerNormPostAllGatherOp) {
+  // Test case 1: Basic LayerNormPostAllGather with weight and bias
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> statsShape = {1, 1, 32, 64};
+  llvm::SmallVector<int64_t> weightShape = {128};
+  llvm::SmallVector<int64_t> biasShape = {128};
+
+  auto input = createEmptyTensor(inputShape);
+  auto stats = createEmptyTensor(statsShape);
+  auto weight = createEmptyTensor(weightShape);
+  auto bias = createEmptyTensor(biasShape);
+  auto outputType = createRankedTensorType(inputShape);
+
+  llvm::APFloat epsilon(1e-12f);
+
+  LayerNormPostAllGatherOp op = builder.create<LayerNormPostAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input, stats, weight, bias, epsilon,
+      nullptr, nullptr, nullptr, nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, layerNormPostAllGatherOpMinimal) {
+  // Test case 2: LayerNormPostAllGather without optional tensors
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> statsShape = {1, 1, 32, 64};
+
+  auto input = createEmptyTensor(inputShape);
+  auto stats = createEmptyTensor(statsShape);
+  auto outputType = createRankedTensorType(inputShape);
+
+  llvm::APFloat epsilon(1e-12f);
+
+  LayerNormPostAllGatherOp op = builder.create<LayerNormPostAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input, stats, nullptr, nullptr,
+      epsilon, nullptr, nullptr, nullptr, nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, layerNormPostAllGatherOpL1Memory) {
+  // Test case 3: LayerNormPostAllGather with L1 memory buffers
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  llvm::SmallVector<int64_t> statsShape = {1, 1, 32, 64};
+  llvm::SmallVector<int64_t> weightShape = {128};
+  llvm::SmallVector<int64_t> biasShape = {128};
+
+  const TTNNLayoutAttr inputLayout_L1 = CreateTiledLayout(
+      inputShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr statsLayout_L1 = CreateTiledLayout(
+      statsShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr tensorLayout_L1 = CreateTiledLayout(
+      weightShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto input =
+      createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout_L1);
+  auto stats =
+      createEmptyTensor(statsShape, builder.getBF16Type(), statsLayout_L1);
+  auto weight =
+      createEmptyTensor(weightShape, builder.getBF16Type(), tensorLayout_L1);
+  auto bias =
+      createEmptyTensor(biasShape, builder.getBF16Type(), tensorLayout_L1);
+  auto outputType = createRankedTensorType(inputShape, builder.getBF16Type());
+
+  llvm::APFloat epsilon(1e-12f);
+
+  LayerNormPostAllGatherOp op = builder.create<LayerNormPostAllGatherOp>(
+      builder.getUnknownLoc(), outputType, input, stats, weight, bias, epsilon,
+      nullptr, nullptr, nullptr, nullptr);
+  op->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(op.getOperation());
+  if (!constraintsExp) {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
+              outputLayoutReadBack] = constraintsExp.get();
+  EXPECT_GT(cbSize, 0);
+  EXPECT_GE(l1PeakSize, 0);
+  EXPECT_GT(outputSize, 0);
+
+  auto runtimeExp = getOpRuntime(op.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, groupNormOp) {
   // Test case 1: Basic GroupNorm with weight and bias
   llvm::SmallVector<int64_t> inputShape = {1, 1, 64, 480};

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -8654,6 +8654,118 @@ class TTNNBuilder(Builder):
 
         return new_op, {old_op.result: new_op_result}
 
+    ############### ttnn.LayerNormPostAllGatherOp ###############
+
+    @tag(ttnn.LayerNormPostAllGatherOp)
+    def layer_norm_post_all_gather(
+        self,
+        input: Operand,
+        stats: Operand,
+        weight: Optional[Operand] = None,
+        bias: Optional[Operand] = None,
+        epsilon: float = 1e-12,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.layer_norm_post_all_gather)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(input)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input_golden = self._get_golden_tensor(input)
+        stats_golden = self._get_golden_tensor(stats)
+        weight_golden = self._get_golden_tensor(weight) if weight is not None else None
+        bias_golden = self._get_golden_tensor(bias) if bias is not None else None
+        epsilon_attr = FloatAttr.get_f32(epsilon)
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input_golden,
+            stats_golden,
+            weight_golden,
+            bias_golden,
+            epsilon_attr,
+            mlir_output_type,
+        )
+        result = self.create_ttnn_tensor(golden_output.shape, mlir_output_type)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        output_dtype = self._get_data_type_attribute(input)
+
+        op = ttnn_op(
+            result,
+            input,
+            stats,
+            loc=loc,
+            weight=weight,
+            bias=bias,
+            epsilon=epsilon_attr,
+            dtype=output_dtype,
+        )
+        op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(ttnn.LayerNormPostAllGatherOp)
+    def layer_norm_post_all_gather_parser(
+        self,
+        old_op: ttnn.LayerNormPostAllGatherOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(
+            TTNNBuilder.layer_norm_post_all_gather_parser
+        )
+
+        in0 = global_dict[old_op.input]
+        stats = global_dict[old_op.stats]
+        weight = global_dict[old_op.weight] if old_op.weight is not None else None
+        bias = global_dict[old_op.bias] if old_op.bias is not None else None
+        result = old_op.result.type
+
+        new_op = ttnn_op(
+            result,
+            in0,
+            stats,
+            loc=old_op.location,
+            weight=weight,
+            bias=bias,
+            epsilon=old_op.epsilon,
+            dtype=old_op.dtype,
+            memory_config=old_op.memory_config,
+            compute_config=old_op.compute_config,
+            program_config=old_op.program_config,
+        )
+        new_op_result = new_op.result
+
+        input_golden = self._get_golden_tensor(in0)
+        stats_golden = self._get_golden_tensor(stats)
+        weight_golden = self._get_golden_tensor(weight) if weight is not None else None
+        bias_golden = self._get_golden_tensor(bias) if bias is not None else None
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input_golden,
+            stats_golden,
+            weight_golden,
+            bias_golden,
+            old_op.epsilon,
+            result.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op, {old_op.result: new_op_result}
+
     ############### ttnn.AllGatherOp ###############
 
     @tag(ttnn.AllGatherOp)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6413,6 +6413,38 @@ def ttnn_layer_norm_pre_all_gather_golden(
     return GoldenMapTensor.apply_shardwise(input_float, compute_stats)
 
 
+def ttnn_layer_norm_post_all_gather_golden(
+    input: GoldenMapTensor,
+    stats: GoldenMapTensor,
+    weight: Optional[GoldenMapTensor],
+    bias: Optional[GoldenMapTensor],
+    epsilon: FloatAttr,
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    # The stats tensor is ignored for the golden reference.  The hardware
+    # kernel reconstructs E(x) and E(x^2) from the gathered statistics and
+    # then applies standard layer normalization.  Rather than replicating the
+    # kernel's tiled-reduce logic (which depends on tile width, device count
+    # and a bfloat16 scaler), we compute the reference output directly using
+    # the input tensor — exactly as tt-metal's own test does.
+    del stats
+
+    epsilon = unpack_mlir_attr(epsilon)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    def compute_ln(shard):
+        shard_float = shard.float()
+        normalized_shape = shard_float.shape[-1:]
+        w = weight.shard_map[0].float() if weight is not None else None
+        b = bias.shard_map[0].float() if bias is not None else None
+        out = torch.nn.functional.layer_norm(
+            shard_float, normalized_shape, w, b, epsilon
+        )
+        return out.to(output_dtype)
+
+    return GoldenMapTensor.apply_shardwise(input, compute_ln)
+
+
 def ttnn_group_norm_golden(
     input: GoldenMapTensor,
     weight: Optional[GoldenMapTensor],
@@ -6951,6 +6983,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.LinearOp: ttnn_linear_golden,
     ttnn.LayerNormOp: ttnn_layer_norm_golden,
     ttnn.LayerNormPreAllGatherOp: ttnn_layer_norm_pre_all_gather_golden,
+    ttnn.LayerNormPostAllGatherOp: ttnn_layer_norm_post_all_gather_golden,
     ttnn.GroupNormOp: ttnn_group_norm_golden,
     ttnn.RMSNormOp: rms_norm_golden,
     # Tensor manipulation

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -38,6 +38,8 @@
 #include "operations/normalization/batch_norm/batch_norm.hpp"
 #include "operations/normalization/groupnorm/groupnorm.hpp"
 #include "operations/normalization/layernorm/layernorm.hpp"
+#include "operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
+#include "operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
 #include "operations/normalization/rmsnorm/rmsnorm.hpp"
 #include "operations/normalization/softmax/softmax.hpp"
 #include "operations/pool/generic/generic_pools.hpp"


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7596

### Summary
- Add layer_norm_post_all_gather op to the TTNN dialect, completing the second half of the distributed layer normalization pipeline (complementing the existing layer_norm_pre_all_gather op)
- Full end-to-end support across all compiler layers: op definition (ODS), verifier, flatbuffer serialization, EmitC/EmitPy lowering, runtime execution, op model interface, builder API, and golden mapping

### Checklist
- [x] New/Existing tests provide coverage for changes
