### PR TITLE
[TTNN] Refactor SDPA fusing: move pre-scale extraction to analyze phase

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3473,6 +3473,12 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
+      }
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -3536,6 +3542,12 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
+      }
+    }];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -335,6 +335,15 @@ public:
   static TTNNOperandsWorkarounds
   createSortOpOperandsWorkarounds(ttnn::SortOp op);
 
+  // Create workarounds for SDPA ops: cast f32 inputs to bf16.
+  // tt-metal SDPA only supports bf16/bfp8_b/bfp4_b.
+  // Issue page: https://github.com/tenstorrent/tt-metal/issues/36717
+  static TTNNOperandsWorkarounds
+  createScaledDotProductAttentionOpOperandsWorkarounds(Operation *op);
+
+  static TTNNOperandsWorkarounds
+  createScaledDotProductAttentionDecodeOpOperandsWorkarounds(Operation *op);
+
   static TTNNOperandsWorkarounds
   createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(
       Operation *op);

--- a/include/ttmlir/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.h
@@ -42,10 +42,8 @@ private:
 
   // Constant Extraction
   std::optional<float> extractConstant(Value v) const;
-
-  // Q/K Extraction with Scale Handling
-  std::pair<Value, std::optional<float>> extractTensorWithScale(Value v) const;
-  bool extractQKWithScales(Value a, Value b, SDPAComponents &c) const;
+  std::pair<Value, std::optional<float>>
+  extractMultiplyWithConstant(Value v) const;
 
   // Pattern Matching
   bool matchSoftmaxPath(Value v, SDPAComponents &c) const;
@@ -53,15 +51,10 @@ private:
   bool matchScoreChain(Value v, SDPAComponents &c) const;
 
   // Input Canonicalization
-  static Value castToBF16IfNeeded(Value v, PatternRewriter &rewriter);
-  static Value restoreElementTypeIfNeeded(Value v, Type elementType,
-                                          PatternRewriter &rewriter);
-  static Type getTargetElementType(Value v);
-  std::pair<Value, Type> analyzeQ(Value v) const;
-  std::tuple<Value, Type, bool> analyzeK(Value v) const;
-  std::pair<Value, Type> analyzeV(Value v) const;
-  Value prepareMask(Value v) const;
-  void prepareInputsForSDPA(SDPAComponents &c, PatternRewriter &rewriter) const;
+  std::pair<Value, std::optional<float>> analyzeQ(Value v) const;
+  std::tuple<Value, bool, std::optional<float>> analyzeK(Value v) const;
+  Value analyzeV(Value v) const;
+  bool prepareInputsForSDPA(SDPAComponents &c, PatternRewriter &rewriter) const;
 
   // Key Un-transpose
   Value unTransposeKeyIfNeeded(Value query, Value key, Value value,

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -889,6 +889,94 @@ TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(
       .addOutputOperandWorkaround(indicesWorkaround);
 }
 
+// Create workarounds for SDPA prefill op: cast f32 inputs to bf16.
+// tt-metal SDPA only supports bf16/bfp8_b/bfp4_b.
+// Issue page: https://github.com/tenstorrent/tt-metal/issues/36717
+TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
+    createScaledDotProductAttentionOpOperandsWorkarounds(Operation *op) {
+  TTNNOperandWorkarounds bf16Workaround;
+  bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+  TTNNOperandWorkarounds emptyWorkaround;
+
+  auto sdpaOp = cast<ScaledDotProductAttentionOp>(op);
+
+  TTNNOperandsWorkarounds operandsWorkaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+
+  // Query, key, value: cast to bf16 if f32.
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+
+  // Attention mask (optional).
+  if (sdpaOp.getAttentionMask()) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  }
+
+  // Attention sink (optional).
+  if (sdpaOp.getAttentionSink()) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+  }
+
+  // Output: cast to bf16 if f32.
+  operandsWorkaround =
+      operandsWorkaround.addOutputOperandWorkaround(bf16Workaround);
+
+  return operandsWorkaround;
+}
+
+// Create workarounds for SDPA decode op: cast f32 inputs to bf16.
+// tt-metal SDPA only supports bf16/bfp8_b/bfp4_b.
+// Issue page: https://github.com/tenstorrent/tt-metal/issues/36717
+TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
+    createScaledDotProductAttentionDecodeOpOperandsWorkarounds(Operation *op) {
+  TTNNOperandWorkarounds bf16Workaround;
+  bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+  TTNNOperandWorkarounds emptyWorkaround;
+
+  auto sdpaOp = cast<ScaledDotProductAttentionDecodeOp>(op);
+
+  TTNNOperandsWorkarounds operandsWorkaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+
+  // Query, key, value: cast to bf16 if f32.
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  operandsWorkaround =
+      operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+
+  // Attention mask (optional).
+  if (sdpaOp.getAttentionMask()) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(bf16Workaround);
+  }
+
+  // Cur pos tensor (optional).
+  if (sdpaOp.getCurPosTensor()) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+  }
+
+  // Attention sink (optional).
+  if (sdpaOp.getAttentionSink()) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(emptyWorkaround);
+  }
+
+  // Output: cast to bf16 if f32.
+  operandsWorkaround =
+      operandsWorkaround.addOutputOperandWorkaround(bf16Workaround);
+
+  return operandsWorkaround;
+}
+
 TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
     createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(
         Operation *op) {

--- a/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -158,49 +158,17 @@ std::optional<float> SDPAFusing::extractConstant(Value v) const {
   return std::nullopt;
 }
 
-// ============================================================================
-// Q/K Extraction with Scale Handling
-// ============================================================================
-
 std::pair<Value, std::optional<float>>
-SDPAFusing::extractTensorWithScale(Value v) const {
-  std::optional<float> scale;
-
-  Value skipped = ttmlir::utils::lookThrough<TypecastOp>(v);
-  if (auto mulOp = skipped.getDefiningOp<MultiplyOp>()) {
+SDPAFusing::extractMultiplyWithConstant(Value v) const {
+  if (auto mulOp = v.getDefiningOp<MultiplyOp>()) {
     if (auto s = extractConstant(mulOp.getRhs())) {
-      scale = s;
-      return {mulOp.getLhs(), scale};
+      return {mulOp.getLhs(), s};
     }
     if (auto s = extractConstant(mulOp.getLhs())) {
-      scale = s;
-      return {mulOp.getRhs(), scale};
+      return {mulOp.getRhs(), s};
     }
   }
-
-  return {v, scale};
-}
-
-bool SDPAFusing::extractQKWithScales(Value a, Value b,
-                                     SDPAComponents &c) const {
-  auto [query, qScale] = extractTensorWithScale(a);
-  auto [key, kScale] = extractTensorWithScale(b);
-
-  bool hasPostMatmulScale = c.scale.has_value();
-  bool hasPreScale = qScale.has_value() || kScale.has_value();
-  if (hasPostMatmulScale && hasPreScale) {
-    return false;
-  }
-
-  c.query = query;
-  c.key = key;
-
-  if (hasPreScale) {
-    float qs = qScale.value_or(1.0f);
-    float ks = kScale.value_or(1.0f);
-    c.scale = qs * ks;
-  }
-  return true;
+  return {v, std::nullopt};
 }
 
 // ============================================================================
@@ -274,9 +242,8 @@ bool SDPAFusing::matchScoreComputation(Value v, SDPAComponents &c) const {
 
   if (auto linearOp = v.getDefiningOp<LinearOp>()) {
     c.scoreOp = linearOp;
-    if (!extractQKWithScales(linearOp.getA(), linearOp.getB(), c)) {
-      return false;
-    }
+    c.query = linearOp.getA();
+    c.key = linearOp.getB();
     if (linearOp.getBias()) {
       c.mask = linearOp.getBias();
     }
@@ -323,9 +290,8 @@ bool SDPAFusing::matchScoreChain(Value v, SDPAComponents &c) const {
   if (auto matmul = v.getDefiningOp<MatmulOp>()) {
     if (matmul != c.attentionMatmul) {
       c.scoreOp = matmul;
-      if (!extractQKWithScales(matmul.getA(), matmul.getB(), c)) {
-        return false;
-      }
+      c.query = matmul.getA();
+      c.key = matmul.getB();
       return true;
     }
   }
@@ -334,81 +300,44 @@ bool SDPAFusing::matchScoreChain(Value v, SDPAComponents &c) const {
 }
 
 // ============================================================================
-// Input Canonicalization (dtype/TM/mask)
+// Input Canonicalization
 // ============================================================================
 
-Value SDPAFusing::castToBF16IfNeeded(Value v, PatternRewriter &rewriter) {
-  auto vType = cast<RankedTensorType>(v.getType());
-  if (!vType.getElementType().isF32()) {
-    return v;
+std::pair<Value, std::optional<float>> SDPAFusing::analyzeQ(Value v) const {
+  // Look through typecast to find multiply-with-constant (pre-scale on Q).
+  Value skipped = ttmlir::utils::lookThrough<TypecastOp>(v);
+  auto [inner, scale] = extractMultiplyWithConstant(skipped);
+  if (scale) {
+    v = inner;
   }
 
-  auto dataType = ttcore::DataType::BFloat16;
-  auto castType = utils::RankedTensorTypeFactory::create(vType, dataType);
-  return rewriter.create<TypecastOp>(
-      v.getLoc(), castType, v,
-      ttcore::DataTypeAttr::get(rewriter.getContext(), dataType));
-}
-
-Value SDPAFusing::restoreElementTypeIfNeeded(Value v, Type elementType,
-                                             PatternRewriter &rewriter) {
-  auto vType = cast<RankedTensorType>(v.getType());
-  if (vType.getElementType() == elementType) {
-    return v;
-  }
-
-  auto dataType = ttcore::elementTypeToDataType(elementType);
-  auto castType = utils::RankedTensorTypeFactory::create(vType, dataType);
-  return rewriter.create<TypecastOp>(
-      v.getLoc(), castType, v,
-      ttcore::DataTypeAttr::get(rewriter.getContext(), dataType));
-}
-
-Type SDPAFusing::getTargetElementType(Value v) {
-  Type lastSeen = cast<RankedTensorType>(v.getType()).getElementType();
-  while (Operation *defOp = v.getDefiningOp()) {
-    if (isa<TypecastOp, ReshapeOp, PermuteOp, RepeatInterleaveOp>(defOp)) {
-      v = defOp->getOperand(0);
-      lastSeen = cast<RankedTensorType>(v.getType()).getElementType();
-      continue;
-    }
-
-    break;
-  }
-  return lastSeen;
-}
-
-std::pair<Value, Type> SDPAFusing::analyzeQ(Value v) const {
   if (auto typecastOp = v.getDefiningOp<TypecastOp>()) {
     v = typecastOp.getInput();
   }
 
-  if (auto loadCached = v.getDefiningOp<ttcore::LoadCachedOp>()) {
-    auto funcOp = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
-        loadCached, loadCached.getCalleeAttr());
-    if (funcOp) {
-      unsigned resultIdx = cast<OpResult>(v).getResultNumber();
-      for (auto &block : funcOp.getBody()) {
-        if (auto returnOp = dyn_cast<func::ReturnOp>(block.getTerminator())) {
-          Value innerV = returnOp.getOperand(resultIdx);
-          auto [originalTensor, scale] = extractTensorWithScale(innerV);
-          return {v, getTargetElementType(originalTensor)};
-        }
-      }
-    }
-  }
-
-  return {v, getTargetElementType(v)};
+  return {v, scale};
 }
 
-std::tuple<Value, Type, bool> SDPAFusing::analyzeK(Value v) const {
-  Type targetDtype = getTargetElementType(v);
+std::tuple<Value, bool, std::optional<float>>
+SDPAFusing::analyzeK(Value v) const {
   bool skippedTranspose = false;
+  std::optional<float> scale;
 
   while (Operation *defOp = v.getDefiningOp()) {
     if (isa<TypecastOp>(defOp)) {
       v = defOp->getOperand(0);
       continue;
+    }
+
+    // Walk through multiply-with-constant (pre-scale on K).
+    // The elementwise commute pass may place this before or after the permute.
+    if (!scale) {
+      auto [inner, s] = extractMultiplyWithConstant(v);
+      if (s) {
+        scale = s;
+        v = inner;
+        continue;
+      }
     }
 
     if (auto repeatOp = dyn_cast<RepeatInterleaveOp>(defOp)) {
@@ -430,12 +359,10 @@ std::tuple<Value, Type, bool> SDPAFusing::analyzeK(Value v) const {
     break;
   }
 
-  return {v, targetDtype, skippedTranspose};
+  return {v, skippedTranspose, scale};
 }
 
-std::pair<Value, Type> SDPAFusing::analyzeV(Value v) const {
-  Type targetDtype = getTargetElementType(v);
-
+Value SDPAFusing::analyzeV(Value v) const {
   while (Operation *defOp = v.getDefiningOp()) {
     if (isa<TypecastOp>(defOp)) {
       v = defOp->getOperand(0);
@@ -453,34 +380,42 @@ std::pair<Value, Type> SDPAFusing::analyzeV(Value v) const {
     break;
   }
 
-  return {v, targetDtype};
+  return v;
 }
 
 // Prepare SDPA inputs for the hardware op. This involves several steps:
 //
-//  1. Analyze Q, K, V to look through typecasts, repeat-interleave, and
-//     permute ops, recovering the original element types and detecting key
+//  1. Analyze Q, K, V to look through typecasts, repeat-interleave, multiply
+//     (pre-scale), and permute ops, extracting pre-scales and detecting key
 //     transposition.
-//  2. Validate and accept the "prepared" (looked-through) versions of Q, K, V
+//  2. Combine pre-scales (from Q and K) into c.scale.
+//  3. Validate and accept the "prepared" (looked-through) versions of Q, K, V
 //     if their shapes are compatible.
-//  3. Un-transpose K if needed ([B, H, D, S] -> [B, H, S, D]).
-//  4. Restore original element types that were stripped during analysis.
+//  4. Un-transpose K if needed ([B, H, D, S] -> [B, H, S, D]).
 //  5. Unsqueeze the attention mask to 4D if it is lower-rank.
 //  6. Handle attention sink batch dimension from load_cached ops.
 //  7. Unsqueeze Q, K, V to 4D by prepending 1s if they are 3D. Some frontends
 //     squeeze away the head dimension when num_heads=1.
-void SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
+bool SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
                                       PatternRewriter &rewriter) const {
-  auto [preparedQ, preparedQElementType] = analyzeQ(c.query);
-  auto [preparedK, preparedKElementType, skippedKTranspose] = analyzeK(c.key);
-  auto [preparedV, preparedVElementType] = analyzeV(c.value);
+  auto [preparedQ, qPreScale] = analyzeQ(c.query);
+  auto [preparedK, skippedKTranspose, kPreScale] = analyzeK(c.key);
+  Value preparedV = analyzeV(c.value);
+
+  // Reject ambiguous double-scaling (both post-matmul and pre-matmul scales).
+  bool hasPostScale = c.scale.has_value();
+  bool hasPreScale = qPreScale.has_value() || kPreScale.has_value();
+  if (hasPostScale && hasPreScale) {
+    return false;
+  }
+
+  // Combine pre-scales into c.scale.
+  if (hasPreScale) {
+    c.scale = qPreScale.value_or(1.0f) * kPreScale.value_or(1.0f);
+  }
 
   if (validateShapes(preparedQ, c.key, c.value)) {
-    c.query =
-        restoreElementTypeIfNeeded(preparedQ, preparedQElementType, rewriter);
-  } else {
-    c.query =
-        restoreElementTypeIfNeeded(c.query, preparedQElementType, rewriter);
+    c.query = preparedQ;
   }
 
   if (validateShapes(c.query, preparedK, preparedV)) {
@@ -492,9 +427,6 @@ void SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
     c.key = unTransposeKeyIfNeeded(c.query, c.key, c.value, rewriter,
                                    c.attentionMatmul.getLoc());
   }
-
-  c.key = restoreElementTypeIfNeeded(c.key, preparedKElementType, rewriter);
-  c.value = restoreElementTypeIfNeeded(c.value, preparedVElementType, rewriter);
 
   if (c.mask) {
     c.mask = ttmlir::utils::lookThrough<TypecastOp, RepeatOp>(c.mask);
@@ -515,8 +447,6 @@ void SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
                                  /*memory_config=*/MemoryConfigAttr())
               .getResult();
     }
-
-    c.mask = restoreElementTypeIfNeeded(c.mask, preparedQElementType, rewriter);
   }
 
   if (c.attentionSink) {
@@ -588,6 +518,8 @@ void SDPAFusing::prepareInputsForSDPA(SDPAComponents &c,
   c.query = unsqueezeTo4D(c.query);
   c.key = unsqueezeTo4D(c.key);
   c.value = unsqueezeTo4D(c.value);
+
+  return true;
 }
 
 // ============================================================================
@@ -723,7 +655,9 @@ SDPAFusing::matchAndRewrite(MatmulOp srcOp,
     return failure();
   }
 
-  prepareInputsForSDPA(c, rewriter);
+  if (!prepareInputsForSDPA(c, rewriter)) {
+    return failure();
+  }
 
   return createSDPAOp(rewriter, c);
 }
@@ -739,18 +673,6 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
 
   auto originalOutputType =
       mlir::cast<RankedTensorType>(c.attentionMatmul.getResult().getType());
-  Type originalElementType = originalOutputType.getElementType();
-
-  // Cast inputs to bf16 if they are f32, since tt-metal SDPA only supports
-  // bf16/bfp8_b/bfp4_b. The output will be cast back to the original dtype.
-  // TODO(tt-metal): Remove this once tt-metal adds f32 support.
-  // tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/36717
-  c.query = castToBF16IfNeeded(c.query, rewriter);
-  c.key = castToBF16IfNeeded(c.key, rewriter);
-  c.value = castToBF16IfNeeded(c.value, rewriter);
-  if (c.mask) {
-    c.mask = castToBF16IfNeeded(c.mask, rewriter);
-  }
 
   // Workaround for https://github.com/tenstorrent/tt-metal/issues/40470:
   // tt-metal's SDPA kernel computes exp((sink - max) * scale), applying scale
@@ -810,9 +732,6 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         ttmlir::utils::inversePermutation(kToDecodePermutation), rewriter,
         c.attentionMatmul.getLoc());
 
-    finalResult =
-        restoreElementTypeIfNeeded(finalResult, originalElementType, rewriter);
-
     finalResult = squeezeToOriginalRank(finalResult, originalOutputType,
                                         rewriter, c.attentionMatmul.getLoc());
 
@@ -840,11 +759,9 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         /*sliding_window_size=*/IntegerAttr(), c.attentionSink,
         /*memory_config=*/MemoryConfigAttr());
 
-    Value finalResult = restoreElementTypeIfNeeded(
-        sdpaOp.getResult(), originalElementType, rewriter);
-
-    finalResult = squeezeToOriginalRank(finalResult, originalOutputType,
-                                        rewriter, c.attentionMatmul.getLoc());
+    Value finalResult =
+        squeezeToOriginalRank(sdpaOp.getResult(), originalOutputType, rewriter,
+                              c.attentionMatmul.getLoc());
 
     rewriter.replaceOp(c.attentionMatmul, finalResult);
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
@@ -4,11 +4,11 @@ module @test_sdpa_workaround attributes {} {
   // Test 1: Workaround should NOT apply - unaligned sequence length with mask
   // (tt-metal now handles sequence padding internally)
   func.func public @test_sdpa_no_workaround_unaligned_seq_with_mask(
-    %query: tensor<2x8x31x64xf32>,
-    %key: tensor<2x8x31x64xf32>,
-    %value: tensor<2x8x31x64xf32>,
-    %mask: tensor<2x1x31x31xf32>
-  ) -> tensor<2x8x31x64xf32> {
+    %query: tensor<2x8x31x64xbf16>,
+    %key: tensor<2x8x31x64xbf16>,
+    %value: tensor<2x8x31x64xbf16>,
+    %mask: tensor<2x1x31x31xbf16>
+  ) -> tensor<2x8x31x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_no_workaround_unaligned_seq_with_mask
 
     // CHECK-NOT: ttnn.pad
@@ -18,18 +18,18 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
       is_causal = false
-    }> : (tensor<2x8x31x64xf32>, tensor<2x8x31x64xf32>,
-         tensor<2x8x31x64xf32>, tensor<2x1x31x31xf32>)
-      -> tensor<2x8x31x64xf32>
-    return %result : tensor<2x8x31x64xf32>
+    }> : (tensor<2x8x31x64xbf16>, tensor<2x8x31x64xbf16>,
+         tensor<2x8x31x64xbf16>, tensor<2x1x31x31xbf16>)
+      -> tensor<2x8x31x64xbf16>
+    return %result : tensor<2x8x31x64xbf16>
   }
 
   // Test 2: Workaround should NOT apply - no mask
   func.func public @test_sdpa_no_workaround_no_mask(
-    %query: tensor<2x8x31x64xf32>,
-    %key: tensor<2x8x31x64xf32>,
-    %value: tensor<2x8x31x64xf32>
-  ) -> tensor<2x8x31x64xf32> {
+    %query: tensor<2x8x31x64xbf16>,
+    %key: tensor<2x8x31x64xbf16>,
+    %value: tensor<2x8x31x64xbf16>
+  ) -> tensor<2x8x31x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_no_workaround_no_mask
 
     // CHECK-NOT: ttnn.pad
@@ -39,19 +39,19 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
       is_causal = true
-    }> : (tensor<2x8x31x64xf32>, tensor<2x8x31x64xf32>,
-         tensor<2x8x31x64xf32>)
-      -> tensor<2x8x31x64xf32>
-    return %result : tensor<2x8x31x64xf32>
+    }> : (tensor<2x8x31x64xbf16>, tensor<2x8x31x64xbf16>,
+         tensor<2x8x31x64xbf16>)
+      -> tensor<2x8x31x64xbf16>
+    return %result : tensor<2x8x31x64xbf16>
   }
 
   // Test 3: Workaround should NOT apply - already aligned
   func.func public @test_sdpa_no_workaround_aligned(
-    %query: tensor<2x8x64x64xf32>,
-    %key: tensor<2x8x64x64xf32>,
-    %value: tensor<2x8x64x64xf32>,
-    %mask: tensor<2x1x64x64xf32>
-  ) -> tensor<2x8x64x64xf32> {
+    %query: tensor<2x8x64x64xbf16>,
+    %key: tensor<2x8x64x64xbf16>,
+    %value: tensor<2x8x64x64xbf16>,
+    %mask: tensor<2x1x64x64xbf16>
+  ) -> tensor<2x8x64x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_no_workaround_aligned
 
     // CHECK-NOT: ttnn.pad
@@ -61,19 +61,19 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
       is_causal = false
-    }> : (tensor<2x8x64x64xf32>, tensor<2x8x64x64xf32>,
-         tensor<2x8x64x64xf32>, tensor<2x1x64x64xf32>)
-      -> tensor<2x8x64x64xf32>
-    return %result : tensor<2x8x64x64xf32>
+    }> : (tensor<2x8x64x64xbf16>, tensor<2x8x64x64xbf16>,
+         tensor<2x8x64x64xbf16>, tensor<2x1x64x64xbf16>)
+      -> tensor<2x8x64x64xbf16>
+    return %result : tensor<2x8x64x64xbf16>
   }
 
   // Test 4: Workaround SHOULD apply - unaligned head_dim
   func.func public @test_sdpa_workaround_unaligned_head_dim(
-    %query: tensor<2x8x64x48xf32>,
-    %key: tensor<2x8x64x48xf32>,
-    %value: tensor<2x8x64x48xf32>,
-    %mask: tensor<2x1x64x64xf32>
-  ) -> tensor<2x8x64x48xf32> {
+    %query: tensor<2x8x64x48xbf16>,
+    %key: tensor<2x8x64x48xbf16>,
+    %value: tensor<2x8x64x48xbf16>,
+    %mask: tensor<2x1x64x64xbf16>
+  ) -> tensor<2x8x64x48xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_workaround_unaligned_head_dim
 
     // CHECK: %[[PADDED_QUERY:[0-9]+]] = "ttnn.pad"(%arg0)
@@ -96,18 +96,18 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
       is_causal = false
-    }> : (tensor<2x8x64x48xf32>, tensor<2x8x64x48xf32>,
-         tensor<2x8x64x48xf32>, tensor<2x1x64x64xf32>)
-      -> tensor<2x8x64x48xf32>
-    return %result : tensor<2x8x64x48xf32>
+    }> : (tensor<2x8x64x48xbf16>, tensor<2x8x64x48xbf16>,
+         tensor<2x8x64x48xbf16>, tensor<2x1x64x64xbf16>)
+      -> tensor<2x8x64x48xbf16>
+    return %result : tensor<2x8x64x48xbf16>
   }
 
   // Test 5: Workaround SHOULD apply - unaligned head_dim without mask
   func.func public @test_sdpa_workaround_unaligned_head_dim_no_mask(
-    %query: tensor<2x8x64x48xf32>,
-    %key: tensor<2x8x64x48xf32>,
-    %value: tensor<2x8x64x48xf32>
-  ) -> tensor<2x8x64x48xf32> {
+    %query: tensor<2x8x64x48xbf16>,
+    %key: tensor<2x8x64x48xbf16>,
+    %value: tensor<2x8x64x48xbf16>
+  ) -> tensor<2x8x64x48xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_workaround_unaligned_head_dim_no_mask
 
     // CHECK: %[[PADDED_QUERY:[0-9]+]] = "ttnn.pad"(%arg0)
@@ -130,20 +130,20 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
       is_causal = true
-    }> : (tensor<2x8x64x48xf32>, tensor<2x8x64x48xf32>,
-         tensor<2x8x64x48xf32>)
-      -> tensor<2x8x64x48xf32>
-    return %result : tensor<2x8x64x48xf32>
+    }> : (tensor<2x8x64x48xbf16>, tensor<2x8x64x48xbf16>,
+         tensor<2x8x64x48xbf16>)
+      -> tensor<2x8x64x48xbf16>
+    return %result : tensor<2x8x64x48xbf16>
   }
 
   // Test 6: Workaround SHOULD apply - both unaligned seq and head_dim, only
   // head_dim should be padded (sequence padding no longer needed)
   func.func public @test_sdpa_workaround_unaligned_seq_and_head_dim(
-    %query: tensor<2x8x31x48xf32>,
-    %key: tensor<2x8x31x48xf32>,
-    %value: tensor<2x8x31x48xf32>,
-    %mask: tensor<2x1x31x31xf32>
-  ) -> tensor<2x8x31x48xf32> {
+    %query: tensor<2x8x31x48xbf16>,
+    %key: tensor<2x8x31x48xbf16>,
+    %value: tensor<2x8x31x48xbf16>,
+    %mask: tensor<2x1x31x31xbf16>
+  ) -> tensor<2x8x31x48xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_workaround_unaligned_seq_and_head_dim
 
     // Only head_dim padding, no sequence padding
@@ -168,20 +168,20 @@ module @test_sdpa_workaround attributes {} {
     %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value, %mask) <{
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>,
       is_causal = false
-    }> : (tensor<2x8x31x48xf32>, tensor<2x8x31x48xf32>,
-         tensor<2x8x31x48xf32>, tensor<2x1x31x31xf32>)
-      -> tensor<2x8x31x48xf32>
-    return %result : tensor<2x8x31x48xf32>
+    }> : (tensor<2x8x31x48xbf16>, tensor<2x8x31x48xbf16>,
+         tensor<2x8x31x48xbf16>, tensor<2x1x31x31xbf16>)
+      -> tensor<2x8x31x48xbf16>
+    return %result : tensor<2x8x31x48xbf16>
   }
 
   // Test 7: Decode workaround SHOULD apply - mask num_heads=1 needs broadcast
   // to match query num_heads. tt-metal requires mask[2] == num_heads for decode.
   func.func public @test_sdpa_decode_workaround_broadcast_mask_heads(
-    %query: tensor<1x32x32x64xf32>,
-    %key: tensor<32x32x128x64xf32>,
-    %value: tensor<32x32x128x64xf32>,
-    %mask: tensor<32x1x1x128xf32>
-  ) -> tensor<1x32x32x64xf32> {
+    %query: tensor<1x32x32x64xbf16>,
+    %key: tensor<32x32x128x64xbf16>,
+    %value: tensor<32x32x128x64xbf16>,
+    %mask: tensor<32x1x1x128xbf16>
+  ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_workaround_broadcast_mask_heads
 
     // Mask should be broadcast from [32, 1, 1, 128] to [32, 1, 32, 128]
@@ -194,19 +194,19 @@ module @test_sdpa_workaround attributes {} {
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>,
       is_causal = false,
       scale = 0.125 : f32
-    }> : (tensor<1x32x32x64xf32>, tensor<32x32x128x64xf32>,
-         tensor<32x32x128x64xf32>, tensor<32x1x1x128xf32>)
-      -> tensor<1x32x32x64xf32>
-    return %result : tensor<1x32x32x64xf32>
+    }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
+         tensor<32x32x128x64xbf16>, tensor<32x1x1x128xbf16>)
+      -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
   }
 
   // Test 8: Decode workaround should NOT apply - mask already has correct num_heads
   func.func public @test_sdpa_decode_no_workaround_mask_heads_match(
-    %query: tensor<1x32x32x64xf32>,
-    %key: tensor<32x32x128x64xf32>,
-    %value: tensor<32x32x128x64xf32>,
-    %mask: tensor<32x1x32x128xf32>
-  ) -> tensor<1x32x32x64xf32> {
+    %query: tensor<1x32x32x64xbf16>,
+    %key: tensor<32x32x128x64xbf16>,
+    %value: tensor<32x32x128x64xbf16>,
+    %mask: tensor<32x1x32x128xbf16>
+  ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_no_workaround_mask_heads_match
 
     // No repeat needed - mask already has num_heads=32
@@ -217,18 +217,18 @@ module @test_sdpa_workaround attributes {} {
       operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 0>,
       is_causal = false,
       scale = 0.125 : f32
-    }> : (tensor<1x32x32x64xf32>, tensor<32x32x128x64xf32>,
-         tensor<32x32x128x64xf32>, tensor<32x1x32x128xf32>)
-      -> tensor<1x32x32x64xf32>
-    return %result : tensor<1x32x32x64xf32>
+    }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
+         tensor<32x32x128x64xbf16>, tensor<32x1x32x128xbf16>)
+      -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
   }
 
   // Test 9: Decode workaround should NOT apply - no mask
   func.func public @test_sdpa_decode_no_workaround_no_mask(
-    %query: tensor<1x32x32x64xf32>,
-    %key: tensor<32x32x128x64xf32>,
-    %value: tensor<32x32x128x64xf32>
-  ) -> tensor<1x32x32x64xf32> {
+    %query: tensor<1x32x32x64xbf16>,
+    %key: tensor<32x32x128x64xbf16>,
+    %value: tensor<32x32x128x64xbf16>
+  ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_no_workaround_no_mask
 
     // CHECK-NOT: ttnn.repeat
@@ -238,9 +238,9 @@ module @test_sdpa_workaround attributes {} {
       operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0>,
       is_causal = false,
       scale = 0.125 : f32
-    }> : (tensor<1x32x32x64xf32>, tensor<32x32x128x64xf32>,
-         tensor<32x32x128x64xf32>)
-      -> tensor<1x32x32x64xf32>
-    return %result : tensor<1x32x32x64xf32>
+    }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
+         tensor<32x32x128x64xbf16>)
+      -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
   }
 }


### PR DESCRIPTION
## Context

The SDPA fusing pattern had pre-scale extraction (detecting `Q * scale` and `K * scale`) interleaved with structural matching in `matchScoreChain`/`extractQKWithScales`. This made the pattern fragile to upstream IR transformations — for example, when the elementwise commute pass reorders `multiply(K, scale)` before `permute(transpose)`, the scale becomes invisible to `extractTensorWithScale` which only looked through `TypecastOp`.

This PR simplifies the fusing pattern by cleanly separating **structural matching** (finding the matmul/softmax/mask pattern) from **input canonicalization** (extracting scales, stripping typecasts/permutes/repeat-interleaves). Pre-scale extraction now lives in `analyzeQ`/`analyzeK` alongside the other canonicalization logic, where it naturally handles ops in any order.

Additionally, the f32→bf16 dtype workaround was moved out of the fusing pattern and into the `TTNNWorkarounds` pass where it belongs. This also means the `FusionValidator` automatically applies it during validation, since it already runs the workarounds pass internally.

## Summary
- Move per-operand pre-scale extraction (Q\*scale, K\*scale) from structural matching (`extractQKWithScales`/`extractTensorWithScale`) into the preparation phase (`analyzeQ`/`analyzeK`)
- Move f32→bf16 dtype workaround from the fusing pattern into the `TTNNWorkarounds` pass (registered on `ScaledDotProductAttentionOp` and `ScaledDotProductAttentionDecodeOp`)
- Remove `extractTensorWithScale`, `extractQKWithScales`, `castToBF16IfNeeded`, `restoreElementTypeIfNeeded`, `getTargetElementType`
- Add `extractMultiplyWithConstant` helper
- Simplify `matchScoreChain` and `matchScoreComputation` to directly assign `c.query`/`c.key` from matmul/linear operands

## Test plan
- [x] All 3 SDPA fusing test files pass (sdpa.mlir, sdpa_decode.mlir, sdpa_in_models.mlir)
- [x] All 8 fusing tests pass (SDPA, RoPE, TopK, NLP concat heads)
- [x] All 28 workaround tests pass (including updated sdpa_pad_sequence_dim_workaround.mlir)
- [x] Llama layer IR produces `ttnn.scaled_dot_product_attention_decode` with correct scale
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)