### PR TITLE
Rename logger component for validation fallback pass

### DIFF
--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -40,7 +40,8 @@ enum class LogComponent {
   Test,
   General,
   D2MFusion,
-  FusionValidator
+  FusionValidator,
+  ValidationFallback
 };
 
 // Log levels in order of verbosity
@@ -73,6 +74,8 @@ inline constexpr const char *getLogComponentStr(LogComponent type) {
     return "d2m-fusion";
   case LogComponent::FusionValidator:
     return "fusion-validator";
+  case LogComponent::ValidationFallback:
+    return "validation-fallback";
   }
   return "unknown";
 }

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -193,7 +193,7 @@ public:
         std::vector<TTNNLayoutAttr> inputLayouts =
             utils::extractInputLayouts(operation);
 
-        TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+        TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                      "Validating operation {} at {} with {} input layouts, "
                      "with {} output layouts, {} first output layout",
                      operation->getName(), operation->getLoc(),
@@ -205,7 +205,7 @@ public:
             op_constraint_validation::validateOperation(operation, inputLayouts,
                                                         configs[0]);
         if (originalResult.isNotImplemented()) {
-          TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+          TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                        "Operation {} at {} not supported for validation: {}",
                        operation->getName(), operation->getLoc(),
                        originalResult.errorMessage);
@@ -226,7 +226,7 @@ public:
               // Output layout mismatch - need to update the IR to match the
               // expected layout and insert necessary conversions back to the
               // expected layout.
-              TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+              TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                            "Operation {} at {} passed validation but output "
                            "layout index {} mismatch: expected output layout: "
                            "{}, backend output layout: {}",
@@ -243,7 +243,7 @@ public:
                 operation, inputLayouts, inputLayouts, originalResult, configs);
           } else {
             TTMLIR_TRACE(
-                ttmlir::LogComponent::OpValidation,
+                ttmlir::LogComponent::ValidationFallback,
                 "Operation {} at {} passed validation with original config",
                 operation->getName(), operation->getLoc());
           }
@@ -254,7 +254,7 @@ public:
           // ToLayout ops)
           if (originalResult.status ==
               op_constraint_validation::ValidationStatus::OutOfMemoryError) {
-            TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+            TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                          "OOM error detected, trying config fallbacks first "
                          "for operation {} at {}",
                          operation->getName(), operation->getLoc());
@@ -275,7 +275,7 @@ public:
           if (!fixed && originalResult.status !=
                             op_constraint_validation::ValidationStatus::
                                 OutOfMemoryError) {
-            TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+            TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                          "Trying config fallbacks for non-OOM error (status: "
                          "{}) at operation {} at {}",
                          op_constraint_validation::validationStatusToString(
@@ -287,7 +287,7 @@ public:
 
           if (fixed) {
             operationsFixed++;
-            TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+            TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                          "Operation {} at {} fixed with fallback configuration",
                          operation->getName(), operation->getLoc());
           } else {
@@ -303,7 +303,7 @@ public:
     });
 
     // Log validation summary
-    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+    TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "Operation validation {}: {} operations checked{}, {} fixed",
                  validationFailed ? "FAILED" : "complete",
                  totalOperationsChecked,
@@ -380,14 +380,14 @@ bool tryFallbacks(Operation *operation,
   }
 
   if (originalInputLayouts.empty()) {
-    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+    TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "No TTNN input layouts found for operation {} at {}",
                  operation->getName(), operation->getLoc());
     return false;
   }
 
   TTMLIR_DEBUG(
-      ttmlir::LogComponent::OpValidation,
+      ttmlir::LogComponent::ValidationFallback,
       "Testing fallback combinations for operation {} at {} with {} operands",
       operation->getName(), operation->getLoc(), originalInputLayouts.size());
 
@@ -441,7 +441,7 @@ bool tryFallbacks(Operation *operation,
               return false;
             });
 
-  TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
+  TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                "Generated {} combinations, testing by distance",
                allCombinations.size());
 
@@ -455,14 +455,14 @@ bool tryFallbacks(Operation *operation,
 
     if (!result.isSuccess()) {
       failedAttempts++;
-      TTMLIR_TRACE(ttmlir::LogComponent::OpValidation,
+      TTMLIR_TRACE(ttmlir::LogComponent::ValidationFallback,
                    "Combination failed (status: {}): {}",
                    static_cast<int>(result.status), result.errorMessage);
 
       // Check if we've exceeded the maximum attempts (if limit is set)
       if (maxAttempts > 0 &&
           failedAttempts >= static_cast<size_t>(maxAttempts)) {
-        TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+        TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                      "Reached maximum fallback attempts ({}) for operation {} "
                      "at {}. Terminating early.",
                      maxAttempts, operation->getName(), operation->getLoc());
@@ -473,7 +473,7 @@ bool tryFallbacks(Operation *operation,
     // Found working solution, apply transformations
     applyFallbackTransformations(operation, originalInputLayouts,
                                  candidate.layouts, result, configs);
-    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+    TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "Found working fallback combination with {} operands after {} "
                  "failed attempts",
                  candidate.layouts.size(), failedAttempts);
@@ -570,7 +570,7 @@ createFallbackTransforms(TTNNLayoutAttr originalLayout,
   }
 
   TTMLIR_TRACE(
-      ttmlir::LogComponent::OpValidation,
+      ttmlir::LogComponent::ValidationFallback,
       "Generated {} unique fallback layouts from {} target combinations",
       fallbackLayoutsSet.size(),
       targetDataTypes.size() * targetLayouts.size() * targetBufferTypes.size());
@@ -833,7 +833,7 @@ void applyInputOperandChange(Operation *operation, size_t operandIndex,
   operation->setOperand(operandIndex, toLayoutOp.getResult());
 
   TTMLIR_DEBUG(
-      ttmlir::LogComponent::OpValidation,
+      ttmlir::LogComponent::ValidationFallback,
       "Applied input operand change for operation {} operand {}: "
       "layout {} -> {}, memory layout {} -> {}, buffer type {} -> {}, data "
       "type {} -> {}",
@@ -852,7 +852,7 @@ void applyInputOperandChange(Operation *operation, size_t operandIndex,
 void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
                              TTNNLayoutAttr actualOutputLayout,
                              TTNNLayoutAttr expectedOutputLayout) {
-  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+  TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                "Applying output layout revert for operation {} result {}: "
                "actual layout {}, expected layout {}",
                operation->getName(), resultIndex, actualOutputLayout,
@@ -878,7 +878,7 @@ void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
                                                            "_revert_layout"),
                        currentResultType, result, expectedOutputLayout);
 
-  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+  TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                "Inserted revert ToLayout op after operation {} to restore "
                "expected layout",
                operation->getName());
@@ -887,7 +887,7 @@ void applyOutputLayoutRevert(Operation *operation, size_t resultIndex,
   for (auto &use : uses) {
     Operation *useOp = use.first;
     useOp->setOperand(use.second, revertToLayoutOp.getResult());
-    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+    TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "Updated consumer {}@{} to use reverted layout",
                  useOp->getName(), useOp->getLoc());
   }
@@ -987,7 +987,7 @@ bool tryConfigFallbacks(Operation *operation,
               Conv2dConfigGenerator configGenerator(
                   &convOp, baseConfig, currentSearchSpace, filterOutFn);
 
-              TTMLIR_TRACE(ttmlir::LogComponent::OpValidation,
+              TTMLIR_TRACE(ttmlir::LogComponent::ValidationFallback,
                            "Trying slice config: {} with {} act_block_h values",
                            stringifyEnum(sliceType),
                            currentSearchSpace.actBlockHOverride.size());
@@ -1008,7 +1008,7 @@ bool tryConfigFallbacks(Operation *operation,
                   workingConfig = configAttr;
                   workingResult = result;
                   TTMLIR_DEBUG(
-                      ttmlir::LogComponent::OpValidation,
+                      ttmlir::LogComponent::ValidationFallback,
                       "Found working config with slice type {} after {} "
                       "failed attempts",
                       stringifyEnum(sliceType), failedAttempts);
@@ -1016,7 +1016,7 @@ bool tryConfigFallbacks(Operation *operation,
                 }
 
                 failedAttempts++;
-                TTMLIR_TRACE(ttmlir::LogComponent::OpValidation,
+                TTMLIR_TRACE(ttmlir::LogComponent::ValidationFallback,
                              "Config fallback failed (status: {}): {}",
                              static_cast<int>(result.status),
                              result.errorMessage);
@@ -1025,7 +1025,7 @@ bool tryConfigFallbacks(Operation *operation,
                 // set)
                 if (maxAttempts > 0 &&
                     failedAttempts >= static_cast<size_t>(maxAttempts)) {
-                  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+                  TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                                "Reached maximum fallback attempts ({}) for "
                                "operation {} at {}. Terminating early.",
                                maxAttempts, operation->getName(),
@@ -1034,7 +1034,7 @@ bool tryConfigFallbacks(Operation *operation,
                 }
               }
             }
-            TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+            TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                          "No working config found after {} failed attempts",
                          failedAttempts);
             return false;
@@ -1053,7 +1053,7 @@ bool tryConfigFallbacks(Operation *operation,
       applyOutputLayoutChange(operation, i, workingResult, configs[i]);
     }
 
-    TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+    TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                  "Found working config fallback for operation {} at {}",
                  operation->getName(), operation->getLoc());
     return true;
@@ -1071,7 +1071,7 @@ void applyConfigChange(Operation *operation, Conv2dConfigAttr newConfig) {
     convTranspose2dOp.setConv2dConfigAttr(newConfig);
   }
 
-  TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
+  TTMLIR_DEBUG(ttmlir::LogComponent::ValidationFallback,
                "Applied config change to operation {} at {}: new config = {}",
                operation->getName(), operation->getLoc(), newConfig);
 }


### PR DESCRIPTION
## Summary
- Add dedicated `ValidationFallback` log component to `LogComponent` enum
- Replace all `OpValidation` and `Optimizer` log components in OperationValidationAndFallback with `ValidationFallback` for clearer log filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)