### PR TITLE
Fix PadOp and RepeatInterleaveOp flatbuffer memory config translation

### DIFF
--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2587,9 +2587,7 @@ createPadOp(FlatbufferObjectCache &cache, PadOp op) {
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
                                   /*local_shape*/ std::nullopt);
 
-  auto memoryConfig = op.getMemoryConfig().has_value()
-                          ? toFlatbuffer(cache, op.getMemoryConfig().value())
-                          : 0;
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
   return ::tt::target::ttnn::CreatePadOp(
       *cache.fbb, in, out, cache.fbb->CreateVector<uint32_t>(padding), value,
       op.getUseMulticore(), memoryConfig);
@@ -2780,14 +2778,12 @@ createRepeatInterleaveOp(FlatbufferObjectCache &cache, RepeatInterleaveOp op) {
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
 
                                   /*local_shape*/ std::nullopt);
-  std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
-      op.getMemoryConfig();
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
   uint32_t repeats = op.getRepeats();
   int32_t dim = op.getDim();
 
   return ::tt::target::ttnn::CreateRepeatInterleaveOp(
-      *cache.fbb, input, out, repeats, dim,
-      memoryConfig ? toFlatbuffer(cache, memoryConfig.value()) : 0);
+      *cache.fbb, input, out, repeats, dim, memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::SoftmaxOp>


### PR DESCRIPTION
## Summary
- Use `getMemoryConfigIfNeeded` helper for PadOp and RepeatInterleaveOp flatbuffer serialization
- Ensures consistent memory config handling matching other ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)