### PR TITLE
Greedy optimizer: vit_vision_block silicon perf test

### DIFF
--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/single_block_layer_perf_tests/vit_vision_block.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/single_block_layer_perf_tests/vit_vision_block.mlir
@@ -1,0 +1,4 @@
+// REQUIRES: opmodel, perf
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-permute-matmul-fusion=false" -o vit_vision_block_ttnn.mlir %models/single_blocks_and_layers/vit_vision_block.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn vit_vision_block_ttnn.mlir
+// RUN: ttrt run --benchmark %t.ttnn


### PR DESCRIPTION
## Summary

Adds a single greedy-optimizer silicon perf test for `vit_vision_block` under
`test/ttmlir/Silicon/TTNN/n150/optimizer/single_block_layer_perf_tests/`,
following that directory's uniform convention:

```
// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-permute-matmul-fusion=false" -o vit_vision_block_ttnn.mlir %models/single_blocks_and_layers/vit_vision_block.mlir
// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn vit_vision_block_ttnn.mlir
// RUN: ttrt run --benchmark %t.ttnn
```

- `optimization-level=2` enables the greedy layout-propagation optimizer.
- `experimental-weight-dtype=bfp_bf8` is the current spelling of the former
  `experimental-bfp8-weights=true`.
- `ttrt run --benchmark` is the current perf-run convention (verified not deprecated).

## Scope note

`vit_vision_block` is a single vision block, so it lives with its sibling
single-block/layer perf tests rather than the full-model `models_perf_tests/`
directory. The provisional greedy Dialect lit tests and the other single-block
model perf tests (bert, llama_3_2_1b_decode, phi_2, segformer_vision) already
exist on `main`, so they are not duplicated here — this PR adds only the
missing `vit_vision_block` test.
