### PR TITLE
Disable compute config overrides at optimization level > 0

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -372,8 +372,10 @@ struct TTIRToTTNNDevicePipelineOptions
   // And computeCfgFp32DestAccEn default value is true.
   // This is done as part of generality effort,
   // to boost accuracy on all operations exposing compute kernel config by
-  // default.
-  Option<OptionalMathFidelity> computeCfgMathFidelity{
+  // default. At optimization levels > 0, these are overridden to
+  // Undefined/false to defer to runtime defaults (see
+  // resolveOptimizationLevelOptions).
+  mutable Option<OptionalMathFidelity> computeCfgMathFidelity{
       *this, "compute-cfg-math-fidelity",
       llvm::cl::desc("Set math fidelity for all ttnn operations exposing "
                      "compute kernel config."),
@@ -386,7 +388,7 @@ struct TTIRToTTNNDevicePipelineOptions
                      "Undefined math fidelity")),
       llvm::cl::init(OptionalMathFidelity::HiFi4)};
 
-  Option<bool> computeCfgFp32DestAccEn{
+  mutable Option<bool> computeCfgFp32DestAccEn{
       *this, "compute-cfg-fp32-dest-acc-en",
       llvm::cl::desc("Set fp32 destination accumulation for all ttnn "
                      "operations exposing compute kernel config."),
@@ -442,6 +444,14 @@ struct TTIRToTTNNDevicePipelineOptions
     }
     if (memoryLayoutAnalysisEnabled.getNumOccurrences() == 0) {
       memoryLayoutAnalysisEnabled = (optimizationLevel >= 2);
+    }
+    if (computeCfgMathFidelity.getNumOccurrences() == 0 &&
+        optimizationLevel > 0) {
+      computeCfgMathFidelity = OptionalMathFidelity::Undefined;
+    }
+    if (computeCfgFp32DestAccEn.getNumOccurrences() == 0 &&
+        optimizationLevel > 0) {
+      computeCfgFp32DestAccEn = false;
     }
   }
 };


### PR DESCRIPTION
## Summary
- At optimization levels > 0, set `computeCfgMathFidelity` to `Undefined` and `computeCfgFp32DestAccEn` to `false`, deferring to runtime defaults instead of forcing HiFi4/fp32 acc.
- Level 0 retains the existing defaults (HiFi4, fp32 dest acc enabled) for accuracy.
- Explicit CLI flags still override in all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)