### PR TITLE
Update references to uplift qualification tests in tt-xla

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -105,7 +105,7 @@ jobs:
             gh workflow run ${{ env.WORKFLOW_NAME }} \
               --repo ${{ env.TARGET_REPO }} --ref main \
               --raw-field mlir_override=${{ github.event.pull_request.head.sha }} \
-              --raw-field test_suite=mlir-uplift-qualification.json
+              --raw-field test_suite=full-mlir-uplift-qualification.json
 
           elif [[ "${{ env.TARGET_REPO }}" == "tenstorrent/tt-xla" && "${{ env.WORKFLOW_NAME }}" == "manual-benchmark.yml" ]]; then
             # Perf benchmark in tt-xla/tt-forge against uplifted tt-mlir + tt-metal

--- a/.github/workflows/schedule-nightly-uplift.yml
+++ b/.github/workflows/schedule-nightly-uplift.yml
@@ -162,7 +162,7 @@ jobs:
             ### Checklist
             - **Frontend CI passing links**
               - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
-              - [ ] [tt-xla (mlir-uplift-qualification)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
+              - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
             - **Follow-up Actions**
               - [ ] **Issues filed** to follow up on incomplete changes (if any):
               - [ ] **Frontend fix PRs** ready (if needed by this uplift):


### PR DESCRIPTION
Updates references to qualification tests in tt-xla. Needs to wait for https://github.com/tenstorrent/tt-xla/pull/3980 before merging.