### PR TITLE
[runtime] add per-op tracy zones (ttnn)

### DIFF
--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -104,6 +104,10 @@
 #include "tt/runtime/perf.h"
 #include "tt/runtime/utils.h"
 
+#include "tracy/Tracy.hpp"
+
+#include <cstring>
+
 namespace tt::runtime::ttnn {
 
 using LogType = ::tt::runtime::logger::LogType;
@@ -157,11 +161,15 @@ void ProgramExecutor::runCallback(
 }
 
 void ProgramExecutor::execute() {
+  ZoneScopedN("program_execute");
+  ZoneText(program->name()->c_str(), std::strlen(program->name()->c_str()));
   LOG_DEBUG(LogType::LogRuntimeTTNN,
             "Starting execution of program: ", program->name()->c_str());
   for (const ::tt::target::ttnn::Operation *op : *program->operations()) {
     LOG_DEBUG(LogType::LogRuntimeTTNN,
               "Executing operation: ", op->debug_info()->c_str());
+    // TODO(#7743): Remove these tracy messages.
+    // Currently they are being used by `ttrt perf` for parsing the csv output.
     perf::Env::get().tracyLogOpLocation(std::string(op->loc_info()->c_str()));
     perf::Env::get().tracyLogConstEvalProgram(constEvalProgram);
     perf::Env::get().tracyLogProgramMetadata(
@@ -182,6 +190,9 @@ std::vector<::tt::runtime::Tensor> ProgramExecutor::gatherOutputTensors() {
 }
 
 void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
+  ZoneScoped;
+  ZoneName(::tt::target::ttnn::EnumNameOpType(op->type_type()),
+           std::strlen(::tt::target::ttnn::EnumNameOpType(op->type_type())));
 
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   ::tt::runtime::utils::logMemoryStateIfNeeded(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -28,9 +28,11 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "types_generated.h"
-#include <numeric>
+
+#include "tracy/Tracy.hpp"
 
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <vector>
 
@@ -1946,6 +1948,7 @@ getOpInputRefs(OpContext opContextHandle,
 std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs) {
+  ZoneScoped;
 
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   ::tt::runtime::utils::logMemoryStateIfNeeded(


### PR DESCRIPTION
Add `tracy` profiling zones in `ttnn` executor.

- adds zone for `submit` - used for tracking all host-side activity when submitting a program for execution
- adds `program_execute` zone for each individual program we execute (program name is added to the zone)
- adds op zone, which is named after the op we're executing, i.e. `MatmulOp`, `EltwiseBinaryOp`, etc.

Ran perf benchmark on `tt-xla` (resnet) - no perf regression observed.