### PR TITLE
[TTNN] Add expanded (trig-identity) RoPE fusing pattern

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.h
@@ -6,23 +6,52 @@
 #define TTMLIR_DIALECT_TTNN_TRANSFORMS_FUSING_ROPEFUSINGPATTERN_H
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Fusing/FusionValidator.h"
 
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir::tt::ttnn::fusing {
 
-// Fuses the RoPE (Rotary Position Embedding) subgraph into a single
-// RotaryEmbeddingOp.
+// Fuses the rotate_half RoPE (Rotary Position Embedding) subgraph into a
+// single RotaryEmbeddingOp.
 //
 // Matches:  (x * cos) + (rotate_half(x) * sin)
+//   where rotate_half(x) = concat(neg(x[half:]), x[:half])
 // Produces: rotary_embedding(x, cos, sin)
-class RoPEFusing : public mlir::OpRewritePattern<AddOp> {
+class RoPERotateHalfFusing : public mlir::OpRewritePattern<AddOp> {
 public:
-  using OpRewritePattern<AddOp>::OpRewritePattern;
+  RoPERotateHalfFusing(mlir::MLIRContext *ctx,
+                       const FusionValidationConfig &config)
+      : OpRewritePattern<AddOp>(ctx), validationConfig(config) {}
 
   mlir::LogicalResult
   matchAndRewrite(AddOp srcOp, mlir::PatternRewriter &rewriter) const override;
+
+private:
+  FusionValidationConfig validationConfig;
+};
+
+// Fuses the expanded (trig-identity) RoPE subgraph into a single
+// RotaryEmbeddingOp.
+//
+// Matches:  concat(
+//             subtract(x[:half] * cos_h, x[half:] * sin_h),
+//             add(x[half:] * cos_h, x[:half] * sin_h))
+//   where cos_h and sin_h are half-dim embeddings.
+// Produces: rotary_embedding(x, concat(cos_h, cos_h), concat(sin_h, sin_h))
+class RoPEExpandedFusing : public mlir::OpRewritePattern<ConcatOp> {
+public:
+  RoPEExpandedFusing(mlir::MLIRContext *ctx,
+                     const FusionValidationConfig &config)
+      : OpRewritePattern<ConcatOp>(ctx), validationConfig(config) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(ConcatOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+
+private:
+  FusionValidationConfig validationConfig;
 };
 
 // Commute a downstream permute through an already-fused RotaryEmbeddingOp

--- a/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -5,11 +5,13 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.h"
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Fusing/FusionValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RotaryEmbeddingOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -67,11 +69,18 @@ class RoPEAnalyzer {
 public:
   std::optional<RoPEInputs> findValidInputs(Value root,
                                             const RoPEComponents &components) {
+    return findValidInputs(root, components.x, components.cos, components.sin);
+  }
+
+  std::optional<RoPEInputs> findValidInputs(Value root,
+                                            ArrayRef<Value> xCandidates,
+                                            ArrayRef<Value> cosCandidates,
+                                            ArrayRef<Value> sinCandidates) {
     SmallVector<Axis> expected = {Axis::B, Axis::H, Axis::S, Axis::D};
 
-    for (Value xCandidate : components.x) {
-      for (Value cosCandidate : components.cos) {
-        for (Value sinCandidate : components.sin) {
+    for (Value xCandidate : xCandidates) {
+      for (Value cosCandidate : cosCandidates) {
+        for (Value sinCandidate : sinCandidates) {
           cache.clear();
           currentX = xCandidate;
           currentCos = cosCandidate;
@@ -195,6 +204,7 @@ private:
     SemanticShape result =
         llvm::TypeSwitch<Operation *, SemanticShape>(op)
             .Case<ttnn::AddOp>([&](auto add) { return visitAdd(add); })
+            .Case<SubtractOp>([&](auto sub) { return visitSubtract(sub); })
             .Case<MultiplyOp>([&](auto mul) { return visitMul(mul); })
             .Case<ConcatOp>([&](auto cat) { return visitConcat(cat); })
             .Case<SliceStaticOp>([&](auto s) { return visitSlice(s); })
@@ -219,6 +229,10 @@ private:
   }
 
   SemanticShape visitAdd(ttnn::AddOp op) {
+    return visitElementwise(op.getLhs(), op.getRhs());
+  }
+
+  SemanticShape visitSubtract(SubtractOp op) {
     return visitElementwise(op.getLhs(), op.getRhs());
   }
 
@@ -450,6 +464,62 @@ bool isValidHalfRotationSlices(SliceStaticOp lhsSlice, SliceStaticOp rhsSlice,
   return true;
 }
 
+// Validates that two slices form complementary halves of the same dimension.
+// Returns the sliced dimension index, or nullopt if invalid. Unlike
+// isValidHalfRotationSlices, this does not require negation — it is used for
+// the expanded RoPE form where both halves are used directly.
+std::optional<size_t> areComplementaryHalfSlices(SliceStaticOp sliceA,
+                                                 SliceStaticOp sliceB) {
+  auto aOpt = getSliceParams(sliceA);
+  auto bOpt = getSliceParams(sliceB);
+  if (!aOpt || !bOpt) {
+    return std::nullopt;
+  }
+  const SliceParams &a = *aOpt;
+  const SliceParams &b = *bOpt;
+
+  if (a.inputShape != b.inputShape || a.inputShape.empty()) {
+    return std::nullopt;
+  }
+
+  auto aDimOpt = findSlicedDim(a);
+  auto bDimOpt = findSlicedDim(b);
+  if (!aDimOpt || !bDimOpt || *aDimOpt != *bDimOpt) {
+    return std::nullopt;
+  }
+  size_t dim = *aDimOpt;
+
+  int64_t dimSize = a.inputShape[dim];
+  if ((dimSize % 2) != 0 || a.steps[dim] != 1 || b.steps[dim] != 1) {
+    return std::nullopt;
+  }
+
+  int64_t half = dimSize / 2;
+  bool aIsFirstHalf = (a.begins[dim] == 0 && a.ends[dim] == half);
+  bool bIsSecondHalf = (b.begins[dim] == half && b.ends[dim] == dimSize);
+  bool aIsSecondHalf = (a.begins[dim] == half && a.ends[dim] == dimSize);
+  bool bIsFirstHalf = (b.begins[dim] == 0 && b.ends[dim] == half);
+
+  if ((aIsFirstHalf && bIsSecondHalf) || (aIsSecondHalf && bIsFirstHalf)) {
+    return dim;
+  }
+
+  return std::nullopt;
+}
+
+// Returns true if the slice selects the first half [0, D/2) of the sliced dim.
+bool isFirstHalfSlice(SliceStaticOp slice) {
+  auto opt = getSliceParams(slice);
+  if (!opt) {
+    return false;
+  }
+  auto dimOpt = findSlicedDim(*opt);
+  if (!dimOpt) {
+    return false;
+  }
+  return opt->begins[*dimOpt] == 0;
+}
+
 // ---------------------------------------------------------------------------
 // Structural pattern matching
 // ---------------------------------------------------------------------------
@@ -578,73 +648,233 @@ bool matchRope(RoPEComponents &c) {
 }
 
 // ---------------------------------------------------------------------------
+// Expanded RoPE structural pattern matching
+// ---------------------------------------------------------------------------
+//
+// Matches the expanded (trig-identity) RoPE form:
+//   concat(
+//     subtract(first_half * cos_h, second_half * sin_h),
+//     add(second_half * cos_h, first_half * sin_h))
+//
+// Where first_half = x[:D/2], second_half = x[D/2:], and cos_h/sin_h are
+// half-dim embeddings.
+
+struct ExpandedRoPEComponents {
+  SmallVector<Value> x;   // Input candidates (TM chain)
+  SmallVector<Value> cos; // Half-dim cosine candidates (TM chain)
+  SmallVector<Value> sin; // Half-dim sine candidates (TM chain)
+  ConcatOp concatOp;      // Root concat
+  SubtractOp subOp;       // subtract(first_half*cos, second_half*sin)
+  AddOp addOp;            // add(second_half*cos, first_half*sin)
+  SmallVector<MultiplyOp, 4> mulOps; // All 4 multiply ops
+};
+
+// For a MultiplyOp, identify the slice operand and the embedding operand.
+// Returns (sliceOp, embeddingValue) or nullopt if neither operand is a slice.
+std::optional<std::pair<SliceStaticOp, Value>>
+classifyMulOperands(MultiplyOp mul) {
+  Value lhs = skipTMs(mul.getLhs());
+  Value rhs = skipTMs(mul.getRhs());
+
+  auto lhsSlice = lhs.getDefiningOp<SliceStaticOp>();
+  auto rhsSlice = rhs.getDefiningOp<SliceStaticOp>();
+
+  // Exactly one operand should be a slice.
+  if (lhsSlice && !rhsSlice) {
+    return std::make_pair(lhsSlice, mul.getRhs());
+  }
+  if (rhsSlice && !lhsSlice) {
+    return std::make_pair(rhsSlice, mul.getLhs());
+  }
+  return std::nullopt;
+}
+
+// Match the expanded RoPE form rooted at a ConcatOp.
+bool matchExpandedRope(ExpandedRoPEComponents &c) {
+  if (c.concatOp.getNumOperands() != 2) {
+    return false;
+  }
+
+  // Operand 0 must be SubtractOp, operand 1 must be AddOp.
+  Value op0 = skipTMs(c.concatOp.getOperand(0));
+  Value op1 = skipTMs(c.concatOp.getOperand(1));
+
+  c.subOp = op0.getDefiningOp<SubtractOp>();
+  c.addOp = op1.getDefiningOp<AddOp>();
+  if (!c.subOp || !c.addOp) {
+    return false;
+  }
+
+  // Extract 4 multiply ops: 2 from subtract, 2 from add.
+  auto subLhsMul = skipTMs(c.subOp.getLhs()).getDefiningOp<MultiplyOp>();
+  auto subRhsMul = skipTMs(c.subOp.getRhs()).getDefiningOp<MultiplyOp>();
+  auto addMul0 = skipTMs(c.addOp.getLhs()).getDefiningOp<MultiplyOp>();
+  auto addMul1 = skipTMs(c.addOp.getRhs()).getDefiningOp<MultiplyOp>();
+
+  if (!subLhsMul || !subRhsMul || !addMul0 || !addMul1) {
+    return false;
+  }
+
+  // Classify each multiply's operands into (slice, embedding).
+  auto subLhs = classifyMulOperands(subLhsMul);
+  auto subRhs = classifyMulOperands(subRhsMul);
+  auto addOp0 = classifyMulOperands(addMul0);
+  auto addOp1 = classifyMulOperands(addMul1);
+
+  if (!subLhs || !subRhs || !addOp0 || !addOp1) {
+    return false;
+  }
+
+  // All 4 slices must come from the same source x.
+  SmallVector<SliceStaticOp, 4> slices = {subLhs->first, subRhs->first,
+                                          addOp0->first, addOp1->first};
+  Value source = slices[0].getInput();
+  for (size_t i = 1; i < slices.size(); ++i) {
+    Value ancestor =
+        findCommonTMAncestor(skipTMs(source), skipTMs(slices[i].getInput()));
+    if (!ancestor) {
+      return false;
+    }
+    source = ancestor;
+  }
+
+  // Slices must form two complementary pairs: first_half [0,D/2) and
+  // second_half [D/2,D). Verify via any two distinct slices.
+  auto dimOpt = areComplementaryHalfSlices(slices[0], slices[1]);
+  if (!dimOpt) {
+    dimOpt = areComplementaryHalfSlices(slices[0], slices[2]);
+  }
+  if (!dimOpt) {
+    return false;
+  }
+
+  // Classify slices as first-half or second-half.
+  bool subLhsIsFirst = isFirstHalfSlice(subLhs->first);
+  bool subRhsIsFirst = isFirstHalfSlice(subRhs->first);
+  bool addOp0IsFirst = isFirstHalfSlice(addOp0->first);
+  bool addOp1IsFirst = isFirstHalfSlice(addOp1->first);
+
+  // The pattern requires:
+  //   sub.lhs = first_half * cos_h
+  //   sub.rhs = second_half * sin_h
+  //   add: one is second_half * cos_h, other is first_half * sin_h
+  if (!subLhsIsFirst || subRhsIsFirst) {
+    return false;
+  }
+
+  // Identify cos_h and sin_h from the subtract branch.
+  // sub.lhs embedding = cos_h, sub.rhs embedding = sin_h.
+  Value cosValue = subLhs->second;
+  Value sinValue = subRhs->second;
+
+  // Cross-validate with the add branch: one add multiply should pair
+  // second_half with cos_h, the other should pair first_half with sin_h.
+  auto matchesEmbedding = [](Value mulEmb, Value expected) {
+    return findCommonTMAncestor(mulEmb, expected) != nullptr ||
+           mulEmb == expected;
+  };
+
+  bool addValid = false;
+  if (!addOp0IsFirst && addOp1IsFirst) {
+    // addMul0 = second_half * cos_h, addMul1 = first_half * sin_h
+    addValid = matchesEmbedding(addOp0->second, cosValue) &&
+               matchesEmbedding(addOp1->second, sinValue);
+  } else if (addOp0IsFirst && !addOp1IsFirst) {
+    // addMul0 = first_half * sin_h, addMul1 = second_half * cos_h
+    addValid = matchesEmbedding(addOp0->second, sinValue) &&
+               matchesEmbedding(addOp1->second, cosValue);
+  }
+
+  if (!addValid) {
+    return false;
+  }
+
+  c.x = collectCandidates(source);
+  c.cos = collectCandidates(cosValue);
+  c.sin = collectCandidates(sinValue);
+  c.mulOps = {subLhsMul, subRhsMul, addMul0, addMul1};
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // Fused op creation
 // ---------------------------------------------------------------------------
+
+// Check whether any of the given ops compute in f32.
+bool anyUsesF32(ArrayRef<Operation *> ops) {
+  for (Operation *op : ops) {
+    auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    if (resultType.getElementType().isF32()) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // Check whether any of the RoPE multiply/add ops compute in f32 and, if so,
 // return a DeviceComputeKernelConfig with fp32_dest_acc_en set.
 DeviceComputeKernelConfigAttr buildComputeConfig(mlir::MLIRContext *ctx,
                                                  const RoPEComponents &c) {
-  auto usesF32 = [](Operation *op) {
-    auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
-    return resultType.getElementType().isF32();
-  };
-  if (usesF32(c.cosMul) || usesF32(c.sinMul) || usesF32(c.addOp)) {
+  if (anyUsesF32({c.cosMul, c.sinMul, c.addOp})) {
     return DeviceComputeKernelConfigAttr::get(ctx).withFp32DestAccEn(true);
   }
   return nullptr;
 }
 
-mlir::LogicalResult createFusedRoPEOp(mlir::PatternRewriter &rewriter,
-                                      AddOp srcOp, const RoPEInputs &inputs,
-                                      const RoPEComponents &components) {
-  op_model::ScopedSingletonDeviceGuard deviceGuard(srcOp.getOperation());
+DeviceComputeKernelConfigAttr
+buildComputeConfig(mlir::MLIRContext *ctx, const ExpandedRoPEComponents &c) {
+  SmallVector<Operation *, 6> ops;
+  for (auto mul : c.mulOps) {
+    ops.push_back(mul);
+  }
+  ops.push_back(c.subOp);
+  ops.push_back(c.addOp);
+  if (anyUsesF32(ops)) {
+    return DeviceComputeKernelConfigAttr::get(ctx).withFp32DestAccEn(true);
+  }
+  return nullptr;
+}
 
-  auto computeConfig = buildComputeConfig(rewriter.getContext(), components);
+// Validate, create, and replace srcOp with a fused RotaryEmbeddingOp.
+// x, cos, sin must be fully prepared (full-dim cos/sin for expanded form).
+// Inserts an output PermuteOp if outPermutation is not the identity.
+mlir::LogicalResult
+createAndReplaceWithRoPEOp(mlir::PatternRewriter &rewriter, Operation *srcOp,
+                           Value x, Value cos, Value sin,
+                           ArrayRef<int64_t> outPermutation,
+                           DeviceComputeKernelConfigAttr computeConfig,
+                           const FusionValidationConfig &validationConfig) {
+  op_model::ScopedSingletonDeviceGuard deviceGuard(srcOp);
+
+  // Validate in an isolated module before committing to fusion.
+  FusionValidator validator(rewriter.getContext(), validationConfig);
+  auto validationResult = validator.validateFusion<RotaryEmbeddingOp>(
+      srcOp, srcOp->getLoc(), {x.getType()}, x, cos, sin,
+      /*token_index=*/nullptr,
+      /*memory_config=*/MemoryConfigAttr(),
+      /*compute_config=*/computeConfig);
+
+  if (!validationResult.isSuccess()) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::FusionValidator,
+                 "RoPE fusion validation failed: {0}",
+                 validationResult.errorMessage);
+    return failure();
+  }
 
   auto ropeOp = rewriter.create<RotaryEmbeddingOp>(
-      srcOp.getLoc(), inputs.x.getType(), inputs.x, inputs.cos, inputs.sin,
+      srcOp->getLoc(), x.getType(), x, cos, sin,
       /*token_index=*/nullptr,
       /*memory_config=*/nullptr,
       /*compute_config=*/computeConfig);
 
-  // Validate the fused op. If validation fails, try the workaround-padded
-  // version since the workaround pass (seq_len tile alignment) hasn't run yet.
-  std::vector<TTNNLayoutAttr> inputLayouts =
-      utils::extractInputLayouts(ropeOp.getOperation());
-  auto resultType = mlir::cast<RankedTensorType>(ropeOp.getType());
-  OpConfig config(mlir::cast<TTNNLayoutAttr>(resultType.getEncoding()));
-  auto validationResult = op_constraint_validation::validateOperation(
-      ropeOp.getOperation(), inputLayouts, config);
-
-  if (!validationResult.isSuccess()) {
-    auto workaround =
-        workarounds::decomposition::getWorkaroundedOp(ropeOp, rewriter);
-    if (workaround) {
-      auto paddedOp = workaround->first;
-      auto sliceOp = workaround->second;
-      inputLayouts = utils::extractInputLayouts(paddedOp.getOperation());
-      resultType = mlir::cast<RankedTensorType>(paddedOp.getType());
-      config = OpConfig(mlir::cast<TTNNLayoutAttr>(resultType.getEncoding()));
-      validationResult = op_constraint_validation::validateOperation(
-          paddedOp.getOperation(), inputLayouts, config);
-      rewriter.eraseOp(sliceOp);
-      rewriter.eraseOp(paddedOp);
-    }
-
-    if (!validationResult.isSuccess()) {
-      rewriter.eraseOp(ropeOp);
-      return failure();
-    }
-  }
-
   Value result = ropeOp.getResult();
-  if (!llvm::equal(inputs.outPermutation,
-                   llvm::seq<int64_t>(0, inputs.outPermutation.size()))) {
+  if (!llvm::equal(outPermutation,
+                   llvm::seq<int64_t>(0, outPermutation.size()))) {
     DenseI64ArrayAttr permutationAttr =
-        rewriter.getDenseI64ArrayAttr(inputs.outPermutation);
+        rewriter.getDenseI64ArrayAttr(outPermutation);
     auto permuted = rewriter.create<ttnn::PermuteOp>(
-        srcOp.getLoc(), srcOp.getType(), result, permutationAttr,
+        srcOp->getLoc(), srcOp->getResult(0).getType(), result, permutationAttr,
         ttnn::MemoryConfigAttr(), mlir::FloatAttr());
     result = permuted.getResult();
   }
@@ -653,15 +883,56 @@ mlir::LogicalResult createFusedRoPEOp(mlir::PatternRewriter &rewriter,
   return success();
 }
 
+// Prepare full-dim cos/sin for the expanded form by concatenating half-dim
+// values with themselves along the D axis.
+std::pair<Value, Value> prepareExpandedCosSin(mlir::PatternRewriter &rewriter,
+                                              ConcatOp srcOp, Value cosHalf,
+                                              Value sinHalf) {
+  int64_t concatDim = srcOp.getDim();
+  auto cosType = mlir::cast<RankedTensorType>(cosHalf.getType());
+  auto sinType = mlir::cast<RankedTensorType>(sinHalf.getType());
+
+  SmallVector<int64_t> cosFullShape(cosType.getShape());
+  cosFullShape[concatDim] *= 2;
+  Attribute cosEncoding = nullptr;
+  if (auto layout =
+          mlir::dyn_cast_or_null<TTNNLayoutAttr>(cosType.getEncoding())) {
+    cosEncoding =
+        layout.withElementType(cosType.getElementType(), cosFullShape);
+  }
+  auto cosFullType = RankedTensorType::get(
+      cosFullShape, cosType.getElementType(), cosEncoding);
+
+  SmallVector<int64_t> sinFullShape(sinType.getShape());
+  sinFullShape[concatDim] *= 2;
+  Attribute sinEncoding = nullptr;
+  if (auto layout =
+          mlir::dyn_cast_or_null<TTNNLayoutAttr>(sinType.getEncoding())) {
+    sinEncoding =
+        layout.withElementType(sinType.getElementType(), sinFullShape);
+  }
+  auto sinFullType = RankedTensorType::get(
+      sinFullShape, sinType.getElementType(), sinEncoding);
+
+  auto cosFull = rewriter.create<ConcatOp>(
+      srcOp.getLoc(), cosFullType, ValueRange{cosHalf, cosHalf}, concatDim,
+      /*memory_config=*/MemoryConfigAttr());
+  auto sinFull = rewriter.create<ConcatOp>(
+      srcOp.getLoc(), sinFullType, ValueRange{sinHalf, sinHalf}, concatDim,
+      /*memory_config=*/MemoryConfigAttr());
+
+  return {cosFull.getResult(), sinFull.getResult()};
+}
+
 } // namespace
 
 // =============================================================================
-// RoPEFusing
+// RoPERotateHalfFusing
 // =============================================================================
 
 mlir::LogicalResult
-RoPEFusing::matchAndRewrite(AddOp srcOp,
-                            mlir::PatternRewriter &rewriter) const {
+RoPERotateHalfFusing::matchAndRewrite(AddOp srcOp,
+                                      mlir::PatternRewriter &rewriter) const {
   RoPEComponents c;
   c.addOp = srcOp;
 
@@ -675,7 +946,49 @@ RoPEFusing::matchAndRewrite(AddOp srcOp,
     return failure();
   }
 
-  return createFusedRoPEOp(rewriter, srcOp, *validInputs, c);
+  auto computeConfig = buildComputeConfig(rewriter.getContext(), c);
+  return createAndReplaceWithRoPEOp(
+      rewriter, srcOp, validInputs->x, validInputs->cos, validInputs->sin,
+      validInputs->outPermutation, computeConfig, validationConfig);
+}
+
+// =============================================================================
+// RoPEExpandedFusing
+// =============================================================================
+
+mlir::LogicalResult
+RoPEExpandedFusing::matchAndRewrite(ConcatOp srcOp,
+                                    mlir::PatternRewriter &rewriter) const {
+  ExpandedRoPEComponents c;
+  c.concatOp = srcOp;
+
+  if (!matchExpandedRope(c)) {
+    return failure();
+  }
+
+  RoPEAnalyzer analyzer;
+  auto validInputs =
+      analyzer.findValidInputs(srcOp.getResult(), c.x, c.cos, c.sin);
+  if (!validInputs) {
+    return failure();
+  }
+
+  // Prepare full-dim cos/sin by doubling the half-dim values.
+  auto [cosFull, sinFull] = prepareExpandedCosSin(
+      rewriter, srcOp, validInputs->cos, validInputs->sin);
+
+  auto computeConfig = buildComputeConfig(rewriter.getContext(), c);
+  auto result = createAndReplaceWithRoPEOp(
+      rewriter, srcOp, validInputs->x, cosFull, sinFull,
+      validInputs->outPermutation, computeConfig, validationConfig);
+
+  if (failed(result)) {
+    // Clean up the intermediate concat ops on failure.
+    rewriter.eraseOp(sinFull.getDefiningOp());
+    rewriter.eraseOp(cosFull.getDefiningOp());
+  }
+
+  return result;
 }
 
 // =============================================================================

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -324,7 +324,9 @@ public:
       FusionValidationConfig validationConfig;
       validationConfig.maxFallbackAttempts = maxFallbackAttempts;
 
-      patterns.add<fusing::RoPEFusing>(&getContext());
+      patterns.add<fusing::RoPERotateHalfFusing>(&getContext(),
+                                                 validationConfig);
+      patterns.add<fusing::RoPEExpandedFusing>(&getContext(), validationConfig);
       patterns.add<fusing::RoPEDecodeFusing>(&getContext());
       patterns.add<fusing::TopKFusing>(&getContext(), validationConfig);
       patterns.add<fusing::SDPAFusing>(&getContext(), validationConfig);

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope.mlir
@@ -258,4 +258,147 @@ module {
     %result = "ttir.add"(%x_cos, %rot_sin_perm) : (tensor<1x32x32x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
     return %result : tensor<1x32x32x64xbf16>
   }
+
+  // =========================================================================
+  // Expanded (trig-identity) RoPE tests
+  // =========================================================================
+  //
+  // Pattern: concat(
+  //            subtract(x[:half] * cos_h, x[half:] * sin_h),
+  //            add(x[half:] * cos_h, x[:half] * sin_h))
+  // where cos_h and sin_h are half-dim embeddings.
+
+  // Basic expanded RoPE: GPT-OSS 20B decode shapes with broadcast cos/sin.
+  // cos_h/sin_h are [1,1,1,32] broadcast to [16,8,1,32] before multiply,
+  // matching the real model where cos/sin are computed once and broadcast.
+  // CHECK-LABEL: @rope_expanded_basic
+  // CHECK: "ttnn.rotary_embedding"
+  // CHECK-NOT: ttnn.subtract"
+  func.func @rope_expanded_basic(
+      %x: tensor<16x8x1x64xbf16>,
+      %cos_h: tensor<1x1x1x32xbf16>,
+      %sin_h: tensor<1x1x1x32xbf16>) -> tensor<16x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [16:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [16:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sub = "ttir.subtract"(%fc, %ss) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %add = "ttir.add"(%sc, %fs) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
+    return %result : tensor<16x8x1x64xbf16>
+  }
+
+  // Expanded RoPE with broadcast cos/sin: batch=32.
+  // CHECK-LABEL: @rope_expanded_broadcast_b32
+  // CHECK: "ttnn.rotary_embedding"
+  // CHECK-NOT: ttnn.subtract"
+  func.func @rope_expanded_broadcast_b32(
+      %x: tensor<32x8x1x64xbf16>,
+      %cos_h: tensor<1x1x1x32xbf16>,
+      %sin_h: tensor<1x1x1x32xbf16>) -> tensor<32x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [32:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<32x8x1x64xbf16>) -> tensor<32x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [32:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<32x8x1x64xbf16>) -> tensor<32x8x1x32xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %sub = "ttir.subtract"(%fc, %ss) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+    %add = "ttir.add"(%sc, %fs) : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x32xbf16>
+
+    %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<32x8x1x32xbf16>, tensor<32x8x1x32xbf16>) -> tensor<32x8x1x64xbf16>
+    return %result : tensor<32x8x1x64xbf16>
+  }
+
+  // Expanded RoPE with head_dim=128, broadcast cos/sin.
+  // CHECK-LABEL: @rope_expanded_head_dim_128
+  // CHECK: "ttnn.rotary_embedding"
+  // CHECK-NOT: ttnn.subtract"
+  func.func @rope_expanded_head_dim_128(
+      %x: tensor<32x8x1x128xbf16>,
+      %cos_h: tensor<1x1x1x64xbf16>,
+      %sin_h: tensor<1x1x1x64xbf16>) -> tensor<32x8x1x128xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 32, 8, 1, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [32:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<32x8x1x128xbf16>) -> tensor<32x8x1x64xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 64:i32], ends = [32:i32, 8:i32, 1:i32, 128:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<32x8x1x128xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %sub = "ttir.subtract"(%fc, %ss) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+    %add = "ttir.add"(%sc, %fs) : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x64xbf16>
+
+    %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<32x8x1x64xbf16>, tensor<32x8x1x64xbf16>) -> tensor<32x8x1x128xbf16>
+    return %result : tensor<32x8x1x128xbf16>
+  }
+
+  // Negative: wrong concat order (add first, subtract second) — not valid RoPE.
+  // CHECK-LABEL: @rope_expanded_wrong_concat_order_no_fuse
+  // CHECK-NOT: ttnn.rotary_embedding"
+  // CHECK: ttnn.concat"
+  func.func @rope_expanded_wrong_concat_order_no_fuse(
+      %x: tensor<16x8x1x64xbf16>,
+      %cos_h: tensor<1x1x1x32xbf16>,
+      %sin_h: tensor<1x1x1x32xbf16>) -> tensor<16x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [16:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [16:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sub = "ttir.subtract"(%fc, %ss) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %add = "ttir.add"(%sc, %fs) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    // Wrong order: add first, subtract second.
+    %result = "ttir.concat"(%add, %sub) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
+    return %result : tensor<16x8x1x64xbf16>
+  }
+
+  // Negative: sub.lhs uses second_half instead of first_half — breaks cross pattern.
+  // CHECK-LABEL: @rope_expanded_wrong_slice_roles_no_fuse
+  // CHECK-NOT: ttnn.rotary_embedding"
+  // CHECK: ttnn.concat"
+  func.func @rope_expanded_wrong_slice_roles_no_fuse(
+      %x: tensor<16x8x1x64xbf16>,
+      %cos_h: tensor<1x1x1x32xbf16>,
+      %sin_h: tensor<1x1x1x32xbf16>) -> tensor<16x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %first = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [16:i32, 8:i32, 1:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [16:i32, 8:i32, 1:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+
+    // sub.lhs uses second_half*cos instead of first_half*cos
+    %sc = "ttir.multiply"(%second, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %fs = "ttir.multiply"(%first, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sub = "ttir.subtract"(%sc, %fs) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %fc = "ttir.multiply"(%first, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %ss = "ttir.multiply"(%second, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %add = "ttir.add"(%fc, %ss) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+
+    %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
+    return %result : tensor<16x8x1x64xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope_in_models.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope_in_models.mlir
@@ -107,4 +107,24 @@ module {
     %result = "ttir.permute"(%rope) <{permutation = array<i64: 2, 0, 1, 3>}> : (tensor<32x8x1x64xbf16>) -> tensor<1x32x8x64xbf16>
     return %result : tensor<1x32x8x64xbf16>
   }
+
+  // GPT-OSS 20B decode: batch=16, 8 heads, seq=1, head_dim=64.
+  // Uses the expanded (trig-identity) RoPE form with half-dim cos/sin
+  // broadcast from [1,1,1,32] to match the model's actual data flow.
+  // CHECK-LABEL: @rope_gpt_oss_20b_decode
+  // CHECK: "ttnn.rotary_embedding"
+  func.func @rope_gpt_oss_20b_decode(%x: tensor<16x8x1x64xbf16>, %cos_h: tensor<1x1x1x32xbf16>, %sin_h: tensor<1x1x1x32xbf16>) -> tensor<16x8x1x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %sin_bc = "ttir.broadcast"(%sin_h) <{broadcast_dimensions = array<i64: 16, 8, 1, 1>}> : (tensor<1x1x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %first = "ttir.slice_static"(%x) <{begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32], ends = [16 : i32, 8 : i32, 1 : i32, 32 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %second = "ttir.slice_static"(%x) <{begins = [0 : i32, 0 : i32, 0 : i32, 32 : i32], ends = [16 : i32, 8 : i32, 1 : i32, 64 : i32], step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<16x8x1x64xbf16>) -> tensor<16x8x1x32xbf16>
+    %0 = "ttir.multiply"(%first, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %1 = "ttir.multiply"(%second, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %2 = "ttir.subtract"(%0, %1) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %3 = "ttir.multiply"(%second, %cos_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %4 = "ttir.multiply"(%first, %sin_bc) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %5 = "ttir.add"(%3, %4) : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x32xbf16>
+    %6 = "ttir.concat"(%2, %5) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
+    return %6 : tensor<16x8x1x64xbf16>
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `RoPEExpandedFusing` pattern matching the alternate RoPE decomposition used by GPT-OSS 20B
- Renames `RoPEFusing` → `RoPERotateHalfFusing` to distinguish the two decomposition forms
- Refactors both RoPE patterns to share validation/creation logic via `createAndReplaceWithRoPEOp` and migrates both to use `FusionValidator`

### Expanded RoPE form (trig-identity decomposition)

The existing `RoPERotateHalfFusing` matches the `rotate_half` form:
```
x * cos + concat(neg(x[half:]), x[:half]) * sin
```

GPT-OSS 20B produces a mathematically equivalent but structurally different form:
```mlir
%first  = ttir.slice_static(%x) [0:D/2]        // first half of head_dim
%second = ttir.slice_static(%x) [D/2:D]         // second half of head_dim

%fc  = ttir.multiply(%first, %cos_h)            // first * cos
%ss  = ttir.multiply(%second, %sin_h)           // second * sin
%sub = ttir.subtract(%fc, %ss)                  // first*cos - second*sin

%sc  = ttir.multiply(%second, %cos_h)           // second * cos
%fs  = ttir.multiply(%first, %sin_h)            // first * sin
%add = ttir.add(%sc, %fs)                       // second*cos + first*sin

%result = ttir.concat(%sub, %add, dim=D)        // → [B,H,S,D]
```

Where `cos_h` and `sin_h` are half-dim (`D/2`) embeddings. This fuses into:
```mlir
%cos_full = ttnn.concat(%cos_h, %cos_h, dim=D)  // [1,1,1,D/2] → [1,1,1,D]
%sin_full = ttnn.concat(%sin_h, %sin_h, dim=D)
%result   = ttnn.rotary_embedding(%x, %cos_full, %sin_full)
```

## Test plan
- [x] Unit tests: expanded form basic, broadcast, head_dim=128
- [x] Negative tests: wrong concat order, wrong slice roles
- [x] Model test: GPT-OSS 20B decode shapes
- [x] Existing rotate_half tests still pass
- [ ] End-to-end validation on actual GPT-OSS 20B model IR

Closes #7715

🤖 Generated with [Claude Code](https://claude.com/claude-code)