### PR TITLE
[wip] Worker owned host tensor caching

### DIFF
--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -12,6 +12,7 @@
 #include "tt/runtime/detail/common/socket.h"
 #include "tt/runtime/detail/distributed/flatbuffer/flatbuffer.h"
 #include "tt/runtime/detail/distributed/types/spsc_queue.h"
+#include "tt/runtime/detail/distributed/worker/tensor_data_cache.h"
 #include "tt/runtime/types.h"
 
 namespace tt::runtime::distributed::worker {
@@ -44,6 +45,7 @@ private:
   std::unordered_map<uint64_t, ::tt::runtime::Binary> binaryPool_;
   std::unordered_map<uint64_t, ::tt::runtime::Layout> layoutPool_;
   std::unordered_map<uint64_t, ::tt::runtime::Tensor> tensorPool_;
+  TensorDataCache tensorDataCache_;
 
   ::tt::runtime::Binary
   getOrCreateBinary(const flatbuffers::Vector<uint8_t> *binary,

--- a/runtime/include/tt/runtime/detail/distributed/worker/tensor_data_cache.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/tensor_data_cache.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_DETAIL_DISTRIBUTED_WORKER_TENSOR_DATA_CACHE_H
+#define TT_RUNTIME_DETAIL_DISTRIBUTED_WORKER_TENSOR_DATA_CACHE_H
+
+#include "ttmlir/Target/Common/types_generated.h"
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace tt::runtime::distributed::worker {
+
+// Cache for immutable tensor data to enable replicated data sharing across
+// workers. Returns a shared_ptr<void> that points to the raw data buffer and
+// shares ownership with the underlying storage, so the buffer stays alive as
+// long as any consumer holds the returned shared_ptr.
+class TensorDataCache {
+public:
+  TensorDataCache() = default;
+  ~TensorDataCache() = default;
+
+  // Returns a shared_ptr<void> pointing to the cached raw data buffer.
+  // Uses the aliasing constructor so the returned ptr shares ownership with the
+  // internal vector storage -- the cache's weak_ptr remains valid as long as
+  // any consumer holds the returned ptr.
+  std::shared_ptr<void> getOrInsert(const uint8_t *tensorDataPtr,
+                                    const std::vector<uint32_t> &shape,
+                                    const std::vector<uint32_t> &stride,
+                                    uint32_t itemSize,
+                                    ::tt::target::DataType dataType);
+
+private:
+  std::unordered_map<uint64_t, std::weak_ptr<std::vector<uint8_t>>> pool_;
+
+  uint64_t getTensorHash(const uint8_t *tensorDataPtr,
+                         const std::vector<uint32_t> &shape,
+                         const std::vector<uint32_t> &stride, uint32_t itemSize,
+                         ::tt::target::DataType dataType);
+};
+
+} // namespace tt::runtime::distributed::worker
+#endif // TT_RUNTIME_DETAIL_DISTRIBUTED_WORKER_TENSOR_DATA_CACHE_H

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -77,6 +77,13 @@
 
 namespace tt::runtime::ttnn {
 
+// Creates host tensor with borrowed storage managed by a shared_ptr (the buffer
+// is on the host and its lifetime is tied to the shared_ptr).
+::tt::runtime::Tensor createBorrowedHostTensor(
+    std::shared_ptr<void> data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType);
+
 // Creates host tensor with borrowed storage (the buffer of the tensor is on the
 // host and it was borrowed from an external buffer which is responsible for its
 // allocation/deallocation).

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -48,6 +49,15 @@ SystemDesc getCurrentSystemDesc(
 
 void launchDistributedRuntime(const DistributedOptions &options = {});
 void shutdownDistributedRuntime();
+
+// Creates host tensor with a view of the input data (the buffer of the tensor
+// is on the host and it was borrowed from an external buffer managed by the
+// given shared_ptr, which keeps the buffer alive for the tensor's lifetime).
+Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
+                                const std::vector<std::uint32_t> &shape,
+                                const std::vector<std::uint32_t> &stride,
+                                std::uint32_t itemsize,
+                                ::tt::target::DataType dataType);
 
 // Creates host tensor with a view of the input data (the buffer of the tensor
 // is on the host and it was borrowed from an external buffer which is
@@ -100,6 +110,12 @@ Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
                          const std::vector<std::uint32_t> &stride,
                          std::uint32_t itemsize);
+
+inline Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
+                                       const TensorDesc &desc) {
+  return ::tt::runtime::createBorrowedHostTensor(
+      std::move(data), desc.shape, desc.stride, desc.itemsize, desc.dataType);
+}
 
 inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensor(data, desc.shape, desc.stride,

--- a/runtime/lib/distributed/worker/CMakeLists.txt
+++ b/runtime/lib/distributed/worker/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(TTRuntimeDistributedWorker
   STATIC
   response_factory.cpp
   command_executor.cpp
+  tensor_data_cache.cpp
 )
 
 set_target_properties(TTRuntimeDistributedWorker PROPERTIES CXX_STANDARD 20)

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -342,15 +342,11 @@ void CommandExecutor::execute(uint64_t commandId,
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();
 
-  // try get from cache
-  std::shared_ptr<std::vector<uint8_t>> cachedTensorData =
-      tensorDataCache_.insert_or_assign(tensorData, shape, stride, itemSize,
-                                        dataType);
+  std::shared_ptr<void> cachedData = tensorDataCache_.getOrInsert(
+      tensorData, shape, stride, itemSize, dataType);
 
-  // ::tt::runtime::Tensor tensor = ::tt::runtime::createOwnedHostTensor(
-  //     tensorData, shape, stride, itemSize, dataType);
   tt::runtime::Tensor tensor = ::tt::runtime::createBorrowedHostTensor(
-      cachedTensorData->data(), shape, stride, itemSize, dataType);
+      std::move(cachedData), shape, stride, itemSize, dataType);
 
   tensor.setGlobalId(tensorGlobalId);
 

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -11,6 +11,7 @@
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
+#include <cstdint>
 #include <thread>
 
 namespace tt::runtime::distributed::worker {
@@ -341,8 +342,15 @@ void CommandExecutor::execute(uint64_t commandId,
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();
 
-  ::tt::runtime::Tensor tensor = ::tt::runtime::createOwnedHostTensor(
-      tensorData, shape, stride, itemSize, dataType);
+  // try get from cache
+  std::shared_ptr<std::vector<uint8_t>> cachedTensorData =
+      tensorDataCache_.insert_or_assign(tensorData, shape, stride, itemSize,
+                                        dataType);
+
+  // ::tt::runtime::Tensor tensor = ::tt::runtime::createOwnedHostTensor(
+  //     tensorData, shape, stride, itemSize, dataType);
+  tt::runtime::Tensor tensor = ::tt::runtime::createBorrowedHostTensor(
+      cachedTensorData->data(), shape, stride, itemSize, dataType);
 
   tensor.setGlobalId(tensorGlobalId);
 

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -342,11 +342,19 @@ void CommandExecutor::execute(uint64_t commandId,
   uint32_t itemSize = command->item_size();
   ::tt::target::DataType dataType = command->data_type();
 
-  std::shared_ptr<void> cachedData = tensorDataCache_.getOrInsert(
-      tensorData, shape, stride, itemSize, dataType);
+  bool canBorrow = tensorData != nullptr &&
+                   ::tt::runtime::utils::isSupportedDataType(dataType);
 
-  tt::runtime::Tensor tensor = ::tt::runtime::createBorrowedHostTensor(
-      std::move(cachedData), shape, stride, itemSize, dataType);
+  tt::runtime::Tensor tensor = [&]() {
+    if (canBorrow) {
+      std::shared_ptr<void> cachedData = tensorDataCache_.getOrInsert(
+          tensorData, shape, stride, itemSize, dataType);
+      return ::tt::runtime::createBorrowedHostTensor(
+          std::move(cachedData), shape, stride, itemSize, dataType);
+    }
+    return ::tt::runtime::createOwnedHostTensor(tensorData, shape, stride,
+                                                itemSize, dataType);
+  }();
 
   tensor.setGlobalId(tensorGlobalId);
 

--- a/runtime/lib/distributed/worker/tensor_data_cache.cpp
+++ b/runtime/lib/distributed/worker/tensor_data_cache.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt/runtime/detail/distributed/worker/tensor_data_cache.h"
+#include "tt/runtime/detail/common/logger.h"
 #include <cstdint>
 #include <numeric>
 #include <tt_stl/reflection.hpp>
@@ -18,8 +19,12 @@ std::shared_ptr<void> TensorDataCache::getOrInsert(
 
   if (pool_.contains(tensorHash)) {
     if (auto cached = pool_.at(tensorHash).lock()) {
+      LOG_INFO("TensorDataCache hit for hash ", tensorHash, ", reusing ",
+               cached->size(), " bytes (pool size: ", pool_.size(), ")");
       return std::shared_ptr<void>(cached, cached->data());
     }
+    LOG_INFO("TensorDataCache stale entry for hash ", tensorHash,
+             ", replacing expired weak_ptr");
   }
 
   uint64_t numElements =
@@ -30,6 +35,9 @@ std::shared_ptr<void> TensorDataCache::getOrInsert(
   auto newVector = std::make_shared<std::vector<uint8_t>>(
       tensorDataPtr, tensorDataPtr + length);
   pool_[tensorHash] = newVector;
+
+  LOG_INFO("TensorDataCache miss for hash ", tensorHash, ", copied ", length,
+           " bytes (pool size: ", pool_.size(), ")");
 
   return std::shared_ptr<void>(newVector, newVector->data());
 }

--- a/runtime/lib/distributed/worker/tensor_data_cache.cpp
+++ b/runtime/lib/distributed/worker/tensor_data_cache.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt/runtime/detail/distributed/worker/tensor_data_cache.h"
+#include <cstdint>
+#include <numeric>
+#include <tt_stl/reflection.hpp>
+
+namespace tt::runtime::distributed::worker {
+
+std::shared_ptr<std::vector<uint8_t>> TensorDataCache::insert_or_assign(
+    const uint8_t *tensorDataPtr, std::vector<uint32_t> shape,
+    std::vector<uint32_t> stride, uint32_t itemSize,
+    ::tt::target::DataType dataType) {
+  uint64_t tensorHash =
+      GetTensorHash(tensorDataPtr, shape, stride, itemSize, dataType);
+  if (_pool.contains(tensorHash)) {
+    if (auto cached = _pool.at(tensorHash).lock()) {
+      return cached;
+    }
+  }
+
+  uint64_t numElements =
+      std::accumulate(shape.begin(), shape.end(), static_cast<std::uint64_t>(1),
+                      std::multiplies<std::uint64_t>());
+  size_t length = numElements * itemSize;
+
+  auto newVector = std::make_shared<std::vector<uint8_t>>(
+      tensorDataPtr, tensorDataPtr + length);
+  _pool[tensorHash] = newVector;
+
+  return newVector;
+}
+
+uint64_t TensorDataCache::GetTensorHash(const uint8_t *tensorDataPtr,
+                                        std::vector<uint32_t> shape,
+                                        std::vector<uint32_t> stride,
+                                        uint32_t itemSize,
+                                        ::tt::target::DataType dataType) {
+  return ttsl::hash::hash_objects_with_default_seed(
+      reinterpret_cast<uintptr_t>(tensorDataPtr), shape, stride, itemSize,
+      static_cast<uint16_t>(dataType));
+}
+
+} // namespace tt::runtime::distributed::worker

--- a/runtime/lib/distributed/worker/tensor_data_cache.cpp
+++ b/runtime/lib/distributed/worker/tensor_data_cache.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,15 +9,16 @@
 
 namespace tt::runtime::distributed::worker {
 
-std::shared_ptr<std::vector<uint8_t>> TensorDataCache::insert_or_assign(
-    const uint8_t *tensorDataPtr, std::vector<uint32_t> shape,
-    std::vector<uint32_t> stride, uint32_t itemSize,
+std::shared_ptr<void> TensorDataCache::getOrInsert(
+    const uint8_t *tensorDataPtr, const std::vector<uint32_t> &shape,
+    const std::vector<uint32_t> &stride, uint32_t itemSize,
     ::tt::target::DataType dataType) {
   uint64_t tensorHash =
-      GetTensorHash(tensorDataPtr, shape, stride, itemSize, dataType);
-  if (_pool.contains(tensorHash)) {
-    if (auto cached = _pool.at(tensorHash).lock()) {
-      return cached;
+      getTensorHash(tensorDataPtr, shape, stride, itemSize, dataType);
+
+  if (pool_.contains(tensorHash)) {
+    if (auto cached = pool_.at(tensorHash).lock()) {
+      return std::shared_ptr<void>(cached, cached->data());
     }
   }
 
@@ -28,14 +29,14 @@ std::shared_ptr<std::vector<uint8_t>> TensorDataCache::insert_or_assign(
 
   auto newVector = std::make_shared<std::vector<uint8_t>>(
       tensorDataPtr, tensorDataPtr + length);
-  _pool[tensorHash] = newVector;
+  pool_[tensorHash] = newVector;
 
-  return newVector;
+  return std::shared_ptr<void>(newVector, newVector->data());
 }
 
-uint64_t TensorDataCache::GetTensorHash(const uint8_t *tensorDataPtr,
-                                        std::vector<uint32_t> shape,
-                                        std::vector<uint32_t> stride,
+uint64_t TensorDataCache::getTensorHash(const uint8_t *tensorDataPtr,
+                                        const std::vector<uint32_t> &shape,
+                                        const std::vector<uint32_t> &stride,
                                         uint32_t itemSize,
                                         ::tt::target::DataType dataType) {
   return ttsl::hash::hash_objects_with_default_seed(

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -281,6 +281,29 @@ void shutdownDistributedRuntime() {
       });
 }
 
+Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
+                                const std::vector<std::uint32_t> &shape,
+                                const std::vector<std::uint32_t> &stride,
+                                std::uint32_t itemsize,
+                                ::tt::target::DataType dataType) {
+  using RetType = Tensor;
+  LOG_ASSERT(itemsize > 0);
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createBorrowedHostTensor(
+            data, shape, stride, itemsize, dataType);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createBorrowedHostTensor(
+            std::move(data), TensorDesc(shape, dataType, itemsize, stride));
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createBorrowedHostTensor",
+                                    HostRuntime::Distributed);
+      });
+}
+
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
                                 const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -167,6 +167,44 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
                                             shouldRetain);
 }
 
+::tt::runtime::Tensor createBorrowedHostTensor(
+    std::shared_ptr<void> data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType) {
+  LOG_ASSERT(
+      data != nullptr ||
+          (shape.size() == 0 ||
+           std::accumulate(shape.begin(), shape.end(), 1,
+                           std::multiplies<std::uint32_t>()) == 0),
+      "Cannot create borrowed tensor with null data unless the volume is 0.");
+  LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(dataType),
+             "Cannot create borrowed tensor with unsupported data type");
+  ::ttnn::Shape ttnnShape(shape);
+
+  switch (dataType) {
+  case ::tt::target::DataType::Float32:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<float>(data, ttnnShape));
+  case ::tt::target::DataType::BFloat16:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<bfloat16>(data, ttnnShape));
+  case ::tt::target::DataType::UInt32:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<uint32_t>(data, ttnnShape));
+  case ::tt::target::DataType::UInt16:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<uint16_t>(data, ttnnShape));
+  case ::tt::target::DataType::UInt8:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<uint8_t>(data, ttnnShape));
+  case ::tt::target::DataType::Int32:
+    return utils::createRuntimeTensorFromTTNN(
+        utils::createBorrowedTTNNTensor<int32_t>(data, ttnnShape));
+  default:
+    LOG_FATAL("Unsupported data type");
+  }
+}
+
 ::tt::runtime::Tensor
 createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
                          const std::vector<std::uint32_t> &stride,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4011

### Problem description
CreateOwnedHostTensor is broadcast for every shard and replica to every worker, leading to host memory usage that scales with the device count in the entire cluster leading to host OOM on trivial sized models over a large enough cluster (eg. quad galaxy)

### What's changed
- Deduplicate worker tensor shards using a tensor cache, where cache entry lifetimes are tied to the lifetimes of the runtime tensors they back. 
- Add CreateBorrowedHostTensor API that accepts a shared_ptr rather than raw data ptr so this change may be scoped only to multihost worker

### Checklist
- [ ] New/Existing tests provide coverage for changes
