### PR TITLE
[StableHLO] Add Multi-Query Attention (MQA) support to SDPA sharding rules

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -146,54 +146,6 @@ getScatterShardingRule(mlir::stablehlo::ScatterOp scatterOp) {
   return builder.build();
 }
 
-static mlir::sdy::OpShardingRuleAttr
-getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
-  auto qType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
-  auto kType = llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
-  auto vType = llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
-  auto outType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
-
-  // SDPA requires Q/K/V and output to have identical shapes.
-  if (qType.getShape() != kType.getShape() ||
-      qType.getShape() != vType.getShape() ||
-      qType.getShape() != outType.getShape()) {
-    return mlir::sdy::OpShardingRuleAttr();
-  }
-
-  ArrayRef<int64_t> shape = qType.getShape();
-
-  // SDPA is assumed to operate on 4D tensors: [B, H, S, D]
-  // If the shape does not match, conservatively fallback to a pointwise rule.
-  if (shape.size() != 4) {
-    return mlir::sdy::OpShardingRuleBuilder::buildPointwise(op);
-  }
-
-  // SDPA can shard batch (B) and head (H) dimensions freely.
-  // Sequence (S) and hidden (D) dimensions generally require replication,
-  // unless a more advanced distributed attention algorithm is implemented.
-  //
-  // Dimension assignment:
-  // dim 0 -> Batch
-  // dim 1 -> Head
-  // dim 2 -> Sequence length
-  // dim 3 -> Hidden size
-  auto getFactorType = [&](int64_t dim) -> mlir::sdy::FactorType {
-    if (dim == 0 || dim == 1) {
-      // Allow sharding
-      return mlir::sdy::FactorType::kPassThrough;
-    }
-    // Disallow sharding, require replication
-    return mlir::sdy::FactorType::kNeedReplication;
-  };
-
-  // Build the final sharding rule:
-  // - Pass-through on B/H dims
-  // - Replication on S/D dims
-  return mlir::sdy::OpShardingRuleBuilder(op)
-      .addPointwise(shape, getFactorType)
-      .build();
-}
-
 static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(
     mlir::stablehlo::CustomCallOp op, llvm::ArrayRef<int64_t> operandHeadDims,
     llvm::ArrayRef<int64_t> resultHeadDims, int64_t headSize) {
@@ -212,6 +164,82 @@ static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(
   builder.addFactor(resolvedOperandDims, resolvedResultDims, headSize,
                     mlir::sdy::FactorType::kPassThrough);
   return builder.build();
+}
+
+static mlir::sdy::OpShardingRuleAttr
+getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
+  // Validate minimum required operands (Q, K, V) and result
+  if (op.getNumOperands() < 3 || op.getNumResults() != 1) {
+    op.getOperation()->emitWarning()
+        << "SDPA expects at least 3 operands (Q, K, V) and 1 result";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto qType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto kType = llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto vType = llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
+  auto outType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+
+  if (!qType || !kType || !vType || !outType) {
+    op.getOperation()->emitWarning() << "SDPA requires ranked tensor types";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // SDPA is assumed to operate on 4D tensors: [B, H, S, D]
+  if (qType.getRank() != 4 || kType.getRank() != 4 || vType.getRank() != 4 ||
+      outType.getRank() != 4) {
+    op.getOperation()->emitWarning() << "SDPA requires 4D tensors [B, H, S, D]";
+    return mlir::sdy::OpShardingRuleBuilder::buildPointwise(op);
+  }
+
+  ArrayRef<int64_t> qShape = qType.getShape();
+  ArrayRef<int64_t> kShape = kType.getShape();
+  ArrayRef<int64_t> vShape = vType.getShape();
+  ArrayRef<int64_t> outShape = outType.getShape();
+
+  // Multi-Query/Grouped-Query Attention support:
+  // - Query and output should have the same shape (output follows query)
+  // - Key and Value should have the same shape
+  // - Batch, sequence, and hidden dimensions must match across all tensors
+  // - Head dimensions can differ (Q: num_q_heads, K/V: num_kv_heads)
+  if (qShape[0] != kShape[0] || qShape[0] != vShape[0] ||
+      qShape[0] != outShape[0] || // Batch
+      qShape[2] != kShape[2] || qShape[2] != vShape[2] ||
+      qShape[2] != outShape[2] || // Sequence
+      qShape[3] != kShape[3] || qShape[3] != vShape[3] ||
+      qShape[3] != outShape[3] || // Hidden
+      kShape != vShape ||         // Key and Value must have same shape
+      qShape != outShape) {       // Output must match Query
+    op.getOperation()->emitWarning()
+        << "SDPA shape validation failed: incompatible Q/K/V/Out dimensions";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // Head dimensions: Query and output should match, Key/Value should match
+  const int64_t queryHeadDim = 1;
+  const int64_t kvHeadDim = 1;
+  const int64_t outputHeadDim = 1;
+
+  int64_t queryHeadSize = qShape[queryHeadDim];
+
+  // Build head-sharded rule using the existing helper function
+  SmallVector<int64_t> operandHeadDims(op.getNumOperands(),
+                                       mlir::sdy::kNullDim);
+  SmallVector<int64_t> resultHeadDims(op.getNumResults(), mlir::sdy::kNullDim);
+
+  operandHeadDims[0] = queryHeadDim; // Query head dimension
+  operandHeadDims[1] = kvHeadDim;    // Key head dimension
+  operandHeadDims[2] = kvHeadDim;    // Value head dimension
+
+  // Handle optional attention mask and attention sink (4th operand)
+  // These should not participate in head sharding (use kNullDim)
+  // operandHeadDims[3] = mlir::sdy::kNullDim;  // Already initialized to
+  // kNullDim
+
+  resultHeadDims[0] = outputHeadDim; // Output head dimension
+
+  return buildHeadShardedCustomCallRule(op, operandHeadDims, resultHeadDims,
+                                        queryHeadSize);
 }
 
 // Dispatch function for paged attention CustomCall sharding rules.

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa.mlir
@@ -12,3 +12,55 @@ module @SDPA_Sharding_Head attributes {mhlo.cross_program_prefetches = [], mhlo.
     return %0 : tensor<1x12x32x128xbf16>
   }
 }
+
+// -----
+
+// Test: Multi-Query Attention (MQA) with different Q/K/V head counts
+module @SDPA_MQA_Sharding attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x32x64x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<1x4x64x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<1x4x64x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}) -> tensor<1x32x64x128xbf16> {
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x16x64x128xbf16>, tensor<1x2x64x128xbf16>, tensor<1x2x64x128xbf16>
+    // CHECK-SAME: -> tensor<1x16x64x128xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "True", scale = "0.088388"}} : (tensor<1x32x64x128xbf16>, tensor<1x4x64x128xbf16>, tensor<1x4x64x128xbf16>) -> tensor<1x32x64x128xbf16>
+    return %0 : tensor<1x32x64x128xbf16>
+  }
+}
+
+// -----
+
+// Test: SDPA with Attention Mask (4 operands)
+module @SDPA_AttentionMask attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=4]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2x16x128x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,4,1,1]<=[4]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<2x16x128x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,4,1,1]<=[4]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<2x16x128x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,4,1,1]<=[4]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}, %arg3: tensor<2x1x128x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "attention_mask"}) -> tensor<2x16x128x64xbf16> {
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<2x4x128x64xbf16>, tensor<2x4x128x64xbf16>, tensor<2x4x128x64xbf16>, tensor<2x1x128x128xbf16>
+    // CHECK-SAME: -> tensor<2x4x128x64xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2, %arg3) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "True", is_causal = "False"}} : (tensor<2x16x128x64xbf16>, tensor<2x16x128x64xbf16>, tensor<2x16x128x64xbf16>, tensor<2x1x128x128xbf16>) -> tensor<2x16x128x64xbf16>
+    return %0 : tensor<2x16x128x64xbf16>
+  }
+}
+
+// -----
+
+// Test: MQA with Attention Sink
+module @SDPA_MQA_AttentionSink attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x64x32x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<1x8x32x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<1x8x32x64xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}, %arg3: tensor<64x1xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "attention_sink"}) -> tensor<1x64x32x64xbf16> {
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x32x32x64xbf16>, tensor<1x4x32x64xbf16>, tensor<1x4x32x64xbf16>, tensor<32x1xbf16>
+    // CHECK-SAME: -> tensor<1x32x32x64xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2, %arg3) {api_version = 0 : i32, mhlo.frontend_attributes = {has_attention_mask = "False", has_attention_sink = "True", is_causal = "True"}} : (tensor<1x64x32x64xbf16>, tensor<1x8x32x64xbf16>, tensor<1x8x32x64xbf16>, tensor<64x1xbf16>) -> tensor<1x64x32x64xbf16>
+    return %0 : tensor<1x64x32x64xbf16>
+  }
+}
+
+// -----
+
+// Test: Higher sharding factor (8x mesh)
+module @SDPA_HighSharding attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=8]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x64x256x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,8,1,1]<=[8]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<1x8x256x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,8,1,1]<=[8]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<1x8x256x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,8,1,1]<=[8]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}) -> tensor<1x64x256x128xbf16> {
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x8x256x128xbf16>, tensor<1x1x256x128xbf16>, tensor<1x1x256x128xbf16>
+    // CHECK-SAME: -> tensor<1x8x256x128xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "True", scale = "0.088388"}} : (tensor<1x64x256x128xbf16>, tensor<1x8x256x128xbf16>, tensor<1x8x256x128xbf16>) -> tensor<1x64x256x128xbf16>
+    return %0 : tensor<1x64x256x128xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
closes #7760 

### Problem description
Custom sharding rules only accepts identical shapes for Q/K/V

### What's changed
- Enhanced getSDPAShardingRule to handle MQA patterns with different Q/K/V head dimensions
- Fixed sharding propagation for attention patterns where Query has more heads than Key/Value

### Checklist
- [X] New/Existing tests provide coverage for changes
