### PR TITLE
Support ttnn reduce scatter builder

### DIFF
--- a/test/python/golden/mlir_snippets/ttnn/ttnn_reduce_scatter.mlir
+++ b/test/python/golden/mlir_snippets/ttnn/ttnn_reduce_scatter.mlir
@@ -1,0 +1,13 @@
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 8 + d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 32 + d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x4>]>} {
+  func.func @forward(%arg0: tensor<1x1x32x128xbf16, #ttnn_layout2>) -> tensor<1x1x32x32xbf16, #ttnn_layout1> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x4>}> : () -> !ttnn.device
+    %1 = "ttnn.distribute_tensor"(%arg0, %0) <{mapper_config = #ttnn.mesh_mapper_config<placements = [<shard, 3 : i64>]>}> : (tensor<1x1x32x128xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x32x32xbf16, #ttnn_layout1>
+    %2 = "ttnn.reduce_scatter"(%1) <{cluster_axis = 1 : ui32, reduce_type = #ttcore.reduce_type<sum>, scatter_dim = 3 : si32}> : (tensor<1x1x32x32xbf16, #ttnn_layout1>) -> tensor<1x1x32x8xbf16, #ttnn_layout>
+    %3 = "ttnn.aggregate_tensor"(%2, %0) <{composer_config = #ttnn.mesh_composer_config<dims = [3 : i64]>}> : (tensor<1x1x32x8xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x32x32xbf16, #ttnn_layout1>
+    return %3 : tensor<1x1x32x32xbf16, #ttnn_layout1>
+  }
+}

--- a/test/python/golden/test_parse_split_ops.py
+++ b/test/python/golden/test_parse_split_ops.py
@@ -93,6 +93,7 @@ def test_stablehlo_parsing_splitting_ops(mlir_snippet, request, device):
 
 skip_split_ttnn_tests = [
     "ttnn_all_gather.mlir",
+    "ttnn_reduce_scatter.mlir",
 ]
 
 

--- a/test/python/golden/test_ttnn_ops.py
+++ b/test/python/golden/test_ttnn_ops.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from ttmlir.dialects import ttnn
 
 from builder.base.builder_utils import Operand, Shape
+from builder.base.builder_enums import ReduceType
 from builder.ttnn.ttnn_builder import TTNNBuilder
 from builder.base.builder_apis import compile_and_execute_ttnn
 from test_utils import shape_str, shapes_list_str
@@ -300,6 +301,113 @@ def test_all_gather(
             )
 
             from_dev = builder.from_device(gathered)
+            untilized = builder.to_layout(from_dev, layout=ttnn.Layout.RowMajor)
+            return builder.aggregate_tensor(
+                untilized,
+                device=device,
+                shard_dims=shard_dims,
+            )
+
+    compile_and_execute_ttnn(
+        module,
+        custom_pipeline=(
+            "ttcore-mark-functions-as-forward,"
+            "ttcore-wrap-device-module,"
+            "ttcore.device_module(builtin.module("
+            "ttnn-configure-ccl-ops,ttnn-deallocate))"
+        ),
+        **get_request_kwargs(request),
+        target="ttnn",
+        device=device,
+        mesh_dict=OrderedDict([("x", mesh_shape[0]), ("y", mesh_shape[1])]),
+    )
+
+
+@pytest.mark.parametrize(
+    "test_shape",
+    [
+        (1, 32, 32, 32),
+        (1, 32, 32, 1),
+        (32, 32, 1, 1),
+        (1, 32, 32),
+        (32, 32),
+        (32, 40),
+        (40, 32),
+        (1, 1, 32, 32, 32),
+        (1, 1, 1, 1, 1, 1, 32, 32, 32),
+    ],
+    ids=shape_str,
+)
+@pytest.mark.parametrize(
+    "mesh_shape", [(2, 4), (1, 8), (1, 2), (1, 32), (8, 4)], ids=shape_str
+)
+@pytest.mark.parametrize("scatter_dim", range(4))
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
+def test_reduce_scatter(
+    test_shape: Shape,
+    mesh_shape: Tuple[int, int],
+    scatter_dim: int,
+    cluster_axis: int,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    if scatter_dim >= len(test_shape):
+        pytest.skip("scatter_dim is out of range")
+    if mesh_shape[cluster_axis] == 1:
+        pytest.skip("reduce_scatter across 1 device is meaningless")
+
+    rank_in = len(test_shape)
+    rank_mesh = len(mesh_shape)
+
+    if rank_mesh > rank_in:
+        pytest.skip(
+            f"Mesh shape {mesh_shape} has {rank_mesh} dimensions, but test shape "
+            f"{test_shape} only has {rank_in} dimensions."
+        )
+
+    shard_dims_candidate = list(range(rank_in - rank_mesh, rank_in))
+    for d, factor in zip(shard_dims_candidate, mesh_shape):
+        if test_shape[d] < factor:
+            pytest.skip(
+                f"Tensor dim {d} (size {test_shape[d]}) too small to shard "
+                f"by factor {factor}"
+            )
+
+    shard_dims = list(range(rank_in - rank_mesh, rank_in))
+
+    full_input_shape = list(test_shape)
+    for d, factor in zip(shard_dims, mesh_shape):
+        full_input_shape[d] *= factor
+
+    if full_input_shape[scatter_dim] % mesh_shape[cluster_axis] != 0:
+        pytest.skip(
+            f"scatter_dim {scatter_dim} (size {full_input_shape[scatter_dim]}) "
+            f"not evenly divisible by mesh_shape[{cluster_axis}]={mesh_shape[cluster_axis]}"
+        )
+
+    def module(builder: TTNNBuilder):
+        @builder.func([full_input_shape], [dtype], host_inputs=True)
+        def reduce_scatter(in0: Operand, builder: TTNNBuilder):
+            device = builder.get_device()
+
+            distributed = builder.distribute_tensor(
+                in0,
+                device=device,
+                shard_dims=shard_dims,
+            )
+            tilized = builder.to_layout(distributed, layout=ttnn.Layout.Tile)
+            on_device = builder.to_device(tilized, device=device)
+
+            scattered = builder.reduce_scatter(
+                on_device,
+                reduce_type=ReduceType.Sum,
+                scatter_dim=scatter_dim,
+                cluster_axis=cluster_axis,
+            )
+
+            from_dev = builder.from_device(scattered)
             untilized = builder.to_layout(from_dev, layout=ttnn.Layout.RowMajor)
             return builder.aggregate_tensor(
                 untilized,

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -13,6 +13,7 @@ from ttmlir.dialects import ttnn, ttcore, func
 
 from builder.base.builder import *
 from builder.base.builder_utils import *
+from builder.base.builder_enums import *
 
 from golden import *
 
@@ -8852,6 +8853,108 @@ class TTNNBuilder(Builder):
         golden_output = op_golden_function(
             input0,
             all_gather_dim_attr,
+            cluster_axis_attr,
+            result.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op, {old_op.result: new_op_result}
+
+    ############### ttnn.ReduceScatterOp ###############
+
+    @tag(ttnn.ReduceScatterOp)
+    def reduce_scatter(
+        self,
+        input: Operand,
+        reduce_type: ReduceType,
+        scatter_dim: int,
+        cluster_axis: int,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.reduce_scatter)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(input)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        input0 = self._get_golden_tensor(input)
+        reduce_type_attr = ttcore.ir.ReduceTypeAttr.get(self._ctx, reduce_type.value)
+        scatter_dim_attr = IntegerAttr.get(IntegerType.get_signed(32), scatter_dim)
+        cluster_axis_attr = IntegerAttr.get(IntegerType.get_unsigned(32), cluster_axis)
+
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input0,
+            reduce_type_attr,
+            scatter_dim_attr,
+            cluster_axis_attr,
+            mlir_output_type,
+        )
+        result = self._create_dram_tiled_ttnn_tensor(
+            golden_output.shape, mlir_output_type
+        )
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttnn_op(
+            result,
+            input,
+            reduce_type_attr,
+            scatter_dim_attr,
+            cluster_axis_attr,
+            loc=loc,
+        )
+        new_op_result = op.result
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        return new_op_result
+
+    @parse(ttnn.ReduceScatterOp)
+    def reduce_scatter_parser(
+        self,
+        old_op: ttnn.ReduceScatterOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttnn_op = self.get_opview_from_parser(TTNNBuilder.reduce_scatter_parser)
+
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
+        reduce_type_attr = old_op.reduce_type
+        scatter_dim_attr = old_op.scatter_dim
+        cluster_axis_attr = old_op.cluster_axis
+
+        new_op = ttnn_op(
+            result,
+            in0,
+            reduce_type_attr,
+            scatter_dim_attr,
+            cluster_axis_attr,
+            sub_device_id=old_op.sub_device_id,
+            memory_config=old_op.memory_config,
+            num_links=old_op.num_links,
+            topology=old_op.topology,
+            compute_config=old_op.compute_config,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            input0,
+            reduce_type_attr,
+            scatter_dim_attr,
             cluster_axis_attr,
             result.element_type,
         )

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6650,6 +6650,31 @@ def ttnn_all_gather_golden(
     )
 
 
+def ttnn_reduce_scatter_golden(
+    input: GoldenMapTensor,
+    reduce_type_attr: ttcore.ir.ReduceTypeAttr,
+    scatter_dim_attr: IntegerAttr,
+    cluster_axis_attr: IntegerAttr,
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    reduce_type = ttcore.ir.ReduceTypeAttr.maybe_downcast(reduce_type_attr).value
+    cluster_axis = unpack_mlir_attr(cluster_axis_attr)
+    scatter_dim = unpack_mlir_attr(scatter_dim_attr)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    output_shards = [None] * len(input.shard_map)
+    grouped_shards = input.group_by_axis(cluster_axis)
+    for group in grouped_shards:
+        group_tensors = list(group.values())
+        reduced_tensor = reduce_mapping[reduce_type](group_tensors)
+        scattered_tensor = torch.chunk(reduced_tensor, len(group), dim=scatter_dim)
+        for index, id in enumerate(group.keys()):
+            output_shards[id] = scattered_tensor[index].clone().to(output_dtype)
+    return GoldenMapTensor(
+        {i: t for i, t in enumerate(output_shards)}, input.mesh_shape
+    )
+
+
 ################ TTNN Layout/Device Op Golden Functions ###############
 
 
@@ -7144,6 +7169,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.AllGatherOp: ttnn_all_gather_golden,
     ttnn.GatherOp: ttir_gather_dim_golden,
     ttnn.AllReduceAsyncOp: ttir_all_reduce_golden,
+    ttnn.ReduceScatterOp: ttnn_reduce_scatter_golden,
     # ----- DEBUG OPS -----
     debug.AnnotateOp: debug_annotate_golden,
     debug.RegionStartOp: debug_region_start_golden,


### PR DESCRIPTION
### Ticket                                                                
https://github.com/tenstorrent/tt-mlir/issues/7625                                                                
                                                                                                                  
### Problem description                                                                                           
The ttnn reduce_scatter operation was not supported in the TTNN builder 
                                                                                                                  
### What's changed                                                                                                
Added reduce_scatter support to the TTNN builder by implementing:                                                                                                                                                         
  - Builder method (ttnn_builder.py): Added reduce_scatter (tagged with ttnn.ReduceScatterOp) that constructs the 
  op from parameters (reduce_type, scatter_dim, cluster_axis) and computes the golden output, along with a        
  reduce_scatter_parser that reconstructs the op from existing MLIR while preserving attributes (sub_device_id,   
  memory_config, num_links, topology, compute_config).
  - Golden mapping (mapping.py): Added ttnn_reduce_scatter_golden which groups input shards by cluster axis,
  reduces each group, then scatters along the specified dimension.                                                
  - Tests (test_ttnn_ops.py): Added parametrized test_reduce_scatter, multiple mesh shapes,
  scatter dims, cluster axes, and dtypes.    
  - MLIR snippet (ttnn_reduce_scatter.mlir): Added a golden test snippet for the operation.
                                                                
                                                                                                                  
### Checklist                                                                                                     
- [x] New/Existing tests provide coverage for changes