### PR TITLE
Replace custom CCL canonicalization with SDY built-in patterns

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/ShardyCCLCanonicalization.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ShardyCCLCanonicalization.cpp
@@ -11,89 +11,6 @@ namespace mlir::tt::stablehlo {
 #define GEN_PASS_DEF_SHARDYCCLCANONICALIZATIONPASS
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
 
-// AllReduceAllSliceToReduceScatterPattern - fuses all_reduce + all_slice into
-// reduce_scatter when criteria are met:
-// - each all_reduce use is an all_slice op
-// - all_reduce has exactly one reduction axis
-// - each all_slice has slicing on exactly one dimension with one axis
-// - The axes match between all_reduce and each all_slice
-class AllReduceAllSliceToReduceScatterPattern
-    : public OpRewritePattern<mlir::sdy::AllReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-public:
-  LogicalResult matchAndRewrite(mlir::sdy::AllReduceOp allReduceOp,
-                                PatternRewriter &rewriter) const override {
-    // Check that all_reduce has exactly one reduction axis.
-    auto reductionAxes = allReduceOp.getReductionAxes();
-    if (reductionAxes.size() != 1) {
-      return rewriter.notifyMatchFailure(
-          allReduceOp,
-          "all_reduce has multiple reduction axes, cannot fuse with all_slice");
-    }
-    mlir::StringRef reduceAxis = reductionAxes.front().getName();
-
-    // Collect all users and validate they are all fusable all_slice ops.
-    llvm::SmallVector<mlir::sdy::AllSliceOp> allSliceUsers;
-    for (mlir::Operation *user : allReduceOp.getResult().getUsers()) {
-      auto allSliceOp = mlir::dyn_cast<mlir::sdy::AllSliceOp>(user);
-      if (!allSliceOp) {
-        return rewriter.notifyMatchFailure(
-            allReduceOp, "all_reduce has a user that is not an all_slice op");
-      }
-
-      // Validate all_slice has exactly one sliced dimension with matching axis.
-      auto axesPerDim = allSliceOp.getSlicingAxes();
-      int64_t sliceDim = -1;
-      mlir::StringRef sliceAxis;
-
-      for (auto it = axesPerDim.begin(), e = axesPerDim.end(); it != e; ++it) {
-        llvm::ArrayRef<mlir::sdy::AxisRefAttr> axisRefs = it->getValue();
-        if (axisRefs.empty()) {
-          continue;
-        }
-        if (axisRefs.size() > 1) {
-          return rewriter.notifyMatchFailure(
-              allReduceOp, "all_slice has multiple axes on a single dimension");
-        }
-        if (sliceDim != -1) {
-          return rewriter.notifyMatchFailure(
-              allReduceOp,
-              "all_slice has slicing on multiple dimensions, cannot fuse");
-        }
-        sliceDim = static_cast<int64_t>(std::distance(axesPerDim.begin(), it));
-        sliceAxis = axisRefs.front().getName();
-      }
-
-      if (sliceDim == -1) {
-        return rewriter.notifyMatchFailure(allReduceOp,
-                                           "all_slice has no slicing axes");
-      }
-
-      if (reduceAxis != sliceAxis) {
-        return rewriter.notifyMatchFailure(
-            allReduceOp,
-            "all_reduce and all_slice operate on different mesh axes");
-      }
-
-      allSliceUsers.push_back(allSliceOp);
-    }
-
-    // All users validated - create reduce_scatter for each all_slice.
-    for (mlir::sdy::AllSliceOp allSliceOp : allSliceUsers) {
-      auto reduceScatterOp = rewriter.create<mlir::sdy::ReduceScatterOp>(
-          allReduceOp.getLoc(), allSliceOp.getType(), allReduceOp.getOperand(),
-          allSliceOp.getSlicingAxes(), allSliceOp.getOutSharding());
-      rewriter.replaceOp(allSliceOp, reduceScatterOp.getResult());
-    }
-
-    // Erase the all_reduce (now has no uses).
-    rewriter.eraseOp(allReduceOp);
-
-    return success();
-  }
-};
-
 struct ShardyCCLCanonicalizationPass
     : public impl::ShardyCCLCanonicalizationPassBase<
           ShardyCCLCanonicalizationPass> {
@@ -106,7 +23,11 @@ public:
     MLIRContext *ctx = module.getContext();
 
     RewritePatternSet patterns(ctx);
-    patterns.add<AllReduceAllSliceToReduceScatterPattern>(ctx);
+    mlir::sdy::AllGatherOp::getCanonicalizationPatterns(patterns, ctx);
+    mlir::sdy::AllSliceOp::getCanonicalizationPatterns(patterns, ctx);
+    mlir::sdy::AllReduceOp::getCanonicalizationPatterns(patterns, ctx);
+    mlir::sdy::AllToAllOp::getCanonicalizationPatterns(patterns, ctx);
+    mlir::sdy::ReduceScatterOp::getCanonicalizationPatterns(patterns, ctx);
 
     GreedyRewriteConfig config;
     config.enableConstantCSE(false);

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/canonicalization.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/canonicalization.mlir
@@ -42,10 +42,11 @@ module @NonFusingTest attributes {mhlo.cross_program_prefetches = [], mhlo.input
 
 // -----
 
-// Test that sdy.all_reduce with multiple all_slice users (all matching axes) fuses into multiple reduce_scatters
+// Test that sdy.all_reduce with multiple identical all_slice users fuses into
+// a single reduce_scatter (SDY deduplicates identical all_slice ops).
 // CHECK-LABEL: @MultiUseFusingTest
-// CHECK: sdy.reduce_scatter
-// CHECK: sdy.reduce_scatter
+// CHECK: %[[RS:.*]] = sdy.reduce_scatter
+// CHECK: sdy.return %[[RS]], %[[RS]]
 // CHECK-NOT: sdy.all_slice
 // CHECK-NOT: sdy.all_reduce
 module @MultiUseFusingTest {

--- a/test/ttmlir/Dialect/StableHLO/shardy/shardy_ccl_canonicalization.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/shardy_ccl_canonicalization.mlir
@@ -1,0 +1,44 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --shardy-ccl-canonicalization %s | FileCheck %s
+
+sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+
+// all_reduce + multi-dim all_slice should be fused into
+// reduce_scatter (on the matching axis) + residual all_slice (on the rest).
+// CHECK-LABEL: func.func @reduce_scatter_fusion_multi_dim
+// CHECK-NOT: sdy.all_reduce
+// CHECK: sdy.reduce_scatter [{}, {}, {}, {"_axis_1"}]
+// CHECK: sdy.all_slice [{}, {}, {"_axis_0"}, {}]
+func.func @reduce_scatter_fusion_multi_dim(
+    %arg0: tensor<4x1x32x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {}, {}]>}) -> tensor<4x1x32x2880xbf16> {
+  %0 = sdy.all_reduce {"_axis_1"} %arg0 out_sharding=<@mesh, [{}, {}, {}, {}]> : tensor<4x1x32x2880xbf16>
+  %1 = sdy.all_slice [{}, {}, {"_axis_0"}, {"_axis_1"}] %0 out_sharding=<@mesh, [{}, {}, {"_axis_0"}, {"_axis_1"}]> : tensor<4x1x32x2880xbf16>
+  return %1 : tensor<4x1x32x2880xbf16>
+}
+
+// all_reduce + single-dim all_slice should be fused into a single
+// reduce_scatter with no residual all_slice.
+// CHECK-LABEL: func.func @reduce_scatter_fusion_single_dim
+// CHECK-NOT: sdy.all_reduce
+// CHECK-NOT: sdy.all_slice
+// CHECK: sdy.reduce_scatter [{}, {}, {}, {"_axis_1"}]
+// CHECK: return
+func.func @reduce_scatter_fusion_single_dim(
+    %arg0: tensor<4x1x32x2880xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {}, {}]>}) -> tensor<4x1x32x2880xbf16> {
+  %0 = sdy.all_reduce {"_axis_1"} %arg0 out_sharding=<@mesh, [{}, {}, {}, {}]> : tensor<4x1x32x2880xbf16>
+  %1 = sdy.all_slice [{}, {}, {}, {"_axis_1"}] %0 out_sharding=<@mesh, [{}, {}, {}, {"_axis_1"}]> : tensor<4x1x32x2880xbf16>
+  return %1 : tensor<4x1x32x2880xbf16>
+}
+
+// all_slice(all_gather(x)) with the same axes should cancel out to identity.
+// The dead all_gather remains (no Pure trait) but the all_slice is eliminated.
+// CHECK-LABEL: func.func @all_slice_cancels_all_gather
+// CHECK: sdy.all_gather
+// CHECK-NOT: sdy.all_slice
+// CHECK: return %arg0
+func.func @all_slice_cancels_all_gather(
+    %arg0: tensor<16x1x720xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_1"}]>}) -> tensor<16x1x720xbf16> {
+  %0 = sdy.all_gather [{}, {}, {"_axis_1"}] %arg0 out_sharding=<@mesh, [{}, {}, {}]> : tensor<16x1x720xbf16>
+  %1 = sdy.all_slice [{}, {}, {"_axis_1"}] %0 out_sharding=<@mesh, [{}, {}, {"_axis_1"}]> : tensor<16x1x720xbf16>
+  return %1 : tensor<16x1x720xbf16>
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
we currently use our own canonicalization. However, to take full advantage of community features, we want to adopt the standard version rather than defining our own.

### What's changed
Remove the custom AllReduceAllSliceToReduceScatterPattern and delegate to SDY's built-in canonicalization patterns for all collective ops (AllGather,AllSlice, AllReduce, AllToAll, ReduceScatter).

### Checklist
- [ ] New/Existing tests provide coverage for changes
