### PR TITLE
Uplift third_party/tt-metal to 2a7f3bb631478190be9fc8a735748a3c78af3b42 2026-04-04

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=805f43d03a2d708ca36bacfb70d1deecf837dd9c
+ARG TT_METAL_DEPENDENCIES_COMMIT=2a7f3bb631478190be9fc8a735748a3c78af3b42
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "aa301f48dcd8e9f1b9057a21a79ffc981f551d9f")
+set(TT_METAL_VERSION "2a7f3bb631478190be9fc8a735748a3c78af3b42")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 2a7f3bb631478190be9fc8a735748a3c78af3b42

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):