### PR TITLE
Skip L1 ops in ConstEvalHoistTransform to prevent unaccounted L1 pressure

### DIFF
--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -193,6 +193,22 @@ private:
       return;
     }
 
+    // Skip ops whose results are in L1. Const-eval functions persist their
+    // outputs across function boundaries, so L1 allocations from const-eval
+    // would consume L1 budget during @main execution without the
+    // L1SpillManagement pass being able to account for them.
+    for (auto result : op->getResults()) {
+      if (auto tensorType =
+              mlir::dyn_cast<mlir::RankedTensorType>(result.getType())) {
+        if (auto layoutAttr = mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
+                tensorType.getEncoding())) {
+          if (layoutAttr.hasL1BufferType()) {
+            return;
+          }
+        }
+      }
+    }
+
     auto operandConstEval = [&](mlir::Value operand) {
       if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(operand)) {
         return constParams.contains(blockArg);


### PR DESCRIPTION
## Summary
- Prevents `ConstEvalHoistTransform` from hoisting ops whose results are in L1 into const_eval functions
- Const-eval outputs now stay in DRAM; the DRAM→L1 reshard remains in `@main` where `L1SpillManagement` can account for it

## Problem

`ConstEvalHoistTransform` runs after `L1SpillManagement` in the pipeline and can hoist `to_memory_config` ops with L1 outputs into const_eval functions. These L1 tensors persist across function boundaries — when `@main` executes, the const_eval's L1 allocations are still live, but `L1SpillManagement` made its decisions assuming the full L1 budget was available.

On `qwen_3_4b`, `const_eval_187` produced a 311K/core L1 width-sharded tensor (argmax indices) that consumed ~23% of L1 for the entire duration of `@main`, contributing to a runtime CB/tensor buffer clash.

## Fix

Added an L1 result check in `ConstEvalAnalyze::processOp()` — if any result has `TTNNLayoutAttr` with `hasL1BufferType()`, the op is skipped from const-eval hoisting.

## Test plan
- [x] Verified minimal repro: `arange` + `multiply` + `add` — const_eval returns DRAM after fix (was L1 before)
- [x] Verified full `qwen_3_4b` TTIR compilation — `const_eval_187` returns `#dram, <interleaved>` after fix
- [ ] Existing const_eval tests should pass (hoisting of DRAM ops is unaffected)

Closes #7813

🤖 Generated with [Claude Code](https://claude.com/claude-code)