### PR TITLE
Improve test execution hygiene

### DIFF
--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -35,6 +35,21 @@ static std::string getMangledName(std::string_view funcName) {
   return mangledName;
 }
 
+// Read one line from a popen pipe & strip the trailing newline.
+// Returns true if a line was read (including empty lines before EOF), false on
+// EOF with no data. Handles arbitrarily long C++ mangled names.
+static bool readLine(FILE *pipe, std::string &line) {
+  line.clear();
+  int ch;
+  while ((ch = fgetc(pipe)) != EOF) {
+    if (ch == '\n') {
+      return true;
+    }
+    line += static_cast<char>(ch);
+  }
+  return !line.empty();
+}
+
 // The names of input creation functions are mangled unpredictably
 static std::string getCreateInputsMangledName(std::string_view funcName,
                                               std::string path) {
@@ -47,19 +62,21 @@ static std::string getCreateInputsMangledName(std::string_view funcName,
         "Failed to execute command to get mangled function name");
   }
 
-  char buffer[256];
-  while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
-    std::string funcNameBuffer = buffer;
-    // Remove newline
-    if (!funcNameBuffer.empty() && funcNameBuffer.back() == '\n') {
-      funcNameBuffer.pop_back();
-    }
+  std::string result;
+  std::string funcNameBuffer;
+  while (readLine(pipe, funcNameBuffer)) {
     if (funcNameBuffer.find("create_inputs_for_") != std::string::npos &&
         funcNameBuffer.find(funcName) != std::string::npos) {
-      return funcNameBuffer;
+      result = std::move(funcNameBuffer);
+      break;
     }
   }
-  throw std::runtime_error("Failed to find mangled function name");
+  pclose(pipe);
+
+  if (result.empty()) {
+    throw std::runtime_error("Failed to find mangled function name");
+  }
+  return result;
 }
 
 void *openSo(const std::string &path) {
@@ -83,8 +100,8 @@ void closeSo(void *handle) {
   int ret = dlclose(handle);
 
   if (ret != 0) {
-    std::cerr << "Failed to close shared object: " << dlerror() << std::endl;
-    exit(ret);
+    throw std::runtime_error(std::string("Failed to close shared object: ") +
+                             dlerror());
   }
 }
 
@@ -106,13 +123,8 @@ std::vector<std::string> getSoPrograms(void *so, std::string path) {
         "Failed to execute command to get mangled function names");
   }
 
-  char buffer[256];
-  while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
-    std::string funcName = buffer;
-    // Remove newline
-    if (!funcName.empty() && funcName.back() == '\n') {
-      funcName.pop_back();
-    }
+  std::string funcName;
+  while (readLine(pipe, funcName)) {
     if (!funcName.empty()) {
       functionNames.push_back(funcName);
     }
@@ -159,7 +171,6 @@ createInputs(void *so, std::string funcName, Device device, std::string path) {
   void *setDeviceSymbol = dlsym(so, "setDevice");
   const char *setDeviceError = dlerror();
   if (setDeviceError) {
-    dlclose(so);
     LOG_FATAL("Failed to find setDevice function in dylib.");
   }
   using SetDeviceFunction = void (*)(::ttnn::MeshDevice *);
@@ -175,7 +186,6 @@ createInputs(void *so, std::string funcName, Device device, std::string path) {
   void *createInputsSymbol = dlsym(so, mangledCreateInputsName.c_str());
   char *dlsymError = dlerror();
   if (dlsymError) {
-    dlclose(so);
     LOG_FATAL("Failed to load symbol: ", dlsymError);
   }
   auto createInputsFunc =
@@ -213,7 +223,6 @@ runSoProgram(void *so, const std::string &funcName,
   void *setDeviceSymbol = dlsym(so, "setDevice");
   const char *setDeviceError = dlerror();
   if (setDeviceError) {
-    dlclose(so);
     LOG_FATAL("Failed to find setDevice function in dylib.");
   }
   using SetDeviceFunction = void (*)(::ttnn::MeshDevice *);
@@ -239,7 +248,6 @@ runSoProgram(void *so, const std::string &funcName,
   void *symbol = dlsym(so, mangledName.c_str());
   char *dlsymError = dlerror();
   if (dlsymError) {
-    dlclose(so);
     LOG_FATAL("Failed to load symbol: ", dlsymError);
   }
 

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -192,6 +192,41 @@ class DeferredDevice:
         clear_device_cache()
 
 
+def _reset_device_after_failure():
+    """Close the cached device after an execution failure.
+
+    After a device execution failure the hardware may be in an undefined state.
+    Close the device and clear the cache so the next test's ``device`` fixture
+    opens a fresh one automatically.
+    """
+    global _current_device, _current_device_target, _current_device_mesh_shape, _current_fabric_config
+    if _current_device is None:
+        return
+
+    target = _current_device_target
+    device = _current_device
+
+    try:
+        if target == "emitpy":
+            ttnn.close_mesh_device(device)
+        else:
+            tt_runtime.runtime.close_mesh_device(device)
+            tt_runtime.runtime.set_fabric_config(
+                tt_runtime.runtime.FabricConfig.DISABLED
+            )
+    except Exception as e:
+        print(f"Warning: failed to close device during reset: {e}")
+
+    _current_device = None
+    _current_device_target = None
+    _current_device_mesh_shape = None
+    _current_fabric_config = None
+
+    if target == "emitpy":
+        utils.DeviceGetter._instance = None
+        utils.DeviceGetter._mesh_shape = None
+
+
 def _get_current_environment():
     if "TT_METAL_SIMULATOR" in os.environ:
         return "sim"
@@ -742,6 +777,10 @@ def pytest_runtest_call(item: pytest.Item):
                 f"Unknown failure detected! Please address this or correctly throw a `TTBuilder*` exception instead if this is a compilation issue, runtime error, or golden mismatch. Exception: {exc}:{type(exc)}"
             )
         failure_stage = TTBUILDER_EXCEPTIONS[exc_name]
+
+        if failure_stage == "runtime" and not getattr(item, "skip_exec", False):
+            _reset_device_after_failure()
+
         raise
     finally:
         _safe_add_property(item, "failure_stage", failure_stage)

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -622,10 +622,6 @@ def test_sort(
 @pytest.mark.parametrize("dimension", [2, 1, 0], ids=["dim2", "dim1", "dim0"])
 @pytest.mark.parametrize("descending", [True, False])
 @pytest.mark.parametrize("is_stable", [False])
-@pytest.mark.skip_exec(
-    ("p150",),
-    reason="Flaky on p150 in CI, ticket: https://github.com/tenstorrent/tt-mlir/issues/7571",
-)
 @pytest.mark.parametrize("target", ["ttnn"])
 def test_sort_key_value(
     shape: Shape,

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -1073,6 +1073,8 @@ def execute_py(
                 golden_report[f"program_{program_index}"] = program_golden_report
                 output_tensors[f"program_{program_index}"] = program_output_tensors
 
+    except TTBuilderGoldenException:
+        raise
     except Exception as e:
         raise TTBuilderRuntimeException(e) from e
     finally:
@@ -1172,6 +1174,8 @@ def execute_cpp(
     output_tensors = {}
     golden_report = {}
 
+    emitc_dylib_handle = None
+    exc_in_flight = False
     try:
         emitc_dylib_handle = tt_runtime.runtime.test.open_so(so_path)
         program_names = tt_runtime.runtime.test.get_so_programs(
@@ -1272,7 +1276,19 @@ def execute_cpp(
                 golden_report[f"program_{program_index}"] = program_golden_report
                 output_tensors[f"program_{program_index}"] = program_output_tensors
 
+    except TTBuilderGoldenException:
+        exc_in_flight = True
+        raise
     except Exception as e:
+        exc_in_flight = True
         raise TTBuilderRuntimeException(e) from e
+    finally:
+        if emitc_dylib_handle is not None:
+            try:
+                tt_runtime.runtime.test.close_so(emitc_dylib_handle)
+            except Exception as close_exc:
+                if not exc_in_flight:
+                    raise TTBuilderRuntimeException(close_exc) from close_exc
+                print(f"close_so() failed during cleanup: {close_exc}")
 
     return golden_report, output_tensors

--- a/tools/ttrt/common/emitc.py
+++ b/tools/ttrt/common/emitc.py
@@ -540,7 +540,12 @@ class EmitC:
                     pass
                 gc.collect()
 
-                ttrt.runtime.test.close_so(emitc_dylib_handle)
+                try:
+                    ttrt.runtime.test.close_so(emitc_dylib_handle)
+                except Exception as close_exc:
+                    self.logging.warning(
+                        f"close_so() failed during cleanup: {close_exc}"
+                    )
 
         self.logging.debug(f"finished executing emitc_dylibs")
 


### PR DESCRIPTION
### What's changed
- Detect builder execution failures and close-reopen the device (since we don't have a direct reset API) so it has a clean state for the next test.
- In `getCreateInputsMangledName()`,  `pclose()` is called to match each `popen()` to avoid leaving zombie processes after each emitc test.
- `execute_cpp()` now calls `close_so()` so it doesn't leak one unique `.so` for each emitc test.
- Functions that don't own the `.so` handle no longer calls `dlclose()`.
- `closeSo()` no longer call `exit()` on failure and kill the entire test process w/o proper stack unwinding & cleanup of device state.
- Dynamically determine buffer size for C++ mangled names so it no longer fails for long templated types.
- Execute the ttnn sort key test again on P150, which originally motivated this change.
