### PR TITLE
Increase `build-docs` timeout in CI

### DIFF
--- a/.github/workflows/call-build-docs.yml
+++ b/.github/workflows/call-build-docs.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
 
     container:


### PR DESCRIPTION
Build time for docs has increased, and recently started to fail on 30 min timeout.

Failure on 30 min timeout: https://github.com/tenstorrent/tt-mlir/actions/runs/23979421382/job/69993967952
Test run with the change to 45 min: https://github.com/tenstorrent/tt-mlir/actions/runs/24000482207/job/69995601495