### PR TITLE
Allowing `StableHLOComplexDataTypeConversionPass` to enter `sdy.manual_computation` regions. 

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -32,7 +32,8 @@ def StableHLOComplexDataTypeConversionPass : Pass<"stablehlo-complex-data-type-c
     To add support for elementwise ops with complex types, please register them in `stablehlo-complex-math-expander` pass.
   }];
   let dependentDialects = ["mlir::func::FuncDialect",
-                           "::mlir::stablehlo::StablehloDialect"];
+                           "::mlir::stablehlo::StablehloDialect",
+                           "::mlir::sdy::SdyDialect"];
 }
 
 def RegisterCustomShardingRulePass : Pass<"register-custom-sharding-rule", "::mlir::ModuleOp">

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -447,8 +447,20 @@ struct StableHLOComplexDataTypeConversionPass
         mlir::stablehlo::BroadcastInDimOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
-                        mlir::stablehlo::ImagOp,
-                        mlir::sdy::ManualComputationOp>();
+                        mlir::stablehlo::ImagOp>();
+
+    auto hasComplexType = [](TypeRange types) {
+      return llvm::any_of(types, [](Type t) {
+        auto rtt = mlir::dyn_cast<RankedTensorType>(t);
+        return rtt && mlir::isa<mlir::ComplexType>(rtt.getElementType());
+      });
+    };
+    target.addDynamicallyLegalOp<mlir::sdy::ManualComputationOp>(
+        [hasComplexType](mlir::sdy::ManualComputationOp op) {
+          return !hasComplexType(op.getOperandTypes()) &&
+                 !hasComplexType(op.getResultTypes()) &&
+                 !hasComplexType(op.getBody().front().getArgumentTypes());
+        });
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -340,7 +340,7 @@ static mlir::sdy::TensorShardingPerValueAttr convertShardingsForComplexTypes(
        llvm::zip_equal(shardings.getShardings(), originalTypes)) {
     auto rtt = mlir::dyn_cast<RankedTensorType>(type);
     if (rtt && mlir::isa<ComplexType>(rtt.getElementType())) {
-      // Append a closed, empty DimensionShardingAttr for the trailing dim.
+      // Append "{}" to sharding spec
       SmallVector<mlir::sdy::DimensionShardingAttr> dims(
           sharding.getDimShardings().begin(),
           sharding.getDimShardings().end());
@@ -385,7 +385,6 @@ public:
       newResultTypes.push_back(converted);
     }
 
-    // Update sharding annotations for the new trailing dimension.
     auto newInShardings = convertShardingsForComplexTypes(
         op.getContext(), op.getInShardings(),
         op.getBody().getArgumentTypes());

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -11,6 +11,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "shardy/dialect/sdy/ir/dialect.h"
 #include "stablehlo/dialect/StablehloOps.h"
 
 using namespace mlir;
@@ -323,6 +324,107 @@ public:
 
 } // namespace
 
+// ---------------------------------------------------------------------------
+// Shardy sharding annotation helper
+// ---------------------------------------------------------------------------
+
+// When a complex-typed tensor gains a trailing dim of 2, its sharding
+// annotation needs an extra dimension entry: closed, unsharded.
+// Example: tensor<16x16xcomplex<f32>> with sharding [{}, {}]
+//       -> tensor<16x16x2xf32>       with sharding [{}, {}, {}]
+static mlir::sdy::TensorShardingPerValueAttr convertShardingsForComplexTypes(
+    MLIRContext *ctx, mlir::sdy::TensorShardingPerValueAttr shardings,
+    TypeRange originalTypes) {
+  SmallVector<mlir::sdy::TensorShardingAttr> newShardings;
+  for (auto [sharding, type] :
+       llvm::zip_equal(shardings.getShardings(), originalTypes)) {
+    auto rtt = mlir::dyn_cast<RankedTensorType>(type);
+    if (rtt && mlir::isa<ComplexType>(rtt.getElementType())) {
+      // Append a closed, empty DimensionShardingAttr for the trailing dim.
+      SmallVector<mlir::sdy::DimensionShardingAttr> dims(
+          sharding.getDimShardings().begin(),
+          sharding.getDimShardings().end());
+      dims.push_back(mlir::sdy::DimensionShardingAttr::get(
+          ctx, /*axes=*/{}, /*isClosed=*/true));
+      newShardings.push_back(mlir::sdy::TensorShardingAttr::get(
+          ctx, sharding.getMeshOrRef(), dims, sharding.getReplicatedAxes(),
+          sharding.getUnreducedAxes()));
+    } else {
+      newShardings.push_back(sharding);
+    }
+  }
+  return mlir::sdy::TensorShardingPerValueAttr::get(ctx, newShardings);
+}
+
+// ---------------------------------------------------------------------------
+// Shardy ManualComputation complex type conversion
+// ---------------------------------------------------------------------------
+
+// Converts sdy.manual_computation ops that have complex-typed operands,
+// results, or region block arguments. Updates the op types, sharding
+// annotations, and converts block arg types so that the existing complex
+// decomposition patterns (ComplexOp, RealOp, ImagOp, etc.) can fire on
+// ops inside the region.
+namespace {
+class ShardyManualComputationComplexConversionPattern
+    : public OpConversionPattern<mlir::sdy::ManualComputationOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::sdy::ManualComputationOp op,
+                  mlir::sdy::ManualComputationOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Convert result types.
+    SmallVector<Type> newResultTypes;
+    for (auto type : op.getResultTypes()) {
+      Type converted = getTypeConverter()->convertType(type);
+      if (!converted) {
+        return failure();
+      }
+      newResultTypes.push_back(converted);
+    }
+
+    // Update sharding annotations for the new trailing dimension.
+    auto newInShardings = convertShardingsForComplexTypes(
+        op.getContext(), op.getInShardings(),
+        op.getBody().getArgumentTypes());
+    auto newOutShardings = convertShardingsForComplexTypes(
+        op.getContext(), op.getOutShardings(), op.getResultTypes());
+
+    // Build via OperationState so no implicit block is auto-created;
+    // we then inline the original region and convert its block arg types.
+    OperationState state(op.getLoc(),
+                         mlir::sdy::ManualComputationOp::getOperationName());
+    state.addOperands(adaptor.getOperands());
+    state.addTypes(newResultTypes);
+    state.addAttribute(
+        mlir::sdy::ManualComputationOp::getInShardingsAttrName(state.name),
+        newInShardings);
+    state.addAttribute(
+        mlir::sdy::ManualComputationOp::getOutShardingsAttrName(state.name),
+        newOutShardings);
+    state.addAttribute(
+        mlir::sdy::ManualComputationOp::getManualAxesAttrName(state.name),
+        op.getManualAxesAttr());
+    Region *newRegion = state.addRegion();
+    rewriter.inlineRegionBefore(op.getBody(), *newRegion, newRegion->end());
+
+    Operation *newOpBase = rewriter.create(state);
+
+    // Convert block argument types (complex<f32> -> x2xf32).
+    auto newOp = cast<mlir::sdy::ManualComputationOp>(newOpBase);
+    if (failed(rewriter.convertRegionTypes(&newOp.getBody(),
+                                           *getTypeConverter()))) {
+      return failure();
+    }
+
+    rewriter.replaceOp(op, newOp.getResults());
+    return success();
+  }
+};
+} // namespace
+
 namespace {
 struct StableHLOComplexDataTypeConversionPass
     : public impl::StableHLOComplexDataTypeConversionPassBase<
@@ -341,6 +443,11 @@ struct StableHLOComplexDataTypeConversionPass
       return !mlir::isa<mlir::ComplexType>(resultType.getElementType());
     };
 
+    auto hasComplexElementType = [](Type type) {
+      auto rtt = mlir::dyn_cast<RankedTensorType>(type);
+      return rtt && mlir::isa<ComplexType>(rtt.getElementType());
+    };
+
     target.addDynamicallyLegalOp<
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::ConcatenateOp,
@@ -348,6 +455,13 @@ struct StableHLOComplexDataTypeConversionPass
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
                         mlir::stablehlo::ImagOp>();
+
+    target.addDynamicallyLegalOp<mlir::sdy::ManualComputationOp>(
+        [&](mlir::sdy::ManualComputationOp op) {
+          return llvm::none_of(op.getBody().getArgumentTypes(),
+                               hasComplexElementType) &&
+                 llvm::none_of(op.getResultTypes(), hasComplexElementType);
+        });
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
@@ -374,6 +488,7 @@ struct StableHLOComplexDataTypeConversionPass
         ComplexConstantOpConversionPattern, ComplexSliceOpConversionPattern,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConcatenateOp>,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
+        ShardyManualComputationComplexConversionPattern,
         StablehloComplexToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -332,9 +332,10 @@ public:
 // annotation needs an extra dimension entry: closed, unsharded.
 // Example: tensor<16x16xcomplex<f32>> with sharding [{}, {}]
 //       -> tensor<16x16x2xf32>       with sharding [{}, {}, {}]
-static mlir::sdy::TensorShardingPerValueAttr convertShardingsForComplexTypes(
-    MLIRContext *ctx, mlir::sdy::TensorShardingPerValueAttr shardings,
-    TypeRange originalTypes) {
+static mlir::sdy::TensorShardingPerValueAttr
+convertShardingsForComplexTypes(MLIRContext *ctx,
+                                mlir::sdy::TensorShardingPerValueAttr shardings,
+                                TypeRange originalTypes) {
   SmallVector<mlir::sdy::TensorShardingAttr> newShardings;
   for (auto [sharding, type] :
        llvm::zip_equal(shardings.getShardings(), originalTypes)) {
@@ -342,10 +343,9 @@ static mlir::sdy::TensorShardingPerValueAttr convertShardingsForComplexTypes(
     if (rtt && mlir::isa<ComplexType>(rtt.getElementType())) {
       // Append "{}" to sharding spec
       SmallVector<mlir::sdy::DimensionShardingAttr> dims(
-          sharding.getDimShardings().begin(),
-          sharding.getDimShardings().end());
-      dims.push_back(mlir::sdy::DimensionShardingAttr::get(
-          ctx, /*axes=*/{}, /*isClosed=*/true));
+          sharding.getDimShardings().begin(), sharding.getDimShardings().end());
+      dims.push_back(mlir::sdy::DimensionShardingAttr::get(ctx, /*axes=*/{},
+                                                           /*isClosed=*/true));
       newShardings.push_back(mlir::sdy::TensorShardingAttr::get(
           ctx, sharding.getMeshOrRef(), dims, sharding.getReplicatedAxes(),
           sharding.getUnreducedAxes()));
@@ -386,8 +386,7 @@ public:
     }
 
     auto newInShardings = convertShardingsForComplexTypes(
-        op.getContext(), op.getInShardings(),
-        op.getBody().getArgumentTypes());
+        op.getContext(), op.getInShardings(), op.getBody().getArgumentTypes());
     auto newOutShardings = convertShardingsForComplexTypes(
         op.getContext(), op.getOutShardings(), op.getResultTypes());
 

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -441,25 +441,14 @@ struct StableHLOComplexDataTypeConversionPass
       return !mlir::isa<mlir::ComplexType>(resultType.getElementType());
     };
 
-    auto hasComplexElementType = [](Type type) {
-      auto rtt = mlir::dyn_cast<RankedTensorType>(type);
-      return rtt && mlir::isa<ComplexType>(rtt.getElementType());
-    };
-
     target.addDynamicallyLegalOp<
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::ConcatenateOp,
         mlir::stablehlo::BroadcastInDimOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
-                        mlir::stablehlo::ImagOp>();
-
-    target.addDynamicallyLegalOp<mlir::sdy::ManualComputationOp>(
-        [&](mlir::sdy::ManualComputationOp op) {
-          return llvm::none_of(op.getBody().getArgumentTypes(),
-                               hasComplexElementType) &&
-                 llvm::none_of(op.getResultTypes(), hasComplexElementType);
-        });
+                        mlir::stablehlo::ImagOp,
+                        mlir::sdy::ManualComputationOp>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
@@ -70,3 +70,67 @@ func.func @test_complex_in_manual_computation(
   } : (tensor<16x16xcomplex<f32>>, tensor<128x128xbf16>, tensor<1x16x128xbf16>) -> tensor<1x16x128xbf16>
   return %0 : tensor<1x16x128xbf16>
 }
+
+// Test that ManualComputationOp with complex types created INSIDE the region
+// (not as arguments or results) is still converted. This is the case the
+// reviewer flagged: stablehlo.complex is created from real-valued slices
+// inside the region and consumed by real/imag, without any complex-typed
+// arguments or results on the ManualComputationOp itself.
+
+// CHECK-LABEL: func.func @test_complex_created_inside_manual_computation
+// CHECK-SAME: %arg0: tensor<1x16x1x32xf32>
+// CHECK-SAME: %arg1: tensor<1x16x16x2xf32>
+func.func @test_complex_created_inside_manual_computation(
+    %arg0: tensor<1x16x1x32xf32>,
+    %arg1: tensor<1x16x16x2xf32>
+) -> tensor<1x16x32xf32> {
+  // CHECK: sdy.manual_computation
+  // CHECK-SAME: (%{{.*}}: tensor<1x16x1x32xf32>
+  // CHECK-SAME:  %{{.*}}: tensor<1x16x16x2xf32>
+  //
+  // Verify no complex types remain inside the region:
+  // CHECK-NOT: complex<f32>
+  //
+  // Verify complex ops were decomposed (concatenate from complex->pair):
+  // CHECK: stablehlo.concatenate
+  // CHECK-NOT: complex<f32>
+  // CHECK: sdy.return
+  %0 = sdy.manual_computation(%arg0, %arg1)
+    in_shardings=[<@mesh, [{}, {}, {}, {}]>, <@mesh, [{}, {}, {}, {}]>]
+    out_shardings=[<@mesh, [{}, {}, {}]>]
+    manual_axes={"_axis_0_aux", "_axis_0"}
+    (%a0: tensor<1x16x1x32xf32>, %a1: tensor<1x16x16x2xf32>) {
+      // Reshape input to expose real/imag pairs
+      %1 = stablehlo.reshape %a0 : (tensor<1x16x1x32xf32>) -> tensor<1x16x1x16x2xf32>
+
+      // Split into real and imag components
+      %2 = stablehlo.slice %1 [0:1, 0:16, 0:1, 0:16, 0:1] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %3 = stablehlo.reshape %2 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+      %4 = stablehlo.slice %1 [0:1, 0:16, 0:1, 0:16, 1:2] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %5 = stablehlo.reshape %4 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+
+      // Create complex type INSIDE the region (this is the key scenario)
+      %6 = stablehlo.complex %3, %5 : tensor<1x16x1x16xcomplex<f32>>
+
+      // Use freqs (already real-valued, reshape to broadcast)
+      %7 = stablehlo.reshape %a1 : (tensor<1x16x16x2xf32>) -> tensor<1x16x1x16x2xf32>
+      %8 = stablehlo.slice %7 [0:1, 0:16, 0:1, 0:16, 0:1] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %9 = stablehlo.reshape %8 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+      %10 = stablehlo.slice %7 [0:1, 0:16, 0:1, 0:16, 1:2] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %11 = stablehlo.reshape %10 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+      %12 = stablehlo.complex %9, %11 : tensor<1x16x1x16xcomplex<f32>>
+
+      // Complex multiply inside the region
+      %13 = stablehlo.multiply %6, %12 : tensor<1x16x1x16xcomplex<f32>>
+
+      // Extract real/imag and flatten back to real-valued output
+      %14 = stablehlo.real %13 : (tensor<1x16x1x16xcomplex<f32>>) -> tensor<1x16x1x16xf32>
+      %15 = stablehlo.reshape %14 : (tensor<1x16x1x16xf32>) -> tensor<1x16x1x16x1xf32>
+      %16 = stablehlo.imag %13 : (tensor<1x16x1x16xcomplex<f32>>) -> tensor<1x16x1x16xf32>
+      %17 = stablehlo.reshape %16 : (tensor<1x16x1x16xf32>) -> tensor<1x16x1x16x1xf32>
+      %18 = stablehlo.concatenate %15, %17, dim = 4 : (tensor<1x16x1x16x1xf32>, tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16x2xf32>
+      %19 = stablehlo.reshape %18 : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x32xf32>
+      sdy.return %19 : tensor<1x16x32xf32>
+  } : (tensor<1x16x1x32xf32>, tensor<1x16x16x2xf32>) -> tensor<1x16x32xf32>
+  return %0 : tensor<1x16x32xf32>
+}

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion %s | FileCheck %s
+// REQUIRES: stablehlo
+
+// Test that ComplexDataTypeConversion handles complex types inside
+// sdy.manual_computation regions. This is the pattern produced by
+// complex RoPE (view_as_complex * polar) with SPMD sharding enabled.
+
+sdy.mesh @mesh = <["_axis_0_aux"=1, "_axis_0"=4]>
+
+// CHECK-LABEL: func.func @test_complex_in_manual_computation
+// CHECK-SAME: %arg0: tensor<16x16x2xf32>
+// CHECK-SAME: %arg1: tensor<128x128xbf16>
+// CHECK-SAME: %arg2: tensor<1x16x128xbf16>
+func.func @test_complex_in_manual_computation(
+    %arg0: tensor<16x16xcomplex<f32>>,
+    %arg1: tensor<128x128xbf16>,
+    %arg2: tensor<1x16x128xbf16>
+) -> tensor<1x16x128xbf16> {
+  // Verify sharding for the complex arg gains a third (trailing) dimension:
+  // CHECK: sdy.manual_computation
+  // CHECK-SAME: in_shardings=[<@mesh, [{}, {}, {}]>, <@mesh, [{"_axis_0"}, {}]>, <@mesh, [{}, {}, {}]>]
+  // CHECK-SAME: out_shardings=[<@mesh, [{}, {}, {"_axis_0"}]>]
+  //
+  // Verify block args are converted (complex -> x2xf32):
+  // CHECK-SAME: (%{{.*}}: tensor<16x16x2xf32>
+  // CHECK-SAME:  %{{.*}}: tensor<32x128xbf16>
+  // CHECK-SAME:  %{{.*}}: tensor<1x16x128xbf16>
+  //
+  // Verify no complex types remain inside the region:
+  // CHECK-NOT: complex<f32>
+  // CHECK: sdy.return
+  %0 = sdy.manual_computation(%arg0, %arg1, %arg2)
+    in_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>, <@mesh, [{}, {}, {}]>]
+    out_shardings=[<@mesh, [{}, {}, {"_axis_0"}]>]
+    manual_axes={"_axis_0_aux", "_axis_0"}
+    (%a0: tensor<16x16xcomplex<f32>>, %a1: tensor<32x128xbf16>, %a2: tensor<1x16x128xbf16>) {
+      // Linear projection (non-complex path)
+      %1 = stablehlo.reshape %a2 : (tensor<1x16x128xbf16>) -> tensor<16x128xbf16>
+      %2 = stablehlo.transpose %a1, dims = [1, 0] : (tensor<32x128xbf16>) -> tensor<128x32xbf16>
+      %3 = stablehlo.dot_general %1, %2, contracting_dims = [1] x [0] : (tensor<16x128xbf16>, tensor<128x32xbf16>) -> tensor<16x32xbf16>
+      %4 = stablehlo.reshape %3 : (tensor<16x32xbf16>) -> tensor<1x16x1x32xbf16>
+      %5 = stablehlo.convert %4 : (tensor<1x16x1x32xbf16>) -> tensor<1x16x1x32xf32>
+      %6 = stablehlo.reshape %5 : (tensor<1x16x1x32xf32>) -> tensor<1x16x1x16x2xf32>
+
+      // Split into real/imag and construct complex
+      %7 = stablehlo.slice %6 [0:1, 0:16, 0:1, 0:16, 0:1] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %8 = stablehlo.reshape %7 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+      %9 = stablehlo.slice %6 [0:1, 0:16, 0:1, 0:16, 1:2] : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x1x16x1xf32>
+      %10 = stablehlo.reshape %9 : (tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16xf32>
+      %11 = stablehlo.complex %8, %10 : tensor<1x16x1x16xcomplex<f32>>
+
+      // Complex RoPE multiply: h_complex * freqs
+      %12 = stablehlo.reshape %a0 : (tensor<16x16xcomplex<f32>>) -> tensor<1x16x16xcomplex<f32>>
+      %13 = stablehlo.broadcast_in_dim %12, dims = [0, 1, 3] : (tensor<1x16x16xcomplex<f32>>) -> tensor<1x16x1x16xcomplex<f32>>
+      %14 = stablehlo.multiply %11, %13 : tensor<1x16x1x16xcomplex<f32>>
+
+      // Extract real/imag and flatten back
+      %15 = stablehlo.real %14 : (tensor<1x16x1x16xcomplex<f32>>) -> tensor<1x16x1x16xf32>
+      %16 = stablehlo.reshape %15 : (tensor<1x16x1x16xf32>) -> tensor<1x16x1x16x1xf32>
+      %17 = stablehlo.imag %14 : (tensor<1x16x1x16xcomplex<f32>>) -> tensor<1x16x1x16xf32>
+      %18 = stablehlo.reshape %17 : (tensor<1x16x1x16xf32>) -> tensor<1x16x1x16x1xf32>
+      %19 = stablehlo.concatenate %16, %18, dim = 4 : (tensor<1x16x1x16x1xf32>, tensor<1x16x1x16x1xf32>) -> tensor<1x16x1x16x2xf32>
+      %20 = stablehlo.reshape %19 : (tensor<1x16x1x16x2xf32>) -> tensor<1x16x32xf32>
+      %21 = stablehlo.convert %20 : (tensor<1x16x32xf32>) -> tensor<1x16x32xbf16>
+      sdy.return %21 : tensor<1x16x32xbf16>
+  } : (tensor<16x16xcomplex<f32>>, tensor<128x128xbf16>, tensor<1x16x128xbf16>) -> tensor<1x16x128xbf16>
+  return %0 : tensor<1x16x128xbf16>
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/7832

### Problem description
This PR https://github.com/tenstorrent/tt-mlir/pull/7407 introduced support for operations with complex arguments. Currently, the `StableHLOComplexDataTypeConversionPass` which handles conversion of individual ops with complex tensor to equivalent operations on real tensors cannot enter regions marked with `sdy.manual_computation`. Issue above highlights one such scenario. 

### Why this is the case? 

We do not have a pattern that catches `sdy.manual_computation` op, so the block argument of `sdy.manual_computation` remains complex type. This means that later when we try to match complex patterns for ops inside this region, these ops will have complex arguments (becase the block argument is complex). 

The problem is that for Complex rewrite patterns to kick in (for example patterns for stablehlo.real, stablehlo.imag, ...), the arguments are expected to be real tensors already. Since this is not the case, we can't match any pattern and we are left with illegal complex tensors. 


### What's changed
- added ShardyManualComputationComplexConversionPattern which
       a) rewrites block arguments from complex-> real with trailing dim 2, which allows the complex patterns to kick in for ops inside the `sdy.manual_computation` region.
       b) properly adds another `{}` empty sharding dim for the additional real dimension that is added (we always wanna replicate that dim) 

- added llvm test for this pattern

### Checklist
- [x] tt-xla model test passing: https://github.com/tenstorrent/tt-xla/actions/runs/25075296404