### PR TITLE
Fix PredicateTypeAlignment to update return values

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -122,7 +122,8 @@ def PredicateTypeAlignment : Pass<"ttir-predicate-type-alignment", "::mlir::Modu
       - Elementwise binary (e.g. logical_and): if one operand is i1 and the
         other is not, align to the non-i1 type via typecasts.
       - Comparisons (eq, ne, gt, ge, lt, le), logical_not, reduce_or: result
-        element type matches input/lhs instead of i1.
+        element type matches input/lhs instead of i1; function result types are
+        updated to match return operands when those types change.
       - where: condition is typecast to the true/false value element type.
   }];
 }

--- a/lib/Dialect/TTIR/Transforms/PredicateTypeAlignment.cpp
+++ b/lib/Dialect/TTIR/Transforms/PredicateTypeAlignment.cpp
@@ -5,6 +5,8 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
@@ -230,8 +232,8 @@ struct WhereConditionTypePattern : public mlir::OpRewritePattern<WhereOp> {
     if (!condType.getElementType().isInteger(1)) {
       return rewriter.notifyMatchFailure(op, "condition is not i1");
     }
-    if (trueType != falseType) {
-      return rewriter.notifyMatchFailure(op, "true/false types differ");
+    if (trueType.getElementType() != falseType.getElementType()) {
+      return rewriter.notifyMatchFailure(op, "true/false element types differ");
     }
     if (condType.getElementType() == trueType.getElementType()) {
       return rewriter.notifyMatchFailure(
@@ -249,6 +251,45 @@ struct WhereConditionTypePattern : public mlir::OpRewritePattern<WhereOp> {
     return mlir::success();
   }
 };
+
+/// Comparison / logical patterns change result element types in-place; update
+/// each func's declared result types to match its return operands so the IR
+/// verifies (e.g. ge i1 -> i64 while the signature still claimed i1).
+static void syncFuncResultTypesFromReturns(mlir::func::FuncOp func) {
+  if (func.getBody().empty()) {
+    return;
+  }
+
+  llvm::SmallVector<mlir::Type> inferredResults;
+  for (mlir::Block &block : func.getBody()) {
+    auto ret = mlir::dyn_cast<mlir::func::ReturnOp>(block.getTerminator());
+    if (!ret) {
+      continue;
+    }
+    if (inferredResults.empty()) {
+      inferredResults.append(ret.getOperandTypes().begin(),
+                             ret.getOperandTypes().end());
+    } else if (!llvm::equal(inferredResults, ret.getOperandTypes())) {
+      return;
+    }
+  }
+
+  if (inferredResults.empty()) {
+    return;
+  }
+
+  mlir::FunctionType funcType = func.getFunctionType();
+  if (funcType.getNumResults() != inferredResults.size()) {
+    return;
+  }
+  if (llvm::equal(funcType.getResults(), inferredResults)) {
+    return;
+  }
+
+  mlir::FunctionType newFuncType = mlir::FunctionType::get(
+      func.getContext(), funcType.getInputs(), inferredResults);
+  func.setFunctionType(newFuncType);
+}
 
 struct PredicateTypeAlignment
     : public impl::PredicateTypeAlignmentBase<PredicateTypeAlignment> {
@@ -276,7 +317,11 @@ struct PredicateTypeAlignment
     if (failed(mlir::applyPatternsGreedily(getOperation(), std::move(patterns),
                                            config))) {
       signalPassFailure();
+      return;
     }
+
+    getOperation().walk(
+        [](mlir::func::FuncOp func) { syncFuncResultTypesFromReturns(func); });
   }
 };
 } // namespace

--- a/test/ttmlir/Dialect/TTIR/Transforms/PredicateTypeAlignment/predicate_type_alignment.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/PredicateTypeAlignment/predicate_type_alignment.mlir
@@ -28,6 +28,16 @@ func.func @phase2_ne_result_i32(%arg0: tensor<2x8xi32>, %arg1: tensor<2x8xi32>) 
 }
 
 // -----
+// CHECK-LABEL: func.func @direct_ge_return_signature_updated
+// CHECK-SAME: (%arg0: tensor<4x4xi32>, %arg1: tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK: "ttir.ge"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<4x4xi32>) -> tensor<4x4xi32>
+// CHECK: return %{{.*}} : tensor<4x4xi32>
+func.func @direct_ge_return_signature_updated(%arg0: tensor<4x4xi32>, %arg1: tensor<4x4xi32>) -> tensor<4x4xi1> {
+  %0 = "ttir.ge"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<4x4xi32>) -> tensor<4x4xi1>
+  return %0 : tensor<4x4xi1>
+}
+
+// -----
 // CHECK-LABEL: func.func @phase2_gt_ge_lt_le_result_type
 // CHECK: "ttir.gt"(%arg0, %arg1) : (tensor<3x3xi32>, tensor<3x3xi32>) -> tensor<3x3xi32>
 // CHECK: "ttir.ge"(%arg0, %arg1) : (tensor<3x3xi32>, tensor<3x3xi32>) -> tensor<3x3xi32>

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -846,6 +846,29 @@ def execute_fb(
                     ).reshape(output_device_tensors[device_id].get_shape())
 
                 golden_shard_torch = golden_outputs_torch[i][device_id]
+                if golden_shard_torch.dtype != output_shard_torch.dtype:
+                    # In the ttmetal path, PredicateTypeAlignment changes
+                    # boolean (i1) outputs to match the input element type
+                    # (e.g. i1 -> i64).  The golden was computed before that
+                    # pass and bool is mapped to bfloat16 by
+                    # _get_runtime_compatible_torch_dtype, while the device
+                    # returns the aligned integer type.  Only allow the cast
+                    # in this specific scenario.
+                    is_ttmetal = fbb.file_identifier == "TTM0"
+                    is_predicate_alignment_mismatch = (
+                        golden_shard_torch.dtype == torch.bfloat16
+                    )
+                    if is_ttmetal and is_predicate_alignment_mismatch:
+                        golden_shard_torch = golden_shard_torch.to(
+                            output_shard_torch.dtype
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"Golden/output dtype mismatch: "
+                            f"golden={golden_shard_torch.dtype}, "
+                            f"output={output_shard_torch.dtype} "
+                            f"(output_{i}_device_{device_id})"
+                        )
                 results = check_outputs(
                     golden_shard_torch,
                     output_shard_torch,


### PR DESCRIPTION
### Problem description
When running `PredicateTypeAlignment.cpp` on ops in isolation, the return type isn't updated causing a compilation error.

### What's changed
- `PredicateTypeAlignment.cpp` now updates the return type
- Added lit test
- Added handling in builder runtime for typecasting when `PredicateTypeAlignment.cpp` changes the func return type since the golden computed might not match with output since the golden is computed beforehand and assumes `i1` -> `bf16`


### Checklist
- [ ] New/Existing tests provide coverage for changes
