### PR TITLE
[TTNN] Restructure TTNN pipelines

### DIFF
--- a/.claude/skills/add-op/SKILL.md
+++ b/.claude/skills/add-op/SKILL.md
@@ -761,7 +761,7 @@ Test that the TTIR op converts to TTNN correctly. Cover all operand combinations
 weight, with/without bias).
 
 ```mlir
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 module {
@@ -788,12 +788,15 @@ Test that the StableHLO composite converts to TTIR.
 
 **File:** `test/ttmlir/EmitC/TTNN/<op_name>/<op_name>.mlir` (new file)
 
-Test the full pipeline: TTIR → TTNN → Flatbuffer, and TTNN → EmitC → C++.
+Test the full pipeline: TTIR → TTNN common, then branch into Runtime (Flatbuffer) and EmitC (C++).
 
 ```mlir
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 ```
 

--- a/.claude/skills/add-op/review/generate_review.py
+++ b/.claude/skills/add-op/review/generate_review.py
@@ -543,13 +543,13 @@ def collect_emitted_python(op_name: str, input_mlir: str | None) -> dict:
 
     tmp = f"/tmp/addop_review_{op_name}_ttnn_py.mlir"
     cmd = (
-        f"ttmlir-opt --ttir-to-ttnn-backend-pipeline -o {tmp} {input_mlir}\n"
-        f"ttmlir-opt --ttnn-to-emitpy-pipeline {tmp} "
+        f"ttmlir-opt --ttir-to-ttnn-common-pipeline -o {tmp} {input_mlir}\n"
+        f"ttmlir-opt --ttnn-common-to-emitpy-pipeline {tmp} "
         f"| ttmlir-translate --mlir-to-python"
     )
 
     rc1, err = run_cmd(
-        ["ttmlir-opt", "--ttir-to-ttnn-backend-pipeline", "-o", tmp, input_mlir]
+        ["ttmlir-opt", "--ttir-to-ttnn-common-pipeline", "-o", tmp, input_mlir]
     )
     if rc1 != 0:
         return {"code": f"# Error: TTIR-to-TTNN pipeline failed\n# {err}", "cmd": cmd}
@@ -558,7 +558,7 @@ def collect_emitted_python(op_name: str, input_mlir: str | None) -> dict:
         [
             "bash",
             "-c",
-            f"ttmlir-opt --ttnn-to-emitpy-pipeline {tmp} 2>/dev/null"
+            f"ttmlir-opt --ttnn-common-to-emitpy-pipeline {tmp} 2>/dev/null"
             " | ttmlir-translate --mlir-to-python 2>&1",
         ]
     )
@@ -576,8 +576,8 @@ def collect_emitted_cpp(op_name: str, input_mlir: str | None) -> dict:
     tmp_ttnn = f"/tmp/addop_review_{op_name}_ttnn_c.mlir"
     tmp_emitc = f"/tmp/addop_review_{op_name}_emitc.mlir"
     cmd = (
-        f"ttmlir-opt --ttir-to-ttnn-backend-pipeline -o {tmp_ttnn} {input_mlir}\n"
-        f"ttmlir-opt --ttnn-to-emitc-device-pipeline -o {tmp_emitc} {tmp_ttnn}\n"
+        f"ttmlir-opt --ttir-to-ttnn-common-pipeline -o {tmp_ttnn} {input_mlir}\n"
+        f"ttmlir-opt --ttnn-common-to-emitc-pipeline -o {tmp_emitc} {tmp_ttnn}\n"
         f"ttmlir-translate --mlir-to-cpp {tmp_emitc}"
     )
 
@@ -585,8 +585,8 @@ def collect_emitted_cpp(op_name: str, input_mlir: str | None) -> dict:
         [
             "bash",
             "-c",
-            f"ttmlir-opt --ttir-to-ttnn-backend-pipeline -o {tmp_ttnn} {input_mlir} 2>/dev/null"
-            f" && ttmlir-opt --ttnn-to-emitc-device-pipeline -o {tmp_emitc} {tmp_ttnn} 2>/dev/null"
+            f"ttmlir-opt --ttir-to-ttnn-common-pipeline -o {tmp_ttnn} {input_mlir} 2>/dev/null"
+            f" && ttmlir-opt --ttnn-common-to-emitc-pipeline -o {tmp_emitc} {tmp_ttnn} 2>/dev/null"
             f" && ttmlir-translate --mlir-to-cpp {tmp_emitc} 2>&1",
         ]
     )
@@ -973,8 +973,8 @@ class AsyncDataCollector:
 
         # Step 1: EmitC pipeline (TTIR -> TTNN -> EmitC -> C++)
         pipeline_cmd = (
-            f"ttmlir-opt --ttir-to-ttnn-backend-pipeline -o {tmp_ttnn} {input_mlir}"
-            f" && ttmlir-opt --ttnn-to-emitc-device-pipeline -o {tmp_emitc} {tmp_ttnn}"
+            f"ttmlir-opt --ttir-to-ttnn-common-pipeline -o {tmp_ttnn} {input_mlir}"
+            f" && ttmlir-opt --ttnn-common-to-emitc-pipeline -o {tmp_emitc} {tmp_ttnn}"
             f" && ttmlir-translate --mlir-to-cpp {tmp_emitc} > {tmp_cpp}"
         )
         rc, output = run_cmd(["bash", "-c", pipeline_cmd], timeout=120)

--- a/.github/test_scripts/alchemist.sh
+++ b/.github/test_scripts/alchemist.sh
@@ -66,7 +66,7 @@ cd /tmp/test-generate-python
 echo "Run tt-alchemist API test - generate-python (TTNN input)"
 # First convert TTIR to TTNN using ttmlir-opt
 TTNN_MLIR=/tmp/test-ttnn-input.mlir
-ttmlir-opt --ttir-to-ttnn-backend-pipeline $WORK_DIR/tools/tt-alchemist/test/models/add.mlir -o $TTNN_MLIR
+ttmlir-opt --ttir-to-ttnn-common-pipeline $WORK_DIR/tools/tt-alchemist/test/models/add.mlir -o $TTNN_MLIR
 # Then run tt-alchemist on the TTNN input
 rm -rf /tmp/test-generate-python-ttnn
 tt-alchemist generate-python $TTNN_MLIR --output /tmp/test-generate-python-ttnn

--- a/docs/src/adding-an-op.md
+++ b/docs/src/adding-an-op.md
@@ -268,7 +268,7 @@ You can also manually run `ttmlir-opt` on the test file to see the
 resulting output:
 
 ```bash
-./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=<PATH_TO_SYSTEM_DESC>" --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
+./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=<PATH_TO_SYSTEM_DESC>" --ttir-to-ttnn-runtime-pipeline test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
 ```
 
 ## 5. Define flatbuffer schema for the Op
@@ -348,7 +348,7 @@ Lots of things are happening here, let's break it down:
 
 We can finally generate a binary with our new Op!  We can use the following command:
 ```bash
-./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=<PATH_TO_SYSTEM_DESC>" --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir | ./build/bin/ttmlir-translate --ttnn-to-flatbuffer -o out.ttnn
+./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=<PATH_TO_SYSTEM_DESC>" --ttir-to-ttnn-runtime-pipeline test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir | ./build/bin/ttmlir-translate --ttnn-to-flatbuffer -o out.ttnn
 ```
 
 And we can inspect the with [`ttrt`](./ttrt.md#read):
@@ -414,7 +414,7 @@ Couple things to point out about this process:
 - Tests placed under `test/ttmlir/Dialect` will only test the compiler's capability of compiling the module.
 If you want the module to run on silicon in CI, the test must be placed under `test/ttmlir/Silicon`.
 - Notice the differences between the compilation headers of `test/ttmlir/Silicon/TTNN/simple_matmul.mlir` and `test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir`
-  - `--ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%"`: The `system-desc-path` option specifies the location of the system descriptor
+  - `--ttir-to-ttnn-runtime-pipeline="system-desc-path=%system_desc_path%"`: The `system-desc-path` option specifies the location of the system descriptor
   required for compiling the module. This is crucial for silicon tests, as modules compiled with different system descriptors may vary in silicon compatibility.
   Ensuring the system descriptor accurately reflects the target hardware is essential for running the module correctly.
   - `// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn`: This runs `ttmlir-translate` that serializes the output mlir module to a flatbuffer binary.

--- a/docs/src/builder/ttir-builder.md
+++ b/docs/src/builder/ttir-builder.md
@@ -77,7 +77,7 @@ module {
 
 ## Running a pipeline
 
-`run_ttir_pipeline` runs a pass on the TTIR module to lower it into a backend, using `pipeline_fn`. You can pass `pipeline_fn` in as one of the following: `ttir_to_ttnn_backend_pipeline`, `ttir_to_ttmetal_backend_pipeline` (both found in `ttmlir.passes`), or a custom pipeline built with `create_custom_pipeline_fn`. The default if none is provided is the TTNN pipeline.
+`run_ttir_pipeline` runs a pass on the TTIR module to lower it into a backend, using `pipeline_fn`. You can pass `pipeline_fn` in as one of the following: `ttir_to_ttnn_runtime_pipeline`, `ttir_to_ttmetal_backend_pipeline` (both found in `ttmlir.passes`), or a custom pipeline built with `create_custom_pipeline_fn`. The default if none is provided is the TTNN pipeline.
 
 ```python
 def run_ttir_pipeline(
@@ -97,7 +97,7 @@ def run_ttir_pipeline(
 Let's expand on our previous example
 
 ```python
-from ttmlir.passes import ttir_to_ttnn_backend_pipeline
+from ttmlir.passes import ttir_to_ttnn_runtime_pipeline
 from builder.base.builder import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_utils import build_ttir_module, run_ttir_pipeline
@@ -110,7 +110,7 @@ def model(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
     return builder.multiply(multiply_1, in2)
 
 module, builder = build_ttir_module(model, shapes)
-ttnn_module = run_ttir_pipeline(module, ttir_to_ttnn_backend_pipeline)
+ttnn_module = run_ttir_pipeline(module, ttir_to_ttnn_runtime_pipeline)
 ```
 
 #### Returns

--- a/docs/src/optimizer.md
+++ b/docs/src/optimizer.md
@@ -15,7 +15,7 @@ cmake -G Ninja -B build -DTTMLIR_ENABLE_OPMODEL=ON
 
 Optimizer is disabled by default. To enable it, use the `enable-optimizer` option:
 ```bash
-ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true" input.mlir
+ttmlir-opt --ttir-to-ttnn-runtime-pipeline="enable-optimizer=true" input.mlir
 ```
 
 ## Optimizer Options
@@ -42,7 +42,7 @@ The optimizer provides additional configuration options:
 
 ```bash
 # Enable optimizer with default settings
-ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true max-legal-layouts=8" input.mlir
+ttmlir-opt --ttir-to-ttnn-runtime-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true max-legal-layouts=8" input.mlir
 ```
 
 ## Design Documentation

--- a/docs/src/ttmlir-opt.md
+++ b/docs/src/ttmlir-opt.md
@@ -5,7 +5,7 @@ The `ttmlir` optimizer driver.  This tool is used to run the `ttmlir` compiler p
 ## Simple Test
 
 ```bash
-./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir
+./build/bin/ttmlir-opt --ttir-to-ttnn-runtime-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir
 # Or
 ./build/bin/ttmlir-opt --ttir-to-ttmetal-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir
 ```

--- a/docs/src/ttmlir-translate.md
+++ b/docs/src/ttmlir-translate.md
@@ -19,7 +19,7 @@ Bonus: These two commands can be piped, to avoid writing a `mlir` file to disk, 
 ## Generate flatbuffer file from MLIR
 ```bash
 # First run `ttmlir-opt` to convert to proper dialect
-./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir -o ttnn.mlir
+./build/bin/ttmlir-opt --ttir-to-ttnn-runtime-pipeline test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir -o ttnn.mlir
 
 # Now run `ttmlir-translate` to produce flatbuffer file
 ./build/bin/ttmlir-translate --ttnn-to-flatbuffer ttnn.mlir -o out.ttnn

--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -70,9 +70,9 @@ ttrt query --save-artifacts
 ```
 3. Use `ttmlir-opt` tool in compiler to feed system descriptor. See the [`ttmlir-opt`](./ttmlir-opt.md) documentation for more information on how to generate .mlir files.
 ```bash
-./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=/path/to/system_desc.ttsys" --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/simple_subtract.mlir -o ttnn.mlir
-or (pipe path directly into ttir-to-ttnn-backend-pipeline)
-./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=/path/to/system_desc.ttsys" test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir -o ttnn.mlir
+./build/bin/ttmlir-opt --ttcore-register-device="system-desc-path=/path/to/system_desc.ttsys" --ttir-to-ttnn-runtime-pipeline test/ttmlir/Dialect/TTNN/simple_subtract.mlir -o ttnn.mlir
+or (pipe path directly into ttir-to-ttnn-runtime-pipeline)
+./build/bin/ttmlir-opt --ttir-to-ttnn-runtime-pipeline="system-desc-path=/path/to/system_desc.ttsys" test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir -o ttnn.mlir
 ```
 4. Use `ttmlir-translate` tool in compiler to generate the flatbuffer executable. See the [`ttmlir-translate`](./ttmlir-translate.md) documentation for more information on how to generate flatbuffer files.
 ```bash

--- a/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
+++ b/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
@@ -70,10 +70,10 @@ struct LinalgToLLVMPipelineOptions
       llvm::cl::init(true)};
 };
 
-// Options for the TTIR to LLVM CPU pipeline.
+// Options for the (SHLO + TTIR) to LLVM pipeline, used for CPU execution.
 // Inherits from LinalgToLLVMPipelineOptions to reuse the options.
 //
-struct TTIRToLLVMCPUPipelineOptions : public LinalgToLLVMPipelineOptions {};
+struct SHLOAndTTIRToLLVMPipelineOptions : public LinalgToLLVMPipelineOptions {};
 
 #ifdef TTMLIR_ENABLE_STABLEHLO
 void createStableHLOToTTIRPipeline(
@@ -86,8 +86,8 @@ void createTTIRToNVVMPipeline(OpPassManager &manager,
 void createLinalgToLLVMPipeline(OpPassManager &pm,
                                 const LinalgToLLVMPipelineOptions &options);
 
-void createTTIRToLLVMCPUPipeline(OpPassManager &manager,
-                                 const TTIRToLLVMCPUPipelineOptions &options);
+void createSHLOAndTTIRToLLVMPipeline(
+    OpPassManager &manager, const SHLOAndTTIRToLLVMPipelineOptions &options);
 
 /// Registers all pipelines for the TTIR dialect.
 void registerTTIRPipelines();

--- a/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
+++ b/include/ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h
@@ -10,7 +10,7 @@
 namespace mlir::tt::ttir {
 
 #ifdef TTMLIR_ENABLE_STABLEHLO
-// Options for the TTIR to TTNN backend pipeline.
+// Options for the SHLO to TTIR pipeline.
 //
 struct StableHLOToTTIRPipelineOptions
     : public PassPipelineOptions<StableHLOToTTIRPipelineOptions> {

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -606,27 +606,15 @@ struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
                                      public TTNNToEmitPyDevicePipelineOptions {
 };
 
+// ============================================================
+// Other pipelines.
+// ============================================================
+
 // Recover Structure XLA/Torch pipeline options.
 struct RecoverStructureXLATorchPipelineOptions
     : public PassPipelineOptions<RecoverStructureXLATorchPipelineOptions> {
   // Add any future options here if needed
 };
-
-//===----------------------------------------------------------------------===//
-// End-to-end pipelines, which lower TTIR to various TTNN targets.
-//===----------------------------------------------------------------------===//
-
-void createTTIRToTTNNBackendPipeline(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
-
-void createTTIRToEmitCPipeline(OpPassManager &pm,
-                               const TTIRToEmitCPipelineOptions &options);
-
-void createTTIRToEmitPyPipeline(OpPassManager &pm,
-                                const TTIRToEmitPyPipelineOptions &options);
-
-void createTTNNToEmitPyPipeline(
-    OpPassManager &pm, const TTNNToEmitPyDevicePipelineOptions &options);
 
 void createRecoverStructureXLATorchPipeline(
     OpPassManager &pm, const RecoverStructureXLATorchPipelineOptions &options);

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -21,10 +21,26 @@ class MeshDevice;
 } // namespace tt::tt_metal::distributed
 
 namespace mlir::tt::ttnn {
-// TTIR to TTNN Device pipeline options.
+// ============================================================
+// TTIRToTTNNCommonPipeline - baseline pipeline for lowering TTIR to TTNN.
 //
-struct TTIRToTTNNDevicePipelineOptions
-    : public PassPipelineOptions<TTIRToTTNNDevicePipelineOptions> {
+// It performs the actual heavy-lifting for the TTIR -> TTNN conversion -
+// decompositions, TTIR -> TTNN dialect conversion, optimizer, fusings...
+//
+// Target-specific pipelines (Runtime, EmitPy, EmitC) latch onto the output of
+// this pipeline and perform additional passes, as required by targets.
+//
+// If CPU-hoisting is enabled, `ttcore.cpu_module` op gets created
+// (if it doesn't already exist) and gets populated with TTIR ops.
+// These ops don't get lowered to TTNN, and it's up to the
+// target-specific pipelines to lower these TTIR ops to ops executable on the
+// host CPU, since each target handles CPU-hoisting differently.
+// ============================================================
+
+// TTIR to TTNN common pipeline options.
+//
+struct TTIRToTTNNCommonPipelineOptions
+    : public PassPipelineOptions<TTIRToTTNNCommonPipelineOptions> {
   // Optimization level controls multiple optimization passes.
   // Level 0 (default): All optimizer passes disabled.
   // Level 1: All optimizer passes enabled. Memory layout analysis is disabled.
@@ -488,10 +504,28 @@ struct TTIRToTTNNDevicePipelineOptions
   }
 };
 
-// TTNN to EmitC Device pipeline options.
+// ============================================================
+// Target-specific pipelines, which receive the output of the
+// TTIRToTTNNCommonPipeline and produce IR ready for translation
+// to the specific target (e.g. TTNN Runtime, EmitC, EmitPy).
+// ============================================================
+
+// TTNN common to Runtime pipeline options.
 //
-struct TTNNToEmitCDevicePipelineOptions
-    : public PassPipelineOptions<TTNNToEmitCDevicePipelineOptions> {
+// Currently, inherits from SHLOAndTTIRToLLVMPipelineOptions, since the only
+// thing that the Runtime pipeline does after the common pipeline is lowering
+// the CPU module to LLVM.
+//
+struct TTNNCommonToRuntimePipelineOptions
+    : public ttir::SHLOAndTTIRToLLVMPipelineOptions {};
+
+// TTNN common to EmitC pipeline options.
+//
+// TODO(dmilinkovic): will be extended with CPU-hoisting specific options once
+// CPU-hoisting is supported on EmitC - issue #6100.
+//
+struct TTNNCommonToEmitCPipelineOptions
+    : public PassPipelineOptions<TTNNCommonToEmitCPipelineOptions> {
   Option<bool> targetDylib{*this, "target-dylib",
                            llvm::cl::desc("Tailor passes for dylib target."),
                            llvm::cl::init(false)};
@@ -527,10 +561,10 @@ struct TTNNToEmitCDevicePipelineOptions
       llvm::cl::desc("Prefix for input tensor files"), llvm::cl::init("arg")};
 };
 
-// TTNN to EmitPy Device pipeline options.
+// TTNN common to EmitPy pipeline options.
 //
-struct TTNNToEmitPyDevicePipelineOptions
-    : public PassPipelineOptions<TTNNToEmitPyDevicePipelineOptions> {
+struct TTNNCommonToEmitPyPipelineOptions
+    : public PassPipelineOptions<TTNNCommonToEmitPyPipelineOptions> {
   Option<bool> targetModule{
       *this, "target-module",
       llvm::cl::desc("Tailor passes for Python module target. When enabled, "
@@ -574,22 +608,20 @@ struct TTNNToEmitPyDevicePipelineOptions
       llvm::cl::init(false)};
 };
 
-// TTIR to TTNN backend pipeline options.
-//
-// Inherits from TTIRToTTNNDevicePipelineOptions and
-// TTIRToLLVMCPUPipelineOptions to reuse the options.
-//
-struct TTIRToTTNNBackendPipelineOptions
-    : public TTIRToTTNNDevicePipelineOptions,
-      public ttir::TTIRToLLVMCPUPipelineOptions {};
+// ============================================================
+// End-to-end pipelines, which lower TTIR to specific TTNN targets.
+// ============================================================
 
-// TTIR to EmitC end-to-end pipeline options.
+// TTIR to TTNN Runtime pipeline options.
 //
-// Inherits from TTIRToTTNNDevicePipelineOptions and
-// TTNNToEmitCDevicePipelineOptions to reuse the options.
+struct TTIRToTTNNRuntimePipelineOptions
+    : public TTIRToTTNNCommonPipelineOptions,
+      public TTNNCommonToRuntimePipelineOptions {};
+
+// TTIR to EmitC pipeline options.
 //
-struct TTIRToEmitCPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
-                                    public TTNNToEmitCDevicePipelineOptions {
+struct TTIRToEmitCPipelineOptions : public TTIRToTTNNCommonPipelineOptions,
+                                    public TTNNCommonToEmitCPipelineOptions {
   TTIRToEmitCPipelineOptions() {
     // TODO(dmilinkovic): Remove once CPU-hoisting is supported on EmitC - issue
     // #6100.
@@ -599,11 +631,8 @@ struct TTIRToEmitCPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
 
 // TTIR to EmitPy pipeline options.
 //
-// Inherits from TTIRToTTNNDevicePipelineOptions and
-// TTNNToEmitPyDevicePipelineOptions to reuse the options.
-//
-struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNDevicePipelineOptions,
-                                     public TTNNToEmitPyDevicePipelineOptions {
+struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNCommonPipelineOptions,
+                                     public TTNNCommonToEmitPyPipelineOptions {
 };
 
 // ============================================================

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -504,6 +504,9 @@ struct TTIRToTTNNCommonPipelineOptions
   }
 };
 
+void createTTIRToTTNNCommonPipeline(
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options);
+
 // ============================================================
 // Target-specific pipelines, which receive the output of the
 // TTIRToTTNNCommonPipeline and produce IR ready for translation
@@ -608,6 +611,15 @@ struct TTNNCommonToEmitPyPipelineOptions
       llvm::cl::init(false)};
 };
 
+void createTTNNCommonToRuntimePipeline(
+    OpPassManager &pm, const TTNNCommonToRuntimePipelineOptions &options);
+
+void createTTNNCommonToEmitCPipeline(
+    OpPassManager &pm, const TTNNCommonToEmitCPipelineOptions &options);
+
+void createTTNNCommonToEmitPyPipeline(
+    OpPassManager &pm, const TTNNCommonToEmitPyPipelineOptions &options);
+
 // ============================================================
 // End-to-end pipelines, which lower TTIR to specific TTNN targets.
 // ============================================================
@@ -634,6 +646,15 @@ struct TTIRToEmitCPipelineOptions : public TTIRToTTNNCommonPipelineOptions,
 struct TTIRToEmitPyPipelineOptions : public TTIRToTTNNCommonPipelineOptions,
                                      public TTNNCommonToEmitPyPipelineOptions {
 };
+
+void createTTIRToTTNNRuntimePipeline(
+    OpPassManager &pm, const TTIRToTTNNRuntimePipelineOptions &options);
+
+void createTTIRToEmitCPipeline(OpPassManager &pm,
+                               const TTIRToEmitCPipelineOptions &options);
+
+void createTTIRToEmitPyPipeline(OpPassManager &pm,
+                                const TTIRToEmitPyPipelineOptions &options);
 
 // ============================================================
 // Other pipelines.

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -15,7 +15,7 @@ class MeshDevice;
 
 namespace mlir::tt::ttnn {
 
-struct TTIRToTTNNDevicePipelineOptions;
+struct TTIRToTTNNCommonPipelineOptions;
 
 //===----------------------------------------------------------------------===//
 // TTNNOptimizer
@@ -39,7 +39,7 @@ struct TTNNOptimizerOptions {
   TTNNOptimizerOptions() = default;
 
   explicit TTNNOptimizerOptions(
-      const TTIRToTTNNDevicePipelineOptions &pipelineOptions);
+      const TTIRToTTNNCommonPipelineOptions &pipelineOptions);
 };
 
 std::unique_ptr<::mlir::Pass> createTTNNOptimizer();

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -457,8 +457,8 @@ def TTNNCollectPerfMetrics: Pass<"ttnn-collect-perf-metrics", "::mlir::ModuleOp"
     The metrics are serialized to JSON format for debugging, profiling, and external analysis.
 
     Usage:
-    Enable performance metrics collection in the TTIR to TTNN backend pipeline using:
-    --ttir-to-ttnn-backend-pipeline="ttnn-perf-metrics-enabled=true"
+    Enable performance metrics collection in the TTIR to TTNN runtime pipeline using:
+    --ttir-to-ttnn-runtime-pipeline="ttnn-perf-metrics-enabled=true"
 
     Output file naming:
     - If --ttnn-perf-metrics-output-file is not specified or is the default, files are automatically

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -272,43 +272,40 @@ void createLinalgToLLVMPipeline(OpPassManager &manager,
   }
 }
 
-void createTTIRToLLVMCPUPipeline(OpPassManager &pm,
-                                 const TTIRToLLVMCPUPipelineOptions &options) {
-
-  auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
-
+void createSHLOAndTTIRToLLVMPipeline(
+    OpPassManager &pm, const SHLOAndTTIRToLLVMPipelineOptions &options) {
 #ifdef TTMLIR_ENABLE_STABLEHLO
   // Directly convert any hoisted SHLO ops into linalg ops.
-  cpuPm.addPass(::mlir::stablehlo::createStablehloLegalizeToLinalgPass());
+  pm.addPass(::mlir::stablehlo::createStablehloLegalizeToLinalgPass());
 #endif
 
   // Decomp TTIR to reduce number of conversions we need to support in
   // Linalg/Tosa.
   mlir::tt::TTIRToTTIRDecompositionOptions decompOptions;
   decompOptions.decompConfig = mlir::tt::DecompMode::CPUFallback;
-  cpuPm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass(decompOptions));
+  pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass(decompOptions));
 
-  cpuPm.addPass(mlir::createCanonicalizerPass());
-  cpuPm.addPass(mlir::createCSEPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
 
   // Narrow boolean-producing ops back to i1. ElementTypeNormalization widens
   // i1 → bf16 for hardware, but CPUs handle i1 natively.
-  cpuPm.addPass(ttir::createTTIRCPUBooleanNarrowing());
+  pm.addPass(ttir::createTTIRCPUBooleanNarrowing());
 
   // Lower TTIR to mix of linalg direct, TOSA (which we can subsequently lower
   // to linalg), and Tensor dialect ops.
-  cpuPm.addPass(createConvertTTIRToLinalgPass());
+  pm.addPass(createConvertTTIRToLinalgPass());
 
   // Lower Tosa to linalg/tensor/arith, which we can lower to LLVM.
   TosaToLinalgOptions tosaToLinalgOptions;
   tosaToLinalgOptions.aggressiveReduceConstant = true;
-  tosa::addTosaToLinalgPasses(cpuPm, tosaToLinalgOptions, {}, {});
+  tosa::addTosaToLinalgPasses(pm, tosaToLinalgOptions, {}, {});
   // Add tosa-to-tensor/arith passes to handle tosa.const operations
-  cpuPm.addPass(createTosaToTensorPass());
-  cpuPm.addPass(createTosaToArithPass());
+  pm.addPass(createTosaToTensorPass());
+  pm.addPass(createTosaToArithPass());
 
-  ttir::createLinalgToLLVMPipeline(cpuPm, options);
-  cpuPm.addPass(llvm_util::createLLVMEmitCallingConventionWrapperFuncs());
+  ttir::createLinalgToLLVMPipeline(pm, options);
+  pm.addPass(llvm_util::createLLVMEmitCallingConventionWrapperFuncs());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps/HoistCPUOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps/HoistCPUOps.cpp
@@ -596,7 +596,7 @@ bool canLowerTTIRToLinalg(mlir::Operation *op) {
 
   // Run TTIRToTTIRDecomposition (CPUFallback mode) followed by
   // TTIRToLinalg conversion on the temporary module, mirroring the
-  // TTIRToLLVMCPU pipeline.
+  // SHLOAndTTIRToLLVM pipeline.
   mlir::PassManager pm(context);
   TTIRToTTIRDecompositionOptions decompOptions;
   decompOptions.decompConfig = DecompMode::CPUFallback;

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -292,9 +292,11 @@ void createTTIRToTTMetalPipeline(OpPassManager &pm,
   createTTIRToTTMetalMiddleendPipeline(devicePm, options);
   createTTIRToTTMetalBackendPipeline(devicePm, options);
 
-  // Run lowering to LLVM pass.
-  ttir::TTIRToLLVMCPUPipelineOptions ttirToCPUOptions;
-  ttir::createTTIRToLLVMCPUPipeline(pm, ttirToCPUOptions);
+  // Run pipeline for lowering the CPU module to LLVM.
+  OpPassManager &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
+
+  ttir::SHLOAndTTIRToLLVMPipelineOptions cpuOptions;
+  ttir::createSHLOAndTTIRToLLVMPipeline(cpuPm, cpuOptions);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -30,7 +30,7 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 
 void createTTNNPipelineTTIRPasses(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
 
   ttcore::TTCoreRegisterDevicePassOptions registerDeviceOptions;
   {
@@ -95,7 +95,7 @@ void createTTNNPipelineTTIRPasses(
 }
 
 void createTTNNPipelineAnalysisPasses(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
 
   pm.addPass(mlir::tt::ttnn::createTTNNConfigureCCLOps());
 
@@ -197,7 +197,7 @@ void createTTNNPipelineLoweringPasses(OpPassManager &pm,
 // If optimizer is not enabled we just add fusing pass directly and we don't
 // do op constraint validation.
 void createTTNNFusingPass(OpPassManager &pm,
-                          const TTIRToTTNNDevicePipelineOptions &options) {
+                          const TTIRToTTNNCommonPipelineOptions &options) {
   if (options.enableFusing) {
     if (options.optimizerPassEnabled) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -226,7 +226,7 @@ void createTTNNFusingPass(OpPassManager &pm,
 
 // Create a pass to workaround issues in the TTNN dialect.
 void createTTNNPipelineWorkaroundPass(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
 
   // If the workaround pass is disabled, skip adding it.
   if (options.disableWorkarounds) {
@@ -247,23 +247,14 @@ void createTTNNPipelineWorkaroundPass(
 }
 
 void createTTNNPipelineLayoutDecompositionPass(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
   pm.addPass(createTTNNDecomposeLayouts());
 }
 
 void createTTNNPipelineDeallocPass(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
   pm.addPass(createTTNNDeallocate());
 }
-
-//===----------------------------------------------------------------------===//
-// Intermediate pipelines used to build end-to-end pipelines.
-// Each of these pipelines lowers either the Device or CPU module, which is
-// encoded in the pipeline name.
-//
-// The OpPassManager argument is expected to correspond to the top-level
-// (root) ModuleOp.
-//===----------------------------------------------------------------------===//
 
 // Pipeline which prepares the TTIR ops in the Device module for TTNN
 // lowering, and then lowers them to TTNN dialect.
@@ -271,8 +262,8 @@ void createTTNNPipelineDeallocPass(
 // CPU module does get modified in this pipeline, but only by
 // adding more TTIR ops to it (CPU hoisting passes).
 //
-void createTTIRToTTNNDevicePipeline(
-    OpPassManager &pm, const TTIRToTTNNDevicePipelineOptions &options) {
+void createTTIRToTTNNCommonPipeline(
+    OpPassManager &pm, const TTIRToTTNNCommonPipelineOptions &options) {
   // Resolve options controlled by optimization_level.
   options.resolveOptimizationLevelOptions();
 
@@ -455,25 +446,28 @@ void createRecoverStructureXLATorchPipeline(
   pm.addPass(createTTNNRemoveDeallocs());
 }
 
-// Pipeline which lowers the Device module from TTNN to EmitC dialect.
+// Pipeline which lowers the results of TTIRToTTNNCommonPipeline to an IR ready
+// for translation to Flatbuffer and execution with the TTNN runtime.
 //
-void createTTNNToEmitCDevicePipeline(
-    OpPassManager &pm, const TTNNToEmitCDevicePipelineOptions &options) {
-  // Unwrapping the device module.
-  //
-  // TODO(dmilinkovic): Should be removed after support for generating
-  // a dynamic library from CPU module is implemented inside EmitC translation
-  // pipeline - issue #6100.
-  //
-  pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
+void createTTNNCommonToRuntimePipeline(
+    OpPassManager &pm, const TTNNCommonToRuntimePipelineOptions &options) {
+  auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
 
-  // These passes operate on TTNN IR inside the (now unwrapped) top-level
-  // module.
-  //
-  pm.addPass(createTTNNAdjustDeallocs());
+  // Lower the CPU module to LLVM IR.
+  ttir::createSHLOAndTTIRToLLVMPipeline(cpuPm, options);
+}
+
+// Pipeline which lowers the results of TTIRToTTNNCommonPipeline to EmitC
+// dialect.
+//
+void createTTNNCommonToEmitCPipeline(
+    OpPassManager &pm, const TTNNCommonToEmitCPipelineOptions &options) {
+  auto &devicePm = pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
+
+  devicePm.addPass(createTTNNAdjustDeallocs());
   if (options.tryRecoverStructure) {
     createRecoverStructureXLATorchPipeline(
-        pm, RecoverStructureXLATorchPipelineOptions());
+        devicePm, RecoverStructureXLATorchPipelineOptions());
   }
 
   if (options.targetDylib) {
@@ -483,31 +477,44 @@ void createTTNNToEmitCDevicePipeline(
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = true;
-    pm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
+    devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
   } else {
     // In canonical path, run tuplification + input generation/loading.
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = options.tuplifyInputIfEmpty;
-    pm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
+    devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
 
     if (options.loadInputTensorsFromDisk) {
       TTNNLoadInputTensorsOptions loadOptions;
       loadOptions.tensorLoadDirectory = options.tensorLoadDirectory;
       loadOptions.tensorLoadFilePrefix = options.tensorLoadFilePrefix;
-      pm.addPass(createTTNNLoadInputTensors(loadOptions));
+      devicePm.addPass(createTTNNLoadInputTensors(loadOptions));
     } else {
-      pm.addPass(createTTNNCreateInputGenerators());
+      devicePm.addPass(createTTNNCreateInputGenerators());
     }
   }
 
-  pm.addPass(createConvertTTNNToEmitCPass());
+  devicePm.addPass(createConvertTTNNToEmitCPass());
+
+  // ==============================================================
+  // Root-module passes.
+  // ==============================================================
+
+  // Unwrap the Device module into the top-level module, effectively dropping
+  // the CPU module.
+  //
+  // TODO(dmilinkovic): Should be removed after support for generating
+  // CPU-hoisting on EmitC is implemented - issue #6100.
+  //
+  pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
 }
 
-// Pipeline which lowers the Device module from TTNN to EmitPy dialect.
+// Pipeline which lowers the results of TTIRToTTNNCommon pipeline to EmitPy
+// dialect.
 //
-void createTTNNToEmitPyDevicePipeline(
-    OpPassManager &pm, const TTNNToEmitPyDevicePipelineOptions &options) {
+void createTTNNCommonToEmitPyPipeline(
+    OpPassManager &pm, const TTNNCommonToEmitPyPipelineOptions &options) {
   auto &devicePm = pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
 
   devicePm.addPass(createTTNNAdjustDeallocs());
@@ -578,20 +585,22 @@ void createTTNNToEmitPyDevicePipeline(
   devicePm.addPass(createEmitPyFormExpressionsPass());
 
   devicePm.addPass(createEmitPyNameVarsPass());
-}
 
-// Pipeline which lowers the CPU module from TTIR to EmitPy.
-//
-// TTIR ops are converted directly to ttir_cpu.<op> calls, bypassing
-// TTNN lowering entirely.
-//
-void createTTIRToEmitPyCPUPipeline(OpPassManager &pm) {
   auto &cpuPm = pm.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
 
   // Lower TTIR directly to EmitPy (ttir_cpu).
+  //
   cpuPm.addPass(createConvertTTIRCPUToEmitPyPass());
 
   cpuPm.addPass(createEmitPyNameVarsPass());
+
+  // Link Device and CPU modules into the root module.
+  //
+  pm.addPass(createEmitPyLinkModulesPass());
+
+  // Add Python import statements.
+  //
+  pm.addPass(createEmitPyAddImportsPass());
 }
 
 void createTTNNPipelineD2MPass(OpPassManager &pm) {
@@ -612,23 +621,17 @@ void createTTNNPipelineD2MPass(OpPassManager &pm) {
 // End-to-end pipelines.
 //===----------------------------------------------------------------------===//
 
-// Complete pipeline for lowering TTIR to TTNN backend.
+// Complete pipeline for lowering TTIR to TTNN runtime.
 //
-// Device module: TTIR -> TTNN.
-// CPU module: TTIR (+ StableHLO) -> LLVM.
-//
-void createTTIRToTTNNBackendPipeline(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+void createTTIRToTTNNRuntimePipeline(
+    OpPassManager &pm, const TTIRToTTNNRuntimePipelineOptions &options) {
 
-  createTTIRToTTNNDevicePipeline(pm, options);
+  createTTIRToTTNNCommonPipeline(pm, options);
 
-  ttir::createTTIRToLLVMCPUPipeline(pm, options);
+  createTTNNCommonToRuntimePipeline(pm, options);
 }
 
 // Complete pipeline for lowering TTIR to EmitC.
-//
-// Device module: TTIR -> TTNN -> EmitC.
-// CPU module: TTIR (+ StableHLO) -> LLVM.
 //
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options) {
@@ -637,16 +640,12 @@ void createTTIRToEmitCPipeline(OpPassManager &pm,
         "Trace currently not supported in createTTIRToEmitCPipeline");
   }
 
-  createTTIRToTTNNDevicePipeline(pm, options);
-  createTTNNToEmitCDevicePipeline(pm, options);
+  createTTIRToTTNNCommonPipeline(pm, options);
 
-  // TODO(dmilinkovic): Lower CPU module to LLVM - issue #6100.
+  createTTNNCommonToEmitCPipeline(pm, options);
 }
 
 // Complete pipeline for lowering TTIR to EmitPy.
-//
-// Device module: TTIR -> TTNN -> EmitPy.
-// CPU module: TTIR -> TTNN -> EmitPy (with golden functions).
 //
 void createTTIRToEmitPyPipeline(OpPassManager &pm,
                                 const TTIRToEmitPyPipelineOptions &options) {
@@ -655,36 +654,9 @@ void createTTIRToEmitPyPipeline(OpPassManager &pm,
         "Trace currently not supported in createTTIRToEmitPyPipeline");
   }
 
-  createTTIRToTTNNDevicePipeline(pm, options);
-  createTTNNToEmitPyDevicePipeline(pm, options);
+  createTTIRToTTNNCommonPipeline(pm, options);
 
-  // Lower CPU module to EmitPy using TTNN golden functions.
-  //
-  createTTIRToEmitPyCPUPipeline(pm);
-
-  // Link Device and CPU modules into the root module.
-  //
-  pm.addPass(createEmitPyLinkModulesPass());
-
-  // Add module-level Python import statements.
-  //
-  pm.addPass(createEmitPyAddImportsPass());
-}
-
-// Complete pipeline for lowering TTNN to EmitPy.
-//
-// This pipeline is used when the input is already in TTNN dialect, and assumes
-// the CPU module is still in TTIR.
-//
-// Device module: TTNN -> EmitPy.
-// CPU module: TTIR -> TTNN -> EmitPy (with golden functions).
-//
-void createTTNNToEmitPyPipeline(
-    OpPassManager &pm, const TTNNToEmitPyDevicePipelineOptions &options) {
-  createTTNNToEmitPyDevicePipeline(pm, options);
-  createTTIRToEmitPyCPUPipeline(pm);
-  pm.addPass(createEmitPyLinkModulesPass());
-  pm.addPass(createEmitPyAddImportsPass());
+  createTTNNCommonToEmitPyPipeline(pm, options);
 }
 
 //===----------------------------------------------------------------------===//
@@ -692,29 +664,67 @@ void createTTNNToEmitPyPipeline(
 //===----------------------------------------------------------------------===//
 
 void registerTTNNPipelines() {
-  // TTIR to TTNN backend pipeline.
+  // TTIR to TTNN Common pipeline.
   //
   mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTIRToTTNNBackendPipelineOptions>(
+      mlir::tt::ttnn::TTIRToTTNNCommonPipelineOptions>(
+      "ttir-to-ttnn-common-pipeline",
+      "Common pipeline lowering TTIR to TTNN. "
+      "Lowers the Device module to TTNN, and leaves the CPU module as TTIR. ",
+      mlir::tt::ttnn::createTTIRToTTNNCommonPipeline);
+
+  // =================================================================
+  // Target-specific pipelines, which all take the results of TTIRToTTNNCommon
+  // as input.
+  // =================================================================
+
+  // TTNN Common to Runtime pipeline.
+  //
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttnn::TTNNCommonToRuntimePipelineOptions>(
+      "ttnn-common-to-runtime-pipeline",
+      "Pipeline lowering results of TTIRToTTNNCommon pipeline to an IR ready "
+      "for Flatbuffer translation and Runtime execution.",
+      mlir::tt::ttnn::createTTNNCommonToRuntimePipeline);
+
+  // TTNN Common to EmitPy pipeline.
+  //
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttnn::TTNNCommonToEmitPyPipelineOptions>(
+      "ttnn-common-to-emitpy-pipeline",
+      "Pipeline lowering results of TTIRToTTNNCommon pipeline to EmitPy.",
+      mlir::tt::ttnn::createTTNNCommonToEmitPyPipeline);
+
+  // TTNN Common to EmitC pipeline.
+  //
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttnn::TTNNCommonToEmitCPipelineOptions>(
+      "ttnn-common-to-emitc-pipeline",
+      "Pipeline lowering results of TTIRToTTNNCommon pipeline to EmitC.",
+      mlir::tt::ttnn::createTTNNCommonToEmitCPipeline);
+
+  // ==============================================================
+  // End-to-end pipelines, which compose the TTIRToTTNNCommon pipeline with a
+  // target-specific pipeline.
+  // ==============================================================
+
+  // TTIR to TTNN runtime pipeline.
+  //
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttnn::TTIRToTTNNRuntimePipelineOptions>(
+      "ttir-to-ttnn-runtime-pipeline",
+      "Pipeline lowering TTIR to TTNN for tt-mlir Runtime execution.",
+      mlir::tt::ttnn::createTTIRToTTNNRuntimePipeline);
+
+  // Backwards-compatible ttir-to-ttnn-backend-pipeline, which is the same as
+  // ttir-to-ttnn-runtime-pipeline.
+  //
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttnn::TTIRToTTNNRuntimePipelineOptions>(
       "ttir-to-ttnn-backend-pipeline",
-      "Pipeline lowering TTIR to TTNN backend.",
-      mlir::tt::ttnn::createTTIRToTTNNBackendPipeline);
-
-  // TTNN to EmitC Device pipeline.
-  //
-  mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTNNToEmitCDevicePipelineOptions>(
-      "ttnn-to-emitc-device-pipeline",
-      "Pipeline lowering TTNN to EmitC in the Device module.",
-      mlir::tt::ttnn::createTTNNToEmitCDevicePipeline);
-
-  // TTNN to EmitPy Device pipeline.
-  //
-  mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTNNToEmitPyDevicePipelineOptions>(
-      "ttnn-to-emitpy-device-pipeline",
-      "Pipeline lowering TTNN to EmitPy in the Device module.",
-      mlir::tt::ttnn::createTTNNToEmitPyDevicePipeline);
+      "Pipeline lowering TTIR to TTNN for backend execution. Deprecated, use "
+      "ttir-to-ttnn-runtime-pipeline instead.",
+      mlir::tt::ttnn::createTTIRToTTNNRuntimePipeline);
 
   // TTIR to EmitC pipeline.
   //
@@ -727,13 +737,6 @@ void registerTTNNPipelines() {
   mlir::PassPipelineRegistration<mlir::tt::ttnn::TTIRToEmitPyPipelineOptions>(
       "ttir-to-emitpy-pipeline", "Pipeline lowering TTIR to EmitPy.",
       mlir::tt::ttnn::createTTIRToEmitPyPipeline);
-
-  // TTNN to EmitPy pipeline.
-  //
-  mlir::PassPipelineRegistration<
-      mlir::tt::ttnn::TTNNToEmitPyDevicePipelineOptions>(
-      "ttnn-to-emitpy-pipeline", "Pipeline lowering TTNN to EmitPy.",
-      mlir::tt::ttnn::createTTNNToEmitPyPipeline);
 
   // Recover Structure XLA/Torch pipeline.
   //

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -722,8 +722,7 @@ void registerTTNNPipelines() {
   mlir::PassPipelineRegistration<
       mlir::tt::ttnn::TTIRToTTNNRuntimePipelineOptions>(
       "ttir-to-ttnn-backend-pipeline",
-      "Pipeline lowering TTIR to TTNN for backend execution. Deprecated, use "
-      "ttir-to-ttnn-runtime-pipeline instead.",
+      "DEPRECATED, use ttir-to-ttnn-runtime-pipeline instead.",
       mlir::tt::ttnn::createTTIRToTTNNRuntimePipeline);
 
   // TTIR to EmitC pipeline.

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -497,14 +497,10 @@ void createTTNNCommonToEmitCPipeline(
 
   devicePm.addPass(createConvertTTNNToEmitCPass());
 
-  // ==============================================================
-  // Root-module passes.
-  // ==============================================================
-
   // Unwrap the Device module into the top-level module, effectively dropping
   // the CPU module.
   //
-  // TODO(dmilinkovic): Should be removed after support for generating
+  // TODO(dmilinkovic): Should be removed after support for
   // CPU-hoisting on EmitC is implemented - issue #6100.
   //
   pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -462,12 +462,18 @@ void createTTNNCommonToRuntimePipeline(
 //
 void createTTNNCommonToEmitCPipeline(
     OpPassManager &pm, const TTNNCommonToEmitCPipelineOptions &options) {
-  auto &devicePm = pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
+  // Unwrap the Device module into the top-level module, effectively dropping
+  // the CPU module.
+  //
+  // TODO(dmilinkovic): Should be removed after support for
+  // CPU-hoisting on EmitC is implemented - issue #6100.
+  //
+  pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
 
-  devicePm.addPass(createTTNNAdjustDeallocs());
+  pm.addPass(createTTNNAdjustDeallocs());
   if (options.tryRecoverStructure) {
     createRecoverStructureXLATorchPipeline(
-        devicePm, RecoverStructureXLATorchPipelineOptions());
+        pm, RecoverStructureXLATorchPipelineOptions());
   }
 
   if (options.targetDylib) {
@@ -477,33 +483,25 @@ void createTTNNCommonToEmitCPipeline(
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = true;
-    devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
+    pm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
   } else {
     // In canonical path, run tuplification + input generation/loading.
     //
     TTNNTuplifyTensorsOptions tuplifyOptions;
     tuplifyOptions.tuplifyInputIfEmpty = options.tuplifyInputIfEmpty;
-    devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
+    pm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
 
     if (options.loadInputTensorsFromDisk) {
       TTNNLoadInputTensorsOptions loadOptions;
       loadOptions.tensorLoadDirectory = options.tensorLoadDirectory;
       loadOptions.tensorLoadFilePrefix = options.tensorLoadFilePrefix;
-      devicePm.addPass(createTTNNLoadInputTensors(loadOptions));
+      pm.addPass(createTTNNLoadInputTensors(loadOptions));
     } else {
-      devicePm.addPass(createTTNNCreateInputGenerators());
+      pm.addPass(createTTNNCreateInputGenerators());
     }
   }
 
-  devicePm.addPass(createConvertTTNNToEmitCPass());
-
-  // Unwrap the Device module into the top-level module, effectively dropping
-  // the CPU module.
-  //
-  // TODO(dmilinkovic): Should be removed after support for
-  // CPU-hoisting on EmitC is implemented - issue #6100.
-  //
-  pm.addPass(ttcore::createTTCoreUnwrapDeviceModulePass());
+  pm.addPass(createConvertTTNNToEmitCPass());
 }
 
 // Pipeline which lowers the results of TTIRToTTNNCommon pipeline to EmitPy

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -51,7 +51,7 @@
 namespace mlir::tt::ttnn {
 
 TTNNOptimizerOptions::TTNNOptimizerOptions(
-    const TTIRToTTNNDevicePipelineOptions &pipelineOptions)
+    const TTIRToTTNNCommonPipelineOptions &pipelineOptions)
     : insertMemReconfig(pipelineOptions.insertMemReconfig),
       overrideOutputLayout(pipelineOptions.overrideOutputLayout),
       overrideConv2dConfig(pipelineOptions.overrideConv2dConfig),

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -99,7 +99,7 @@ void populatePassesModule(nb::module_ &m) {
       nb::arg("module"), nb::arg("options") = "", nb::arg("print_ir") = false);
 
   m.def(
-      "ttir_to_ttnn_backend_pipeline",
+      "ttir_to_ttnn_runtime_pipeline",
       [](MlirModule module, std::string options = "", bool printIr = false) {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getName());
@@ -113,7 +113,7 @@ void populatePassesModule(nb::module_ &m) {
         }
 
         const auto *pipeline =
-            mlir::PassPipelineInfo::lookup("ttir-to-ttnn-backend-pipeline");
+            mlir::PassPipelineInfo::lookup("ttir-to-ttnn-runtime-pipeline");
 
         std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
             [](const llvm::Twine &) { return mlir::failure(); };

--- a/python/common/compile_and_run.py
+++ b/python/common/compile_and_run.py
@@ -47,7 +47,7 @@ def ttir_to_ttnn(
     ),
 ) -> Module:
     """
-    Runs `ttir-to-ttnn-backend-pipeline` compiler pass on `module` in a safe way.
+    Runs `ttir-to-ttnn-runtime-pipeline` compiler pass on `module` in a safe way.
 
     This is a segfault resistant function. It runs the pybound compiler pass in a
     separate process, thus protecting the caller of this function from any unpredictable
@@ -63,7 +63,7 @@ def ttir_to_ttnn(
     """
     m = module if isinstance(module, str) else str(module)
     return run_compilation_process(
-        ttir_to_ttnn_backend_pipeline_worker, (m, system_desc)
+        ttir_to_ttnn_runtime_pipeline_worker, (m, system_desc)
     )
 
 

--- a/python/common/compile_and_run_internal.py
+++ b/python/common/compile_and_run_internal.py
@@ -11,7 +11,7 @@ from ttmlir.ir import Module
 from ttmlir.passes import (
     stablehlo_to_ttir_pipeline,
     ttir_to_ttmetal_backend_pipeline,
-    ttir_to_ttnn_backend_pipeline,
+    ttir_to_ttnn_runtime_pipeline,
     ttmetal_to_flatbuffer_file,
     ttnn_to_flatbuffer_file,
 )
@@ -42,11 +42,11 @@ def stablehlo_to_ttir_pipeline_worker(
         result_queue.put(CompilationProcessResult.error(str(e)))
 
 
-def ttir_to_ttnn_backend_pipeline_worker(
+def ttir_to_ttnn_runtime_pipeline_worker(
     module_str: str, system_desc: str, result_queue: queues.Queue
 ) -> None:
     """
-    Wrapper around `ttir_to_ttnn_backend_pipeline` pybound pass.
+    Wrapper around `ttir_to_ttnn_runtime_pipeline` pybound pass.
 
     It is not resistant to segfaults, i.e. some unpredictable errors that can happen
     inside the pybound call. Thus it is meant to be used as a worker for a Process
@@ -55,7 +55,7 @@ def ttir_to_ttnn_backend_pipeline_worker(
     try:
         module = create_mlir_module_from_string(module_str)
 
-        ttir_to_ttnn_backend_pipeline(module, f"system-desc-path={system_desc}")
+        ttir_to_ttnn_runtime_pipeline(module, f"system-desc-path={system_desc}")
 
         result_queue.put(CompilationProcessResult.success(str(module)))
     except Exception as e:

--- a/test/ttmlir/Dialect/EmitC/compute_kernel_config_test.mlir
+++ b/test/ttmlir/Dialect/EmitC/compute_kernel_config_test.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% compute-cfg-math-fidelity=lofi" --ttnn-to-emitc-device-pipeline -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path% compute-cfg-math-fidelity=lofi" --ttnn-common-to-emitc-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // CHECK: ::MathFidelity::LoFi

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-to-emitc-device-pipeline -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" --ttnn-common-to-emitc-pipeline -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_target_dylib_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_target_dylib_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitc-pipeline="target-dylib=true system-desc-path=%system_desc_path%" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttcore-unwrap-device-module --ttnn-to-emitc-device-pipeline="target-dylib=true" -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" --ttnn-common-to-emitc-pipeline="target-dylib=true" -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 //

--- a/test/ttmlir/Dialect/EmitPy/ttir_to_emitpy_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitPy/ttir_to_emitpy_pipeline_sanity.mlir
@@ -2,7 +2,7 @@
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 //
 // RUN: ttmlir-opt --ttir-to-emitpy-pipeline="system-desc-path=%system_desc_path% split-files=false" -o %t_direct.mlir %s
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-to-emitpy-device-pipeline="split-files=false" --emitpy-add-imports --ttcore-unwrap-device-module -o %t_indirect.mlir %s
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" --ttnn-common-to-emitpy-pipeline="split-files=false" -o %t_indirect.mlir %s
 // RUN: diff %t_direct.mlir %t_indirect.mlir
 // RUN: FileCheck %s --input-file=%t_direct.mlir
 

--- a/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm_training.mlir
+++ b/test/ttmlir/EmitC/TTNN/batch_norm/batch_norm_training.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_assymetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_assymetric_padding.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_bf16.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_bf16.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
@@ -1,6 +1,8 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_f32.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_f32.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // TODO (#2507): conv2d currently fails when run in group. Merge this with

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_activation.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_activation.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights_and_prepare_conv2d_bias.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights_and_prepare_conv2d_bias.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv3d_with_config.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/depthwise_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/depthwise_conv2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/depthwise_separable_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/depthwise_separable_conv2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/dilated_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/dilated_conv2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/grouped_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/grouped_conv2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/pointwise_conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/pointwise_conv2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias_asymmetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_bias_asymmetric_padding.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
+++ b/test/ttmlir/EmitC/TTNN/data_movement/scatter.mlir
@@ -1,8 +1,11 @@
 // REQUIRES: stablehlo
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // default

--- a/test/ttmlir/EmitC/TTNN/dropout/dropout.mlir
+++ b/test/ttmlir/EmitC/TTNN/dropout/dropout.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/element_type_normalization/block_type_conversion.mlir
+++ b/test/ttmlir/EmitC/TTNN/element_type_normalization/block_type_conversion.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module  {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/add.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/add.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @atan2(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/bitwise.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/bitwise.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
   func.func @bitwise_and(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> tensor<64x128xi32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/compare.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/compare.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @lt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/divide.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/divide.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/gelu_bw.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/gelu_bw.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logical.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logical.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logical_and(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalleftshift.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalleftshift.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logicalleftshift(%arg0: tensor<5xui32>, %arg1: tensor<5xui32>) -> tensor<5xui32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalrightshift.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/logicalrightshift.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logicalrightshift(%arg0: tensor<5xui32>, %arg1: tensor<5xui32>) -> tensor<5xui32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @minimum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/multiply.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/multiply.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/pow.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/pow.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @pow_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @remainder(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/subtract.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/subtract.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_where(%arg0: tensor<13x37xbf16>, %arg1: tensor<13x37xbf16>) -> tensor<13x37xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/abs.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/abs.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @abs(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/acos.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/acos.mlir
@@ -1,7 +1,10 @@
 // TODO(vtsilytskyiTT): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @acos(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/asin.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/asin.mlir
@@ -1,7 +1,10 @@
 // TODO(vtsilytskyiTT): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @asin(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/asinh.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/asinh.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovicTT): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @asinh_f32(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/atan.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/atan.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @atan(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/bitwise_not.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/bitwise_not.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @bitwise_not(%arg0: tensor<64x128xi32>) -> tensor<64x128xi32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cbrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/ceil.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/ceil.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @ceil(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/cos.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/cos.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cos(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/erf.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/erf.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @erf(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/erfc.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/erfc.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @erfc(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/exp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/exp.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/expm1.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/expm1.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @expm1(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/floor.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/floor.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/gelu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/gelu.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @gelu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/isfinite.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/isfinite.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @isfinite(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/leaky_relu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/leaky_relu.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @leaky_relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/log.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/log.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @log(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/log1p.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/log1p.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @log1p(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/logical_not.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/logical_not.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @logical_not(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/neg.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/neg.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @neg(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/reciprocal.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/reciprocal.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @reciprocal(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/relu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/relu.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/relu6.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/relu6.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @relu6(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/rsqrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/rsqrt.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @rsqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sigmoid.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sigmoid.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sigmoid(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sign.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sign.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sign(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/silu.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/silu.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @silu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sin.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sin.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sin(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/sqrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/sqrt.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @sqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/tan.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/tan.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @tan(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/tanh.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/tanh.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @tanh(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/gather/gather.mlir
+++ b/test/ttmlir/EmitC/TTNN/gather/gather.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/group_norm/group_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/group_norm/group_norm.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/paged_fill_cache.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/paged_update_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/paged_update_cache.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/kv_cache/update_cache.mlir
+++ b/test/ttmlir/EmitC/TTNN/kv_cache/update_cache.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @update_cache(%arg0: tensor<1x8x16x128xbf16>, %arg1: tensor<1x8x1x128xbf16>, %arg2: tensor<1xi32>) -> tensor<1x8x16x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/layer_norm/layer_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/layer_norm/layer_norm.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/matmul/linear.mlir
+++ b/test/ttmlir/EmitC/TTNN/matmul/linear.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/matmul/matmul.mlir
+++ b/test/ttmlir/EmitC/TTNN/matmul/matmul.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @matmul(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {

--- a/test/ttmlir/EmitC/TTNN/memory/multiple_ops.mlir
+++ b/test/ttmlir/EmitC/TTNN/memory/multiple_ops.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 //
 // This test tests multiple ops. It runs a single "ttir.add" op but it is expected that several other memory-related ops will be generated in the TTNN dialect:

--- a/test/ttmlir/EmitC/TTNN/memory/typecast.mlir
+++ b/test/ttmlir/EmitC/TTNN/memory/typecast.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @typecast(%arg0: tensor<64x128xf32>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/models/llama_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/llama_attention.mlir
@@ -1,5 +1,8 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/llama_attention.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/llama_attention.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // https://huggingface.co/meta-llama/Llama-3.2-1B

--- a/test/ttmlir/EmitC/TTNN/models/mnist.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/mnist.mlir
@@ -1,5 +1,8 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/mnist.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/mnist.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward %s -o %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module %s -o %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // Temporary workaround for running optimizer tests in CI is to run optimizer locally and run the rest of the pipeline on obtained IR:

--- a/test/ttmlir/EmitC/TTNN/models/resnet.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/resnet.mlir
@@ -1,5 +1,8 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/resnet_hf.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %models/resnet_hf.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir

--- a/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @embedding(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=true" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // RUN: FileCheck %s --input-file %t.mlir
 

--- a/test/ttmlir/EmitC/TTNN/other/cumsum.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/cumsum.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @cumsum(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/embedding.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/embedding.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @embedding(%arg0: tensor<32x32xbf16>, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/other/pad.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/pad.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 //
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/other/softmax.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/softmax.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @softmax(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {

--- a/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/avg_pool2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/global_avg_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/global_avg_pool2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/max_pool2d.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/max_pool2d_with_indices.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/max_pool2d_with_indices.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module attributes {} {

--- a/test/ttmlir/EmitC/TTNN/pooling/upsample.mlir
+++ b/test/ttmlir/EmitC/TTNN/pooling/upsample.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/quantization/dequantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/dequantize.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/quantization/quantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/quantize.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/quantization/requantize.mlir
+++ b/test/ttmlir/EmitC/TTNN/quantization/requantize.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // EmitC lowering generates ttnn::constant()/ttnn::full() calls for scale/zero_point tensors, but these functions currently don't exist in TTNN C++ API.

--- a/test/ttmlir/EmitC/TTNN/rand/rand.mlir
+++ b/test/ttmlir/EmitC/TTNN/rand/rand.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 // UNSUPPORTED: true
 // https://github.com/tenstorrent/tt-mlir/issues/4383

--- a/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/argmax.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func public @argmax_2d(%arg0: tensor<64x64xf32>) -> tensor<64xi32> {

--- a/test/ttmlir/EmitC/TTNN/reduction/max.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/max.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<32x32x64xbf16>) -> tensor<1x1x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/min.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/min.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xf32>) -> tensor<f32> {

--- a/test/ttmlir/EmitC/TTNN/reduction/prod.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/prod.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x1x32x4xbf16> {

--- a/test/ttmlir/EmitC/TTNN/reduction/sum.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/sum.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {

--- a/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
+++ b/test/ttmlir/EmitC/TTNN/rms_norm/rms_norm.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 module {

--- a/test/ttmlir/EmitC/TTNN/sanity_add.mlir
+++ b/test/ttmlir/EmitC/TTNN/sanity_add.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {

--- a/test/ttmlir/EmitC/TTNN/sanity_two_fns.mlir
+++ b/test/ttmlir/EmitC/TTNN/sanity_two_fns.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {

--- a/test/ttmlir/EmitC/TTNN/sort/sort.mlir
+++ b/test/ttmlir/EmitC/TTNN/sort/sort.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_sort(%arg0: tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xi16>) {

--- a/test/ttmlir/EmitC/TTNN/tensor/concat.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/concat.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @concat(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/construct.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/construct.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --convert-ttir-to-ttnn -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --convert-ttir-to-ttnn --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/full.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/full.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @full_float() -> tensor<64x128xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @ones() -> tensor<13x24x56x42xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/repeat.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/repeat.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-repeat-folding-workaround-pass=false" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-repeat-folding-workaround-pass=false" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @repeat_interleave(%arg0: tensor<4x6xf32>) -> tensor<4x24xf32> {

--- a/test/ttmlir/EmitC/TTNN/tensor/reshape.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/reshape.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @slice(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice_dynamic.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 // UNSUPPORTED: true

--- a/test/ttmlir/EmitC/TTNN/tensor/transpose.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/transpose.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @transpose(%arg0: tensor<64x128xbf16>) -> tensor<128x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path% enable-const-eval=false" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @zeros() -> tensor<13x24x56x42xbf16> {

--- a/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor_serialization/dump_load.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #system_memory = #ttnn.buffer_type<system_memory>

--- a/test/ttmlir/EmitC/TTNN/topk/test_topk.mlir
+++ b/test/ttmlir/EmitC/TTNN/topk/test_topk.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_basic_top_k(%input: tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xi32>) {

--- a/test/ttmlir/EmitC/TTNN/topk_router_gpt/topk_router_gpt.mlir
+++ b/test/ttmlir/EmitC/TTNN/topk_router_gpt/topk_router_gpt.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 func.func @test_topk_router_gpt(

--- a/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 func.func @concatenate_heads(%arg0: tensor<1x24x32x128xbf16>) -> tensor<1x32x3072xbf16> {

--- a/test/ttmlir/EmitC/TTNN/transformer/nlp_create_qkv_heads_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/nlp_create_qkv_heads_decode.mlir
@@ -1,6 +1,9 @@
-// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward -o %t.mlir %s
-// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t.mlir
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttcore-mark-functions-as-forward --ttcore-wrap-device-module -o %t.mlir %s
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline -o %t_rt.mlir %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %basename_t.ttnn %t_rt.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline="tuplify-input-if-empty=true" -o %t2.mlir %t.mlir
 // RUN: ttmlir-translate --mlir-to-cpp -o %basename_t.cpp %t2.mlir
 
 #dram = #ttnn.buffer_type<dram>

--- a/test/ttmlir/EmitC/TTNN/transformer/paged_scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/paged_scaled_dot_product_attention_decode.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 module @sdpa {
     func.func public @sdpa_causal(%arg0: tensor<1x1x12x64xbf16>, %arg1: tensor<128x12x32x64xbf16>, %arg2: tensor<128x12x32x64xbf16>, %arg3: tensor<1x4xi32>, %arg4: tensor<1xi32>) -> tensor<1x1x12x64xbf16> {

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 module {

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 module {

--- a/test/ttmlir/EmitC/TTNN/transformer/split_query_key_value_and_split_heads.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/split_query_key_value_and_split_heads.mlir
@@ -1,7 +1,10 @@
 // TODO(dmilinkovic): re-enable CPU-hoisted const-eval once EmitC support for CPU-hoisted ops lands - issue #6100.
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-to-emitc-device-pipeline %t.mlir > %t2.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="enable-cpu-hoisted-const-eval=false system-desc-path=%system_desc_path%" %s > %t.mlir
+//
+// RUN: ttmlir-opt --ttnn-common-to-runtime-pipeline %t.mlir > %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir > %basename_t.ttnn
+//
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 func.func @split_qkv_and_split_heads(%arg0: tensor<2x32x3072xf32>) -> (tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>, tensor<2x16x32x64xf32>) {

--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -5,7 +5,7 @@
 ## import relevant packages
 
 ```python
-from ttmlir.passes import ttir_to_ttnn_backend_pipeline
+from ttmlir.passes import ttir_to_ttnn_runtime_pipeline
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 from builder.ttnn.ttnn_builder import TTNNBuilder

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -19,7 +19,7 @@ from ttmlir.dialects import func, ttcore, ttnn, ttir, sdy
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
-    ttir_to_ttnn_backend_pipeline,
+    ttir_to_ttnn_runtime_pipeline,
     ttir_to_ttmetal_backend_pipeline,
     translate_to_cpp,
     translate_to_python,
@@ -825,7 +825,7 @@ def compile_ttnn_to_flatbuffer(
     Compiles a TTNN function to flatbuffer format.
 
     This helper function generates a TTNN mlir module runs the compilation
-    pipeline using ttir-to-ttnn-backend-pipeline and finally generates a flatbuffer.
+    pipeline using ttir-to-ttnn-runtime-pipeline and finally generates a flatbuffer.
 
     Parameters
     ----------
@@ -1248,7 +1248,7 @@ def compile_ttir_module_to_flatbuffer(
         pipeline_fn = (
             custom_pipeline
             if custom_pipeline
-            else wrap_pipeline_with_print_ir(ttir_to_ttnn_backend_pipeline)
+            else wrap_pipeline_with_print_ir(ttir_to_ttnn_runtime_pipeline)
         )
         to_target = ttnn_to_flatbuffer_bin
         to_file = ttnn_to_flatbuffer_file

--- a/tools/builder/base/builder_utils.py
+++ b/tools/builder/base/builder_utils.py
@@ -19,7 +19,7 @@ from ttmlir.dialects import func, ttcore, ttnn, ttir
 from ttmlir.passmanager import PassManager
 from ttmlir.passes import (
     tt_populate_argument_types,
-    ttir_to_ttnn_backend_pipeline,
+    ttir_to_ttnn_runtime_pipeline,
     ttnn_to_flatbuffer_file,
     ttir_to_ttmetal_backend_pipeline,
     ttmetal_to_flatbuffer_file,

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -406,6 +406,7 @@ class ModelRunner:
             ttnn_ir_file,
             "-o",
             runtime_ir_file,
+            "--mlir-print-debuginfo",
         ]
 
         self.log("Running TTNN Common to Runtime Pipeline")

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -332,19 +332,19 @@ class ModelRunner:
 
         compile_command = [
             f"{self._build_dir}/bin/ttmlir-opt",
-            f"--ttir-to-ttnn-backend-pipeline={overrides_string}",
+            f"--ttir-to-ttnn-common-pipeline={overrides_string}",
             ttir_ir_file if not FLATBUFFER else ttir_module_path,
             "-o",
             ttnn_ir_file,
             "--mlir-print-debuginfo",
         ]
 
-        self.log("Running compile TTIR to TTNN Backend Pipeline")
+        self.log("Running compile TTIR to TTNN Common Pipeline")
         self.log("With options: " + overrides_string)
 
         compile_process = self.run_in_subprocess(compile_command)
         if compile_process.returncode != 0:
-            error = "Error running compile TTIR to TTNN Backend Pipeline"
+            error = "Error running compile TTIR to TTNN Common Pipeline"
             self.log(error, severity=logging.error)
             raise ExplorerRunException(error)
         self.progress = 20
@@ -352,7 +352,7 @@ class ModelRunner:
         ########################### EmitC Generation #############################
 
         if self.get_generate_cpp_code(model_path):
-            # Backend Pipeline has already been run, the file is stored to ttnn_ir_file
+            # Common Pipeline has already been run, the file is stored to ttnn_ir_file
             # The translation to flatbuffer will happen, need to run the pass to emitc and then store the artifact
             self.log("Enabled C++ Code Generation w/ EmitC")
 
@@ -361,7 +361,7 @@ class ModelRunner:
             )
             emitc_command = [
                 f"{self._build_dir}/bin/ttmlir-opt",
-                "--ttnn-to-emitc-device-pipeline",
+                "--ttnn-common-to-emitc-pipeline",
                 ttnn_ir_file,
                 "-o",
                 emitc_ir_file,
@@ -393,6 +393,29 @@ class ModelRunner:
                 self.log(error, severity=logging.error)
                 raise ExplorerRunException(error)
 
+        ####################### Runtime Pipeline (for Flatbuffer) #################
+
+        # Lower the common pipeline output to a form ready for flatbuffer
+        # translation.
+        runtime_ir_file = (
+            f"{state.model_output_dir}/{model_name.replace('.mlir', '_runtime.mlir')}"
+        )
+        runtime_command = [
+            f"{self._build_dir}/bin/ttmlir-opt",
+            "--ttnn-common-to-runtime-pipeline",
+            ttnn_ir_file,
+            "-o",
+            runtime_ir_file,
+        ]
+
+        self.log("Running TTNN Common to Runtime Pipeline")
+
+        runtime_process = self.run_in_subprocess(runtime_command)
+        if runtime_process.returncode != 0:
+            error = "Error running TTNN Common to Runtime Pipeline"
+            self.log(error, severity=logging.error)
+            raise ExplorerRunException(error)
+
         ############################## Translate #################################
 
         # Need this flatbuffer file to inherit the golden data
@@ -423,7 +446,7 @@ class ModelRunner:
                 )
 
             # Get module from file
-            with open(ttnn_ir_file, "r") as f:
+            with open(runtime_ir_file, "r") as f:
                 ttnn_module = utils.parse_mlir_str(f.read())
 
             self.log("Running TTNN to Flatbuffer File")
@@ -444,7 +467,7 @@ class ModelRunner:
             to_flatbuffer_command = [
                 f"{self._build_dir}/bin/ttmlir-translate",
                 "--ttnn-to-flatbuffer",
-                ttnn_ir_file,
+                runtime_ir_file,
                 "-o",
                 flatbuffer_file,
             ]

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -409,7 +409,7 @@ class ModelRunner:
             "--mlir-print-debuginfo",
         ]
 
-        self.log("Running TTNN Common to Runtime Pipeline")
+        self.log("Running ttnn-common-to-runtime-pipeline")
 
         runtime_process = self.run_in_subprocess(runtime_command)
         if runtime_process.returncode != 0:

--- a/tools/scripts/update_llm_perf_tests.sh
+++ b/tools/scripts/update_llm_perf_tests.sh
@@ -116,7 +116,7 @@ create_test_file_if_missing() {
 
     cat > "$test_file" << EOF
 // REQUIRES: opmodel, perf
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-permute-matmul-fusion=false" -o ${model_name}_ttnn.mlir %models/single_blocks_and_layers/${model_name}.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline="system-desc-path=%system_desc_path% optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-permute-matmul-fusion=false" -o ${model_name}_ttnn.mlir %models/single_blocks_and_layers/${model_name}.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn ${model_name}_ttnn.mlir
 // RUN: ttrt run --benchmark %t.ttnn
 EOF

--- a/tools/tt-alchemist/csrc/include/utils.hpp
+++ b/tools/tt-alchemist/csrc/include/utils.hpp
@@ -5,9 +5,10 @@
 #ifndef TT_ALCHEMIST_UTILS_HPP
 #define TT_ALCHEMIST_UTILS_HPP
 
+#include "llvm/Support/Error.h"
+
 #include <dlfcn.h>
 #include <filesystem>
-#include <llvm/Support/Error.h>
 
 namespace mlir {
 class ModuleOp;

--- a/tools/tt-alchemist/csrc/include/utils.hpp
+++ b/tools/tt-alchemist/csrc/include/utils.hpp
@@ -7,6 +7,7 @@
 
 #include <dlfcn.h>
 #include <filesystem>
+#include <llvm/Support/Error.h>
 
 namespace mlir {
 class ModuleOp;
@@ -75,7 +76,8 @@ inline std::filesystem::path get_templates_dir() {
 
 enum class CodeGenerationTarget { Cpp, Python };
 
-std::string getPipelineName(mlir::ModuleOp module, CodeGenerationTarget target);
+llvm::Expected<std::string> getPipelineName(mlir::ModuleOp module,
+                                            CodeGenerationTarget target);
 
 bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
                  const std::string &pipelineName,

--- a/tools/tt-alchemist/csrc/lib/utils.cpp
+++ b/tools/tt-alchemist/csrc/lib/utils.cpp
@@ -61,10 +61,11 @@ llvm::Expected<std::string> getPipelineName(mlir::ModuleOp module,
           extractInnerModule<mlir::tt::ttcore::CPUModuleOp>(module)) {
     if (hasOpsOfDialect(cpuModule, "llvm")) {
       return llvm::make_error<llvm::StringError>(
-          "CPU module is already lowered to LLVM dialect, which means that the "
-          "output of the ttir-to-ttnn-runtime-pipeline have been fed into the "
-          "tt-alchemist. Instead, use the outputs of the "
-          "ttir-to-ttnn-common-pipeline, or the initial TTIR module.",
+          "CPU module has already been lowered to the LLVM dialect, "
+          "indicating that the output of the ttir-to-ttnn-runtime-pipeline "
+          "was passed to tt-alchemist. Please provide either the output of "
+          "the ttir-to-ttnn-common-pipeline or the original TTIR module "
+          "instead.",
           llvm::inconvertibleErrorCode());
     }
   }

--- a/tools/tt-alchemist/csrc/lib/utils.cpp
+++ b/tools/tt-alchemist/csrc/lib/utils.cpp
@@ -4,13 +4,13 @@
 
 #include "utils.hpp"
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 
 #include "llvm/Support/Error.h"
-#include "llvm/Support/LogicalResult.h"
 
 #include <iostream>
 
@@ -42,10 +42,8 @@ mlir::ModuleOp extractInnerModule(mlir::ModuleOp module) {
     return nullptr;
   }
 
-  return *(*ops.begin())
-              .getBodyRegion()
-              .template getOps<mlir::ModuleOp>()
-              .begin();
+  return *(
+      (*ops.begin()).getBodyRegion().template getOps<mlir::ModuleOp>().begin());
 }
 
 } // namespace

--- a/tools/tt-alchemist/csrc/lib/utils.cpp
+++ b/tools/tt-alchemist/csrc/lib/utils.cpp
@@ -7,6 +7,10 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/LogicalResult.h"
 
 #include <iostream>
 
@@ -14,34 +18,77 @@ namespace tt::alchemist::utils {
 
 namespace {
 
-bool isOnlyTTNN(mlir::ModuleOp module) {
-  bool hasTTIR = false;
-  bool hasTTNN = false;
+// Check if the module contains ops of the provided dialect.
+//
+bool hasOpsOfDialect(mlir::ModuleOp module, llvm::StringRef dialectNamespace) {
+  return module
+      ->walk([&](mlir::Operation *op) {
+        if (op->getDialect() &&
+            op->getDialect()->getNamespace() == dialectNamespace) {
+          return mlir::WalkResult::interrupt();
+        }
+        return mlir::WalkResult::advance();
+      })
+      .wasInterrupted();
+}
 
-  module->walk([&](mlir::Operation *op) {
-    llvm::StringRef dialectName = op->getDialect()->getNamespace();
-    if (dialectName == "ttir") {
-      hasTTIR = true;
-    } else if (dialectName == "ttnn") {
-      hasTTNN = true;
-    }
-  });
+// Extract the inner module of the given type from the provided module.
+// Used for extracting the inner modules from DeviceModuleOp and CPUModuleOp.
+//
+template <typename T>
+mlir::ModuleOp extractInnerModule(mlir::ModuleOp module) {
+  auto ops = module.getBodyRegion().getOps<T>();
+  if (ops.empty()) {
+    return nullptr;
+  }
 
-  return hasTTNN && !hasTTIR;
+  return *(*ops.begin())
+              .getBodyRegion()
+              .template getOps<mlir::ModuleOp>()
+              .begin();
 }
 
 } // namespace
 
-std::string getPipelineName(mlir::ModuleOp module,
-                            CodeGenerationTarget target) {
-  bool ttnnInput = isOnlyTTNN(module);
+// Helper function to determine which pipeline to run based on the current state
+// of the module.
+//
+llvm::Expected<std::string> getPipelineName(mlir::ModuleOp module,
+                                            CodeGenerationTarget target) {
+  // If CPU module exists, it might have already been lowered to LLVM dialect.
+  //
+  if (auto cpuModule =
+          extractInnerModule<mlir::tt::ttcore::CPUModuleOp>(module)) {
+    if (hasOpsOfDialect(cpuModule, "llvm")) {
+      return llvm::make_error<llvm::StringError>(
+          "CPU module is already lowered to LLVM dialect, which means that the "
+          "output of the ttir-to-ttnn-runtime-pipeline have been fed into the "
+          "tt-alchemist. Instead, use the outputs of the "
+          "ttir-to-ttnn-common-pipeline, or the initial TTIR module.",
+          llvm::inconvertibleErrorCode());
+    }
+  }
+
+  // We should run the E2E pipeline if we have TTIR ops in the Device module.
+  // Otherwise, we can run the target-specific pipeline which assumes TTNN ops
+  // in the Device module.
+  //
+  mlir::ModuleOp moduleToCheck = module;
+
+  if (auto deviceModule =
+          extractInnerModule<mlir::tt::ttcore::DeviceModuleOp>(module)) {
+    moduleToCheck = deviceModule;
+  }
+
+  bool shouldRunE2EPipeline = hasOpsOfDialect(moduleToCheck, "ttir");
 
   switch (target) {
   case CodeGenerationTarget::Cpp:
-    return ttnnInput ? "ttnn-to-emitc-device-pipeline"
-                     : "ttir-to-emitc-pipeline";
+    return shouldRunE2EPipeline ? "ttir-to-emitc-pipeline"
+                                : "ttnn-common-to-emitc-pipeline";
   case CodeGenerationTarget::Python:
-    return ttnnInput ? "ttnn-to-emitpy-pipeline" : "ttir-to-emitpy-pipeline";
+    return shouldRunE2EPipeline ? "ttir-to-emitpy-pipeline"
+                                : "ttnn-common-to-emitpy-pipeline";
   }
 }
 
@@ -76,7 +123,14 @@ bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
 bool runPipeline(mlir::PassManager &pm, mlir::ModuleOp module,
                  CodeGenerationTarget target,
                  const std::string &pipelineOptions) {
-  std::string pipelineName = getPipelineName(module, target);
+  auto pipelineNameOrError = getPipelineName(module, target);
+  if (!pipelineNameOrError) {
+    std::cout << "Failed to determine which pipeline to run: "
+              << llvm::toString(pipelineNameOrError.takeError()) << std::endl;
+    return false;
+  }
+
+  std::string pipelineName = *pipelineNameOrError;
   return runPipeline(pm, module, pipelineName, pipelineOptions);
 }
 

--- a/tools/tt-alchemist/python/tt_alchemist/cli.py
+++ b/tools/tt-alchemist/python/tt_alchemist/cli.py
@@ -34,9 +34,12 @@ def model_to_cpp_cmd(input_file, verbose):
 
         success = model_to_cpp(input_file)
 
+        if not success:
+            sys.exit(1)
+
     except Exception as e:
         click.echo(f"Error: {str(e)}", err=True)
-        return 1
+        sys.exit(1)
 
 
 @cli.command()
@@ -50,9 +53,12 @@ def model_to_python_cmd(input_file, verbose):
 
         success = model_to_python(input_file)
 
+        if not success:
+            sys.exit(1)
+
     except Exception as e:
         click.echo(f"Error: {str(e)}", err=True)
-        return 1
+        sys.exit(1)
 
 
 @cli.command()
@@ -101,13 +107,12 @@ def generate_cpp_cmd(input_file, output_dir, mode, pipeline_options, verbose):
         success = generate_cpp(input_file, output_dir, is_local, pipeline_options)
         if success:
             click.echo(f"Successfully generated {mode} solution in: {output_dir}")
-            return 0
         else:
             click.echo(f"Failed to generate {mode} solution in: {output_dir}")
-            return 1
+            sys.exit(1)
     except Exception as e:
         click.echo(f"Error: {str(e)}", err=True)
-        return 1
+        sys.exit(1)
 
 
 @cli.command()
@@ -156,13 +161,12 @@ def generate_python_cmd(input_file, output_dir, mode, pipeline_options, verbose)
         success = generate_python(input_file, output_dir, is_local, pipeline_options)
         if success:
             click.echo(f"Successfully generated {mode} solution in: {output_dir}")
-            return 0
         else:
             click.echo(f"Failed to generate {mode} solution in: {output_dir}")
-            return 1
+            sys.exit(1)
     except Exception as e:
         click.echo(f"Error: {str(e)}", err=True)
-        return 1
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Ticket
#6927 

### Problem description
TTNN pipelines have been refactored as part of #6361, so that there are dedicated `Device` and `CPU` pipelines running against the corresponding modules. E2E pipelines are composing these `Device` and `CPU` pipelines to achieve conversions for desired targets.

Current setup would require a major refactor of PJRT device implementation in tt-xla, coupling it to the concepts of Device/CPU module differentiation, which would unnecessarily complicate it.

Upon further consideration, this setup can be simplified in order to decrease the number of pipelines, while making them easier to grasp. The internal distinction between `Device` and `CPU` pipelines is now an implementation detail — pipeline users only need to think in terms of a common TTNN pipeline and target-specific pipelines.

Moreover, the new setup enables performing bulk of the effort in TTIR -> TTNN conversion only once when targeting both Runtime and Codegen at the same time, thus saving significant amount of time when compiling large models. This was working fine before CPU-hoisting was introduced by default.

### Note

**The changes are split into simple and easily-reviewable commits.**

### New pipelines setup

<img width="2560" height="864" alt="pipelines-new" src="https://github.com/user-attachments/assets/f0d989ad-acea-4f5d-a9d1-c5c8ed07589c" />


#### `TTIRToTTNNCommonPipeline`
- Common (base) pipeline for all TTNN targets.
- Performs the heavy-lifting for the TTIR → TTNN conversion: decompositions, TTIR → TTNN dialect conversion, optimizer, fusings...
- Lowers the Device module to TTNN and populates the CPU module with hoisted TTIR ops (if CPU-hoisting is enabled), but does **not** lower the CPU module — that's left to the target-specific pipelines, since each target handles CPU execution differently.

#### Target-specific pipelines (take output of `TTIRToTTNNCommonPipeline`)
- **`TTNNCommonToRuntimePipeline`** — Lowers the CPU module to LLVM IR, producing IR ready for Flatbuffer translation and TTNN runtime execution.
- **`TTNNCommonToEmitCPipeline`** — Lowers the Device module from TTNN to EmitC dialect. Unwraps the Device module into the top-level module (CPU-hoisting not yet supported on EmitC, see #6100).
- **`TTNNCommonToEmitPyPipeline`** — Lowers the Device module from TTNN to EmitPy, lowers the CPU module from TTIR to EmitPy (`ttir_cpu` calls), links modules, and adds Python imports.

#### End-to-end pipelines (compose common + target-specific)
- **`TTIRToTTNNRuntimePipeline`** — `TTIR` → `TTNN Common` → `Runtime`. Replaces the old `TTIRToTTNNBackendPipeline` (kept as a deprecated alias).
- **`TTIRToEmitCPipeline`** — `TTIR` → `TTNN Common` → `EmitC`.
- **`TTIRToEmitPyPipeline`** —  `TTIR` → `TTNN Common` → `EmitPy`.

### What's changed

- **Pipeline restructuring**: Replaced `TTIRToTTNNDevicePipeline` + separate CPU pipelines with a single `TTIRToTTNNCommonPipeline` that handles both Device and CPU modules, plus target-specific pipelines that finish the job.
- **Pipeline renaming**: `TTIRToTTNNBackendPipeline` → `TTIRToTTNNRuntimePipeline` (old name kept as deprecated alias). `TTNNToEmitCDevicePipeline` → `TTNNCommonToEmitCPipeline`. `TTNNToEmitPyDevicePipeline` → `TTNNCommonToEmitPyPipeline`.
- **Explorer updates**: Now runs `ttir-to-ttnn-common-pipeline` followed by `ttnn-common-to-runtime-pipeline` (and optionally `ttnn-common-to-emitc-pipeline`) as separate steps, instead of the monolithic backend pipeline.
- **Alchemist updates**: Pipeline selection logic updated to detect the module's dialect state and choose between `ttir-to-ttnn-common-pipeline`, `ttnn-common-to-runtime-pipeline`, or the combined `ttir-to-ttnn-runtime-pipeline`.

### Future work
- Replace other usages of `TTIRToTTNNBackendPipeline` with `TTIRToTTNNRuntimePipeline`

### Checklist
- [x] New/Existing tests provide coverage for changes


<!-- xla-validate -->
---
### tt-xla Validation

**Base (uplifted):** `a53ca15e`
**tt-xla branch:** `dmilinkovic/uplift-restructured-pipelines`

| Test Suite | Run | Status |
|------------|-----|--------|
| full-mlir-uplift-qualification | [Run #24513516965](https://github.com/tenstorrent/tt-xla/actions/runs/24513516965) | :white_check_mark: passed |
<!-- /xla-validate -->


