### PR TITLE
Update CODEOWNERS: Add Claude skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,9 @@ LICENSE @nsmithtt
 /docs/ @nsmithtt @sdjordjevicTT
 /docs/src/specs/ttnn-optimizer.md @rpavlovicTT @odjuricicTT
 
+# Claude Skills
+/.claude/skills/ @nsmithtt @sdjordjevicTT @svuckovicTT
+
 # tt-mlir Bindings
 /include/ttmlir/Bindings/ @tapspatel
 /include/ttmlir-c/ @tapspatel
@@ -190,7 +193,7 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /tools/scripts/ @nsmithtt @ddilbazTT
 
 # python golden tests
-test/python/golden/test_metal_dma.py @bgrady-tt
+test/python/golden/test_metal_dma.py @nsmithtt
 
 # model snippet tests
 test/python/golden/mlir_snippets/models/ @nsmithtt @tapspatel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -193,7 +193,7 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /tools/scripts/ @nsmithtt @ddilbazTT
 
 # python golden tests
-test/python/golden/test_metal_dma.py @nsmithtt
+test/python/golden/test_metal_dma.py @vtangTT
 
 # model snippet tests
 test/python/golden/mlir_snippets/models/ @nsmithtt @tapspatel


### PR DESCRIPTION
### Ticket
Ad-hoc

### Problem description
No Claude skills ownership.

### What's changed
Add ownership for claude skills.
Also removed bgrady-tt from CODEOWNERS to avoid the error:
```
Unknown owner on line 196: make sure @bgrady-tt exists and has write access to the repository
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
