### PR TITLE
TypecastOp constant folding

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Dialect/CommonFolders.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
@@ -3208,16 +3209,158 @@ void mlir::tt::ttir::TransposeOp::getCanonicalizationPatterns(
   }
   return success();
 }
+
 //===----------------------------------------------------------------------===//
 // TypecastOp
 //===----------------------------------------------------------------------===//
 
+static ::mlir::OpFoldResult
+foldIdentityTypecast(mlir::tt::ttir::TypecastOp op) {
+  if (op.getType() == op.getInput().getType()) {
+    return op.getInput();
+  }
+  return nullptr;
+}
+
+// Helper to check if a float cast can be folded based on the conversion status.
+static bool isFloatCastFoldSuccessful(llvm::APFloat::opStatus status) {
+  // Don't fold if the conversion failed, as runtime semantics don't match IEEE
+  // 754 in some special cases (e.g. overflow, NaN). Fold if the status is not
+  // OK solely because the conversion is inexact.
+  return status == llvm::APFloat::opOK || status == llvm::APFloat::opInexact;
+}
+
+// Helper to check if an integer constant cast can be safely folded.
+static bool isIntCastFoldSafe(const llvm::APInt &value,
+                              mlir::IntegerType sourceType,
+                              mlir::IntegerType targetType) {
+  unsigned targetWidth = targetType.getWidth();
+
+  if (targetType.isUnsigned()) {
+    if (!sourceType.isUnsigned() && value.isNegative()) {
+      // Don't fold if the value is negative and the target type is unsigned.
+      return false;
+    }
+    // Don't fold if the value overflows.
+    return value.isIntN(targetWidth);
+  }
+
+  if (targetType.isSigned()) {
+    if (!sourceType.isSigned()) {
+      // Don't fold if the value overflows/underflows. This is checked
+      // separately for unsigned source to avoid casting large positive
+      // integers to negative.
+      return value.isIntN(targetWidth - 1);
+    }
+    // Don't fold if the value overflows/underflows.
+    return value.isSignedIntN(targetWidth);
+  }
+
+  // Fold conversion to signless integer type only if it would be correct for
+  // both signed and unsigned target types.
+  return value.isIntN(targetWidth - 1);
+}
+
+static ::mlir::OpFoldResult
+constantFoldTypecast(mlir::tt::ttir::TypecastOp op,
+                     mlir::tt::ttir::TypecastOp::FoldAdaptor adaptor) {
+  auto input =
+      mlir::dyn_cast_if_present<mlir::ElementsAttr>(adaptor.getInput());
+  if (!input) {
+    return nullptr;
+  }
+  if (!input.isSplat() && !shouldFold(op)) {
+    return nullptr;
+  }
+
+  // We ignore `conservative_folding` attribute of typecast op here, because it
+  // is meant for folding of consecutive ops without the known input. Constant
+  // folding will not cause issues that this attribute is designed to prevent,
+  // like the removal of narrowing conversions in conversion chains.
+
+  auto outputType = op.getResult().getType();
+  auto outputElementType = outputType.getElementType();
+  auto inputElementType = input.getElementType();
+
+  if (inputElementType.isFloat()) {
+    if (auto targetType = mlir::dyn_cast<FloatType>(outputElementType)) {
+      return constFoldCastOp<mlir::FloatAttr, mlir::FloatAttr, llvm::APFloat,
+                             llvm::APFloat, void>(
+          adaptor.getOperands(), outputType,
+          [targetType](llvm::APFloat value, bool &castStatus) -> llvm::APFloat {
+            bool losesInfo{};
+            llvm::APFloat::opStatus status =
+                value.convert(targetType.getFloatSemantics(),
+                              llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+            castStatus = isFloatCastFoldSuccessful(status);
+            return value;
+          });
+    }
+
+    if (auto targetType = mlir::dyn_cast<IntegerType>(outputElementType)) {
+      return constFoldCastOp<mlir::FloatAttr, mlir::IntegerAttr, llvm::APFloat,
+                             llvm::APInt, void>(
+          adaptor.getOperands(), outputType,
+          [targetType](const llvm::APFloat &value,
+                       bool &castStatus) -> llvm::APInt {
+            llvm::APSInt intValue(targetType.getWidth(),
+                                  targetType.isUnsigned());
+            bool isExact{};
+            llvm::APFloat::opStatus status = value.convertToInteger(
+                intValue, llvm::APFloat::rmTowardZero, &isExact);
+            castStatus = isFloatCastFoldSuccessful(status);
+            return intValue;
+          });
+    }
+  }
+
+  if (auto sourceType = mlir::dyn_cast<mlir::IntegerType>(inputElementType)) {
+    if (auto targetType = mlir::dyn_cast<FloatType>(outputElementType)) {
+      return constFoldCastOp<mlir::IntegerAttr, mlir::FloatAttr, llvm::APInt,
+                             llvm::APFloat, void>(
+          adaptor.getOperands(), outputType,
+          [sourceType, targetType](const llvm::APInt &value,
+                                   bool &castStatus) -> llvm::APFloat {
+            llvm::APFloat floatValue(targetType.getFloatSemantics());
+            // If target type is a signless integer, we treat it as signed to
+            // keep negative floats negative after conversion.
+            bool isSigned = !sourceType.isUnsigned();
+            llvm::APFloat::opStatus status = floatValue.convertFromAPInt(
+                value, isSigned, llvm::APFloat::rmNearestTiesToEven);
+            castStatus = isFloatCastFoldSuccessful(status);
+            return floatValue;
+          });
+    }
+
+    if (auto targetType = mlir::dyn_cast<IntegerType>(outputElementType)) {
+      return constFoldCastOp<mlir::IntegerAttr, mlir::IntegerAttr, llvm::APInt,
+                             llvm::APInt, void>(
+          adaptor.getOperands(), outputType,
+          [sourceType, targetType](const llvm::APInt &value,
+                                   bool &castStatus) -> llvm::APInt {
+            castStatus = isIntCastFoldSafe(value, sourceType, targetType);
+            if (sourceType.isUnsigned()) {
+              return value.zextOrTrunc(targetType.getWidth());
+            }
+            return value.sextOrTrunc(targetType.getWidth());
+          });
+    }
+  }
+
+  return nullptr;
+}
+
 // TypecastOp folder
 mlir::OpFoldResult mlir::tt::ttir::TypecastOp::fold(FoldAdaptor adaptor) {
-  if (getType() == getInput().getType()) {
-    return getInput();
+  if (auto foldResult = foldIdentityTypecast(*this)) {
+    return foldResult;
   }
-  return {};
+
+  if (auto foldResult = constantFoldTypecast(*this, adaptor)) {
+    return foldResult;
+  }
+
+  return nullptr;
 }
 
 static bool isNarrowingConversion(const ::mlir::tt::ttcore::DataType srcDtype,

--- a/test/ttmlir/Dialect/TTIR/canonicalize/clamp_op_canonicalize.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/clamp_op_canonicalize.mlir
@@ -56,9 +56,10 @@ module @jit_clamp {
     %0 = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
     %2 = "ttir.typecast"(%0) : (tensor<1xf32>) -> tensor<1xbf16>
     %4 = "ttir.reshape"(%2) <{shape = [1 : i32]}> : (tensor<1xbf16>) -> tensor<1xbf16>
-    // CHECK: [[MIN:[0-9]+]] = "ttir.broadcast"
-    // CHECK-SAME: <{broadcast_dimensions = array<i64: 1, 16>}> :
-    // CHECK-SAME: (tensor<1x1xbf16>) -> tensor<1x16xbf16>
+    // CHECK: [[MIN:[0-9]+]] = "ttir.full"
+    // CHECK-SAME: fill_value = 3.000000e+00 : f32
+    // CHECK-SAME: shape = array<i32: 1, 16>
+    // CHECK-SAME: () -> tensor<1x16xbf16>
     // CHECK: [[MAX:[0-9]+]] = "ttir.broadcast"
     // CHECK-SAME: <{broadcast_dimensions = array<i64: 1, 16>}> :
     // CHECK-SAME: (tensor<1x1xbf16>) -> tensor<1x16xbf16>

--- a/test/ttmlir/Dialect/TTIR/canonicalize/typecast_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/typecast_fold_tests.mlir
@@ -1,0 +1,241 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @typecast_const_f32_to_si8() -> tensor<3xsi8> {
+    %0 = "ttir.constant"() {
+      value = dense<[1.700000e+00, -2.300000e+00, 3.000000e+00]> : tensor<3xf32>
+    } : () -> tensor<3xf32>
+
+    // CHECK-LABEL: func.func @typecast_const_f32_to_si8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1, -2, 3]> : tensor<3xsi8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<3xf32>) -> tensor<3xsi8>
+    return %1 : tensor<3xsi8>
+  }
+
+  func.func @no_fold_f32_to_si8() -> tensor<3xi8> {
+    %0 = "ttir.full"() {
+      fill_value = 128.000000e+00 : f32,
+      shape = array<i32: 3>
+    } : () -> tensor<3xf32>
+
+    // CHECK-LABEL: func.func @no_fold_f32_to_si8
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 1.280000e+02 : f32
+    // CHECK: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<3xf32>) -> tensor<3xi8>
+    return %1 : tensor<3xi8>
+  }
+
+  func.func @typecast_const_f32_to_ui8() -> tensor<3xui8> {
+    %0 = "ttir.constant"() {
+      value = dense<[1.700000e+00, 222.300000e+00, 3.000000e+00]> : tensor<3xf32>
+    } : () -> tensor<3xf32>
+
+    // CHECK-LABEL: func.func @typecast_const_f32_to_ui8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1, 222, 3]> : tensor<3xui8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<3xf32>) -> tensor<3xui8>
+    return %1 : tensor<3xui8>
+  }
+
+  func.func @typecast_const_si32_to_f32() -> tensor<3xf32> {
+    %0 = "ttir.constant"() {
+      value = dense<[1, -2, 3]> : tensor<3xsi32>
+    } : () -> tensor<3xsi32>
+
+    // CHECK-LABEL: func.func @typecast_const_si32_to_f32
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, -2.000000e+00, 3.000000e+00]> : tensor<3xf32>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<3xsi32>) -> tensor<3xf32>
+    return %1 : tensor<3xf32>
+  }
+
+  func.func @typecast_const_f32_to_bf16() -> tensor<4xbf16> {
+    %0 = "ttir.constant"() {
+      value = dense<[1.000000e+00, 2.000000e+00, 3.141593e+00, -4.000000e+00]> : tensor<4xf32>
+    } : () -> tensor<4xf32>
+
+    // CHECK-LABEL: func.func @typecast_const_f32_to_bf16
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 2.000000e+00, 3.14{{[0-9]*(e\+00)?}}, -4.000000e+00]> : tensor<4xbf16>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xf32>) -> tensor<4xbf16>
+    return %1 : tensor<4xbf16>
+  }
+
+  func.func @typecast_const_f16_to_f32() -> tensor<4xf32> {
+    %0 = "ttir.constant"() {
+      value = dense<[1.000000e+00, 2.000000e+00, 3.141593e+00, -4.000000e+00]> : tensor<4xf16>
+    } : () -> tensor<4xf16>
+
+    // CHECK-LABEL: func.func @typecast_const_f16_to_f32
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 2.000000e+00, 3.14{{[0-9]*(e\+00)?}}, -4.000000e+00]> : tensor<4xf32>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xf16>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @typecast_const_ui16_to_ui8() -> tensor<4xui8> {
+    %0 = "ttir.constant"() {
+      value = dense<[255, 0, 1, 42]> : tensor<4xui16>
+    } : () -> tensor<4xui16>
+    // CHECK-LABEL: func.func @typecast_const_ui16_to_ui8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[255, 0, 1, 42]> : tensor<4xui8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xui16>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
+  }
+
+  func.func @typecast_const_ui8_to_ui16() -> tensor<4xui16> {
+    %0 = "ttir.constant"() {
+      value = dense<[255, 0, 1, 42]> : tensor<4xui8>
+    } : () -> tensor<4xui8>
+    // CHECK-LABEL: func.func @typecast_const_ui8_to_ui16
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[255, 0, 1, 42]> : tensor<4xui16>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xui8>) -> tensor<4xui16>
+    return %1 : tensor<4xui16>
+  }
+
+  func.func @typecast_const_si32_to_si8() -> tensor<4xsi8> {
+    %0 = "ttir.constant"() {
+      value = dense<[127, -128, -1, 0]> : tensor<4xsi32>
+    } : () -> tensor<4xsi32>
+
+    // CHECK-LABEL: func.func @typecast_const_si32_to_si8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[127, -128, -1, 0]> : tensor<4xsi8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xsi32>) -> tensor<4xsi8>
+    return %1 : tensor<4xsi8>
+  }
+
+  func.func @no_fold_si32_to_si8() -> tensor<4xsi8> {
+    %0 = "ttir.constant"() {
+      value = dense<[128, -129, -1, 0]> : tensor<4xsi32>
+    } : () -> tensor<4xsi32>
+
+    // CHECK-LABEL: func.func @no_fold_si32_to_si8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[128, -129, -1, 0]> : tensor<4xsi32>
+    // CHECK: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xsi32>) -> tensor<4xsi8>
+    return %1 : tensor<4xsi8>
+  }
+
+  func.func @typecast_const_si8_to_ui8() -> tensor<4xui8> {
+    %0 = "ttir.constant"() {
+      value = dense<[127, 0, 1, 2]> : tensor<4xsi8>
+    } : () -> tensor<4xsi8>
+
+    // CHECK-LABEL: func.func @typecast_const_si8_to_ui8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[127, 0, 1, 2]> : tensor<4xui8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xsi8>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
+  }
+
+  func.func @no_fold_si8_to_ui8() -> tensor<4xui8> {
+    %0 = "ttir.constant"() {
+      value = dense<[-1, 0, 1, 2]> : tensor<4xsi8>
+    } : () -> tensor<4xsi8>
+
+    // CHECK-LABEL: func.func @no_fold_si8_to_ui8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[-1, 0, 1, 2]> : tensor<4xsi8>
+    // CHECK: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xsi8>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
+  }
+
+  func.func @typecast_const_ui8_to_si8() -> tensor<4xsi8> {
+    %0 = "ttir.constant"() {
+      value = dense<[127, 0, 1, 2]> : tensor<4xui8>
+    } : () -> tensor<4xui8>
+
+    // CHECK-LABEL: func.func @typecast_const_ui8_to_si8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[127, 0, 1, 2]> : tensor<4xsi8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xui8>) -> tensor<4xsi8>
+    return %1 : tensor<4xsi8>
+  }
+
+  func.func @no_fold_ui8_to_si8() -> tensor<4xsi8> {
+    %0 = "ttir.constant"() {
+      value = dense<[128, 0, 1, 2]> : tensor<4xui8>
+    } : () -> tensor<4xui8>
+
+    // CHECK-LABEL: func.func @no_fold_ui8_to_si8
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[128, 0, 1, 2]> : tensor<4xui8>
+    // CHECK: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xui8>) -> tensor<4xsi8>
+    return %1 : tensor<4xsi8>
+  }
+
+  func.func @typecast_const_ui8_to_si16() -> tensor<4xsi16> {
+    %0 = "ttir.full"() {
+      fill_value = 255 : i32,
+      shape = array<i32: 4>
+    } : () -> tensor<4xui8>
+
+    // CHECK-LABEL: func.func @typecast_const_ui8_to_si16
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 255 : i32
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xui8>) -> tensor<4xsi16>
+    return %1 : tensor<4xsi16>
+  }
+
+  func.func @typecast_const_si16_to_ui8() -> tensor<4xui8> {
+    %0 = "ttir.full"() {
+      fill_value = 255 : i32,
+      shape = array<i32: 4>
+    } : () -> tensor<4xsi16>
+
+    // CHECK-LABEL: func.func @typecast_const_si16_to_ui8
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 255 : i32
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xsi16>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
+  }
+
+  func.func @typecast_const_i32_to_i8() -> tensor<4xi8> {
+    %0 = "ttir.full"() {
+      fill_value = 127 : i32,
+      shape = array<i32: 4>
+    } : () -> tensor<4xi32>
+
+    // CHECK-LABEL: func.func @typecast_const_i32_to_i8
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 127 : i32
+    // CHECK-SAME: -> tensor<4xi8>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xi32>) -> tensor<4xi8>
+    return %1 : tensor<4xi8>
+  }
+
+  func.func @typecast_const_chain() -> tensor<4xbf16> {
+    %0 = "ttir.constant"() {
+      value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf16>
+    } : () -> tensor<4xf16>
+    // CHECK-LABEL: func.func @typecast_const_chain
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xbf16>
+    // CHECK-NOT: "ttir.typecast"
+    %1 = "ttir.typecast"(%0) : (tensor<4xf16>) -> tensor<4xf32>
+    %2 = "ttir.typecast"(%1) : (tensor<4xf32>) -> tensor<4xbf16>
+    return %2 : tensor<4xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #7907 

### Problem description
We should fold `ttir.typecast` when its input is constant to avoid having to "look through" it to find creation ops.

### What's changed
Implement `fold` method for `ttir.typecast` op.

### Checklist
- [x] New/Existing tests provide coverage for changes
