### PR TITLE
[D2M] Split GridSelection analysis to separate file

### DIFF
--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -33,10 +33,10 @@ struct OperandGridInfo {
 struct GenericGridAnalysisResult {
   llvm::SmallVector<OperandGridInfo, 4> operandInfos;
   llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids;
-  // Generic's target grid shape: the full device grid by default, or the
-  // scoped range when the generic is nested in a d2m.spatial region. Used
-  // for virtual grid physical mapping.
-  llvm::SmallVector<int64_t> deviceGrid;
+  // The effective target grid for this generic: the full device grid by
+  // default, or the range scoped by an enclosing d2m.spatial region. Used
+  // as the 2D placement bound for virtual grid physical mapping.
+  llvm::SmallVector<int64_t> effectiveTargetGrid;
 };
 
 /// Module-level analysis that computes optimal grid assignments for all

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -33,27 +33,24 @@ struct OperandGridInfo {
 struct GenericGridAnalysisResult {
   llvm::SmallVector<OperandGridInfo, 4> operandInfos;
   llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids;
-  // Device grid shape used for virtual grid physical mapping.
+  // Generic's target grid shape: the full device grid by default, or the
+  // scoped range when the generic is nested in a d2m.spatial region. Used
+  // for virtual grid physical mapping.
   llvm::SmallVector<int64_t> deviceGrid;
-  bool ttnnMode;
 };
 
 /// Module-level analysis that computes optimal grid assignments for all
 /// d2m.generic ops before any IR modification.
 ///
 /// Usage pattern (matches BlockFactorAnalysis):
-///   GridAnalysis gridAnalysis(moduleOp, options);
+///   GridAnalysis gridAnalysis(moduleOp, deviceGridShape, ttnnMode);
 ///   for (auto genericOp : ...) {
 ///     const auto *result = gridAnalysis.lookup(genericOp);
 ///     // apply transforms using result
 ///   }
 struct GridAnalysis {
-  struct Options {
-    llvm::SmallVector<int64_t> deviceGridShape;
-    bool ttnnMode = false;
-  };
-
-  GridAnalysis(Operation *moduleOp, const Options &opts);
+  GridAnalysis(Operation *moduleOp, ArrayRef<int64_t> deviceGridShape,
+               bool ttnnMode);
 
   /// Look up the pre-computed grid analysis for a generic op.
   /// Returns nullptr if the generic was skipped.

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -16,55 +16,26 @@
 
 namespace mlir::tt::d2m {
 
-/// Configuration for GridAnalysis grid computation.
-struct GridConfig {
-  llvm::SmallVector<int64_t> targetGridShape;
-  bool ttnnMode;
-};
-
-/// Classification of how a GenericOp operand should be updated during the
-/// grid selection transform phase.
-enum class OperandUpdateKind {
-  ToLayout,
-  TTNNTensor,
-  Empty,
-  ViewLayout,
-  CompositeView,
-  None,
-};
-
-/// Per-operand analysis result describing the chosen grid and which op needs
-/// updating.
+/// Per-operand analysis result describing the chosen grid for a GenericOp
+/// operand. The concrete update strategy is recovered at apply time from the
+/// operand's defining op.
 struct OperandGridInfo {
-  unsigned operandIndex;
+  Value operand;
   llvm::SmallVector<int64_t> selectedGrid;
-  llvm::SmallVector<int64_t> targetGrid; // Per-operand target grid used for
-                                         // grid computation and alignment.
-  OperandUpdateKind updateKind;
+  llvm::SmallVector<int64_t> targetGrid;
 
-  // Op handles — only the relevant one is set based on updateKind.
-  d2m::ToLayoutOp toLayoutOp;
-  Value ttnnOperand;
-  d2m::EmptyOp emptyOp;
-  d2m::ViewLayoutOp viewLayoutOp;
-  d2m::CompositeViewOp compositeViewOp;
-
-  // For ViewLayout operands whose input is a ToLayoutOp: the ToLayoutOp's
-  // independently computed optimal grid and op handle.
-  llvm::SmallVector<int64_t> toLayoutGrid;
-  d2m::ToLayoutOp behindViewToLayoutOp;
+  // Set only when the operand is a ViewLayoutOp whose input is a ToLayoutOp
+  // that should have its grid optimized independently; empty otherwise.
+  llvm::SmallVector<int64_t> behindViewToLayoutGrid;
 };
 
 /// Per-GenericOp analysis result containing all grid decisions.
 struct GenericGridAnalysisResult {
   llvm::SmallVector<OperandGridInfo, 4> operandInfos;
   llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids;
+  // Device grid shape used for virtual grid physical mapping.
+  llvm::SmallVector<int64_t> deviceGrid;
   bool ttnnMode;
-
-  // The effective target grid used for grid computation. Defaults to the full
-  // device grid; per-op/operand decisions can constrain it (e.g. square for
-  // matmul k-dim).
-  llvm::SmallVector<int64_t> effectiveTargetGrid;
 };
 
 /// Module-level analysis that computes optimal grid assignments for all
@@ -88,10 +59,14 @@ struct GridAnalysis {
   /// Returns nullptr if the generic was skipped.
   const GenericGridAnalysisResult *lookup(GenericOp genericOp) const;
 
+  /// Check if an operand traces back to a TTNNMetalLayoutCastOp through
+  /// ViewLayoutOp chains.
+  static bool isTTNNOperand(Value operand);
+
 private:
   /// Analyze a single GenericOp and compute grid decisions for all operands.
   GenericGridAnalysisResult analyzeGenericOp(GenericOp genericOp,
-                                             const GridConfig &config);
+                                             ArrayRef<int64_t> targetGridShape);
 
   /// Compute the target grid shape for a generic, accounting for spatial
   /// region grid ranges.
@@ -106,13 +81,10 @@ private:
       ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids,
       ArrayRef<llvm::SmallVector<int64_t>> physicalShapes);
 
-  /// Check if an operand traces back to a TTNNMetalLayoutCastOp through
-  /// ViewLayoutOp chains.
-  static bool isTTNNOperand(Value operand);
-
   llvm::DenseMap<Operation *, std::unique_ptr<GenericGridAnalysisResult>>
       results;
   llvm::SmallVector<int64_t> deviceGridShape;
+  bool ttnnMode;
 };
 
 } // namespace mlir::tt::d2m

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -25,8 +25,9 @@ struct OperandGridInfo {
   llvm::SmallVector<int64_t> targetGrid;
 
   // Set only when the operand is a ViewLayoutOp whose input is a ToLayoutOp
-  // that should have its grid optimized independently; empty otherwise.
-  llvm::SmallVector<int64_t> behindViewToLayoutGrid;
+  // that should have its grid optimized independently. Carries the optimal
+  // grid for that upstream ToLayoutOp's own tensor shape. Empty otherwise.
+  llvm::SmallVector<int64_t> viewSourceGrid;
 };
 
 /// Per-GenericOp analysis result containing all grid decisions.

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_ANALYSIS_GRIDANALYSIS_H
+#define TTMLIR_DIALECT_D2M_ANALYSIS_GRIDANALYSIS_H
+
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <memory>
+
+namespace mlir::tt::d2m {
+
+/// Configuration for GridAnalysis grid computation.
+struct GridConfig {
+  llvm::SmallVector<int64_t> targetGridShape;
+  bool ttnnMode;
+};
+
+/// Classification of how a GenericOp operand should be updated during the
+/// grid selection transform phase.
+enum class OperandUpdateKind {
+  ToLayout,
+  TTNNTensor,
+  Empty,
+  ViewLayout,
+  CompositeView,
+  None,
+};
+
+/// Per-operand analysis result describing the chosen grid and which op needs
+/// updating.
+struct OperandGridInfo {
+  unsigned operandIndex;
+  llvm::SmallVector<int64_t> selectedGrid;
+  llvm::SmallVector<int64_t> targetGrid; // Per-operand target grid used for
+                                         // grid computation and alignment.
+  OperandUpdateKind updateKind;
+
+  // Op handles — only the relevant one is set based on updateKind.
+  d2m::ToLayoutOp toLayoutOp;
+  Value ttnnOperand;
+  d2m::EmptyOp emptyOp;
+  d2m::ViewLayoutOp viewLayoutOp;
+  d2m::CompositeViewOp compositeViewOp;
+
+  // For ViewLayout operands whose input is a ToLayoutOp: the ToLayoutOp's
+  // independently computed optimal grid and op handle.
+  llvm::SmallVector<int64_t> toLayoutGrid;
+  d2m::ToLayoutOp behindViewToLayoutOp;
+};
+
+/// Per-GenericOp analysis result containing all grid decisions.
+struct GenericGridAnalysisResult {
+  llvm::SmallVector<OperandGridInfo, 4> operandInfos;
+  llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids;
+  bool ttnnMode;
+
+  // The effective target grid used for grid computation. Defaults to the full
+  // device grid; per-op/operand decisions can constrain it (e.g. square for
+  // matmul k-dim).
+  llvm::SmallVector<int64_t> effectiveTargetGrid;
+};
+
+/// Module-level analysis that computes optimal grid assignments for all
+/// d2m.generic ops before any IR modification.
+///
+/// Usage pattern (matches BlockFactorAnalysis):
+///   GridAnalysis gridAnalysis(moduleOp, options);
+///   for (auto genericOp : ...) {
+///     const auto *result = gridAnalysis.lookup(genericOp);
+///     // apply transforms using result
+///   }
+struct GridAnalysis {
+  struct Options {
+    llvm::SmallVector<int64_t> deviceGridShape;
+    bool ttnnMode = false;
+  };
+
+  GridAnalysis(Operation *moduleOp, const Options &opts);
+
+  /// Look up the pre-computed grid analysis for a generic op.
+  /// Returns nullptr if the generic was skipped.
+  const GenericGridAnalysisResult *lookup(GenericOp genericOp) const;
+
+private:
+  /// Analyze a single GenericOp and compute grid decisions for all operands.
+  GenericGridAnalysisResult analyzeGenericOp(GenericOp genericOp,
+                                             const GridConfig &config);
+
+  /// Compute the target grid shape for a generic, accounting for spatial
+  /// region grid ranges.
+  llvm::SmallVector<int64_t> getTargetGridShape(GenericOp genericOp) const;
+
+  /// Normalize operand grids within a generic to ensure consistency across
+  /// operands sharing loop dimensions. Physical shapes are required to ensure
+  /// promoted grid factors evenly divide all affected operands.
+  static llvm::SmallVector<llvm::SmallVector<int64_t>>
+  normalizeOperandGridsForGeneric(
+      GenericOp genericOp,
+      ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids,
+      ArrayRef<llvm::SmallVector<int64_t>> physicalShapes);
+
+  /// Check if an operand traces back to a TTNNMetalLayoutCastOp through
+  /// ViewLayoutOp chains.
+  static bool isTTNNOperand(Value operand);
+
+  llvm::DenseMap<Operation *, std::unique_ptr<GenericGridAnalysisResult>>
+      results;
+  llvm::SmallVector<int64_t> deviceGridShape;
+};
+
+} // namespace mlir::tt::d2m
+
+#endif // TTMLIR_DIALECT_D2M_ANALYSIS_GRIDANALYSIS_H

--- a/include/ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h
@@ -1,15 +1,21 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef TTMLIR_DIALECT_D2M_UTILS_GRIDSELECTIONUTILS_H
 #define TTMLIR_DIALECT_D2M_UTILS_GRIDSELECTIONUTILS_H
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 
-namespace mlir::tt::d2m::utils {
+namespace mlir::tt::d2m {
+
+namespace utils {
 
 // Compute optimal grid shape for a given physical shape and target grid by
 // finding the largest grid dimensions that evenly divide the physical shape.
@@ -17,8 +23,54 @@ namespace mlir::tt::d2m::utils {
 // even distribution of work.
 llvm::SmallVector<int64_t>
 computeOptimalBlockShardedGrid(ArrayRef<int64_t> physicalShape,
-                               ArrayRef<int64_t> targetSquareGridShape);
+                               ArrayRef<int64_t> targetGrid);
 
-} // namespace mlir::tt::d2m::utils
+// Compute optimal virtual grid shape for a given physical shape and target
+// grid. For ND tensors, explores Cartesian product of dimension factors.
+// For 2D tensors, finds the largest factor of the sharded dimension. Returns
+// empty vector if utilization is too low (signals fallback to block sharding).
+llvm::SmallVector<int64_t>
+computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
+                          ArrayRef<int64_t> targetGrid);
+
+// Determine whether a tensor should use a virtual grid based on its physical
+// shape and the target grid. Returns true when block sharding yields low grid
+// utilization or when the tensor is ND.
+bool shouldImplementAsVirtualGrid(mlir::RankedTensorType tensorType,
+                                  ArrayRef<int64_t> physicalShape,
+                                  ArrayRef<int64_t> targetGrid);
+
+// Compute the optimal grid for a tensor, choosing between virtual grid and
+// block sharding based on heuristics.
+llvm::SmallVector<int64_t> computeOptimalGrid(mlir::RankedTensorType tensorType,
+                                              ArrayRef<int64_t> physicalShape,
+                                              ArrayRef<int64_t> targetGrid);
+
+// Compute physical shape for a MetalLayoutAttr. In TTNN mode, returns the raw
+// physical shape without alignment adjustments. Otherwise, computes grid-aware
+// dimension alignments and derives the physical shape (always tile-aligned).
+llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
+                                                ArrayRef<int64_t> targetGrid,
+                                                bool ttnnMode,
+                                                mlir::OpBuilder &builder);
+
+// Create a new MetalLayoutAttr with the given optimal grid and proper dimension
+// alignments.
+ttcore::MetalLayoutAttr layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
+                                              ArrayRef<int64_t> targetGrid,
+                                              bool ttnnMode,
+                                              ArrayRef<int64_t> optimalGrid,
+                                              mlir::OpBuilder &builder);
+
+// Create a new RankedTensorType with the given optimal grid, recomputing the
+// device shape and layout accordingly.
+mlir::RankedTensorType tensorWithOptimalGrid(mlir::RankedTensorType oldTensor,
+                                             ArrayRef<int64_t> targetGrid,
+                                             bool ttnnMode,
+                                             ArrayRef<int64_t> optimalGrid,
+                                             mlir::OpBuilder &builder);
+
+} // namespace utils
+} // namespace mlir::tt::d2m
 
 #endif // TTMLIR_DIALECT_D2M_UTILS_GRIDSELECTIONUTILS_H

--- a/include/ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h
@@ -51,24 +51,20 @@ llvm::SmallVector<int64_t> computeOptimalGrid(mlir::RankedTensorType tensorType,
 // dimension alignments and derives the physical shape (always tile-aligned).
 llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
                                                 ArrayRef<int64_t> targetGrid,
-                                                bool ttnnMode,
-                                                mlir::OpBuilder &builder);
+                                                bool ttnnMode);
 
-// Create a new MetalLayoutAttr with the given optimal grid and proper dimension
-// alignments.
+// Create a new MetalLayoutAttr with grid-aware dimension alignments for the
+// given target grid.
 ttcore::MetalLayoutAttr layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
                                               ArrayRef<int64_t> targetGrid,
-                                              bool ttnnMode,
-                                              ArrayRef<int64_t> optimalGrid,
-                                              mlir::OpBuilder &builder);
+                                              bool ttnnMode);
 
 // Create a new RankedTensorType with the given optimal grid, recomputing the
 // device shape and layout accordingly.
 mlir::RankedTensorType tensorWithOptimalGrid(mlir::RankedTensorType oldTensor,
                                              ArrayRef<int64_t> targetGrid,
                                              bool ttnnMode,
-                                             ArrayRef<int64_t> optimalGrid,
-                                             mlir::OpBuilder &builder);
+                                             ArrayRef<int64_t> optimalGrid);
 
 } // namespace utils
 } // namespace mlir::tt::d2m

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -367,7 +367,8 @@ static void setInsertionPointToFuncStart(OpBuilder &rewriter,
     rewriter.setInsertionPoint(firstLoop);
   } else {
     // Keep insertion before the block terminator (func.return). Using
-    // setInsertionPointToEnd can place new ops after return in loopless kernels.
+    // setInsertionPointToEnd can place new ops after return in loopless
+    // kernels.
     rewriter.setInsertionPoint(entry.getTerminator());
   }
 }

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -366,7 +366,9 @@ static void setInsertionPointToFuncStart(OpBuilder &rewriter,
   if (firstLoop) {
     rewriter.setInsertionPoint(firstLoop);
   } else {
-    rewriter.setInsertionPointToEnd(&entry);
+    // Keep insertion before the block terminator (func.return). Using
+    // setInsertionPointToEnd can place new ops after return in loopless kernels.
+    rewriter.setInsertionPoint(entry.getTerminator());
   }
 }
 
@@ -804,13 +806,13 @@ public:
       if (auto func = op->template getParentOfType<func::FuncOp>();
           !hasMatmulInit(func)) {
         setInsertionPointToFuncStart(rewriter, func);
-        auto transpose = i32(rewriter, op->getLoc(), 0);
+        auto transposeInit = i32(rewriter, op->getLoc(), 0);
         rewriter.create<ttkernel::MatmulInitOp>(op->getLoc(), cbA, cbB, outCB,
-                                                transpose);
+                                                transposeInit);
       }
 
-      auto transpose = i32(rewriter, op->getLoc(), 0);
       rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+      auto transpose = i32(rewriter, op->getLoc(), 0);
       rewriter.create<ttkernel::MatmulInitShortOp>(op->getLoc(), cbA, cbB,
                                                    transpose);
       rewriter.create<ttkernel::MatmulTilesOp>(op->getLoc(), cbA, cbB,

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -351,8 +351,8 @@ static void setInsertionPointAfterOperands(OpBuilder &rewriter,
   }
 }
 
-static void setInsertionPointToFuncStart(OpBuilder &rewriter,
-                                         func::FuncOp func) {
+static void setInsertionPointToFuncStart(OpBuilder &rewriter, func::FuncOp func,
+                                         Operation *computeOp) {
   Block &entry = func.getBody().front();
   Operation *firstLoop = nullptr;
 
@@ -365,12 +365,18 @@ static void setInsertionPointToFuncStart(OpBuilder &rewriter,
 
   if (firstLoop) {
     rewriter.setInsertionPoint(firstLoop);
-  } else {
-    // Keep insertion before the block terminator (func.return). Using
-    // setInsertionPointToEnd can place new ops after return in loopless
-    // kernels.
-    rewriter.setInsertionPoint(entry.getTerminator());
+    return;
   }
+
+  // Loopless kernel: insert immediately before the entry-level ancestor of
+  // the compute op so that the init op precedes the compute. Setting
+  // insertion to the block terminator would place it after the compute,
+  // leaving the matmul HW uninitialized.
+  Operation *ancestor = computeOp;
+  while (ancestor && ancestor->getBlock() != &entry) {
+    ancestor = ancestor->getParentOp();
+  }
+  rewriter.setInsertionPoint(ancestor ? ancestor : entry.getTerminator());
 }
 
 static bool hasMatmulInit(func::FuncOp func) {
@@ -806,7 +812,7 @@ public:
       // beginning of the func, and only if no MatmulInit already exists.
       if (auto func = op->template getParentOfType<func::FuncOp>();
           !hasMatmulInit(func)) {
-        setInsertionPointToFuncStart(rewriter, func);
+        setInsertionPointToFuncStart(rewriter, func, op);
         auto transposeInit = i32(rewriter, op->getLoc(), 0);
         rewriter.create<ttkernel::MatmulInitOp>(op->getLoc(), cbA, cbB, outCB,
                                                 transposeInit);

--- a/lib/Dialect/D2M/Analysis/CMakeLists.txt
+++ b/lib/Dialect/D2M/Analysis/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRD2MAnalysis
   GenericOpBufferAnalysis.cpp
   CBProducerConsumer.cpp
   GenericInterchangeAnalysis.cpp
+  GridAnalysis.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir
@@ -18,4 +19,5 @@ add_mlir_dialect_library(MLIRD2MAnalysis
     MLIRD2MAllocation
     MLIRD2MUtils
     MLIRTTCoreDialect
+    MLIRTTIRDialect
 )

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -154,21 +154,18 @@ GridAnalysis::normalizeOperandGridsForGeneric(
 }
 
 GenericGridAnalysisResult
-GridAnalysis::analyzeGenericOp(GenericOp genericOp, const GridConfig &config) {
+GridAnalysis::analyzeGenericOp(GenericOp genericOp,
+                               ArrayRef<int64_t> targetGridShape) {
   OpBuilder builder(genericOp->getContext());
   GenericGridAnalysisResult result;
-  result.ttnnMode = config.ttnnMode;
-
-  // The effective target grid is the full device grid, used for virtual grid
-  // physical mapping (findLegalPhysicalGridForVolume).
-  result.effectiveTargetGrid =
-      llvm::SmallVector<int64_t>(config.targetGridShape);
+  result.ttnnMode = ttnnMode;
+  result.deviceGrid = llvm::SmallVector<int64_t>(targetGridShape);
 
   // Build per-operand target grids. When a loop dimension maps to different
   // operand-dim positions across operands (e.g. matmul K is dim 1 of LHS but
   // dim 0 of RHS), those positions must use min(gridDims) so that
   // computeGridAwareDimAlignments produces consistent alignments.
-  int64_t minGridDim = *llvm::min_element(config.targetGridShape);
+  int64_t minGridDim = *llvm::min_element(targetGridShape);
   auto indexingMaps = genericOp.getIndexingMapsValue();
   unsigned numLoopDims = indexingMaps.front().getNumDims();
 
@@ -217,7 +214,7 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp, const GridConfig &config) {
     unsigned rank = gridShape.size();
 
     // Start from the full device grid, then cap cross-axis positions.
-    SmallVector<int64_t> opTarget(config.targetGridShape);
+    SmallVector<int64_t> opTarget(targetGridShape);
     // targetGridShape is 2D; cross-axis positions index into the last 2 dims
     // of the operand shape. Map them to the 2D target grid.
     for (unsigned pos : crossAxisPositions[operandIdx]) {
@@ -241,67 +238,36 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp, const GridConfig &config) {
                "GridSelection expects GenericOp inputs/outputs to have "
                "MetalLayoutAttr");
 
-    unsigned idx = static_cast<unsigned>(operandIndex);
     ArrayRef<int64_t> targetGrid = perOperandTargetGrids[operandIndex];
-    llvm::SmallVector<int64_t> physShape = utils::computePhysicalShape(
-        operand, targetGrid, config.ttnnMode, builder);
+    llvm::SmallVector<int64_t> physShape =
+        utils::computePhysicalShape(operand, targetGrid, ttnnMode, builder);
     physicalShapes.push_back(physShape);
     auto optimalGrid =
         utils::computeOptimalGrid(operandType, physShape, targetGrid);
     optimalOperandGrids.push_back(optimalGrid);
 
     OperandGridInfo info;
-    info.operandIndex = idx;
+    info.operand = operand;
     info.selectedGrid = optimalGrid; // Will be updated after normalization.
     info.targetGrid = perOperandTargetGrids[operandIndex];
 
-    if (isTTNNOperand(operand)) {
-      info.updateKind = OperandUpdateKind::TTNNTensor;
-      info.ttnnOperand = operand;
-    } else if (auto viewLayout = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
-      // Track non-reinterpret views so their output type can be updated to
-      // match the normalized grid. Reinterpret views are just type casts and
-      // their grid must match the input — don't update them.
-      if (!viewLayout.getReinterpretLayout()) {
-        info.updateKind = OperandUpdateKind::ViewLayout;
-        info.viewLayoutOp = viewLayout;
-      } else {
-        info.updateKind = OperandUpdateKind::None;
-      }
-
-      // If the view's input is a ToLayoutOp, also compute the optimal grid for
-      // that ToLayoutOp independently.
+    // If the operand is a view over a ToLayoutOp (not fronting a TTNN cast),
+    // pre-compute the ToLayoutOp's own optimal grid so it can be updated
+    // independently at apply time.
+    if (auto viewLayout = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
       if (auto toLayoutOp =
               viewLayout.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
         if (!toLayoutOp.getInput()
                  .getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
           auto inputType = mlir::cast<mlir::RankedTensorType>(
               viewLayout.getInput().getType());
-
           llvm::SmallVector<int64_t> inputPhysShape =
               utils::computePhysicalShape(viewLayout.getInput(), targetGrid,
-                                          config.ttnnMode, builder);
-          auto inputOptimalGrid =
+                                          ttnnMode, builder);
+          info.behindViewToLayoutGrid =
               utils::computeOptimalGrid(inputType, inputPhysShape, targetGrid);
-
-          info.behindViewToLayoutOp = toLayoutOp;
-          info.toLayoutGrid = inputOptimalGrid;
         }
       }
-    } else if (auto compositeViewOp =
-                   operand.getDefiningOp<d2m::CompositeViewOp>()) {
-      info.updateKind = OperandUpdateKind::CompositeView;
-      info.compositeViewOp = compositeViewOp;
-    } else if (auto toLayoutOp = operand.getDefiningOp<d2m::ToLayoutOp>()) {
-      info.updateKind = OperandUpdateKind::ToLayout;
-      info.toLayoutOp = toLayoutOp;
-    } else if (auto emptyOp = operand.getDefiningOp<d2m::EmptyOp>()) {
-      info.updateKind = OperandUpdateKind::Empty;
-      info.emptyOp = emptyOp;
-    } else {
-      // Block arguments or producers we don't rewrite: record the selected
-      // grid but skip the per-op update phase.
-      info.updateKind = OperandUpdateKind::None;
     }
 
     result.operandInfos.push_back(std::move(info));
@@ -311,13 +277,18 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp, const GridConfig &config) {
   result.normalizedOperandGrids = normalizeOperandGridsForGeneric(
       genericOp, optimalOperandGrids, physicalShapes);
 
-  // Propagate normalized grids back to ViewLayout operand infos only.
-  // Other operand kinds (ToLayout, Empty, TTNN, CompositeView) use their
-  // independently computed optimal grids — normalization may produce grids
-  // that exceed what the individual tensor can physically support.
-  for (auto &info : result.operandInfos) {
-    if (info.updateKind == OperandUpdateKind::ViewLayout) {
-      info.selectedGrid = result.normalizedOperandGrids[info.operandIndex];
+  // Propagate normalized grids back to non-reinterpret ViewLayout operands
+  // only. Other operand kinds use their independently computed optimal
+  // grids — normalization may produce grids that exceed what the individual
+  // tensor can physically support.
+  for (unsigned idx = 0; idx < result.operandInfos.size(); ++idx) {
+    OperandGridInfo &info = result.operandInfos[idx];
+    if (isTTNNOperand(info.operand)) {
+      continue;
+    }
+    auto view = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
+    if (view && !view.getReinterpretLayout()) {
+      info.selectedGrid = result.normalizedOperandGrids[idx];
     }
   }
 
@@ -341,7 +312,7 @@ GridAnalysis::getTargetGridShape(GenericOp genericOp) const {
 }
 
 GridAnalysis::GridAnalysis(Operation *moduleOp, const Options &opts)
-    : deviceGridShape(opts.deviceGridShape) {
+    : deviceGridShape(opts.deviceGridShape), ttnnMode(opts.ttnnMode) {
   moduleOp->walk([&](GenericOp genericOp) {
     // Skip explicit datamovement form — users manage grids manually.
     if (genericOp.isExplicitDatamovementForm()) {
@@ -352,11 +323,9 @@ GridAnalysis::GridAnalysis(Operation *moduleOp, const Options &opts)
     }
 
     llvm::SmallVector<int64_t> targetGridShape = getTargetGridShape(genericOp);
-    GridConfig config{targetGridShape, opts.ttnnMode};
-
     results[genericOp.getOperation()] =
         std::make_unique<GenericGridAnalysisResult>(
-            analyzeGenericOp(genericOp, config));
+            analyzeGenericOp(genericOp, targetGridShape));
   });
 }
 

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -158,7 +158,6 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
                                ArrayRef<int64_t> targetGridShape) {
   OpBuilder builder(genericOp->getContext());
   GenericGridAnalysisResult result;
-  result.ttnnMode = ttnnMode;
   result.deviceGrid = llvm::SmallVector<int64_t>(targetGridShape);
 
   // Build per-operand target grids. When a loop dimension maps to different
@@ -311,8 +310,9 @@ GridAnalysis::getTargetGridShape(GenericOp genericOp) const {
   return llvm::SmallVector<int64_t>(deviceGridShape);
 }
 
-GridAnalysis::GridAnalysis(Operation *moduleOp, const Options &opts)
-    : deviceGridShape(opts.deviceGridShape), ttnnMode(opts.ttnnMode) {
+GridAnalysis::GridAnalysis(Operation *moduleOp,
+                           ArrayRef<int64_t> deviceGridShape, bool ttnnMode)
+    : deviceGridShape(deviceGridShape), ttnnMode(ttnnMode) {
   moduleOp->walk([&](GenericOp genericOp) {
     // Skip explicit datamovement form — users manage grids manually.
     if (genericOp.isExplicitDatamovementForm()) {

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -262,7 +262,7 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
           llvm::SmallVector<int64_t> inputPhysShape =
               utils::computePhysicalShape(viewLayout.getInput(), targetGrid,
                                           ttnnMode);
-          info.behindViewToLayoutGrid =
+          info.viewSourceGrid =
               utils::computeOptimalGrid(inputType, inputPhysShape, targetGrid);
         }
       }

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -158,7 +158,7 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
                                ArrayRef<int64_t> targetGridShape) {
   OpBuilder builder(genericOp->getContext());
   GenericGridAnalysisResult result;
-  result.deviceGrid = llvm::SmallVector<int64_t>(targetGridShape);
+  result.effectiveTargetGrid = llvm::SmallVector<int64_t>(targetGridShape);
 
   // Build per-operand target grids. When a loop dimension maps to different
   // operand-dim positions across operands (e.g. matmul K is dim 1 of LHS but

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
+
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::tt::d2m {
+
+bool GridAnalysis::isTTNNOperand(Value operand) {
+  while (auto view = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
+    operand = view.getInput();
+  }
+  return operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>() != nullptr;
+}
+
+// Find the largest value <= maxFactor that divides all the given physical
+// dimensions. Returns 1 if no better common factor exists.
+static int64_t findLargestCommonFactor(int64_t maxFactor,
+                                       ArrayRef<int64_t> physicalDims) {
+  for (int64_t f = maxFactor; f > 1; --f) {
+    bool dividesAll = true;
+    for (int64_t dim : physicalDims) {
+      if (dim % f != 0) {
+        dividesAll = false;
+        break;
+      }
+    }
+    if (dividesAll) {
+      return f;
+    }
+  }
+  return 1;
+}
+
+llvm::SmallVector<llvm::SmallVector<int64_t>>
+GridAnalysis::normalizeOperandGridsForGeneric(
+    GenericOp genericOp,
+    ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids,
+    ArrayRef<llvm::SmallVector<int64_t>> physicalShapes) {
+  if (optimalOperandGrids.empty()) {
+    return {};
+  }
+
+  TT_assert(optimalOperandGrids.size() ==
+            genericOp.getInputsAndOutputs().size());
+  TT_assert(physicalShapes.size() == optimalOperandGrids.size());
+
+  llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids(
+      optimalOperandGrids.begin(), optimalOperandGrids.end());
+
+  uint64_t numInputs = genericOp.getInputs().size();
+  // Map: loopDim -> list of (operandIndex, operandDimIdx) pairs that reference
+  // this loop dimension in their indexing maps.
+  llvm::DenseMap<int64_t, llvm::SmallVector<std::pair<uint64_t, uint64_t>>>
+      dimToInputOperandDims;
+
+  auto indexingMaps = genericOp.getIndexingMapsValue();
+  for (uint64_t operandIndex = 0; operandIndex < numInputs; ++operandIndex) {
+    AffineMap operandIndexingMap = indexingMaps[operandIndex];
+    auto results = operandIndexingMap.getResults();
+    for (auto [operandDimIdx, expr] : llvm::enumerate(results)) {
+      auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
+      if (!dimExpr) {
+        continue;
+      }
+      int64_t loopDim = dimExpr.getPosition();
+      dimToInputOperandDims[loopDim].push_back(
+          std::make_pair(operandIndex, static_cast<uint64_t>(operandDimIdx)));
+    }
+  }
+
+  // For each loop dimension shared by multiple inputs, find the largest grid
+  // factor that evenly divides all operands' physical shapes for that dim.
+  for (auto &it : dimToInputOperandDims) {
+    auto &entries = it.second;
+    if (entries.size() < 2) {
+      continue;
+    }
+
+    int64_t maxFactor = 0;
+    SmallVector<int64_t> physDimsForLoop;
+    for (auto [operandIndex, operandDimIdx] : entries) {
+      maxFactor = std::max(maxFactor,
+                           normalizedOperandGrids[operandIndex][operandDimIdx]);
+      physDimsForLoop.push_back(physicalShapes[operandIndex][operandDimIdx]);
+    }
+
+    int64_t commonFactor = findLargestCommonFactor(maxFactor, physDimsForLoop);
+
+    for (auto [operandIndex, operandDimIdx] : entries) {
+      normalizedOperandGrids[operandIndex][operandDimIdx] = commonFactor;
+    }
+  }
+
+  // Compute grid dim constraints implied by the generic's outputs.
+  auto outputIndexingMap =
+      genericOp.getIndexingMapsValue()[genericOp.getOutputs()
+                                           .getBeginOperandIndex()];
+  auto outputShape =
+      optimalOperandGrids[genericOp.getOutputs().getBeginOperandIndex()];
+  std::optional<SmallVector<int64_t>> outputConstraints =
+      d2m::utils::computeDimConstraints(
+          llvm::ArrayRef<AffineMap>(outputIndexingMap),
+          llvm::ArrayRef<SmallVector<int64_t>>(outputShape));
+
+  // Apply output constraints to input operands, but only if the constraint
+  // divides the input's physical shape for that dimension.
+  if (outputConstraints) {
+    for (auto [operandIndex, operand] :
+         llvm::enumerate(genericOp.getInputsAndOutputsMutable())) {
+      if (genericOp.isDpsInit(&operand)) {
+        continue;
+      }
+
+      AffineMap indexingMap = genericOp.getIndexingMap(operandIndex);
+      auto results = indexingMap.getResults();
+      TT_assertv(results.size() == normalizedOperandGrids[operandIndex].size(),
+                 "indexing map results size does not match normalized operand "
+                 "grids size");
+
+      for (auto [resultIdx, expr] : llvm::enumerate(results)) {
+        auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
+        if (!dimExpr) {
+          continue;
+        }
+        int64_t dimPos = dimExpr.getPosition();
+        int64_t constraint = (*outputConstraints)[dimPos];
+        if (constraint != 0) {
+          int64_t physDim = physicalShapes[operandIndex][resultIdx];
+          if (physDim % constraint == 0) {
+            normalizedOperandGrids[operandIndex][resultIdx] = constraint;
+          } else {
+            // Output constraint doesn't divide this operand's physical dim;
+            // find the largest factor that divides both.
+            normalizedOperandGrids[operandIndex][resultIdx] =
+                findLargestCommonFactor(constraint, {physDim, constraint});
+          }
+        }
+      }
+    }
+  }
+
+  return normalizedOperandGrids;
+}
+
+GenericGridAnalysisResult
+GridAnalysis::analyzeGenericOp(GenericOp genericOp, const GridConfig &config) {
+  OpBuilder builder(genericOp->getContext());
+  GenericGridAnalysisResult result;
+  result.ttnnMode = config.ttnnMode;
+
+  // The effective target grid is the full device grid, used for virtual grid
+  // physical mapping (findLegalPhysicalGridForVolume).
+  result.effectiveTargetGrid =
+      llvm::SmallVector<int64_t>(config.targetGridShape);
+
+  // Build per-operand target grids. When a loop dimension maps to different
+  // operand-dim positions across operands (e.g. matmul K is dim 1 of LHS but
+  // dim 0 of RHS), those positions must use min(gridDims) so that
+  // computeGridAwareDimAlignments produces consistent alignments.
+  int64_t minGridDim = *llvm::min_element(config.targetGridShape);
+  auto indexingMaps = genericOp.getIndexingMapsValue();
+  unsigned numLoopDims = indexingMaps.front().getNumDims();
+
+  // For each loop dim, find which operand-dim positions it maps to. If it
+  // appears at different positions across operands, mark those positions as
+  // needing the min constraint.
+  // crossAxisPositions[operandIdx] = set of operand-dim positions that need
+  // min(gridDims).
+  SmallVector<llvm::DenseSet<unsigned>> crossAxisPositions(
+      genericOp.getInputsAndOutputs().size());
+  for (unsigned loopDim = 0; loopDim < numLoopDims; ++loopDim) {
+    SmallVector<std::pair<unsigned, unsigned>> occurrences;
+    for (auto [operandIdx, map] : llvm::enumerate(indexingMaps)) {
+      for (auto [pos, expr] : llvm::enumerate(map.getResults())) {
+        auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
+        if (dimExpr && dimExpr.getPosition() == loopDim) {
+          occurrences.push_back({operandIdx, pos});
+        }
+      }
+    }
+    bool isCrossAxis = false;
+    if (occurrences.size() > 1) {
+      unsigned firstPos = occurrences.front().second;
+      for (auto [opIdx, pos] : occurrences) {
+        if (pos != firstPos) {
+          isCrossAxis = true;
+          break;
+        }
+      }
+    }
+    if (isCrossAxis) {
+      for (auto [opIdx, pos] : occurrences) {
+        crossAxisPositions[opIdx].insert(pos);
+      }
+    }
+  }
+
+  // Build per-operand target grids.
+  SmallVector<SmallVector<int64_t>> perOperandTargetGrids;
+  for (auto [operandIdx, operand] :
+       llvm::enumerate(genericOp.getInputsAndOutputs())) {
+    auto operandType = mlir::cast<mlir::RankedTensorType>(operand.getType());
+    auto operandLayout =
+        mlir::cast<ttcore::MetalLayoutAttr>(operandType.getEncoding());
+    auto gridShape = operandLayout.getGridShape(operandType);
+    unsigned rank = gridShape.size();
+
+    // Start from the full device grid, then cap cross-axis positions.
+    SmallVector<int64_t> opTarget(config.targetGridShape);
+    // targetGridShape is 2D; cross-axis positions index into the last 2 dims
+    // of the operand shape. Map them to the 2D target grid.
+    for (unsigned pos : crossAxisPositions[operandIdx]) {
+      if (pos >= rank - opTarget.size()) {
+        unsigned targetIdx = pos - (rank - opTarget.size());
+        opTarget[targetIdx] = minGridDim;
+      }
+    }
+    perOperandTargetGrids.push_back(opTarget);
+  }
+
+  llvm::SmallVector<llvm::SmallVector<int64_t>> optimalOperandGrids;
+  llvm::SmallVector<llvm::SmallVector<int64_t>> physicalShapes;
+
+  for (auto [operandIndex, operand] :
+       llvm::enumerate(genericOp.getInputsAndOutputs())) {
+    auto operandType = mlir::cast<mlir::RankedTensorType>(operand.getType());
+    auto operandLayout =
+        mlir::dyn_cast<ttcore::MetalLayoutAttr>(operandType.getEncoding());
+    TT_assertv(operandLayout,
+               "GridSelection expects GenericOp inputs/outputs to have "
+               "MetalLayoutAttr");
+
+    unsigned idx = static_cast<unsigned>(operandIndex);
+    ArrayRef<int64_t> targetGrid = perOperandTargetGrids[operandIndex];
+    llvm::SmallVector<int64_t> physShape = utils::computePhysicalShape(
+        operand, targetGrid, config.ttnnMode, builder);
+    physicalShapes.push_back(physShape);
+    auto optimalGrid =
+        utils::computeOptimalGrid(operandType, physShape, targetGrid);
+    optimalOperandGrids.push_back(optimalGrid);
+
+    OperandGridInfo info;
+    info.operandIndex = idx;
+    info.selectedGrid = optimalGrid; // Will be updated after normalization.
+    info.targetGrid = perOperandTargetGrids[operandIndex];
+
+    if (isTTNNOperand(operand)) {
+      info.updateKind = OperandUpdateKind::TTNNTensor;
+      info.ttnnOperand = operand;
+    } else if (auto viewLayout = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
+      // Track non-reinterpret views so their output type can be updated to
+      // match the normalized grid. Reinterpret views are just type casts and
+      // their grid must match the input — don't update them.
+      if (!viewLayout.getReinterpretLayout()) {
+        info.updateKind = OperandUpdateKind::ViewLayout;
+        info.viewLayoutOp = viewLayout;
+      } else {
+        info.updateKind = OperandUpdateKind::None;
+      }
+
+      // If the view's input is a ToLayoutOp, also compute the optimal grid for
+      // that ToLayoutOp independently.
+      if (auto toLayoutOp =
+              viewLayout.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
+        if (!toLayoutOp.getInput()
+                 .getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
+          auto inputType = mlir::cast<mlir::RankedTensorType>(
+              viewLayout.getInput().getType());
+
+          llvm::SmallVector<int64_t> inputPhysShape =
+              utils::computePhysicalShape(viewLayout.getInput(), targetGrid,
+                                          config.ttnnMode, builder);
+          auto inputOptimalGrid =
+              utils::computeOptimalGrid(inputType, inputPhysShape, targetGrid);
+
+          info.behindViewToLayoutOp = toLayoutOp;
+          info.toLayoutGrid = inputOptimalGrid;
+        }
+      }
+    } else if (auto compositeViewOp =
+                   operand.getDefiningOp<d2m::CompositeViewOp>()) {
+      info.updateKind = OperandUpdateKind::CompositeView;
+      info.compositeViewOp = compositeViewOp;
+    } else if (auto toLayoutOp = operand.getDefiningOp<d2m::ToLayoutOp>()) {
+      info.updateKind = OperandUpdateKind::ToLayout;
+      info.toLayoutOp = toLayoutOp;
+    } else if (auto emptyOp = operand.getDefiningOp<d2m::EmptyOp>()) {
+      info.updateKind = OperandUpdateKind::Empty;
+      info.emptyOp = emptyOp;
+    } else {
+      // Block arguments or producers we don't rewrite: record the selected
+      // grid but skip the per-op update phase.
+      info.updateKind = OperandUpdateKind::None;
+    }
+
+    result.operandInfos.push_back(std::move(info));
+  }
+
+  // Normalize the operand grids for the generic operation.
+  result.normalizedOperandGrids = normalizeOperandGridsForGeneric(
+      genericOp, optimalOperandGrids, physicalShapes);
+
+  // Propagate normalized grids back to ViewLayout operand infos only.
+  // Other operand kinds (ToLayout, Empty, TTNN, CompositeView) use their
+  // independently computed optimal grids — normalization may produce grids
+  // that exceed what the individual tensor can physically support.
+  for (auto &info : result.operandInfos) {
+    if (info.updateKind == OperandUpdateKind::ViewLayout) {
+      info.selectedGrid = result.normalizedOperandGrids[info.operandIndex];
+    }
+  }
+
+  return result;
+}
+
+llvm::SmallVector<int64_t>
+GridAnalysis::getTargetGridShape(GenericOp genericOp) const {
+  mlir::Region *region = genericOp->getParentRegion();
+  if (auto spatialOp = mlir::dyn_cast<d2m::SpatialOp>(region->getParentOp())) {
+    mlir::ArrayAttr gridRangesAttr = spatialOp.getGridRanges();
+    unsigned regionIndex = region->getRegionNumber();
+    if (gridRangesAttr && regionIndex < gridRangesAttr.size()) {
+      ttcore::CoreRangeAttr range =
+          mlir::cast<ttcore::CoreRangeAttr>(gridRangesAttr[regionIndex]);
+      return {range.getEndCoord().getY() - range.getStartCoord().getY() + 1,
+              range.getEndCoord().getX() - range.getStartCoord().getX() + 1};
+    }
+  }
+  return llvm::SmallVector<int64_t>(deviceGridShape);
+}
+
+GridAnalysis::GridAnalysis(Operation *moduleOp, const Options &opts)
+    : deviceGridShape(opts.deviceGridShape) {
+  moduleOp->walk([&](GenericOp genericOp) {
+    // Skip explicit datamovement form — users manage grids manually.
+    if (genericOp.isExplicitDatamovementForm()) {
+      return;
+    }
+    if (genericOp->hasAttr("d2m.skip_grid_selection")) {
+      return;
+    }
+
+    llvm::SmallVector<int64_t> targetGridShape = getTargetGridShape(genericOp);
+    GridConfig config{targetGridShape, opts.ttnnMode};
+
+    results[genericOp.getOperation()] =
+        std::make_unique<GenericGridAnalysisResult>(
+            analyzeGenericOp(genericOp, config));
+  });
+}
+
+const GenericGridAnalysisResult *
+GridAnalysis::lookup(GenericOp genericOp) const {
+  auto it = results.find(genericOp.getOperation());
+  if (it == results.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -156,7 +156,6 @@ GridAnalysis::normalizeOperandGridsForGeneric(
 GenericGridAnalysisResult
 GridAnalysis::analyzeGenericOp(GenericOp genericOp,
                                ArrayRef<int64_t> targetGridShape) {
-  OpBuilder builder(genericOp->getContext());
   GenericGridAnalysisResult result;
   result.effectiveTargetGrid = llvm::SmallVector<int64_t>(targetGridShape);
 
@@ -239,7 +238,7 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
 
     ArrayRef<int64_t> targetGrid = perOperandTargetGrids[operandIndex];
     llvm::SmallVector<int64_t> physShape =
-        utils::computePhysicalShape(operand, targetGrid, ttnnMode, builder);
+        utils::computePhysicalShape(operand, targetGrid, ttnnMode);
     physicalShapes.push_back(physShape);
     auto optimalGrid =
         utils::computeOptimalGrid(operandType, physShape, targetGrid);
@@ -262,7 +261,7 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
               viewLayout.getInput().getType());
           llvm::SmallVector<int64_t> inputPhysShape =
               utils::computePhysicalShape(viewLayout.getInput(), targetGrid,
-                                          ttnnMode, builder);
+                                          ttnnMode);
           info.behindViewToLayoutGrid =
               utils::computeOptimalGrid(inputType, inputPhysShape, targetGrid);
         }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -141,9 +141,8 @@ void d2m::EmptyOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
     auto gridShape = llvm::to_vector(metalLayout.getGridShape(resultType));
     if (ttmlir::d2m::utils::grids::requiresVirtualGrid(gridShape,
                                                        targetGridShape)) {
-      auto squareGrid = utils::getSquareTargetGrid(targetGridShape);
       auto physGrid = utils::findLegalPhysicalGridForVolume(
-          ttmlir::utils::volume<int64_t>(gridShape), squareGrid);
+          ttmlir::utils::volume<int64_t>(gridShape), targetGridShape);
       TT_assertv(!physGrid.empty(),
                  "Virtual grid required but no legal physical grid found for "
                  "volume {}; target grid [{},{}]",

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -73,7 +73,7 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
   }
 
   RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
-      outputType, targetGrid, ttnnMode, optimalGrid, builder);
+      outputType, targetGrid, ttnnMode, optimalGrid);
   builder.setInsertionPoint(emptyOp);
 
   // Determine if the chosen grid is virtual (exceeds 2D device bounds or is
@@ -340,7 +340,7 @@ static void applyCompositeViewUpdate(const OperandGridInfo &info,
   auto outType =
       mlir::cast<RankedTensorType>(compositeView.getResult().getType());
   RankedTensorType newOutType = utils::tensorWithOptimalGrid(
-      outType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+      outType, info.targetGrid, ttnnMode, info.selectedGrid);
   auto outLayout =
       mlir::cast<ttcore::MetalLayoutAttr>(newOutType.getEncoding());
 
@@ -439,7 +439,7 @@ static void applyEmptyOpUpdate(const OperandGridInfo &info,
   auto emptyType =
       mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
   RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
-      emptyType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+      emptyType, info.targetGrid, ttnnMode, info.selectedGrid);
   builder.setInsertionPoint(emptyOp);
 
   mlir::AffineMapAttr virtualGridInverseMapping =
@@ -541,7 +541,7 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
   auto oldLayout =
       mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
   RankedTensorType newResultType = utils::tensorWithOptimalGrid(
-      oldResultType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+      oldResultType, info.targetGrid, ttnnMode, info.selectedGrid);
 
   // Compose the original remapping with a reblock map that maps from the
   // old output shape to the new output shape.

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
@@ -29,287 +30,16 @@
 
 namespace mlir::tt::d2m {
 
-struct GridSelectionConfig {
-  ArrayRef<int64_t> targetGridShape;
-  ArrayRef<int64_t> targetSquareGridShape;
-  bool ttnnMode;
-};
-
-//--------------------------------------------------------
-// Virtual Grid
-//--------------------------------------------------------
-
-static std::pair<unsigned, double>
-findMaxDimAndAspectRatio(ArrayRef<int64_t> physicalShape) {
-
-  // Find max aspect ratio between any dim and the other dims combined.
-  double aspectRatio = 1.0;
-  unsigned maxDimIndex = 0;
-  for (size_t i = 0; i < physicalShape.size(); ++i) {
-    double ratio = physicalShape[i];
-    for (size_t j = 0; j < physicalShape.size(); ++j) {
-      if (i == j) {
-        continue;
-      }
-      ratio /= physicalShape[j];
-    }
-    if (ratio > aspectRatio) {
-      aspectRatio = ratio;
-      maxDimIndex = i;
-    }
-  }
-  return {maxDimIndex, aspectRatio};
-}
-
-static llvm::SmallVector<int64_t>
-computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
-                          ArrayRef<int64_t> targetSquareGridShape) {
-
-  int64_t targetGridVolume = ttmlir::utils::volume(targetSquareGridShape);
-  if (physicalShape.size() != 2) {
-
-    // Compute factors for all dims.
-    SmallVector<SmallVector<int64_t>> factors =
-        llvm::to_vector(llvm::map_range(physicalShape, [](int64_t dim) {
-          return ttmlir::utils::getFactors(dim);
-        }));
-
-    auto factorCombinations =
-        ttmlir::utils::computeCartesianProduct<int64_t>(factors);
-
-    // Find grid with the greatest volume that is less than or equal to the
-    // target grid volume.
-    SmallVector<int64_t> bestGrid = {0};
-    int64_t bestGridVolume = 0;
-    for (const auto &grid : factorCombinations) {
-      int64_t gridVolume = ttmlir::utils::volume<int64_t>(grid);
-      if (gridVolume <= targetGridVolume && gridVolume > bestGridVolume) {
-        auto physGrid = utils::findLegalPhysicalGridForVolume(
-            gridVolume, targetSquareGridShape);
-        if (!physGrid.empty()) {
-
-          bestGrid = grid;
-          bestGridVolume = ttmlir::utils::volume<int64_t>(bestGrid);
-        }
-      }
-    }
-    return bestGrid;
-  }
-
-  // If not ND sharded, compute grid for 2D height or width sharding (Nx1, 1xN).
-  auto [shardedDimIndex, aspectRatio] = findMaxDimAndAspectRatio(physicalShape);
-
-  // Find the largest factor of the sharded dimension that fits within the
-  // target grid volume.
-  int64_t bestFactor = 0;
-  const auto factors =
-      ttmlir::utils::getFactors(physicalShape[shardedDimIndex]);
-  for (int64_t factor : llvm::reverse(factors)) {
-    if (factor <= targetGridVolume) {
-      auto physGrid =
-          utils::findLegalPhysicalGridForVolume(factor, targetSquareGridShape);
-      if (!physGrid.empty()) {
-        bestFactor = factor;
-        break;
-      }
-    }
-  }
-
-  // If packing utilization is too low (<=25%), signal infeasibility by
-  // returning an empty grid so the caller can fall back to block sharding.
-  if (bestFactor == 0 ||
-      bestFactor <= static_cast<int64_t>(0.25 * targetGridVolume)) {
-    return {};
-  }
-
-  llvm::SmallVector<int64_t> grid;
-  for (size_t i = 0; i < physicalShape.size(); ++i) {
-    if (i == shardedDimIndex) {
-      grid.push_back(bestFactor);
-    } else {
-      grid.push_back(1);
-    }
-  }
-  return grid;
-}
-
-//--------------------------------------------------------
-// Virtual Grid END
-//--------------------------------------------------------
-
 // ----------------------------------------------------------------------------
-// Grid optimization utilities
+// Transform helpers — these modify the IR to apply grid decisions.
 // ----------------------------------------------------------------------------
-
-// Compute physical shape for a MetalLayoutAttr. In TTNN mode, returns the raw
-// physical shape without alignment adjustments. Otherwise, computes grid-aware
-// dimension alignments and derives the physical shape (always tile-aligned).
-static llvm::SmallVector<int64_t>
-computePhysicalShape(Value operand, const GridSelectionConfig &config,
-                     OpBuilder &builder) {
-
-  auto tensorType = mlir::cast<mlir::RankedTensorType>(operand.getType());
-  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
-
-  // TTNN tensors do not require dim-alignment.
-  if (config.ttnnMode) {
-    return layout.getPhysicalShape(ttcore::TileType::getDefaultShape());
-  }
-
-  llvm::SmallVector<int64_t> tileShape;
-  if (auto tileType =
-          mlir::dyn_cast<ttcore::TileType>(tensorType.getElementType())) {
-    tileShape = llvm::to_vector(tileType.getShape());
-  } else {
-    // Always tile-align when calculating the physical shape, even in the row
-    // major case.
-    tileShape = llvm::to_vector(ttcore::TileType::getDefaultShape());
-  }
-
-  llvm::SmallVector<int64_t> alignments =
-      ttcore::MetalLayoutAttr::computeGridAwareDimAlignments(
-          layout.getLogicalShape(), config.targetSquareGridShape,
-          layout.getNormalizedIntervals());
-
-  auto tempLayout = ttcore::MetalLayoutAttr::get(
-      builder.getContext(), layout.getLogicalShape(), layout.getOobVal(),
-      layout.getMemorySpace(), layout.getMemoryLayout(),
-      layout.getCollapsedIntervals(), alignments);
-
-  return tempLayout.getPhysicalShape(
-      llvm::ArrayRef(tileShape.data(), tileShape.size()));
-}
-
-// The following is a simple heuristic that determines (A) if a tensor _can_
-// be implemented as a virtual grid and (B) if it makes sense to do so based
-// on low grid utilization with regular block sharding.
-static bool shouldImplementAsVirtualGrid(RankedTensorType tensorType,
-                                         ArrayRef<int64_t> physicalShape,
-                                         const GridSelectionConfig &config) {
-
-  ttcore::MetalLayoutAttr layout =
-      mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
-
-  // For now, only non-collapsed 2D virtual grids on L1 are supported.
-  if (layout.hasNonTrivialCollapsedDims(tensorType.getShape()) ||
-      layout.getMemoryLayout() == ttcore::TensorMemoryLayout::Interleaved) {
-    return false;
-  }
-  if (physicalShape.size() != 2) {
-    return true;
-  }
-  auto blockShardedGrid = utils::computeOptimalBlockShardedGrid(
-      physicalShape, config.targetSquareGridShape);
-  auto blockShardedGridVolume =
-      ttmlir::utils::volume<int64_t>(blockShardedGrid);
-  int64_t targetGridVolume =
-      ttmlir::utils::volume<int64_t>(config.targetSquareGridShape);
-  bool lowGridUtilization = blockShardedGridVolume < 0.5 * targetGridVolume;
-  return lowGridUtilization;
-}
-
-static llvm::SmallVector<int64_t>
-computeOptimalGrid(mlir::RankedTensorType tensorType,
-                   ArrayRef<int64_t> physicalShape,
-                   const GridSelectionConfig &config) {
-  if (shouldImplementAsVirtualGrid(tensorType, physicalShape, config)) {
-    auto virtualGrid =
-        computeOptimalVirtualGrid(physicalShape, config.targetSquareGridShape);
-    if (!virtualGrid.empty()) {
-      return virtualGrid;
-    }
-  }
-  return utils::computeOptimalBlockShardedGrid(physicalShape,
-                                               config.targetSquareGridShape);
-}
-
-static ttcore::MetalLayoutAttr
-layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
-                      const GridSelectionConfig &config,
-                      ArrayRef<int64_t> optimalGrid, OpBuilder &builder) {
-  llvm::SmallVector<int64_t> newDimAlignments;
-  if (config.ttnnMode) {
-    // TTNN tensors use simple tile-aligned dim alignments without grid-aware
-    // padding adjustments.
-    newDimAlignments.assign(oldLayout.getLogicalShape().size(), 1);
-    auto defaultTileShape = ttcore::TileType::getDefaultShape();
-    newDimAlignments[newDimAlignments.size() - 1] = defaultTileShape[1];
-    newDimAlignments[newDimAlignments.size() - 2] = defaultTileShape[0];
-  } else {
-    newDimAlignments = ttcore::MetalLayoutAttr::computeGridAwareDimAlignments(
-        oldLayout.getLogicalShape(), config.targetSquareGridShape,
-        oldLayout.getNormalizedIntervals());
-  }
-
-  return ttcore::MetalLayoutAttr::get(
-      builder.getContext(), oldLayout.getLogicalShape(), oldLayout.getOobVal(),
-      oldLayout.getMemorySpace(), oldLayout.getMemoryLayout(),
-      oldLayout.getCollapsedIntervals(), newDimAlignments);
-}
-
-static RankedTensorType tensorWithOptimalGrid(RankedTensorType oldTensor,
-                                              const GridSelectionConfig &config,
-                                              ArrayRef<int64_t> optimalGrid,
-                                              OpBuilder &builder) {
-  auto oldLayout = mlir::cast<ttcore::MetalLayoutAttr>(oldTensor.getEncoding());
-
-  llvm::SmallVector<int64_t> tileShape;
-  Type elementType = oldTensor.getElementType();
-  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
-    tileShape = llvm::to_vector(tileType.getShape());
-    elementType = tileType.getElementType();
-  }
-
-  ttcore::MetalLayoutAttr newLayout =
-      layoutWithOptimalGrid(oldLayout, config, optimalGrid, builder);
-
-  llvm::SmallVector<int64_t> deviceShape = newLayout.getDeviceShape(
-      optimalGrid, llvm::ArrayRef(tileShape.data(), tileShape.size()));
-
-  Type newElementType =
-      tileShape.empty()
-          ? elementType
-          : ttcore::TileType::get(elementType, llvm::ArrayRef(tileShape));
-  return RankedTensorType::get(deviceShape, newElementType, newLayout);
-}
-
-// Rebuild a ToLayoutOp and its associated EmptyOp at a new target type.
-// The EmptyOp builder handles VGM (virtual grid mapping) computation
-// automatically when the grid requires virtualization.
-// Returns the new ToLayoutOp, or nullptr if the old op has no EmptyOp output.
-static d2m::ToLayoutOp
-rebuildToLayoutWithType(d2m::ToLayoutOp toLayoutOp, RankedTensorType newType,
-                        const GridSelectionConfig &config, OpBuilder &builder) {
-  auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
-  if (!emptyOp) {
-    return nullptr;
-  }
-
-  builder.setInsertionPoint(emptyOp);
-  auto newEmptyOp = builder.create<d2m::EmptyOp>(
-      emptyOp.getLoc(), newType.getShape(), newType.getElementType(),
-      newType.getEncoding(), config.targetSquareGridShape);
-
-  builder.setInsertionPoint(toLayoutOp);
-  return builder.create<d2m::ToLayoutOp>(toLayoutOp.getLoc(),
-                                         toLayoutOp.getInput(), newEmptyOp);
-}
-
-// Erase a ToLayoutOp and its EmptyOp output (if no longer used).
-static void eraseToLayoutAndEmpty(d2m::ToLayoutOp toLayoutOp) {
-  auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
-  toLayoutOp.erase();
-  if (emptyOp && emptyOp.getResult().use_empty()) {
-    emptyOp.erase();
-  }
-}
 
 // Update a ToLayoutOp and its associated EmptyOp to use a specified grid by
 // recreating the MetalLayoutAttr with the given grid and proper dimension
-// alignments, then inserting a reblock ViewLayoutOp to preserve IR correctness
-// for downstream consumers.
+// alignments.
 static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
-                                 const GridSelectionConfig &config,
+                                 ArrayRef<int64_t> targetGrid,
+                                 ArrayRef<int64_t> deviceGrid, bool ttnnMode,
                                  ArrayRef<int64_t> optimalGrid,
                                  OpBuilder &builder) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
@@ -342,14 +72,42 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
     return;
   }
 
-  RankedTensorType newTensorType =
-      tensorWithOptimalGrid(outputType, config, optimalGrid, builder);
+  RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
+      outputType, targetGrid, ttnnMode, optimalGrid, builder);
+  builder.setInsertionPoint(emptyOp);
 
-  auto newToLayoutOp =
-      rebuildToLayoutWithType(toLayoutOp, newTensorType, config, builder);
-  if (!newToLayoutOp) {
-    return;
+  // Determine if the chosen grid is virtual (exceeds 2D device bounds or is
+  // ND). Note: VGM is NOT propagated from the to_layout's input here — the
+  // output EmptyOp has its own grid/shard strategy. VGM for DMA addresses
+  // is traced through the stream's input at DMA lowering time.
+  mlir::AffineMapAttr virtualGridInverseMapping;
+  mlir::AffineMapAttr virtualGridForwardMapping;
+  auto device = ttcore::lookupDevice(toLayoutOp);
+  auto workerGridShape = device.getWorkerGrid().getShape();
+  bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
+      optimalGrid, workerGridShape);
+  if (isVirtual) {
+    auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
+        ttmlir::utils::volume<int64_t>(optimalGrid), deviceGrid);
+    TT_assertv(!physicalGridShape.empty(),
+               "Unable to find 2D rect that can fit virtual grid {} within "
+               "device grid {}",
+               ttmlir::utils::formatIterable(optimalGrid, "x"),
+               ttmlir::utils::formatIterable(deviceGrid, "x"));
+    auto [forwardMap, inverseMap] =
+        ttmlir::d2m::utils::grids::createCoreVirtMaps(
+            builder.getContext(), optimalGrid, physicalGridShape);
+    virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
+    virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
   }
+
+  auto newEmptyOp = builder.create<d2m::EmptyOp>(
+      emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
+      virtualGridForwardMapping);
+
+  builder.setInsertionPoint(toLayoutOp);
+  auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
+      toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
 
   // Reblock it back to original shape to preserve IR correctness.
   // The view chain that applyViews composes through depends on this
@@ -423,18 +181,13 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
   }
   toLayoutOp.getResult(0).replaceAllUsesWith(view.getResult());
 
-  eraseToLayoutAndEmpty(toLayoutOp);
-}
-
-static bool isTTNNOperand(Value operand) {
-  while (auto view = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
-    operand = view.getInput();
+  toLayoutOp.erase();
+  if (emptyOp.getResult().use_empty()) {
+    emptyOp.erase();
   }
-  return operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>() != nullptr;
 }
 
 static void insertViewForTTNNDRAMTensor(Value operand,
-                                        const GridSelectionConfig &config,
                                         ArrayRef<int64_t> optimalGrid,
                                         OpBuilder &builder) {
   while (auto viewOp = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
@@ -490,9 +243,10 @@ static void insertViewForTTNNDRAMTensor(Value operand,
   castOp.getResult().replaceAllUsesExcept(viewOp.getResult(), viewOp);
 }
 
-static void optimizeTTNNMetalLayoutCastOpGrid(
-    ttir::TTNNMetalLayoutCastOp castOp, const GridSelectionConfig &config,
-    ArrayRef<int64_t> optimalGrid, OpBuilder &builder) {
+static void
+optimizeTTNNMetalLayoutCastOpGrid(ttir::TTNNMetalLayoutCastOp castOp,
+                                  ArrayRef<int64_t> optimalGrid,
+                                  OpBuilder &builder) {
   auto outputType =
       mlir::cast<mlir::RankedTensorType>(castOp.getResult().getType());
   auto outputLayout =
@@ -530,270 +284,58 @@ static void optimizeTTNNMetalLayoutCastOpGrid(
                                           newViewLayoutOp);
 }
 
-struct ToLayoutUpdateInfo {
-  d2m::ToLayoutOp op;
-  unsigned operandIndex;
-  llvm::SmallVector<int64_t> grid;
-};
+// ----------------------------------------------------------------------------
+// Transform phases — apply pre-computed grid decisions to the IR.
+// ----------------------------------------------------------------------------
 
-struct TTNNTensorUpdateInfo {
-  Value operand;
-  unsigned operandIndex;
-  llvm::SmallVector<int64_t> grid;
-};
-
-struct EmptyUpdateInfo {
-  d2m::EmptyOp op;
-  unsigned operandIndex;
-  llvm::SmallVector<int64_t> grid;
-};
-
-struct ViewLayoutUpdateInfo {
-  d2m::ViewLayoutOp op;
-  unsigned operandIndex;
-  llvm::SmallVector<int64_t> grid;
-};
-
-struct CompositeViewUpdateInfo {
-  d2m::CompositeViewOp op;
-  unsigned operandIndex;
-  llvm::SmallVector<int64_t> grid;
-};
-
-struct GridAnalysisResult {
-  llvm::SmallVector<llvm::SmallVector<int64_t>> optimalOperandGrids;
-  llvm::SmallVector<ToLayoutUpdateInfo> toLayouts;
-  llvm::SmallVector<TTNNTensorUpdateInfo> ttnnTensors;
-  llvm::SmallVector<EmptyUpdateInfo> emptyOps;
-  llvm::SmallVector<ViewLayoutUpdateInfo> viewLayouts;
-  llvm::SmallVector<CompositeViewUpdateInfo> compositeViews;
-};
-
-// This function normalizes the operand grids for a generic operation by
-// ensuring that the grids are consistent across all operands that share the
-// same loop dimension. We also need to make sure that the grids respect any
-// constraints implied by the outputs' grids. If multiple operands participate
-// in the same loop dimension, the corresponding grid extents must agree.
-static llvm::SmallVector<llvm::SmallVector<int64_t>>
-normalizeOperandGridsForGeneric(
-    d2m::GenericOp genericOp,
-    ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids) {
-  if (optimalOperandGrids.empty()) {
-    return {};
-  }
-
-  TT_assert(optimalOperandGrids.size() ==
-            genericOp.getInputsAndOutputs().size());
-
-  // First, normalize input operand grids for operands that share loop
-  // dimensions. For example, in a matmul, the two inputs share the reduction
-  // dimension. If their independently chosen optimal grids differ along that
-  // dimension, promote the grid factor for that *dimension only* to the
-  // maximum across all inputs that share it.
-  llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids(
-      optimalOperandGrids.begin(), optimalOperandGrids.end());
-
-  uint64_t numInputs = genericOp.getInputs().size();
-  // Map: loopDim -> list of (operandIndex, operandDimIdx) pairs that reference
-  // this loop dimension in their indexing maps.
-  llvm::DenseMap<int64_t, llvm::SmallVector<std::pair<uint64_t, uint64_t>>>
-      dimToInputOperandDims;
-
-  auto indexingMaps = genericOp.getIndexingMapsValue();
-  for (uint64_t operandIndex = 0; operandIndex < numInputs; ++operandIndex) {
-    AffineMap operandIndexingMap = indexingMaps[operandIndex];
-    auto results = operandIndexingMap.getResults();
-    for (auto [operandDimIdx, expr] : llvm::enumerate(results)) {
-      auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
-      if (!dimExpr) {
-        continue;
-      }
-      int64_t loopDim = dimExpr.getPosition();
-      dimToInputOperandDims[loopDim].push_back(
-          std::make_pair(operandIndex, static_cast<uint64_t>(operandDimIdx)));
-    }
-  }
-
-  // For each loop dimension that is used by multiple inputs, promote the grid
-  // size associated with that loop dimension to the maximum across those
-  // inputs.
-  for (auto &it : dimToInputOperandDims) {
-    auto &entries = it.second;
-    if (entries.size() < 2) {
-      continue;
-    }
-
-    int64_t maxFactor = 0;
-    TT_assertv(
-        entries.size() <= normalizedOperandGrids.size(),
-        "adjusted operand grids size does not match dim-operand mapping size");
-    for (auto [operandIndex, operandDimIdx] : entries) {
-      TT_assertv(operandDimIdx < normalizedOperandGrids[operandIndex].size(),
-                 "operand dim index out of bounds on adjusted operand grids");
-      maxFactor = std::max(maxFactor,
-                           normalizedOperandGrids[operandIndex][operandDimIdx]);
-    }
-    for (auto [operandIndex, operandDimIdx] : entries) {
-      TT_assertv(operandDimIdx < normalizedOperandGrids[operandIndex].size(),
-                 "operand dim index out of bounds on adjusted operand grids");
-      normalizedOperandGrids[operandIndex][operandDimIdx] = maxFactor;
-    }
-  }
-
-  // Compute grid dim constraints implied by the generic's outputs. These
-  // constraints describe which loop dimensions must agree across operands.
-  auto outputIndexingMap =
-      genericOp.getIndexingMapsValue()[genericOp.getOutputs()
-                                           .getBeginOperandIndex()];
-  auto outputShape =
-      optimalOperandGrids[genericOp.getOutputs().getBeginOperandIndex()];
-  std::optional<SmallVector<int64_t>> outputConstraints =
-      utils::computeDimConstraints(
-          llvm::ArrayRef<AffineMap>(outputIndexingMap),
-          llvm::ArrayRef<SmallVector<int64_t>>(outputShape));
-
-  // Ensure that input operand grid shapes respect any constraints implied by
-  // the outputs' grids. If multiple operands participate in the same loop
-  // dimension, the corresponding grid extents must agree.
-  if (outputConstraints) {
-    for (auto [operandIndex, operand] :
-         llvm::enumerate(genericOp.getInputsAndOutputsMutable())) {
-      if (genericOp.isDpsInit(&operand)) {
-        continue;
-      }
-
-      AffineMap indexingMap = genericOp.getIndexingMap(operandIndex);
-      auto results = indexingMap.getResults();
-      TT_assertv(results.size() == normalizedOperandGrids[operandIndex].size(),
-                 "indexing map results size does not match normalized operand "
-                 "grids size");
-
-      for (auto [resultIdx, expr] : llvm::enumerate(results)) {
-        auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
-        if (!dimExpr) {
-          continue;
-        }
-        int64_t dimPos = dimExpr.getPosition();
-        int64_t constraint = (*outputConstraints)[dimPos];
-        if (constraint != 0) {
-          normalizedOperandGrids[operandIndex][resultIdx] = constraint;
-        }
-      }
-    }
-  }
-
-  return normalizedOperandGrids;
-}
-
-// Phase 1: Analyze each operand of a GenericOp and compute optimal grids.
-// We compute grids independently per operand to mirror the old TTIRToD2M
-// behavior, ensuring compatibility with existing grid assignment logic.
-static GridAnalysisResult
-analyzeOperandsAndComputeGrids(d2m::GenericOp genericOp,
-                               const GridSelectionConfig &config) {
-  OpBuilder builder(genericOp->getContext());
-  GridAnalysisResult result;
-
-  for (auto [operandIndex, operand] :
-       llvm::enumerate(genericOp.getInputsAndOutputs())) {
-    auto operandType = mlir::cast<mlir::RankedTensorType>(operand.getType());
-    auto operandLayout =
-        mlir::dyn_cast<ttcore::MetalLayoutAttr>(operandType.getEncoding());
-    TT_assertv(operandLayout,
-               "GridSelection expects GenericOp inputs/outputs to have "
-               "MetalLayoutAttr");
-
-    unsigned idx = static_cast<unsigned>(operandIndex);
-    llvm::SmallVector<int64_t> physShape =
-        computePhysicalShape(operand, config, builder);
-    auto optimalGrid = computeOptimalGrid(operandType, physShape, config);
-    result.optimalOperandGrids.push_back(optimalGrid);
-
-    if (isTTNNOperand(operand)) {
-      result.ttnnTensors.push_back({operand, idx, optimalGrid});
-    } else if (auto viewLayout = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
-      // Track non-reinterpret views so their output type can be updated to
-      // match the normalized grid. Reinterpret views are just type casts and
-      // their grid must match the input — don't update them.
-      if (!viewLayout.getReinterpretLayout()) {
-        result.viewLayouts.push_back({viewLayout, idx, optimalGrid});
-      }
-
-      // If the view's input is a ToLayoutOp, also compute and apply the
-      // optimal grid for that ToLayoutOp independently.
-      if (auto toLayoutOp =
-              viewLayout.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
-        if (!toLayoutOp.getInput()
-                 .getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
-          auto inputType = mlir::cast<mlir::RankedTensorType>(
-              viewLayout.getInput().getType());
-
-          llvm::SmallVector<int64_t> inputPhysShape =
-              computePhysicalShape(viewLayout.getInput(), config, builder);
-          auto inputOptimalGrid =
-              computeOptimalGrid(inputType, inputPhysShape, config);
-
-          result.toLayouts.push_back({toLayoutOp, idx, inputOptimalGrid});
-        }
-      }
-    } else if (auto compositeViewOp =
-                   operand.getDefiningOp<d2m::CompositeViewOp>()) {
-      result.compositeViews.push_back({compositeViewOp, idx, optimalGrid});
-    } else if (auto toLayoutOp = operand.getDefiningOp<d2m::ToLayoutOp>()) {
-      result.toLayouts.push_back({toLayoutOp, idx, optimalGrid});
-    } else if (auto emptyOp = operand.getDefiningOp<d2m::EmptyOp>()) {
-      result.emptyOps.push_back({emptyOp, idx, optimalGrid});
-    }
-  }
-
-  // Normalize the operand grids for the generic operation - see the comment on
-  // this function for details.
-  result.optimalOperandGrids =
-      normalizeOperandGridsForGeneric(genericOp, result.optimalOperandGrids);
-
-  // Propagate normalized grids back to view layout update infos, since their
-  // grids may have been adjusted during normalization.
-  for (auto &info : result.viewLayouts) {
-    info.grid = result.optimalOperandGrids[info.operandIndex];
-  }
-
-  return result;
-}
-
-// Phase 2: Update ToLayoutOps with their optimal grids.
-static void updateToLayoutOps(ArrayRef<ToLayoutUpdateInfo> toLayoutsToUpdate,
-                              const GridSelectionConfig &config) {
-  if (toLayoutsToUpdate.empty()) {
+static void applyToLayoutUpdates(ArrayRef<const OperandGridInfo *> toLayouts,
+                                 ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
+  if (toLayouts.empty()) {
     return;
   }
 
-  OpBuilder builder(toLayoutsToUpdate.front().op->getContext());
-  for (auto &info : toLayoutsToUpdate) {
-    optimizeToLayoutGrid(info.op, config, info.grid, builder);
+  OpBuilder builder(toLayouts.front()->toLayoutOp->getContext());
+  for (const auto *info : toLayouts) {
+    optimizeToLayoutGrid(info->toLayoutOp, info->targetGrid, deviceGrid,
+                         ttnnMode, info->selectedGrid, builder);
   }
 }
 
-// Phase 3: Update TTNN tensors with their optimal grids.
 static void
-updateTTNNTensors(ArrayRef<TTNNTensorUpdateInfo> TTNNTensorsToUpdate,
-                  const GridSelectionConfig &config) {
-  if (TTNNTensorsToUpdate.empty()) {
+applyBehindViewToLayoutUpdates(ArrayRef<const OperandGridInfo *> infos,
+                               ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
+  if (infos.empty()) {
     return;
   }
 
-  OpBuilder builder(TTNNTensorsToUpdate.front().operand.getContext());
-  for (auto &info : TTNNTensorsToUpdate) {
+  OpBuilder builder(infos.front()->behindViewToLayoutOp->getContext());
+  for (const auto *info : infos) {
+    optimizeToLayoutGrid(info->behindViewToLayoutOp, info->targetGrid,
+                         deviceGrid, ttnnMode, info->toLayoutGrid, builder);
+  }
+}
+
+static void
+applyTTNNTensorUpdates(ArrayRef<const OperandGridInfo *> ttnnTensors) {
+  if (ttnnTensors.empty()) {
+    return;
+  }
+
+  OpBuilder builder(ttnnTensors.front()->ttnnOperand.getContext());
+  for (const auto *info : ttnnTensors) {
     auto metalTensor =
-        mlir::cast<mlir::RankedTensorType>(info.operand.getType());
+        mlir::cast<mlir::RankedTensorType>(info->ttnnOperand.getType());
     auto metalLayout =
         mlir::cast<ttcore::MetalLayoutAttr>(metalTensor.getEncoding());
     if (metalLayout.getMemorySpace() == ttcore::MemorySpace::DeviceDRAM) {
-      insertViewForTTNNDRAMTensor(info.operand, config, info.grid, builder);
+      insertViewForTTNNDRAMTensor(info->ttnnOperand, info->selectedGrid,
+                                  builder);
     } else if (auto castOp =
-                   info.operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
-      optimizeTTNNMetalLayoutCastOpGrid(castOp, config, info.grid, builder);
-    } else if (auto viewOp = info.operand.getDefiningOp<d2m::ViewLayoutOp>()) {
-      // Erase the view op and directly operate on the defining cast.
+                   info->ttnnOperand
+                       .getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
+      optimizeTTNNMetalLayoutCastOpGrid(castOp, info->selectedGrid, builder);
+    } else if (auto viewOp =
+                   info->ttnnOperand.getDefiningOp<d2m::ViewLayoutOp>()) {
       auto originalOperand = viewOp.getInput();
       auto castOp =
           originalOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>();
@@ -802,7 +344,7 @@ updateTTNNTensors(ArrayRef<TTNNTensorUpdateInfo> TTNNTensorsToUpdate,
           "Expected a TTNNMetalLayoutCastOp as the input of the view op.");
       viewOp.getResult().replaceAllUsesWith(originalOperand);
       viewOp.erase();
-      optimizeTTNNMetalLayoutCastOpGrid(castOp, config, info.grid, builder);
+      optimizeTTNNMetalLayoutCastOpGrid(castOp, info->selectedGrid, builder);
     } else {
       llvm_unreachable("Expected a TTNNMetalLayoutCastOp or a ViewLayoutOp");
     }
@@ -810,23 +352,23 @@ updateTTNNTensors(ArrayRef<TTNNTensorUpdateInfo> TTNNTensorsToUpdate,
 }
 
 static void
-updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
-                       const GridSelectionConfig &config) {
-  if (compositeViewsToUpdate.empty()) {
+applyCompositeViewUpdates(ArrayRef<const OperandGridInfo *> compositeViews,
+                          ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
+  if (compositeViews.empty()) {
     return;
   }
 
-  OpBuilder builder(compositeViewsToUpdate.front().op->getContext());
-  for (const auto &info : compositeViewsToUpdate) {
-    auto compositeView = info.op;
+  OpBuilder builder(compositeViews.front()->compositeViewOp->getContext());
+  for (const auto *info : compositeViews) {
+    auto compositeView = info->compositeViewOp;
     int32_t concatDim = compositeView.getDim();
 
     // Compute the output type first — its grid-aware dim alignments determine
     // what physical shapes the inputs must match on non-concat dimensions.
     auto outType =
         mlir::cast<RankedTensorType>(compositeView.getResult().getType());
-    RankedTensorType newOutType =
-        tensorWithOptimalGrid(outType, config, info.grid, builder);
+    RankedTensorType newOutType = utils::tensorWithOptimalGrid(
+        outType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
     auto outLayout =
         mlir::cast<ttcore::MetalLayoutAttr>(newOutType.getEncoding());
 
@@ -834,7 +376,7 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
     //  - Non-concat dims use the output's grid-aware alignment (so physical
     //    sizes match).
     //  - The concat dim uses tile-only alignment (so each input's contribution
-    //    isn't independently inflated, keeping sum ≤ output).
+    //    isn't independently inflated, keeping sum <= output).
     auto outDimAlignments = outLayout.getDimAlignments();
 
     SmallVector<Value> reblockedInputs;
@@ -852,11 +394,10 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
 
       // Derive input dim alignments from the output, overriding the concat
       // dim with tile-only alignment so each input's contribution isn't
-      // independently inflated.
-      // Note: concatDim is already normalized to [0, rank) by TTIRToD2M.
-      // For tile dims (height/width), use the tile shape alignment (e.g. 32).
-      // For batch dims, use 1 — no tile alignment is required and the output's
-      // grid-aware alignment handles the final padded result.
+      // independently inflated. concatDim is already normalized to
+      // [0, logicalRank) by TTIRToD2M; the trailing two logical dims map to
+      // the tile's height/width (tileIdx 0/1), earlier dims are batch dims
+      // where tile alignment isn't required (fall back to 1).
       llvm::SmallVector<int64_t> inputAlignments(outDimAlignments.begin(),
                                                  outDimAlignments.end());
       int64_t logicalRank = inputLayout.getLogicalShape().size();
@@ -870,8 +411,8 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
           inputAlignments);
 
       auto inputPhysShape = coordLayout.getPhysicalShape(tileShape);
-      auto inputOptimalGrid =
-          computeOptimalGrid(inputType, inputPhysShape, config);
+      auto inputOptimalGrid = utils::computeOptimalGrid(
+          inputType, inputPhysShape, info->targetGrid);
 
       llvm::SmallVector<int64_t> deviceShape =
           coordLayout.getDeviceShape(inputOptimalGrid, tileShape);
@@ -884,13 +425,22 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
       // inputs must coexist in L1 on a single core.
       if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
           toLayoutOp && input.hasOneUse()) {
-        auto newToLayoutOp =
-            rebuildToLayoutWithType(toLayoutOp, newInputType, config, builder);
-        if (newToLayoutOp) {
+        auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
+        if (emptyOp) {
+          builder.setInsertionPoint(emptyOp);
+          auto newEmptyOp = builder.create<d2m::EmptyOp>(
+              emptyOp.getLoc(), newInputType.getShape(),
+              newInputType.getElementType(), newInputType.getEncoding(),
+              deviceGrid);
+          builder.setInsertionPoint(toLayoutOp);
+          auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
+              toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
           toLayoutOp.getResult(0).replaceAllUsesWith(
               newToLayoutOp.getResult(0));
-          eraseToLayoutAndEmpty(toLayoutOp);
-
+          toLayoutOp.erase();
+          if (emptyOp.getResult().use_empty()) {
+            emptyOp.erase();
+          }
           reblockedInputs.push_back(newToLayoutOp.getResult(0));
           continue;
         }
@@ -912,23 +462,21 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
   }
 }
 
-static void updateEmptyOps(ArrayRef<EmptyUpdateInfo> emptyOpsToUpdate,
-                           const GridSelectionConfig &config) {
-  if (emptyOpsToUpdate.empty()) {
+static void applyEmptyOpUpdates(ArrayRef<const OperandGridInfo *> emptyOps,
+                                ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
+  if (emptyOps.empty()) {
     return;
   }
 
-  OpBuilder builder(emptyOpsToUpdate.front().op->getContext());
-  for (auto &info : emptyOpsToUpdate) {
-    EmptyOp emptyOp = info.op;
+  OpBuilder builder(emptyOps.front()->emptyOp->getContext());
+  for (const auto *info : emptyOps) {
+    EmptyOp emptyOp = info->emptyOp;
     auto emptyType =
         mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
-    RankedTensorType newTensorType =
-        tensorWithOptimalGrid(emptyType, config, info.grid, builder);
-    builder.setInsertionPoint(info.op);
+    RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
+        emptyType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
+    builder.setInsertionPoint(emptyOp);
 
-    // Propagate virtualGridInverseMapping if the old EmptyOp had one, or
-    // compute a new one if the grid is virtual.
     mlir::AffineMapAttr virtualGridInverseMapping =
         emptyOp.getVirtualGridInverseMappingAttr();
     mlir::AffineMapAttr virtualGridForwardMapping =
@@ -937,16 +485,15 @@ static void updateEmptyOps(ArrayRef<EmptyUpdateInfo> emptyOpsToUpdate,
       auto device = ttcore::lookupDevice(emptyOp);
       auto workerGridShape = device.getWorkerGrid().getShape();
       bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-          info.grid, workerGridShape);
+          info->selectedGrid, workerGridShape);
       if (isVirtual) {
         auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-            ttmlir::utils::volume<int64_t>(info.grid),
-            config.targetSquareGridShape);
+            ttmlir::utils::volume<int64_t>(info->selectedGrid), deviceGrid);
         TT_assertv(!physicalGridShape.empty(),
                    "Unable to find 2D rect that can fit virtual grid");
         auto [forwardMap, inverseMap] =
             ttmlir::d2m::utils::grids::createCoreVirtMaps(
-                builder.getContext(), info.grid, physicalGridShape);
+                builder.getContext(), info->selectedGrid, physicalGridShape);
         virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
         virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
       }
@@ -1022,21 +569,21 @@ deriveGenericGridAttr(d2m::GenericOp genericOp,
 // the normalized grid. The remapping is composed with a reblock map that
 // accounts for the shape change from the old grid to the new grid.
 static void
-updateViewLayoutOps(ArrayRef<ViewLayoutUpdateInfo> viewLayoutsToUpdate,
-                    const GridSelectionConfig &config) {
-  if (viewLayoutsToUpdate.empty()) {
+applyViewLayoutUpdates(ArrayRef<const OperandGridInfo *> viewLayouts,
+                       bool ttnnMode) {
+  if (viewLayouts.empty()) {
     return;
   }
 
-  OpBuilder builder(viewLayoutsToUpdate.front().op->getContext());
-  for (auto &info : viewLayoutsToUpdate) {
-    d2m::ViewLayoutOp viewOp = info.op;
+  OpBuilder builder(viewLayouts.front()->viewLayoutOp->getContext());
+  for (const auto *info : viewLayouts) {
+    d2m::ViewLayoutOp viewOp = info->viewLayoutOp;
     auto oldResultType =
         mlir::cast<RankedTensorType>(viewOp.getResult().getType());
     auto oldLayout =
         mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
-    RankedTensorType newResultType =
-        tensorWithOptimalGrid(oldResultType, config, info.grid, builder);
+    RankedTensorType newResultType = utils::tensorWithOptimalGrid(
+        oldResultType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
 
     // Compose the original remapping with a reblock map that maps from the
     // old output shape to the new output shape. This mirrors what
@@ -1078,7 +625,7 @@ updateViewLayoutOps(ArrayRef<ViewLayoutUpdateInfo> viewLayoutsToUpdate,
   }
 }
 
-// Phase 5: Recreate the d2m.generic with updated operands.
+// Recreate the d2m.generic with updated operands.
 // After updating ToLayout and ViewLayout ops, the generic's operands have
 // new types with the selected grids. The generic grid is still anchored by the
 // output operand's chosen grid, but we must re-materialize the generic attrs
@@ -1110,25 +657,60 @@ recreateGenericOp(d2m::GenericOp genericOp,
   genericOp.erase();
 }
 
-// Assign optimized grids to all ToLayoutOps feeding into a GenericOp by
-// computing the optimal grid per tensor independently, mirroring the old
-// TTIRToD2M behavior.
-static void assignGrids(d2m::GenericOp genericOp,
-                        const GridSelectionConfig &config) {
-  GridAnalysisResult analysis =
-      analyzeOperandsAndComputeGrids(genericOp, config);
+// ----------------------------------------------------------------------------
+// Apply all grid decisions from a GenericGridAnalysisResult to a GenericOp.
+// ----------------------------------------------------------------------------
 
-  updateToLayoutOps(analysis.toLayouts, config);
+static void applyGridDecisions(d2m::GenericOp genericOp,
+                               const GenericGridAnalysisResult &result) {
+  // Build per-kind update lists from the structured operand infos.
+  SmallVector<const OperandGridInfo *> toLayouts;
+  SmallVector<const OperandGridInfo *> behindViewToLayouts;
+  SmallVector<const OperandGridInfo *> ttnnTensors;
+  SmallVector<const OperandGridInfo *> emptyOps;
+  SmallVector<const OperandGridInfo *> viewLayouts;
+  SmallVector<const OperandGridInfo *> compositeViews;
 
-  updateTTNNTensors(analysis.ttnnTensors, config);
+  for (const auto &info : result.operandInfos) {
+    switch (info.updateKind) {
+    case OperandUpdateKind::ToLayout:
+      toLayouts.push_back(&info);
+      break;
+    case OperandUpdateKind::TTNNTensor:
+      ttnnTensors.push_back(&info);
+      break;
+    case OperandUpdateKind::Empty:
+      emptyOps.push_back(&info);
+      break;
+    case OperandUpdateKind::ViewLayout:
+      viewLayouts.push_back(&info);
+      break;
+    case OperandUpdateKind::CompositeView:
+      compositeViews.push_back(&info);
+      break;
+    case OperandUpdateKind::None:
+      break;
+    }
 
-  updateEmptyOps(analysis.emptyOps, config);
+    // Handle ToLayoutOps that are behind a ViewLayoutOp.
+    if (info.behindViewToLayoutOp) {
+      behindViewToLayouts.push_back(&info);
+    }
+  }
 
-  updateCompositeViewOps(analysis.compositeViews, config);
+  // effectiveTargetGrid is the full device grid, used for virtual grid
+  // physical mapping. Per-operand target grids (info->targetGrid) are used
+  // for alignment computation.
+  ArrayRef<int64_t> deviceGrid = result.effectiveTargetGrid;
+  bool ttnnMode = result.ttnnMode;
 
-  updateViewLayoutOps(analysis.viewLayouts, config);
-
-  recreateGenericOp(genericOp, analysis.optimalOperandGrids);
+  applyToLayoutUpdates(toLayouts, deviceGrid, ttnnMode);
+  applyBehindViewToLayoutUpdates(behindViewToLayouts, deviceGrid, ttnnMode);
+  applyTTNNTensorUpdates(ttnnTensors);
+  applyEmptyOpUpdates(emptyOps, deviceGrid, ttnnMode);
+  applyCompositeViewUpdates(compositeViews, deviceGrid, ttnnMode);
+  applyViewLayoutUpdates(viewLayouts, ttnnMode);
+  recreateGenericOp(genericOp, result.normalizedOperandGrids);
 }
 
 // Resolve to a value that dominates the spatial op by following view_layout
@@ -1210,26 +792,28 @@ public:
   void runOnOperation() override {
     ModuleOp module = getOperation();
 
-    module.walk([&](d2m::GenericOp genericOp) {
-      // Skip explicit datamovement form - users manage grids manually
-      if (genericOp.isExplicitDatamovementForm()) {
-        return;
-      }
-      if (genericOp->hasAttr("d2m.skip_grid_selection")) {
-        return;
-      }
-      llvm::SmallVector<int64_t> targetGridShape =
-          getTargetGridShape(genericOp);
-      llvm::SmallVector<int64_t> targetSquareGridShape =
-          d2m::utils::getSquareTargetGrid(targetGridShape);
-      GridSelectionConfig config{targetGridShape, targetSquareGridShape,
-                                 this->ttnnMode};
-      assignGrids(genericOp, config);
-    });
+    // Phase 1: Analyze all generics (no IR mutation).
+    GridAnalysis::Options opts;
+    opts.deviceGridShape = getDeviceGridShape();
+    opts.ttnnMode = this->ttnnMode;
+    GridAnalysis gridAnalysis(module, opts);
 
-    // Rebuild each SpatialOp's ins/outs from the operands actually used by
-    // generics in its regions (e.g. after stream_layout splits one cast into
-    // multiple operands per region).
+    // Phase 2: Apply transforms using pre-computed analysis.
+    // Collect generics first because the walk is invalidated by IR mutation.
+    SmallVector<d2m::GenericOp> generics;
+    module.walk(
+        [&](d2m::GenericOp genericOp) { generics.push_back(genericOp); });
+
+    for (auto genericOp : generics) {
+      const auto *result = gridAnalysis.lookup(genericOp);
+      if (!result) {
+        continue;
+      }
+      applyGridDecisions(genericOp, *result);
+    }
+
+    // Phase 3: Rebuild each SpatialOp's ins/outs from the operands actually
+    // used by generics in its regions.
     module.walk([&](d2m::SpatialOp spatialOp) {
       reconstructSpatialOperands(spatialOp);
     });
@@ -1247,25 +831,6 @@ private:
         mlir::tt::ttcore::lookupDevice(moduleOp);
     assert(device && "Device not found");
     return llvm::to_vector(device.getWorkerGrid().getShape());
-  }
-
-  // Returns the target grid shape for genericOp. If it is inside a
-  // d2m.spatial region, uses that region's grid_ranges entry; otherwise
-  // returns the device-wide grid shape.
-  llvm::SmallVector<int64_t> getTargetGridShape(d2m::GenericOp genericOp) {
-    mlir::Region *region = genericOp->getParentRegion();
-    if (auto spatialOp =
-            mlir::dyn_cast<d2m::SpatialOp>(region->getParentOp())) {
-      mlir::ArrayAttr gridRangesAttr = spatialOp.getGridRanges();
-      unsigned regionIndex = region->getRegionNumber();
-      if (gridRangesAttr && regionIndex < gridRangesAttr.size()) {
-        ttcore::CoreRangeAttr range =
-            mlir::cast<ttcore::CoreRangeAttr>(gridRangesAttr[regionIndex]);
-        return {range.getEndCoord().getY() - range.getStartCoord().getY() + 1,
-                range.getEndCoord().getX() - range.getStartCoord().getX() + 1};
-      }
-    }
-    return getDeviceGridShape();
   }
 };
 } // namespace

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -302,7 +302,7 @@ static void applyBehindViewToLayoutUpdate(const OperandGridInfo &info,
   auto view = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
   auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
   optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGrid,
-                       ttnnMode, info.behindViewToLayoutGrid, builder);
+                       ttnnMode, info.viewSourceGrid, builder);
 }
 
 static void applyTTNNTensorUpdate(const OperandGridInfo &info,
@@ -679,7 +679,7 @@ static void applyGridDecisions(d2m::GenericOp genericOp,
     case Kind::Skip:
       break;
     }
-    if (!info.behindViewToLayoutGrid.empty()) {
+    if (!info.viewSourceGrid.empty()) {
       applyBehindViewToLayoutUpdate(info, effectiveTargetGrid, ttnnMode,
                                     builder);
     }

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -39,8 +39,8 @@ namespace mlir::tt::d2m {
 // alignments.
 static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
                                  ArrayRef<int64_t> targetGrid,
-                                 ArrayRef<int64_t> deviceGrid, bool ttnnMode,
-                                 ArrayRef<int64_t> optimalGrid,
+                                 ArrayRef<int64_t> effectiveTargetGrid,
+                                 bool ttnnMode, ArrayRef<int64_t> optimalGrid,
                                  OpBuilder &builder) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
   if (!emptyOp) {
@@ -88,12 +88,12 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
       optimalGrid, workerGridShape);
   if (isVirtual) {
     auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-        ttmlir::utils::volume<int64_t>(optimalGrid), deviceGrid);
+        ttmlir::utils::volume<int64_t>(optimalGrid), effectiveTargetGrid);
     TT_assertv(!physicalGridShape.empty(),
                "Unable to find 2D rect that can fit virtual grid {} within "
                "device grid {}",
                ttmlir::utils::formatIterable(optimalGrid, "x"),
-               ttmlir::utils::formatIterable(deviceGrid, "x"));
+               ttmlir::utils::formatIterable(effectiveTargetGrid, "x"));
     auto [forwardMap, inverseMap] =
         ttmlir::d2m::utils::grids::createCoreVirtMaps(
             builder.getContext(), optimalGrid, physicalGridShape);
@@ -289,20 +289,20 @@ optimizeTTNNMetalLayoutCastOpGrid(ttir::TTNNMetalLayoutCastOp castOp,
 // ----------------------------------------------------------------------------
 
 static void applyToLayoutUpdate(const OperandGridInfo &info,
-                                ArrayRef<int64_t> deviceGrid, bool ttnnMode,
-                                OpBuilder &builder) {
+                                ArrayRef<int64_t> effectiveTargetGrid,
+                                bool ttnnMode, OpBuilder &builder) {
   auto toLayoutOp = info.operand.getDefiningOp<d2m::ToLayoutOp>();
-  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, deviceGrid, ttnnMode,
-                       info.selectedGrid, builder);
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGrid,
+                       ttnnMode, info.selectedGrid, builder);
 }
 
 static void applyBehindViewToLayoutUpdate(const OperandGridInfo &info,
-                                          ArrayRef<int64_t> deviceGrid,
+                                          ArrayRef<int64_t> effectiveTargetGrid,
                                           bool ttnnMode, OpBuilder &builder) {
   auto view = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
   auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
-  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, deviceGrid, ttnnMode,
-                       info.behindViewToLayoutGrid, builder);
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGrid,
+                       ttnnMode, info.behindViewToLayoutGrid, builder);
 }
 
 static void applyTTNNTensorUpdate(const OperandGridInfo &info,
@@ -330,7 +330,7 @@ static void applyTTNNTensorUpdate(const OperandGridInfo &info,
 }
 
 static void applyCompositeViewUpdate(const OperandGridInfo &info,
-                                     ArrayRef<int64_t> deviceGrid,
+                                     ArrayRef<int64_t> effectiveTargetGrid,
                                      bool ttnnMode, OpBuilder &builder) {
   auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
   int32_t concatDim = compositeView.getDim();
@@ -403,7 +403,7 @@ static void applyCompositeViewUpdate(const OperandGridInfo &info,
         auto newEmptyOp = builder.create<d2m::EmptyOp>(
             emptyOp.getLoc(), newInputType.getShape(),
             newInputType.getElementType(), newInputType.getEncoding(),
-            deviceGrid);
+            effectiveTargetGrid);
         builder.setInsertionPoint(toLayoutOp);
         auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
             toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
@@ -433,8 +433,8 @@ static void applyCompositeViewUpdate(const OperandGridInfo &info,
 }
 
 static void applyEmptyOpUpdate(const OperandGridInfo &info,
-                               ArrayRef<int64_t> deviceGrid, bool ttnnMode,
-                               OpBuilder &builder) {
+                               ArrayRef<int64_t> effectiveTargetGrid,
+                               bool ttnnMode, OpBuilder &builder) {
   EmptyOp emptyOp = info.operand.getDefiningOp<d2m::EmptyOp>();
   auto emptyType =
       mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
@@ -453,7 +453,8 @@ static void applyEmptyOpUpdate(const OperandGridInfo &info,
         info.selectedGrid, workerGridShape);
     if (isVirtual) {
       auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-          ttmlir::utils::volume<int64_t>(info.selectedGrid), deviceGrid);
+          ttmlir::utils::volume<int64_t>(info.selectedGrid),
+          effectiveTargetGrid);
       TT_assertv(!physicalGridShape.empty(),
                  "Unable to find 2D rect that can fit virtual grid");
       auto [forwardMap, inverseMap] =
@@ -619,11 +620,11 @@ recreateGenericOp(d2m::GenericOp genericOp,
 static void applyGridDecisions(d2m::GenericOp genericOp,
                                const GenericGridAnalysisResult &result,
                                bool ttnnMode) {
-  // deviceGrid is the generic's target grid (full device grid, or the range
-  // scoped by an enclosing d2m.spatial region), used for virtual grid
+  // effectiveTargetGrid is the generic's target grid (full device grid, or the
+  // range scoped by an enclosing d2m.spatial region), used for virtual grid
   // physical mapping. Per-operand target grids (info.targetGrid) are used
   // for alignment computation.
-  ArrayRef<int64_t> deviceGrid = result.deviceGrid;
+  ArrayRef<int64_t> effectiveTargetGrid = result.effectiveTargetGrid;
   OpBuilder builder(genericOp->getContext());
 
   // Classify operands upfront: once apply* mutates IR, defining ops for
@@ -666,20 +667,21 @@ static void applyGridDecisions(d2m::GenericOp genericOp,
       applyTTNNTensorUpdate(info, builder);
       break;
     case Kind::CompositeView:
-      applyCompositeViewUpdate(info, deviceGrid, ttnnMode, builder);
+      applyCompositeViewUpdate(info, effectiveTargetGrid, ttnnMode, builder);
       break;
     case Kind::ToLayout:
-      applyToLayoutUpdate(info, deviceGrid, ttnnMode, builder);
+      applyToLayoutUpdate(info, effectiveTargetGrid, ttnnMode, builder);
       break;
     case Kind::Empty:
-      applyEmptyOpUpdate(info, deviceGrid, ttnnMode, builder);
+      applyEmptyOpUpdate(info, effectiveTargetGrid, ttnnMode, builder);
       break;
     case Kind::ViewLayout:
     case Kind::Skip:
       break;
     }
     if (!info.behindViewToLayoutGrid.empty()) {
-      applyBehindViewToLayoutUpdate(info, deviceGrid, ttnnMode, builder);
+      applyBehindViewToLayoutUpdate(info, effectiveTargetGrid, ttnnMode,
+                                    builder);
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -294,10 +294,11 @@ static void applyToLayoutUpdates(ArrayRef<const OperandGridInfo *> toLayouts,
     return;
   }
 
-  OpBuilder builder(toLayouts.front()->toLayoutOp->getContext());
+  OpBuilder builder(toLayouts.front()->operand.getContext());
   for (const auto *info : toLayouts) {
-    optimizeToLayoutGrid(info->toLayoutOp, info->targetGrid, deviceGrid,
-                         ttnnMode, info->selectedGrid, builder);
+    auto toLayoutOp = info->operand.getDefiningOp<d2m::ToLayoutOp>();
+    optimizeToLayoutGrid(toLayoutOp, info->targetGrid, deviceGrid, ttnnMode,
+                         info->selectedGrid, builder);
   }
 }
 
@@ -308,10 +309,12 @@ applyBehindViewToLayoutUpdates(ArrayRef<const OperandGridInfo *> infos,
     return;
   }
 
-  OpBuilder builder(infos.front()->behindViewToLayoutOp->getContext());
+  OpBuilder builder(infos.front()->operand.getContext());
   for (const auto *info : infos) {
-    optimizeToLayoutGrid(info->behindViewToLayoutOp, info->targetGrid,
-                         deviceGrid, ttnnMode, info->toLayoutGrid, builder);
+    auto view = info->operand.getDefiningOp<d2m::ViewLayoutOp>();
+    auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
+    optimizeToLayoutGrid(toLayoutOp, info->targetGrid, deviceGrid, ttnnMode,
+                         info->behindViewToLayoutGrid, builder);
   }
 }
 
@@ -321,21 +324,19 @@ applyTTNNTensorUpdates(ArrayRef<const OperandGridInfo *> ttnnTensors) {
     return;
   }
 
-  OpBuilder builder(ttnnTensors.front()->ttnnOperand.getContext());
+  OpBuilder builder(ttnnTensors.front()->operand.getContext());
   for (const auto *info : ttnnTensors) {
+    Value ttnnOperand = info->operand;
     auto metalTensor =
-        mlir::cast<mlir::RankedTensorType>(info->ttnnOperand.getType());
+        mlir::cast<mlir::RankedTensorType>(ttnnOperand.getType());
     auto metalLayout =
         mlir::cast<ttcore::MetalLayoutAttr>(metalTensor.getEncoding());
     if (metalLayout.getMemorySpace() == ttcore::MemorySpace::DeviceDRAM) {
-      insertViewForTTNNDRAMTensor(info->ttnnOperand, info->selectedGrid,
-                                  builder);
+      insertViewForTTNNDRAMTensor(ttnnOperand, info->selectedGrid, builder);
     } else if (auto castOp =
-                   info->ttnnOperand
-                       .getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
+                   ttnnOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
       optimizeTTNNMetalLayoutCastOpGrid(castOp, info->selectedGrid, builder);
-    } else if (auto viewOp =
-                   info->ttnnOperand.getDefiningOp<d2m::ViewLayoutOp>()) {
+    } else if (auto viewOp = ttnnOperand.getDefiningOp<d2m::ViewLayoutOp>()) {
       auto originalOperand = viewOp.getInput();
       auto castOp =
           originalOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>();
@@ -358,9 +359,9 @@ applyCompositeViewUpdates(ArrayRef<const OperandGridInfo *> compositeViews,
     return;
   }
 
-  OpBuilder builder(compositeViews.front()->compositeViewOp->getContext());
+  OpBuilder builder(compositeViews.front()->operand.getContext());
   for (const auto *info : compositeViews) {
-    auto compositeView = info->compositeViewOp;
+    auto compositeView = info->operand.getDefiningOp<d2m::CompositeViewOp>();
     int32_t concatDim = compositeView.getDim();
 
     // Compute the output type first — its grid-aware dim alignments determine
@@ -468,9 +469,9 @@ static void applyEmptyOpUpdates(ArrayRef<const OperandGridInfo *> emptyOps,
     return;
   }
 
-  OpBuilder builder(emptyOps.front()->emptyOp->getContext());
+  OpBuilder builder(emptyOps.front()->operand.getContext());
   for (const auto *info : emptyOps) {
-    EmptyOp emptyOp = info->emptyOp;
+    EmptyOp emptyOp = info->operand.getDefiningOp<d2m::EmptyOp>();
     auto emptyType =
         mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
     RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
@@ -575,9 +576,9 @@ applyViewLayoutUpdates(ArrayRef<const OperandGridInfo *> viewLayouts,
     return;
   }
 
-  OpBuilder builder(viewLayouts.front()->viewLayoutOp->getContext());
+  OpBuilder builder(viewLayouts.front()->operand.getContext());
   for (const auto *info : viewLayouts) {
-    d2m::ViewLayoutOp viewOp = info->viewLayoutOp;
+    d2m::ViewLayoutOp viewOp = info->operand.getDefiningOp<d2m::ViewLayoutOp>();
     auto oldResultType =
         mlir::cast<RankedTensorType>(viewOp.getResult().getType());
     auto oldLayout =
@@ -663,7 +664,7 @@ recreateGenericOp(d2m::GenericOp genericOp,
 
 static void applyGridDecisions(d2m::GenericOp genericOp,
                                const GenericGridAnalysisResult &result) {
-  // Build per-kind update lists from the structured operand infos.
+  // Classify each operand by its defining op and bucket into per-kind lists.
   SmallVector<const OperandGridInfo *> toLayouts;
   SmallVector<const OperandGridInfo *> behindViewToLayouts;
   SmallVector<const OperandGridInfo *> ttnnTensors;
@@ -672,36 +673,32 @@ static void applyGridDecisions(d2m::GenericOp genericOp,
   SmallVector<const OperandGridInfo *> compositeViews;
 
   for (const auto &info : result.operandInfos) {
-    switch (info.updateKind) {
-    case OperandUpdateKind::ToLayout:
-      toLayouts.push_back(&info);
-      break;
-    case OperandUpdateKind::TTNNTensor:
+    Value operand = info.operand;
+    if (GridAnalysis::isTTNNOperand(operand)) {
       ttnnTensors.push_back(&info);
-      break;
-    case OperandUpdateKind::Empty:
-      emptyOps.push_back(&info);
-      break;
-    case OperandUpdateKind::ViewLayout:
-      viewLayouts.push_back(&info);
-      break;
-    case OperandUpdateKind::CompositeView:
+    } else if (auto view = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
+      // Reinterpret views are type casts only; their grid must match the
+      // input, so skip them here.
+      if (!view.getReinterpretLayout()) {
+        viewLayouts.push_back(&info);
+      }
+    } else if (operand.getDefiningOp<d2m::CompositeViewOp>()) {
       compositeViews.push_back(&info);
-      break;
-    case OperandUpdateKind::None:
-      break;
+    } else if (operand.getDefiningOp<d2m::ToLayoutOp>()) {
+      toLayouts.push_back(&info);
+    } else if (operand.getDefiningOp<d2m::EmptyOp>()) {
+      emptyOps.push_back(&info);
     }
 
-    // Handle ToLayoutOps that are behind a ViewLayoutOp.
-    if (info.behindViewToLayoutOp) {
+    if (!info.behindViewToLayoutGrid.empty()) {
       behindViewToLayouts.push_back(&info);
     }
   }
 
-  // effectiveTargetGrid is the full device grid, used for virtual grid
-  // physical mapping. Per-operand target grids (info->targetGrid) are used
-  // for alignment computation.
-  ArrayRef<int64_t> deviceGrid = result.effectiveTargetGrid;
+  // deviceGrid is the full device grid, used for virtual grid physical
+  // mapping. Per-operand target grids (info->targetGrid) are used for
+  // alignment computation.
+  ArrayRef<int64_t> deviceGrid = result.deviceGrid;
   bool ttnnMode = result.ttnnMode;
 
   applyToLayoutUpdates(toLayouts, deviceGrid, ttnnMode);

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -288,224 +288,187 @@ optimizeTTNNMetalLayoutCastOpGrid(ttir::TTNNMetalLayoutCastOp castOp,
 // Transform phases — apply pre-computed grid decisions to the IR.
 // ----------------------------------------------------------------------------
 
-static void applyToLayoutUpdates(ArrayRef<const OperandGridInfo *> toLayouts,
-                                 ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
-  if (toLayouts.empty()) {
-    return;
-  }
+static void applyToLayoutUpdate(const OperandGridInfo &info,
+                                ArrayRef<int64_t> deviceGrid, bool ttnnMode,
+                                OpBuilder &builder) {
+  auto toLayoutOp = info.operand.getDefiningOp<d2m::ToLayoutOp>();
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, deviceGrid, ttnnMode,
+                       info.selectedGrid, builder);
+}
 
-  OpBuilder builder(toLayouts.front()->operand.getContext());
-  for (const auto *info : toLayouts) {
-    auto toLayoutOp = info->operand.getDefiningOp<d2m::ToLayoutOp>();
-    optimizeToLayoutGrid(toLayoutOp, info->targetGrid, deviceGrid, ttnnMode,
-                         info->selectedGrid, builder);
+static void applyBehindViewToLayoutUpdate(const OperandGridInfo &info,
+                                          ArrayRef<int64_t> deviceGrid,
+                                          bool ttnnMode, OpBuilder &builder) {
+  auto view = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
+  auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, deviceGrid, ttnnMode,
+                       info.behindViewToLayoutGrid, builder);
+}
+
+static void applyTTNNTensorUpdate(const OperandGridInfo &info,
+                                  OpBuilder &builder) {
+  Value ttnnOperand = info.operand;
+  auto metalTensor = mlir::cast<mlir::RankedTensorType>(ttnnOperand.getType());
+  auto metalLayout =
+      mlir::cast<ttcore::MetalLayoutAttr>(metalTensor.getEncoding());
+  if (metalLayout.getMemorySpace() == ttcore::MemorySpace::DeviceDRAM) {
+    insertViewForTTNNDRAMTensor(ttnnOperand, info.selectedGrid, builder);
+  } else if (auto castOp =
+                 ttnnOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
+    optimizeTTNNMetalLayoutCastOpGrid(castOp, info.selectedGrid, builder);
+  } else if (auto viewOp = ttnnOperand.getDefiningOp<d2m::ViewLayoutOp>()) {
+    auto originalOperand = viewOp.getInput();
+    auto castOp = originalOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>();
+    TT_assertv(castOp,
+               "Expected a TTNNMetalLayoutCastOp as the input of the view op.");
+    viewOp.getResult().replaceAllUsesWith(originalOperand);
+    viewOp.erase();
+    optimizeTTNNMetalLayoutCastOpGrid(castOp, info.selectedGrid, builder);
+  } else {
+    llvm_unreachable("Expected a TTNNMetalLayoutCastOp or a ViewLayoutOp");
   }
 }
 
-static void
-applyBehindViewToLayoutUpdates(ArrayRef<const OperandGridInfo *> infos,
-                               ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
-  if (infos.empty()) {
-    return;
-  }
+static void applyCompositeViewUpdate(const OperandGridInfo &info,
+                                     ArrayRef<int64_t> deviceGrid,
+                                     bool ttnnMode, OpBuilder &builder) {
+  auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
+  int32_t concatDim = compositeView.getDim();
 
-  OpBuilder builder(infos.front()->operand.getContext());
-  for (const auto *info : infos) {
-    auto view = info->operand.getDefiningOp<d2m::ViewLayoutOp>();
-    auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
-    optimizeToLayoutGrid(toLayoutOp, info->targetGrid, deviceGrid, ttnnMode,
-                         info->behindViewToLayoutGrid, builder);
-  }
-}
+  // Compute the output type first — its grid-aware dim alignments determine
+  // what physical shapes the inputs must match on non-concat dimensions.
+  auto outType =
+      mlir::cast<RankedTensorType>(compositeView.getResult().getType());
+  RankedTensorType newOutType = utils::tensorWithOptimalGrid(
+      outType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+  auto outLayout =
+      mlir::cast<ttcore::MetalLayoutAttr>(newOutType.getEncoding());
 
-static void
-applyTTNNTensorUpdates(ArrayRef<const OperandGridInfo *> ttnnTensors) {
-  if (ttnnTensors.empty()) {
-    return;
-  }
+  // Build per-input dim alignments that are coordinated with the output:
+  //  - Non-concat dims use the output's grid-aware alignment (so physical
+  //    sizes match).
+  //  - The concat dim uses tile-only alignment (so each input's contribution
+  //    isn't independently inflated, keeping sum <= output).
+  auto outDimAlignments = outLayout.getDimAlignments();
 
-  OpBuilder builder(ttnnTensors.front()->operand.getContext());
-  for (const auto *info : ttnnTensors) {
-    Value ttnnOperand = info->operand;
-    auto metalTensor =
-        mlir::cast<mlir::RankedTensorType>(ttnnOperand.getType());
-    auto metalLayout =
-        mlir::cast<ttcore::MetalLayoutAttr>(metalTensor.getEncoding());
-    if (metalLayout.getMemorySpace() == ttcore::MemorySpace::DeviceDRAM) {
-      insertViewForTTNNDRAMTensor(ttnnOperand, info->selectedGrid, builder);
-    } else if (auto castOp =
-                   ttnnOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
-      optimizeTTNNMetalLayoutCastOpGrid(castOp, info->selectedGrid, builder);
-    } else if (auto viewOp = ttnnOperand.getDefiningOp<d2m::ViewLayoutOp>()) {
-      auto originalOperand = viewOp.getInput();
-      auto castOp =
-          originalOperand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>();
-      TT_assertv(
-          castOp,
-          "Expected a TTNNMetalLayoutCastOp as the input of the view op.");
-      viewOp.getResult().replaceAllUsesWith(originalOperand);
-      viewOp.erase();
-      optimizeTTNNMetalLayoutCastOpGrid(castOp, info->selectedGrid, builder);
-    } else {
-      llvm_unreachable("Expected a TTNNMetalLayoutCastOp or a ViewLayoutOp");
+  SmallVector<Value> reblockedInputs;
+  for (Value input : compositeView.getInputs()) {
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    auto inputLayout =
+        mlir::dyn_cast<ttcore::MetalLayoutAttr>(inputType.getEncoding());
+    if (!inputLayout) {
+      reblockedInputs.push_back(input);
+      continue;
     }
-  }
-}
 
-static void
-applyCompositeViewUpdates(ArrayRef<const OperandGridInfo *> compositeViews,
-                          ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
-  if (compositeViews.empty()) {
-    return;
-  }
+    auto tileType = mlir::cast<ttcore::TileType>(inputType.getElementType());
+    auto tileShape = tileType.getShape();
 
-  OpBuilder builder(compositeViews.front()->operand.getContext());
-  for (const auto *info : compositeViews) {
-    auto compositeView = info->operand.getDefiningOp<d2m::CompositeViewOp>();
-    int32_t concatDim = compositeView.getDim();
+    // Derive input dim alignments from the output, overriding the concat
+    // dim with tile-only alignment so each input's contribution isn't
+    // independently inflated. concatDim is already normalized to
+    // [0, logicalRank) by TTIRToD2M; the trailing two logical dims map to
+    // the tile's height/width (tileIdx 0/1), earlier dims are batch dims
+    // where tile alignment isn't required (fall back to 1).
+    llvm::SmallVector<int64_t> inputAlignments(outDimAlignments.begin(),
+                                               outDimAlignments.end());
+    int64_t logicalRank = inputLayout.getLogicalShape().size();
+    int64_t tileIdx = concatDim - (logicalRank - 2);
+    inputAlignments[concatDim] = (tileIdx >= 0) ? tileShape[tileIdx] : 1;
 
-    // Compute the output type first — its grid-aware dim alignments determine
-    // what physical shapes the inputs must match on non-concat dimensions.
-    auto outType =
-        mlir::cast<RankedTensorType>(compositeView.getResult().getType());
-    RankedTensorType newOutType = utils::tensorWithOptimalGrid(
-        outType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
-    auto outLayout =
-        mlir::cast<ttcore::MetalLayoutAttr>(newOutType.getEncoding());
+    auto coordLayout = ttcore::MetalLayoutAttr::get(
+        builder.getContext(), inputLayout.getLogicalShape(),
+        inputLayout.getOobVal(), inputLayout.getMemorySpace(),
+        inputLayout.getMemoryLayout(), inputLayout.getCollapsedIntervals(),
+        inputAlignments);
 
-    // Build per-input dim alignments that are coordinated with the output:
-    //  - Non-concat dims use the output's grid-aware alignment (so physical
-    //    sizes match).
-    //  - The concat dim uses tile-only alignment (so each input's contribution
-    //    isn't independently inflated, keeping sum <= output).
-    auto outDimAlignments = outLayout.getDimAlignments();
+    auto inputPhysShape = coordLayout.getPhysicalShape(tileShape);
+    auto inputOptimalGrid =
+        utils::computeOptimalGrid(inputType, inputPhysShape, info.targetGrid);
 
-    SmallVector<Value> reblockedInputs;
-    for (Value input : compositeView.getInputs()) {
-      auto inputType = mlir::cast<RankedTensorType>(input.getType());
-      auto inputLayout =
-          mlir::dyn_cast<ttcore::MetalLayoutAttr>(inputType.getEncoding());
-      if (!inputLayout) {
-        reblockedInputs.push_back(input);
+    llvm::SmallVector<int64_t> deviceShape =
+        coordLayout.getDeviceShape(inputOptimalGrid, tileShape);
+    auto newInputType = RankedTensorType::get(
+        deviceShape, inputType.getElementType(), coordLayout);
+
+    // When the input comes directly from a to_layout op with a single use,
+    // update the to_layout's grid so that data is physically distributed
+    // across multiple cores, preventing L1 overflow when multiple concat
+    // inputs must coexist in L1 on a single core.
+    if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
+        toLayoutOp && input.hasOneUse()) {
+      auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
+      if (emptyOp) {
+        builder.setInsertionPoint(emptyOp);
+        auto newEmptyOp = builder.create<d2m::EmptyOp>(
+            emptyOp.getLoc(), newInputType.getShape(),
+            newInputType.getElementType(), newInputType.getEncoding(),
+            deviceGrid);
+        builder.setInsertionPoint(toLayoutOp);
+        auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
+            toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
+        toLayoutOp.getResult(0).replaceAllUsesWith(newToLayoutOp.getResult(0));
+        toLayoutOp.erase();
+        if (emptyOp.getResult().use_empty()) {
+          emptyOp.erase();
+        }
+        reblockedInputs.push_back(newToLayoutOp.getResult(0));
         continue;
       }
-
-      auto tileType = mlir::cast<ttcore::TileType>(inputType.getElementType());
-      auto tileShape = tileType.getShape();
-
-      // Derive input dim alignments from the output, overriding the concat
-      // dim with tile-only alignment so each input's contribution isn't
-      // independently inflated. concatDim is already normalized to
-      // [0, logicalRank) by TTIRToD2M; the trailing two logical dims map to
-      // the tile's height/width (tileIdx 0/1), earlier dims are batch dims
-      // where tile alignment isn't required (fall back to 1).
-      llvm::SmallVector<int64_t> inputAlignments(outDimAlignments.begin(),
-                                                 outDimAlignments.end());
-      int64_t logicalRank = inputLayout.getLogicalShape().size();
-      int64_t tileIdx = concatDim - (logicalRank - 2);
-      inputAlignments[concatDim] = (tileIdx >= 0) ? tileShape[tileIdx] : 1;
-
-      auto coordLayout = ttcore::MetalLayoutAttr::get(
-          builder.getContext(), inputLayout.getLogicalShape(),
-          inputLayout.getOobVal(), inputLayout.getMemorySpace(),
-          inputLayout.getMemoryLayout(), inputLayout.getCollapsedIntervals(),
-          inputAlignments);
-
-      auto inputPhysShape = coordLayout.getPhysicalShape(tileShape);
-      auto inputOptimalGrid = utils::computeOptimalGrid(
-          inputType, inputPhysShape, info->targetGrid);
-
-      llvm::SmallVector<int64_t> deviceShape =
-          coordLayout.getDeviceShape(inputOptimalGrid, tileShape);
-      auto newInputType = RankedTensorType::get(
-          deviceShape, inputType.getElementType(), coordLayout);
-
-      // When the input comes directly from a to_layout op with a single use,
-      // update the to_layout's grid so that data is physically distributed
-      // across multiple cores, preventing L1 overflow when multiple concat
-      // inputs must coexist in L1 on a single core.
-      if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
-          toLayoutOp && input.hasOneUse()) {
-        auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
-        if (emptyOp) {
-          builder.setInsertionPoint(emptyOp);
-          auto newEmptyOp = builder.create<d2m::EmptyOp>(
-              emptyOp.getLoc(), newInputType.getShape(),
-              newInputType.getElementType(), newInputType.getEncoding(),
-              deviceGrid);
-          builder.setInsertionPoint(toLayoutOp);
-          auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
-              toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
-          toLayoutOp.getResult(0).replaceAllUsesWith(
-              newToLayoutOp.getResult(0));
-          toLayoutOp.erase();
-          if (emptyOp.getResult().use_empty()) {
-            emptyOp.erase();
-          }
-          reblockedInputs.push_back(newToLayoutOp.getResult(0));
-          continue;
-        }
-      }
-
-      builder.setInsertionPoint(compositeView);
-      auto view = builder.create<d2m::ViewLayoutOp>(compositeView.getLoc(),
-                                                    newInputType, input);
-      reblockedInputs.push_back(view.getResult());
     }
 
     builder.setInsertionPoint(compositeView);
-    auto newCompositeView = builder.create<d2m::CompositeViewOp>(
-        compositeView.getLoc(), newOutType, reblockedInputs,
-        compositeView.getDim());
-
-    compositeView.getResult().replaceAllUsesWith(newCompositeView.getResult());
-    compositeView.erase();
+    auto view = builder.create<d2m::ViewLayoutOp>(compositeView.getLoc(),
+                                                  newInputType, input);
+    reblockedInputs.push_back(view.getResult());
   }
+
+  builder.setInsertionPoint(compositeView);
+  auto newCompositeView = builder.create<d2m::CompositeViewOp>(
+      compositeView.getLoc(), newOutType, reblockedInputs,
+      compositeView.getDim());
+
+  compositeView.getResult().replaceAllUsesWith(newCompositeView.getResult());
+  compositeView.erase();
 }
 
-static void applyEmptyOpUpdates(ArrayRef<const OperandGridInfo *> emptyOps,
-                                ArrayRef<int64_t> deviceGrid, bool ttnnMode) {
-  if (emptyOps.empty()) {
-    return;
-  }
+static void applyEmptyOpUpdate(const OperandGridInfo &info,
+                               ArrayRef<int64_t> deviceGrid, bool ttnnMode,
+                               OpBuilder &builder) {
+  EmptyOp emptyOp = info.operand.getDefiningOp<d2m::EmptyOp>();
+  auto emptyType =
+      mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
+  RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
+      emptyType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+  builder.setInsertionPoint(emptyOp);
 
-  OpBuilder builder(emptyOps.front()->operand.getContext());
-  for (const auto *info : emptyOps) {
-    EmptyOp emptyOp = info->operand.getDefiningOp<d2m::EmptyOp>();
-    auto emptyType =
-        mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
-    RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
-        emptyType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
-    builder.setInsertionPoint(emptyOp);
-
-    mlir::AffineMapAttr virtualGridInverseMapping =
-        emptyOp.getVirtualGridInverseMappingAttr();
-    mlir::AffineMapAttr virtualGridForwardMapping =
-        emptyOp.getVirtualGridForwardMappingAttr();
-    if (!virtualGridInverseMapping) {
-      auto device = ttcore::lookupDevice(emptyOp);
-      auto workerGridShape = device.getWorkerGrid().getShape();
-      bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-          info->selectedGrid, workerGridShape);
-      if (isVirtual) {
-        auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-            ttmlir::utils::volume<int64_t>(info->selectedGrid), deviceGrid);
-        TT_assertv(!physicalGridShape.empty(),
-                   "Unable to find 2D rect that can fit virtual grid");
-        auto [forwardMap, inverseMap] =
-            ttmlir::d2m::utils::grids::createCoreVirtMaps(
-                builder.getContext(), info->selectedGrid, physicalGridShape);
-        virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
-        virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
-      }
+  mlir::AffineMapAttr virtualGridInverseMapping =
+      emptyOp.getVirtualGridInverseMappingAttr();
+  mlir::AffineMapAttr virtualGridForwardMapping =
+      emptyOp.getVirtualGridForwardMappingAttr();
+  if (!virtualGridInverseMapping) {
+    auto device = ttcore::lookupDevice(emptyOp);
+    auto workerGridShape = device.getWorkerGrid().getShape();
+    bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
+        info.selectedGrid, workerGridShape);
+    if (isVirtual) {
+      auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
+          ttmlir::utils::volume<int64_t>(info.selectedGrid), deviceGrid);
+      TT_assertv(!physicalGridShape.empty(),
+                 "Unable to find 2D rect that can fit virtual grid");
+      auto [forwardMap, inverseMap] =
+          ttmlir::d2m::utils::grids::createCoreVirtMaps(
+              builder.getContext(), info.selectedGrid, physicalGridShape);
+      virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
+      virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
     }
-
-    auto newEmptyOp = builder.create<d2m::EmptyOp>(
-        emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
-        virtualGridForwardMapping);
-    emptyOp.getResult().replaceAllUsesWith(newEmptyOp.getResult());
-    emptyOp.erase();
   }
+
+  auto newEmptyOp = builder.create<d2m::EmptyOp>(
+      emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
+      virtualGridForwardMapping);
+  emptyOp.getResult().replaceAllUsesWith(newEmptyOp.getResult());
+  emptyOp.erase();
 }
 
 // Derive grid (including virtual grid mapping) from the
@@ -566,64 +529,55 @@ deriveGenericGridAttr(d2m::GenericOp genericOp,
   return deriveGridAttrForOutput(output, gridShape, builder);
 }
 
-// Update ViewLayoutOps by recreating them with a new output type that matches
+// Update a ViewLayoutOp by recreating it with a new output type that matches
 // the normalized grid. The remapping is composed with a reblock map that
 // accounts for the shape change from the old grid to the new grid.
-static void
-applyViewLayoutUpdates(ArrayRef<const OperandGridInfo *> viewLayouts,
-                       bool ttnnMode) {
-  if (viewLayouts.empty()) {
-    return;
+static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
+                                  OpBuilder &builder) {
+  d2m::ViewLayoutOp viewOp = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
+  auto oldResultType =
+      mlir::cast<RankedTensorType>(viewOp.getResult().getType());
+  auto oldLayout =
+      mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
+  RankedTensorType newResultType = utils::tensorWithOptimalGrid(
+      oldResultType, info.targetGrid, ttnnMode, info.selectedGrid, builder);
+
+  // Compose the original remapping with a reblock map that maps from the
+  // old output shape to the new output shape.
+  llvm::SmallVector<int64_t> oldShape(oldResultType.getShape());
+  llvm::SmallVector<int64_t> newShape(newResultType.getShape());
+
+  // If dim alignments changed, align-up the old shape to match.
+  auto newLayout =
+      mlir::cast<ttcore::MetalLayoutAttr>(newResultType.getEncoding());
+  if (!llvm::equal(oldLayout.getDimAlignments(),
+                   newLayout.getDimAlignments())) {
+    llvm::SmallVector<int64_t> tileShape;
+    if (auto tileType =
+            mlir::dyn_cast<ttcore::TileType>(oldResultType.getElementType())) {
+      tileShape = llvm::to_vector(tileType.getShape());
+    }
+    TT_assert(ttmlir::utils::volume(oldLayout.getGridShape(oldResultType)) ==
+              1);
+    oldShape = newLayout.getDeviceShape(oldLayout.getGridShape(oldResultType),
+                                        tileShape);
   }
 
-  OpBuilder builder(viewLayouts.front()->operand.getContext());
-  for (const auto *info : viewLayouts) {
-    d2m::ViewLayoutOp viewOp = info->operand.getDefiningOp<d2m::ViewLayoutOp>();
-    auto oldResultType =
-        mlir::cast<RankedTensorType>(viewOp.getResult().getType());
-    auto oldLayout =
-        mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
-    RankedTensorType newResultType = utils::tensorWithOptimalGrid(
-        oldResultType, info->targetGrid, ttnnMode, info->selectedGrid, builder);
-
-    // Compose the original remapping with a reblock map that maps from the
-    // old output shape to the new output shape. This mirrors what
-    // the old grid selection did for view storage.
-    llvm::SmallVector<int64_t> oldShape(oldResultType.getShape());
-    llvm::SmallVector<int64_t> newShape(newResultType.getShape());
-
-    // If dim alignments changed, align-up the old shape to match.
-    auto newLayout =
-        mlir::cast<ttcore::MetalLayoutAttr>(newResultType.getEncoding());
-    if (!llvm::equal(oldLayout.getDimAlignments(),
-                     newLayout.getDimAlignments())) {
-      llvm::SmallVector<int64_t> tileShape;
-      if (auto tileType = mlir::dyn_cast<ttcore::TileType>(
-              oldResultType.getElementType())) {
-        tileShape = llvm::to_vector(tileType.getShape());
-      }
-      TT_assert(ttmlir::utils::volume(oldLayout.getGridShape(oldResultType)) ==
-                1);
-      oldShape = newLayout.getDeviceShape(oldLayout.getGridShape(oldResultType),
-                                          tileShape);
-    }
-
-    mlir::AffineMap newRemapping = viewOp.getRemapping();
-    if (!llvm::equal(oldShape, newShape)) {
-      TT_assert(ttmlir::utils::volume<int64_t>(oldShape) ==
-                ttmlir::utils::volume<int64_t>(newShape));
-      mlir::AffineMap reblockMap = ttmlir::utils::calculateReblockMap(
-          oldShape, newShape, builder.getContext());
-      newRemapping = newRemapping.compose(reblockMap);
-    }
-
-    builder.setInsertionPoint(viewOp);
-    auto newViewOp = builder.create<d2m::ViewLayoutOp>(
-        viewOp.getLoc(), newResultType, viewOp.getInput(), newRemapping,
-        viewOp.getReinterpretLayout());
-    viewOp.getResult().replaceAllUsesWith(newViewOp.getResult());
-    viewOp.erase();
+  mlir::AffineMap newRemapping = viewOp.getRemapping();
+  if (!llvm::equal(oldShape, newShape)) {
+    TT_assert(ttmlir::utils::volume<int64_t>(oldShape) ==
+              ttmlir::utils::volume<int64_t>(newShape));
+    mlir::AffineMap reblockMap = ttmlir::utils::calculateReblockMap(
+        oldShape, newShape, builder.getContext());
+    newRemapping = newRemapping.compose(reblockMap);
   }
+
+  builder.setInsertionPoint(viewOp);
+  auto newViewOp = builder.create<d2m::ViewLayoutOp>(
+      viewOp.getLoc(), newResultType, viewOp.getInput(), newRemapping,
+      viewOp.getReinterpretLayout());
+  viewOp.getResult().replaceAllUsesWith(newViewOp.getResult());
+  viewOp.erase();
 }
 
 // Recreate the d2m.generic with updated operands.
@@ -663,50 +617,79 @@ recreateGenericOp(d2m::GenericOp genericOp,
 // ----------------------------------------------------------------------------
 
 static void applyGridDecisions(d2m::GenericOp genericOp,
-                               const GenericGridAnalysisResult &result) {
-  // Classify each operand by its defining op and bucket into per-kind lists.
-  SmallVector<const OperandGridInfo *> toLayouts;
-  SmallVector<const OperandGridInfo *> behindViewToLayouts;
-  SmallVector<const OperandGridInfo *> ttnnTensors;
-  SmallVector<const OperandGridInfo *> emptyOps;
-  SmallVector<const OperandGridInfo *> viewLayouts;
-  SmallVector<const OperandGridInfo *> compositeViews;
+                               const GenericGridAnalysisResult &result,
+                               bool ttnnMode) {
+  // deviceGrid is the generic's target grid (full device grid, or the range
+  // scoped by an enclosing d2m.spatial region), used for virtual grid
+  // physical mapping. Per-operand target grids (info.targetGrid) are used
+  // for alignment computation.
+  ArrayRef<int64_t> deviceGrid = result.deviceGrid;
+  OpBuilder builder(genericOp->getContext());
 
+  // Classify operands upfront: once apply* mutates IR, defining ops for
+  // operand values may be erased, so we can't re-query the kind mid-pass.
+  enum class Kind {
+    TTNNTensor,
+    ViewLayout,
+    CompositeView,
+    ToLayout,
+    Empty,
+    Skip
+  };
+  llvm::SmallVector<Kind, 4> kinds;
+  kinds.reserve(result.operandInfos.size());
   for (const auto &info : result.operandInfos) {
     Value operand = info.operand;
     if (GridAnalysis::isTTNNOperand(operand)) {
-      ttnnTensors.push_back(&info);
+      kinds.push_back(Kind::TTNNTensor);
     } else if (auto view = operand.getDefiningOp<d2m::ViewLayoutOp>()) {
       // Reinterpret views are type casts only; their grid must match the
-      // input, so skip them here.
-      if (!view.getReinterpretLayout()) {
-        viewLayouts.push_back(&info);
-      }
+      // input, so don't rewrite them.
+      kinds.push_back(view.getReinterpretLayout() ? Kind::Skip
+                                                  : Kind::ViewLayout);
     } else if (operand.getDefiningOp<d2m::CompositeViewOp>()) {
-      compositeViews.push_back(&info);
+      kinds.push_back(Kind::CompositeView);
     } else if (operand.getDefiningOp<d2m::ToLayoutOp>()) {
-      toLayouts.push_back(&info);
+      kinds.push_back(Kind::ToLayout);
     } else if (operand.getDefiningOp<d2m::EmptyOp>()) {
-      emptyOps.push_back(&info);
-    }
-
-    if (!info.behindViewToLayoutGrid.empty()) {
-      behindViewToLayouts.push_back(&info);
+      kinds.push_back(Kind::Empty);
+    } else {
+      kinds.push_back(Kind::Skip);
     }
   }
 
-  // deviceGrid is the full device grid, used for virtual grid physical
-  // mapping. Per-operand target grids (info->targetGrid) are used for
-  // alignment computation.
-  ArrayRef<int64_t> deviceGrid = result.deviceGrid;
-  bool ttnnMode = result.ttnnMode;
+  // Pass 1: producer-side rewrites. View layouts are handled in pass 2 so
+  // they see the final state after upstream producers are rewritten.
+  for (auto [info, kind] : llvm::zip_equal(result.operandInfos, kinds)) {
+    switch (kind) {
+    case Kind::TTNNTensor:
+      applyTTNNTensorUpdate(info, builder);
+      break;
+    case Kind::CompositeView:
+      applyCompositeViewUpdate(info, deviceGrid, ttnnMode, builder);
+      break;
+    case Kind::ToLayout:
+      applyToLayoutUpdate(info, deviceGrid, ttnnMode, builder);
+      break;
+    case Kind::Empty:
+      applyEmptyOpUpdate(info, deviceGrid, ttnnMode, builder);
+      break;
+    case Kind::ViewLayout:
+    case Kind::Skip:
+      break;
+    }
+    if (!info.behindViewToLayoutGrid.empty()) {
+      applyBehindViewToLayoutUpdate(info, deviceGrid, ttnnMode, builder);
+    }
+  }
 
-  applyToLayoutUpdates(toLayouts, deviceGrid, ttnnMode);
-  applyBehindViewToLayoutUpdates(behindViewToLayouts, deviceGrid, ttnnMode);
-  applyTTNNTensorUpdates(ttnnTensors);
-  applyEmptyOpUpdates(emptyOps, deviceGrid, ttnnMode);
-  applyCompositeViewUpdates(compositeViews, deviceGrid, ttnnMode);
-  applyViewLayoutUpdates(viewLayouts, ttnnMode);
+  // Pass 2: view layout rewrites.
+  for (auto [info, kind] : llvm::zip_equal(result.operandInfos, kinds)) {
+    if (kind == Kind::ViewLayout) {
+      applyViewLayoutUpdate(info, ttnnMode, builder);
+    }
+  }
+
   recreateGenericOp(genericOp, result.normalizedOperandGrids);
 }
 
@@ -790,10 +773,7 @@ public:
     ModuleOp module = getOperation();
 
     // Phase 1: Analyze all generics (no IR mutation).
-    GridAnalysis::Options opts;
-    opts.deviceGridShape = getDeviceGridShape();
-    opts.ttnnMode = this->ttnnMode;
-    GridAnalysis gridAnalysis(module, opts);
+    GridAnalysis gridAnalysis(module, getDeviceGridShape(), this->ttnnMode);
 
     // Phase 2: Apply transforms using pre-computed analysis.
     // Collect generics first because the walk is invalidated by IR mutation.
@@ -806,7 +786,7 @@ public:
       if (!result) {
         continue;
       }
-      applyGridDecisions(genericOp, *result);
+      applyGridDecisions(genericOp, *result, this->ttnnMode);
     }
 
     // Phase 3: Rebuild each SpatialOp's ins/outs from the operands actually

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -69,7 +69,22 @@ struct TensorInfo {
 // Helper to extract scalar type from potentially tiled type.
 static Type getScalarType(Type type) {
   if (auto tileType = mlir::dyn_cast<ttcore::TileType>(type)) {
-    return tileType.getElementType();
+    // For block-float tiles, TileType::getElementType returns another
+    // TileType with the same DataType (see dataTypeToElementType), which is
+    // not usable as a scalar element type. Map to the uncompressed scalar
+    // equivalent explicitly.
+    switch (tileType.getDataType()) {
+    case ttcore::DataType::BFP_Float8:
+    case ttcore::DataType::BFP_Float4:
+    case ttcore::DataType::BFP_Float2:
+      return Float32Type::get(type.getContext());
+    case ttcore::DataType::BFP_BFloat8:
+    case ttcore::DataType::BFP_BFloat4:
+    case ttcore::DataType::BFP_BFloat2:
+      return BFloat16Type::get(type.getContext());
+    default:
+      return tileType.getElementType();
+    }
   }
   return type;
 }

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -1201,9 +1201,10 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
 
-    // Use square grid to simplify virtual grid bounce calculations.
-    llvm::SmallVector<int64_t> targetGridShape =
-        d2m::utils::getSquareTargetGrid(getTargetGridShape());
+    // Use the full device grid; squaring here would mismatch the target grid
+    // that d2m-grid-selection picked from and produce unplaceable virtual
+    // grids on non-square devices (e.g. Blackhole 10x13).
+    llvm::SmallVector<int64_t> targetGridShape = getTargetGridShape();
 
     patterns.add<D2MLowerToLayoutRewriter>(&getContext(), targetGridShape);
     GreedyRewriteConfig config;

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -1201,7 +1201,7 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
 
-    // Use square grid to simplify virtual grid bounce calculations
+    // Use square grid to simplify virtual grid bounce calculations.
     llvm::SmallVector<int64_t> targetGridShape =
         d2m::utils::getSquareTargetGrid(getTargetGridShape());
 

--- a/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
+++ b/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
@@ -4,26 +4,30 @@
 
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Utils.h"
 
 namespace mlir::tt::d2m::utils {
 
 llvm::SmallVector<int64_t>
 computeOptimalBlockShardedGrid(ArrayRef<int64_t> physicalShape,
-                               ArrayRef<int64_t> targetSquareGridShape) {
+                               ArrayRef<int64_t> targetGrid) {
   llvm::SmallVector<int64_t> grid(physicalShape.size(), 1);
 
-  TT_assert(targetSquareGridShape.size() == 2u);
-  TT_assert(physicalShape.size() >= targetSquareGridShape.size());
+  TT_assert(targetGrid.size() == 2u);
+  TT_assert(physicalShape.size() >= targetGrid.size());
 
   // For tensors with rank > 2, only shard across the last two dimensions
   // (which correspond to the 2D worker grid).
-  const size_t dimOffset = physicalShape.size() - targetSquareGridShape.size();
+  const size_t dimOffset = physicalShape.size() - targetGrid.size();
 
-  for (size_t i = 0; i < targetSquareGridShape.size(); ++i) {
+  for (size_t i = 0; i < targetGrid.size(); ++i) {
     const int64_t dim = physicalShape[dimOffset + i];
     TT_assert(dim > 0);
     // Search downward from the target grid size to find the largest divisor.
-    for (int64_t g = targetSquareGridShape[i]; g > 0; g--) {
+    for (int64_t g = targetGrid[i]; g > 0; g--) {
       if (dim % g == 0) {
         grid[dimOffset + i] = g;
         break;
@@ -33,6 +37,223 @@ computeOptimalBlockShardedGrid(ArrayRef<int64_t> physicalShape,
 
   TT_assert(grid.size() == physicalShape.size());
   return grid;
+}
+
+// Find which dimension has the maximum aspect ratio relative to others.
+static std::pair<unsigned, double>
+findMaxDimAndAspectRatio(ArrayRef<int64_t> physicalShape) {
+  double aspectRatio = 1.0;
+  unsigned maxDimIndex = 0;
+  for (size_t i = 0; i < physicalShape.size(); ++i) {
+    double ratio = physicalShape[i];
+    for (size_t j = 0; j < physicalShape.size(); ++j) {
+      if (i == j) {
+        continue;
+      }
+      ratio /= physicalShape[j];
+    }
+    if (ratio > aspectRatio) {
+      aspectRatio = ratio;
+      maxDimIndex = i;
+    }
+  }
+  return {maxDimIndex, aspectRatio};
+}
+
+llvm::SmallVector<int64_t>
+computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
+                          ArrayRef<int64_t> targetGrid) {
+
+  int64_t targetGridVolume = ttmlir::utils::volume(targetGrid);
+  if (physicalShape.size() != 2) {
+
+    // Compute factors for all dims.
+    SmallVector<SmallVector<int64_t>> factors =
+        llvm::to_vector(llvm::map_range(physicalShape, [](int64_t dim) {
+          return ttmlir::utils::getFactors(dim);
+        }));
+
+    auto factorCombinations =
+        ttmlir::utils::computeCartesianProduct<int64_t>(factors);
+
+    // Find grid with the greatest volume that is less than or equal to the
+    // target grid volume.
+    SmallVector<int64_t> bestGrid = {0};
+    int64_t bestGridVolume = 0;
+    for (const auto &grid : factorCombinations) {
+      int64_t gridVolume = ttmlir::utils::volume<int64_t>(grid);
+      if (gridVolume <= targetGridVolume && gridVolume > bestGridVolume) {
+        auto physGrid =
+            utils::findLegalPhysicalGridForVolume(gridVolume, targetGrid);
+        if (!physGrid.empty()) {
+
+          bestGrid = grid;
+          bestGridVolume = ttmlir::utils::volume<int64_t>(bestGrid);
+        }
+      }
+    }
+    return bestGrid;
+  }
+
+  // If not ND sharded, compute grid for 2D height or width sharding (Nx1, 1xN).
+  auto [shardedDimIndex, aspectRatio] = findMaxDimAndAspectRatio(physicalShape);
+
+  // Find the largest factor of the sharded dimension that fits within the
+  // target grid volume.
+  int64_t bestFactor = 0;
+  const auto factors =
+      ttmlir::utils::getFactors(physicalShape[shardedDimIndex]);
+  for (int64_t factor : llvm::reverse(factors)) {
+    if (factor <= targetGridVolume) {
+      auto physGrid = utils::findLegalPhysicalGridForVolume(factor, targetGrid);
+      if (!physGrid.empty()) {
+        bestFactor = factor;
+        break;
+      }
+    }
+  }
+
+  // If packing utilization is too low (<=25%), signal infeasibility by
+  // returning an empty grid so the caller can fall back to block sharding.
+  if (bestFactor == 0 ||
+      bestFactor <= static_cast<int64_t>(0.25 * targetGridVolume)) {
+    return {};
+  }
+
+  llvm::SmallVector<int64_t> grid;
+  for (size_t i = 0; i < physicalShape.size(); ++i) {
+    if (i == shardedDimIndex) {
+      grid.push_back(bestFactor);
+    } else {
+      grid.push_back(1);
+    }
+  }
+  return grid;
+}
+
+bool shouldImplementAsVirtualGrid(mlir::RankedTensorType tensorType,
+                                  ArrayRef<int64_t> physicalShape,
+                                  ArrayRef<int64_t> targetGrid) {
+
+  ttcore::MetalLayoutAttr layout =
+      mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
+
+  // For now, only non-collapsed 2D virtual grids on L1 are supported.
+  if (layout.hasNonTrivialCollapsedDims(tensorType.getShape()) ||
+      layout.getMemoryLayout() == ttcore::TensorMemoryLayout::Interleaved) {
+    return false;
+  }
+  if (physicalShape.size() != 2) {
+    return true;
+  }
+  auto blockShardedGrid =
+      computeOptimalBlockShardedGrid(physicalShape, targetGrid);
+  auto blockShardedGridVolume =
+      ttmlir::utils::volume<int64_t>(blockShardedGrid);
+  int64_t targetGridVolume = ttmlir::utils::volume<int64_t>(targetGrid);
+  bool lowGridUtilization = blockShardedGridVolume < 0.5 * targetGridVolume;
+  return lowGridUtilization;
+}
+
+llvm::SmallVector<int64_t> computeOptimalGrid(mlir::RankedTensorType tensorType,
+                                              ArrayRef<int64_t> physicalShape,
+                                              ArrayRef<int64_t> targetGrid) {
+  if (shouldImplementAsVirtualGrid(tensorType, physicalShape, targetGrid)) {
+    auto virtualGrid = computeOptimalVirtualGrid(physicalShape, targetGrid);
+    if (!virtualGrid.empty()) {
+      return virtualGrid;
+    }
+  }
+  return computeOptimalBlockShardedGrid(physicalShape, targetGrid);
+}
+
+llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
+                                                ArrayRef<int64_t> targetGrid,
+                                                bool ttnnMode,
+                                                mlir::OpBuilder &builder) {
+
+  auto tensorType = mlir::cast<mlir::RankedTensorType>(operand.getType());
+  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
+
+  // TTNN tensors do not require dim-alignment.
+  if (ttnnMode) {
+    return layout.getPhysicalShape(ttcore::TileType::getDefaultShape());
+  }
+
+  llvm::SmallVector<int64_t> tileShape;
+  if (auto tileType =
+          mlir::dyn_cast<ttcore::TileType>(tensorType.getElementType())) {
+    tileShape = llvm::to_vector(tileType.getShape());
+  } else {
+    // Always tile-align when calculating the physical shape, even in the row
+    // major case.
+    tileShape = llvm::to_vector(ttcore::TileType::getDefaultShape());
+  }
+
+  llvm::SmallVector<int64_t> alignments =
+      ttcore::MetalLayoutAttr::computeGridAwareDimAlignments(
+          layout.getLogicalShape(), targetGrid,
+          layout.getNormalizedIntervals());
+
+  auto tempLayout = ttcore::MetalLayoutAttr::get(
+      builder.getContext(), layout.getLogicalShape(), layout.getOobVal(),
+      layout.getMemorySpace(), layout.getMemoryLayout(),
+      layout.getCollapsedIntervals(), alignments);
+
+  return tempLayout.getPhysicalShape(
+      llvm::ArrayRef(tileShape.data(), tileShape.size()));
+}
+
+ttcore::MetalLayoutAttr layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
+                                              ArrayRef<int64_t> targetGrid,
+                                              bool ttnnMode,
+                                              ArrayRef<int64_t> optimalGrid,
+                                              mlir::OpBuilder &builder) {
+  llvm::SmallVector<int64_t> newDimAlignments;
+  if (ttnnMode) {
+    // TTNN tensors use simple tile-aligned dim alignments without grid-aware
+    // padding adjustments.
+    newDimAlignments.assign(oldLayout.getLogicalShape().size(), 1);
+    auto defaultTileShape = ttcore::TileType::getDefaultShape();
+    newDimAlignments[newDimAlignments.size() - 1] = defaultTileShape[1];
+    newDimAlignments[newDimAlignments.size() - 2] = defaultTileShape[0];
+  } else {
+    newDimAlignments = ttcore::MetalLayoutAttr::computeGridAwareDimAlignments(
+        oldLayout.getLogicalShape(), targetGrid,
+        oldLayout.getNormalizedIntervals());
+  }
+
+  return ttcore::MetalLayoutAttr::get(
+      builder.getContext(), oldLayout.getLogicalShape(), oldLayout.getOobVal(),
+      oldLayout.getMemorySpace(), oldLayout.getMemoryLayout(),
+      oldLayout.getCollapsedIntervals(), newDimAlignments);
+}
+
+mlir::RankedTensorType tensorWithOptimalGrid(mlir::RankedTensorType oldTensor,
+                                             ArrayRef<int64_t> targetGrid,
+                                             bool ttnnMode,
+                                             ArrayRef<int64_t> optimalGrid,
+                                             mlir::OpBuilder &builder) {
+  auto oldLayout = mlir::cast<ttcore::MetalLayoutAttr>(oldTensor.getEncoding());
+
+  llvm::SmallVector<int64_t> tileShape;
+  Type elementType = oldTensor.getElementType();
+  if (auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType)) {
+    tileShape = llvm::to_vector(tileType.getShape());
+    elementType = tileType.getElementType();
+  }
+
+  ttcore::MetalLayoutAttr newLayout = layoutWithOptimalGrid(
+      oldLayout, targetGrid, ttnnMode, optimalGrid, builder);
+
+  llvm::SmallVector<int64_t> deviceShape = newLayout.getDeviceShape(
+      optimalGrid, llvm::ArrayRef(tileShape.data(), tileShape.size()));
+
+  Type newElementType =
+      tileShape.empty()
+          ? elementType
+          : ttcore::TileType::get(elementType, llvm::ArrayRef(tileShape));
+  return RankedTensorType::get(deviceShape, newElementType, newLayout);
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
+++ b/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
@@ -39,11 +39,11 @@ computeOptimalBlockShardedGrid(ArrayRef<int64_t> physicalShape,
   return grid;
 }
 
-// Find which dimension has the maximum aspect ratio relative to others.
-static std::pair<unsigned, double>
-findMaxDimAndAspectRatio(ArrayRef<int64_t> physicalShape) {
-  double aspectRatio = 1.0;
-  unsigned maxDimIndex = 0;
+// Find the dimension whose size-to-(product-of-others) ratio is largest.
+// Returns 0 if no dim exceeds ratio 1.0 (i.e. balanced shape).
+static unsigned findShardedDimIndex(ArrayRef<int64_t> physicalShape) {
+  double bestRatio = 1.0;
+  unsigned bestIndex = 0;
   for (size_t i = 0; i < physicalShape.size(); ++i) {
     double ratio = physicalShape[i];
     for (size_t j = 0; j < physicalShape.size(); ++j) {
@@ -52,12 +52,12 @@ findMaxDimAndAspectRatio(ArrayRef<int64_t> physicalShape) {
       }
       ratio /= physicalShape[j];
     }
-    if (ratio > aspectRatio) {
-      aspectRatio = ratio;
-      maxDimIndex = i;
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      bestIndex = i;
     }
   }
-  return {maxDimIndex, aspectRatio};
+  return bestIndex;
 }
 
 llvm::SmallVector<int64_t>
@@ -96,7 +96,7 @@ computeOptimalVirtualGrid(ArrayRef<int64_t> physicalShape,
   }
 
   // If not ND sharded, compute grid for 2D height or width sharding (Nx1, 1xN).
-  auto [shardedDimIndex, aspectRatio] = findMaxDimAndAspectRatio(physicalShape);
+  unsigned shardedDimIndex = findShardedDimIndex(physicalShape);
 
   // Find the largest factor of the sharded dimension that fits within the
   // target grid volume.

--- a/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
+++ b/lib/Dialect/D2M/Utils/GridSelectionUtils.cpp
@@ -169,8 +169,7 @@ llvm::SmallVector<int64_t> computeOptimalGrid(mlir::RankedTensorType tensorType,
 
 llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
                                                 ArrayRef<int64_t> targetGrid,
-                                                bool ttnnMode,
-                                                mlir::OpBuilder &builder) {
+                                                bool ttnnMode) {
 
   auto tensorType = mlir::cast<mlir::RankedTensorType>(operand.getType());
   auto layout = mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
@@ -196,7 +195,7 @@ llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
           layout.getNormalizedIntervals());
 
   auto tempLayout = ttcore::MetalLayoutAttr::get(
-      builder.getContext(), layout.getLogicalShape(), layout.getOobVal(),
+      operand.getContext(), layout.getLogicalShape(), layout.getOobVal(),
       layout.getMemorySpace(), layout.getMemoryLayout(),
       layout.getCollapsedIntervals(), alignments);
 
@@ -206,9 +205,7 @@ llvm::SmallVector<int64_t> computePhysicalShape(mlir::Value operand,
 
 ttcore::MetalLayoutAttr layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
                                               ArrayRef<int64_t> targetGrid,
-                                              bool ttnnMode,
-                                              ArrayRef<int64_t> optimalGrid,
-                                              mlir::OpBuilder &builder) {
+                                              bool ttnnMode) {
   llvm::SmallVector<int64_t> newDimAlignments;
   if (ttnnMode) {
     // TTNN tensors use simple tile-aligned dim alignments without grid-aware
@@ -224,16 +221,16 @@ ttcore::MetalLayoutAttr layoutWithOptimalGrid(ttcore::MetalLayoutAttr oldLayout,
   }
 
   return ttcore::MetalLayoutAttr::get(
-      builder.getContext(), oldLayout.getLogicalShape(), oldLayout.getOobVal(),
-      oldLayout.getMemorySpace(), oldLayout.getMemoryLayout(),
-      oldLayout.getCollapsedIntervals(), newDimAlignments);
+      oldLayout.getContext(), oldLayout.getLogicalShape(),
+      oldLayout.getOobVal(), oldLayout.getMemorySpace(),
+      oldLayout.getMemoryLayout(), oldLayout.getCollapsedIntervals(),
+      newDimAlignments);
 }
 
 mlir::RankedTensorType tensorWithOptimalGrid(mlir::RankedTensorType oldTensor,
                                              ArrayRef<int64_t> targetGrid,
                                              bool ttnnMode,
-                                             ArrayRef<int64_t> optimalGrid,
-                                             mlir::OpBuilder &builder) {
+                                             ArrayRef<int64_t> optimalGrid) {
   auto oldLayout = mlir::cast<ttcore::MetalLayoutAttr>(oldTensor.getEncoding());
 
   llvm::SmallVector<int64_t> tileShape;
@@ -243,8 +240,8 @@ mlir::RankedTensorType tensorWithOptimalGrid(mlir::RankedTensorType oldTensor,
     elementType = tileType.getElementType();
   }
 
-  ttcore::MetalLayoutAttr newLayout = layoutWithOptimalGrid(
-      oldLayout, targetGrid, ttnnMode, optimalGrid, builder);
+  ttcore::MetalLayoutAttr newLayout =
+      layoutWithOptimalGrid(oldLayout, targetGrid, ttnnMode);
 
   llvm::SmallVector<int64_t> deviceShape = newLayout.getDeviceShape(
       optimalGrid, llvm::ArrayRef(tileShape.data(), tileShape.size()));

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -243,6 +243,11 @@ def test_reduce_outer_4d(
             "Outer dim 1 reduction incorrect for a=3, b=4: block factor "
             "analysis splits the reduction dim due to odd batch size, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
         )
+    # TODO: (a=3, b=8, dim_arg=[1]) fails on p150 with L1 OOM after the
+    # non-square grid selection changes. Re-enable once grid selection handles
+    # this combination without exhausting L1.
+    if dim_arg == [1] and a == 3 and b == 8:
+        pytest.skip("L1 OOM on p150 with current grid selection")
 
     reduce_type = _4D_OUTER_REDUCE[(a, b, m, n, dim_arg[0])]
     tile_size = 32

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -244,11 +244,11 @@ def test_reduce_outer_4d(
             "Outer dim 1 reduction incorrect for a=3, b=4: block factor "
             "analysis splits the reduction dim due to odd batch size, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
         )
-    # TODO: (a=3, b=8, dim_arg=[1]) fails on p150 with L1 OOM after the
-    # non-square grid selection changes. Re-enable once grid selection handles
-    # this combination without exhausting L1.
+    # TODO(#8079): (a=3, b=8, dim_arg=[1]) fails on p150 with L1 OOM on the
+    # non-square 10x13 grid. Re-enable once grid selection handles non-square
+    # grids without inflating per-core L1.
     if dim_arg == [1] and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
-        pytest.skip("L1 OOM on p150 with current grid selection")
+        pytest.skip("L1 OOM on non-square grid (see #8079)")
 
     reduce_type = _4D_OUTER_REDUCE[(a, b, m, n, dim_arg[0])]
     tile_size = 32

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -13,7 +13,7 @@ from ttmlir.ir import *
 from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir
-from conftest import get_request_kwargs
+from conftest import get_request_kwargs, get_board_id
 
 pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
@@ -231,6 +231,7 @@ def test_reduce_outer_4d(
     dtype: torch.dtype,
     request,
     device,
+    system_desc,
 ):
     total_tiles = a * b * m * n
     if dim_arg == [0] and total_tiles >= 128:
@@ -246,7 +247,7 @@ def test_reduce_outer_4d(
     # TODO: (a=3, b=8, dim_arg=[1]) fails on p150 with L1 OOM after the
     # non-square grid selection changes. Re-enable once grid selection handles
     # this combination without exhausting L1.
-    if dim_arg == [1] and a == 3 and b == 8:
+    if dim_arg == [1] and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
         pytest.skip("L1 OOM on p150 with current grid selection")
 
     reduce_type = _4D_OUTER_REDUCE[(a, b, m, n, dim_arg[0])]

--- a/test/python/golden/test_metal_tms.py
+++ b/test/python/golden/test_metal_tms.py
@@ -37,32 +37,43 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
     "shape, permutation",
     [
         # 2d transpose
-        [(32, 128 * 500), [1, 0]],
+        pytest.param(
+            (32, 128 * 500),
+            [1, 0],
+            marks=pytest.mark.skip_config(
+                ["sim"],
+                reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
+            ),
+        ),
         pytest.param(
             (32, 128 * 501),
             [1, 0],
-            marks=pytest.mark.skip_config(
-                ["n150"],
-                ["n300"],
-                # TODO: p150 fails with L1 OOM after the non-square grid
-                # selection changes. Drop the p150 entry once grid selection
-                # handles this shape without exhausting L1.
-                ["p150"],
-                reason="L1 memory usage exceeds capacity #7559",
-            ),
+            marks=[
+                pytest.mark.skip_config(
+                    ["n150"],
+                    ["n300"],
+                    reason="L1 memory usage exceeds capacity #7559",
+                ),
+                pytest.mark.skip_config(
+                    ["p150"],
+                    reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
+                ),
+            ],
         ),
         pytest.param(
             (32, 128 * 800),
             [1, 0],
-            marks=pytest.mark.skip_config(
-                ["n150"],
-                ["n300"],
-                # TODO: p150 fails with L1 OOM after the non-square grid
-                # selection changes. Drop the p150 entry once grid selection
-                # handles this shape without exhausting L1.
-                ["p150"],
-                reason="L1 memory usage exceeds capacity #7559",
-            ),
+            marks=[
+                pytest.mark.skip_config(
+                    ["n150"],
+                    ["n300"],
+                    reason="L1 memory usage exceeds capacity #7559",
+                ),
+                pytest.mark.skip_config(
+                    ["p150"],
+                    reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
+                ),
+            ],
         ),
         pytest.param(
             (32, 128 * 801),
@@ -131,11 +142,17 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         pytest.param(
             (32, 8, 128, 128),
             [0, 1, 3, 2],
-            marks=pytest.mark.skip_config(
-                ["p150"],
-                ["p300"],
-                reason="L1 memory usage exceeds capacity on p150/p300",
-            ),
+            marks=[
+                pytest.mark.skip_config(
+                    ["p150"],
+                    ["p300"],
+                    reason="L1 memory usage exceeds capacity on p150/p300",
+                ),
+                pytest.mark.skip_config(
+                    ["sim"],
+                    reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
+                ),
+            ],
         ),
         # 4d complex permutes (llama3-70b, qwen3-32b)
         [(32, 1, 1, 128), [2, 1, 0, 3]],
@@ -148,7 +165,14 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         [(1, 32, 8, 128), [0, 2, 1, 3]],
         [(1, 32, 96, 128), [0, 2, 1, 3]],
         # 4d inner permutes (glm-358b)
-        [(1, 96, 32, 128), [0, 1, 3, 2]],
+        pytest.param(
+            (1, 96, 32, 128),
+            [0, 1, 3, 2],
+            marks=pytest.mark.skip_config(
+                ["sim"],
+                reason="L1 memory usage exceeds capacity on non-square grid (see #8079)",
+            ),
+        ),
         # 3d inner permutes (gpt_oss-120b)
         [(1, 128, 32), [0, 2, 1]],
         # 4d outer permutes (gpt_oss-120b)

--- a/test/python/golden/test_metal_tms.py
+++ b/test/python/golden/test_metal_tms.py
@@ -44,6 +44,10 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
             marks=pytest.mark.skip_config(
                 ["n150"],
                 ["n300"],
+                # TODO: p150 fails with L1 OOM after the non-square grid
+                # selection changes. Drop the p150 entry once grid selection
+                # handles this shape without exhausting L1.
+                ["p150"],
                 reason="L1 memory usage exceeds capacity #7559",
             ),
         ),
@@ -53,6 +57,10 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
             marks=pytest.mark.skip_config(
                 ["n150"],
                 ["n300"],
+                # TODO: p150 fails with L1 OOM after the non-square grid
+                # selection changes. Drop the p150 entry once grid selection
+                # handles this shape without exhausting L1.
+                ["p150"],
                 reason="L1 memory usage exceeds capacity #7559",
             ),
         ),

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
@@ -1,8 +1,8 @@
 // RUN: ttmlir-opt --split-input-file --ttcore-register-device --d2m-grid-selection %s | FileCheck %s
 
 // d2m-grid-selection: generic inside d2m.spatial uses each region's CoreRange extent for target
-// grid sizing (not the full device grid). Square grid_ranges only: pass applies getSquareTargetGrid
-// to that extent. Non-origin region output buffers may use d2m.empty VGM so grid CHECKs include maps.
+// grid sizing (not the full device grid). Non-origin region output buffers may use d2m.empty VGM
+// so grid CHECKs include maps.
 // -----
 // Grid 2x2 at origin: generic keeps grid 2x2.
 #any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
GridSelection pass is quite large and complex.

### What's changed
Update GridSelection to split separate analysis, cleanup, and fix some issues (forcing square on p150, etc).
Allow nonsquare grids, disable a few tests this breaks, fix a related LowerToLayout bug. Fix an insertion-point bug in D2MToTTKernel.cpp as well.


### Checklist
- [ ] New/Existing tests provide coverage for changes
