### PR TITLE
[d2m] ttir.ones and ttir.zeros support

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -33,6 +33,7 @@
 
 #include <array>
 #include <limits>
+#include <type_traits>
 
 namespace mlir::tt {
 
@@ -2476,30 +2477,65 @@ class D2MEmptyOpRewriter : public OpConversionPattern<ttir::EmptyOp> {
   }
 };
 
-class D2MFullOpRewriter : public OpConversionPattern<ttir::FullOp>,
-                          D2MNamedRewriterCommon {
+/// Lowers `ttir.full`, `ttir.zeros`, and `ttir.ones` through
+/// `lowerRankedTensorFillViaGeneric` (`d2m.tile_fill` + remote_store).
+template <typename OpTy>
+class D2MFullLikeOpRewriter : public OpConversionPattern<OpTy>,
+                              D2MNamedRewriterCommon {
+  static_assert(std::is_same_v<OpTy, ttir::FullOp> ||
+                std::is_same_v<OpTy, ttir::ZerosOp> ||
+                std::is_same_v<OpTy, ttir::OnesOp>);
+
+  static mlir::Attribute getFillAttr(OpTy op, RankedTensorType resultType) {
+    if constexpr (std::is_same_v<OpTy, ttir::FullOp>) {
+      return op.getFillValueAttr();
+    }
+    Type elemTy = resultType.getElementType();
+    constexpr bool kOnes = std::is_same_v<OpTy, ttir::OnesOp>;
+    if (auto floatTy = mlir::dyn_cast<mlir::FloatType>(elemTy)) {
+      return mlir::FloatAttr::get(floatTy, kOnes ? 1.0 : 0.0);
+    }
+    if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(elemTy)) {
+      return mlir::IntegerAttr::get(intTy, static_cast<int64_t>(kOnes ? 1 : 0));
+    }
+    return {};
+  }
+
 public:
-  D2MFullOpRewriter(const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
-                    ttcore::MemorySpace defaultInputMemSpace,
-                    ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
-                    bool collapseTensors, bool enableMulticastInference)
-      : OpConversionPattern<ttir::FullOp>(typeConverter, ctx),
+  D2MFullLikeOpRewriter(const TypeConverter &typeConverter,
+                        mlir::MLIRContext *ctx,
+                        ttcore::MemorySpace defaultInputMemSpace,
+                        ttcore::MemorySpace defaultOutputMemSpace,
+                        bool ttnnMode, bool collapseTensors,
+                        bool enableMulticastInference)
+      : OpConversionPattern<OpTy>(typeConverter, ctx),
         D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
 
   LogicalResult
-  matchAndRewrite(ttir::FullOp op, ttir::FullOp::Adaptor adaptor,
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
+    (void)adaptor;
     RankedTensorType resultType = op.getResult().getType();
-    Attribute fillAttr = op.getFillValueAttr();
-    mlir::FailureOr<mlir::Value> filled =
-        lowerRankedTensorFillViaGeneric(rewriter, loc, resultType, fillAttr);
-    if (mlir::failed(filled)) {
+    mlir::Attribute fillAttr = getFillAttr(op, resultType);
+    if (!fillAttr) {
       return rewriter.notifyMatchFailure(
-          op, "full lowering expects float or integer fill attribute and "
-              "matching tensor element type");
+          op, "expected float or integer tensor element type (zeros/ones) or "
+              "fill value attribute (full)");
+    }
+
+    mlir::FailureOr<mlir::Value> filled = lowerRankedTensorFillViaGeneric(
+        rewriter, op.getLoc(), resultType, fillAttr);
+    if (mlir::failed(filled)) {
+      if constexpr (std::is_same_v<OpTy, ttir::FullOp>) {
+        return rewriter.notifyMatchFailure(
+            op,
+            "full lowering expects float or integer fill attribute matching "
+            "tensor element type");
+      }
+      return rewriter.notifyMatchFailure(
+          op, "could not lower zeros/ones fill via tile_fill");
     }
     rewriter.replaceOp(op, *filled);
     return success();
@@ -3536,6 +3572,10 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MPermuteRewriter,
     D2MMatmulBlockToLinalgGeneric,
     D2MTensorManipulationOpRewriter<ttir::PermuteOp, permuteLogicalInfo>,
+    // Full / zeros / ones (constant fill via tile_fill).
+    D2MFullLikeOpRewriter<ttir::FullOp>,
+    D2MFullLikeOpRewriter<ttir::ZerosOp>,
+    D2MFullLikeOpRewriter<ttir::OnesOp>,
     // CCL
     D2MAllGatherRewriter
   >(typeConverter, ctx, defaultInputMemSpace, defaultOutputMemSpace, ttnnMode, collapseTensors, enableMulticastInference);
@@ -3548,9 +3588,6 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
 
   // Creation ops 1:1 conversion.
   patterns.add<D2MEmptyOpRewriter>(typeConverter, ctx);
-  patterns.add<D2MFullOpRewriter>(
-      typeConverter, ctx, defaultInputMemSpace, defaultOutputMemSpace, ttnnMode,
-      collapseTensors, enableMulticastInference);
 
   // Mesh ops 1:1 conversion.
   patterns.add<D2MMeshShardOpRewriter>(typeConverter, ctx);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -2479,19 +2479,20 @@ class D2MEmptyOpRewriter : public OpConversionPattern<ttir::EmptyOp> {
 
 /// Lowers `ttir.full`, `ttir.zeros`, and `ttir.ones` through
 /// `lowerRankedTensorFillViaGeneric` (`d2m.tile_fill` + remote_store).
-template <typename OpTy>
-class D2MFullLikeOpRewriter : public OpConversionPattern<OpTy>,
-                              D2MNamedRewriterCommon {
-  static_assert(std::is_same_v<OpTy, ttir::FullOp> ||
-                std::is_same_v<OpTy, ttir::ZerosOp> ||
-                std::is_same_v<OpTy, ttir::OnesOp>);
+template <typename ConcreteOp>
+class D2MConstantFillOpRewriter : public OpConversionPattern<ConcreteOp>,
+                                  D2MNamedRewriterCommon {
+  static_assert(std::is_same_v<ConcreteOp, ttir::FullOp> ||
+                std::is_same_v<ConcreteOp, ttir::ZerosOp> ||
+                std::is_same_v<ConcreteOp, ttir::OnesOp>);
 
-  static mlir::Attribute getFillAttr(OpTy op, RankedTensorType resultType) {
-    if constexpr (std::is_same_v<OpTy, ttir::FullOp>) {
+  static mlir::Attribute getFillAttr(ConcreteOp op,
+                                     RankedTensorType resultType) {
+    if constexpr (std::is_same_v<ConcreteOp, ttir::FullOp>) {
       return op.getFillValueAttr();
     }
     Type elemTy = resultType.getElementType();
-    constexpr bool kOnes = std::is_same_v<OpTy, ttir::OnesOp>;
+    constexpr bool kOnes = std::is_same_v<ConcreteOp, ttir::OnesOp>;
     if (auto floatTy = mlir::dyn_cast<mlir::FloatType>(elemTy)) {
       return mlir::FloatAttr::get(floatTy, kOnes ? 1.0 : 0.0);
     }
@@ -2502,21 +2503,21 @@ class D2MFullLikeOpRewriter : public OpConversionPattern<OpTy>,
   }
 
 public:
-  D2MFullLikeOpRewriter(const TypeConverter &typeConverter,
-                        mlir::MLIRContext *ctx,
-                        ttcore::MemorySpace defaultInputMemSpace,
-                        ttcore::MemorySpace defaultOutputMemSpace,
-                        bool ttnnMode, bool collapseTensors,
-                        bool enableMulticastInference)
-      : OpConversionPattern<OpTy>(typeConverter, ctx),
+  D2MConstantFillOpRewriter(const TypeConverter &typeConverter,
+                            mlir::MLIRContext *ctx,
+                            ttcore::MemorySpace defaultInputMemSpace,
+                            ttcore::MemorySpace defaultOutputMemSpace,
+                            bool ttnnMode, bool collapseTensors,
+                            bool enableMulticastInference)
+      : OpConversionPattern<ConcreteOp>(typeConverter, ctx),
         D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
 
   LogicalResult
-  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+  matchAndRewrite(ConcreteOp op, typename ConcreteOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    (void)adaptor;
+    Location loc = op.getLoc();
     RankedTensorType resultType = op.getResult().getType();
     mlir::Attribute fillAttr = getFillAttr(op, resultType);
     if (!fillAttr) {
@@ -2525,17 +2526,11 @@ public:
               "fill value attribute (full)");
     }
 
-    mlir::FailureOr<mlir::Value> filled = lowerRankedTensorFillViaGeneric(
-        rewriter, op.getLoc(), resultType, fillAttr);
+    mlir::FailureOr<mlir::Value> filled =
+        lowerRankedTensorFillViaGeneric(rewriter, loc, resultType, fillAttr);
     if (mlir::failed(filled)) {
-      if constexpr (std::is_same_v<OpTy, ttir::FullOp>) {
-        return rewriter.notifyMatchFailure(
-            op,
-            "full lowering expects float or integer fill attribute matching "
-            "tensor element type");
-      }
       return rewriter.notifyMatchFailure(
-          op, "could not lower zeros/ones fill via tile_fill");
+          op, "could not lower constant fill via tile_fill");
     }
     rewriter.replaceOp(op, *filled);
     return success();
@@ -3573,9 +3568,9 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MMatmulBlockToLinalgGeneric,
     D2MTensorManipulationOpRewriter<ttir::PermuteOp, permuteLogicalInfo>,
     // Full / zeros / ones (constant fill via tile_fill).
-    D2MFullLikeOpRewriter<ttir::FullOp>,
-    D2MFullLikeOpRewriter<ttir::ZerosOp>,
-    D2MFullLikeOpRewriter<ttir::OnesOp>,
+    D2MConstantFillOpRewriter<ttir::FullOp>,
+    D2MConstantFillOpRewriter<ttir::ZerosOp>,
+    D2MConstantFillOpRewriter<ttir::OnesOp>,
     // CCL
     D2MAllGatherRewriter
   >(typeConverter, ctx, defaultInputMemSpace, defaultOutputMemSpace, ttnnMode, collapseTensors, enableMulticastInference);

--- a/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/RankNormalization.cpp
@@ -123,6 +123,12 @@ public:
       updateArangeDimension(arangeOp);
     } else if (auto sliceOp = dyn_cast<ttir::SliceStaticOp>(newOp)) {
       updateSliceStaticAttrs(sliceOp);
+    } else if (auto fullOp = dyn_cast<ttir::FullOp>(newOp)) {
+      updateDenseI32ShapeAttr(fullOp);
+    } else if (auto zerosOp = dyn_cast<ttir::ZerosOp>(newOp)) {
+      updateDenseI32ShapeAttr(zerosOp);
+    } else if (auto onesOp = dyn_cast<ttir::OnesOp>(newOp)) {
+      updateDenseI32ShapeAttr(onesOp);
     }
 
     rewriter.replaceOp(op, newOp->getResults());
@@ -130,6 +136,22 @@ public:
   }
 
 private:
+  /// Ops with `DenseI32ArrayAttr` `shape` (ttir.full, zeros, ones): keep shape
+  /// attr aligned with the promoted result rank.
+  template <typename OpTy>
+  static void updateDenseI32ShapeAttr(OpTy op) {
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
+    if (!resultType) {
+      return;
+    }
+    ArrayRef<int32_t> currentShape = op.getShape();
+    if (static_cast<int64_t>(currentShape.size()) == resultType.getRank()) {
+      return;
+    }
+    OpBuilder builder(op.getContext());
+    op.setShapeAttr(builder.getDenseI32ArrayAttr(expandShape(currentShape)));
+  }
+
   static void updateConstantValueAttr(ttir::ConstantOp constantOp) {
     auto valueAttr = dyn_cast<DenseElementsAttr>(constantOp.getValue());
     if (!valueAttr) {

--- a/test/python/golden/test_metal_constants.py
+++ b/test/python/golden/test_metal_constants.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# End-to-end golden tests for ttir.constant through the TTMetal pipeline.
-# Each test compiles a TTIR module containing a constant op and runs it on
-# device, verifying the output matches a torch golden.
+# End-to-end golden tests for ttir.constant, ttir.ones, and ttir.zeros through
+# the TTMetal pipeline. Each test compiles a TTIR module and runs it on device,
+# verifying the output matches a torch golden.
 
 import pytest
 import torch
@@ -19,8 +19,10 @@ from builder.base.builder_apis import compile_and_execute_ttir
 
 pytestmark = pytest.mark.frontend("ttir")
 
+_CONSTANT_ONES_ZEROS_SHAPES = [(128, 128), (128,), (1, 128, 128)]
 
-@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
+
+@pytest.mark.parametrize("shape", _CONSTANT_ONES_ZEROS_SHAPES, ids=shape_str)
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -38,8 +40,6 @@ def test_constant(
     request,
     device,
 ):
-    """Standalone constant with no inputs: the constant tensor is the sole output."""
-
     def module(builder: TTIRBuilder):
         if dtype.is_floating_point:
             tensor = torch.full(shape, 1.25, dtype=dtype)
@@ -64,6 +64,78 @@ def test_constant(
     compile_and_execute_ttir(module, **kwargs)
 
 
+@pytest.mark.parametrize("shape", _CONSTANT_ONES_ZEROS_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float32,
+        torch.bfloat16,
+        torch.int32 | SkipIf("sim"),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_ones(
+    shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([], [])
+        def ones_fn(
+            builder: TTIRBuilder,
+            unit_attrs: List[str] = None,
+        ):
+            return builder.ones(shape, dtype, unit_attrs=unit_attrs)
+
+    kwargs = {
+        "target": target,
+        **get_request_kwargs(request),
+        "device": device,
+        "atol": 0,
+        "check_atol": True,
+    }
+    compile_and_execute_ttir(module, **kwargs)
+
+
+@pytest.mark.parametrize("shape", _CONSTANT_ONES_ZEROS_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float32,
+        torch.bfloat16,
+        torch.int32 | SkipIf("sim"),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_zeros(
+    shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([], [])
+        def zeros_fn(
+            builder: TTIRBuilder,
+            unit_attrs: List[str] = None,
+        ):
+            return builder.zeros(shape, dtype, unit_attrs=unit_attrs)
+
+    kwargs = {
+        "target": target,
+        **get_request_kwargs(request),
+        "device": device,
+        "atol": 0,
+        "check_atol": True,
+    }
+    compile_and_execute_ttir(module, **kwargs)
+
+
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize(
     "dtype",
@@ -72,8 +144,6 @@ def test_constant(
 )
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_constant_unary(shape, dtype: torch.dtype, target: str, request, device):
-    """Constant fed into a unary op: creates a constant tensor and applies abs."""
-
     if dtype.is_floating_point:
         bias = torch.full(shape, 1.25, dtype=dtype)
     else:
@@ -114,8 +184,6 @@ def test_constant_binary(
     request,
     device,
 ):
-    """Constant as one operand of a binary op: maximum(input, constant)."""
-
     if dtype.is_floating_point:
         low, high = -4.0, 4.0
         midpoint = (low + high) / 2
@@ -163,12 +231,6 @@ def test_constant_ternary(
     request,
     device,
 ):
-    """Constant as one operand of a ternary op: where(cond, x, constant).
-
-    Uses set_goldens to supply explicit cond and x input tensors so the
-    where condition and true-branch values are deterministic.
-    """
-
     if dtype.is_floating_point:
         value = torch.full(shape, -2.0, dtype=dtype)
     else:

--- a/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
@@ -210,6 +210,23 @@ func.func @constant_1d_promoted() -> tensor<4xi64> {
 }
 
 // =============================================================================
+// Test 10b2: 1D ttir.full - shape attr promoted to match result (verifier)
+// =============================================================================
+// ttir.full requires `shape` to match the result tensor shape; rank normalization
+// promotes tensor<1xsi32> to tensor<1x1xsi32> and must prepend 1 to `shape`.
+
+// CHECK-LABEL: func.func @full_1d_with_1d_arg
+// CHECK-SAME: (%arg0: tensor<1x1xsi32>) -> tensor<1x1xsi32>
+// CHECK: %[[F:.*]] = "ttir.full"() <{fill_value = 128 : i32, shape = array<i32: 1, 1>}> : () -> tensor<1x1xsi32>
+// CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %[[F]]) : (tensor<1x1xsi32>, tensor<1x1xsi32>) -> tensor<1x1xsi32>
+// CHECK: return %[[ADD]] : tensor<1x1xsi32>
+func.func @full_1d_with_1d_arg(%arg0: tensor<1xsi32>) -> tensor<1xsi32> {
+  %0 = "ttir.full"() <{fill_value = 128 : i32, shape = array<i32: 1>}> : () -> tensor<1xsi32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<1xsi32>, tensor<1xsi32>) -> tensor<1xsi32>
+  return %1 : tensor<1xsi32>
+}
+
+// =============================================================================
 // Test 10c: 1D arange - result type promoted to 2D, arange_dimension 0 -> 1
 // =============================================================================
 // ttir.arange verifies result shape at arange_dimension equals (end-start)/step;

--- a/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/rank_normalization.mlir
@@ -210,7 +210,7 @@ func.func @constant_1d_promoted() -> tensor<4xi64> {
 }
 
 // =============================================================================
-// Test 10b2: 1D ttir.full - shape attr promoted to match result (verifier)
+// 1D ttir.full - shape attr promoted to match result (verifier)
 // =============================================================================
 // ttir.full requires `shape` to match the result tensor shape; rank normalization
 // promotes tensor<1xsi32> to tensor<1x1xsi32> and must prepend 1 to `shape`.
@@ -224,6 +224,36 @@ func.func @full_1d_with_1d_arg(%arg0: tensor<1xsi32>) -> tensor<1xsi32> {
   %0 = "ttir.full"() <{fill_value = 128 : i32, shape = array<i32: 1>}> : () -> tensor<1xsi32>
   %1 = "ttir.add"(%arg0, %0) : (tensor<1xsi32>, tensor<1xsi32>) -> tensor<1xsi32>
   return %1 : tensor<1xsi32>
+}
+
+// =============================================================================
+// 1D ttir.zeros - shape attr promoted to match result
+// =============================================================================
+
+// CHECK-LABEL: func.func @zeros_1d_promoted
+// CHECK-SAME: (%arg0: tensor<1x64xf32>) -> tensor<1x64xf32>
+// CHECK: %[[Z:.*]] = "ttir.zeros"() <{shape = array<i32: 1, 64>}> : () -> tensor<1x64xf32>
+// CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %[[Z]]) : (tensor<1x64xf32>, tensor<1x64xf32>) -> tensor<1x64xf32>
+// CHECK: return %[[ADD]] : tensor<1x64xf32>
+func.func @zeros_1d_promoted(%arg0: tensor<64xf32>) -> tensor<64xf32> {
+  %0 = "ttir.zeros"() <{shape = array<i32: 64>}> : () -> tensor<64xf32>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+  return %1 : tensor<64xf32>
+}
+
+// =============================================================================
+// 1D ttir.ones - shape attr promoted to match result
+// =============================================================================
+
+// CHECK-LABEL: func.func @ones_1d_promoted
+// CHECK-SAME: (%arg0: tensor<1x128xbf16>) -> tensor<1x128xbf16>
+// CHECK: %[[O:.*]] = "ttir.ones"() <{shape = array<i32: 1, 128>}> : () -> tensor<1x128xbf16>
+// CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %[[O]]) : (tensor<1x128xbf16>, tensor<1x128xbf16>) -> tensor<1x128xbf16>
+// CHECK: return %[[ADD]] : tensor<1x128xbf16>
+func.func @ones_1d_promoted(%arg0: tensor<128xbf16>) -> tensor<128xbf16> {
+  %0 = "ttir.ones"() <{shape = array<i32: 128>}> : () -> tensor<128xbf16>
+  %1 = "ttir.add"(%arg0, %0) : (tensor<128xbf16>, tensor<128xbf16>) -> tensor<128xbf16>
+  return %1 : tensor<128xbf16>
 }
 
 // =============================================================================


### PR DESCRIPTION
### Problem description
Need to support these ops in ttmetal and there's an issue in rank normalization with ttir.full for 1d tensors where the attribute needs to be updated

### What's changed
- Refactored `TTIRToD2M.cpp` to lower `ttir.full`, `ttir.ones` and `ttir.zeros` thru the same rewriter, just passing in a different fill attr
- Changed RankNorm to update the shape attribute on these ops 
- Added builder and lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
