### PR TITLE
Support remote_load mcast from dynamic values

### DIFF
--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -74,26 +74,17 @@ public:
     auto genericOp = remoteLoad->getParentOfType<GenericOp>();
     TT_assertv(genericOp, "RemoteLoad must be inside a GenericOp");
 
-    // Derive which dimensions are multicast from mcastShape.
-    // A dimension is multicast if mcastShape[i] > 1.
-    // Also calculate mcast volume.
-    SmallVector<bool> isMcastDim;
-    size_t mcastVolume = 1;
-    for (Value mcastDimVal : remoteLoad.getMcastShape()) {
-      int64_t dimSize = 1;
-      if (auto constantOp = mcastDimVal.getDefiningOp<arith::ConstantOp>()) {
-        if (auto intAttr = mlir::dyn_cast<IntegerAttr>(constantOp.getValue())) {
-          dimSize = intAttr.getInt();
-        }
-      }
-      isMcastDim.push_back(dimSize > 1);
-      mcastVolume *= dimSize;
-    }
-
     Value zero = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
     Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
                                                    rewriter.getIndexAttr(1));
+
+    // Calculate mcast volume dynamically by multiplying all mcastShape dims.
+    Value mcastVolume = one;
+    for (Value mcastDimVal : remoteLoad.getMcastShape()) {
+      mcastVolume =
+          rewriter.create<arith::MulIOp>(loc, mcastVolume, mcastDimVal);
+    }
 
     // Get pre-allocated semaphores for synchronization.
     // These must have been set by D2MPreallocateMcastSemaphores pass.
@@ -103,8 +94,8 @@ public:
 
     // Number of receivers is mcastVolume - 1 (excluding sender itself).
     // The sender waits for this many semaphore increments before multicasting.
-    Value numReceiversVal = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexType(), rewriter.getIndexAttr(mcastVolume - 1));
+    Value numReceiversVal =
+        rewriter.create<arith::SubIOp>(loc, mcastVolume, one);
 
     // Determine if this core is the sender.
     // The sender is at position mcastStartIndex[i] for each multicast
@@ -113,19 +104,17 @@ public:
     Value isSender = nullptr;
     AffineMap gridMapping = genericOp.getGrid().getPhysicalToVirtMap();
     ValueRange mcastStartIndex = remoteLoad.getMcastStartIndex();
-    for (size_t i = 0; i < isMcastDim.size(); ++i) {
-      if (isMcastDim[i]) {
-        Value coreIdx = rewriter.create<CoreIndexOp>(
-            loc, static_cast<int64_t>(i), gridMapping);
-        Value condition = rewriter.create<arith::CmpIOp>(
-            loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, coreIdx,
-            mcastStartIndex[i]);
-        if (isSender) {
-          isSender = rewriter.create<arith::AndIOp>(loc, isSender, condition)
-                         .getResult();
-        } else {
-          isSender = condition;
-        }
+    for (auto [i, mcastIdx] : llvm::enumerate(mcastStartIndex)) {
+      Value coreIdx = rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i),
+                                                   gridMapping);
+      Value condition = rewriter.create<arith::CmpIOp>(
+          loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, coreIdx,
+          mcastIdx);
+      if (isSender) {
+        isSender = rewriter.create<arith::AndIOp>(loc, isSender, condition)
+                       .getResult();
+      } else {
+        isSender = condition;
       }
     }
     TT_assertv(isSender, "No multicast dimensions found in mcastShape");
@@ -171,29 +160,11 @@ public:
         [&](OpBuilder &builder, Location loc) {
           // Receiver: signal ready and wait for sender to finish.
           SmallVector<Value> senderCoreIndex;
-          Value zeroIdx = builder.create<arith::ConstantOp>(
-              loc, builder.getIndexType(), builder.getIndexAttr(0));
-
-          // Build sender core index by reading actual core positions.
-          // For dimensions that are multicast, sender is at mcastStartIndex.
-          // For non-multicast dimensions, use current core position.
-          // Pass grid mapping for proper virtualization support.
-          for (size_t i = 0; i < isMcastDim.size(); ++i) {
-            if (isMcastDim[i]) {
-              // Multicast dimension - sender is at mcastStartIndex.
-              senderCoreIndex.push_back(mcastStartIndex[i]);
-            } else {
-              // Non-multicast dimension - use current core's position.
-              Value currentCoreIdx = builder.create<CoreIndexOp>(
-                  loc, static_cast<int64_t>(i), gridMapping);
-              senderCoreIndex.push_back(currentCoreIdx);
-            }
-          }
 
           builder.create<SemaphoreIncOp>(loc, receiversReadySemaphore, one,
-                                         senderCoreIndex);
+                                         mcastStartIndex);
           builder.create<SemaphoreWaitOp>(loc, senderFinishedSemaphore, one,
-                                          zeroIdx);
+                                          zero);
 
           // Note: CB already reserved before the if/else, so receiver has
           // proper access to the multicast data.

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -109,26 +109,17 @@ public:
     auto genericOp = remoteLoad->getParentOfType<GenericOp>();
     TT_assertv(genericOp, "RemoteLoad must be inside a GenericOp");
 
-    // Derive which dimensions are multicast from mcastShape.
-    // A dimension is multicast if mcastShape[i] > 1.
-    // Also calculate mcast volume.
-    SmallVector<bool> isMcastDim;
-    size_t mcastVolume = 1;
-    for (Value mcastDimVal : remoteLoad.getMcastShape()) {
-      int64_t dimSize = 1;
-      if (auto constantOp = mcastDimVal.getDefiningOp<arith::ConstantOp>()) {
-        if (auto intAttr = mlir::dyn_cast<IntegerAttr>(constantOp.getValue())) {
-          dimSize = intAttr.getInt();
-        }
-      }
-      isMcastDim.push_back(dimSize > 1);
-      mcastVolume *= dimSize;
-    }
-
     Value zero = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
     Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
                                                    rewriter.getIndexAttr(1));
+
+    // Calculate mcast volume dynamically by multiplying all mcastShape dims.
+    Value mcastVolume = one;
+    for (Value mcastDimVal : remoteLoad.getMcastShape()) {
+      mcastVolume =
+          rewriter.create<arith::MulIOp>(loc, mcastVolume, mcastDimVal);
+    }
 
     // Get pre-allocated semaphores for synchronization.
     // These must have been set by D2MPreallocateMcastSemaphores pass.
@@ -138,8 +129,8 @@ public:
 
     // Number of receivers is mcastVolume - 1 (excluding sender itself).
     // The sender waits for this many semaphore increments before multicasting.
-    Value numReceiversVal = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexType(), rewriter.getIndexAttr(mcastVolume - 1));
+    Value numReceiversVal =
+        rewriter.create<arith::SubIOp>(loc, mcastVolume, one);
 
     // Determine if this core is the sender.
     // The sender is at position mcastStartIndex[i] for each multicast
@@ -148,19 +139,17 @@ public:
     Value isSender = nullptr;
     AffineMap gridMapping = genericOp.getGrid().getPhysicalToVirtMap();
     ValueRange mcastStartIndex = remoteLoad.getMcastStartIndex();
-    for (size_t i = 0; i < isMcastDim.size(); ++i) {
-      if (isMcastDim[i]) {
-        Value coreIdx = rewriter.create<CoreIndexOp>(
-            loc, static_cast<int64_t>(i), gridMapping);
-        Value condition = rewriter.create<arith::CmpIOp>(
-            loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, coreIdx,
-            mcastStartIndex[i]);
-        if (isSender) {
-          isSender = rewriter.create<arith::AndIOp>(loc, isSender, condition)
-                         .getResult();
-        } else {
-          isSender = condition;
-        }
+    for (auto [i, mcastIdx] : llvm::enumerate(mcastStartIndex)) {
+      Value coreIdx = rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i),
+                                                   gridMapping);
+      Value condition = rewriter.create<arith::CmpIOp>(
+          loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, coreIdx,
+          mcastIdx);
+      if (isSender) {
+        isSender = rewriter.create<arith::AndIOp>(loc, isSender, condition)
+                       .getResult();
+      } else {
+        isSender = condition;
       }
     }
     TT_assertv(isSender, "No multicast dimensions found in mcastShape");
@@ -210,24 +199,6 @@ public:
         [&](OpBuilder &builder, Location loc) {
           // Receiver: signal ready and wait for sender to finish.
           SmallVector<Value> senderCoreIndex;
-          Value zeroIdx = builder.create<arith::ConstantOp>(
-              loc, builder.getIndexType(), builder.getIndexAttr(0));
-
-          // Build sender core index by reading actual core positions.
-          // For dimensions that are multicast, sender is at mcastStartIndex.
-          // For non-multicast dimensions, use current core position.
-          // Pass grid mapping for proper virtualization support.
-          for (size_t i = 0; i < isMcastDim.size(); ++i) {
-            if (isMcastDim[i]) {
-              // Multicast dimension - sender is at mcastStartIndex.
-              senderCoreIndex.push_back(mcastStartIndex[i]);
-            } else {
-              // Non-multicast dimension - use current core's position.
-              Value currentCoreIdx = builder.create<CoreIndexOp>(
-                  loc, static_cast<int64_t>(i), gridMapping);
-              senderCoreIndex.push_back(currentCoreIdx);
-            }
-          }
 
           SmallVector<Value> physicalSenderCoreIndex =
               mapVirtualToPhysicalCoreIndex(builder, loc, genericOp.getGrid(),
@@ -235,7 +206,7 @@ public:
           builder.create<SemaphoreIncOp>(loc, receiversReadySemaphore, one,
                                          physicalSenderCoreIndex);
           builder.create<SemaphoreWaitOp>(loc, senderFinishedSemaphore, one,
-                                          zeroIdx);
+                                          zero);
 
           // Note: CB already reserved before the if/else, so receiver has
           // proper access to the multicast data.

--- a/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerLoadStoreOpsToDMA.cpp
@@ -197,12 +197,9 @@ public:
           builder.create<scf::YieldOp>(loc);
         },
         [&](OpBuilder &builder, Location loc) {
-          // Receiver: signal ready and wait for sender to finish.
-          SmallVector<Value> senderCoreIndex;
-
           SmallVector<Value> physicalSenderCoreIndex =
               mapVirtualToPhysicalCoreIndex(builder, loc, genericOp.getGrid(),
-                                            senderCoreIndex);
+                                            mcastStartIndex);
           builder.create<SemaphoreIncOp>(loc, receiversReadySemaphore, one,
                                          physicalSenderCoreIndex);
           builder.create<SemaphoreWaitOp>(loc, senderFinishedSemaphore, one,

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_mcast_virt_to_physical.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_mcast_virt_to_physical.mlir
@@ -34,8 +34,7 @@ module attributes {ttcore.system_desc = #system_desc} {
     // CHECK-NOT: d2m.dma_write %{{.*}}, %{{.*}} core[%c0, %c0] mcast
     // CHECK: d2m.semaphore_set %{{.*}}, %c1, core[%c1, %c1] mcast[%c1, %c2]
     // Receiver signals readiness at the mapped physical sender core.
-    // CHECK: affine.apply
-    // CHECK-NEXT: d2m.semaphore_inc
+    // CHECK: d2m.semaphore_inc
     d2m.generic {block_factors = [1, 1], grid = #grid_v2p, indexing_maps = [#map, #map], iterator_types = [#parallel, #reduction], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
         ins(%arg0 : memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
         outs(%alloc : memref<2x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>)  {

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_ops_to_dma_dynamic_mcast.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_ops_to_dma_dynamic_mcast.mlir
@@ -1,0 +1,71 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-preallocate-mcast-semaphores --d2m-lower-load-store-ops-to-dma %s | FileCheck %s
+
+#dram = #ttcore.memory_space<dram>
+#l1 = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#reduction = #ttcore.iterator_type<reduction>
+
+module {
+  // Test that multicast remote_load lowering works when mcastShape values are
+  // dynamic (not arith.constant). Prior to this fix, the pass extracted constant
+  // integer values from arith.constant ops to compute mcast volume statically.
+  // Non-constant values were silently treated as dim=1, producing incorrect
+  // lowerings. The fix computes mcast volume dynamically via arith.muli.
+  //
+  // CHECK-LABEL: func.func @test_mcast_dynamic_shape
+  func.func @test_mcast_dynamic_shape(%arg0: memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, %mcast_y: index, %mcast_x: index) {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+
+    d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<4x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #reduction], threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]}
+        ins(%arg0 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>)
+        outs(%alloc : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+    ^datamovement0:
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg1 = %c0 to %c1 step %c1 {
+        %core0 = d2m.core_index(0) : index
+        %core1 = d2m.core_index(1) : index
+        scf.for %arg2 = %c0 to %c1 step %c1 {
+          %0 = arith.addi %core0, %arg1 : index
+          %1 = arith.addi %core1, %arg2 : index
+          // Both mcastShape dims are dynamic (function arguments, not constants).
+          d2m.remote_load %arg0[%0, %1] into %cb0 mcore[%c0, %c0] mshape[%mcast_y, %mcast_x] : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> into !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+        } {d2m.blocking_loop = 1}
+      } {d2m.blocking_loop = 0}
+    }, {
+    ^compute0:
+      %cb0 = d2m.get_cb(0) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %cb1 = d2m.get_cb(1) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg1 = %c0 to %c1 step %c1 {
+        scf.for %arg2 = %c0 to %c1 step %c1 {
+          %0 = d2m.wait %cb0 : <memref<2x4x!ttcore.tile<32x32, f32>, #l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+        } {d2m.blocking_loop = 1}
+      } {d2m.blocking_loop = 0}
+    }
+    return
+  }
+}
+
+// The remote_load must be replaced by the full mcast lowering.
+// CHECK-NOT: d2m.remote_load
+
+// Dynamic mcast volume: arith.muli computes volume from the dynamic mshape dims.
+// CHECK: %[[VOL:.*]] = arith.muli
+// Dynamic receiver count: arith.subi computes (volume - 1).
+// CHECK: %[[NUM_RECV:.*]] = arith.subi %[[VOL]],
+
+// Sender/receiver branch structure.
+// CHECK: scf.if
+// Sender path: DMA read, wait for receivers ready, multicast write, signal done.
+// CHECK: d2m.dma_read
+// CHECK: d2m.semaphore_wait %{{.*}}, %[[NUM_RECV]]
+// CHECK: d2m.dma_write
+// CHECK: d2m.semaphore_set
+// Receiver path: signal ready, wait for sender.
+// CHECK: d2m.semaphore_inc
+// CHECK: d2m.semaphore_wait


### PR DESCRIPTION
Today's remote_load is hard coded to take inputs from an arith.constant, but this makes it impossible to form a mcast address based off of runtime variables.  It is also trivial for GCC constant folding to perform this optimization on our behalf if the input happens to be constant.
