### PR TITLE
[d2m] Grid selection for tilized concat ops can pick multi core

### DIFF
--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -273,9 +273,41 @@ static RankedTensorType tensorWithOptimalGrid(RankedTensorType oldTensor,
   return RankedTensorType::get(deviceShape, newElementType, newLayout);
 }
 
+// Rebuild a ToLayoutOp and its associated EmptyOp at a new target type.
+// The EmptyOp builder handles VGM (virtual grid mapping) computation
+// automatically when the grid requires virtualization.
+// Returns the new ToLayoutOp, or nullptr if the old op has no EmptyOp output.
+static d2m::ToLayoutOp
+rebuildToLayoutWithType(d2m::ToLayoutOp toLayoutOp, RankedTensorType newType,
+                        const GridSelectionConfig &config, OpBuilder &builder) {
+  auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
+  if (!emptyOp) {
+    return nullptr;
+  }
+
+  builder.setInsertionPoint(emptyOp);
+  auto newEmptyOp = builder.create<d2m::EmptyOp>(
+      emptyOp.getLoc(), newType.getShape(), newType.getElementType(),
+      newType.getEncoding(), config.targetSquareGridShape);
+
+  builder.setInsertionPoint(toLayoutOp);
+  return builder.create<d2m::ToLayoutOp>(toLayoutOp.getLoc(),
+                                         toLayoutOp.getInput(), newEmptyOp);
+}
+
+// Erase a ToLayoutOp and its EmptyOp output (if no longer used).
+static void eraseToLayoutAndEmpty(d2m::ToLayoutOp toLayoutOp) {
+  auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
+  toLayoutOp.erase();
+  if (emptyOp && emptyOp.getResult().use_empty()) {
+    emptyOp.erase();
+  }
+}
+
 // Update a ToLayoutOp and its associated EmptyOp to use a specified grid by
 // recreating the MetalLayoutAttr with the given grid and proper dimension
-// alignments.
+// alignments, then inserting a reblock ViewLayoutOp to preserve IR correctness
+// for downstream consumers.
 static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
                                  const GridSelectionConfig &config,
                                  ArrayRef<int64_t> optimalGrid,
@@ -312,42 +344,12 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
 
   RankedTensorType newTensorType =
       tensorWithOptimalGrid(outputType, config, optimalGrid, builder);
-  builder.setInsertionPoint(emptyOp);
 
-  // Determine if the chosen grid is virtual (exceeds 2D device bounds or is
-  // ND). Note: VGM is NOT propagated from the to_layout's input here — the
-  // output EmptyOp has its own grid/shard strategy. VGM for DMA addresses
-  // is traced through the stream's input at DMA lowering time.
-  mlir::AffineMapAttr virtualGridInverseMapping;
-  mlir::AffineMapAttr virtualGridForwardMapping;
-  auto device = ttcore::lookupDevice(toLayoutOp);
-  auto workerGridShape = device.getWorkerGrid().getShape();
-  bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-      optimalGrid, workerGridShape);
-  if (isVirtual) {
-    auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-        ttmlir::utils::volume<int64_t>(optimalGrid),
-        config.targetSquareGridShape);
-    TT_assertv(
-        !physicalGridShape.empty(),
-        "Unable to find 2D rect that can fit virtual grid {} within "
-        "device grid {}",
-        ttmlir::utils::formatIterable(optimalGrid, "x"),
-        ttmlir::utils::formatIterable(config.targetSquareGridShape, "x"));
-    auto [forwardMap, inverseMap] =
-        ttmlir::d2m::utils::grids::createCoreVirtMaps(
-            builder.getContext(), optimalGrid, physicalGridShape);
-    virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
-    virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
+  auto newToLayoutOp =
+      rebuildToLayoutWithType(toLayoutOp, newTensorType, config, builder);
+  if (!newToLayoutOp) {
+    return;
   }
-
-  auto newEmptyOp = builder.create<d2m::EmptyOp>(
-      emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
-      virtualGridForwardMapping);
-
-  builder.setInsertionPoint(toLayoutOp);
-  auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
-      toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
 
   // Reblock it back to original shape to preserve IR correctness.
   // The view chain that applyViews composes through depends on this
@@ -421,10 +423,7 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
   }
   toLayoutOp.getResult(0).replaceAllUsesWith(view.getResult());
 
-  toLayoutOp.erase();
-  if (emptyOp.getResult().use_empty()) {
-    emptyOp.erase();
-  }
+  eraseToLayoutAndEmpty(toLayoutOp);
 }
 
 static bool isTTNNOperand(Value operand) {
@@ -885,24 +884,12 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
       // inputs must coexist in L1 on a single core.
       if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
           toLayoutOp && input.hasOneUse()) {
-        auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
-        if (emptyOp) {
-          builder.setInsertionPoint(emptyOp);
-          auto newEmptyOp = builder.create<d2m::EmptyOp>(
-              emptyOp.getLoc(), newInputType.getShape(),
-              newInputType.getElementType(), newInputType.getEncoding(),
-              config.targetSquareGridShape);
-
-          builder.setInsertionPoint(toLayoutOp);
-          auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
-              toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
-
+        auto newToLayoutOp =
+            rebuildToLayoutWithType(toLayoutOp, newInputType, config, builder);
+        if (newToLayoutOp) {
           toLayoutOp.getResult(0).replaceAllUsesWith(
               newToLayoutOp.getResult(0));
-          toLayoutOp.erase();
-          if (emptyOp.getResult().use_empty()) {
-            emptyOp.erase();
-          }
+          eraseToLayoutAndEmpty(toLayoutOp);
 
           reblockedInputs.push_back(newToLayoutOp.getResult(0));
           continue;

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -837,6 +837,10 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
         continue;
       }
 
+      // Use the original physical shape (tile-only alignment) for grid
+      // computation. Grid-aware alignment would inflate each input's concat
+      // dimension independently, making the sum of inputs exceed the output's
+      // physical size and breaking the composite_view concat invariant.
       auto tileType = mlir::cast<ttcore::TileType>(inputType.getElementType());
       auto inputPhysShape = inputLayout.getPhysicalShape(tileType.getShape());
       auto inputOptimalGrid =
@@ -852,12 +856,18 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
       // update the to_layout's grid so that data is physically distributed
       // across multiple cores. This prevents L1 memory overflow when multiple
       // concat inputs must coexist in L1 on a single core.
+      //
+      // Use reblockShapedType (not tensorWithOptimalGrid) to preserve the
+      // existing dim alignments. Recomputing grid-aware dim alignments per
+      // input would give each input different padding on the concat dimension,
+      // breaking the composite_view invariant that input physical dims sum to
+      // <= the output's physical dim.
       if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
           toLayoutOp && input.hasOneUse()) {
         auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
         if (emptyOp) {
-          RankedTensorType newTensorType = tensorWithOptimalGrid(
-              inputType, config, inputOptimalGrid, builder);
+          auto newTensorType = mlir::cast<RankedTensorType>(
+              utils::reblockShapedType(inputType, inputOptimalGrid));
 
           builder.setInsertionPoint(emptyOp);
           auto newEmptyOp = builder.create<d2m::EmptyOp>(

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -822,11 +822,11 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
     auto compositeView = info.op;
 
     // The composite_view handles its own inputs instead of relying on
-    // updateToLayoutOps, and does not use computePhysicalShape to recreate the
-    // input with its grid-aligned shape.
-    // Views don't own the data and we want to stack other views on top of the
-    // composite_view, it might be difficult to update the upstream to_layout:
-    // e.g. one input is from a slicing view.
+    // updateToLayoutOps. When a composite_view input comes directly from a
+    // single-use to_layout, we update the to_layout's grid to physically
+    // distribute data across multiple cores, preventing L1 overflow when
+    // multiple inputs must coexist. For other inputs (e.g. from slicing
+    // views), we insert a view_layout to logically reblock.
     SmallVector<Value> reblockedInputs;
     for (Value input : compositeView.getInputs()) {
       auto inputType = mlir::cast<RankedTensorType>(input.getType());
@@ -846,6 +846,39 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
       if (llvm::ArrayRef(currentGrid) == llvm::ArrayRef(inputOptimalGrid)) {
         reblockedInputs.push_back(input);
         continue;
+      }
+
+      // When the input comes directly from a to_layout op with a single use,
+      // update the to_layout's grid so that data is physically distributed
+      // across multiple cores. This prevents L1 memory overflow when multiple
+      // concat inputs must coexist in L1 on a single core.
+      if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
+          toLayoutOp && input.hasOneUse()) {
+        auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
+        if (emptyOp) {
+          RankedTensorType newTensorType = tensorWithOptimalGrid(
+              inputType, config, inputOptimalGrid, builder);
+
+          builder.setInsertionPoint(emptyOp);
+          auto newEmptyOp = builder.create<d2m::EmptyOp>(
+              emptyOp.getLoc(), newTensorType.getShape(),
+              newTensorType.getElementType(), newTensorType.getEncoding(),
+              config.targetSquareGridShape);
+
+          builder.setInsertionPoint(toLayoutOp);
+          auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
+              toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
+
+          toLayoutOp.getResult(0).replaceAllUsesWith(
+              newToLayoutOp.getResult(0));
+          toLayoutOp.erase();
+          if (emptyOp.getResult().use_empty()) {
+            emptyOp.erase();
+          }
+
+          reblockedInputs.push_back(newToLayoutOp.getResult(0));
+          continue;
+        }
       }
 
       auto viewTensorType = mlir::cast<RankedTensorType>(

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -854,19 +854,15 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
       // Derive input dim alignments from the output, overriding the concat
       // dim with tile-only alignment so each input's contribution isn't
       // independently inflated.
+      // Note: concatDim is already normalized to [0, rank) by TTIRToD2M.
+      // For tile dims (height/width), use the tile shape alignment (e.g. 32).
+      // For batch dims, use 1 — no tile alignment is required and the output's
+      // grid-aware alignment handles the final padded result.
       llvm::SmallVector<int64_t> inputAlignments(outDimAlignments.begin(),
                                                  outDimAlignments.end());
       int64_t logicalRank = inputLayout.getLogicalShape().size();
-      int64_t concatLogicalDim =
-          concatDim < 0 ? logicalRank + concatDim : concatDim;
-      if (concatLogicalDim >= 0 &&
-          concatLogicalDim < static_cast<int64_t>(inputAlignments.size())) {
-        int64_t tileIdx = (concatLogicalDim >= logicalRank - 2)
-                              ? concatLogicalDim - (logicalRank - 2)
-                              : -1;
-        inputAlignments[concatLogicalDim] =
-            (tileIdx >= 0) ? tileShape[tileIdx] : 1;
-      }
+      int64_t tileIdx = concatDim - (logicalRank - 2);
+      inputAlignments[concatDim] = (tileIdx >= 0) ? tileShape[tileIdx] : 1;
 
       auto coordLayout = ttcore::MetalLayoutAttr::get(
           builder.getContext(), inputLayout.getLogicalShape(),

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -820,13 +820,24 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
   OpBuilder builder(compositeViewsToUpdate.front().op->getContext());
   for (const auto &info : compositeViewsToUpdate) {
     auto compositeView = info.op;
+    int32_t concatDim = compositeView.getDim();
 
-    // The composite_view handles its own inputs instead of relying on
-    // updateToLayoutOps. When a composite_view input comes directly from a
-    // single-use to_layout, we update the to_layout's grid to physically
-    // distribute data across multiple cores, preventing L1 overflow when
-    // multiple inputs must coexist. For other inputs (e.g. from slicing
-    // views), we insert a view_layout to logically reblock.
+    // Compute the output type first — its grid-aware dim alignments determine
+    // what physical shapes the inputs must match on non-concat dimensions.
+    auto outType =
+        mlir::cast<RankedTensorType>(compositeView.getResult().getType());
+    RankedTensorType newOutType =
+        tensorWithOptimalGrid(outType, config, info.grid, builder);
+    auto outLayout =
+        mlir::cast<ttcore::MetalLayoutAttr>(newOutType.getEncoding());
+
+    // Build per-input dim alignments that are coordinated with the output:
+    //  - Non-concat dims use the output's grid-aware alignment (so physical
+    //    sizes match).
+    //  - The concat dim uses tile-only alignment (so each input's contribution
+    //    isn't independently inflated, keeping sum ≤ output).
+    auto outDimAlignments = outLayout.getDimAlignments();
+
     SmallVector<Value> reblockedInputs;
     for (Value input : compositeView.getInputs()) {
       auto inputType = mlir::cast<RankedTensorType>(input.getType());
@@ -837,42 +848,53 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
         continue;
       }
 
-      // Use the original physical shape (tile-only alignment) for grid
-      // computation. Grid-aware alignment would inflate each input's concat
-      // dimension independently, making the sum of inputs exceed the output's
-      // physical size and breaking the composite_view concat invariant.
       auto tileType = mlir::cast<ttcore::TileType>(inputType.getElementType());
-      auto inputPhysShape = inputLayout.getPhysicalShape(tileType.getShape());
+      auto tileShape = tileType.getShape();
+
+      // Derive input dim alignments from the output, overriding the concat
+      // dim with tile-only alignment so each input's contribution isn't
+      // independently inflated.
+      llvm::SmallVector<int64_t> inputAlignments(outDimAlignments.begin(),
+                                                 outDimAlignments.end());
+      int64_t logicalRank = inputLayout.getLogicalShape().size();
+      int64_t concatLogicalDim =
+          concatDim < 0 ? logicalRank + concatDim : concatDim;
+      if (concatLogicalDim >= 0 &&
+          concatLogicalDim < static_cast<int64_t>(inputAlignments.size())) {
+        int64_t tileIdx = (concatLogicalDim >= logicalRank - 2)
+                              ? concatLogicalDim - (logicalRank - 2)
+                              : -1;
+        inputAlignments[concatLogicalDim] =
+            (tileIdx >= 0) ? tileShape[tileIdx] : 1;
+      }
+
+      auto coordLayout = ttcore::MetalLayoutAttr::get(
+          builder.getContext(), inputLayout.getLogicalShape(),
+          inputLayout.getOobVal(), inputLayout.getMemorySpace(),
+          inputLayout.getMemoryLayout(), inputLayout.getCollapsedIntervals(),
+          inputAlignments);
+
+      auto inputPhysShape = coordLayout.getPhysicalShape(tileShape);
       auto inputOptimalGrid =
           computeOptimalGrid(inputType, inputPhysShape, config);
 
-      auto currentGrid = inputLayout.getGridShape(inputType);
-      if (llvm::ArrayRef(currentGrid) == llvm::ArrayRef(inputOptimalGrid)) {
-        reblockedInputs.push_back(input);
-        continue;
-      }
+      llvm::SmallVector<int64_t> deviceShape =
+          coordLayout.getDeviceShape(inputOptimalGrid, tileShape);
+      auto newInputType = RankedTensorType::get(
+          deviceShape, inputType.getElementType(), coordLayout);
 
       // When the input comes directly from a to_layout op with a single use,
       // update the to_layout's grid so that data is physically distributed
-      // across multiple cores. This prevents L1 memory overflow when multiple
-      // concat inputs must coexist in L1 on a single core.
-      //
-      // Use reblockShapedType (not tensorWithOptimalGrid) to preserve the
-      // existing dim alignments. Recomputing grid-aware dim alignments per
-      // input would give each input different padding on the concat dimension,
-      // breaking the composite_view invariant that input physical dims sum to
-      // <= the output's physical dim.
+      // across multiple cores, preventing L1 overflow when multiple concat
+      // inputs must coexist in L1 on a single core.
       if (auto toLayoutOp = input.getDefiningOp<d2m::ToLayoutOp>();
           toLayoutOp && input.hasOneUse()) {
         auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
         if (emptyOp) {
-          auto newTensorType = mlir::cast<RankedTensorType>(
-              utils::reblockShapedType(inputType, inputOptimalGrid));
-
           builder.setInsertionPoint(emptyOp);
           auto newEmptyOp = builder.create<d2m::EmptyOp>(
-              emptyOp.getLoc(), newTensorType.getShape(),
-              newTensorType.getElementType(), newTensorType.getEncoding(),
+              emptyOp.getLoc(), newInputType.getShape(),
+              newInputType.getElementType(), newInputType.getEncoding(),
               config.targetSquareGridShape);
 
           builder.setInsertionPoint(toLayoutOp);
@@ -891,18 +913,11 @@ updateCompositeViewOps(ArrayRef<CompositeViewUpdateInfo> compositeViewsToUpdate,
         }
       }
 
-      auto viewTensorType = mlir::cast<RankedTensorType>(
-          utils::reblockShapedType(inputType, inputOptimalGrid));
       builder.setInsertionPoint(compositeView);
       auto view = builder.create<d2m::ViewLayoutOp>(compositeView.getLoc(),
-                                                    viewTensorType, input);
+                                                    newInputType, input);
       reblockedInputs.push_back(view.getResult());
     }
-
-    auto outType =
-        mlir::cast<RankedTensorType>(compositeView.getResult().getType());
-    RankedTensorType newOutType =
-        tensorWithOptimalGrid(outType, config, info.grid, builder);
 
     builder.setInsertionPoint(compositeView);
     auto newCompositeView = builder.create<d2m::CompositeViewOp>(

--- a/test/python/golden/ttir_ops/data_movement/test_data_movement.py
+++ b/test/python/golden/ttir_ops/data_movement/test_data_movement.py
@@ -66,6 +66,17 @@ pytestmark = pytest.mark.frontend("ttir")
         ([(3, 2, 96, 64), (3, 2, 32, 64), (3, 2, 64, 64)], 2),
         ([(4, 2, 64, 64), (4, 1, 64, 64), (4, 3, 64, 64)], 1),
         ([(3, 3, 64, 64), (2, 3, 64, 64), (1, 3, 64, 64)], 0),
+        ##################################
+        #    Large tensors (multi-core)  #
+        ##################################
+        # These exercise the grid selection path where concat inputs are
+        # large enough that single-core allocation would overflow L1,
+        # requiring the to_layout ops to distribute data across cores.
+        ([(1, 32, 128, 64), (1, 32, 128, 64)], 3),
+        ([(1, 32, 128, 128), (1, 32, 128, 128)], 3),
+        ([(1, 32, 64, 128), (1, 32, 64, 128)], 2),
+        ([(512, 512), (512, 512)], 1),
+        ([(512, 512), (512, 512)], 0),
     ],
 )
 @pytest.mark.parametrize("target", ["ttnn", "ttmetal", "emitpy"])

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_concat.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_concat.mlir
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns --d2m-grid-selection --canonicalize %s | FileCheck %s
+
+// Verify that grid selection propagates multi-core grids to upstream to_layout
+// ops for concat inputs. Without this, large concat inputs remain on a 1x1
+// grid and overflow L1 when multiple buffers must coexist.
+
+#any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+// Test: Large 4D concat along dim 3 (the shape that triggered L1 overflow).
+// Each input is 1x32x128x64 bf16 = 524,288 bytes. On a 1x1x1x1 grid, three
+// concurrent buffers would need ~1.5MB, exceeding ~1.4MB usable L1.
+// Grid selection should distribute the to_layout outputs across multiple cores.
+module attributes {ttcore.device = #any_device} {
+  func.func @concat_large_4d(%arg0: tensor<1x32x128x64xbf16>, %arg1: tensor<1x32x128x64xbf16>) -> tensor<1x32x128x128xbf16> {
+    // CHECK-LABEL: func.func @concat_large_4d
+    //
+    // Verify to_layout ops use a multi-core grid (1x8x4x2), NOT 1x1x1x1.
+    // CHECK: d2m.to_layout %arg0, %{{.*}} : tensor<1x32x128x64xbf16> into tensor<1x8x4x2x
+    // CHECK: d2m.to_layout %arg1, %{{.*}} : tensor<1x32x128x64xbf16> into tensor<1x8x4x2x
+    //
+    // Verify composite_view and generic still exist with a multi-core grid.
+    // CHECK: d2m.composite_view
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<1x4x4x4
+    %0 = "ttir.concat"(%arg0, %arg1) <{dim = 3 : si32}> : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x128xbf16>
+    return %0 : tensor<1x32x128x128xbf16>
+  }
+}
+
+// -----
+
+#any_device_2 = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+// Test: 2D concat where inputs are large enough to benefit from multi-core.
+module attributes {ttcore.device = #any_device_2} {
+  func.func @concat_large_2d(%arg0: tensor<256x256xbf16>, %arg1: tensor<256x256xbf16>) -> tensor<256x512xbf16> {
+    // CHECK-LABEL: func.func @concat_large_2d
+    // CHECK: d2m.composite_view
+    // CHECK: d2m.generic {{{.*}}grid = #ttcore.grid<
+    %0 = "ttir.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<256x256xbf16>, tensor<256x256xbf16>) -> tensor<256x512xbf16>
+    return %0 : tensor<256x512xbf16>
+  }
+}
+
+// -----
+
+#any_device_3 = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+// Test: 3-input concat to verify all upstream to_layout ops get updated.
+module attributes {ttcore.device = #any_device_3} {
+  func.func @concat_three_inputs(%arg0: tensor<1x32x128x64xbf16>, %arg1: tensor<1x32x128x64xbf16>, %arg2: tensor<1x32x128x64xbf16>) -> tensor<1x32x128x192xbf16> {
+    // CHECK-LABEL: func.func @concat_three_inputs
+    // All three to_layout ops should use multi-core grids (not 1x1x1x1).
+    // CHECK: d2m.to_layout %arg0, %{{.*}} : tensor<1x32x128x64xbf16> into tensor<1x8x4x2x
+    // CHECK: d2m.to_layout %arg1, %{{.*}} : tensor<1x32x128x64xbf16> into tensor<1x8x4x2x
+    // CHECK: d2m.to_layout %arg2, %{{.*}} : tensor<1x32x128x64xbf16> into tensor<1x8x4x2x
+    // CHECK: d2m.composite_view
+    // CHECK: d2m.generic
+    %0 = "ttir.concat"(%arg0, %arg1, %arg2) <{dim = 3 : si32}> : (tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>) -> tensor<1x32x128x192xbf16>
+    return %0 : tensor<1x32x128x192xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #7936 

### Problem description
Concat ran into an OOM allocator issue because we were trying to tilize both inputs to concat on single core

### What's changed
- Updated grid selection to look at `to_layout` input to concat and if it doesn't come from a view, allow grid selection to pick an optimal grid
- Added lit and builder tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
