### PR TITLE
[d2m] arange bf16/i32 support

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2494,7 +2494,8 @@ def D2M_FillArangeTileOp : D2M_GenericRegionOp<"fill_arange_tile",
   let summary = "Write full linear index pattern to a tile CB";
   let description = [{
       The `fill_arange_tile` operation writes a linear index pattern
-      to a tile CB, where element[i,j] = i * 32 + j (the linear index as float).
+      to a tile CB, where element[i,j] = i * 32 + j in the tile's native data
+      format (f32, bf16, or i32).
 
       This is used for arange operations. Each element gets its linear index value
       (0-1023) within the tile, which can be used to compute global indices.

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -2964,8 +2964,7 @@ def TTKernel_ExperimentalFillArangeTileOp : TTKernel_Op<"experimental::fill_aran
     let summary = "Experimental Write Full Linear Index Tile Op";
     let description = [{
       Writes a full linear index tile pattern to a CB, where element[i,j] = i * 32 + j
-      (linear index as float, 0-1023). This is used for arange operations to generate
-      index tiles directly in L1 memory.
+      (0-1023) in the CB's native data format (Float32, Float16_b, or Int32).
 
       The resulting tile looks like:
       [[  0,   1,   2, ...,  31],

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_padding_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_padding_llks.h
@@ -138,11 +138,12 @@ ALWI void write_col_mask_tile(uint32_t validCols, uint32_t cb_id) {
 // Index tile functions for arange operations
 // =============================================================================
 
-// Write a FULL INDEX tile to L1 in F32 format.
-// Each element gets its linear index: element[i,j] = i * 32 + j (0-1023)
-// This is used for arange operations where we need the global element index
-// within a tile.
-inline void _fill_arange_tile_to_l1_(volatile uint32_t *ptr) {
+// Write a FULL INDEX tile to L1: element[i,j] = i * 32 + j (0-1023).
+// Templated on DataFormat so the index is encoded in the CB's native format.
+// Float32 writes 4-byte IEEE 754 elements; Float16_b writes 2-byte bfloat16
+// elements; Int32 writes 4-byte raw integer elements.
+template <DataFormat df, typename T>
+inline void _fill_arange_tile_to_l1_(volatile T *ptr) {
   uint32_t count = 0;
 
   for (uint32_t i = 0; i < 2; ++i) {      // Face row (0-1)
@@ -150,22 +151,35 @@ inline void _fill_arange_tile_to_l1_(volatile uint32_t *ptr) {
       for (uint32_t k = 0; k < 16; ++k) { // Row within face
         uint32_t global_row = k + 16 * i;
         for (uint32_t l = 0; l < 16; ++l) { // Col within face
-          uint32_t global_col = l + 16 * j;
-          uint32_t linear_idx = global_row * 32 + global_col;
-          uint32_t val = float_to_bits(static_cast<float>(linear_idx));
-          ptr[count++] = val;
+          uint32_t linear_idx = global_row * 32 + (l + 16 * j);
+          if constexpr (df == DataFormat::Float32) {
+            ptr[count++] = float_to_bits(static_cast<float>(linear_idx));
+          } else if constexpr (df == DataFormat::Float16_b) {
+            ptr[count++] = static_cast<uint16_t>(
+                float_to_bits(static_cast<float>(linear_idx)) >> 16);
+          } else if constexpr (df == DataFormat::Int32) {
+            ptr[count++] = linear_idx;
+          }
         }
       }
     }
   }
 }
 
+template <DataFormat df = DataFormat::Float32>
 ALWI void fill_arange_tile(uint32_t cb_id) {
+  static_assert(df == DataFormat::Float32 || df == DataFormat::Float16_b ||
+                    df == DataFormat::Int32,
+                "fill_arange_tile: unsupported DataFormat");
 #ifdef TRISC_UNPACK
   uint32_t write_addr = (get_local_cb_interface(cb_id).fifo_rd_ptr) << 4;
-  volatile tt_l1_ptr uint32_t *ptr =
-      reinterpret_cast<volatile tt_l1_ptr uint32_t *>(write_addr);
-  _fill_arange_tile_to_l1_(ptr);
+  if constexpr (df == DataFormat::Float32 || df == DataFormat::Int32) {
+    auto *ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(write_addr);
+    _fill_arange_tile_to_l1_<df>(ptr);
+  } else if constexpr (df == DataFormat::Float16_b) {
+    auto *ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t *>(write_addr);
+    _fill_arange_tile_to_l1_<df>(ptr);
+  }
 #endif
 }
 

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -2550,12 +2550,14 @@ public:
         ttcore::getDeviceLayout(output).getRank() / 2;
 
     // Create scratch tensor for index tile (single tile per core).
-    Type f32Type = rewriter.getF32Type();
+    auto outputTileType =
+        mlir::cast<ttcore::TileType>(outputTensorType.getElementType());
+    Type outputElemType = outputTileType.getElementType();
     llvm::ArrayRef<int64_t> gridShape =
         outputLayout.getGridShape(outputTensorType);
     SmallVector<int64_t> scratchShape(gridShape.begin(), gridShape.end());
     scratchShape.append({1, 1}); // One tile
-    auto tileType = ttcore::TileType::get(f32Type);
+    auto tileType = ttcore::TileType::get(outputElemType);
     SmallVector<int64_t> scratchLogicalShape = {1, 1};
     auto scratchLayout = ttcore::MetalLayoutAttr::get(
         rewriter.getContext(), scratchLogicalShape, ttcore::OOBVal::Undef,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -374,7 +374,8 @@ public:
       return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (
         std::is_same_v<SourceOp, ttkernel::ExperimentalWriteRowMaskTileOp> ||
-        std::is_same_v<SourceOp, ttkernel::ExperimentalWriteColMaskTileOp>) {
+        std::is_same_v<SourceOp, ttkernel::ExperimentalWriteColMaskTileOp> ||
+        std::is_same_v<SourceOp, ttkernel::ExperimentalFillArangeTileOp>) {
       auto cbType = mlir::cast<ttkernel::CBType>(op.getCb().getType());
       auto tileType = mlir::cast<ttcore::TileType>(cbType.getElementType());
       SmallVector<Attribute, 1> template_args;

--- a/lib/Dialect/D2M/Transforms/DecomposeArange.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeArange.cpp
@@ -66,12 +66,22 @@ struct DecomposeArangeBlockPattern : OpRewritePattern<ArangeBlockOp> {
     rewriter.create<FillArangeTileOp>(loc, indexTileMemref);
 
     // === STEP 2: Scalar constants for arange start and step ===
-    Value startF = rewriter.create<arith::ConstantOp>(
-        loc, elemType,
-        rewriter.getFloatAttr(elemType, static_cast<double>(start)));
-    Value stepF = rewriter.create<arith::ConstantOp>(
-        loc, elemType,
-        rewriter.getFloatAttr(elemType, static_cast<double>(step)));
+    // arith ops require signless integers; tile element types may be si32/ui32.
+    bool isIntElem = isa<IntegerType>(elemType);
+    Type scalarType = isIntElem ? cast<Type>(IntegerType::get(
+                                      rewriter.getContext(),
+                                      cast<IntegerType>(elemType).getWidth()))
+                                : elemType;
+    auto makeScalarAttr = [&](int64_t val) -> TypedAttr {
+      return isIntElem
+                 ? cast<TypedAttr>(rewriter.getIntegerAttr(scalarType, val))
+                 : cast<TypedAttr>(rewriter.getFloatAttr(
+                       scalarType, static_cast<double>(val)));
+    };
+    Value startVal = rewriter.create<arith::ConstantOp>(loc, scalarType,
+                                                        makeScalarAttr(start));
+    Value stepVal = rewriter.create<arith::ConstantOp>(loc, scalarType,
+                                                       makeScalarAttr(step));
 
     // === STEP 3: Create nested loops over tiles ===
     // Get this core's coordinates.
@@ -137,20 +147,27 @@ struct DecomposeArangeBlockPattern : OpRewritePattern<ArangeBlockOp> {
     // Total offset (index type)
     Value tileOffsetIdx =
         rewriter.create<arith::AddIOp>(loc, rowContrib, colContrib);
-    Value tileOffsetI64 = rewriter.create<arith::IndexCastOp>(
-        loc, rewriter.getI64Type(), tileOffsetIdx);
-    Value tileOffsetF =
-        rewriter.create<arith::SIToFPOp>(loc, elemType, tileOffsetI64);
+    Value tileOffsetScalar;
+    if (isIntElem) {
+      tileOffsetScalar =
+          rewriter.create<arith::IndexCastOp>(loc, scalarType, tileOffsetIdx);
+    } else {
+      Value tileOffsetI64 = rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getI64Type(), tileOffsetIdx);
+      tileOffsetScalar =
+          rewriter.create<arith::SIToFPOp>(loc, scalarType, tileOffsetI64);
+    }
 
     // === STEP 6: Tile arithmetic with scalar RHS ===
     Value globalIndexTile =
-        rewriter.create<TileAddOp>(loc, tileType, localIndexTile, tileOffsetF)
+        rewriter
+            .create<TileAddOp>(loc, tileType, localIndexTile, tileOffsetScalar)
             .getResult();
     Value scaledTile =
-        rewriter.create<TileMulOp>(loc, tileType, globalIndexTile, stepF)
+        rewriter.create<TileMulOp>(loc, tileType, globalIndexTile, stepVal)
             .getResult();
     Value resultTile =
-        rewriter.create<TileAddOp>(loc, tileType, scaledTile, startF)
+        rewriter.create<TileAddOp>(loc, tileType, scaledTile, startVal)
             .getResult();
 
     // === STEP 7: Store result tile to output ===

--- a/test/python/golden/test_metal_tms.py
+++ b/test/python/golden/test_metal_tms.py
@@ -368,7 +368,9 @@ def test_reshape(
         ((1, 128), 0, 1),  # Four tiles (from GPT model)
     ],
 )
-@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.bfloat16, torch.int32], ids=["f32", "bf16", "i32"]
+)
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_arange(
     shape: tuple,

--- a/test/python/golden/test_metal_tms.py
+++ b/test/python/golden/test_metal_tms.py
@@ -385,11 +385,15 @@ def test_arange(
 
     Tests tiled arange implementation with various shapes and parameters.
     """
+
+    if dtype == torch.int32:
+        pytest.xfail(
+            reason="Currently no llk for multiplying a tile with a scalar for i32, Issue: https://github.com/tenstorrent/tt-mlir/issues/7946"
+        )
+
     num_elements = shape[0] * shape[1]
     end = start + num_elements * step
     arange_dimension = 1  # Arange is always on the last dimension
-
-    golden = torch.arange(start, end, step, dtype=dtype).reshape(shape)
 
     def arange_module(builder: TTIRBuilder):
         @builder.func([shape], [dtype])
@@ -415,4 +419,6 @@ def test_arange(
         device=device,
         custom_pipeline="ttir-to-ttmetal-pipeline",
         **get_request_kwargs(request),
+        atol=1e-6,
+        check_atol=True,
     )


### PR DESCRIPTION
### Problem description
We don't currently support arange for any dtype besides f32

### What's changed
- Added parametrization to support bf16/i32 aranges as well
- i32 support blocked on llk support but compiler infra is there
- Added builder tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
