### PR TITLE
Uplift third_party/tt-metal to 90c914ef258b5cc92ad172f3604b784ec77253ca 2026-04-14

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=3fa4d753550dba1d4aacc9af45b111ae540f63fc
+ARG TT_METAL_DEPENDENCIES_COMMIT=90c914ef258b5cc92ad172f3604b784ec77253ca
 
 # Install dependencies
 RUN <<EOT

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -533,16 +533,16 @@ getConv2dConfig(const std::optional<Conv2dConfigAttr> &conv2dConfig) {
 // there's no clear usecase for it other than conversion from
 // MathFidelity to ::ttnn::MathFidelity. Therefore, I decided to
 // not expose it for now. Subject to change in the future.
-::MathFidelity getMathFidelity(MathFidelity mathFidelity) {
+::tt::tt_metal::MathFidelity getMathFidelity(MathFidelity mathFidelity) {
   switch (mathFidelity) {
   case MathFidelity::LoFi:
-    return ::MathFidelity::LoFi;
+    return ::tt::tt_metal::MathFidelity::LoFi;
   case MathFidelity::HiFi2:
-    return ::MathFidelity::HiFi2;
+    return ::tt::tt_metal::MathFidelity::HiFi2;
   case MathFidelity::HiFi3:
-    return ::MathFidelity::HiFi3;
+    return ::tt::tt_metal::MathFidelity::HiFi3;
   case MathFidelity::HiFi4:
-    return ::MathFidelity::HiFi4;
+    return ::tt::tt_metal::MathFidelity::HiFi4;
   }
 }
 

--- a/runtime/include/tt/runtime/detail/common/common.h
+++ b/runtime/include/tt/runtime/detail/common/common.h
@@ -121,22 +121,22 @@ inline ::tt::target::Arch toTargetArch(::tt::ARCH arch) {
   }
 }
 
-inline UnpackToDestMode
+inline ::tt::tt_metal::UnpackToDestMode
 toUnpackToDestMode(const tt::target::UnpackToDestMode &unpackToDestMode) {
   switch (unpackToDestMode) {
   case tt::target::UnpackToDestMode::Fp32:
-    return UnpackToDestMode::UnpackToDestFp32;
+    return ::tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
   case tt::target::UnpackToDestMode::Default:
-    return UnpackToDestMode::Default;
+    return ::tt::tt_metal::UnpackToDestMode::Default;
   }
 }
 
-inline std::vector<UnpackToDestMode>
+inline std::vector<::tt::tt_metal::UnpackToDestMode>
 toUnpackToDestModes(const ::flatbuffers::Vector<tt::target::UnpackToDestMode>
                         *unpackToDestModesFB) {
   // Metal asserts that unpack_to_dest_mode.size() == NUM_CIRCULAR_BUFFERS.
-  std::vector<UnpackToDestMode> unpackToDestModes(NUM_CIRCULAR_BUFFERS,
-                                                  UnpackToDestMode::Default);
+  std::vector<::tt::tt_metal::UnpackToDestMode> unpackToDestModes(
+      NUM_CIRCULAR_BUFFERS, ::tt::tt_metal::UnpackToDestMode::Default);
   if (unpackToDestModesFB == nullptr) {
     return unpackToDestModes;
   }

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -46,7 +46,8 @@ const ::tt::target::ttnn::Program *getProgram(const Binary &executableHandle,
 
 ::tt::target::DataType fromTTNNDataType(::ttnn::DataType dataType);
 
-MathFidelity toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity);
+::tt::tt_metal::MathFidelity
+toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity);
 
 ::ttnn::Layout toTTNNLayout(::tt::target::TensorLayout layout);
 

--- a/runtime/lib/ttmetal/kernels.cpp
+++ b/runtime/lib/ttmetal/kernels.cpp
@@ -144,19 +144,19 @@ createKernelConfig(
     computeConfig.compile_args = compileArgs;
     switch (fbComputeConfig->math_fidelity()) {
     case tt::target::MathFidelity::HiFi4: {
-      computeConfig.math_fidelity = MathFidelity::HiFi4;
+      computeConfig.math_fidelity = ::tt::tt_metal::MathFidelity::HiFi4;
       break;
     }
     case tt::target::MathFidelity::HiFi3: {
-      computeConfig.math_fidelity = MathFidelity::HiFi3;
+      computeConfig.math_fidelity = ::tt::tt_metal::MathFidelity::HiFi3;
       break;
     }
     case tt::target::MathFidelity::HiFi2: {
-      computeConfig.math_fidelity = MathFidelity::HiFi2;
+      computeConfig.math_fidelity = ::tt::tt_metal::MathFidelity::HiFi2;
       break;
     }
     case tt::target::MathFidelity::LoFi: {
-      computeConfig.math_fidelity = MathFidelity::LoFi;
+      computeConfig.math_fidelity = ::tt::tt_metal::MathFidelity::LoFi;
       break;
     }
     }

--- a/runtime/lib/ttnn/operations/conv/conv3d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv3d.cpp
@@ -82,8 +82,8 @@ void run(const ::tt::target::ttnn::Conv3dOp *op, ProgramContext &context) {
   }
 
   auto deviceComputeConfig = ::ttnn::init_device_compute_kernel_config(
-      targetDevice.arch(), computeConfig, MathFidelity::HiFi4, true, true,
-      false);
+      targetDevice.arch(), computeConfig, ::tt::tt_metal::MathFidelity::HiFi4,
+      true, true, false);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(

--- a/runtime/lib/ttnn/operations/data_movement/write_tensor.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/write_tensor.cpp
@@ -25,7 +25,6 @@ void run(const ::tt::target::ttnn::WriteTensorOp *op, ProgramContext &context) {
 
   // Note: copy_to_device replaced write_tensor and does not have a blocking
   // parameter. The operation is always blocking.
-  ::tt::tt_metal::tensor_impl::copy_to_device(hostTensor, deviceTensor,
-                                              ttnnCqId);
+  ::tt::tt_metal::copy_to_device(hostTensor, deviceTensor, ttnnCqId);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -115,7 +115,7 @@ createKernelConfigDescriptor(
   switch (kernelDesc.config_type()) {
   case ::tt::target::ttnn::KernelConfig::ComputeKernelConfig: {
     const auto *computeConfig = kernelDesc.config_as_ComputeKernelConfig();
-    std::vector<UnpackToDestMode> unpackToDestModes =
+    std::vector<::tt::tt_metal::UnpackToDestMode> unpackToDestModes =
         common::toUnpackToDestModes(computeConfig->unpack_to_dest_modes());
     return ::tt::tt_metal::ComputeConfigDescriptor{
         .math_fidelity = tt::runtime::ttnn::utils::toTTNNMathFidelity(

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -32,7 +32,7 @@ static void copyTensorFromHostToDevice(const ::ttnn::Tensor &srcTensor,
                  dstTensor.storage_type() == ::ttnn::StorageType::DEVICE,
              "srcTensor must be on host and dstTensor must be on device");
 
-  ::tt::tt_metal::tensor_impl::copy_to_device(srcTensor, dstTensor);
+  ::tt::tt_metal::copy_to_device(srcTensor, dstTensor);
 }
 
 static void copyTensorFromDeviceToDevice(const ::ttnn::Tensor &srcTensor,
@@ -41,7 +41,7 @@ static void copyTensorFromDeviceToDevice(const ::ttnn::Tensor &srcTensor,
                  dstTensor.storage_type() == ::ttnn::StorageType::DEVICE,
              "srcTensor must be on device and dstTensor must be on device");
   ::ttnn::Tensor hostSrcTensor = ::ttnn::from_device(srcTensor);
-  ::tt::tt_metal::tensor_impl::copy_to_device(hostSrcTensor, dstTensor);
+  ::tt::tt_metal::copy_to_device(hostSrcTensor, dstTensor);
 }
 
 static void runTraceProgramAndCaptureTrace(

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -210,16 +210,17 @@ getProgram(const ::tt::runtime::Binary &executableHandle,
   }
 }
 
-MathFidelity toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity) {
+::tt::tt_metal::MathFidelity
+toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity) {
   switch (mathFidelity) {
   case ::tt::target::MathFidelity::LoFi:
-    return MathFidelity::LoFi;
+    return ::tt::tt_metal::MathFidelity::LoFi;
   case ::tt::target::MathFidelity::HiFi2:
-    return MathFidelity::HiFi2;
+    return ::tt::tt_metal::MathFidelity::HiFi2;
   case ::tt::target::MathFidelity::HiFi3:
-    return MathFidelity::HiFi3;
+    return ::tt::tt_metal::MathFidelity::HiFi3;
   case ::tt::target::MathFidelity::HiFi4:
-    return MathFidelity::HiFi4;
+    return ::tt::tt_metal::MathFidelity::HiFi4;
   }
 }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "30959e41c3cab7b14b8420d0a1d071b370d4966d")
+set(TT_METAL_VERSION "90c914ef258b5cc92ad172f3604b784ec77253ca")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 90c914ef258b5cc92ad172f3604b784ec77253ca

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):https://github.com/tenstorrent/tt-forge-onnx/actions/runs/24396198119
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):https://github.com/tenstorrent/tt-xla/actions/runs/24396202938
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):