### PR TITLE
[tt-alchemist] Register pipeline-dependent dialects to fix appendDialectRegistry assertion crash

### DIFF
--- a/tools/tt-alchemist/csrc/lib/tt_alchemist.cpp
+++ b/tools/tt-alchemist/csrc/lib/tt_alchemist.cpp
@@ -7,17 +7,24 @@
 #include "tt-alchemist/tt_alchemist_c_api.hpp"
 
 // MLIR includes
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Quant/IR/Quant.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/MLIRContext.h"
 #ifdef TTMLIR_ENABLE_STABLEHLO
 #include "shardy/dialect/sdy/ir/dialect.h"
 #endif
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
+#include "ttmlir/Dialect/EmitPy/IR/EmitPy.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
@@ -38,8 +45,12 @@ TTAlchemist::TTAlchemist() {
 
   registry.insert<mlir::tt::ttcore::TTCoreDialect, mlir::tt::ttir::TTIRDialect,
                   mlir::tt::d2m::D2MDialect, mlir::tt::ttnn::TTNNDialect,
-                  mlir::func::FuncDialect, mlir::emitc::EmitCDialect,
-                  mlir::LLVM::LLVMDialect, mlir::quant::QuantDialect
+                  mlir::tt::emitpy::EmitPyDialect, mlir::func::FuncDialect,
+                  mlir::emitc::EmitCDialect, mlir::LLVM::LLVMDialect,
+                  mlir::quant::QuantDialect, mlir::arith::ArithDialect,
+                  mlir::math::MathDialect, mlir::tensor::TensorDialect,
+                  mlir::linalg::LinalgDialect, mlir::scf::SCFDialect,
+                  mlir::tosa::TosaDialect
 #ifdef TTMLIR_ENABLE_STABLEHLO
                   ,
                   mlir::sdy::SdyDialect


### PR DESCRIPTION
### Problem description
`tt-alchemist generate-python` crashed with an MLIR assertion failure on any model that triggers CPU-hoisted const-eval with 
```
mlir::MLIRContext::appendDialectRegistry(const DialectRegistry &): Assertion `impl->multiThreadedExecutionContext == 0 && "appending to the MLIRContext dialect registry while in a multi-threaded execution context"' failed.
```

This crash originates from `canLowerTTIRToLinalg`, which creates an inner pass manager to trial-lower ops to Linalg. When `PassManager::run()` is called, MLIR performs two steps in sequence:
1. registers dialects the passes need
2. marks the context as being in a multi-threaded execution

Since `canLowerTTIRToLinalg` is called from an outer pass manager run (which is already in multi-threaded execution), the inner pass manager run crashes if some of its passes have dependent dialects that are not already in the context's dialect registry.

_Note_: The reason `ttmlir-opt` was not failing is because it uses `registerAllDialects()` at startup. Also, the cpp codegen path was not influenced by this since CPU-hoisting is disabled for EmitC.
### What's changed
This PR registers new dialects on `TTAlchemist` creation.
### Checklist
- [ ] New/Existing tests provide coverage for changes
