### PR TITLE
Fix per-op bf16 weight_dtype override defeated by global override

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
@@ -103,11 +103,13 @@ public:
         op.getLoc(), newWeightType, weight,
         ttcore::DataTypeAttr::get(rewriter.getContext(), dtype));
 
-    // Update op to use the typecast result and clean up the attribute.
-    rewriter.modifyOpInPlace(op, [&]() {
-      op.getBMutable().assign(typecastOp.getResult());
-      op->removeAttr("ttcore.weight_dtype");
-    });
+    // Update op to use the typecast result. The per-op "ttcore.weight_dtype"
+    // attribute is intentionally kept: the greedy rewriter may re-match this
+    // op, and without the attribute it would fall back to the global default,
+    // defeating per-op overrides (e.g. bf16 overridden by global bfp_bf8).
+    // The attribute is discardable and harmless in the final IR.
+    rewriter.modifyOpInPlace(
+        op, [&]() { op.getBMutable().assign(typecastOp.getResult()); });
 
     return mlir::success();
   }

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bf16_override_f32_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bf16_override_f32_weight.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
+
+// Test bf16 per-op override when the weight is f32 and the global default is
+// bfp_bf8. The per-op override must win: only a single f32->bf16 typecast
+// should be inserted, NOT a chained f32->bf16->bfp_bf8. This guards against
+// a greedy-rewriter re-match after the attribute is consumed.
+
+#dram = #ttnn.buffer_type<dram>
+
+module attributes {} {
+  // CHECK-LABEL: func.func @test_bf16_override_f32_weight
+  func.func @test_bf16_override_f32_weight(
+    %arg0: tensor<64x720xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x23x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>>,
+    %arg1: tensor<720x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<23x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}
+  ) -> tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>> {
+
+    // Per-op says bf16. Should insert exactly one f32->bf16 typecast.
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: -> tensor<720x128xbf16,
+
+    // Must NOT see a second typecast to bfp_bf8 from the global default.
+    // CHECK-NOT: supportedDataTypes<bfp_bf8>
+
+    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
+    %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bf16"} : (tensor<64x720xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x23x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>>, tensor<720x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<23x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>>) -> tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>>
+
+    return %0 : tensor<64x128xf32, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #7956

### Problem description
When a matmul carries ttcore.weight_dtype = "bf16" and the global target is bfp_bf8, the greedy rewriter re-matches after the first f32 to bf16 typecast because removeAttr drops the per-op annotation. On re-match the global bfp_bf8 applies, producing a spurious bf16 to fp_bf8 chain that defeats the override.

### What's changed
Preserve the per-op ttcore.weight_dtype attribute instead of removing it after conversion. On re-match the pattern sees the same per-op override and hits the "already target dtype" bail-out. 
Cons: The attribute remains in the IR as a harmless discardable annotation.

### Checklist
Added lit test in` test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bf16_override_f32_weight.mlir
`