### PR TITLE
[EmitPy] Separate forward inputs into activations and named weights

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -19,6 +19,11 @@ namespace mlir::tt::ttcore {
 
 constexpr inline llvm::StringLiteral g_kvCacheAttrName = "ttcore.kv_cache";
 
+constexpr inline llvm::StringLiteral g_originalActivationNamesAttrName =
+    "ttcore.original_activation_names";
+constexpr inline llvm::StringLiteral g_originalWeightNamesAttrName =
+    "ttcore.original_weight_names";
+
 class DeviceOp;
 class DeviceAttr;
 class SystemDescAttr;

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -178,6 +178,37 @@ def TTNNCreateMainForTest: Pass<"ttnn-create-main-for-test", "::mlir::ModuleOp">
   }];
 }
 
+def TTNNSplitActivationsAndWeights : Pass<"ttnn-split-activations-and-weights", "::mlir::ModuleOp"> {
+  let summary = "Split forward function arguments into activations tuple and weights dictionary.";
+  let description = [{
+    This pass rewrites each forward function of device module by separating its tensor arguments into activations and weights.
+    Activation arguments are packed into a tuple, while weight arguments are packed into a dictionary.
+
+    Given a forward function like this:
+
+    ```mlir
+    func.func @forward(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+                       %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>})
+        -> tensor<32x32xbf16> {
+      ...
+    }
+    ```
+
+    The pass will produce:
+
+    ```mlir
+    func.func @forward(%arg0: tuple<tensor<32x32xbf16>>,
+                       %arg1: !ttcore.dict)
+        -> tensor<32x32xbf16>
+        attributes {ttcore.original_argument_types = [...]} {
+      %input0 = ttcore.get_tuple_element %arg0[0] : ...
+      %weight0 = ttcore.get_key_value %arg1["weight_0"] : ...
+      ...
+    }
+    ```
+  }];
+}
+
 def TTNNTuplifyTensors: Pass<"ttnn-tuplify-tensors", "::mlir::ModuleOp"> {
   let summary = "Tuplify tensors in all funcs within a module.";
   let description = [{
@@ -551,7 +582,7 @@ def TTNNPrepareConstEvalCaching : Pass<"ttnn-prepare-const-eval-caching", "::mli
   let description = [{
     Packs the results of all LoadCachedOps into a single global caching
     dictionary per forward function.  For each forward function containing
-    LoadCachedOps it creates a global dictionary (e.g. `_cached_forward`),
+    LoadCachedOps it creates a global dictionary (e.g. `ce_cache_forward`),
     retrieves it at the top of the function body, and stores each
     LoadCachedOp result under its callee name.
   }];

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -178,7 +178,7 @@ def TTNNCreateMainForTest: Pass<"ttnn-create-main-for-test", "::mlir::ModuleOp">
   }];
 }
 
-def TTNNSplitActivationsAndWeights : Pass<"ttnn-split-activations-and-weights", "::mlir::ModuleOp"> {
+def TTNNSplitForwardFuncArgsByType : Pass<"ttnn-split-forward-func-args-by-type", "::mlir::ModuleOp"> {
   let summary = "Split forward function arguments into activations tuple and weights dictionary.";
   let description = [{
     This pass rewrites each forward function of device module by separating its tensor arguments into activations and weights.

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -178,6 +178,37 @@ def TTNNCreateMainForTest: Pass<"ttnn-create-main-for-test", "::mlir::ModuleOp">
   }];
 }
 
+def TTNNSplitActivationsAndWeights : Pass<"ttnn-split-activations-and-weights", "::mlir::ModuleOp"> {
+  let summary = "Split forward function arguments into activations tuple and weights dictionary.";
+  let description = [{
+    This pass rewrites each forward function of device module by separating its tensor arguments into activations and weights.
+    Activation arguments are packed into a tuple, while weight arguments are packed into a dictionary.
+
+    Given a forward function like this:
+
+    ```mlir
+    func.func @forward(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+                       %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>})
+        -> tensor<32x32xbf16> {
+      ...
+    }
+    ```
+
+    The pass will produce:
+
+    ```mlir
+    func.func @forward(%arg0: tuple<tensor<32x32xbf16>>,
+                       %arg1: !ttcore.dict)
+        -> tensor<32x32xbf16>
+        attributes {ttcore.original_argument_types = [...]} {
+      %input0 = ttcore.get_tuple_element %arg0[0] : ...
+      %weight0 = ttcore.get_key_value %arg1["weight_0"] : ...
+      ...
+    }
+    ```
+  }];
+}
+
 def TTNNTuplifyTensors: Pass<"ttnn-tuplify-tensors", "::mlir::ModuleOp"> {
   let summary = "Tuplify tensors in all funcs within a module.";
   let description = [{
@@ -568,7 +599,7 @@ def TTNNPrepareConstEvalCaching : Pass<"ttnn-prepare-const-eval-caching", "::mli
   let description = [{
     Packs the results of all LoadCachedOps into a single global caching
     dictionary per forward function.  For each forward function containing
-    LoadCachedOps it creates a global dictionary (e.g. `_cached_forward`),
+    LoadCachedOps it creates a global dictionary (e.g. `ce_cache_forward`),
     retrieves it at the top of the function body, and stores each
     LoadCachedOp result under its callee name.
   }];

--- a/include/ttmlir/FunctionTypes.h
+++ b/include/ttmlir/FunctionTypes.h
@@ -95,6 +95,10 @@ constexpr inline llvm::StringLiteral kImportedDeclarationValue =
 
 /// Attribute name for the source file of an imported declaration.
 constexpr inline llvm::StringLiteral kImportedFromAttrName = "tt.imported_from";
+
+/// Attribute name marking whether a forward device function inputs were
+/// split into activations and weights by TTNNSplitActivationsAndWeights.
+constexpr inline llvm::StringLiteral kSplitInputAttrName = "tt.is_split_input";
 } // namespace detail
 
 /// Returns the string value for the given function type.
@@ -198,13 +202,24 @@ inline void clearFunctionType(mlir::func::FuncOp funcOp) {
   funcOp->removeAttr(detail::kFunctionTypeAttrName);
 }
 
+/// Removes the split input attribute from the given function.
+inline void clearSplitInput(mlir::func::FuncOp funcOp) {
+  funcOp->removeAttr(detail::kSplitInputAttrName);
+}
+
 //===----------------------------------------------------------------------===//
 // Convenience query functions
 //===----------------------------------------------------------------------===//
 
-/// Returns true if the function is marked as a forward device function.
+/// Returns true if the function is a forward device function.
 inline bool isForwardDeviceFunc(mlir::func::FuncOp funcOp) {
   return hasFunctionType(funcOp, FunctionType::ForwardDevice);
+}
+
+/// Returns true if the function's inputs were split into activations and
+/// weights.
+inline bool isSplitInput(mlir::func::FuncOp funcOp) {
+  return funcOp->hasAttr(detail::kSplitInputAttrName);
 }
 
 /// Returns true if the function is marked as a forward CPU function.
@@ -274,6 +289,13 @@ inline void setImportedFrom(mlir::func::FuncOp funcOp,
                             llvm::StringRef fileName) {
   funcOp->setAttr(detail::kImportedFromAttrName,
                   mlir::StringAttr::get(funcOp->getContext(), fileName));
+}
+
+/// Marks a forward device function as having split inputs by
+/// TTNNSplitActivationsAndWeights.
+inline void setSplitInput(mlir::func::FuncOp funcOp) {
+  funcOp->setAttr(detail::kSplitInputAttrName,
+                  mlir::UnitAttr::get(funcOp->getContext()));
 }
 
 /// Gets the source file attribute from an imported declaration function.

--- a/include/ttmlir/FunctionTypes.h
+++ b/include/ttmlir/FunctionTypes.h
@@ -96,9 +96,10 @@ constexpr inline llvm::StringLiteral kImportedDeclarationValue =
 /// Attribute name for the source file of an imported declaration.
 constexpr inline llvm::StringLiteral kImportedFromAttrName = "tt.imported_from";
 
-/// Attribute name marking whether a forward device function inputs were
-/// split into activations and weights by TTNNSplitActivationsAndWeights.
-constexpr inline llvm::StringLiteral kSplitInputAttrName = "tt.is_split_input";
+/// Attribute name marking whether a forward device function arguments were
+/// split into activations and weights by TTNNSplitForwardFuncArgsByType.
+constexpr inline llvm::StringLiteral kSplitForwardFuncArgsByTypeAttrName =
+    "tt.has_split_func_args_by_type";
 } // namespace detail
 
 /// Returns the string value for the given function type.
@@ -202,9 +203,10 @@ inline void clearFunctionType(mlir::func::FuncOp funcOp) {
   funcOp->removeAttr(detail::kFunctionTypeAttrName);
 }
 
-/// Removes the split input attribute from the given function.
-inline void clearSplitInput(mlir::func::FuncOp funcOp) {
-  funcOp->removeAttr(detail::kSplitInputAttrName);
+/// Removes the split forward function arguments attribute from the given
+/// function.
+inline void clearSplitForwardFuncArgsByType(mlir::func::FuncOp funcOp) {
+  funcOp->removeAttr(detail::kSplitForwardFuncArgsByTypeAttrName);
 }
 
 //===----------------------------------------------------------------------===//
@@ -216,10 +218,10 @@ inline bool isForwardDeviceFunc(mlir::func::FuncOp funcOp) {
   return hasFunctionType(funcOp, FunctionType::ForwardDevice);
 }
 
-/// Returns true if the function's inputs were split into activations and
+/// Returns true if the function's arguments were split into activations and
 /// weights.
-inline bool isSplitInput(mlir::func::FuncOp funcOp) {
-  return funcOp->hasAttr(detail::kSplitInputAttrName);
+inline bool hasSplitForwardFuncArgsByType(mlir::func::FuncOp funcOp) {
+  return funcOp->hasAttr(detail::kSplitForwardFuncArgsByTypeAttrName);
 }
 
 /// Returns true if the function is marked as a forward CPU function.
@@ -292,9 +294,12 @@ inline void setImportedFrom(mlir::func::FuncOp funcOp,
 }
 
 /// Marks a forward device function as having split inputs by
-/// TTNNSplitActivationsAndWeights.
-inline void setSplitInput(mlir::func::FuncOp funcOp) {
-  funcOp->setAttr(detail::kSplitInputAttrName,
+/// TTNNSplitForwardFuncArgsByType.
+inline void setSplitForwardFuncArgsByType(mlir::func::FuncOp funcOp) {
+  assert(isForwardDeviceFunc(funcOp) &&
+         "can only set split forward function arguments by type attribute on "
+         "forward device functions");
+  funcOp->setAttr(detail::kSplitForwardFuncArgsByTypeAttrName,
                   mlir::UnitAttr::get(funcOp->getContext()));
 }
 

--- a/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
+++ b/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
@@ -8,6 +8,8 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Pass/Pass.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/FunctionTypes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
@@ -20,6 +22,39 @@ namespace mlir::tt {
 #include "ttmlir/Conversion/Passes.h.inc"
 
 namespace {
+
+// Infer an argument name from the function-level ttcore.original_argument_types
+// attribute if present.
+std::optional<std::string> inferArgNameFromOriginalTypes(func::FuncOp funcOp,
+                                                         unsigned argIdx) {
+  auto origTypesAttr =
+      funcOp->getAttrOfType<ArrayAttr>("ttcore.original_argument_types");
+  if (!origTypesAttr) {
+    return std::nullopt;
+  }
+
+  bool hasActivations = false, hasWeights = false;
+  for (Attribute attr : origTypesAttr) {
+    auto typeAttr = mlir::dyn_cast<ttcore::ArgumentTypeAttr>(attr);
+    assert(typeAttr &&
+           "Expected attribute to be of type ttcore::ArgumentTypeAttr");
+    if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
+      hasActivations = true;
+    } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
+               typeAttr.getValue() == ttcore::ArgumentType::Constant) {
+      hasWeights = true;
+    }
+  }
+
+  if (hasActivations && argIdx == 0) {
+    return "activations";
+  }
+  if (hasWeights && argIdx == (hasActivations ? 1 : 0)) {
+    return "weights";
+  }
+
+  return std::nullopt;
+}
 
 class EmitPyNameVarsPass : public impl::EmitPyNameVarsBase<EmitPyNameVarsPass> {
 public:
@@ -90,13 +125,12 @@ public:
       for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
         std::string argName;
 
-        // Check if an emitpy.name attribute already exists for this argument.
-        // If so, use it instead of generating a new name.
         if (auto existingNameAttr =
                 funcOp.getArgAttrOfType<StringAttr>(i, "emitpy.name")) {
           argName = existingNameAttr.getValue().str();
-        } else if (isa<emitpy::DictType>(funcOp.getArgument(i).getType())) {
-          argName = "ce_cache";
+        } else if (auto inferredName =
+                       inferArgNameFromOriginalTypes(funcOp, i)) {
+          argName = *inferredName;
         } else {
           argName = funcOp.getNumArguments() > 1 ? "input_" + std::to_string(i)
                                                  : "input";

--- a/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
+++ b/lib/Conversion/TTNNToEmitPy/EmitPyNameVars.cpp
@@ -8,7 +8,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Pass/Pass.h"
 #include "ttmlir/Dialect/EmitPy/IR/EmitPyOps.h"
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -23,37 +23,29 @@ namespace mlir::tt {
 
 namespace {
 
-// Infer an argument name from the function-level ttcore.original_argument_types
-// attribute if present.
-std::optional<std::string> inferArgNameFromOriginalTypes(func::FuncOp funcOp,
-                                                         unsigned argIdx) {
-  auto origTypesAttr =
-      funcOp->getAttrOfType<ArrayAttr>("ttcore.original_argument_types");
-  if (!origTypesAttr) {
-    return std::nullopt;
+// Resolves the variable name for a function argument. Resolution
+// order:
+//   1) Honor any `emitpy.name` already attached upstream.
+//   2) If the function is forward function and the arguments were split by
+//   type, use a type-specific name ("activations" or "weights").
+//   3) Fall back to a generic `arg_N` (or `arg` when there's a single arg).
+static std::string getEmitPyNameForFuncArg(func::FuncOp funcOp,
+                                           unsigned argIdx) {
+  if (auto existingName =
+          funcOp.getArgAttrOfType<StringAttr>(argIdx, "emitpy.name")) {
+    return existingName.getValue().str();
   }
 
-  bool hasActivations = false, hasWeights = false;
-  for (Attribute attr : origTypesAttr) {
-    auto typeAttr = mlir::dyn_cast<ttcore::ArgumentTypeAttr>(attr);
-    assert(typeAttr &&
-           "Expected attribute to be of type ttcore::ArgumentTypeAttr");
-    if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
-      hasActivations = true;
-    } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
-               typeAttr.getValue() == ttcore::ArgumentType::Constant) {
-      hasWeights = true;
+  if (ttmlir::utils::hasSplitForwardFuncArgsByType(funcOp)) {
+    if (funcOp.getArgAttr(argIdx, ttcore::g_originalActivationNamesAttrName)) {
+      return "activations";
+    }
+    if (funcOp.getArgAttr(argIdx, ttcore::g_originalWeightNamesAttrName)) {
+      return "weights";
     }
   }
 
-  if (hasActivations && argIdx == 0) {
-    return "activations";
-  }
-  if (hasWeights && argIdx == (hasActivations ? 1 : 0)) {
-    return "weights";
-  }
-
-  return std::nullopt;
+  return funcOp.getNumArguments() > 1 ? "arg_" + std::to_string(argIdx) : "arg";
 }
 
 class EmitPyNameVarsPass : public impl::EmitPyNameVarsBase<EmitPyNameVarsPass> {
@@ -123,18 +115,7 @@ public:
       }
 
       for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
-        std::string argName;
-
-        if (auto existingNameAttr =
-                funcOp.getArgAttrOfType<StringAttr>(i, "emitpy.name")) {
-          argName = existingNameAttr.getValue().str();
-        } else if (auto inferredName =
-                       inferArgNameFromOriginalTypes(funcOp, i)) {
-          argName = *inferredName;
-        } else {
-          argName = funcOp.getNumArguments() > 1 ? "input_" + std::to_string(i)
-                                                 : "input";
-        }
+        std::string argName = getEmitPyNameForFuncArg(funcOp, i);
 
         // Check if parameter name collides with the function name
         if (reservedNames.contains(argName)) {
@@ -149,6 +130,17 @@ public:
 
     // Handle subscript operations:
     module.walk([&](emitpy::SubscriptOp subscriptOp) {
+      // If a name hint was already attached upstream (e.g. by the split forward
+      // function arguments pass passing the original activation name), keep
+      // it.
+      //
+      if (auto existingNameAttr =
+              subscriptOp->getAttrOfType<StringAttr>("emitpy.name")) {
+        valueNames.insert(
+            {subscriptOp.getResult(), existingNameAttr.getValue().str()});
+        return;
+      }
+
       Value operand = subscriptOp.getOperand(0);
       Value indexValue = subscriptOp.getIndex();
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/FunctionTypes.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -2887,13 +2888,17 @@ public:
     Location loc = setKVOp.getLoc();
     Value key = emitDictKey(rewriter, loc, setKVOp.getKey());
 
-    // Pack values to set into a list.
-    auto tensorListType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
-    auto tensorListOp = rewriter.create<emitpy::CallOpaqueOp>(
-        loc, tensorListType, ttnn_to_emitpy::kCreateListFunctionName,
-        adaptor.getValues());
-    auto value = tensorListOp.getResult(0);
+    Value value;
+    if (adaptor.getValues().size() == 1) {
+      value = adaptor.getValues().front();
+    } else {
+      auto tensorListType =
+          emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
+      auto tensorListOp = rewriter.create<emitpy::CallOpaqueOp>(
+          loc, tensorListType, ttnn_to_emitpy::kCreateListFunctionName,
+          adaptor.getValues());
+      value = tensorListOp.getResult(0);
+    }
 
     // Build an expression that computes the subscript lvalue.
     SmallVector<Value> exprOperands = {adaptor.getDict(), key};
@@ -2938,13 +2943,20 @@ public:
     Location loc = getKVOp.getLoc();
     Value key = emitDictKey(rewriter, loc, getKVOp.getKey());
 
-    auto tensorListType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
     llvm::SmallVector<Type> convertedTypes;
     for (auto resultType : getKVOp.getResultTypes()) {
       convertedTypes.push_back(getTypeConverter()->convertType(resultType));
     }
 
+    if (getKVOp.getNumResults() == 1) {
+      auto value = rewriter.create<emitpy::SubscriptOp>(loc, convertedTypes[0],
+                                                        adaptor.getDict(), key);
+      rewriter.replaceOp(getKVOp, value);
+      return success();
+    }
+
+    auto tensorListType =
+        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
     llvm::SmallVector<Value> results;
     auto value = rewriter
                      .create<emitpy::SubscriptOp>(loc, tensorListType,
@@ -3005,7 +3017,7 @@ public:
   matchAndRewrite(func::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.modifyOpInPlace(funcOp, [&funcOp]() {
+    rewriter.modifyOpInPlace(funcOp, [&funcOp, &rewriter]() {
       // Preserve emitpy.name attributes before removing all argument
       // attributes.
       SmallVector<Attribute> emitPyNames;
@@ -3021,9 +3033,23 @@ public:
           funcOp.setArgAttr(i, ttnn_to_emitpy::kNameAttr, emitPyNames[i]);
         }
       }
+
+      if (ttmlir::utils::isConstEvalWrapperFunc(funcOp)) {
+        funcOp.setArgAttr(0, ttnn_to_emitpy::kNameAttr,
+                          StringAttr::get(rewriter.getContext(), "ce_cache"));
+        if (funcOp.getNumArguments() > 1 && isDictArgumentType(funcOp, 1)) {
+          funcOp.setArgAttr(1, ttnn_to_emitpy::kNameAttr,
+                            StringAttr::get(rewriter.getContext(), "weights"));
+        }
+      }
     });
 
     return success();
+  }
+
+  static bool isDictArgumentType(func::FuncOp funcOp, size_t argIndex) {
+    auto argType = funcOp.getArgument(argIndex).getType();
+    return isa<ttcore::DictType>(argType) || isa<emitpy::DictType>(argType);
   }
 };
 } // namespace

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -2677,10 +2677,16 @@ public:
         loc, rewriter.getIndexType(), std::to_string(adaptor.getIndex()));
 
     // Create subscript operation
-    Value subscriptResult = rewriter.create<emitpy::SubscriptOp>(
+    auto subscriptOp = rewriter.create<emitpy::SubscriptOp>(
         loc, resultType, adaptor.getOperand(), indexAsVal);
 
-    rewriter.replaceOp(getTupleElementOp, subscriptResult);
+    // Forward the `emitpy.name` codegen hint, if any
+    //
+    if (auto nameAttr = getTupleElementOp->getAttr("emitpy.name")) {
+      subscriptOp->setAttr("emitpy.name", nameAttr);
+    }
+
+    rewriter.replaceOp(getTupleElementOp, subscriptOp.getResult());
 
     return success();
   }
@@ -3016,20 +3022,43 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     rewriter.modifyOpInPlace(funcOp, [&funcOp, &rewriter]() {
-      // Preserve emitpy.name attributes before removing all argument
-      // attributes.
+      // Preserve attributes that downstream passes still need
+      // before removing all argument attributes.
+      //
       SmallVector<Attribute> emitPyNames;
+      unsigned activationNamesAttrIdx = 0, weightNamesAttrIdx = 0;
+      Attribute activationNamesAttr, weightNamesAttr;
       for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
         emitPyNames.push_back(funcOp.getArgAttr(i, ttnn_to_emitpy::kNameAttr));
+        if (Attribute attr = funcOp.getArgAttr(
+                i, ttcore::g_originalActivationNamesAttrName)) {
+          activationNamesAttr = attr;
+          activationNamesAttrIdx = i;
+        }
+        if (Attribute attr =
+                funcOp.getArgAttr(i, ttcore::g_originalWeightNamesAttrName)) {
+          weightNamesAttr = attr;
+          weightNamesAttrIdx = i;
+        }
       }
 
       funcOp.removeArgAttrsAttr();
 
-      // Restore emitpy.name attributes.
+      // Restore preserved attributes.
       for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
         if (emitPyNames[i]) {
           funcOp.setArgAttr(i, ttnn_to_emitpy::kNameAttr, emitPyNames[i]);
         }
+      }
+      if (activationNamesAttr) {
+        funcOp.setArgAttr(activationNamesAttrIdx,
+                          ttcore::g_originalActivationNamesAttrName,
+                          activationNamesAttr);
+      }
+      if (weightNamesAttr) {
+        funcOp.setArgAttr(weightNamesAttrIdx,
+                          ttcore::g_originalWeightNamesAttrName,
+                          weightNamesAttr);
       }
 
       if (ttmlir::utils::isConstEvalWrapperFunc(funcOp)) {

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/FunctionTypes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Value.h"
@@ -2885,13 +2886,17 @@ public:
     Location loc = setKVOp.getLoc();
     Value key = emitDictKey(rewriter, loc, setKVOp.getKey());
 
-    // Pack values to set into a list.
-    auto tensorListType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
-    auto tensorListOp = rewriter.create<emitpy::CallOpaqueOp>(
-        loc, tensorListType, ttnn_to_emitpy::kCreateListFunctionName,
-        adaptor.getValues());
-    auto value = tensorListOp.getResult(0);
+    Value value;
+    if (adaptor.getValues().size() == 1) {
+      value = adaptor.getValues().front();
+    } else {
+      auto tensorListType =
+          emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
+      auto tensorListOp = rewriter.create<emitpy::CallOpaqueOp>(
+          loc, tensorListType, ttnn_to_emitpy::kCreateListFunctionName,
+          adaptor.getValues());
+      value = tensorListOp.getResult(0);
+    }
 
     // Build an expression that computes the subscript lvalue.
     SmallVector<Value> exprOperands = {adaptor.getDict(), key};
@@ -2936,13 +2941,20 @@ public:
     Location loc = getKVOp.getLoc();
     Value key = emitDictKey(rewriter, loc, getKVOp.getKey());
 
-    auto tensorListType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
     llvm::SmallVector<Type> convertedTypes;
     for (auto resultType : getKVOp.getResultTypes()) {
       convertedTypes.push_back(getTypeConverter()->convertType(resultType));
     }
 
+    if (getKVOp.getNumResults() == 1) {
+      auto value = rewriter.create<emitpy::SubscriptOp>(loc, convertedTypes[0],
+                                                        adaptor.getDict(), key);
+      rewriter.replaceOp(getKVOp, value);
+      return success();
+    }
+
+    auto tensorListType =
+        emitpy::OpaqueType::get(rewriter.getContext(), "[ttnn.Tensor]");
     llvm::SmallVector<Value> results;
     auto value = rewriter
                      .create<emitpy::SubscriptOp>(loc, tensorListType,
@@ -3003,7 +3015,7 @@ public:
   matchAndRewrite(func::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.modifyOpInPlace(funcOp, [&funcOp]() {
+    rewriter.modifyOpInPlace(funcOp, [&funcOp, &rewriter]() {
       // Preserve emitpy.name attributes before removing all argument
       // attributes.
       SmallVector<Attribute> emitPyNames;
@@ -3019,9 +3031,23 @@ public:
           funcOp.setArgAttr(i, ttnn_to_emitpy::kNameAttr, emitPyNames[i]);
         }
       }
+
+      if (ttmlir::utils::isConstEvalWrapperFunc(funcOp)) {
+        funcOp.setArgAttr(0, ttnn_to_emitpy::kNameAttr,
+                          StringAttr::get(rewriter.getContext(), "ce_cache"));
+        if (funcOp.getNumArguments() > 1 && isDictArgumentType(funcOp, 1)) {
+          funcOp.setArgAttr(1, ttnn_to_emitpy::kNameAttr,
+                            StringAttr::get(rewriter.getContext(), "weights"));
+        }
+      }
     });
 
     return success();
+  }
+
+  static bool isDictArgumentType(func::FuncOp funcOp, size_t argIndex) {
+    auto argType = funcOp.getArgument(argIndex).getType();
+    return isa<ttcore::DictType>(argType) || isa<emitpy::DictType>(argType);
   }
 };
 } // namespace

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -530,8 +530,11 @@ void createTTNNToEmitPyDevicePipeline(
     devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
     devicePm.addPass(createTTNNPrepareModuleForExport());
   } else {
-    // In canonical path, run tuplification + input generation/loading.
+    // In canonical path, first split forward functions inputs that have
+    // ttcore.argument_type on all args into activations and weights. Then
+    // tuplify everything else.
     //
+    devicePm.addPass(createTTNNSplitActivationsAndWeights());
     devicePm.addPass(createTTNNTuplifyTensors());
 
     if (options.loadInputTensorsFromDisk) {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -544,11 +544,11 @@ void createTTNNCommonToEmitPyPipeline(
     devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
     devicePm.addPass(createTTNNPrepareModuleForExport());
   } else {
-    // In canonical path, first split forward functions inputs that have
-    // ttcore.argument_type on all args into activations and weights. Then
-    // tuplify everything else.
+    // In canonical path, split forward functions inputs that have
+    // ttcore.argument_type attribute set on all args into activations and
+    // weights first. Then tuplify everything else.
     //
-    devicePm.addPass(createTTNNSplitActivationsAndWeights());
+    devicePm.addPass(createTTNNSplitForwardFuncArgsByType());
     devicePm.addPass(createTTNNTuplifyTensors());
 
     if (options.loadInputTensorsFromDisk) {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -544,8 +544,11 @@ void createTTNNCommonToEmitPyPipeline(
     devicePm.addPass(createTTNNTuplifyTensors(tuplifyOptions));
     devicePm.addPass(createTTNNPrepareModuleForExport());
   } else {
-    // In canonical path, run tuplification + input generation/loading.
+    // In canonical path, first split forward functions inputs that have
+    // ttcore.argument_type on all args into activations and weights. Then
+    // tuplify everything else.
     //
+    devicePm.addPass(createTTNNSplitActivationsAndWeights());
     devicePm.addPass(createTTNNTuplifyTensors());
 
     if (options.loadInputTensorsFromDisk) {

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -35,6 +35,7 @@ namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNLOADINPUTTENSORS
 #define GEN_PASS_DEF_TTNNDEALLOCATE
 #define GEN_PASS_DEF_TTNNTUPLIFYTENSORS
+#define GEN_PASS_DEF_TTNNSPLITACTIVATIONSANDWEIGHTS
 #define GEN_PASS_DEF_TTNNEMPYWORKAROUNDS
 #define GEN_PASS_DEF_TTNNPREPAREMODULEFOREXPORT
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
@@ -263,8 +264,34 @@ public:
   }
 };
 
+/// Recovers the original flat argument indices for activations and weights
+/// from the ttcore.original_argument_types attribute. This is needed to
+static void recoverOriginalArgIndices(func::FuncOp funcOp,
+                                      SmallVector<size_t> &activationIndices,
+                                      SmallVector<size_t> &weightIndices) {
+  auto origTypesAttr =
+      funcOp->getAttrOfType<ArrayAttr>("ttcore.original_argument_types");
+  assert(origTypesAttr && "Expected ttcore.original_argument_types on function "
+                          "that has split activation and weight inputs!");
+  for (unsigned i = 0; i < origTypesAttr.size(); ++i) {
+    auto typeAttr = mlir::cast<ttcore::ArgumentTypeAttr>(origTypesAttr[i]);
+    if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
+      activationIndices.push_back(i);
+    } else {
+      weightIndices.push_back(i);
+    }
+  }
+}
+
 template <typename Derived>
 class TTNNInputFunctionCreatorBase {
+  /// Bundles the input generator functions created for a single forward
+  /// function.
+  struct ForwardFuncInputGeneratorOps {
+    func::FuncOp forwardFuncOp;
+    SmallVector<func::FuncOp, 2> inputGeneratorOps;
+  };
+
 protected:
   void runOnOperationImpl(ModuleOp moduleOp, IRRewriter &rewriter,
                           const std::string &functionPrefix) {
@@ -289,27 +316,54 @@ protected:
         rewriter.modifyOpInPlace(funcOp, [&]() { funcOp.setSymName("_main"); });
       }
 
-      if (funcOp.isPrivate()) {
+      if (!ttmlir::utils::isForwardDeviceFunc(funcOp) || funcOp.isPrivate()) {
         return mlir::WalkResult::skip();
       }
 
-      forwardFuncOps.push_back(funcOp);
+      if (funcOp.getFunctionType().getNumInputs() > 0) {
+        forwardFuncOps.push_back(funcOp);
+      }
+
       return mlir::WalkResult::advance();
     });
 
-    // Iterate over all func ops and add input tensor functions if needed.
+    // Iterate over all forward functions and add input tensor functions if
+    // needed.
     //
-    llvm::SmallVector<std::pair<mlir::func::FuncOp, mlir::func::FuncOp>, 1>
-        forwardAndInputFuncOps;
-    for (mlir::func::FuncOp forwardFuncOp : forwardFuncOps) {
-      rewriter.setInsertionPointToEnd(block);
-      mlir::func::FuncOp inputFuncOp;
-      // Only create input function if the forward function has inputs
-      if (!forwardFuncOp.getFunctionType().getInputs().empty()) {
-        inputFuncOp = createInputFunctionImpl(rewriter, forwardFuncOp.getLoc(),
-                                              forwardFuncOp, functionPrefix);
+    SmallVector<ForwardFuncInputGeneratorOps, 1> forwardAndInputFuncOps;
+    for (func::FuncOp forwardFuncOp : forwardFuncOps) {
+      ForwardFuncInputGeneratorOps entry;
+      entry.forwardFuncOp = forwardFuncOp;
+
+      if (ttmlir::utils::isSplitInput(forwardFuncOp)) {
+        SmallVector<size_t> activationOrigIndices, weightOrigIndices;
+        recoverOriginalArgIndices(forwardFuncOp, activationOrigIndices,
+                                  weightOrigIndices);
+
+        for (auto type : forwardFuncOp.getFunctionType().getInputs()) {
+          if (auto tupleType = dyn_cast<mlir::TupleType>(type)) {
+            entry.inputGeneratorOps.push_back(createTupleInputFunctionImpl(
+                rewriter, block, forwardFuncOp.getLoc(), forwardFuncOp,
+                functionPrefix + "activations_for_", tupleType,
+                activationOrigIndices));
+          }
+          if (isa<ttcore::DictType>(type)) {
+            entry.inputGeneratorOps.push_back(createDictInputFunctionImpl(
+                rewriter, block, forwardFuncOp.getLoc(), forwardFuncOp,
+                functionPrefix + "weights_for_", weightOrigIndices));
+          }
+        }
+      } else {
+        auto inputs = forwardFuncOp.getFunctionType().getInputs();
+        assert(inputs.size() == 1 && isa<mlir::TupleType>(inputs[0]) &&
+               "Expected upstream pass to have tuplified inputs!");
+        entry.inputGeneratorOps.push_back(createTupleInputFunctionImpl(
+            rewriter, block, forwardFuncOp.getLoc(), forwardFuncOp,
+            functionPrefix + "inputs_for_",
+            mlir::cast<mlir::TupleType>(inputs[0])));
       }
-      forwardAndInputFuncOps.emplace_back(forwardFuncOp, inputFuncOp);
+
+      forwardAndInputFuncOps.push_back(entry);
     }
 
     // Create a main function to call input functions and forward funcs.
@@ -317,87 +371,144 @@ protected:
     createMainFunction(moduleOp, rewriter, forwardAndInputFuncOps);
   }
 
-  func::FuncOp createInputFunctionImpl(IRRewriter &rewriter, Location loc,
-                                       func::FuncOp forwardFuncOp,
-                                       const std::string &functionPrefix) {
+  // Creates a function input generator for a tuple of tensors.
+  func::FuncOp createTupleInputFunctionImpl(
+      IRRewriter &rewriter, Block *block, Location loc,
+      func::FuncOp forwardFuncOp, const std::string &functionPrefix,
+      mlir::TupleType tupleType, ArrayRef<size_t> originalArgIndices = {}) {
     MLIRContext *ctx = rewriter.getContext();
-
-    // Create a new function that will handle the input tensors.
-    //
-    std::string inputFuncName = functionPrefix + forwardFuncOp.getName().str();
-
-    // Create the function type.
-    //
-    llvm::SmallVector<mlir::Type> returnTypes =
-        llvm::to_vector(forwardFuncOp.getFunctionType().getInputs());
-    if (returnTypes.empty()) {
-      returnTypes = {mlir::TupleType::get(ctx, {})};
-    }
-    FunctionType functionType = mlir::FunctionType::get(ctx, {}, returnTypes);
+    std::string funcName = functionPrefix + forwardFuncOp.getName().str();
+    FunctionType functionType = mlir::FunctionType::get(ctx, {}, tupleType);
 
     // Create the function.
     //
-    func::FuncOp inputFuncOp =
-        rewriter.create<mlir::func::FuncOp>(loc, inputFuncName, functionType);
+    rewriter.setInsertionPointToEnd(block);
+    func::FuncOp funcOp =
+        rewriter.create<mlir::func::FuncOp>(loc, funcName, functionType);
 
     // Mark this function as an input generator function.
     //
-    ttmlir::utils::setFunctionType(inputFuncOp,
+    ttmlir::utils::setFunctionType(funcOp,
                                    ttmlir::utils::FunctionType::InputGenerator);
 
     // Add a Block to func op and set insertion point to the beginning of the
     // Block.
     //
-    rewriter.modifyOpInPlace(inputFuncOp, [&]() {
-      rewriter.setInsertionPointToStart(inputFuncOp.addEntryBlock());
+    rewriter.modifyOpInPlace(funcOp, [&]() {
+      rewriter.setInsertionPointToStart(funcOp.addEntryBlock());
     });
 
-    // Create/load input tensors.
+    // Create/load tensors.
     //
-    assert(
-        returnTypes.size() == 1 && mlir::isa<TupleType>(returnTypes.front()) &&
-        "Expected input function to return a single tuple of input tensors!");
-
     SmallVector<Value> tensors;
-    size_t argIndex = 0;
-    for (const Type &type :
-         mlir::cast<mlir::TupleType>(returnTypes[0]).getTypes()) {
-      // Ensure that the type is a RankedTensorType.
-      //
-      RankedTensorType rankedTensorType =
-          mlir::dyn_cast<RankedTensorType>(type);
+    for (auto [i, type] : llvm::enumerate(tupleType.getTypes())) {
+      auto rankedTensorType = mlir::dyn_cast<RankedTensorType>(type);
       assert(rankedTensorType &&
-             "Expected input tensor to be of type RankedTensorType!");
+             "Expected tensor to be of type RankedTensorType!");
 
+      size_t argIndex = originalArgIndices.empty() ? i : originalArgIndices[i];
       tensors.push_back(static_cast<Derived *>(this)->createTensor(
           rewriter, loc, rankedTensorType, argIndex));
-      argIndex++;
     }
 
     // Create a tuple from the tensors.
     //
     ttcore::TupleOp tuple =
-        rewriter.create<ttcore::TupleOp>(loc, returnTypes, tensors);
+        rewriter.create<ttcore::TupleOp>(loc, tupleType, tensors);
 
     // Create ReturnOp.
     //
     rewriter.create<func::ReturnOp>(forwardFuncOp.getLoc(),
                                     tuple->getResults());
 
-    return inputFuncOp;
+    return funcOp;
+  }
+
+  // Creates a function input generator for a dictionary of tensors. This is
+  // used to pack weights into a dictionary.
+  func::FuncOp
+  createDictInputFunctionImpl(IRRewriter &rewriter, Block *block, Location loc,
+                              func::FuncOp forwardFuncOp,
+                              const std::string &functionPrefix,
+                              ArrayRef<size_t> originalArgIndices = {}) {
+    MLIRContext *ctx = rewriter.getContext();
+    std::string forwardFuncName = forwardFuncOp.getName().str();
+    std::string funcName = functionPrefix + forwardFuncName;
+    auto dictType = ttcore::DictType::get(ctx);
+    auto functionType = mlir::FunctionType::get(ctx, {}, {dictType});
+
+    // Create the global dictionary (module-level).
+    //
+    rewriter.setInsertionPointToEnd(block);
+    std::string dictName = forwardFuncName + "_weights";
+    rewriter.create<ttcore::GlobalOp>(loc, dictName, dictType,
+                                      /*index=*/IntegerAttr());
+
+    // Create the function.
+    //
+    func::FuncOp funcOp =
+        rewriter.create<mlir::func::FuncOp>(loc, funcName, functionType);
+
+    // Mark this function as an input generator function.
+    //
+    ttmlir::utils::setFunctionType(funcOp,
+                                   ttmlir::utils::FunctionType::InputGenerator);
+
+    // Add a Block to func op and set insertion point to the beginning of the
+    // Block.
+    //
+    rewriter.modifyOpInPlace(funcOp, [&]() {
+      rewriter.setInsertionPointToStart(funcOp.addEntryBlock());
+    });
+
+    // Retrieve the global dictionary.
+    //
+    Value dict = rewriter.create<ttcore::GetGlobalOp>(loc, dictType, dictName)
+                     ->getResult(0);
+
+    // Collect tensor names and types from GetKeyValueOp ops in the
+    // forward function body. All GetKeyValueOps in the forward function body
+    // are relevant since at this point all of them are created by
+    // TTNNSplitActivationsAndWeights pass.
+    //
+    SmallVector<std::pair<Attribute, Type>> namesAndTypes;
+    forwardFuncOp.walk([&](ttcore::GetKeyValueOp op) {
+      namesAndTypes.push_back({op.getKeyAttr(), op.getResult(0).getType()});
+    });
+
+    // Create/load tensors and store them in the dictionary.
+    //
+    for (auto [i, nameAndType] : llvm::enumerate(namesAndTypes)) {
+      auto &[key, type] = nameAndType;
+      auto rankedTensorType = mlir::dyn_cast<RankedTensorType>(type);
+      assert(rankedTensorType &&
+             "Expected tensor to be of type RankedTensorType!");
+
+      size_t argIndex = originalArgIndices.empty() ? i : originalArgIndices[i];
+      Value tensor = static_cast<Derived *>(this)->createTensor(
+          rewriter, loc, rankedTensorType, argIndex);
+
+      rewriter.create<ttcore::SetKeyValueOp>(loc, dict, key, tensor);
+    }
+
+    // Create ReturnOp.
+    //
+    rewriter.create<func::ReturnOp>(funcOp.getLoc(), dict);
+
+    return funcOp;
   }
 
 private:
   void createMainFunction(
       ModuleOp moduleOp, IRRewriter &rewriter,
-      llvm::SmallVector<std::pair<mlir::func::FuncOp, mlir::func::FuncOp>, 1>
-          forwardAndInputFuncOps) {
+      SmallVector<ForwardFuncInputGeneratorOps, 1> forwardAndInputFuncOps) {
+    MLIRContext *ctx = rewriter.getContext();
     std::string mainFuncName = "main";
 
     // Create a function type.
     //
-    FunctionType functionType = mlir::FunctionType::get(
-        rewriter.getContext(), {}, rewriter.getI32Type());
+    FunctionType functionType =
+        mlir::FunctionType::get(ctx, {}, rewriter.getI32Type());
 
     // Set insertion point to end of the block.
     //
@@ -420,17 +531,13 @@ private:
       rewriter.setInsertionPointToStart(mainFuncOp.addEntryBlock());
     });
 
-    for (auto [forwardFuncOp, inputFuncOp] : forwardAndInputFuncOps) {
-
+    for (auto &[forwardFuncOp, inputGeneratorOps] : forwardAndInputFuncOps) {
       llvm::SmallVector<Value> operands;
-      // Generate/load the input tensors for a forwardFuncOp if needed.
-      // inputFuncOp will be null if the forward function has no inputs.
-      //
-      if (inputFuncOp) {
-        func::CallOp tensors = rewriter.create<mlir::func::CallOp>(
-            forwardFuncOp.getLoc(), inputFuncOp,
+      for (auto generatorOp : inputGeneratorOps) {
+        func::CallOp call = rewriter.create<mlir::func::CallOp>(
+            forwardFuncOp.getLoc(), generatorOp,
             /*operands=*/ValueRange());
-        operands = tensors->getResults();
+        operands.push_back(call.getResult(0));
       }
 
       // Call a forward function. If there are input tensors, pass them as
@@ -463,7 +570,7 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
-    runOnOperationImpl(moduleOp, rewriter, "create_inputs_for_");
+    runOnOperationImpl(moduleOp, rewriter, "create_");
   }
 
   mlir::Value createTensor(IRRewriter &rewriter, Location loc, Type type,
@@ -521,7 +628,7 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
-    runOnOperationImpl(moduleOp, rewriter, "load_inputs_for_");
+    runOnOperationImpl(moduleOp, rewriter, "load_");
   }
 
   mlir::Value createTensor(IRRewriter &rewriter, Location loc, Type type,
@@ -811,6 +918,203 @@ private:
   }
 };
 
+// Splits the inputs of the forward functions into activations and
+// weights. Only performed on forward functions which inputs have
+// ttcore.argument_type attributes set, so that each input argument can
+// be properly classified as an activation or a weight.
+class TTNNSplitActivationsAndWeights
+    : public impl::TTNNSplitActivationsAndWeightsBase<
+          TTNNSplitActivationsAndWeights> {
+public:
+  using impl::TTNNSplitActivationsAndWeightsBase<
+      TTNNSplitActivationsAndWeights>::TTNNSplitActivationsAndWeightsBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    MLIRContext &ctx = getContext();
+    IRRewriter rewriter(&ctx);
+
+    // Ensure that the module has a single region and a single block within
+    // that region.
+    //
+    assert(moduleOp->getRegions().size() == 1);
+    assert(moduleOp->getRegion(0).hasOneBlock());
+
+    Block *block = moduleOp.getBody(0);
+
+    // Collect forward functions eligible for splitting.
+    //
+    SmallVector<func::FuncOp> forwardFuncOps;
+    block->walk([&](func::FuncOp funcOp) {
+      if (!ttmlir::utils::isForwardDeviceFunc(funcOp)) {
+        return mlir::WalkResult::skip();
+      }
+      if (funcOp.getFunctionType().getNumInputs() == 0) {
+        return mlir::WalkResult::skip();
+      }
+      if (isMissingArgTypes(funcOp)) {
+        return mlir::WalkResult::skip();
+      }
+      forwardFuncOps.push_back(funcOp);
+      return mlir::WalkResult::advance();
+    });
+
+    for (func::FuncOp funcOp : forwardFuncOps) {
+      mlir::FunctionType oldFunctionType = funcOp.getFunctionType();
+
+      // Classify the function arguments into activations and weights.
+      //
+      llvm::SmallDenseSet<unsigned> activationArgIndices, weightArgIndices;
+      SmallVector<Attribute> originalArgTypes;
+      SmallVector<Attribute> originalArgNames;
+      classifyFuncArguments(funcOp, activationArgIndices, weightArgIndices,
+                            originalArgTypes, originalArgNames);
+
+      bool hasActivations = !activationArgIndices.empty();
+      bool hasWeights = !weightArgIndices.empty();
+
+      assert((hasActivations || hasWeights) &&
+             "Expected at least one activation or weight argument!");
+
+      // Collect the activation argument types.
+      //
+      SmallVector<mlir::Type> activationTypes;
+      for (unsigned i = 0; i < oldFunctionType.getNumInputs(); ++i) {
+        if (activationArgIndices.count(i)) {
+          activationTypes.push_back(oldFunctionType.getInput(i));
+        }
+      }
+
+      // Create and set the new function type.
+      //
+      SmallVector<mlir::Type> newInputType;
+      if (hasActivations) {
+        newInputType.push_back(mlir::TupleType::get(&ctx, activationTypes));
+      }
+      if (hasWeights) {
+        newInputType.push_back(ttcore::DictType::get(&ctx));
+      }
+
+      mlir::FunctionType newFunctionType =
+          oldFunctionType.clone(newInputType, oldFunctionType.getResults());
+
+      rewriter.modifyOpInPlace(funcOp, [&funcOp, &newFunctionType]() {
+        funcOp.setFunctionType(newFunctionType);
+        funcOp->removeAttr(funcOp.getArgAttrsAttrName());
+      });
+
+      // Save original argument types and names as function-level attributes
+      // before the function signature is modified.
+      //
+      assert(!originalArgTypes.empty() && "Expected argument types to be set!");
+      funcOp->setAttr("ttcore.original_argument_types",
+                      ArrayAttr::get(&ctx, originalArgTypes));
+      if (!originalArgNames.empty()) {
+        funcOp->setAttr("ttcore.original_argument_names",
+                        ArrayAttr::get(&ctx, originalArgNames));
+      }
+
+      // Insert the new block arguments.
+      //
+      Block &entryBlock = funcOp.getBody().front();
+      BlockArgument activationsTuple, weightsDict;
+      unsigned newArgsCount = 0;
+      if (hasActivations) {
+        activationsTuple = entryBlock.insertArgument(
+            newArgsCount, newInputType[newArgsCount], funcOp.getLoc());
+        ++newArgsCount;
+      }
+      if (hasWeights) {
+        weightsDict = entryBlock.insertArgument(
+            newArgsCount, newInputType[newArgsCount], funcOp.getLoc());
+        ++newArgsCount;
+      }
+
+      // Create ops to unpack original arguments from the tuple (activations)
+      // or dict (weights), and replace all uses of the original arguments with
+      // the unpacked values.
+      //
+      rewriter.setInsertionPointToStart(&entryBlock);
+      size_t activationsTupleIdx = 0;
+      size_t weightsNameIdx = 0;
+      for (unsigned idx = 0; idx < oldFunctionType.getNumInputs(); ++idx) {
+        Type originalType = oldFunctionType.getInputs()[idx];
+        Value getElement;
+        if (activationArgIndices.count(idx)) {
+          getElement = rewriter
+                           .create<ttcore::GetTupleElementOp>(
+                               funcOp.getLoc(), originalType, activationsTuple,
+                               activationsTupleIdx++)
+                           ->getResult(0);
+        } else {
+          assert(weightArgIndices.count(idx) && "Expected weight argument!");
+          getElement = rewriter
+                           .create<ttcore::GetKeyValueOp>(
+                               funcOp.getLoc(), originalType, weightsDict,
+                               originalArgNames[weightsNameIdx++])
+                           ->getResult(0);
+        }
+
+        rewriter.replaceAllUsesWith(entryBlock.getArgument(newArgsCount + idx),
+                                    getElement);
+      }
+
+      // Erase original arguments.
+      //
+      entryBlock.eraseArguments(newArgsCount, oldFunctionType.getNumInputs());
+
+      // Mark the function input as split.
+      //
+      ttmlir::utils::setSplitInput(funcOp);
+    }
+  }
+
+  bool isMissingArgTypes(func::FuncOp funcOp) {
+    return llvm::any_of(
+        llvm::seq<unsigned>(0, funcOp.getFunctionType().getNumInputs()),
+        [&](unsigned i) {
+          return funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
+                     i, ttcore::ArgumentTypeAttr::name) == nullptr;
+        });
+  }
+
+  void
+  classifyFuncArguments(func::FuncOp funcOp,
+                        llvm::SmallDenseSet<unsigned> &activationArgIndices,
+                        llvm::SmallDenseSet<unsigned> &weightArgIndices,
+                        llvm::SmallVector<Attribute> &originalArgTypes,
+                        llvm::SmallVector<Attribute> &originalArgNames) {
+    mlir::FunctionType functionType = funcOp.getFunctionType();
+    MLIRContext &ctx = getContext();
+
+    unsigned unnamedWeightsCount = 0;
+    for (unsigned i = 0; i < functionType.getNumInputs(); ++i) {
+      if (auto typeAttr = funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
+              i, ttcore::ArgumentTypeAttr::name)) {
+        originalArgTypes.push_back(typeAttr);
+        if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
+          activationArgIndices.insert(i);
+        } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
+                   typeAttr.getValue() == ttcore::ArgumentType::Constant) {
+          weightArgIndices.insert(i);
+          if (auto nameAttr =
+                  funcOp.getArgAttrOfType<StringAttr>(i, "ttir.name")) {
+            originalArgNames.push_back(
+                StringAttr::get(&ctx, nameAttr.getValue()));
+          } else {
+            originalArgNames.push_back(StringAttr::get(
+                &ctx, "weight_" + std::to_string(unnamedWeightsCount++)));
+          }
+        }
+      } else {
+        llvm_unreachable("Pre-check should have skipped unannotated functions");
+      }
+    }
+  }
+};
+
+// Tuplifies inputs and/or results of all the functions whose inputs and/or
+// results are still flat (i.e. not packed into a tuple or dictionary).
 class TTNNTuplifyTensors
     : public impl::TTNNTuplifyTensorsBase<TTNNTuplifyTensors> {
 

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
@@ -35,7 +36,7 @@ namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNLOADINPUTTENSORS
 #define GEN_PASS_DEF_TTNNDEALLOCATE
 #define GEN_PASS_DEF_TTNNTUPLIFYTENSORS
-#define GEN_PASS_DEF_TTNNSPLITACTIVATIONSANDWEIGHTS
+#define GEN_PASS_DEF_TTNNSPLITFORWARDFUNCARGSBYTYPE
 #define GEN_PASS_DEF_TTNNEMPYWORKAROUNDS
 #define GEN_PASS_DEF_TTNNPREPAREMODULEFOREXPORT
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
@@ -265,20 +266,24 @@ public:
 };
 
 /// Recovers the original flat argument indices for activations and weights
-/// from the ttcore.original_argument_types attribute. This is needed to
+/// from the ttcore.original_argument_types attribute. This is needed to load
+/// the tensor of the proper index when loadInputTensorsFromDisk is enabled.
 static void recoverOriginalArgIndices(func::FuncOp funcOp,
                                       SmallVector<size_t> &activationIndices,
                                       SmallVector<size_t> &weightIndices) {
   auto origTypesAttr =
       funcOp->getAttrOfType<ArrayAttr>("ttcore.original_argument_types");
   assert(origTypesAttr && "Expected ttcore.original_argument_types on function "
-                          "that has split activation and weight inputs!");
+                          "that has split arguments by type!");
   for (unsigned i = 0; i < origTypesAttr.size(); ++i) {
     auto typeAttr = mlir::cast<ttcore::ArgumentTypeAttr>(origTypesAttr[i]);
     if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
       activationIndices.push_back(i);
-    } else {
+    } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
+               typeAttr.getValue() == ttcore::ArgumentType::Constant) {
       weightIndices.push_back(i);
+    } else {
+      llvm_unreachable("Unexpected ttcore::ArgumentType value");
     }
   }
 }
@@ -316,8 +321,13 @@ protected:
         rewriter.modifyOpInPlace(funcOp, [&]() { funcOp.setSymName("_main"); });
       }
 
+      // Skip non-forward device functions and private forward device functions.
+      // The latter is needed because TTNNRecoverStructure decomposes a forward
+      // function's body into private forward device sub-functions (per model
+      // substructure) that don't need input generators.
+      //
       if (!ttmlir::utils::isForwardDeviceFunc(funcOp) || funcOp.isPrivate()) {
-        return mlir::WalkResult::skip();
+        return mlir::WalkResult::advance();
       }
 
       if (funcOp.getFunctionType().getNumInputs() > 0) {
@@ -335,7 +345,7 @@ protected:
       ForwardFuncInputGeneratorOps entry;
       entry.forwardFuncOp = forwardFuncOp;
 
-      if (ttmlir::utils::isSplitInput(forwardFuncOp)) {
+      if (ttmlir::utils::hasSplitForwardFuncArgsByType(forwardFuncOp)) {
         SmallVector<size_t> activationOrigIndices, weightOrigIndices;
         recoverOriginalArgIndices(forwardFuncOp, activationOrigIndices,
                                   weightOrigIndices);
@@ -469,7 +479,7 @@ protected:
     // Collect tensor names and types from GetKeyValueOp ops in the
     // forward function body. All GetKeyValueOps in the forward function body
     // are relevant since at this point all of them are created by
-    // TTNNSplitActivationsAndWeights pass.
+    // TTNNSplitForwardFuncArgsByType pass.
     //
     SmallVector<std::pair<Attribute, Type>> namesAndTypes;
     forwardFuncOp.walk([&](ttcore::GetKeyValueOp op) {
@@ -918,16 +928,16 @@ private:
   }
 };
 
-// Splits the inputs of the forward functions into activations and
+// Splits the forward functions inputs by type into activations and
 // weights. Only performed on forward functions which inputs have
 // ttcore.argument_type attributes set, so that each input argument can
 // be properly classified as an activation or a weight.
-class TTNNSplitActivationsAndWeights
-    : public impl::TTNNSplitActivationsAndWeightsBase<
-          TTNNSplitActivationsAndWeights> {
+class TTNNSplitForwardFuncArgsByType
+    : public impl::TTNNSplitForwardFuncArgsByTypeBase<
+          TTNNSplitForwardFuncArgsByType> {
 public:
-  using impl::TTNNSplitActivationsAndWeightsBase<
-      TTNNSplitActivationsAndWeights>::TTNNSplitActivationsAndWeightsBase;
+  using impl::TTNNSplitForwardFuncArgsByTypeBase<
+      TTNNSplitForwardFuncArgsByType>::TTNNSplitForwardFuncArgsByTypeBase;
 
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
@@ -952,7 +962,7 @@ public:
       if (funcOp.getFunctionType().getNumInputs() == 0) {
         return mlir::WalkResult::skip();
       }
-      if (isMissingArgTypes(funcOp)) {
+      if (!containsArgTypes(funcOp)) {
         return mlir::WalkResult::skip();
       }
       forwardFuncOps.push_back(funcOp);
@@ -962,13 +972,20 @@ public:
     for (func::FuncOp funcOp : forwardFuncOps) {
       mlir::FunctionType oldFunctionType = funcOp.getFunctionType();
 
-      // Classify the function arguments into activations and weights.
+      // Classify the function arguments into activations and weights. Collect
+      // the original arg types (preserved as a function-level attribute) and
+      // the original arg names for activations and weights separately
+      // (preserved as per-arg attributes on the new tuple/dict args).
       //
       llvm::SmallDenseSet<unsigned> activationArgIndices, weightArgIndices;
-      SmallVector<Attribute> originalArgTypes;
-      SmallVector<Attribute> originalArgNames;
-      classifyFuncArguments(funcOp, activationArgIndices, weightArgIndices,
-                            originalArgTypes, originalArgNames);
+      classifyArgIndices(funcOp, activationArgIndices, weightArgIndices);
+      SmallVector<Attribute> originalArgTypes = collectOriginalArgTypes(funcOp);
+      SmallVector<Attribute> originalActivationNames =
+          collectOriginalArgNamesForTargetIndices(
+              funcOp, activationArgIndices, /*unnamedPrefix=*/"activation");
+      SmallVector<Attribute> originalWeightNames =
+          collectOriginalArgNamesForTargetIndices(funcOp, weightArgIndices,
+                                                  /*unnamedPrefix=*/"weight");
 
       bool hasActivations = !activationArgIndices.empty();
       bool hasWeights = !weightArgIndices.empty();
@@ -1003,18 +1020,14 @@ public:
         funcOp->removeAttr(funcOp.getArgAttrsAttrName());
       });
 
-      // Save original argument types and names as function-level attributes
-      // before the function signature is modified.
+      // Save original argument types as a function-level attribute.
       //
       assert(!originalArgTypes.empty() && "Expected argument types to be set!");
       funcOp->setAttr("ttcore.original_argument_types",
                       ArrayAttr::get(&ctx, originalArgTypes));
-      if (!originalArgNames.empty()) {
-        funcOp->setAttr("ttcore.original_argument_names",
-                        ArrayAttr::get(&ctx, originalArgNames));
-      }
 
-      // Insert the new block arguments.
+      // Insert the new block arguments and attach the original argument names
+      // as per-arg attributes.
       //
       Block &entryBlock = funcOp.getBody().front();
       BlockArgument activationsTuple, weightsDict;
@@ -1022,11 +1035,16 @@ public:
       if (hasActivations) {
         activationsTuple = entryBlock.insertArgument(
             newArgsCount, newInputType[newArgsCount], funcOp.getLoc());
+        funcOp.setArgAttr(newArgsCount,
+                          ttcore::g_originalActivationNamesAttrName,
+                          ArrayAttr::get(&ctx, originalActivationNames));
         ++newArgsCount;
       }
       if (hasWeights) {
         weightsDict = entryBlock.insertArgument(
             newArgsCount, newInputType[newArgsCount], funcOp.getLoc());
+        funcOp.setArgAttr(newArgsCount, ttcore::g_originalWeightNamesAttrName,
+                          ArrayAttr::get(&ctx, originalWeightNames));
         ++newArgsCount;
       }
 
@@ -1041,17 +1059,22 @@ public:
         Type originalType = oldFunctionType.getInputs()[idx];
         Value getElement;
         if (activationArgIndices.count(idx)) {
-          getElement = rewriter
-                           .create<ttcore::GetTupleElementOp>(
-                               funcOp.getLoc(), originalType, activationsTuple,
-                               activationsTupleIdx++)
-                           ->getResult(0);
+          // Hint the original activation name onto the unpack op so that the
+          // EmitPy codegen can use it as the local variable name in the
+          // generated Python instead of an anonymous `activations_N`.
+          //
+          auto getTupleElementOp = rewriter.create<ttcore::GetTupleElementOp>(
+              funcOp.getLoc(), originalType, activationsTuple,
+              activationsTupleIdx);
+          getTupleElementOp->setAttr(
+              "emitpy.name", originalActivationNames[activationsTupleIdx++]);
+          getElement = getTupleElementOp->getResult(0);
         } else {
           assert(weightArgIndices.count(idx) && "Expected weight argument!");
           getElement = rewriter
                            .create<ttcore::GetKeyValueOp>(
                                funcOp.getLoc(), originalType, weightsDict,
-                               originalArgNames[weightsNameIdx++])
+                               originalWeightNames[weightsNameIdx++])
                            ->getResult(0);
         }
 
@@ -1065,51 +1088,77 @@ public:
 
       // Mark the function input as split.
       //
-      ttmlir::utils::setSplitInput(funcOp);
+      ttmlir::utils::setSplitForwardFuncArgsByType(funcOp);
     }
   }
 
-  bool isMissingArgTypes(func::FuncOp funcOp) {
-    return llvm::any_of(
+  bool containsArgTypes(func::FuncOp funcOp) {
+    return llvm::all_of(
         llvm::seq<unsigned>(0, funcOp.getFunctionType().getNumInputs()),
         [&](unsigned i) {
           return funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
-                     i, ttcore::ArgumentTypeAttr::name) == nullptr;
+                     i, ttcore::ArgumentTypeAttr::name) != nullptr;
         });
   }
 
-  void
-  classifyFuncArguments(func::FuncOp funcOp,
-                        llvm::SmallDenseSet<unsigned> &activationArgIndices,
-                        llvm::SmallDenseSet<unsigned> &weightArgIndices,
-                        llvm::SmallVector<Attribute> &originalArgTypes,
-                        llvm::SmallVector<Attribute> &originalArgNames) {
-    mlir::FunctionType functionType = funcOp.getFunctionType();
-    MLIRContext &ctx = getContext();
-
-    unsigned unnamedWeightsCount = 0;
-    for (unsigned i = 0; i < functionType.getNumInputs(); ++i) {
-      if (auto typeAttr = funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
-              i, ttcore::ArgumentTypeAttr::name)) {
-        originalArgTypes.push_back(typeAttr);
-        if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
-          activationArgIndices.insert(i);
-        } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
-                   typeAttr.getValue() == ttcore::ArgumentType::Constant) {
-          weightArgIndices.insert(i);
-          if (auto nameAttr =
-                  funcOp.getArgAttrOfType<StringAttr>(i, "ttir.name")) {
-            originalArgNames.push_back(
-                StringAttr::get(&ctx, nameAttr.getValue()));
-          } else {
-            originalArgNames.push_back(StringAttr::get(
-                &ctx, "weight_" + std::to_string(unnamedWeightsCount++)));
-          }
-        }
+  // Classifies forward function argument indices into activation and weight
+  // indices based on each arg's `ttcore.argument_type` attribute.
+  //
+  void classifyArgIndices(func::FuncOp funcOp,
+                          llvm::SmallDenseSet<unsigned> &activationArgIndices,
+                          llvm::SmallDenseSet<unsigned> &weightArgIndices) {
+    for (unsigned i = 0; i < funcOp.getFunctionType().getNumInputs(); ++i) {
+      auto typeAttr = funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
+          i, ttcore::ArgumentTypeAttr::name);
+      assert(typeAttr && "Pre-check should have skipped unannotated functions");
+      if (typeAttr.getValue() == ttcore::ArgumentType::Input) {
+        activationArgIndices.insert(i);
+      } else if (typeAttr.getValue() == ttcore::ArgumentType::Parameter ||
+                 typeAttr.getValue() == ttcore::ArgumentType::Constant) {
+        weightArgIndices.insert(i);
       } else {
-        llvm_unreachable("Pre-check should have skipped unannotated functions");
+        llvm_unreachable("Unexpected ttcore::ArgumentType value");
       }
     }
+  }
+
+  // Collects per-arg `ttcore.argument_type` attributes in the original
+  // argument order.
+  //
+  llvm::SmallVector<Attribute> collectOriginalArgTypes(func::FuncOp funcOp) {
+    llvm::SmallVector<Attribute> originalArgTypes;
+    for (unsigned i = 0; i < funcOp.getFunctionType().getNumInputs(); ++i) {
+      auto typeAttr = funcOp.getArgAttrOfType<ttcore::ArgumentTypeAttr>(
+          i, ttcore::ArgumentTypeAttr::name);
+      assert(typeAttr && "Pre-check should have skipped unannotated functions");
+      originalArgTypes.push_back(typeAttr);
+    }
+    return originalArgTypes;
+  }
+
+  // Collects names for the arguments at `targetArgIndices` in the original
+  // argument order. Uses `ttir.name` arg attribute if present, otherwise
+  // auto-generates names in the form of `<unnamedPrefix>_N`.
+  //
+  llvm::SmallVector<Attribute> collectOriginalArgNamesForTargetIndices(
+      func::FuncOp funcOp,
+      const llvm::SmallDenseSet<unsigned> &targetArgIndices,
+      llvm::StringRef unnamedPrefix) {
+    llvm::SmallVector<Attribute> originalArgNames;
+    MLIRContext &ctx = getContext();
+    unsigned unnamedCount = 0;
+    for (unsigned i = 0; i < funcOp.getFunctionType().getNumInputs(); ++i) {
+      if (!targetArgIndices.contains(i)) {
+        continue;
+      }
+      if (auto nameAttr = funcOp.getArgAttrOfType<StringAttr>(i, "ttir.name")) {
+        originalArgNames.push_back(StringAttr::get(&ctx, nameAttr.getValue()));
+      } else {
+        originalArgNames.push_back(StringAttr::get(
+            &ctx, unnamedPrefix.str() + "_" + std::to_string(unnamedCount++)));
+      }
+    }
+    return originalArgNames;
   }
 };
 

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConstEvalCaching.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConstEvalCaching.cpp
@@ -23,7 +23,7 @@ namespace mlir::tt::ttnn {
 // LoadCachedOps within each forward function into a single global cache
 // dictionary. For each forward function containing LoadCachedOps, it:
 //
-//   1. Creates a global cache dictionary (e.g., `_cached_forward`).
+//   1. Creates a global cache dictionary (e.g., `ce_cache_forward`).
 //   2. Inserts a retrieval of the dictionary at the top of the forward function
 //   body.
 //   3. Creates a separate consteval wrapper function and moves the complete
@@ -37,7 +37,7 @@ namespace mlir::tt::ttnn {
 
 namespace {
 
-constexpr const char *kCachePrefix = "_cached_";
+constexpr const char *kCachePrefix = "ce_cache_";
 constexpr const char *kConstEvalWrapperNamePrefix = "consteval_";
 
 // Collect the sorteddef-use chain of the given ops.
@@ -112,10 +112,17 @@ public:
       // dictionary retrieval in the forward function.
       builder.setInsertionPointAfter(dict);
       Block &forwardBody = funcOp.getBody().front();
-      llvm::SmallVector<Value> callArgs;
-      callArgs.push_back(dict.getResult());
-      callArgs.append(forwardBody.getArguments().begin(),
-                      forwardBody.getArguments().end());
+
+      // Collect the arguments to pass to the consteval wrapper function.
+      SmallVector<Value> callArgs = {dict.getResult()};
+      auto activationIdx = getActivationArgIdx(funcOp);
+      for (unsigned i = 0; i < forwardBody.getNumArguments(); ++i) {
+        if (activationIdx && *activationIdx == i) {
+          continue;
+        }
+        callArgs.push_back(forwardBody.getArgument(i));
+      }
+
       auto cacheDict = builder.create<func::CallOp>(
           funcOp.getLoc(), kConstEvalWrapperNamePrefix + funcOp.getName().str(),
           TypeRange{dictType}, callArgs);
@@ -147,18 +154,38 @@ public:
     }
   }
 
+  /// Return the index of the activations argument if it exists.
+  std::optional<unsigned> getActivationArgIdx(func::FuncOp funcOp) {
+    if (!ttmlir::utils::isSplitInput(funcOp)) {
+      return std::nullopt;
+    }
+
+    for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
+      if (isa<TupleType>(funcOp.getArgument(i).getType())) {
+        return i;
+      }
+    }
+    return std::nullopt;
+  }
+
+  // Create the consteval wrapper function.
   LogicalResult
   createConstEvalWrapper(OpBuilder &builder, func::FuncOp forwardFunc,
                          llvm::SmallVector<ttcore::LoadCachedOp> &loadCachedOps,
                          Value cacheDict) {
-    // Create the consteval wrapper function.
     std::string wrapperName =
         kConstEvalWrapperNamePrefix + forwardFunc.getName().str();
     auto dictType = ttcore::DictType::get(&getContext());
-    llvm::SmallVector<Type> wrapperArgTypes;
-    wrapperArgTypes.push_back(dictType);
-    wrapperArgTypes.append(forwardFunc.getArgumentTypes().begin(),
-                           forwardFunc.getArgumentTypes().end());
+
+    llvm::SmallVector<Type> wrapperArgTypes = {dictType};
+    auto activationIdx = getActivationArgIdx(forwardFunc);
+    for (unsigned i = 0; i < forwardFunc.getNumArguments(); ++i) {
+      if (activationIdx && *activationIdx == i) {
+        continue;
+      }
+      wrapperArgTypes.push_back(forwardFunc.getArgument(i).getType());
+    }
+
     auto wrapperFuncType = builder.getFunctionType(wrapperArgTypes, {dictType});
 
     builder.setInsertionPointAfter(forwardFunc);
@@ -176,9 +203,14 @@ public:
     // arguments.
     IRMapping mapping;
     mapping.map(cacheDict, wrapperBody.getArgument(0));
+    unsigned wrapperArgIdx = 1;
     for (unsigned i = 0; i < forwardFunc.getNumArguments(); ++i) {
-      wrapperFunc.setArgAttrs(i + 1, forwardFunc.getArgAttrDict(i));
-      mapping.map(forwardBody.getArgument(i), wrapperBody.getArgument(i + 1));
+      if (activationIdx && *activationIdx == i) {
+        continue;
+      }
+      mapping.map(forwardBody.getArgument(i),
+                  wrapperBody.getArgument(wrapperArgIdx));
+      wrapperFunc.setArgAttrs(wrapperArgIdx++, forwardFunc.getArgAttrDict(i));
     }
 
     // Collect all ops from the forward function to clone into the wrapper.

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConstEvalCaching.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConstEvalCaching.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/FunctionTypes.h"
 
@@ -30,8 +31,11 @@ namespace mlir::tt::ttnn {
 //   const-eval logic of that forward function into it.
 //   4. Inserts a call to the consteval wrapper function after the dictionary
 //   retrieval in the forward function body. The consteval wrapper function
-//   receives the global cache dictionary and the forward function inputs as
-//   arguments.
+//   receives the global cache dictionary as its first argument. When the
+//   forward function has been split by type (TTNNSplitForwardFuncArgsByType),
+//   only its weights dict is forwarded to the wrapper, since activations
+//   are runtime inputs and never participate in const-eval; otherwise all
+//   forward arguments are passed through.
 //
 //===----------------------------------------------------------------------===//
 
@@ -40,7 +44,36 @@ namespace {
 constexpr const char *kCachePrefix = "ce_cache_";
 constexpr const char *kConstEvalWrapperNamePrefix = "consteval_";
 
-// Collect the sorteddef-use chain of the given ops.
+// Returns the weights-dict from the forward function signature if it exists.
+// Returns an empty BlockArgument otherwise.
+static BlockArgument findWeightsDictArg(func::FuncOp funcOp) {
+  for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
+    if (funcOp.getArgAttr(i, ttcore::g_originalWeightNamesAttrName)) {
+      return funcOp.getArgument(i);
+    }
+  }
+  return {};
+}
+
+// Returns the forward function arguments that should be passed to the
+// consteval wrapper. If the forward function arguments were split by type, only
+// the weights dictionary is passed. Otherwise, every forward function
+// argument is passed.
+//
+static SmallVector<BlockArgument>
+getConstEvalForwardArgs(func::FuncOp forwardFunc) {
+  SmallVector<BlockArgument> result;
+  if (ttmlir::utils::hasSplitForwardFuncArgsByType(forwardFunc)) {
+    if (BlockArgument weights = findWeightsDictArg(forwardFunc)) {
+      result.push_back(weights);
+    }
+  } else {
+    llvm::append_range(result, forwardFunc.getArguments());
+  }
+  return result;
+}
+
+// Collect the sorted def-use chain of the given ops.
 static llvm::SmallVector<Operation *>
 collectSortedDefUseChain(llvm::SmallVector<Operation *> &ops, Block *block) {
   llvm::SetVector<Operation *> result;
@@ -111,17 +144,11 @@ public:
       // Insert a call to the consteval wrapper function after the cache
       // dictionary retrieval in the forward function.
       builder.setInsertionPointAfter(dict);
-      Block &forwardBody = funcOp.getBody().front();
 
       // Collect the arguments to pass to the consteval wrapper function.
+      //
       SmallVector<Value> callArgs = {dict.getResult()};
-      auto activationIdx = getActivationArgIdx(funcOp);
-      for (unsigned i = 0; i < forwardBody.getNumArguments(); ++i) {
-        if (activationIdx && *activationIdx == i) {
-          continue;
-        }
-        callArgs.push_back(forwardBody.getArgument(i));
-      }
+      llvm::append_range(callArgs, getConstEvalForwardArgs(funcOp));
 
       auto cacheDict = builder.create<func::CallOp>(
           funcOp.getLoc(), kConstEvalWrapperNamePrefix + funcOp.getName().str(),
@@ -145,27 +172,13 @@ public:
       llvm::SmallVector<Operation *> loadCachedPtrs(loadCachedOps.begin(),
                                                     loadCachedOps.end());
       llvm::SmallVector<Operation *> defChainOps =
-          collectSortedDefUseChain(loadCachedPtrs, &forwardBody);
+          collectSortedDefUseChain(loadCachedPtrs, &funcOp.getBody().front());
       for (auto *op : llvm::reverse(defChainOps)) {
         if (op->use_empty()) {
           op->erase();
         }
       }
     }
-  }
-
-  /// Return the index of the activations argument if it exists.
-  std::optional<unsigned> getActivationArgIdx(func::FuncOp funcOp) {
-    if (!ttmlir::utils::isSplitInput(funcOp)) {
-      return std::nullopt;
-    }
-
-    for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
-      if (isa<TupleType>(funcOp.getArgument(i).getType())) {
-        return i;
-      }
-    }
-    return std::nullopt;
   }
 
   // Create the consteval wrapper function.
@@ -177,14 +190,15 @@ public:
         kConstEvalWrapperNamePrefix + forwardFunc.getName().str();
     auto dictType = ttcore::DictType::get(&getContext());
 
+    // Build the wrapper signature. Consteval cache dictionary is always the
+    // first argument. After that, some or all of the forward function arguments
+    // are passed.
+    //
+    SmallVector<BlockArgument> argsToForward =
+        getConstEvalForwardArgs(forwardFunc);
+
     llvm::SmallVector<Type> wrapperArgTypes = {dictType};
-    auto activationIdx = getActivationArgIdx(forwardFunc);
-    for (unsigned i = 0; i < forwardFunc.getNumArguments(); ++i) {
-      if (activationIdx && *activationIdx == i) {
-        continue;
-      }
-      wrapperArgTypes.push_back(forwardFunc.getArgument(i).getType());
-    }
+    llvm::append_range(wrapperArgTypes, ValueRange(argsToForward).getTypes());
 
     auto wrapperFuncType = builder.getFunctionType(wrapperArgTypes, {dictType});
 
@@ -203,14 +217,10 @@ public:
     // arguments.
     IRMapping mapping;
     mapping.map(cacheDict, wrapperBody.getArgument(0));
-    unsigned wrapperArgIdx = 1;
-    for (unsigned i = 0; i < forwardFunc.getNumArguments(); ++i) {
-      if (activationIdx && *activationIdx == i) {
-        continue;
-      }
-      mapping.map(forwardBody.getArgument(i),
-                  wrapperBody.getArgument(wrapperArgIdx));
-      wrapperFunc.setArgAttrs(wrapperArgIdx++, forwardFunc.getArgAttrDict(i));
+    for (auto [idx, forwardArg] : llvm::enumerate(argsToForward)) {
+      mapping.map(forwardArg, wrapperBody.getArgument(idx + 1));
+      wrapperFunc.setArgAttrs(
+          idx + 1, forwardFunc.getArgAttrDict(forwardArg.getArgNumber()));
     }
 
     // Collect all ops from the forward function to clone into the wrapper.

--- a/test/ttmlir/Dialect/EmitPy/TTNN/consteval/global.mlir
+++ b/test/ttmlir/Dialect/EmitPy/TTNN/consteval/global.mlir
@@ -9,9 +9,9 @@ module {
   // CHECK: emitpy.file "main" {
   // CHECK:   emitpy.import from "consteval" import "consteval_forward"
   // CHECK:   func.func private @consteval_forward
-  // CHECK:   emitpy.global @_cached_forward = #emitpy.opaque<"{}">
+  // CHECK:   emitpy.global @ce_cache_forward = #emitpy.opaque<"{}">
   // CHECK:   func.func @forward(
-  // CHECK:     emitpy.global_statement @_cached_forward
+  // CHECK:     emitpy.global_statement @ce_cache_forward
   // CHECK:     call @consteval_forward
   // CHECK: }
   // CHECK: emitpy.file "consteval" {

--- a/test/ttmlir/Dialect/EmitPy/no_split_files.mlir
+++ b/test/ttmlir/Dialect/EmitPy/no_split_files.mlir
@@ -27,9 +27,9 @@ module {
 // CHECK:   func.func private @forward_const_eval_0(
 // CHECK:     call @cpu_hoisted_const_eval_{{.*}}
 // CHECK-NOT: emitpy.file
-// CHECK:   emitpy.global @_cached_forward = #emitpy.opaque<"{}">
+// CHECK:   emitpy.global @ce_cache_forward = #emitpy.opaque<"{}">
 // CHECK:   func.func @forward(
-// CHECK:     emitpy.global_statement @_cached_forward
+// CHECK:     emitpy.global_statement @ce_cache_forward
 // CHECK:     call @consteval_forward
 // CHECK:     emitpy.call_opaque "ttnn.add"
 // CHECK:     emitpy.call_opaque "ttnn.add"

--- a/test/ttmlir/Dialect/EmitPy/split_files.mlir
+++ b/test/ttmlir/Dialect/EmitPy/split_files.mlir
@@ -23,9 +23,9 @@ module {
 // CHECK:     emitpy.import import "utils"
 // CHECK:     emitpy.import from "consteval" import "consteval_forward"
 // CHECK:     func.func private @consteval_forward
-// CHECK:     emitpy.global @_cached_forward = #emitpy.opaque<"{}">
+// CHECK:     emitpy.global @ce_cache_forward = #emitpy.opaque<"{}">
 // CHECK:     func.func @forward(
-// CHECK:       emitpy.global_statement @_cached_forward
+// CHECK:       emitpy.global_statement @ce_cache_forward
 // CHECK:       call @consteval_forward({{.*}})
 // CHECK:       emitpy.call_opaque "ttnn.add"
 // CHECK:       emitpy.call_opaque "ttnn.add"

--- a/test/ttmlir/EmitPy/TTNN/load_input/load_input.mlir
+++ b/test/ttmlir/EmitPy/TTNN/load_input/load_input.mlir
@@ -11,17 +11,17 @@
 // RUN: FileCheck %s --check-prefix=CUSTOM-FULL --input-file=%t.custom_full.mlir
 
 module {
-  // DEFAULT: load_tensor{{.*}}args = [#emitpy.opaque<"\22arg0.tensorbin\22"
   // DEFAULT: load_tensor{{.*}}args = [#emitpy.opaque<"\22arg1.tensorbin\22"
+  // DEFAULT: load_tensor{{.*}}args = [#emitpy.opaque<"\22arg0.tensorbin\22"
 
-  // CUSTOM-DIR: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/arg0.tensorbin\22"
   // CUSTOM-DIR: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/arg1.tensorbin\22"
+  // CUSTOM-DIR: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/arg0.tensorbin\22"
 
-  // CUSTOM-PREFIX: load_tensor{{.*}}args = [#emitpy.opaque<"\22input0.tensorbin\22"
   // CUSTOM-PREFIX: load_tensor{{.*}}args = [#emitpy.opaque<"\22input1.tensorbin\22"
+  // CUSTOM-PREFIX: load_tensor{{.*}}args = [#emitpy.opaque<"\22input0.tensorbin\22"
 
-  // CUSTOM-FULL: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/input0.tensorbin\22"
   // CUSTOM-FULL: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/input1.tensorbin\22"
+  // CUSTOM-FULL: load_tensor{{.*}}args = [#emitpy.opaque<"\22tensors/input0.tensorbin\22"
   func.func @add(%arg0 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1 : tensor<32x32xbf16> { ttcore.argument_type = #ttcore.argument_type<input> }) -> tensor<32x32xbf16> {
     %0 = "ttir.add"(%arg0, %arg0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %1 = "ttir.subtract"(%arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>

--- a/test/ttmlir/EmitPy/const_eval_no_split_files.mlir
+++ b/test/ttmlir/EmitPy/const_eval_no_split_files.mlir
@@ -6,7 +6,7 @@
 // 1. No file section labels are emitted
 // 2. Imports appear at the top
 // 3. cpu_hoisted_const_eval and forward_const_eval_0() are defined at module level
-// 4. forward() calls consteval_forward wrapper with global _cached_forward
+// 4. forward() calls consteval_forward wrapper with global ce_cache_forward
 // 5. consteval_forward() contains the caching if-guard and its dict argument is named "ce_cache"
 
 // CHECK-NOT: # File:
@@ -17,16 +17,19 @@
 // CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}(
 // CHECK:   ttir_cpu.add(
 // CHECK-LABEL: def forward_const_eval_0(
-// CHECK: _cached_forward = {}
-// CHECK: def forward(input
-// CHECK:   global _cached_forward
-// CHECK:   _cached_forward = consteval_forward(
+// CHECK:   cpu_hoisted_const_eval_{{.*}}(
+// CHECK: ce_cache_forward = {}
+// CHECK-LABEL: def forward(activations, weights)
+// CHECK:   global ce_cache_forward
+// CHECK:   ce_cache_forward = consteval_forward(ce_cache_forward, weights)
 // CHECK:   ttnn.add(
 // CHECK:   ttnn.add(
 // CHECK-NOT: # File:
-// CHECK-LABEL: def consteval_forward(ce_cache
+// CHECK-LABEL: def consteval_forward(ce_cache, weights)
 // CHECK:   if not ce_cache:
 // CHECK:     forward_const_eval_0(
+// CHECK:   return ce_cache
+
 
 module {
   func.func @forward(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},

--- a/test/ttmlir/EmitPy/const_eval_split_files.mlir
+++ b/test/ttmlir/EmitPy/const_eval_split_files.mlir
@@ -5,7 +5,7 @@
 // Verify the Python output when split-files is enabled (default):
 // 1. Two file sections are emitted: "main" and "consteval"
 // 2. Imports appear under each file label
-// 3. Main file: forward() calls consteval_forward(), uses _cached_forward global
+// 3. Main file: forward() calls consteval_forward(), uses ce_cache_forward global
 // 4. Consteval file: cpu_hoisted_const_eval, forward_const_eval_0() and
 //    consteval_forward() with caching
 // 5. consteval_forward() contains the caching if-guard and its dict argument is named "ce_cache"
@@ -14,10 +14,10 @@
 // CHECK: import ttnn
 // CHECK: import utils
 // CHECK: from consteval import consteval_forward
-// CHECK: _cached_forward = {}
-// CHECK: def forward(input
-// CHECK:   global _cached_forward
-// CHECK:   _cached_forward = consteval_forward(_cached_forward
+// CHECK: ce_cache_forward = {}
+// CHECK-LABEL: def forward(activations, weights)
+// CHECK:   global ce_cache_forward
+// CHECK:   ce_cache_forward = consteval_forward(ce_cache_forward, weights)
 // CHECK:   ttnn.add(
 // CHECK:   ttnn.add(
 // CHECK-LABEL: # File: "consteval"
@@ -28,7 +28,7 @@
 // CHECK:   ttir_cpu.add(
 // CHECK-LABEL: def forward_const_eval_0(input):
 // CHECK:   cpu_hoisted_const_eval_{{.*}}(
-// CHECK: def consteval_forward(ce_cache, input_1
+// CHECK: def consteval_forward(ce_cache, weights)
 // CHECK:   if not ce_cache:
 // CHECK:     forward_const_eval_0(
 // CHECK:   return ce_cache

--- a/test/ttmlir/EmitPy/const_eval_split_files.mlir
+++ b/test/ttmlir/EmitPy/const_eval_split_files.mlir
@@ -26,7 +26,7 @@
 // CHECK: import ttir_cpu
 // CHECK-LABEL: def cpu_hoisted_const_eval_{{.*}}(
 // CHECK:   ttir_cpu.add(
-// CHECK-LABEL: def forward_const_eval_0(input):
+// CHECK-LABEL: def forward_const_eval_0(arg):
 // CHECK:   cpu_hoisted_const_eval_{{.*}}(
 // CHECK: def consteval_forward(ce_cache, weights)
 // CHECK:   if not ce_cache:

--- a/test/ttmlir/EmitPy/fold_expressions.mlir
+++ b/test/ttmlir/EmitPy/fold_expressions.mlir
@@ -6,19 +6,27 @@
 // RUN: ttmlir-translate --mlir-to-python -o %t.py %t.mlir
 // RUN: FileCheck %s --input-file=%t.py
 
-// Verify that the EmitPyFormExpressions pass produces compact Python output:
-// 1. Dict GET: string constant is inlined into subscript: dict["key"]
-// 2. List-into-call: util_create_list is inlined into callee: f([x])
-// 3. Dict SET: string key and list creation are inlined: dict["key"] = [v[0]]
+// Verify that the EmitPyFormExpressions pass produces compact Python output
+// by inlining single-use PyExpressionInterface ops into ExpressionOps:
+//
+// 1. Dict GET: string constant is inlined into subscript — dict["key"]
+// 2. List wrapping: util_create_list is inlined — return [x]
+// 3. Dict SET: string key is inlined into subscript assignment — dict["key"] = val
 
+// forward() — dict GET for weight access and const-eval cache lookup.
+//
 // CHECK-LABEL: def forward(
-// CHECK:   _cached_forward["forward_const_eval_0"]
+// CHECK:   weights["weight_0"]
+// CHECK:   ce_cache_forward["forward_const_eval_0"]
 // CHECK-NOT: const{{.*}} = "forward_const_eval_0"
+// CHECK:   return [{{.*}}]
 
-// CHECK-LABEL: def consteval_forward(ce_cache, input_1):
+// consteval_forward() — dict GET for weight keys, dict SET for cache entry.
+//
+// CHECK-LABEL: def consteval_forward(ce_cache, weights
 // CHECK:   if not ce_cache:
-// CHECK:     forward_const_eval_0_0 = forward_const_eval_0([
-// CHECK:     ce_cache["forward_const_eval_0"] = [forward_const_eval_0_0[0]]
+// CHECK:     forward_const_eval_0([weights["weight_0"], weights["weight_1"]])
+// CHECK:     ce_cache["forward_const_eval_0"] =
 // CHECK:   return ce_cache
 
 module {


### PR DESCRIPTION
### Problem description
Generated Python code from the EmitPy pipeline treats all forward function arguments as a single, flat tuple, making it hard to distinguish activations from weights. 
### What's changed
This PR improves code readability by separating forward function inputs into activations and weights. Moreover, it packs the weights into a global dictionary where each weight is stored under a key corresponding to its fully qualified name. 

- `TTNNSplitForwardFuncArgsByType`: A pass introduced to rewrite a forward function signature to accept one tuple for activations and one dictionary for weights:
  - Argument type info is extracted from the `ttcore.argument_type` attribute, so all function arguments must carry this attribute for the pass to process a function. 
  - Weight dictionary keys are derived from `ttir.name` attributes when present, or auto-generated otherwise (e.g., `weight_0`). 

- `TTNNTuplifyTensors`: This pass remains unchanged, but the set of functions it processes is reduced. For functions with split input, it is now only responsible for tuplifying the result.
- `TTNNInputFunctionCreatorBase`: Now generates separate input generator functions for activations and weights when the forward function input is split.
- `TTNNPrepareConstEvalCaching`: Activations are not passed to the consteval wrapper functions anymore.
- `TTNNToEmitPy`: Conversion patterns for `SetKeyValueOp` and `GetKeyValueOp` are updated to avoid unnecessary list wrapping for single values.
- `EmitPyNameVars`: Activations and weights names are now inferred from the preserved `ttcore.original_activation/weight_names` attributes.

_Note:_ This is relevant only for the canonical Python codegen path. Additionally, this will be enabled for the canonical C++ codegen path. Other codegen paths (EmitC dylib and EmitPy target module) remain unchanged. 

### Checklist
- [x] New/Existing tests provide coverage for changes
