### PR TITLE
Implement height sharded preference for #7474

### DIFF
--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -60,6 +60,30 @@ static uint32_t getActBlockHOverride(const BeamCandidate &c) {
   return UINT32_MAX;
 }
 
+static std::optional<TensorMemoryLayout>
+getTensorMemoryLayout(const BeamCandidate &c) {
+  // First try conv2dConfig's shard_layout if explicitly set
+  if (auto *conv2d =
+          std::get_if<Conv2dAttrs>(&c.configHint.opSpecificAttrs)) {
+    if (conv2d->conv2dConfig.has_value() && conv2d->conv2dConfig.value()) {
+      auto shardLayout = conv2d->conv2dConfig.value().getShardLayout();
+      if (shardLayout.has_value()) {
+        return shardLayout;
+      }
+    }
+  }
+
+  // Fall back to the actual validated output layout
+  if (!c.outputLayouts.empty()) {
+    auto memLayout = c.outputLayouts[0].getMemLayout();
+    if (memLayout) {
+      return memLayout.getValue();
+    }
+  }
+
+  return std::nullopt;
+}
+
 bool Conv2dRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
                                      const BeamCandidate &b) const {
   // Prefer act_block_h_override=0 (auto, best), then higher over lower.
@@ -74,6 +98,19 @@ bool Conv2dRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
       return false;
     }
     return abhA > abhB;
+  }
+
+  // Tie breaker: Prefer HeightSharded over all other layouts (e.g.
+  // BlockSharded). When LayoutScores are equal, HS consistently produces
+  // better runtime kernel configs (ABH=8 vs ABH=64 for BS).
+  auto layoutA = getTensorMemoryLayout(a);
+  auto layoutB = getTensorMemoryLayout(b);
+  if (layoutA.has_value() && layoutB.has_value()) {
+    bool aIsHS = layoutA.value() == TensorMemoryLayout::HeightSharded;
+    bool bIsHS = layoutB.value() == TensorMemoryLayout::HeightSharded;
+    if (aIsHS != bIsHS) {
+      return aIsHS;
+    }
   }
   return false;
 }

--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -63,8 +63,7 @@ static uint32_t getActBlockHOverride(const BeamCandidate &c) {
 static std::optional<TensorMemoryLayout>
 getTensorMemoryLayout(const BeamCandidate &c) {
   // First try conv2dConfig's shard_layout if explicitly set
-  if (auto *conv2d =
-          std::get_if<Conv2dAttrs>(&c.configHint.opSpecificAttrs)) {
+  if (auto *conv2d = std::get_if<Conv2dAttrs>(&c.configHint.opSpecificAttrs)) {
     if (conv2d->conv2dConfig.has_value() && conv2d->conv2dConfig.value()) {
       auto shardLayout = conv2d->conv2dConfig.value().getShardLayout();
       if (shardLayout.has_value()) {

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -169,63 +169,57 @@ public:
   }
 
   // Create a Conv2dOp for testing
-  Conv2dOp
-  createMockConv2dOp(
-    const llvm::ArrayRef<int64_t> &inputShape = {1, 32, 32, 256},
-    const llvm::ArrayRef<int64_t> &weightShape = {128, 256, 3, 3},
-    const llvm::ArrayRef<int64_t> &biasShape = {1, 1, 1, 128}) {
+  Conv2dOp createMockConv2dOp(
+      const llvm::ArrayRef<int64_t> &inputShape = {1, 32, 32, 256},
+      const llvm::ArrayRef<int64_t> &weightShape = {128, 256, 3, 3},
+      const llvm::ArrayRef<int64_t> &biasShape = {1, 1, 1, 128}) {
 
-    int32_t in_channels   = inputShape[3];
-    int32_t out_channels  = weightShape[0];
-    int32_t batch_size    = inputShape[0];
-    int32_t input_height  = inputShape[1];
-    int32_t input_width   = inputShape[2];
-    int32_t groups        = 1;
+    int32_t in_channels = inputShape[3];
+    int32_t out_channels = weightShape[0];
+    int32_t batch_size = inputShape[0];
+    int32_t input_height = inputShape[1];
+    int32_t input_width = inputShape[2];
+    int32_t groups = 1;
     llvm::SmallVector<int32_t, 2> kernel_size = {
-        static_cast<int32_t>(weightShape[2]), 
+        static_cast<int32_t>(weightShape[2]),
         static_cast<int32_t>(weightShape[3])};
-    llvm::SmallVector<int32_t, 2> stride   = {1, 1};
-    llvm::SmallVector<int32_t, 2> padding  = {0, 0};
+    llvm::SmallVector<int32_t, 2> stride = {1, 1};
+    llvm::SmallVector<int32_t, 2> padding = {0, 0};
     llvm::SmallVector<int32_t, 2> dilation = {1, 1};
     auto device = builder.create<GetDeviceOp>(
-      builder.getUnknownLoc(),
-      MeshShapeAttr::get(&context, 1, 1),
-      MeshOffsetAttr::get(&context, 0, 0));
-
+        builder.getUnknownLoc(), MeshShapeAttr::get(&context, 1, 1),
+        MeshOffsetAttr::get(&context, 0, 0));
 
     auto inputLayout = createL1InterleavedLayout(inputShape);
-    auto inputTensorType =
-        mlir::RankedTensorType::get(inputShape, 
-          builder.getBF16Type(), inputLayout);
+    auto inputTensorType = mlir::RankedTensorType::get(
+        inputShape, builder.getBF16Type(), inputLayout);
     auto input = builder.create<OnesOp>(
         builder.getUnknownLoc(), inputTensorType,
         /*device=*/nullptr, ShapeAttr::get(&context, inputShape),
         /*dtype=*/nullptr, /*layout=*/nullptr, /*memory_config=*/nullptr);
 
     auto weightLayout = createL1InterleavedLayout(weightShape);
-    auto weightTensorType =
-        mlir::RankedTensorType::get(weightShape, 
-          builder.getBF16Type(), weightLayout);
+    auto weightTensorType = mlir::RankedTensorType::get(
+        weightShape, builder.getBF16Type(), weightLayout);
     auto weight = builder.create<OnesOp>(
         builder.getUnknownLoc(), weightTensorType,
         /*device=*/nullptr, ShapeAttr::get(&context, weightShape),
         /*dtype=*/nullptr, /*layout=*/nullptr, /*memory_config=*/nullptr);
 
     llvm::SmallVector<int64_t> outputShape = {
-      batch_size,
-      (input_height + 2*padding[0] - dilation[0] * (kernel_size[0] - 1) - 1) 
-        / stride[0] + 1,
-      (input_width + 2*padding[1] - dilation[1] * (kernel_size[1] - 1) - 1) 
-        / stride[1] + 1,
-      out_channels
-    };
-    auto outputLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::HeightSharded);
-    auto outputTensorType =
-        mlir::RankedTensorType::get(biasShape, 
-          builder.getBF16Type(), outputLayout);
-    
+        batch_size,
+        (input_height + 2 * padding[0] - dilation[0] * (kernel_size[0] - 1) -
+         1) / stride[0] +
+            1,
+        (input_width + 2 * padding[1] - dilation[1] * (kernel_size[1] - 1) -
+         1) / stride[1] +
+            1,
+        out_channels};
+    auto outputLayout = createTiledLayout(outputShape, BufferType::L1,
+                                          TensorMemoryLayout::HeightSharded);
+    auto outputTensorType = mlir::RankedTensorType::get(
+        biasShape, builder.getBF16Type(), outputLayout);
+
     return builder.create<Conv2dOp>(builder.getUnknownLoc(), outputTensorType,
                                     input.getResult(), weight.getResult(),
                                     /*bias=*/nullptr,
@@ -487,22 +481,17 @@ TEST_F(OpModelStrategyTest, Conv2dPreferHeightSharded) {
                         /*requiresReshard=*/false, /*outputL1Usage=*/32768};
   auto outputShape = conv2dOp.getResult().getType().getShape();
 
-  auto interLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::Interleaved);
-  auto hsLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::HeightSharded);
-  auto wsLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::WidthSharded);
-  auto bsLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::BlockSharded);
-  auto ndLayout = createTiledLayout(outputShape, 
-                          BufferType::L1,
-                          TensorMemoryLayout::NDSharded);
-  
+  auto interLayout = createTiledLayout(outputShape, BufferType::L1,
+                                       TensorMemoryLayout::Interleaved);
+  auto hsLayout = createTiledLayout(outputShape, BufferType::L1,
+                                    TensorMemoryLayout::HeightSharded);
+  auto wsLayout = createTiledLayout(outputShape, BufferType::L1,
+                                    TensorMemoryLayout::WidthSharded);
+  auto bsLayout = createTiledLayout(outputShape, BufferType::L1,
+                                    TensorMemoryLayout::BlockSharded);
+  auto ndLayout = createTiledLayout(outputShape, BufferType::L1,
+                                    TensorMemoryLayout::NDSharded);
+
   BeamCandidate interCandidate;
   interCandidate.score = tiedScore;
   interCandidate.outputLayouts = {interLayout};
@@ -522,7 +511,7 @@ TEST_F(OpModelStrategyTest, Conv2dPreferHeightSharded) {
   BeamCandidate ndCandidate;
   ndCandidate.score = tiedScore;
   ndCandidate.outputLayouts = {ndLayout};
-  
+
   // Function preferCandidate() should prefer HeighSharded over any other.
   // HeighSharded vs Interleaved.
   EXPECT_TRUE(preferCandidate(conv2dOp, hsCandidate, interCandidate));

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -168,6 +168,84 @@ public:
                                     /*compute_kernel_config=*/nullptr);
   }
 
+  // Create a Conv2dOp for testing
+  Conv2dOp
+  createMockConv2dOp(
+    const llvm::ArrayRef<int64_t> &inputShape = {1, 32, 32, 256},
+    const llvm::ArrayRef<int64_t> &weightShape = {128, 256, 3, 3},
+    const llvm::ArrayRef<int64_t> &biasShape = {1, 1, 1, 128}) {
+
+    int32_t in_channels   = inputShape[3];
+    int32_t out_channels  = weightShape[0];
+    int32_t batch_size    = inputShape[0];
+    int32_t input_height  = inputShape[1];
+    int32_t input_width   = inputShape[2];
+    int32_t groups        = 1;
+    llvm::SmallVector<int32_t, 2> kernel_size = {
+        static_cast<int32_t>(weightShape[2]), 
+        static_cast<int32_t>(weightShape[3])};
+    llvm::SmallVector<int32_t, 2> stride   = {1, 1};
+    llvm::SmallVector<int32_t, 2> padding  = {0, 0};
+    llvm::SmallVector<int32_t, 2> dilation = {1, 1};
+    auto device = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(),
+      MeshShapeAttr::get(&context, 1, 1),
+      MeshOffsetAttr::get(&context, 0, 0));
+
+
+    auto inputLayout = createL1InterleavedLayout(inputShape);
+    auto inputTensorType =
+        mlir::RankedTensorType::get(inputShape, 
+          builder.getBF16Type(), inputLayout);
+    auto input = builder.create<OnesOp>(
+        builder.getUnknownLoc(), inputTensorType,
+        /*device=*/nullptr, ShapeAttr::get(&context, inputShape),
+        /*dtype=*/nullptr, /*layout=*/nullptr, /*memory_config=*/nullptr);
+
+    auto weightLayout = createL1InterleavedLayout(weightShape);
+    auto weightTensorType =
+        mlir::RankedTensorType::get(weightShape, 
+          builder.getBF16Type(), weightLayout);
+    auto weight = builder.create<OnesOp>(
+        builder.getUnknownLoc(), weightTensorType,
+        /*device=*/nullptr, ShapeAttr::get(&context, weightShape),
+        /*dtype=*/nullptr, /*layout=*/nullptr, /*memory_config=*/nullptr);
+
+    llvm::SmallVector<int64_t> outputShape = {
+      batch_size,
+      (input_height + 2*padding[0] - dilation[0] * (kernel_size[0] - 1) - 1) 
+        / stride[0] + 1,
+      (input_width + 2*padding[1] - dilation[1] * (kernel_size[1] - 1) - 1) 
+        / stride[1] + 1,
+      out_channels
+    };
+    auto outputLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::HeightSharded);
+    auto outputTensorType =
+        mlir::RankedTensorType::get(biasShape, 
+          builder.getBF16Type(), outputLayout);
+    
+    return builder.create<Conv2dOp>(builder.getUnknownLoc(), outputTensorType,
+                                    input.getResult(), weight.getResult(),
+                                    /*bias=*/nullptr,
+                                    /*device=*/device,
+                                    /*in_channels=*/in_channels,
+                                    /*out_channels=*/out_channels,
+                                    /*batch_size=*/batch_size,
+                                    /*input_height=*/input_height,
+                                    /*input_width=*/input_width,
+                                    /*kernel_size=*/kernel_size,
+                                    /*stride=*/stride,
+                                    /*padding=*/padding,
+                                    /*dilation=*/dilation,
+                                    /*groups=*/groups,
+                                    /*dtype=*/nullptr,
+                                    /*conv2d_config=*/nullptr,
+                                    /*compute_config=*/nullptr,
+                                    /*conv2d_slice_config=*/nullptr);
+  }
+
   // Create legal configs for an elementwise op (DRAM + L1-interleaved).
   std::vector<OpConfig> createElementwiseLegalConfigs(
       const llvm::ArrayRef<int64_t> &shape = {1, 1, 32, 32}) {
@@ -399,6 +477,72 @@ TEST_F(OpModelStrategyTest, ScoreCandidateWithReshard) {
   EXPECT_TRUE(withReshard.requiresReshard);
   EXPECT_FALSE(withoutReshard.requiresReshard);
   EXPECT_TRUE(withoutReshard > withReshard);
+}
+
+TEST_F(OpModelStrategyTest, Conv2dPreferHeightSharded) {
+  auto conv2dOp = createMockConv2dOp();
+  // Identical scores — same core count, same L1 usage (reproduces the tie
+  // from issue #7474: BS 8x8 and HS 64x1 both score 64 cores, 32768 L1).
+  LayoutScore tiedScore{/*coreCount=*/64, /*isSharded=*/true, /*isL1=*/true,
+                        /*requiresReshard=*/false, /*outputL1Usage=*/32768};
+  auto outputShape = conv2dOp.getResult().getType().getShape();
+
+  auto interLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::Interleaved);
+  auto hsLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::HeightSharded);
+  auto wsLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::WidthSharded);
+  auto bsLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::BlockSharded);
+  auto ndLayout = createTiledLayout(outputShape, 
+                          BufferType::L1,
+                          TensorMemoryLayout::NDSharded);
+  
+  BeamCandidate interCandidate;
+  interCandidate.score = tiedScore;
+  interCandidate.outputLayouts = {interLayout};
+
+  BeamCandidate hsCandidate;
+  hsCandidate.score = tiedScore;
+  hsCandidate.outputLayouts = {hsLayout};
+
+  BeamCandidate wsCandidate;
+  wsCandidate.score = tiedScore;
+  wsCandidate.outputLayouts = {wsLayout};
+
+  BeamCandidate bsCandidate;
+  bsCandidate.score = tiedScore;
+  bsCandidate.outputLayouts = {bsLayout};
+
+  BeamCandidate ndCandidate;
+  ndCandidate.score = tiedScore;
+  ndCandidate.outputLayouts = {ndLayout};
+  
+  // Function preferCandidate() should prefer HeighSharded over any other.
+  // HeighSharded vs Interleaved.
+  EXPECT_TRUE(preferCandidate(conv2dOp, hsCandidate, interCandidate));
+  EXPECT_FALSE(preferCandidate(conv2dOp, interCandidate, hsCandidate));
+
+  // HeighSharded vs WidthSharded.
+  EXPECT_TRUE(preferCandidate(conv2dOp, hsCandidate, wsCandidate));
+  EXPECT_FALSE(preferCandidate(conv2dOp, wsCandidate, hsCandidate));
+
+  // HeighSharded vs BlockSharded.
+  EXPECT_TRUE(preferCandidate(conv2dOp, hsCandidate, bsCandidate));
+  EXPECT_FALSE(preferCandidate(conv2dOp, bsCandidate, hsCandidate));
+
+  // HeighSharded vs NDSharded.
+  EXPECT_TRUE(preferCandidate(conv2dOp, hsCandidate, ndCandidate));
+  EXPECT_FALSE(preferCandidate(conv2dOp, ndCandidate, hsCandidate));
+
+  // Equal layouts, no preference.
+  EXPECT_FALSE(preferCandidate(conv2dOp, hsCandidate, hsCandidate));
+  EXPECT_FALSE(preferCandidate(conv2dOp, bsCandidate, bsCandidate));
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
### Ticket
PR for #7474 

### Problem description
According to #7474, when the greedy optimizer scores Conv2d/ConvTranspose2d ``HeightSharded`` and ``BlockSharded`` candidates with the same score, the tie breaker depends on arbitrary sorting order. Even though it has been empirically observed that ``HeightSharded`` consistently produces significantly faster runtime results.

### What's changed
It was proposed that a tie breaker be implemented for ``conv2d`` and ``conv_transpose2d`` that prefers ``HeightSharded`` layouts. This has been implemented here.

- Added tie breaker logic to ``Conv2dRuleBook``'s ``preferCandidate()`` that prefers ``HeightSharded`` layout over all others. As suggested by original issue.
- Added unit-test to confirm ``HeightSharded`` is preferred over all other types.

### Checklist
- [x] New/Existing tests provide coverage for changes
