### PR TITLE
Discard trace warmup outputs

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4577,13 +4577,12 @@ public:
       if (is_first_call) {
         is_first_call = false;
         [trace_id,
-         actual_output_0,..., actual_output_m,
          global_input_0,..., global_input_n,
          global_output_0,..., global_output_m]
             = capture_calle(input_0,..., input_n);
-        return actual_output_0,..., actual_output_m;
+        return global_output_0,..., global_output_m;
       } else {
-        return execute_calle(trace_id);
+        execute_calle(trace_id);
         return global_output_0,..., global_output_m;
       }
     }
@@ -4699,22 +4698,8 @@ public:
           loc, getGlobalVariable(rewriter, loc, traceId),
           getTraceId.getResult(0));
 
-      // local_output_0 = std::get<outputBaseIndex + i>(v);
-      // ...
-      // local_output_n = std::get<outputBaseIndex + n>(v);
-      const size_t outputBaseIndex = 1;
-      for (size_t i = 0; i < returnVariable.size(); ++i) {
-        std::string getName =
-            "::std::get<" + std::to_string(outputBaseIndex + i) + ">";
-        auto getResult = rewriter.create<emitc::CallOpaqueOp>(
-            loc, ttnnTensorType, getName, nullptr, nullptr,
-            captureTuple.getResult(0));
-        rewriter.create<emitc::AssignOp>(loc, returnVariable[i].getResult(),
-                                         getResult.getResult(0));
-      }
-
       // input_i = std::get<inputBaseIndex + i>(v)
-      const size_t inputBaseIndex = 1 + returnVariable.size();
+      const size_t inputBaseIndex = 1;
       for (size_t i = 0; i < traceInputVariable.size(); ++i) {
         std::string getName =
             "::std::get<" + std::to_string(inputBaseIndex + i) + ">";
@@ -4726,6 +4711,8 @@ public:
             getResult.getResult(0));
       }
 
+      // output_i = std::get<traceOutputBaseIndex + i>(v)
+      // Output slots also serve as the actual outputs for the first invocation.
       const size_t traceOutputBaseIndex =
           inputBaseIndex + traceInputVariable.size();
       for (size_t i = 0; i < traceOutputVariable.size(); ++i) {
@@ -4737,6 +4724,13 @@ public:
         rewriter.create<emitc::AssignOp>(
             loc, getGlobalVariable(rewriter, loc, traceOutputVariable[i]),
             getResult.getResult(0));
+      }
+
+      // Return the output slots as the actual outputs for the first call.
+      for (size_t i = 0; i < returnVariable.size(); ++i) {
+        rewriter.create<emitc::AssignOp>(
+            loc, returnVariable[i].getResult(),
+            loadGlobalVariable(rewriter, loc, traceOutputVariable[i]));
       }
 
       rewriter.create<emitc::YieldOp>(loc);

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4724,10 +4724,8 @@ public:
         rewriter.create<emitc::AssignOp>(
             loc, getGlobalVariable(rewriter, loc, traceOutputVariable[i]),
             getResult.getResult(0));
-      }
 
-      // Return the output slots as the actual outputs for the first call.
-      for (size_t i = 0; i < returnVariable.size(); ++i) {
+        // Return the output slot as the actual output for the first call.
         rewriter.create<emitc::AssignOp>(
             loc, returnVariable[i].getResult(),
             loadGlobalVariable(rewriter, loc, traceOutputVariable[i]));

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -392,12 +392,7 @@ private:
     // 1. traceId - Identifier for the captured trace
     // 2. trace input slots - Persistent device memory for input data
     // 3. trace output slots - Persistent device memory for output data
-    //
-    // The trace output slots serve double duty: they are the buffers that the
-    // captured trace writes to on replay, AND they provide the actual output
-    // values for the first (capture) invocation. The warmup call's results are
-    // deallocated immediately after use to avoid holding redundant copies in
-    // device memory during trace capture.
+
     llvm::SmallVector<mlir::Type> outputTypes;
 
     // Trace ID for the captured trace, used for correlation between capture and
@@ -499,9 +494,7 @@ private:
     }
 
     // Execute the trace function once without capture to compile programs and
-    // populate program cache. The results are not used — the subsequent
-    // deallocation pass will insert deallocates for them, freeing device memory
-    // before trace capture begins.
+    // populate program cache.
     builder.create<func::CallOp>(runAndCaptureTraceFunc.getLoc(), traceFunc,
                                  traceInputSlots);
 
@@ -520,9 +513,12 @@ private:
                                             deviceOp, beginTraceCaptureOp,
                                             /*cq_id=*/0);
 
+    // Execute the trace once to fill output slots with real computed values.
+    builder.create<ttnn::ExecuteTraceOp>(runAndCaptureTraceFunc.getLoc(),
+                                         deviceOp, beginTraceCaptureOp,
+                                         /*cq_id=*/0, /*blocking=*/false);
+
     // Assemble return values: trace ID and persistent slots.
-    // The trace output slots serve as both the captured trace's output buffers
-    // and the actual outputs for the first invocation.
     llvm::SmallVector<mlir::Value> returnValues;
 
     // Return the trace ID for correlation with execution.
@@ -532,8 +528,8 @@ private:
     for (mlir::Value inputSlot : traceInputSlots) {
       returnValues.push_back(inputSlot);
     }
-    // Return the trace output slots for all outputs that will be captured on
-    // device. These also serve as the actual outputs for the first invocation.
+    // Return the trace output slots. After the execute_trace above, these
+    // contain valid computed results for the first invocation.
     for (mlir::Value outputSlot : captureTraceCall.getResults()) {
       returnValues.push_back(outputSlot);
     }

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -390,20 +390,19 @@ private:
 
     // The capture function returns multiple values for trace management:
     // 1. traceId - Identifier for the captured trace
-    // 2. actual outputs - Results from the first execution (non-traced)
-    // 3. trace input slots - Persistent device memory for input data
-    // 4. trace output slots - Persistent device memory for output data
+    // 2. trace input slots - Persistent device memory for input data
+    // 3. trace output slots - Persistent device memory for output data
+    //
+    // The trace output slots serve double duty: they are the buffers that the
+    // captured trace writes to on replay, AND they provide the actual output
+    // values for the first (capture) invocation. The warmup call's results are
+    // deallocated immediately after use to avoid holding redundant copies in
+    // device memory during trace capture.
     llvm::SmallVector<mlir::Type> outputTypes;
 
     // Trace ID for the captured trace, used for correlation between capture and
     // execution.
     outputTypes.push_back(utils::getTraceIdType(context));
-
-    // Actual outputs from the first execution of the trace function
-    // (non-traced).
-    for (mlir::Type outputType : traceFunc.getFunctionType().getResults()) {
-      outputTypes.push_back(outputType);
-    }
 
     // Trace input slots for all inputs (including constants/parameters and KV
     // cache) that are persisted on device.
@@ -412,6 +411,7 @@ private:
     }
 
     // Trace output slots for all outputs that will be captured on device.
+    // These are also used as the actual outputs for the first invocation.
     for (mlir::Type outputType : traceFunc.getFunctionType().getResults()) {
       outputTypes.push_back(outputType);
     }
@@ -499,10 +499,11 @@ private:
     }
 
     // Execute the trace function once without capture to compile programs and
-    // populate program cache. The results are discarded since this execution is
-    // just for warming up.
-    auto traceFuncCall = builder.create<func::CallOp>(
-        runAndCaptureTraceFunc.getLoc(), traceFunc, traceInputSlots);
+    // populate program cache. The results are not used — the subsequent
+    // deallocation pass will insert deallocates for them, freeing device memory
+    // before trace capture begins.
+    builder.create<func::CallOp>(runAndCaptureTraceFunc.getLoc(), traceFunc,
+                                 traceInputSlots);
 
     // Start capturing the trace.
     auto beginTraceCaptureOp = builder.create<ttnn::BeginTraceCaptureOp>(
@@ -519,22 +520,20 @@ private:
                                             deviceOp, beginTraceCaptureOp,
                                             /*cq_id=*/0);
 
-    // Assemble return values: trace ID, actual outputs, and persistent slots.
+    // Assemble return values: trace ID and persistent slots.
+    // The trace output slots serve as both the captured trace's output buffers
+    // and the actual outputs for the first invocation.
     llvm::SmallVector<mlir::Value> returnValues;
 
     // Return the trace ID for correlation with execution.
     returnValues.push_back(beginTraceCaptureOp.getTraceId());
-    // Return the actual outputs from the first execution (non-traced).
-    for (mlir::Value output : traceFuncCall.getResults()) {
-      returnValues.push_back(output);
-    }
     // Return the trace input slots for all inputs (including
     // constants/parameters and KV cache) that are persisted on device.
     for (mlir::Value inputSlot : traceInputSlots) {
       returnValues.push_back(inputSlot);
     }
     // Return the trace output slots for all outputs that will be captured on
-    // device.
+    // device. These also serve as the actual outputs for the first invocation.
     for (mlir::Value outputSlot : captureTraceCall.getResults()) {
       returnValues.push_back(outputSlot);
     }

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -66,8 +66,7 @@ static void runTraceProgramAndCaptureTrace(
       executor.gatherOutputTensors();
 
   // Outputs are returned in the order of: traceId, trace input slots, trace
-  // output slots. The trace output slots serve double duty as both the captured
-  // trace's output buffers and the actual outputs for the first invocation.
+  // output slots.
   size_t expectedNumOutputs = 1 + op->inputs()->size() + op->outputs()->size();
   LOG_ASSERT(outputTensors.size() == expectedNumOutputs,
              "Mismatched number of output tensors, expected: ",
@@ -98,8 +97,7 @@ static void runTraceProgramAndCaptureTrace(
     inputSlots.emplace_back(std::move(inputSlot));
   }
 
-  // Handle trace output slots. These are also used as the actual outputs
-  // for the first invocation (inserted into the tensor pool below).
+  // Handle trace output slots.
   std::vector<::tt::runtime::Tensor> outputSlots;
   for (size_t i = 0; i < op->outputs()->size(); i++) {
     ::tt::runtime::Tensor &outputSlot = outputTensors[currOutputIndex++];
@@ -112,10 +110,7 @@ static void runTraceProgramAndCaptureTrace(
     outputSlots.emplace_back(std::move(outputSlot));
   }
 
-  // Insert output slots into the tensor pool as the actual outputs for the
-  // first invocation. This is the same pattern used in executeTrace — the
-  // retained output slots serve as both the trace replay buffers and the
-  // outputs visible to the caller.
+  // Use output slots as the actual outputs for the first invocation.
   for (size_t i = 0; i < op->outputs()->size(); i++) {
     tensorPool.insertRuntimeTensorAndValidate(op->outputs()->Get(i),
                                               outputSlots[i]);

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -65,10 +65,10 @@ static void runTraceProgramAndCaptureTrace(
   std::vector<::tt::runtime::Tensor> outputTensors =
       executor.gatherOutputTensors();
 
-  // Outputs will be returned in the order of traceId, actual outputs, trace
-  // input slots, trace output slots
-  size_t expectedNumOutputs =
-      1 + op->outputs()->size() + op->inputs()->size() + op->outputs()->size();
+  // Outputs are returned in the order of: traceId, trace input slots, trace
+  // output slots. The trace output slots serve double duty as both the captured
+  // trace's output buffers and the actual outputs for the first invocation.
+  size_t expectedNumOutputs = 1 + op->inputs()->size() + op->outputs()->size();
   LOG_ASSERT(outputTensors.size() == expectedNumOutputs,
              "Mismatched number of output tensors, expected: ",
              expectedNumOutputs, " got: ", outputTensors.size());
@@ -85,12 +85,6 @@ static void runTraceProgramAndCaptureTrace(
       ::tt::runtime::ttnn::utils::getScalarFromTensor<uint32_t>(traceIdTensor);
   ::ttnn::MeshTraceId meshTraceId(traceId);
 
-  // Handle trace function outputs
-  for (size_t i = 0; i < op->outputs()->size(); i++) {
-    tensorPool.insertRuntimeTensorAndValidate(op->outputs()->Get(i),
-                                              outputTensors[currOutputIndex++]);
-  }
-
   // Handle trace input slots
   std::vector<::tt::runtime::Tensor> inputSlots;
   for (size_t i = 0; i < op->inputs()->size(); i++) {
@@ -104,7 +98,8 @@ static void runTraceProgramAndCaptureTrace(
     inputSlots.emplace_back(std::move(inputSlot));
   }
 
-  // Handle trace output slots
+  // Handle trace output slots. These are also used as the actual outputs
+  // for the first invocation (inserted into the tensor pool below).
   std::vector<::tt::runtime::Tensor> outputSlots;
   for (size_t i = 0; i < op->outputs()->size(); i++) {
     ::tt::runtime::Tensor &outputSlot = outputTensors[currOutputIndex++];
@@ -115,6 +110,15 @@ static void runTraceProgramAndCaptureTrace(
     // output slots need to be retained
     outputSlotWrapper.setRetain(true);
     outputSlots.emplace_back(std::move(outputSlot));
+  }
+
+  // Insert output slots into the tensor pool as the actual outputs for the
+  // first invocation. This is the same pattern used in executeTrace — the
+  // retained output slots serve as both the trace replay buffers and the
+  // outputs visible to the caller.
+  for (size_t i = 0; i < op->outputs()->size(); i++) {
+    tensorPool.insertRuntimeTensorAndValidate(op->outputs()->Get(i),
+                                              outputSlots[i]);
   }
 
   TraceData traceData{.traceId = meshTraceId,

--- a/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
@@ -35,15 +35,15 @@ func.func @test_capture_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>, 
 func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   return %arg0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -67,15 +67,15 @@ func.func @test_input_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %a
 func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   return %arg0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xf32, #layout_f32>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xf32, #layout_f32>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %arg1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>
+  return %3, %1, %arg1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -124,15 +124,15 @@ func.func @test_no_trace_function(%arg0: tensor<32x32xbf16, #host_layout>, %arg1
 func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   return %arg0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -157,15 +157,15 @@ func.func @test_output_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -
 func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   return %arg0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -191,13 +191,13 @@ func.func private @trace_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<3
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %2 = call @trace_fn(%arg0) : (tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%arg0) : (tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%arg0) : (tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %arg0, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>
+  return %3, %arg0, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -223,15 +223,15 @@ func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32x
   %1 = "ttnn.add"(%arg0, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
@@ -255,15 +255,15 @@ func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32x
   %0 = "ttnn.add"(%arg0, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func @test_execute_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
@@ -284,15 +284,15 @@ func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32x
   %0 = "ttnn.add"(%arg0, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>, %arg1: tensor<32x32xbf16, #layout>) {
   return
@@ -316,15 +316,15 @@ func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32x
   %0 = "ttnn.add"(%arg0, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
   "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  %2 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
   %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %2, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
 }
 func.func private @execute_fn(%arg0: tensor<32x32xbf16, #layout>) {
   return

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
@@ -7,6 +7,7 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_creation_ops
   // CHECK: "ttnn.write_tensor"
+  // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
@@ -10,6 +10,7 @@ module {
   // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func private @execute_trace_0_creation_ops
   // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
@@ -17,6 +17,7 @@ module {
   // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func private @execute_trace_0_matmul_with_multiply
   // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
@@ -14,6 +14,7 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_matmul_with_multiply
   // CHECK: "ttnn.write_tensor"
+  // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
@@ -11,6 +11,7 @@ module {
   // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func private @execute_trace_0_matmul_with_multiply
   // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
@@ -8,6 +8,7 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_matmul_with_multiply
   // CHECK: "ttnn.write_tensor"
+  // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/merge_to_layout_with_mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/merge_to_layout_with_mesh_shard.mlir
@@ -14,6 +14,7 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_merge_to_layout_mesh_shard
   // CHECK: "ttnn.write_tensor"
+  // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/merge_to_layout_with_mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/merge_to_layout_with_mesh_shard.mlir
@@ -17,6 +17,7 @@ module {
   // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func private @execute_trace_0_merge_to_layout_mesh_shard
   // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
@@ -26,6 +26,11 @@ module {
     // CHECK-SAME: buffer_type<dram>
     // CHECK-SAME: ttcore.kv_cache
 
+    // CHECK: "ttnn.deallocate"
+    // CHECK: "ttnn.begin_trace_capture"
+    // CHECK: "ttnn.end_trace_capture"
+    // CHECK: "ttnn.execute_trace"
+
     // CHECK-LABEL: func.func @main(
     // CHECK: "ttnn.mesh_shard"
     // CHECK: "ttnn.mesh_shard"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
@@ -12,6 +12,7 @@ module {
   // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func private @execute_trace_0_single_add
   // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
@@ -9,6 +9,7 @@ module {
   // CHECK: "ttnn.write_tensor"
   // CHECK-NOT: "ttnn.from_device"(%arg0)
   // CHECK-NOT: "ttnn.from_device"(%arg1)
+  // CHECK: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 


### PR DESCRIPTION
### Problem description
Llama3.1-70B was [failing](https://github.com/tenstorrent/tt-xla/actions/runs/23825530884/job/69447587067) in tt-xla LLMBOX benchmarks due to DRAM OOM.

One of the main causes is that during trace capture:

```
func.func private @run_and_capture_trace_3_main(...)
    %0 = "ttnn.get_device"()
    %1 = "ttnn.empty"(%0)
    %2 = "ttnn.empty"(%0)
    "ttnn.write_tensor"(%arg0, %1)
    "ttnn.write_tensor"(%arg1, %2)
    %3:3 = call @trace_3_main(...)                            //warmup
    %4 = "ttnn.begin_trace_capture"(%0)
    %5:3 = call @trace_3_main(...)                            //capture
    "ttnn.end_trace_capture"(%0, %4)
    return %4, %3#0, %3#1, %3#2, [input_slots...], %5#0, %5#1, %5#2
```

both warmup outputs (%3:3 - real, computed values of first invocation) and capture output slots (%5:3 - output slots for future execute trace results, arbitrary values) were used, serving different purposes.

Llama3.1-70B outputs are: 
- cache_position `tensor<1xsi32>`
- logits per user `tensor<32x18x128256xbf16>` - huge for prefill (sequence_len=18) !
- next_token_ids per user `tensor<32x1xsi32>`

Proposed solution is to discard warmup outputs and use trace output slots as outputs for first model run.
In order to fill output slots with actual computed values, trace is executed immediately after capture.

### What's changed
Discarded warmup outputs as return values for `run_and_capture_trace` function.
Added `execute_trace` after capture to populate trace output slots with real values.

Example of IR after change:

```
func.func private @run_and_capture_trace_1_main
    %0 = "ttnn.get_device"()
    %1 = "ttnn.empty"(%0)
    %2 = "ttnn.empty"(%0)
    "ttnn.write_tensor"(%arg0, %1)
    "ttnn.write_tensor"(%arg1, %2)
    %3:3 = call @trace_3_main(...)
    "ttnn.deallocate"(%3#1)
    "ttnn.deallocate"(%3#0)
    "ttnn.deallocate"(%3#2)
    %4 = "ttnn.begin_trace_capture"(%0)
    %5:3 = call @trace_3_main(...)
    "ttnn.end_trace_capture"(%0, %4)
    "ttnn.execute_trace"(%0, %4)
    return %4, [input_slots], [output_slots with real values from first invocation]
```

### Checklist
- [ ] tt-xla benchmarks
    - [x] [Llama3.1-70B on LLMBOX](https://github.com/tenstorrent/tt-xla/actions/runs/24465776763/job/71494762947)
- [ ] tt-xla model tests
