### PR TITLE
Unify codeowners for tooling (builder, goldens, chisel, ttrt)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,11 @@
 /env/ @nsmithtt @vwellsTT
 /env/patches/shardy* @tenstorrent/forge-developers-mlir-stablehlo
 *.fbs @nsmithtt
-/.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT @tt-mpantic
 LICENSE @nsmithtt
 
 # CI
 /.github/ @tenstorrent/forge-developers-mlir-devops
+/.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT @tt-mpantic
 
 # Build
 *.cmake @tenstorrent/forge-developers-mlir-build
@@ -171,14 +171,11 @@ test/ttmlir/Dialect/StableHLO @tenstorrent/forge-developers-mlir-stablehlo
 /tools/ttnn-jit/ @xanderchin @vtangTT @arminaleTT @sgholamiTT
 /test/ttnn-jit/ @xanderchin @vtangTT @arminaleTT @sgholamiTT
 
-# TTIRBuilder
-/tools/builder @tapspatel @jgrimTT @dlokeTT
-
-# Chisel
-/tools/chisel @jgrimTT @mmilosevicTT @ndrakulicTT
-
-# ttrt
-/tools/ttrt @tapspatel @jgrimTT @dlokeTT
+# Tooling
+/tools/builder @tenstorrent/forge-developers-mlir-tooling
+/tools/chisel @tenstorrent/forge-developers-mlir-tooling
+/tools/golden @tenstorrent/forge-developers-mlir-tooling
+/tools/ttrt @tenstorrent/forge-developers-mlir-tooling
 
 # tt-explorer
 /tools/explorer/ @tenstorrent/forge-developers-mlir-explorer


### PR DESCRIPTION
### What's changed

1. As rule for `.github/CODEOWNERS` was before the `.github` it was overwritten, so it only needed approves from ` forge-developers-mlir-devops `. Changed the order of the rules. FYI: @vmilosevic 

2. Unified codeowners for tooling (builder, chisel, ttrt) and added `/tools/goldens` to that list.
