### PR TITLE
Support GQA/MQA in SDPA custom call sharding rule

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -148,50 +148,141 @@ getScatterShardingRule(mlir::stablehlo::ScatterOp scatterOp) {
 
 static mlir::sdy::OpShardingRuleAttr
 getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() < 3 || op.getNumResults() != 1) {
+    op.getOperation()->emitWarning()
+        << "SDPA expects at least 3 operands (Q, K, V) and 1 result";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
   auto qType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
   auto kType = llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
   auto vType = llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
   auto outType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
 
-  // SDPA requires Q/K/V and output to have identical shapes.
-  if (qType.getShape() != kType.getShape() ||
-      qType.getShape() != vType.getShape() ||
-      qType.getShape() != outType.getShape()) {
+  if (!qType || !kType || !vType || !outType) {
+    op.getOperation()->emitWarning() << "SDPA requires ranked tensor types";
     return mlir::sdy::OpShardingRuleAttr();
   }
 
-  ArrayRef<int64_t> shape = qType.getShape();
-
-  // SDPA is assumed to operate on 4D tensors: [B, H, S, D]
-  // If the shape does not match, conservatively fallback to a pointwise rule.
-  if (shape.size() != 4) {
+  // SDPA operates on 4D tensors: [B, H, S, D]
+  if (qType.getRank() != 4 || kType.getRank() != 4 || vType.getRank() != 4 ||
+      outType.getRank() != 4) {
+    op.getOperation()->emitWarning() << "SDPA requires 4D tensors [B, H, S, D]";
     return mlir::sdy::OpShardingRuleBuilder::buildPointwise(op);
   }
 
-  // SDPA can shard batch (B) and head (H) dimensions freely.
-  // Sequence (S) and hidden (D) dimensions generally require replication,
-  // unless a more advanced distributed attention algorithm is implemented.
+  ArrayRef<int64_t> qShape = qType.getShape();
+  ArrayRef<int64_t> kShape = kType.getShape();
+  ArrayRef<int64_t> vShape = vType.getShape();
+  ArrayRef<int64_t> outShape = outType.getShape();
+
+  // Grouped-Query / Multi-Query Attention support:
+  //   Q/Out: [B, num_q_heads,  S, D]
+  //   K/V:   [B, num_kv_heads, S, D]
+  // Constraints:
+  //   - Q and Output must have the same shape
+  //   - K and V must have the same shape
+  //   - B, S, D must match across all tensors
+  //   - num_q_heads must be divisible by num_kv_heads (GQA group ratio)
+  if (kShape != vShape || qShape != outShape || qShape[0] != kShape[0] || // B
+      qShape[2] != kShape[2] ||                                           // S
+      qShape[3] != kShape[3]) {                                           // D
+    op.getOperation()->emitWarning()
+        << "SDPA shape validation failed: incompatible Q/K/V/Out dimensions";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t qHeads = qShape[1];
+  int64_t kvHeads = kShape[1];
+
+  // Supported SDPA head layouts:
+  //   - MHA: qHeads == kvHeads
+  //   - GQA: qHeads > kvHeads and qHeads % kvHeads == 0
+  //   - MQA: kvHeads == 1 (special case of GQA)
+  //
+  // Branch explicitly between the identical-head MHA case and the grouped-head
+  // GQA/MQA case for clarity.
+
+  // For standard MHA (qHeads == kvHeads), all tensors have identical shapes
+  // so we can use the efficient addPointwise builder.
+  if (qHeads == kvHeads) {
+    auto getFactorType = [](int64_t dim) -> mlir::sdy::FactorType {
+      if (dim == 0 || dim == 1) {
+        return mlir::sdy::FactorType::kPassThrough;
+      }
+      return mlir::sdy::FactorType::kNeedReplication;
+    };
+    return mlir::sdy::OpShardingRuleBuilder(op)
+        .addPointwise(qShape, getFactorType)
+        .build();
+  }
+
+  auto isStaticPositiveDim = [](int64_t dim) {
+    return !ShapedType::isDynamic(dim) && dim > 0;
+  };
+  if (!isStaticPositiveDim(qShape[0]) || !isStaticPositiveDim(qHeads) ||
+      !isStaticPositiveDim(kvHeads) || !isStaticPositiveDim(qShape[2]) ||
+      !isStaticPositiveDim(qShape[3])) {
+    op.getOperation()->emitWarning()
+        << "SDPA GQA/MQA path requires static, positive B/H/S/D dimensions";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  if (qHeads % kvHeads != 0) {
+    op.getOperation()->emitWarning()
+        << "SDPA: num_q_heads (" << qHeads
+        << ") must be divisible by num_kv_heads (" << kvHeads << ")";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // GQA/MQA path: Q/Out have more heads than K/V, so we cannot use
+  // addPointwise (requires identical shapes), so build the B/H/S/D factors
+  // explicitly.
   //
   // Dimension assignment:
-  // dim 0 -> Batch
-  // dim 1 -> Head
-  // dim 2 -> Sequence length
-  // dim 3 -> Hidden size
-  auto getFactorType = [&](int64_t dim) -> mlir::sdy::FactorType {
-    if (dim == 0 || dim == 1) {
-      // Allow sharding
-      return mlir::sdy::FactorType::kPassThrough;
-    }
-    // Disallow sharding, require replication
-    return mlir::sdy::FactorType::kNeedReplication;
+  //   dim 0 -> Batch         (kPassThrough)
+  //   dim 1 -> Head          (kPassThrough via explicit head factor)
+  //   dim 2 -> Sequence len  (kNeedReplication)
+  //   dim 3 -> Hidden size   (kNeedReplication)
+  //
+  // Head dimension: single factor with size = qHeads linking Q/K/V/Out dim 1.
+  // For GQA, K/V dim 1 (kvHeads) differs from the factor size (qHeads), but
+  // Shardy handles this proportionally: sharding by F gives qHeads/F Q-heads
+  // and kvHeads/F KV-heads, preserving the GQA ratio.
+  // This is the same pattern used by paged SDPA decode.
+  int64_t numOperands = op.getNumOperands();
+
+  sdy::OpShardingRuleBuilder builder(op);
+
+  // Helper: build operand dim vector with Q/K/V dims set, rest kNullDim.
+  auto makeOpDims = [&](int64_t qDim, int64_t kDim,
+                        int64_t vDim) -> SmallVector<int64_t> {
+    SmallVector<int64_t> dims(numOperands, sdy::kNullDim);
+    dims[0] = qDim;
+    dims[1] = kDim;
+    dims[2] = vDim;
+    return dims;
   };
 
-  // Build the final sharding rule:
-  // - Pass-through on B/H dims
-  // - Replication on S/D dims
-  return mlir::sdy::OpShardingRuleBuilder(op)
-      .addPointwise(shape, getFactorType)
-      .build();
+  // Batch (dim 0): kPassThrough — can be sharded freely.
+  builder.addFactor(makeOpDims(0, 0, 0), {0}, qShape[0],
+                    sdy::FactorType::kPassThrough);
+
+  // Head (dim 1): kPassThrough — can be sharded.
+  // Single factor links Q/K/V/Out head dims together using Q's head count.
+  builder.addFactor(makeOpDims(1, 1, 1), {1}, qHeads,
+                    sdy::FactorType::kPassThrough);
+
+  // Sequence length (dim 2): kNeedReplication — cannot shard without
+  // distributed attention support.
+  builder.addFactor(makeOpDims(2, 2, 2), {2}, qShape[2],
+                    sdy::FactorType::kNeedReplication);
+
+  // Hidden size (dim 3): kNeedReplication — cannot shard.
+  builder.addFactor(makeOpDims(3, 3, 3), {3}, qShape[3],
+                    sdy::FactorType::kNeedReplication);
+
+  return builder.build();
 }
 
 static mlir::sdy::OpShardingRuleAttr buildHeadShardedCustomCallRule(

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa.mlir
@@ -12,3 +12,19 @@ module @SDPA_Sharding_Head attributes {mhlo.cross_program_prefetches = [], mhlo.
     return %0 : tensor<1x12x32x128xbf16>
   }
 }
+
+// -----
+
+// CHECK-LABEL: module @SDPA_Sharding_GQA_Head
+module @SDPA_Sharding_GQA_Head attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x8x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<1x4x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<1x4x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[1,2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}) -> tensor<1x8x32x128xbf16> {
+    // GQA keeps the Q:KV head ratio while sharding the input head dimension.
+    // The custom call runs on the local shard shapes inside manual_computation.
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x4x32x128xbf16>, tensor<1x2x32x128xbf16>, tensor<1x2x32x128xbf16>
+    // CHECK-SAME: -> tensor<1x4x32x128xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "False"}} : (tensor<1x8x32x128xbf16>, tensor<1x4x32x128xbf16>, tensor<1x4x32x128xbf16>) -> tensor<1x8x32x128xbf16>
+    return %0 : tensor<1x8x32x128xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/7760)

### Problem description
The existing SDPA sharding rule required Q, K, V, and output tensors to have identical shapes, which prevented sharding for Grouped-Query Attention (GQA) and Multi-Query Attention (MQA) where K/V have fewer heads than Q.

### What's changed
- Relax shape equality to per-dimension validation: B, S, D must match   across all tensors; Q==Out and K==V shapes must match
- Validate GQA group ratio (num_q_heads % num_kv_heads == 0)
- Preserve efficient addPointwise path for standard MHA (equal heads)
- For GQA/MQA, manually construct per-dimension factors with a single head factor sized to num_q_heads, allowing Shardy to proportionally shard K/V heads while preserving the GQA ratio
- Add input validation and warning diagnostics for shape mismatches

### Checklist
- [ ] New/Existing tests provide coverage for changes
