### PR TITLE
[EraseInverseOps] Add TTIRCommuteReshapeThroughReduce pattern

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/Utils.h
@@ -242,6 +242,15 @@ mlir::LogicalResult broadcastValue(mlir::PatternRewriter &rewriter,
                                    mlir::Value &output, mlir::Location loc,
                                    bool frontUnsqueeze);
 
+// Given a "from" shape and a "to" shape with the same total element count,
+// find the dimension in `toShape` whose size and trailing-stride (product of
+// all dimensions to its right) match the dimension at position `dim` in
+// `fromShape`. This identifies the dimension preserved by a reshape between
+// the two shapes (i.e. neither split nor merged). Returns -1 if no such
+// dimension exists. `dim` uses LTR (left-to-right) indexing.
+int64_t findMatchingDim(llvm::ArrayRef<int64_t> fromShape,
+                        llvm::ArrayRef<int64_t> toShape, int64_t dim);
+
 // Given a reshape operation and an input dimension position (RTL - right to
 // left, 0 = rightmost), finds the corresponding output dimension position where
 // that dimension maps to. Returns -1 if no matching dimension is found.

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
@@ -269,41 +269,6 @@ private:
     return true;
   }
 };
-// Find the corresponding reduce dimension in a reshaped tensor by matching
-// stride and reduction length. Returns -1 if the reduce dimension was split
-// or merged by the reshape (commute not possible).
-static int64_t findReduceDimInReshapedTensor(llvm::ArrayRef<int64_t> fromShape,
-                                             llvm::ArrayRef<int64_t> toShape,
-                                             int64_t reduceDim) {
-  int64_t fromRank = fromShape.size();
-  int64_t toRank = toShape.size();
-
-  if (reduceDim < 0) {
-    reduceDim += fromRank;
-  }
-
-  assert(reduceDim >= 0 && reduceDim < fromRank && "Invalid reduce dimension");
-
-  int64_t reductionLength = fromShape[reduceDim];
-
-  // Compute stride of reduceDim in fromShape.
-  int64_t fromStride = 1;
-  for (int64_t i = reduceDim + 1; i < fromRank; ++i) {
-    fromStride *= fromShape[i];
-  }
-
-  // Find a dimension in toShape with the same stride and length.
-  int64_t toStride = 1;
-  for (int64_t dim = toRank - 1; dim >= 0; dim--) {
-    if (toStride == fromStride && toShape[dim] == reductionLength) {
-      return dim;
-    }
-    toStride *= toShape[dim];
-  }
-
-  return -1;
-}
-
 template <typename ReduceOpType, CommuteDirection commuteDirection>
 class TTIRCommuteReshapeThroughReduce
     : public TTIRCommuteOpRewritePattern<ReshapeOp, ReduceOpType,
@@ -364,8 +329,7 @@ public:
     auto reshapeOutputShape = reshapeOperand.getResult().getType().getShape();
 
     // Map reduce dims from reshape-output space back to reshape-input space.
-    auto newDimArgs =
-        mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
+    auto newDimArgs = mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
     assert(!newDimArgs.empty() &&
            "isCommuteDownwardsFavorable should have ensured valid mapping");
 
@@ -403,9 +367,10 @@ private:
     for (Attribute attr : op.getDimArg()->getValue()) {
       int64_t d = cast<IntegerAttr>(attr).getInt();
       d = d < 0 ? d + fromRank : d;
-      int64_t mapped = findReduceDimInReshapedTensor(fromShape, toShape, d);
+      int64_t mapped = utils::findMatchingDim(fromShape, toShape, d);
       if (mapped == -1) {
-        return {}; // Can't map this dim — commute not possible.
+        // Can't map this dim — commute not possible.
+        return {};
       }
       reduceDims.push_back(mapped);
     }
@@ -414,9 +379,9 @@ private:
 
   // Create a new reduce op with the given dims on the given input.
   ReduceOpType createReduceOp(ReduceOpType origOp, Value newInput,
-                               ArrayRef<int64_t> newDims,
-                               ArrayRef<int64_t> inputShape,
-                               PatternRewriter &rewriter) const {
+                              ArrayRef<int64_t> newDims,
+                              ArrayRef<int64_t> inputShape,
+                              PatternRewriter &rewriter) const {
     SmallVector<Attribute> dimAttrs;
     for (int64_t d : newDims) {
       dimAttrs.push_back(rewriter.getI32IntegerAttr(d));
@@ -437,8 +402,8 @@ private:
         RankedTensorType::get(outputShape, origOp.getType().getElementType(),
                               origOp.getType().getEncoding());
     return rewriter.create<ReduceOpType>(origOp->getLoc(), outputType, newInput,
-                                          origOp.getKeepDimAttr(),
-                                          newDimArgAttr);
+                                         origOp.getKeepDimAttr(),
+                                         newDimArgAttr);
   }
 
   bool isCommuteUpwardsViable(ReduceOpType op,
@@ -469,13 +434,10 @@ private:
 
   bool isCommuteDownwardsFavorable(ReduceOpType op,
                                    ReshapeOp reshapeOperand) const override {
-    auto reshapeOutputShape =
-        reshapeOperand.getResult().getType().getShape();
-    auto reshapeInputShape =
-        reshapeOperand.getInput().getType().getShape();
+    auto reshapeOutputShape = reshapeOperand.getResult().getType().getShape();
+    auto reshapeInputShape = reshapeOperand.getInput().getType().getShape();
 
-    auto mapped =
-        mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
+    auto mapped = mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
     if (mapped.empty()) {
       return false;
     }

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
@@ -408,6 +408,29 @@ private:
 
   bool isCommuteUpwardsViable(ReduceOpType op,
                               ReshapeOp reshapeUser) const override {
+    // The upwards rewrite creates a reshape from the reduce input directly to
+    // the original reshape's output shape, then reduces it in place. For that
+    // to produce valid IR (matching element count AND matching result type
+    // for the replaced reshape) the reduce must preserve both element count
+    // and rank — i.e. keep_dim must be true and every reduce dim must have
+    // size 1 in the reduce input. Without this guard the rewrite can build
+    // an invalid reshape or a result-type mismatch when reductionLength > 1.
+    if (!op.getKeepDim()) {
+      return false;
+    }
+    auto reduceInputShape =
+        cast<RankedTensorType>(op.getInput().getType()).getShape();
+    if (!op.getDimArg()) {
+      return llvm::all_of(reduceInputShape, [](int64_t d) { return d == 1; });
+    }
+    int64_t rank = reduceInputShape.size();
+    for (Attribute attr : op.getDimArg()->getValue()) {
+      int64_t d = cast<IntegerAttr>(attr).getInt();
+      d = d < 0 ? d + rank : d;
+      if (reduceInputShape[d] != 1) {
+        return false;
+      }
+    }
     return true;
   }
 

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ReduceCommutePatterns.cpp
@@ -269,6 +269,222 @@ private:
     return true;
   }
 };
+// Find the corresponding reduce dimension in a reshaped tensor by matching
+// stride and reduction length. Returns -1 if the reduce dimension was split
+// or merged by the reshape (commute not possible).
+static int64_t findReduceDimInReshapedTensor(llvm::ArrayRef<int64_t> fromShape,
+                                             llvm::ArrayRef<int64_t> toShape,
+                                             int64_t reduceDim) {
+  int64_t fromRank = fromShape.size();
+  int64_t toRank = toShape.size();
+
+  if (reduceDim < 0) {
+    reduceDim += fromRank;
+  }
+
+  assert(reduceDim >= 0 && reduceDim < fromRank && "Invalid reduce dimension");
+
+  int64_t reductionLength = fromShape[reduceDim];
+
+  // Compute stride of reduceDim in fromShape.
+  int64_t fromStride = 1;
+  for (int64_t i = reduceDim + 1; i < fromRank; ++i) {
+    fromStride *= fromShape[i];
+  }
+
+  // Find a dimension in toShape with the same stride and length.
+  int64_t toStride = 1;
+  for (int64_t dim = toRank - 1; dim >= 0; dim--) {
+    if (toStride == fromStride && toShape[dim] == reductionLength) {
+      return dim;
+    }
+    toStride *= toShape[dim];
+  }
+
+  return -1;
+}
+
+template <typename ReduceOpType, CommuteDirection commuteDirection>
+class TTIRCommuteReshapeThroughReduce
+    : public TTIRCommuteOpRewritePattern<ReshapeOp, ReduceOpType,
+                                         commuteDirection> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ReshapeOp, ReduceOpType, commuteDirection>::TTIRCommuteOpRewritePattern;
+
+  // Commute upwards: reduce(D, kd) → reshape(S) ⟹ reshape(S') → reduce(D',
+  // kd)
+  void performCommuteUpwardsRewrite(ReduceOpType op, ReshapeOp reshapeUser,
+                                    PatternRewriter &rewriter) const override {
+    auto reduceInputType = cast<RankedTensorType>(op.getInput().getType());
+    auto reshapeOutputType =
+        cast<RankedTensorType>(reshapeUser.getResult().getType());
+
+    auto reduceInputShape = reduceInputType.getShape();
+    auto reshapeOutputShape = reshapeOutputType.getShape();
+
+    // Map reduce dims from reduce-input space to reshape-output space.
+    auto newDimArgs = mapReduceDims(reduceInputShape, reshapeOutputShape, op);
+    assert(!newDimArgs.empty() &&
+           "isCommuteUpwardsFavorable should have ensured valid mapping");
+
+    // Create reshape: input → reshapeOutputShape
+    auto newReshapeType = RankedTensorType::get(
+        reshapeOutputShape, reduceInputType.getElementType(),
+        reshapeOutputType.getEncoding());
+    SmallVector<int32_t> reshapeShape(reshapeOutputShape.begin(),
+                                      reshapeOutputShape.end());
+    auto newReshape = rewriter.create<ReshapeOp>(
+        reshapeUser->getLoc(), newReshapeType, op.getInput(),
+        rewriter.getI32ArrayAttr(reshapeShape));
+
+    // Create reduce with mapped dims on the reshaped tensor.
+    auto newReduce = createReduceOp(op, newReshape.getResult(), newDimArgs,
+                                    reshapeOutputShape, rewriter);
+
+    SmallVector<Operation *> users(op->getUsers());
+    assert(llvm::all_of(users,
+                        [&](Operation *user) {
+                          return checkIdenticalTms(reshapeUser, user);
+                        }) &&
+           "isCommuteUpwardsViable/Favorable should have ensured all users "
+           "are identical TMs");
+
+    for (auto *user : users) {
+      rewriter.replaceOp(user, newReduce);
+    }
+  }
+
+  // Commute downwards: reshape(S) → reduce(D, kd) ⟹ reduce(D', kd) →
+  // reshape(S')
+  void
+  performCommuteDownwardsRewrite(ReduceOpType op, ReshapeOp reshapeOperand,
+                                 PatternRewriter &rewriter) const override {
+    auto reshapeInputShape = reshapeOperand.getInput().getType().getShape();
+    auto reshapeOutputShape = reshapeOperand.getResult().getType().getShape();
+
+    // Map reduce dims from reshape-output space back to reshape-input space.
+    auto newDimArgs =
+        mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
+    assert(!newDimArgs.empty() &&
+           "isCommuteDownwardsFavorable should have ensured valid mapping");
+
+    // Create reduce on the original (pre-reshape) input with mapped dims.
+    auto newReduce = createReduceOp(op, reshapeOperand.getInput(), newDimArgs,
+                                    reshapeInputShape, rewriter);
+
+    // Create reshape to produce the original output shape.
+    auto originalOutputType = cast<RankedTensorType>(op.getResult().getType());
+    auto originalOutputShape = originalOutputType.getShape();
+    SmallVector<int32_t> reshapeShape(originalOutputShape.begin(),
+                                      originalOutputShape.end());
+    auto newReshape = rewriter.create<ReshapeOp>(
+        reshapeOperand->getLoc(), op.getType(), newReduce,
+        rewriter.getI32ArrayAttr(reshapeShape));
+
+    rewriter.replaceOp(op, newReshape.getResult());
+  }
+
+private:
+  // Map each reduce dim from fromShape to the corresponding dim in toShape.
+  // Returns empty vector if any dim can't be mapped (commute not valid).
+  SmallVector<int64_t> mapReduceDims(ArrayRef<int64_t> fromShape,
+                                     ArrayRef<int64_t> toShape,
+                                     ReduceOpType op) const {
+    int64_t fromRank = fromShape.size();
+    SmallVector<int64_t> reduceDims;
+
+    if (!op.getDimArg()) {
+      // Reduce all dims — always valid since total element count is the same.
+      reduceDims = llvm::to_vector(llvm::seq<int64_t>(0, toShape.size()));
+      return reduceDims;
+    }
+
+    for (Attribute attr : op.getDimArg()->getValue()) {
+      int64_t d = cast<IntegerAttr>(attr).getInt();
+      d = d < 0 ? d + fromRank : d;
+      int64_t mapped = findReduceDimInReshapedTensor(fromShape, toShape, d);
+      if (mapped == -1) {
+        return {}; // Can't map this dim — commute not possible.
+      }
+      reduceDims.push_back(mapped);
+    }
+    return reduceDims;
+  }
+
+  // Create a new reduce op with the given dims on the given input.
+  ReduceOpType createReduceOp(ReduceOpType origOp, Value newInput,
+                               ArrayRef<int64_t> newDims,
+                               ArrayRef<int64_t> inputShape,
+                               PatternRewriter &rewriter) const {
+    SmallVector<Attribute> dimAttrs;
+    for (int64_t d : newDims) {
+      dimAttrs.push_back(rewriter.getI32IntegerAttr(d));
+    }
+    ArrayAttr newDimArgAttr = ArrayAttr::get(rewriter.getContext(), dimAttrs);
+
+    llvm::SmallDenseSet<int64_t> reducedDimSet(newDims.begin(), newDims.end());
+    SmallVector<int64_t> outputShape;
+    for (auto [i, dim] : llvm::enumerate(inputShape)) {
+      if (!reducedDimSet.count(i)) {
+        outputShape.push_back(dim);
+      } else if (origOp.getKeepDim()) {
+        outputShape.push_back(1);
+      }
+    }
+
+    auto outputType =
+        RankedTensorType::get(outputShape, origOp.getType().getElementType(),
+                              origOp.getType().getEncoding());
+    return rewriter.create<ReduceOpType>(origOp->getLoc(), outputType, newInput,
+                                          origOp.getKeepDimAttr(),
+                                          newDimArgAttr);
+  }
+
+  bool isCommuteUpwardsViable(ReduceOpType op,
+                              ReshapeOp reshapeUser) const override {
+    return true;
+  }
+
+  bool isCommuteUpwardsFavorable(ReduceOpType op,
+                                 ReshapeOp reshapeUser) const override {
+    auto reduceInputShape =
+        cast<RankedTensorType>(op.getInput().getType()).getShape();
+    auto reshapeOutputShape =
+        cast<RankedTensorType>(reshapeUser.getResult().getType()).getShape();
+
+    auto mapped = mapReduceDims(reduceInputShape, reshapeOutputShape, op);
+    if (mapped.empty()) {
+      return false;
+    }
+
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+
+  bool isCommuteDownwardsViable(ReduceOpType op,
+                                ReshapeOp reshapeOperand) const override {
+    return true;
+  }
+
+  bool isCommuteDownwardsFavorable(ReduceOpType op,
+                                   ReshapeOp reshapeOperand) const override {
+    auto reshapeOutputShape =
+        reshapeOperand.getResult().getType().getShape();
+    auto reshapeInputShape =
+        reshapeOperand.getInput().getType().getShape();
+
+    auto mapped =
+        mapReduceDims(reshapeOutputShape, reshapeInputShape, op);
+    if (mapped.empty()) {
+      return false;
+    }
+
+    // Always favorable — reduce has a single tensor operand (the input from
+    // the reshape), so there are no other operands to worry about.
+    return true;
+  }
+};
 } // namespace
 
 template <CommuteDirection commuteDirection>
@@ -281,7 +497,15 @@ void populateReduceCommutePatterns(MLIRContext *ctx,
                TTIRCommutePermuteThroughReduce<ProdOp, commuteDirection>,
                TTIRCommutePermuteThroughReduce<ReduceAndOp, commuteDirection>,
                TTIRCommutePermuteThroughReduce<ReduceOrOp, commuteDirection>,
-               TTIRCommutePermuteThroughReduce<ArgMaxOp, commuteDirection>>(
+               TTIRCommutePermuteThroughReduce<ArgMaxOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<SumOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<MeanOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<MaxOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<MinOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<ProdOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<ReduceAndOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<ReduceOrOp, commuteDirection>,
+               TTIRCommuteReshapeThroughReduce<ArgMaxOp, commuteDirection>>(
       ctx);
 }
 

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/SoftmaxCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/SoftmaxCommutePatterns.cpp
@@ -13,58 +13,6 @@ namespace mlir::tt::ttir {
 
 namespace {
 
-int64_t
-findNewSoftmaxDimByStrideAndReductionLen(llvm::ArrayRef<int64_t> inputShape,
-                                         llvm::ArrayRef<int64_t> outputShape,
-                                         int64_t softmaxDim) {
-  // Stride of new softmax dim in new shape must match stride of old
-  // softmax dim in old shape, and same for length.
-  //
-  // Example 1 (Valid commute):
-  //   Input shape      = [2, 3, 4]
-  //   Softmax dim      = 2  (stride = 1, reduction length = 4)
-  //   Reshape          = [6, 4]
-  // The new softmax dim is 1, since output dim 1 still has stride = 1 and
-  // reduction length = 4.
-  //
-  // Example 2 (Invalid Commute)
-  //   Input shape      = [2, 3, 4]
-  //   Softmax dim      = 1  (stride = 4, reduction length = 3)
-  //   Reshape          = [2, 12]
-  //   output strides = [12, 1],  Hence, we can't apply softmax because no
-  //   dimension in output has stride 4 and reduction len = 3
-  int64_t inputDims = inputShape.size();
-  int64_t outputDims = outputShape.size();
-
-  if (softmaxDim < 0) {
-    softmaxDim += inputDims;
-  }
-
-  assert(softmaxDim >= 0 && softmaxDim < inputDims &&
-         "Invalid softmax Dimension");
-
-  int64_t softmaxReductionLength = inputShape[softmaxDim];
-  int64_t inputStride = 1;
-  for (int64_t i = softmaxDim + 1; i < inputDims; ++i) {
-    inputStride *= inputShape[i];
-  };
-
-  // Commute is valid if
-  // 1. Input Stride of softmax dimension is preserved in output, and
-  // 2. The number of elements the over which softmax normalizes/reduces should
-  // also match
-  int64_t outputStride = 1;
-  for (int64_t dim = outputDims - 1; dim >= 0; dim--) {
-    if (outputStride == inputStride &&
-        outputShape[dim] == softmaxReductionLength) {
-      return dim;
-    }
-    outputStride *= outputShape[dim];
-  };
-
-  return -1;
-}
-
 template <CommuteDirection commuteDirection>
 // <TMOp, Op, CommuteDirection>
 class TTIRCommuteReshapeThroughSoftmax
@@ -90,8 +38,11 @@ public:
     auto softmaxInputShape = softmaxInputType.getShape();
     auto outputReshapeShape = outputReshapeType.getShape();
     int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
-    // We are mapping the softmax axis from softmax input to reshape user output
-    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+    if (softmaxDim < 0) {
+      softmaxDim += softmaxInputShape.size();
+    }
+    // Map the softmax axis from softmax input to reshape user output.
+    int64_t newSoftmaxDim = utils::findMatchingDim(
         softmaxInputShape, outputReshapeShape, softmaxDim);
     assert(newSoftmaxDim != -1 &&
            "Invalid Softmax Dimension, isCommuteUpwardsFavorable should have "
@@ -144,9 +95,12 @@ public:
     auto reshapeOperandInputShape =
         reshapeOperand.getInput().getType().getShape();
     int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
-    // We are mapping the softmax axis from reshape operand output to reshape
-    // operand input
-    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+    if (softmaxDim < 0) {
+      softmaxDim += reshapeOperandOutputShape.size();
+    }
+    // Map the softmax axis from reshape operand output to reshape operand
+    // input.
+    int64_t newSoftmaxDim = utils::findMatchingDim(
         reshapeOperandOutputShape, reshapeOperandInputShape, softmaxDim);
     assert(newSoftmaxDim != -1 &&
            "Invalid Softmax Dimension, isCommuteDownwardsFavorable should have "
@@ -191,9 +145,12 @@ private:
     auto outputReshapeShape =
         cast<RankedTensorType>(reshapeUser.getResult().getType()).getShape();
     int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+    if (softmaxDim < 0) {
+      softmaxDim += softmaxInputShape.size();
+    }
 
-    // We are mapping the softmax axis from softmax input to reshape user output
-    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+    // Map the softmax axis from softmax input to reshape user output.
+    int64_t newSoftmaxDim = utils::findMatchingDim(
         softmaxInputShape, outputReshapeShape, softmaxDim);
     if (newSoftmaxDim == -1) {
       return false;
@@ -227,10 +184,13 @@ private:
     auto reshapeOperandInputShape =
         reshapeOperand.getInput().getType().getShape();
     int64_t softmaxDim = static_cast<int64_t>(op.getDimension());
+    if (softmaxDim < 0) {
+      softmaxDim += reshapeOperandOutputShape.size();
+    }
 
-    // We are mapping the softmax axis from reshape operand output to reshape
-    // operand input
-    int64_t newSoftmaxDim = findNewSoftmaxDimByStrideAndReductionLen(
+    // Map the softmax axis from reshape operand output to reshape operand
+    // input.
+    int64_t newSoftmaxDim = utils::findMatchingDim(
         reshapeOperandOutputShape, reshapeOperandInputShape, softmaxDim);
     if (newSoftmaxDim == -1) {
       return false;

--- a/lib/Dialect/TTIR/Utils/Utils.cpp
+++ b/lib/Dialect/TTIR/Utils/Utils.cpp
@@ -64,42 +64,56 @@ mlir::LogicalResult broadcastValue(mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
+int64_t findMatchingDim(llvm::ArrayRef<int64_t> fromShape,
+                        llvm::ArrayRef<int64_t> toShape, int64_t dim) {
+  int64_t fromRank = fromShape.size();
+  int64_t toRank = toShape.size();
+
+  if (dim < 0 || dim >= fromRank) {
+    return -1;
+  }
+
+  int64_t dimSize = fromShape[dim];
+
+  // Stride of `dim` is the product of all dimensions trailing it.
+  int64_t fromStride = 1;
+  for (int64_t i = dim + 1; i < fromRank; ++i) {
+    fromStride *= fromShape[i];
+  }
+
+  // Walk toShape right-to-left, accumulating stride. A matching dim must have
+  // the same trailing-stride and the same size. Once accumulated stride
+  // exceeds fromStride it can never match again, so we can stop early.
+  int64_t toStride = 1;
+  for (int64_t i = toRank - 1; i >= 0; --i) {
+    if (toStride > fromStride) {
+      break;
+    }
+    if (toStride == fromStride && toShape[i] == dimSize) {
+      return i;
+    }
+    toStride *= toShape[i];
+  }
+
+  return -1;
+}
+
 int64_t findMatchingDimRTL(ReshapeOp reshapeOp, int64_t dimRTL) {
   auto inputShape = reshapeOp.getInput().getType().getShape();
   auto outputShape = reshapeOp.getResult().getType().getShape();
   int64_t inputRank = inputShape.size();
   int64_t outputRank = outputShape.size();
 
-  // Validate dimRTL is within bounds.
   if (dimRTL < 0 || dimRTL >= inputRank) {
     return -1;
   }
 
-  // RTL position 0 is the rightmost dimension.
-  // The number of trailing dimensions equals the RTL position.
-  int64_t inputDimSize = inputShape[inputRank - 1 - dimRTL];
-
-  // Calculate stride of the input dimension (product of trailing dimensions).
-  auto inputTrailing = inputShape.take_back(dimRTL);
-  int64_t inputStride =
-      std::accumulate(inputTrailing.begin(), inputTrailing.end(), int64_t{1},
-                      std::multiplies<>());
-
-  // Search for a dimension in output with the same size and stride.
-  // Check dimensions from right to left, accumulating stride incrementally.
-  int64_t outputStride = 1;
-  for (int64_t i = outputRank - 1; i >= 0; --i) {
-    if (outputStride > inputStride) {
-      break;
-    }
-    if (outputStride == inputStride && outputShape[i] == inputDimSize) {
-      return outputRank - 1 - i;
-    }
-    outputStride *= outputShape[i];
+  int64_t ltrDim = inputRank - 1 - dimRTL;
+  int64_t ltrResult = findMatchingDim(inputShape, outputShape, ltrDim);
+  if (ltrResult == -1) {
+    return -1;
   }
-
-  // No dimension with the same size and stride found.
-  return -1;
+  return outputRank - 1 - ltrResult;
 }
 
 bool preservesDim(mlir::Operation *op, int64_t dim) {

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_reduce.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_reduce.mlir
@@ -1,0 +1,118 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="enable-commute-upwards=false" -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module {
+    // Motivating LLaMA-70B RMS norm case: a leading reshape that only
+    // rearranges outer dims while preserving the reduce dim gets pushed past
+    // the reduce, leaving the reshape on the much smaller post-reduce tensor.
+    func.func @test_reshape_sum_commute_downwards(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK-SAME: keep_dim = true
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK-SAME: shape = [32 : i32, 1 : i32, 1 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x1x4096xbf16>) -> tensor<32x1x1xbf16>
+        return %2 : tensor<32x1x1xbf16>
+    }
+
+    // keep_dim=false: reduce dim is dropped from the post-reduce shape, then
+    // the trailing reshape compensates.
+    func.func @test_reshape_sum_commute_downwards_keepdim_false(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK-SAME: keep_dim = false
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK-SAME: shape = [32 : i32, 1 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<32x1x4096xbf16>) -> tensor<32x1xbf16>
+        return %2 : tensor<32x1xbf16>
+    }
+
+    // Multi-dim reduce: every reduce dim must map back to the pre-reshape
+    // shape; here both inner dims are preserved by the reshape.
+    func.func @test_reshape_sum_commute_downwards_multi_dim(%arg0: tensor<1x32x4x16x64xbf16>) -> tensor<32x4x1x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [3 : i32, 4 : i32]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK-SAME: shape = [32 : i32, 4 : i32, 1 : i32, 1 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 4 : i32, 16 : i32, 64 : i32]}> : (tensor<1x32x4x16x64xbf16>) -> tensor<32x4x16x64xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [2 : i32, 3 : i32], keep_dim = true}> : (tensor<32x4x16x64xbf16>) -> tensor<32x4x1x1xbf16>
+        return %2 : tensor<32x4x1x1xbf16>
+    }
+
+    // Negative dim_arg must be normalized before mapping.
+    func.func @test_reshape_sum_commute_downwards_negative_dim(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK-SAME: shape = [32 : i32, 1 : i32, 1 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<32x1x4096xbf16>) -> tensor<32x1x1xbf16>
+        return %2 : tensor<32x1x1xbf16>
+    }
+
+    // Reduce dim was created by splitting an input dim — cannot map back, so
+    // commute is rejected.
+    func.func @test_reshape_sum_no_commute_split_reduce_dim(%arg0: tensor<32x4096xbf16>) -> tensor<32x64x1xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK-SAME: shape = [32 : i32, 64 : i32, 64 : i32]
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%[[RESHAPE]]
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK: return %[[SUM]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 64 : i32, 64 : i32]}> : (tensor<32x4096xbf16>) -> tensor<32x64x64xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x64x64xbf16>) -> tensor<32x64x1xbf16>
+        return %2 : tensor<32x64x1xbf16>
+    }
+
+    // Reduce dim is the merge of two input dims — cannot map back.
+    func.func @test_reshape_sum_no_commute_merged_reduce_dim(%arg0: tensor<1x160x160x128xbf16>) -> tensor<1x1x128xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK-SAME: shape = [1 : i32, 25600 : i32, 128 : i32]
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%[[RESHAPE]]
+        // CHECK-SAME: dim_arg = [1 : i32]
+        // CHECK: return %[[SUM]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 25600 : i32, 128 : i32]}> : (tensor<1x160x160x128xbf16>) -> tensor<1x25600x128xbf16>
+        %2 = "ttir.sum"(%1) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<1x25600x128xbf16>) -> tensor<1x1x128xbf16>
+        return %2 : tensor<1x1x128xbf16>
+    }
+
+    // The pattern is templated over multiple reduce ops — spot-check mean.
+    func.func @test_reshape_mean_commute_downwards(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1x1xbf16> {
+        // CHECK: %[[MEAN:[0-9]+]] = "ttir.mean"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[MEAN]]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.mean"(%1) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x1x4096xbf16>) -> tensor<32x1x1xbf16>
+        return %2 : tensor<32x1x1xbf16>
+    }
+
+    // ...and max.
+    func.func @test_reshape_max_commute_downwards(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1x1xbf16> {
+        // CHECK: %[[MAX:[0-9]+]] = "ttir.max"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[MAX]]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.max"(%1) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x1x4096xbf16>) -> tensor<32x1x1xbf16>
+        return %2 : tensor<32x1x1xbf16>
+    }
+
+    // No dim_arg means reduce-all. The pattern expands this into an explicit
+    // dim_arg covering every input dim, so the resulting sum operates on the
+    // pre-reshape input. Output shape matches the original — the trailing
+    // identity reshape is folded away.
+    func.func @test_reshape_sum_commute_downwards_reduce_all(%arg0: tensor<1x32x4096xbf16>) -> tensor<1x1x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
+        // CHECK: return %[[SUM]]
+        %1 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 4096 : i32]}> : (tensor<1x32x4096xbf16>) -> tensor<32x1x4096xbf16>
+        %2 = "ttir.sum"(%1) <{keep_dim = true}> : (tensor<32x1x4096xbf16>) -> tensor<1x1x1xbf16>
+        return %2 : tensor<1x1x1xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_reduce.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_reduce.mlir
@@ -1,0 +1,42 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=true enable-commute-downwards=false" -o %t %s
+// RUN: FileCheck --input-file=%t %s
+
+module {
+    // A reduce with reduction length > 1 changes total element count, so the
+    // new reshape of the pre-reduce input cannot produce the original
+    // post-reshape shape; the pattern must refuse the commute.
+    func.func @test_reshape_sum_no_commute_upwards(%arg0: tensor<1x32x4096xbf16>) -> tensor<32x1xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: dim_arg = [2 : i32]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK-SAME: shape = [32 : i32, 1 : i32]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.sum"(%arg0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<1x32x4096xbf16>) -> tensor<1x32x1xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 1 : i32]}> : (tensor<1x32x1xbf16>) -> tensor<32x1xbf16>
+        return %2 : tensor<32x1xbf16>
+    }
+
+    // keep_dim=false version of the same scenario — still cannot commute.
+    func.func @test_reshape_sum_no_commute_upwards_keepdim_false(%arg0: tensor<1x32x4096xbf16>) -> tensor<32xbf16> {
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%arg0
+        // CHECK-SAME: keep_dim = false
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[SUM]]
+        // CHECK: return %[[RESHAPE]]
+        %1 = "ttir.sum"(%arg0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<1x32x4096xbf16>) -> tensor<1x32xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [32 : i32]}> : (tensor<1x32xbf16>) -> tensor<32xbf16>
+        return %2 : tensor<32xbf16>
+    }
+
+    // Trivial reduce (size-1 reduce dim) preserves element count; if the
+    // reshape also preserves a compatibly-strided size-1 dim, the pattern can
+    // commute the reshape upwards.
+    func.func @test_reshape_sum_commute_upwards_trivial(%arg0: tensor<2x1x1x8xbf16>) -> tensor<2x1x8xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0
+        // CHECK-SAME: shape = [2 : i32, 1 : i32, 8 : i32]
+        // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"(%[[RESHAPE]]
+        // CHECK: return %[[SUM]]
+        %1 = "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<2x1x1x8xbf16>) -> tensor<2x1x1x8xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [2 : i32, 1 : i32, 8 : i32]}> : (tensor<2x1x1x8xbf16>) -> tensor<2x1x8xbf16>
+        return %2 : tensor<2x1x8xbf16>
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TTIRCommuteReshapeThroughReduce` pattern to the EraseInverseOps pass, enabling reshape ops to commute through reduce ops (both upward and downward)
- Uses stride-matching to map reduce dimensions between original and reshaped tensor shapes, rejecting cases where reshape splits or merges the reduce dimension

## Performance
- n150 benchmarks: https://github.com/tenstorrent/tt-xla/actions/runs/24445828995 (all pass except gemma — pre-existing issue fixed by 8b78aede6d)
- n300-llmbox benchmarks: https://github.com/tenstorrent/tt-xla/actions/runs/24459002367