### PR TITLE
[CHISEL] Add IRModule Wrapper

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -7,6 +7,8 @@
           "image": "tracy",
               "script": "ttrt.sh", "args": ["perf", "Silicon/TTNN/$RUNS_ON/perf"] },
 
+    { "runs-on": "n150", "image": "tracy", "script": "chisel.sh" },
+
     { "runs-on": "n150",
           "image": "tracy",
               "script": "test-ttrt.sh" },

--- a/.github/test_scripts/chisel.sh
+++ b/.github/test_scripts/chisel.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e -o pipefail
+
+pytest -v tools/chisel/tests/ \
+    --binary "$BUILD_DIR/test/ttmlir/Silicon/TTNN/n150" \
+    --junit-xml="$TEST_REPORT_PATH"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
   add_subdirectory(builder)
   add_subdirectory(golden)
   add_subdirectory(profiler)
+  add_subdirectory(chisel)
 
   if (TTMLIR_ENABLE_PYKERNEL)
     add_subdirectory(pykernel)

--- a/tools/chisel/CMakeLists.txt
+++ b/tools/chisel/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(AddMLIRPython)
+
+declare_mlir_python_sources(ChiselSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/chisel"
+  SOURCES
+    __init__.py
+    ops.py
+)
+
+add_mlir_python_modules(ChiselPythonModules
+  ROOT_PREFIX "${TTMLIR_PYTHON_PACKAGES_DIR}/chisel"
+  INSTALL_PREFIX "python_packages/chisel"
+  DECLARED_SOURCES ChiselSources
+)

--- a/tools/chisel/chisel/__init__.py
+++ b/tools/chisel/chisel/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/chisel/chisel/ops.py
+++ b/tools/chisel/chisel/ops.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLIR operation utilities: IRModule wrapper and tensor operand extraction.
+"""
+from ttmlir.dialects import func
+from ttmlir.ir import (
+    AsmState,
+    BlockArgument,
+    Context,
+    Module,
+    OpResult,
+    Operation,
+    Value,
+    WalkOrder,
+    WalkResult,
+)
+
+
+def get_op_outputs(op: Operation) -> list[OpResult]:
+    """Extract output tensors (results with shape and element_type) from a MLIR operation."""
+    return [
+        result
+        for result in op.results
+        if hasattr(result.type, "shape") and hasattr(result.type, "element_type")
+    ]
+
+
+def get_op_inputs(op: Operation) -> list[Value]:
+    """Extract input tensors (operands with shape and element_type) from a MLIR operation."""
+    return [
+        operand
+        for operand in op.operands
+        if hasattr(operand.type, "shape") and hasattr(operand.type, "element_type")
+    ]
+
+
+class IRModule:
+    """
+    Wrapper around a MLIR Module with function lookup and operation traversal.
+
+    Accepts a MLIR source string, parses it internally, and provides cached
+    access to functions, operations, and assembly state.
+    """
+
+    def __init__(
+        self,
+        mlir_source: str,
+        functions: list[str],
+    ):
+        self.context = Context()
+        self.context.allow_unregistered_dialects = True
+        self.module: Module = Module.parse(mlir_source, self.context)
+
+        self._functions: dict[str, func.FuncOp] = {
+            name: self._find_function(name) for name in functions
+        }
+        self._function_ops: dict[str, list[Operation]] = {}
+        self._function_outputs: dict[str, list[Value]] = {}
+        for name in functions:
+            ops, outputs = self._extract_function_ops(name)
+            self._function_ops[name] = ops
+            self._function_outputs[name] = outputs
+        self._asm_state: dict[str, AsmState] = {
+            name: AsmState(self._functions[name]) for name in functions
+        }
+
+    def get_asm_state(self, function_name: str) -> AsmState:
+        """AsmState for the given function (speeds up get_name calls)."""
+        return self._asm_state[function_name]
+
+    def get_function(self, function_name: str) -> func.FuncOp:
+        """The func.FuncOp for the given function."""
+        return self._functions[function_name]
+
+    def get_function_inputs(self, function_name: str) -> list[BlockArgument]:
+        """Input arguments of the given function."""
+        return self._functions[function_name].arguments
+
+    def get_function_outputs(self, function_name: str) -> list[Value]:
+        """Output values of the given function (operands of func.return)."""
+        return self._function_outputs[function_name]
+
+    def get_function_ops(self, function_name: str) -> list[Operation]:
+        """Operations in the given function body."""
+        return self._function_ops[function_name]
+
+    def _extract_function_ops(self, name: str) -> tuple[list[Operation], list[Value]]:
+        assert name in self._functions
+        func_op = self._functions[name]
+        ops = []
+        outputs = []
+
+        def _visitor(op):
+            # Skip the FuncOp itself — Python bindings only expose walk() on
+            # Operation, not Region, so we walk the FuncOp and skip it to match
+            # the C++ entry.getBody().walk() in FuncOpToProgram.h.
+            if op == func_op.operation:
+                return WalkResult.ADVANCE
+            if op.name == "func.return":
+                outputs.extend(op.operands)
+                return WalkResult.ADVANCE
+            ops.append(op)
+            return WalkResult.ADVANCE
+
+        func_op.operation.walk(_visitor, walk_order=WalkOrder.PRE_ORDER)
+        return ops, outputs
+
+    def _find_function(self, name: str) -> func.FuncOp:
+        result = None
+
+        def _visitor(op):
+            nonlocal result
+            opview = op.opview
+            if isinstance(opview, func.FuncOp):
+                if opview.name.value == name:
+                    result = opview
+                    return WalkResult.INTERRUPT
+                return WalkResult.SKIP
+            return WalkResult.ADVANCE
+
+        self.module.operation.walk(_visitor, walk_order=WalkOrder.PRE_ORDER)
+        if result is None:
+            raise ValueError(f"Function {name} not found in module")
+        return result

--- a/tools/chisel/tests/conftest.py
+++ b/tools/chisel/tests/conftest.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--binary",
+        help="Path to a .ttnn file or directory to search recursively.",
+    )
+
+
+def _find_ttnn_files(directory):
+    """Recursively discover .ttnn files in a directory, sorted alphabetically."""
+    found = []
+    for root, _, files in os.walk(directory):
+        for f in files:
+            if f.endswith(".ttnn"):
+                found.append(os.path.join(root, f))
+    found.sort()
+    return found
+
+
+def _collect_binary_paths(config):
+    p = config.getoption("binary")
+    if p is None:
+        return []
+    if os.path.isdir(p):
+        return _find_ttnn_files(p)
+    return [p]
+
+
+def pytest_generate_tests(metafunc):
+    if "binary_path" in metafunc.fixturenames:
+        paths = _collect_binary_paths(metafunc.config)
+        if not paths:
+            binary_opt = metafunc.config.getoption("binary", default=None)
+            if binary_opt is None:
+                pytest.fail(
+                    "No binary specified. Use --binary to provide a .ttnn file or directory."
+                )
+            else:
+                pytest.fail(f"No .ttnn flatbuffers found under '{binary_opt}'.")
+        metafunc.parametrize("binary_path", paths)

--- a/tools/chisel/tests/test_ir_module.py
+++ b/tools/chisel/tests/test_ir_module.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Cross-validate IRModule against the flatbuffer binary: op walk order,
+tensor shapes, and element types.
+"""
+import pytest
+import ttrt.binary
+
+from chisel.ops import IRModule
+
+
+@pytest.fixture
+def binary(binary_path):
+    return ttrt.binary.load_binary_from_path(binary_path)
+
+
+@pytest.fixture
+def ir_module(binary):
+    mlir_json = ttrt.binary.mlir_as_dict(binary)
+    functions = [binary.get_program_name(i) for i in range(binary.get_num_programs())]
+    return IRModule(mlir_source=mlir_json["source"], functions=functions)
+
+
+def _iterate_programs(binary):
+    """Yield (index, name) for each program."""
+    for i in range(binary.get_num_programs()):
+        yield i, binary.get_program_name(i)
+
+
+def test_ops(ir_module, binary):
+    """Cross-validate walk order, debug info, and tensor shapes against the flatbuffer."""
+    for prog_idx, prog_name in _iterate_programs(binary):
+        mlir_ops = ir_module.get_function_ops(prog_name)
+        fb_ops = ttrt.binary.program_ops_as_dict(binary, prog_idx)
+
+        assert len(mlir_ops) == len(fb_ops), (
+            f"Program '{prog_name}': count mismatch "
+            f"(MLIR={len(mlir_ops)}, FB={len(fb_ops)})"
+        )
+
+        for i, (mlir_op, fb_op) in enumerate(zip(mlir_ops, fb_ops, strict=True)):
+            mlir_debug = mlir_op.get_asm(enable_debug_info=True)
+            fb_debug = fb_op.get("debug_info", "")
+            assert mlir_debug == fb_debug, (
+                f"Program '{prog_name}' op {i}: debug info mismatch\n"
+                f"  MLIR: {mlir_debug}\n"
+                f"  FB:   {fb_debug}"
+            )


### PR DESCRIPTION
### Problem description

Chisel is a differential debugging tool that compares golden (CPU) execution against device execution op-by-op. Its core mechanism relies on walking MLIR ops in the same order that the flatbuffer runtime fires `preOp`/`postOp` callbacks - if those two walks diverge at any index, Chisel will correlate the wrong golden op to the wrong device callback, producing silent false positives or misleading diffs.

Before building the full callback machinery, we need to establish:
1. A reusable `IRModule` wrapper that parses the TTNN MLIR embedded in a flatbuffer and exposes an ordered op list per function
2. A test that cross-validates this walk order against the flatbuffer's own op serialization on real compiled binaries

### What's changed

**`tools/chisel/chisel/ops.py` — `IRModule` wrapper**

Parses a MLIR source string, looks up named functions, and caches per-function op lists, outputs, and `AsmState` objects. The `_extract_function_ops` walk is pre-order and skips the `FuncOp` itself, mirroring the C++ `entry.getBody().walk()` in `FuncOpToProgram.h` — this is the invariant that keeps the Python-side op ordering consistent with what the runtime will walk. 

**CI** — new `chisel.sh` test script runs `pytest tools/chisel/tests/` against `n150` compiled binaries;

### Checklist
- [ ] New/Existing tests provide coverage for changes
