### PR TITLE
D2M: Add TTMetal lowering for d2m.spatial

### DIFF
--- a/include/ttmlir/Conversion/D2MToTTMetal/D2MToTTMetal.h
+++ b/include/ttmlir/Conversion/D2MToTTMetal/D2MToTTMetal.h
@@ -22,7 +22,8 @@ void populateD2MToTTMetalPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
     ttmetal::MathFidelity mathFidelity = ttmetal::MathFidelity::HiFi4);
 
-void populateSpatialOpPatterns(MLIRContext *ctx, RewritePatternSet &patterns);
+void populateD2MToTTMetalSpatialOpPattern(MLIRContext *ctx,
+                                          RewritePatternSet &patterns);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTMetalPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/ttmlir/Conversion/D2MToTTMetal/D2MToTTMetal.h
+++ b/include/ttmlir/Conversion/D2MToTTMetal/D2MToTTMetal.h
@@ -22,6 +22,8 @@ void populateD2MToTTMetalPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
     ttmetal::MathFidelity mathFidelity = ttmetal::MathFidelity::HiFi4);
 
+void populateSpatialOpPatterns(MLIRContext *ctx, RewritePatternSet &patterns);
+
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTMetalPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertD2MToTTMetalPass(const d2m::ConvertD2MToTTMetalOptions &options);

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -9,15 +9,21 @@
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include <cstdint>
 #include <mlir-c/IR.h>
+#include <optional>
 
 namespace mlir::tt::ttmetal {
 
@@ -61,13 +67,10 @@ public:
 
   static ArrayAttr convertThreadsToKernelConfigs(
       Builder &builder, mlir::ValueRange inputOutputOperands, ArrayAttr threads,
-      ArrayRef<int64_t> physicalGridShape, const SymbolTable &symbolTable,
+      CoreRangeAttr coreRange, const SymbolTable &symbolTable,
       ttmetal::MathFidelity mathFidelity) {
     SmallVector<Attribute> kernelConfigs;
     int unassignedNocCounter = 0;
-
-    auto coreRange = ttmetal::CoreRangeAttr::getPhysicalCoreRange(
-        builder.getContext(), physicalGridShape);
 
     for (Attribute threadAttr : threads) {
       d2m::ThreadAttr thread = mlir::cast<d2m::ThreadAttr>(threadAttr);
@@ -182,10 +185,10 @@ public:
     }
 
     ArrayAttr threads = op.getThreads();
-    auto physicalGridShape = op.getPhysicalGridShape();
+    CoreRangeAttr coreRange = coreRangeAttrFromOp(rewriter, op);
     auto kernelConfigs = convertThreadsToKernelConfigs(
-        rewriter, op.getInputsAndOutputs(), threads, physicalGridShape,
-        symbolTable, mathFidelity_);
+        rewriter, op.getInputsAndOutputs(), threads, coreRange, symbolTable,
+        mathFidelity_);
     rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
         op, args, cbs, cbPorts, kernelConfigs,
         op.getFabricConnectionConfigAttr());
@@ -193,8 +196,54 @@ public:
   };
 
 private:
+  /// From the op's grid: virt_to_physical over the virtual grid bbox when
+  /// present (2D); else offset (0,0) with extent from getPhysicalGridShape().
+  static CoreRangeAttr coreRangeAttrFromOp(Builder &builder, d2m::GenericOp op);
+
   ttmetal::MathFidelity mathFidelity_;
 };
+
+CoreRangeAttr D2MGenericRewriter::coreRangeAttrFromOp(Builder &builder,
+                                                      d2m::GenericOp op) {
+  MLIRContext *ctx = builder.getContext();
+  SmallVector<int64_t> physicalGridShape = op.getPhysicalGridShape();
+  ttcore::GridAttr grid = op.getGrid();
+  AffineMap v2p = grid.getVirtToPhysicalMap();
+  if (v2p.isEmpty() || grid.getShape().size() != 2 || v2p.getNumDims() != 2) {
+    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
+  }
+
+  unsigned numRes = v2p.getNumResults();
+  unsigned yIdx;
+  unsigned xIdx;
+  if (numRes == 3) {
+    yIdx = 1;
+    xIdx = 2;
+  } else if (numRes == 2) {
+    yIdx = 0;
+    xIdx = 1;
+  } else {
+    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
+  }
+
+  d2m::utils::BoundingBox virtBox;
+  virtBox.start = {0, 0};
+  virtBox.end = {grid.getShape()[0] - 1, grid.getShape()[1] - 1};
+  d2m::utils::BoundingBox physBox =
+      d2m::utils::getProjectedBoundingBox(virtBox, v2p);
+  if (physBox.start.size() <= xIdx) {
+    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
+  }
+
+  int64_t y0 = physBox.start[yIdx];
+  int64_t x0 = physBox.start[xIdx];
+  int64_t y1 = physBox.end[yIdx];
+  int64_t x1 = physBox.end[xIdx];
+  SmallVector<int64_t> offset = {y0, x0};
+  SmallVector<int64_t> size = {y1 - y0 + 1, x1 - x0 + 1};
+  return CoreRangeAttr::get(ctx, offset, size);
+}
+
 } // namespace
 
 namespace {
@@ -434,6 +483,287 @@ public:
     return success();
   }
 };
+
+/// Second-phase lowering for d2m.spatial:
+/// - Merge all nested ttmetal.enqueue_program ops into one enqueue_program.
+/// - Keep cb_ports unchanged.
+/// - Remap enqueue args indices in kernel args when args lists are
+/// concatenated.
+class SpatialOpRewriter : public OpConversionPattern<d2m::SpatialOp> {
+public:
+  using OpConversionPattern<d2m::SpatialOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::SpatialOp op, d2m::SpatialOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    (void)adaptor;
+
+    if (op.getNumResults() != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "SpatialOp with results is not supported in TTMetal lowering");
+    }
+
+    ArrayAttr gridRanges = op.getGridRanges();
+    SpatialRemapTable remapTable;
+    SmallVector<ttmetal::EnqueueProgramOp> regionEnqueues;
+    SmallVector<Value> mergedCbs;
+    SmallVector<int64_t> mergedCbPorts;
+    SmallVector<Attribute> mergedKernelConfigs;
+    ttcore::FabricConnectionConfigAttr mergedFabricConfig = nullptr;
+    SmallVector<Operation *> preEnqueueOps;
+    SmallVector<Operation *> postEnqueueOps;
+
+    for (auto [regionIndex, region] : llvm::enumerate(op.getRegions())) {
+      auto spatialCoreRange =
+          mlir::cast<ttcore::CoreRangeAttr>(gridRanges.getValue()[regionIndex]);
+      CoreRangeAttr spatialMetalRange =
+          ttCoreSpatialRangeToTtmetalCoreRange(rewriter, spatialCoreRange);
+      ttmetal::EnqueueProgramOp enqueueProgram = nullptr;
+      LogicalResult collectResult = collectRegionOps(
+          region, preEnqueueOps, postEnqueueOps, enqueueProgram);
+      if (failed(collectResult)) {
+        return rewriter.notifyMatchFailure(
+            op, "each spatial region must contain exactly one enqueue_program");
+      }
+      regionEnqueues.push_back(enqueueProgram);
+      remapTable.addEnqueueArgs(enqueueProgram);
+
+      llvm::append_range(mergedCbs, enqueueProgram.getCbs());
+      llvm::append_range(mergedCbPorts, enqueueProgram.getCbPorts());
+      for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
+        mergedKernelConfigs.push_back(remapKernelConfig(
+            kernelConfig, spatialMetalRange, enqueueProgram, remapTable));
+      }
+
+      auto enqueueFabricConfig = enqueueProgram.getFabricConnectionConfigAttr();
+      if (hasConflictingFabricConfig(mergedFabricConfig, enqueueFabricConfig)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to merge region enqueue_program ops due to fabric "
+                "config conflict");
+      }
+      if (enqueueFabricConfig) {
+        mergedFabricConfig = enqueueFabricConfig;
+      }
+    }
+
+    if (mergedKernelConfigs.empty()) {
+      return rewriter.notifyMatchFailure(
+          op, "SpatialOp has no nested enqueue_program");
+    }
+
+    for (Operation *operation : preEnqueueOps) {
+      rewriter.moveOpBefore(operation, op);
+    }
+
+    rewriter.create<ttmetal::EnqueueProgramOp>(
+        op.getLoc(), remapTable.getUnifiedArgs(), mergedCbs, mergedCbPorts,
+        rewriter.getArrayAttr(mergedKernelConfigs), mergedFabricConfig);
+
+    for (Operation *operation : postEnqueueOps) {
+      rewriter.moveOpBefore(operation, op);
+    }
+
+    for (ttmetal::EnqueueProgramOp enqueueProgram : regionEnqueues) {
+      rewriter.eraseOp(enqueueProgram);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  class SpatialRemapTable {
+    using LocalKey = std::pair<Operation *, size_t>;
+
+    SmallVector<Value> unifiedArgs_;
+    DenseMap<Value, size_t> ioToUnifiedIdx_;
+    DenseMap<LocalKey, size_t> ioArgMap_;
+    DenseMap<LocalKey, size_t> globalSemaphoreArgMap_;
+
+  public:
+    void addEnqueueArgs(ttmetal::EnqueueProgramOp enqueueProgram) {
+      Operation *op = enqueueProgram.getOperation();
+      for (const auto [idx, arg] : llvm::enumerate(enqueueProgram.getArgs())) {
+        size_t localIdx = static_cast<size_t>(idx);
+        if (mlir::isa<ttmetal::GlobalSemaphoreType>(arg.getType())) {
+          size_t unifiedIdx = unifiedArgs_.size();
+          unifiedArgs_.push_back(arg);
+          globalSemaphoreArgMap_.insert({{op, localIdx}, unifiedIdx});
+          continue;
+        }
+
+        auto it = ioToUnifiedIdx_.find(arg);
+        size_t unifiedIdx;
+        if (it == ioToUnifiedIdx_.end()) {
+          unifiedIdx = unifiedArgs_.size();
+          ioToUnifiedIdx_.insert({arg, unifiedIdx});
+          unifiedArgs_.push_back(arg);
+        } else {
+          unifiedIdx = it->second;
+        }
+        ioArgMap_.insert({{op, localIdx}, unifiedIdx});
+      }
+    }
+
+    ArrayRef<Value> getUnifiedArgs() const { return unifiedArgs_; }
+
+    std::optional<size_t> lookupIO(ttmetal::EnqueueProgramOp enqueueProgram,
+                                   size_t localIdx) const {
+      auto it = ioArgMap_.find({enqueueProgram.getOperation(), localIdx});
+      if (it != ioArgMap_.end()) {
+        return it->second;
+      }
+      return std::nullopt;
+    }
+
+    std::optional<size_t>
+    lookupGlobalSemaphore(ttmetal::EnqueueProgramOp enqueueProgram,
+                          size_t localIdx) const {
+      auto it = globalSemaphoreArgMap_.find(
+          {enqueueProgram.getOperation(), localIdx});
+      if (it != globalSemaphoreArgMap_.end()) {
+        return it->second;
+      }
+      return std::nullopt;
+    }
+  };
+
+  static KernelArgAttr remapKernelArg(Builder &builder, KernelArgAttr kernelArg,
+                                      ttmetal::EnqueueProgramOp enqueueProgram,
+                                      const SpatialRemapTable &remapTable) {
+    size_t operandIndex = kernelArg.getOperandIndex();
+    if (kernelArg.getType() == ttkernel::ArgType::BufferAddress) {
+      if (auto unified = remapTable.lookupIO(enqueueProgram, operandIndex)) {
+        operandIndex = *unified;
+      }
+    } else if (kernelArg.getType() == ttkernel::ArgType::GlobalSemaphore) {
+      if (auto unified =
+              remapTable.lookupGlobalSemaphore(enqueueProgram, operandIndex)) {
+        operandIndex = *unified;
+      }
+    }
+    return builder.getAttr<KernelArgAttr>(kernelArg.getType(), operandIndex);
+  }
+
+  static KernelArgsAttr
+  remapKernelArgs(Builder &builder, KernelArgsAttr kernelArgs,
+                  ttmetal::EnqueueProgramOp enqueueProgram,
+                  const SpatialRemapTable &remapTable) {
+    SmallVector<KernelArgAttr> remappedRuntimeArgs;
+    SmallVector<KernelArgAttr> remappedCompileTimeArgs;
+    remappedRuntimeArgs.reserve(kernelArgs.getRtArgs().size());
+    remappedCompileTimeArgs.reserve(kernelArgs.getCtArgs().size());
+
+    for (KernelArgAttr runtimeArg : kernelArgs.getRtArgs()) {
+      remappedRuntimeArgs.push_back(
+          remapKernelArg(builder, runtimeArg, enqueueProgram, remapTable));
+    }
+    for (KernelArgAttr compileTimeArg : kernelArgs.getCtArgs()) {
+      remappedCompileTimeArgs.push_back(
+          remapKernelArg(builder, compileTimeArg, enqueueProgram, remapTable));
+    }
+
+    return builder.getAttr<KernelArgsAttr>(remappedRuntimeArgs,
+                                           remappedCompileTimeArgs);
+  }
+
+  static Attribute remapKernelConfig(Attribute kernelConfig,
+                                     CoreRangeAttr spatialCoreRange,
+                                     ttmetal::EnqueueProgramOp enqueueProgram,
+                                     const SpatialRemapTable &remapTable) {
+    Builder builder(kernelConfig.getContext());
+    return TypeSwitch<Attribute, Attribute>(kernelConfig)
+        .Case<ComputeConfigAttr>([&](ComputeConfigAttr computeConfig) {
+          return ComputeConfigAttr::get(
+              computeConfig.getContext(), computeConfig.getKernelSymbol(),
+              spatialCoreRange,
+              remapKernelArgs(builder, computeConfig.getKernelArgs(),
+                              enqueueProgram, remapTable),
+              computeConfig.getMathFidelity(), computeConfig.getFp32DestAccEn(),
+              computeConfig.getDstFullSyncEn(),
+              computeConfig.getMathApproxMode(),
+              computeConfig.getUnpackToDestMode());
+        })
+        .Case<NocConfigAttr>([&](NocConfigAttr nocConfig) {
+          return NocConfigAttr::get(
+              nocConfig.getContext(), nocConfig.getKernelSymbol(),
+              spatialCoreRange,
+              remapKernelArgs(builder, nocConfig.getKernelArgs(),
+                              enqueueProgram, remapTable),
+              nocConfig.getNocIndex());
+        })
+        .Case<EthernetConfigAttr>([&](EthernetConfigAttr ethernetConfig) {
+          return EthernetConfigAttr::get(
+              ethernetConfig.getContext(), ethernetConfig.getKernelSymbol(),
+              spatialCoreRange,
+              remapKernelArgs(builder, ethernetConfig.getKernelArgs(),
+                              enqueueProgram, remapTable),
+              ethernetConfig.getEthType(), ethernetConfig.getNocIndex());
+        })
+        .Default([](Attribute) -> Attribute {
+          llvm_unreachable(
+              "unexpected kernel config attribute kind in spatial merge");
+        });
+  }
+
+  static bool hasConflictingFabricConfig(
+      ttcore::FabricConnectionConfigAttr mergedFabricConfig,
+      ttcore::FabricConnectionConfigAttr enqueueFabricConfig) {
+    return mergedFabricConfig && enqueueFabricConfig &&
+           mergedFabricConfig != enqueueFabricConfig;
+  }
+
+  static LogicalResult
+  collectRegionOps(Region &region, SmallVector<Operation *> &preEnqueueOps,
+                   SmallVector<Operation *> &postEnqueueOps,
+                   ttmetal::EnqueueProgramOp &regionEnqueueProgram) {
+    Block &block = region.front();
+    bool seenEnqueue = false;
+    unsigned enqueueCount = 0;
+
+    for (Operation &innerOperation : block) {
+      if (isa<d2m::SpatialYieldOp>(innerOperation)) {
+        continue;
+      }
+
+      if (auto enqueueProgram =
+              dyn_cast<ttmetal::EnqueueProgramOp>(&innerOperation)) {
+        ++enqueueCount;
+        if (enqueueCount > 1) {
+          return failure();
+        }
+        regionEnqueueProgram = enqueueProgram;
+        seenEnqueue = true;
+        continue;
+      }
+
+      if (!seenEnqueue) {
+        preEnqueueOps.push_back(&innerOperation);
+      } else {
+        postEnqueueOps.push_back(&innerOperation);
+      }
+    }
+    if (enqueueCount != 1) {
+      return failure();
+    }
+    return success();
+  }
+
+  static CoreRangeAttr
+  ttCoreSpatialRangeToTtmetalCoreRange(Builder &builder,
+                                       ttcore::CoreRangeAttr cr);
+};
+
+CoreRangeAttr SpatialOpRewriter::ttCoreSpatialRangeToTtmetalCoreRange(
+    Builder &builder, ttcore::CoreRangeAttr cr) {
+  auto sc = cr.getStartCoord();
+  auto ec = cr.getEndCoord();
+  SmallVector<int64_t> offset = {sc.getY(), sc.getX()};
+  SmallVector<int64_t> size = {ec.getY() - sc.getY() + 1,
+                               ec.getX() - sc.getX() + 1};
+  return CoreRangeAttr::get(builder.getContext(), offset, size);
+}
+
 } // namespace
 
 } // namespace mlir::tt::ttmetal
@@ -450,6 +780,10 @@ void populateD2MToTTMetalPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
       ttmetal::D2MResetGlobalSemaphoreRewriter, ttmetal::D2MViewLayoutRewriter>(
       ctx);
   patterns.add<ttmetal::D2MGenericRewriter>(ctx, mathFidelity);
+}
+
+void populateSpatialOpPatterns(MLIRContext *ctx, RewritePatternSet &patterns) {
+  patterns.add<ttmetal::SpatialOpRewriter>(ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -780,7 +780,8 @@ void populateD2MToTTMetalPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<ttmetal::D2MGenericRewriter>(ctx, mathFidelity);
 }
 
-void populateSpatialOpPatterns(MLIRContext *ctx, RewritePatternSet &patterns) {
+void populateD2MToTTMetalSpatialOpPattern(MLIRContext *ctx,
+                                          RewritePatternSet &patterns) {
   patterns.add<ttmetal::SpatialOpRewriter>(ctx);
 }
 

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <cstdint>
@@ -551,15 +552,17 @@ public:
 
       const size_t mergedCbSlotBase = mergedCbs.size();
       llvm::append_range(mergedCbs, enqueueProgram.getCbs());
-      for (int64_t ignored : enqueueProgram.getCbPorts()) {
-        (void)ignored;
-        if (mergedCbPorts.size() >= chipNumCbs) {
-          return rewriter.notifyMatchFailure(
-              op,
-              "merged spatial enqueue_program cb_ports exceed chip num_cbs");
-        }
-        mergedCbPorts.push_back(static_cast<int64_t>(mergedCbPorts.size()));
+      // Workaround: rebuild cb_ports as a contiguous global range when merging.
+      const size_t regionCbPortCount = enqueueProgram.getCbPorts().size();
+      if (mergedCbPorts.size() + regionCbPortCount > chipNumCbs) {
+        return rewriter.notifyMatchFailure(
+            op, "merged spatial enqueue_program cb_ports exceed chip num_cbs");
       }
+      const int64_t portBase = static_cast<int64_t>(mergedCbPorts.size());
+      llvm::append_range(
+          mergedCbPorts,
+          llvm::seq<int64_t>(
+              portBase, portBase + static_cast<int64_t>(regionCbPortCount)));
       for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
         mergedKernelConfigs.push_back(
             remapKernelConfig(kernelConfig, spatialMetalRange, enqueueProgram,

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -474,7 +474,9 @@ public:
 
 /// Second-phase lowering for d2m.spatial:
 /// - Merge all nested ttmetal.enqueue_program ops into one enqueue_program.
-/// - Keep cb_ports unchanged.
+/// - Keep cb_ports unchanged (concatenated per region). CB hardware ids are
+/// per-core; spatial regions use disjoint core ranges, so CBPort kernel-arg
+/// indices are not shifted across regions.
 /// - Remap enqueue args indices in kernel args when args lists are
 /// concatenated.
 class SpatialOpRewriter : public OpConversionPattern<d2m::SpatialOp> {

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -484,8 +485,11 @@ public:
 
 /// Second-phase lowering for d2m.spatial:
 /// - Merge all nested ttmetal.enqueue_program ops into one enqueue_program.
-/// - Concatenate per-region `cbs` / `cb_ports`. Hardware port ids may repeat
-/// across disjoint spatial regions.
+/// - Concatenate per-region `cbs`. Temporary workaround: remap hardware
+/// `cb_ports` to globally unique ids (sequential 0..N-1) so merged regions do
+/// not reuse the same CB port id when circular-buffer placement is
+/// over-approximated to the full worker grid (see TTMetalToFlatbuffer
+/// circular_buffer_config).
 /// - Remap kernel-arg indices for merged enqueue: BufferAddress,
 /// GlobalSemaphore, and CBPort. Runtime resolves CBPort by indexing the merged
 /// `cbs` list, then reads that entry's hardware port.
@@ -503,6 +507,26 @@ public:
     }
 
     ArrayAttr gridRanges = op.getGridRanges();
+    unsigned chipNumCbs = 0;
+    bool foundSystemDesc = false;
+    for (Operation *walk = op->getParentOp(); walk;
+         walk = walk->getParentOp()) {
+      if (auto mod = dyn_cast<mlir::ModuleOp>(walk)) {
+        if (auto systemDesc = mod->getAttrOfType<ttcore::SystemDescAttr>(
+                ttcore::SystemDescAttr::name)) {
+          chipNumCbs = systemDesc.getChipDesc(0).getNumCBs();
+          foundSystemDesc = true;
+          break;
+        }
+      }
+    }
+    if (!foundSystemDesc) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "missing ttcore.system_desc on an enclosing module for spatial CB "
+          "port remap");
+    }
+
     SpatialRemapTable remapTable;
     SmallVector<Value> mergedCbs;
     SmallVector<int64_t> mergedCbPorts;
@@ -527,7 +551,15 @@ public:
 
       const size_t mergedCbSlotBase = mergedCbs.size();
       llvm::append_range(mergedCbs, enqueueProgram.getCbs());
-      llvm::append_range(mergedCbPorts, enqueueProgram.getCbPorts());
+      for (int64_t ignored : enqueueProgram.getCbPorts()) {
+        (void)ignored;
+        if (mergedCbPorts.size() >= chipNumCbs) {
+          return rewriter.notifyMatchFailure(
+              op,
+              "merged spatial enqueue_program cb_ports exceed chip num_cbs");
+        }
+        mergedCbPorts.push_back(static_cast<int64_t>(mergedCbPorts.size()));
+      }
       for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
         mergedKernelConfigs.push_back(
             remapKernelConfig(kernelConfig, spatialMetalRange, enqueueProgram,

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -716,7 +716,6 @@ private:
                    SmallVector<Operation *> &postEnqueueOps,
                    ttmetal::EnqueueProgramOp &regionEnqueueProgram) {
     Block &block = region.front();
-    bool seenEnqueue = false;
     unsigned enqueueCount = 0;
 
     for (Operation &innerOperation : block) {
@@ -731,11 +730,10 @@ private:
           return failure();
         }
         regionEnqueueProgram = enqueueProgram;
-        seenEnqueue = true;
         continue;
       }
 
-      if (!seenEnqueue) {
+      if (enqueueCount == 0) {
         preEnqueueOps.push_back(&innerOperation);
       } else {
         postEnqueueOps.push_back(&innerOperation);

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Conversion/D2MToTTMetal/D2MToTTMetal.h"
 
+#include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
@@ -201,21 +202,27 @@ private:
   ttmetal::MathFidelity mathFidelity_;
 };
 
-// CoreRange from d2m.generic grid: project the full virtual bbox through
-// virt_to_physical when the grid map is usable; otherwise
-// getPhysicalCoreRange(getPhysicalGridShape()).
+// CoreRange from d2m.generic grid: when virt_to_physical is present, project
+// the virtual bounding box through it (rank must match map dims; 2 or 3
+// results). When the map is empty, skip that projection and return the core
+// range implied by the op's physical grid alone.
 CoreRangeAttr D2MGenericRewriter::coreRangeAttrFromOp(Builder &builder,
                                                       d2m::GenericOp op) {
   MLIRContext *ctx = builder.getContext();
   ttcore::GridAttr grid = op.getGrid();
   AffineMap virtToPhysMap = grid.getVirtToPhysicalMap();
   ArrayRef<int64_t> gridShape = grid.getShape();
-  if (virtToPhysMap.isEmpty() || gridShape.size() != 2 ||
-      virtToPhysMap.getNumDims() != 2 ||
-      (virtToPhysMap.getNumResults() != 2 &&
-       virtToPhysMap.getNumResults() != 3)) {
+  if (virtToPhysMap.isEmpty()) {
     return CoreRangeAttr::getPhysicalCoreRange(ctx, op.getPhysicalGridShape());
   }
+
+  TT_assertv(gridShape.size() == virtToPhysMap.getNumDims(),
+             "virt_to_physical num dims {} must match grid rank {}",
+             virtToPhysMap.getNumDims(), gridShape.size());
+  TT_assertv((virtToPhysMap.getNumResults() == 2u ||
+              virtToPhysMap.getNumResults() == 3u),
+             "virt_to_physical must have 2 or 3 results (got {})",
+             virtToPhysMap.getNumResults());
 
   if (virtToPhysMap.getNumResults() == 3) {
     virtToPhysMap = virtToPhysMap.getSubMap({1, 2});

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -474,11 +474,11 @@ public:
 
 /// Second-phase lowering for d2m.spatial:
 /// - Merge all nested ttmetal.enqueue_program ops into one enqueue_program.
-/// - Keep cb_ports unchanged (concatenated per region). CB hardware ids are
-/// per-core; spatial regions use disjoint core ranges, so CBPort kernel-arg
-/// indices are not shifted across regions.
-/// - Remap enqueue args indices in kernel args when args lists are
-/// concatenated.
+/// - Concatenate per-region `cbs` / `cb_ports`. Hardware port ids may repeat
+/// across disjoint spatial regions.
+/// - Remap kernel-arg indices for merged enqueue: BufferAddress,
+/// GlobalSemaphore, and CBPort. Runtime resolves CBPort by indexing the merged
+/// `cbs` list, then reads that entry's hardware port.
 class SpatialOpRewriter : public OpConversionPattern<d2m::SpatialOp> {
 public:
   using OpConversionPattern<d2m::SpatialOp>::OpConversionPattern;
@@ -518,11 +518,13 @@ public:
       regionEnqueues.push_back(enqueueProgram);
       remapTable.addEnqueueArgs(enqueueProgram);
 
+      const size_t mergedCbSlotBase = mergedCbs.size();
       llvm::append_range(mergedCbs, enqueueProgram.getCbs());
       llvm::append_range(mergedCbPorts, enqueueProgram.getCbPorts());
       for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
-        mergedKernelConfigs.push_back(remapKernelConfig(
-            kernelConfig, spatialMetalRange, enqueueProgram, remapTable));
+        mergedKernelConfigs.push_back(
+            remapKernelConfig(kernelConfig, spatialMetalRange, enqueueProgram,
+                              remapTable, mergedCbSlotBase));
       }
 
       auto enqueueFabricConfig = enqueueProgram.getFabricConnectionConfigAttr();
@@ -620,7 +622,8 @@ private:
 
   static KernelArgAttr remapKernelArg(Builder &builder, KernelArgAttr kernelArg,
                                       ttmetal::EnqueueProgramOp enqueueProgram,
-                                      const SpatialRemapTable &remapTable) {
+                                      const SpatialRemapTable &remapTable,
+                                      size_t mergedCbSlotBase) {
     size_t operandIndex = kernelArg.getOperandIndex();
     if (kernelArg.getType() == ttkernel::ArgType::BufferAddress) {
       if (auto unified = remapTable.lookupIO(enqueueProgram, operandIndex)) {
@@ -631,6 +634,8 @@ private:
               remapTable.lookupGlobalSemaphore(enqueueProgram, operandIndex)) {
         operandIndex = *unified;
       }
+    } else if (kernelArg.getType() == ttkernel::ArgType::CBPort) {
+      operandIndex += mergedCbSlotBase;
     }
     return builder.getAttr<KernelArgAttr>(kernelArg.getType(), operandIndex);
   }
@@ -638,19 +643,21 @@ private:
   static KernelArgsAttr
   remapKernelArgs(Builder &builder, KernelArgsAttr kernelArgs,
                   ttmetal::EnqueueProgramOp enqueueProgram,
-                  const SpatialRemapTable &remapTable) {
+                  const SpatialRemapTable &remapTable,
+                  size_t mergedCbSlotBase) {
     SmallVector<KernelArgAttr> remappedRuntimeArgs;
     SmallVector<KernelArgAttr> remappedCompileTimeArgs;
     remappedRuntimeArgs.reserve(kernelArgs.getRtArgs().size());
     remappedCompileTimeArgs.reserve(kernelArgs.getCtArgs().size());
 
     for (KernelArgAttr runtimeArg : kernelArgs.getRtArgs()) {
-      remappedRuntimeArgs.push_back(
-          remapKernelArg(builder, runtimeArg, enqueueProgram, remapTable));
+      remappedRuntimeArgs.push_back(remapKernelArg(
+          builder, runtimeArg, enqueueProgram, remapTable, mergedCbSlotBase));
     }
     for (KernelArgAttr compileTimeArg : kernelArgs.getCtArgs()) {
       remappedCompileTimeArgs.push_back(
-          remapKernelArg(builder, compileTimeArg, enqueueProgram, remapTable));
+          remapKernelArg(builder, compileTimeArg, enqueueProgram, remapTable,
+                         mergedCbSlotBase));
     }
 
     return builder.getAttr<KernelArgsAttr>(remappedRuntimeArgs,
@@ -660,7 +667,8 @@ private:
   static Attribute remapKernelConfig(Attribute kernelConfig,
                                      CoreRangeAttr spatialCoreRange,
                                      ttmetal::EnqueueProgramOp enqueueProgram,
-                                     const SpatialRemapTable &remapTable) {
+                                     const SpatialRemapTable &remapTable,
+                                     size_t mergedCbSlotBase) {
     Builder builder(kernelConfig.getContext());
     return TypeSwitch<Attribute, Attribute>(kernelConfig)
         .Case<ComputeConfigAttr>([&](ComputeConfigAttr computeConfig) {
@@ -668,7 +676,7 @@ private:
               computeConfig.getContext(), computeConfig.getKernelSymbol(),
               spatialCoreRange,
               remapKernelArgs(builder, computeConfig.getKernelArgs(),
-                              enqueueProgram, remapTable),
+                              enqueueProgram, remapTable, mergedCbSlotBase),
               computeConfig.getMathFidelity(), computeConfig.getFp32DestAccEn(),
               computeConfig.getDstFullSyncEn(),
               computeConfig.getMathApproxMode(),
@@ -679,7 +687,7 @@ private:
               nocConfig.getContext(), nocConfig.getKernelSymbol(),
               spatialCoreRange,
               remapKernelArgs(builder, nocConfig.getKernelArgs(),
-                              enqueueProgram, remapTable),
+                              enqueueProgram, remapTable, mergedCbSlotBase),
               nocConfig.getNocIndex());
         })
         .Case<EthernetConfigAttr>([&](EthernetConfigAttr ethernetConfig) {
@@ -687,7 +695,7 @@ private:
               ethernetConfig.getContext(), ethernetConfig.getKernelSymbol(),
               spatialCoreRange,
               remapKernelArgs(builder, ethernetConfig.getKernelArgs(),
-                              enqueueProgram, remapTable),
+                              enqueueProgram, remapTable, mergedCbSlotBase),
               ethernetConfig.getEthType(), ethernetConfig.getNocIndex());
         })
         .Default([](Attribute) -> Attribute {

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -231,9 +231,13 @@ CoreRangeAttr D2MGenericRewriter::coreRangeAttrFromOp(Builder &builder,
     virtToPhysMap = virtToPhysMap.getSubMap({1, 2});
   }
 
+  llvm::SmallVector<int64_t> start(gridShape.size(), 0);
+  llvm::SmallVector<int64_t> end;
+  for (auto dim : gridShape) {
+    end.push_back(dim - 1);
+  }
   d2m::utils::BoundingBox physBox = d2m::utils::getProjectedBoundingBox(
-      d2m::utils::BoundingBox{{0, 0}, {gridShape[0] - 1, gridShape[1] - 1}},
-      virtToPhysMap);
+      d2m::utils::BoundingBox{start, end}, virtToPhysMap);
 
   const int64_t y0 = physBox.start[0];
   const int64_t x0 = physBox.start[1];

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -196,51 +196,39 @@ public:
   };
 
 private:
-  /// From the op's grid: virt_to_physical over the virtual grid bbox when
-  /// present (2D); else offset (0,0) with extent from getPhysicalGridShape().
   static CoreRangeAttr coreRangeAttrFromOp(Builder &builder, d2m::GenericOp op);
 
   ttmetal::MathFidelity mathFidelity_;
 };
 
+// CoreRange from d2m.generic grid: project the full virtual bbox through
+// virt_to_physical when the grid map is usable; otherwise
+// getPhysicalCoreRange(getPhysicalGridShape()).
 CoreRangeAttr D2MGenericRewriter::coreRangeAttrFromOp(Builder &builder,
                                                       d2m::GenericOp op) {
   MLIRContext *ctx = builder.getContext();
-  SmallVector<int64_t> physicalGridShape = op.getPhysicalGridShape();
   ttcore::GridAttr grid = op.getGrid();
   AffineMap v2p = grid.getVirtToPhysicalMap();
-  if (v2p.isEmpty() || grid.getShape().size() != 2 || v2p.getNumDims() != 2) {
-    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
+  ArrayRef<int64_t> vshape = grid.getShape();
+  const unsigned n = v2p.getNumResults();
+  if (v2p.isEmpty() || vshape.size() != 2 || v2p.getNumDims() != 2 ||
+      (n != 2 && n != 3)) {
+    return CoreRangeAttr::getPhysicalCoreRange(ctx, op.getPhysicalGridShape());
   }
 
-  unsigned numRes = v2p.getNumResults();
-  unsigned yIdx;
-  unsigned xIdx;
-  if (numRes == 3) {
-    yIdx = 1;
-    xIdx = 2;
-  } else if (numRes == 2) {
-    yIdx = 0;
-    xIdx = 1;
-  } else {
-    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
+  if (n == 3) {
+    v2p = v2p.getSubMap({1, 2});
   }
 
-  d2m::utils::BoundingBox virtBox;
-  virtBox.start = {0, 0};
-  virtBox.end = {grid.getShape()[0] - 1, grid.getShape()[1] - 1};
-  d2m::utils::BoundingBox physBox =
-      d2m::utils::getProjectedBoundingBox(virtBox, v2p);
-  if (physBox.start.size() <= xIdx) {
-    return CoreRangeAttr::getPhysicalCoreRange(ctx, physicalGridShape);
-  }
+  d2m::utils::BoundingBox physBox = d2m::utils::getProjectedBoundingBox(
+      d2m::utils::BoundingBox{{0, 0}, {vshape[0] - 1, vshape[1] - 1}}, v2p);
 
-  int64_t y0 = physBox.start[yIdx];
-  int64_t x0 = physBox.start[xIdx];
-  int64_t y1 = physBox.end[yIdx];
-  int64_t x1 = physBox.end[xIdx];
-  SmallVector<int64_t> offset = {y0, x0};
-  SmallVector<int64_t> size = {y1 - y0 + 1, x1 - x0 + 1};
+  const int64_t y0 = physBox.start[0];
+  const int64_t x0 = physBox.start[1];
+  const int64_t y1 = physBox.end[0];
+  const int64_t x1 = physBox.end[1];
+  int64_t offset[] = {y0, x0};
+  int64_t size[] = {y1 - y0 + 1, x1 - x0 + 1};
   return CoreRangeAttr::get(ctx, offset, size);
 }
 

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -493,10 +494,9 @@ public:
   using OpConversionPattern<d2m::SpatialOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(d2m::SpatialOp op, d2m::SpatialOp::Adaptor adaptor,
+  matchAndRewrite(d2m::SpatialOp op,
+                  [[maybe_unused]] d2m::SpatialOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    (void)adaptor;
-
     if (op.getNumResults() != 0) {
       return rewriter.notifyMatchFailure(
           op, "SpatialOp with results is not supported in TTMetal lowering");
@@ -517,13 +517,13 @@ public:
           mlir::cast<ttcore::CoreRangeAttr>(gridRanges.getValue()[regionIndex]);
       CoreRangeAttr spatialMetalRange =
           ttCoreSpatialRangeToTtmetalCoreRange(rewriter, spatialCoreRange);
-      ttmetal::EnqueueProgramOp enqueueProgram = nullptr;
-      LogicalResult collectResult = collectRegionOps(
-          region, preEnqueueOps, postEnqueueOps, enqueueProgram);
-      if (failed(collectResult)) {
+      FailureOr<ttmetal::EnqueueProgramOp> maybeEnqueue =
+          collectRegionOps(region, preEnqueueOps, postEnqueueOps);
+      if (failed(maybeEnqueue)) {
         return rewriter.notifyMatchFailure(
             op, "each spatial region must contain exactly one enqueue_program");
       }
+      ttmetal::EnqueueProgramOp enqueueProgram = *maybeEnqueue;
       regionEnqueues.push_back(enqueueProgram);
       remapTable.addEnqueueArgs(enqueueProgram);
 
@@ -720,12 +720,11 @@ private:
            mergedFabricConfig != enqueueFabricConfig;
   }
 
-  static LogicalResult
+  static FailureOr<ttmetal::EnqueueProgramOp>
   collectRegionOps(Region &region, SmallVector<Operation *> &preEnqueueOps,
-                   SmallVector<Operation *> &postEnqueueOps,
-                   ttmetal::EnqueueProgramOp &regionEnqueueProgram) {
+                   SmallVector<Operation *> &postEnqueueOps) {
     Block &block = region.front();
-    unsigned enqueueCount = 0;
+    ttmetal::EnqueueProgramOp onlyEnqueue = nullptr;
 
     for (Operation &innerOperation : block) {
       if (isa<d2m::SpatialYieldOp>(innerOperation)) {
@@ -734,24 +733,23 @@ private:
 
       if (auto enqueueProgram =
               dyn_cast<ttmetal::EnqueueProgramOp>(&innerOperation)) {
-        ++enqueueCount;
-        if (enqueueCount > 1) {
+        if (onlyEnqueue) {
           return failure();
         }
-        regionEnqueueProgram = enqueueProgram;
+        onlyEnqueue = enqueueProgram;
         continue;
       }
 
-      if (enqueueCount == 0) {
+      if (!onlyEnqueue) {
         preEnqueueOps.push_back(&innerOperation);
       } else {
         postEnqueueOps.push_back(&innerOperation);
       }
     }
-    if (enqueueCount != 1) {
+    if (!onlyEnqueue) {
       return failure();
     }
-    return success();
+    return onlyEnqueue;
   }
 
   static CoreRangeAttr

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -504,7 +504,6 @@ public:
 
     ArrayAttr gridRanges = op.getGridRanges();
     SpatialRemapTable remapTable;
-    SmallVector<ttmetal::EnqueueProgramOp> regionEnqueues;
     SmallVector<Value> mergedCbs;
     SmallVector<int64_t> mergedCbPorts;
     SmallVector<Attribute> mergedKernelConfigs;
@@ -524,7 +523,6 @@ public:
             op, "each spatial region must contain exactly one enqueue_program");
       }
       ttmetal::EnqueueProgramOp enqueueProgram = *maybeEnqueue;
-      regionEnqueues.push_back(enqueueProgram);
       remapTable.addEnqueueArgs(enqueueProgram);
 
       const size_t mergedCbSlotBase = mergedCbs.size();
@@ -562,10 +560,6 @@ public:
 
     for (Operation *operation : postEnqueueOps) {
       rewriter.moveOpBefore(operation, op);
-    }
-
-    for (ttmetal::EnqueueProgramOp enqueueProgram : regionEnqueues) {
-      rewriter.eraseOp(enqueueProgram);
     }
 
     rewriter.eraseOp(op);

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -208,20 +208,22 @@ CoreRangeAttr D2MGenericRewriter::coreRangeAttrFromOp(Builder &builder,
                                                       d2m::GenericOp op) {
   MLIRContext *ctx = builder.getContext();
   ttcore::GridAttr grid = op.getGrid();
-  AffineMap v2p = grid.getVirtToPhysicalMap();
-  ArrayRef<int64_t> vshape = grid.getShape();
-  const unsigned n = v2p.getNumResults();
-  if (v2p.isEmpty() || vshape.size() != 2 || v2p.getNumDims() != 2 ||
-      (n != 2 && n != 3)) {
+  AffineMap virtToPhysMap = grid.getVirtToPhysicalMap();
+  ArrayRef<int64_t> gridShape = grid.getShape();
+  if (virtToPhysMap.isEmpty() || gridShape.size() != 2 ||
+      virtToPhysMap.getNumDims() != 2 ||
+      (virtToPhysMap.getNumResults() != 2 &&
+       virtToPhysMap.getNumResults() != 3)) {
     return CoreRangeAttr::getPhysicalCoreRange(ctx, op.getPhysicalGridShape());
   }
 
-  if (n == 3) {
-    v2p = v2p.getSubMap({1, 2});
+  if (virtToPhysMap.getNumResults() == 3) {
+    virtToPhysMap = virtToPhysMap.getSubMap({1, 2});
   }
 
   d2m::utils::BoundingBox physBox = d2m::utils::getProjectedBoundingBox(
-      d2m::utils::BoundingBox{{0, 0}, {vshape[0] - 1, vshape[1] - 1}}, v2p);
+      d2m::utils::BoundingBox{{0, 0}, {gridShape[0] - 1, gridShape[1] - 1}},
+      virtToPhysMap);
 
   const int64_t y0 = physBox.start[0];
   const int64_t x0 = physBox.start[1];

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
@@ -109,7 +109,7 @@ struct ConvertD2MToTTMetal
     targetForSpatial.addIllegalOp<d2m::SpatialOp>();
 
     RewritePatternSet spatialPatterns(&getContext());
-    populateSpatialOpPatterns(&getContext(), spatialPatterns);
+    populateD2MToTTMetalSpatialOpPattern(&getContext(), spatialPatterns);
     if (failed(applyFullConversion(getOperation(), targetForSpatial,
                                    std::move(spatialPatterns)))) {
       signalPassFailure();

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
@@ -77,6 +77,11 @@ struct ConvertD2MToTTMetal
   }
 
   void runOnOperation() final {
+    // Lower D2M in two greedy full-conversion passes. SpatialOp must stay legal
+    // in the first pass so nested D2M can become ttmetal (including one
+    // enqueue_program per spatial region); SpatialOpRewriter in the second pass
+    // merges those enqueue_program ops and then erases the spatial wrapper.
+
     ConversionTarget target(getContext());
     addD2MToTTMetalConversionTargetBase(target);
     target.addLegalOp<d2m::SpatialOp>();
@@ -93,6 +98,11 @@ struct ConvertD2MToTTMetal
       signalPassFailure();
       return;
     }
+
+    // Second pass: only SpatialOp is rewritten here
+    // (populateSpatialOpPatterns). Other D2M uses were eliminated in the first
+    // pass; this target still treats the dialect as illegal so any leftover
+    // non-spatial D2M would fail the pass.
 
     ConversionTarget targetForSpatial(getContext());
     addD2MToTTMetalConversionTargetBase(targetForSpatial);

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetalPass.cpp
@@ -36,6 +36,31 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+/// Shared legality for convert-d2m-to-ttmetal. Does not register d2m.spatial;
+/// callers add SpatialOp as legal (phase 1) or illegal (phase 2).
+static void addD2MToTTMetalConversionTargetBase(ConversionTarget &target) {
+  target.addLegalDialect<BuiltinDialect>();
+  target.addLegalDialect<arith::ArithDialect>();
+  target.addLegalDialect<func::FuncDialect>();
+  target.addLegalDialect<memref::MemRefDialect>();
+  target.addLegalDialect<ttmetal::TTMetalDialect>();
+  target.addLegalDialect<ttkernel::TTKernelDialect>();
+  target.addLegalDialect<ttcore::TTCoreDialect>();
+  target.addLegalDialect<scf::SCFDialect>();
+  target.addLegalDialect<emitc::EmitCDialect>();
+  target.addIllegalDialect<math::MathDialect>();
+  target.addIllegalDialect<d2m::D2MDialect>();
+
+  target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
+    return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
+        op.getMemref().getType().getMemorySpace());
+  });
+  target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
+    return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
+        op.getMemref().getType().getMemorySpace());
+  });
+}
+
 struct ConvertD2MToTTMetal
     : public d2m::impl::ConvertD2MToTTMetalBase<ConvertD2MToTTMetal> {
 
@@ -52,27 +77,9 @@ struct ConvertD2MToTTMetal
   }
 
   void runOnOperation() final {
-    mlir::ConversionTarget target(getContext());
-    target.addLegalDialect<BuiltinDialect>();
-    target.addLegalDialect<arith::ArithDialect>();
-    target.addLegalDialect<func::FuncDialect>();
-    target.addLegalDialect<memref::MemRefDialect>();
-    target.addLegalDialect<ttmetal::TTMetalDialect>();
-    target.addLegalDialect<ttkernel::TTKernelDialect>();
-    target.addLegalDialect<ttcore::TTCoreDialect>();
-    target.addLegalDialect<scf::SCFDialect>();
-    target.addLegalDialect<emitc::EmitCDialect>();
-    target.addIllegalDialect<math::MathDialect>();
-    target.addIllegalDialect<d2m::D2MDialect>();
-
-    target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
-      return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
-          op.getMemref().getType().getMemorySpace());
-    });
-    target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
-      return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
-          op.getMemref().getType().getMemorySpace());
-    });
+    ConversionTarget target(getContext());
+    addD2MToTTMetalConversionTargetBase(target);
+    target.addLegalOp<d2m::SpatialOp>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
@@ -85,6 +92,17 @@ struct ConvertD2MToTTMetal
             applyFullConversion(getOperation(), target, std::move(patterns)))) {
       signalPassFailure();
       return;
+    }
+
+    ConversionTarget targetForSpatial(getContext());
+    addD2MToTTMetalConversionTargetBase(targetForSpatial);
+    targetForSpatial.addIllegalOp<d2m::SpatialOp>();
+
+    RewritePatternSet spatialPatterns(&getContext());
+    populateSpatialOpPatterns(&getContext(), spatialPatterns);
+    if (failed(applyFullConversion(getOperation(), targetForSpatial,
+                                   std::move(spatialPatterns)))) {
+      signalPassFailure();
     }
   }
 };

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -7,8 +7,8 @@
 // 2) Per-region core ranges are preserved in merged kernel configs.
 // 3) Index-based kernel args (global_semaphore operand index) are remapped
 //    when args from multiple enqueues are concatenated.
-// 4) CBPort indices and cb_ports hardware ids are per-core; disjoint spatial
-//    regions keep local 0,1,... CBPort args (cb_ports arrays concatenate).
+// 4) CBPort operand_idx remaps into the merged `cbs` list per region; hardware
+//    cb_ports values still concatenate per region (may repeat across cores).
 
 // Single-region merge smoke test.
 #l1 = #ttcore.memory_space<l1>
@@ -49,8 +49,8 @@ module {
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
   // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, noc0>
   // CHECK-SAME: #ttmetal.compute_config<@cp_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, hifi4, true, false, false, [default]>
-  // CHECK-SAME: #ttmetal.noc_config<@dm_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[5]>]>, noc0>
-  // CHECK-SAME: #ttmetal.compute_config<@cp_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[5]>]>, hifi4, true, false, false, [default]>]
+  // CHECK-SAME: #ttmetal.noc_config<@dm_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <global_semaphore[5]>]>, noc0>
+  // CHECK-SAME: #ttmetal.compute_config<@cp_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>, <global_semaphore[5]>]>, hifi4, true, false, false, [default]>]
   // CHECK-NOT: d2m.spatial
   func.func @spatial_two_regions_global_semaphore_remap(
       %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
@@ -110,7 +110,7 @@ module {
   // CHECK-LABEL: func.func @spatial_two_regions_buffer_address_remap
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
   // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[0]>] ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
-  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[2]>] ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>]
+  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[2]>] ct_args = [<cb_port[2]>, <cb_port[3]>]>, noc0>]
   // CHECK-NOT: d2m.spatial
   func.func @spatial_two_regions_buffer_address_remap(
       %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
@@ -154,7 +154,7 @@ module {
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
   // CHECK: cb_ports = array<i64: 0, 1, 0, 1>
   // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_cbport_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
-  // CHECK-SAME: #ttmetal.noc_config<@dm_cbport_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>]
+  // CHECK-SAME: #ttmetal.noc_config<@dm_cbport_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>]>, noc0>]
   // CHECK: operandSegmentSizes = array<i32: 4, 4>
   // CHECK-NOT: @dm_cbport_r1{{.*}}cb_port[0]
   // CHECK-NOT: d2m.spatial

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -7,6 +7,8 @@
 // 2) Per-region core ranges are preserved in merged kernel configs.
 // 3) Index-based kernel args (global_semaphore operand index) are remapped
 //    when args from multiple enqueues are concatenated.
+// 4) CBPort indices and cb_ports hardware ids are per-core; disjoint spatial
+//    regions keep local 0,1,... CBPort args (cb_ports arrays concatenate).
 
 // Single-region merge smoke test.
 #l1 = #ttcore.memory_space<l1>
@@ -137,6 +139,52 @@ module {
     return
   }
   func.func private @dm_b1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+}
+
+// -----
+
+// Two-region CBPort index remap: second region kernels must reference merged
+// cbs slots [2,3], not [0,1]. Hardware cb_ports ids stay 0,1 per region.
+#l1 = #ttcore.memory_space<l1>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_two_regions_cb_port_remap
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK: cb_ports = array<i64: 0, 1, 0, 1>
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_cbport_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_cbport_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>]
+  // CHECK: operandSegmentSizes = array<i32: 4, 4>
+  // CHECK-NOT: @dm_cbport_r1{{.*}}cb_port[0]
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_two_regions_cb_port_remap(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+      %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+          memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1300} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2300} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_cbport_r0, noc = 0>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_cbport_r1, noc = 0>]}
+            ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      }
+    return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_cbport_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @dm_cbport_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     return
   }
 }

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -1,0 +1,142 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --convert-d2m-to-ttkernel --convert-d2m-to-ttmetal -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Spatial lowering regression test for D2M -> TTMetal.
+// This test validates:
+// 1) Two nested region programs are merged into one ttmetal.enqueue_program.
+// 2) Per-region core ranges are preserved in merged kernel configs.
+// 3) Index-based kernel args (global_semaphore operand index) are remapped
+//    when args from multiple enqueues are concatenated.
+
+// Single-region merge smoke test.
+#l1 = #ttcore.memory_space<l1>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_single_region_merge
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_single_region_merge(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1> {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1100} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>]}
+        ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_single, noc = 0>, #d2m.thread<compute, @cp_single>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+    }
+    return %out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_single() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_single() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+}
+
+// -----
+
+#l1 = #ttcore.memory_space<l1>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_two_regions_global_semaphore_remap
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, noc0>
+  // CHECK-SAME: #ttmetal.compute_config<@cp_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[2]>]>, hifi4, true, false, false, [default]>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[5]>]>, noc0>
+  // CHECK-SAME: #ttmetal.compute_config<@cp_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <global_semaphore[5]>]>, hifi4, true, false, false, [default]>]
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_two_regions_global_semaphore_remap(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+      %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+          memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2000} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %sem_backing0 = memref.alloc() {alignment = 16 : i64, address = 0x3000} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
+    %sem_backing1 = memref.alloc() {alignment = 16 : i64, address = 0x3010} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
+    %sem0 = d2m.create_global_semaphore(%sem_backing0) {value = 0 : ui32} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1> -> !d2m.global_semaphore
+    %sem1 = d2m.create_global_semaphore(%sem_backing1) {value = 0 : ui32} : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1> -> !d2m.global_semaphore
+
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r0, noc = 0>, #d2m.thread<compute, @cp_r0>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%sem0 : !d2m.global_semaphore)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_r1, noc = 0>, #d2m.thread<compute, @cp_r1>]}
+            ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            additionalArgs(%sem1 : !d2m.global_semaphore)
+      }
+
+    d2m.reset_global_semaphore(%sem0) {value = 0 : ui32} : !d2m.global_semaphore
+    d2m.reset_global_semaphore(%sem1) {value = 0 : ui32} : !d2m.global_semaphore
+    memref.dealloc %sem_backing1 : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
+    memref.dealloc %sem_backing0 : memref<8x8x1x1xui32, #ttcore.shard<4x4, 1>, #l1>
+    return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_r0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+  func.func private @dm_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @cp_r1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = global_semaphore, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    return
+  }
+}
+
+// -----
+
+// Two-region BufferAddress argsOffset remap test.
+#l1 = #ttcore.memory_space<l1>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_two_regions_buffer_address_remap
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_b0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[0]>] ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
+  // CHECK-SAME: #ttmetal.noc_config<@dm_b1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args<rt_args = [<buffer_address[2]>] ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>]
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_two_regions_buffer_address_remap(
+      %arg0: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+      %arg1: memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      -> (memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>,
+          memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1200} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2200} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_b0, noc = 0>]}
+            ins(%arg0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_b1, noc = 0>]}
+            ins(%arg1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>)
+      }
+    return %out0, %out1 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1>
+  }
+
+  func.func private @dm_b0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+  func.func private @dm_b1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec<rt_args = [<arg_type = buffer_address, operand_index = 0>] ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+}

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_lowering.mlir
@@ -8,7 +8,8 @@
 // 3) Index-based kernel args (global_semaphore operand index) are remapped
 //    when args from multiple enqueues are concatenated.
 // 4) CBPort operand_idx remaps into the merged `cbs` list per region; hardware
-//    cb_ports values still concatenate per region (may repeat across cores).
+//    cb_ports are reassigned to sequential globally unique ids (temporary
+//    workaround for spatial merge).
 
 // Single-region merge smoke test.
 #l1 = #ttcore.memory_space<l1>
@@ -146,13 +147,13 @@ module {
 // -----
 
 // Two-region CBPort index remap: second region kernels must reference merged
-// cbs slots [2,3], not [0,1]. Hardware cb_ports ids stay 0,1 per region.
+// cbs slots [2,3], not [0,1]. Hardware cb_ports are 0,1,2,3 after merge remap.
 #l1 = #ttcore.memory_space<l1>
 module {
   ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
   // CHECK-LABEL: func.func @spatial_two_regions_cb_port_remap
   // CHECK-COUNT-1: "ttmetal.enqueue_program"
-  // CHECK: cb_ports = array<i64: 0, 1, 0, 1>
+  // CHECK: cb_ports = array<i64: 0, 1, 2, 3>
   // CHECK: kernelConfigs = [#ttmetal.noc_config<@dm_cbport_r0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>
   // CHECK-SAME: #ttmetal.noc_config<@dm_cbport_r1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[3]>]>, noc0>]
   // CHECK: operandSegmentSizes = array<i32: 4, 4>

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_matmul.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_matmul.mlir
@@ -1,10 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-// TTMetal spatial smoke: two regions, two matmuls (mirrors Silicon/TTNN/n150/spatial/spatial_multi_matmul.mlir).
-// IR derived from builder-generated D2M (d2m.to_layout / d2m.spatial); see builder_generated_irs/two_matmuls_basic_multi.mlir.
-
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_matmul.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_matmul.mlir
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TTMetal spatial smoke: two regions, two matmuls (mirrors Silicon/TTNN/n150/spatial/spatial_multi_matmul.mlir).
+// IR derived from builder-generated D2M (d2m.to_layout / d2m.spatial); see builder_generated_irs/two_matmuls_basic_multi.mlir.
+
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+// CHECK-LABEL: func.func @multi_matmul
+// CHECK: "ttmetal.enqueue_program"
+
+#layout = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout1 = #ttcore.metal_layout<logical_shape = 128x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout2 = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1) -> (0, d0, d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+#map3 = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map5 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#reduction = #ttcore.iterator_type<reduction>
+module {
+  func.func @multi_matmul(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>) -> (tensor<64x64xbf16>, tensor<64x64xbf16>) attributes {tt.function_type = "forward_device"} {
+    %0 = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %1 = d2m.to_layout %arg0, %0 : tensor<64x128xbf16> into tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %view = d2m.view_layout %1 remapping = #map : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %3 = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %4 = d2m.to_layout %arg1, %3 : tensor<128x64xbf16> into tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %view_0 = d2m.view_layout %4 remapping = #map : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %6 = d2m.empty() {virtualGridForwardMapping = #map2, virtualGridInverseMapping = #map3} : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %7 = d2m.to_layout %arg0, %6 : tensor<64x128xbf16> into tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %view_1 = d2m.view_layout %7 remapping = #map : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %9 = d2m.empty() {virtualGridForwardMapping = #map2, virtualGridInverseMapping = #map3} : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %10 = d2m.to_layout %arg1, %9 : tensor<128x64xbf16> into tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %view_2 = d2m.view_layout %10 remapping = #map : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %12 = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %view_3 = d2m.view_layout %12 remapping = #map : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %14 = d2m.empty() {virtualGridForwardMapping = #map2, virtualGridInverseMapping = #map3} : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %view_4 = d2m.view_layout %14 remapping = #map : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %16:2 = d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%view, %view_0, %view_1, %view_2 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>, tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>)
+        outs(%view_3, %view_4 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>, tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>) {
+      %21 = d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map4, #map5, #map6], iterator_types = [#parallel, #parallel, #reduction], threads = [#d2m.thread<unified>]}
+          ins(%view, %view_0 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>)
+          outs(%view_3 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>) {
+        %block0 = d2m.block_index(0) : index
+        %block1 = d2m.block_index(1) : index
+        %block2 = d2m.block_index(2) : index
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %22 = tensor.empty() : tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %23 = d2m.remote_load %22 %view[%block0, %block2] mcast[%c0] : tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %24 = tensor.empty() : tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %25 = d2m.remote_load %24 %view_0[%block2, %block1] mcast[%c1] : tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %26 = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
+        "d2m.tile_matmul_block"(%23, %25, %26) : (tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bf16>>) -> ()
+        %27 = d2m.remote_store %view_3[%block0, %block1] %26 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>, tensor<2x2x!ttcore.tile<32x32, bf16>> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+        d2m.yield %27 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+      } : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+      d2m.spatial_yield %21 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+    }, {
+      %21 = d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map4, #map5, #map6], iterator_types = [#parallel, #parallel, #reduction], threads = [#d2m.thread<unified>]}
+          ins(%view_1, %view_2 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>)
+          outs(%view_4 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>) {
+        %block0 = d2m.block_index(0) : index
+        %block1 = d2m.block_index(1) : index
+        %block2 = d2m.block_index(2) : index
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %22 = tensor.empty() : tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %23 = d2m.remote_load %22 %view_1[%block0, %block2] mcast[%c0] : tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %24 = tensor.empty() : tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %25 = d2m.remote_load %24 %view_2[%block2, %block1] mcast[%c1] : tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %26 = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
+        "d2m.tile_matmul_block"(%23, %25, %26) : (tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bf16>>) -> ()
+        %27 = d2m.remote_store %view_4[%block0, %block1] %26 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>, tensor<2x2x!ttcore.tile<32x32, bf16>> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+        d2m.yield %27 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+      } : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+      d2m.spatial_yield %21 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+    } : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>, tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %17 = d2m.empty() : tensor<64x64xbf16>
+    %18 = d2m.to_layout %16#0, %17 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> into tensor<64x64xbf16> -> tensor<64x64xbf16>
+    %19 = d2m.empty() : tensor<64x64xbf16>
+    %20 = d2m.to_layout %16#1, %19 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> into tensor<64x64xbf16> -> tensor<64x64xbf16>
+    return %18, %20 : tensor<64x64xbf16>, tensor<64x64xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_tanh_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_tanh_exp.mlir
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TTMetal spatial smoke: two regions, tanh then exp (mirrors
+// Silicon/TTNN/n150/spatial/spatial_multi_tanh_exp.mlir).
+// 32x32 bf16, 1x1x1x1 tiles; core ranges (0,0)-(0,0) and (1,1)-(1,1).
+// Input/output tiling matches spatial_metal_multi_matmul.mlir: per-region
+// d2m.empty with VGM plus d2m.to_layout for shared %arg0.
+
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+// CHECK-LABEL: func.func @multi_tanh_exp
+// CHECK: "ttmetal.enqueue_program"
+
+#layout = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1) -> (0, d0, d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+#map3 = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#map4 = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+module {
+  func.func @multi_tanh_exp(%arg0: tensor<32x32xbf16>) -> (tensor<32x32xbf16>, tensor<32x32xbf16>) attributes {tt.function_type = "forward_device"} {
+    %0 = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %1 = d2m.to_layout %arg0, %0 : tensor<32x32xbf16> into tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_in_0 = d2m.view_layout %1 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %2 = d2m.empty() {virtualGridForwardMapping = #map2, virtualGridInverseMapping = #map3} : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %3 = d2m.to_layout %arg0, %2 : tensor<32x32xbf16> into tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_in_1 = d2m.view_layout %3 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %o0 = d2m.empty() {virtualGridForwardMapping = #map, virtualGridInverseMapping = #map1} : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_out0 = d2m.view_layout %o0 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %o1 = d2m.empty() {virtualGridForwardMapping = #map2, virtualGridInverseMapping = #map3} : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_out1 = d2m.view_layout %o1 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %r:2 = d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%view_in_0, %view_in_1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+        outs(%view_out0, %view_out1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>) {
+      ^region0():
+        %g0 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map4, #map4], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+            ins(%view_in_0 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+            outs(%view_out0 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>) {
+          %block0 = d2m.block_index(0) : index
+          %block1 = d2m.block_index(1) : index
+          %t0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ld = d2m.remote_load %t0 %view_in_0[%block0, %block1] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %t1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ev = linalg.generic {indexing_maps = [#map4, #map4], iterator_types = ["parallel", "parallel"]} ins(%ld : tensor<1x1x!ttcore.tile<32x32, bf16>>) outs(%t1 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+          ^bb0(%in: !ttcore.tile<32x32, bf16>, %out: !ttcore.tile<32x32, bf16>):
+            %t = "d2m.tile_tanh"(%in) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+            linalg.yield %t : !ttcore.tile<32x32, bf16>
+          } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %b0 = d2m.block_index(0) : index
+          %b1 = d2m.block_index(1) : index
+          %st = d2m.remote_store %view_out0[%b0, %b1] %ev : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+          d2m.yield %st : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+        } : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+        d2m.spatial_yield %g0 : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+    }, {
+      ^region1():
+        %g1 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map4, #map4], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+            ins(%view_in_1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+            outs(%view_out1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>) {
+          %block0 = d2m.block_index(0) : index
+          %block1 = d2m.block_index(1) : index
+          %t0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ld = d2m.remote_load %t0 %view_in_1[%block0, %block1] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %t1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ev = linalg.generic {indexing_maps = [#map4, #map4], iterator_types = ["parallel", "parallel"]} ins(%ld : tensor<1x1x!ttcore.tile<32x32, bf16>>) outs(%t1 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+          ^bb0(%in: !ttcore.tile<32x32, bf16>, %out: !ttcore.tile<32x32, bf16>):
+            %e = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+            linalg.yield %e : !ttcore.tile<32x32, bf16>
+          } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %b0 = d2m.block_index(0) : index
+          %b1 = d2m.block_index(1) : index
+          %st = d2m.remote_store %view_out1[%b0, %b1] %ev : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+          d2m.yield %st : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+        } : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+        d2m.spatial_yield %g1 : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+    } : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %e0 = d2m.empty() : tensor<32x32xbf16>
+    %e1 = d2m.empty() : tensor<32x32xbf16>
+    %out0 = d2m.to_layout %r#0, %e0 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> into tensor<32x32xbf16> -> tensor<32x32xbf16>
+    %out1 = d2m.to_layout %r#1, %e1 : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> into tensor<32x32xbf16> -> tensor<32x32xbf16>
+    return %out0, %out1 : tensor<32x32xbf16>, tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_tanh_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_multi_tanh_exp.mlir
@@ -1,13 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-// TTMetal spatial smoke: two regions, tanh then exp (mirrors
-// Silicon/TTNN/n150/spatial/spatial_multi_tanh_exp.mlir).
-// 32x32 bf16, 1x1x1x1 tiles; core ranges (0,0)-(0,0) and (1,1)-(1,1).
-// Input/output tiling matches spatial_metal_multi_matmul.mlir: per-region
-// d2m.empty with VGM plus d2m.to_layout for shared %arg0.
-
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_exp.mlir
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TTMetal spatial smoke: single region elementwise exp (mirrors
+// Silicon/TTNN/n150/spatial/spatial_single_exp.mlir structure).
+// Uses 32x32 bf16 and a 1x1x1x1 tile grid (TTMetal path); TTNN uses 64x128 dram tiles.
+
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+// CHECK-LABEL: func.func @single_exp
+// CHECK: "ttmetal.enqueue_program"
+
+#layout = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+module {
+  func.func @single_exp(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> attributes {tt.function_type = "forward_device"} {
+    %0 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %1 = d2m.to_layout %arg0, %0 : tensor<32x32xbf16> into tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_in = d2m.view_layout %1 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %3 = d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %view_out = d2m.view_layout %3 remapping = #map : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %result_reg_0_metal = d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>]}
+        ins(%view_in : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+        outs(%view_out : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>) {
+      ^region0():
+        %result_reg_0 = d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map2, #map2], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
+            ins(%view_in : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+            outs(%view_out : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>) {
+          %block0 = d2m.block_index(0) : index
+          %block1 = d2m.block_index(1) : index
+          %t0 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ld = d2m.remote_load %t0 %view_in[%block0, %block1] : tensor<1x1x!ttcore.tile<32x32, bf16>>, tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %t1 = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %ev = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%ld : tensor<1x1x!ttcore.tile<32x32, bf16>>) outs(%t1 : tensor<1x1x!ttcore.tile<32x32, bf16>>) {
+          ^bb0(%in: !ttcore.tile<32x32, bf16>, %out: !ttcore.tile<32x32, bf16>):
+            %e = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+            linalg.yield %e : !ttcore.tile<32x32, bf16>
+          } -> tensor<1x1x!ttcore.tile<32x32, bf16>>
+          %b0 = d2m.block_index(0) : index
+          %b1 = d2m.block_index(1) : index
+          %st = d2m.remote_store %view_out[%b0, %b1] %ev : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x!ttcore.tile<32x32, bf16>> -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+          d2m.yield %st : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+        } : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+        d2m.spatial_yield %result_reg_0 : (tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>)
+    } : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout>
+    %empty_ret = d2m.empty() : tensor<32x32xbf16>
+    %ret = d2m.to_layout %result_reg_0_metal, %empty_ret : tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layout> into tensor<32x32xbf16> -> tensor<32x32xbf16>
+    return %ret : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_exp.mlir
@@ -1,11 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-// TTMetal spatial smoke: single region elementwise exp (mirrors
-// Silicon/TTNN/n150/spatial/spatial_single_exp.mlir structure).
-// Uses 32x32 bf16 and a 1x1x1x1 tile grid (TTMetal path); TTNN uses 64x128 dram tiles.
-
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_matmul_offset.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_matmul_offset.mlir
@@ -1,12 +1,3 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-// TTMetal spatial smoke: single region matmul (same operand shapes as
-// Silicon/TTNN/n150/spatial/spatial_single_matmul_offset.mlir).
-// Uses core_range<(0,0),(0,0)> so the lowered generic grid fits the region;
-// TTNN pins a different worker core via mesh layout on tensors.
-
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir

--- a/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_matmul_offset.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/spatial/spatial_metal_single_matmul_offset.mlir
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TTMetal spatial smoke: single region matmul (same operand shapes as
+// Silicon/TTNN/n150/spatial/spatial_single_matmul_offset.mlir).
+// Uses core_range<(0,0),(0,0)> so the lowered generic grid fits the region;
+// TTNN pins a different worker core via mesh layout on tensors.
+
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path% ttnn-mode=false" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer -o %t.ttm %t.mlir
+
+// CHECK-LABEL: func.func @single_matmul_offset
+// CHECK: "ttmetal.enqueue_program"
+
+#layout = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout1 = #ttcore.metal_layout<logical_shape = 128x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout2 = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map6 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map7 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#reduction = #ttcore.iterator_type<reduction>
+module {
+  func.func @single_matmul_offset(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>) -> tensor<64x64xbf16> attributes {tt.function_type = "forward_device"} {
+    %0 = d2m.empty() : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %1 = d2m.to_layout %arg0, %0 : tensor<64x128xbf16> into tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %view = d2m.view_layout %1 remapping = #map2 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>
+    %3 = d2m.empty() : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %4 = d2m.to_layout %arg1, %3 : tensor<128x64xbf16> into tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %view_0 = d2m.view_layout %4 remapping = #map2 : tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>
+    %12 = d2m.empty() : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %view_3 = d2m.view_layout %12 remapping = #map2 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %result_reg_0_metal = d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>]}
+        ins(%view, %view_0 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>)
+        outs(%view_3 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>) {
+      ^region_0:
+      %21 = d2m.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map5, #map6, #map7], iterator_types = [#parallel, #parallel, #reduction], threads = [#d2m.thread<unified>]}
+          ins(%view, %view_0 : tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1>)
+          outs(%view_3 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>) {
+        %block0 = d2m.block_index(0) : index
+        %block1 = d2m.block_index(1) : index
+        %block2 = d2m.block_index(2) : index
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %22 = tensor.empty() : tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %23 = d2m.remote_load %22 %view[%block0, %block2] mcast[%c0] : tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<1x1x2x4x!ttcore.tile<32x32, bf16>, #layout> -> tensor<2x4x!ttcore.tile<32x32, bf16>>
+        %24 = tensor.empty() : tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %25 = d2m.remote_load %24 %view_0[%block2, %block1] mcast[%c1] : tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<1x1x4x2x!ttcore.tile<32x32, bf16>, #layout1> -> tensor<4x2x!ttcore.tile<32x32, bf16>>
+        %26 = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, bf16>>
+        "d2m.tile_matmul_block"(%23, %25, %26) : (tensor<2x4x!ttcore.tile<32x32, bf16>>, tensor<4x2x!ttcore.tile<32x32, bf16>>, tensor<2x2x!ttcore.tile<32x32, bf16>>) -> ()
+        %27 = d2m.remote_store %view_3[%block0, %block1] %26 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>, tensor<2x2x!ttcore.tile<32x32, bf16>> -> tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+        d2m.yield %27 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+      } : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+      d2m.spatial_yield %21 : (tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>)
+    } : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2>
+    %17 = d2m.empty() : tensor<64x64xbf16>
+    %18 = d2m.to_layout %result_reg_0_metal, %17 : tensor<1x1x2x2x!ttcore.tile<32x32, bf16>, #layout2> into tensor<64x64xbf16> -> tensor<64x64xbf16>
+    return %18 : tensor<64x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
closes #7674 

### Problem description
`d2m.spatial` was only really supported on the TTNN path, so IR with spatial ops did not compile cleanly on TTMetal without ttnn-mode=true. 

### What's changed
1. convert-d2m-to-ttmetal
The pass now lowers `d2m.spatial` on the TTMetal path. It runs in two steps: first it lowers everything inside the spatial op (while the spatial op itself is still allowed), then it runs a second step that removes the spatial op and turns it into `ttmetal.enqueue_program`. When several regions are merged, kernel argument indices (for example global_semaphore) are updated so they still point at the right operands.


### Checklist
- [x] New/Existing tests provide coverage for changes
