### PR TITLE
Add MoeGPTDecodeOp for GPT-OSS fused decode composite legalization

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6021,6 +6021,37 @@ def TTIR_TopKRouterGptOp : TTIR_NamedOp<"topk_router_gpt"> {
   let hasVerifier = 1;
 }
 
+def TTIR_MoeGPTDecodeOp : TTIR_NamedOp<"moe_gpt_decode"> {
+    let summary = "GPT-OSS fused decode composite placeholder.";
+    let description = [{
+      Placeholder TTIR op for the frontend GPT-OSS decode composite. This op
+      carries the decode routing and expert tensors through composite
+      legalization, while the StableHLO decomposition remains available for
+      sharding propagation before legalization.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$hidden_states,
+                         AnyRankedTensor:$topk_indices,
+                         AnyRankedTensor:$topk_scores,
+                         AnyRankedTensor:$dispatch_mapping,
+                         AnyRankedTensor:$moe_gpt_mapping,
+                         AnyRankedTensor:$gate_up_proj,
+                         AnyRankedTensor:$gate_up_proj_bias,
+                         AnyRankedTensor:$down_proj,
+                         AnyRankedTensor:$down_proj_bias,
+                         I64Attr:$num_devices,
+                         I64Attr:$cluster_axis,
+                         I64Attr:$num_experts,
+                         I64Attr:$num_experts_per_tok,
+                         I64Attr:$intermediate_size,
+                         F32Attr:$alpha,
+                         F32Attr:$limit);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTIR_SparseMatmulOp : TTIR_NamedOp<"sparse_matmul"> {
     let summary = "Sparse block matrix multiplication with sparsity mask.";
     let description = [{

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -723,6 +723,9 @@ void populateStableHLOCompositeLegalizationPatterns(
       context, "tenstorrent.gelu");
   patterns.add<StableHLOToTTIRCompositeOpConversionPattern<ttir::GeluOp>>(
       context, "tenstorrent.gelu_tanh");
+  patterns
+      .add<StableHLOToTTIRCompositeOpConversionPattern<ttir::MoeGPTDecodeOp>>(
+          context, "tenstorrent.moe_gpt_decode");
   patterns.add<TenstorrentRMSNormConversionPattern>(context);
   patterns.add<TenstorrentLayerNormConversionPattern>(context);
   patterns.add<TenstorrentGroupNormConversionPattern>(context);

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -37,6 +37,17 @@ static constexpr llvm::StringLiteral allToAllCombineTargetName =
 static constexpr llvm::StringLiteral moeExpertTokenRemapTargetName =
     "tt.moe_expert_token_remap";
 
+static constexpr llvm::StringLiteral topkRouterGptTargetName =
+    "tt.topk_router_gpt";
+
+static constexpr llvm::StringLiteral allToAllDispatchMetadataTargetName =
+    "tt.all_to_all_dispatch_metadata";
+
+static constexpr llvm::StringLiteral moeGptTargetName = "tt.moe_gpt";
+
+static constexpr llvm::StringLiteral selectiveReduceCombineTargetName =
+    "tt.selective_reduce_combine";
+
 static mlir::sdy::OpShardingRuleAttr
 getScatterShardingRule(mlir::stablehlo::ScatterOp scatterOp) {
   mlir::Operation::operand_range inputs = scatterOp.getInputs();
@@ -340,6 +351,115 @@ getPagedAttentionShardingRule(mlir::stablehlo::CustomCallOp op) {
   llvm_unreachable("Unexpected target for paged attention sharding rule");
 
   return mlir::sdy::OpShardingRuleAttr();
+}
+
+// Sharding rule for the decode-only GPT-OSS router.
+// hidden_states [B, S, H], router_weight [E, H], router_bias [E]
+//   -> indices [B, S, K], scores [B, S, K]
+static mlir::sdy::OpShardingRuleAttr
+getTopKRouterGPTShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 2 && op.getNumOperands() != 3) {
+    op.getOperation()->emitWarning()
+        << "topk_router_gpt expects 2 or 3 operands, got "
+        << op.getNumOperands();
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto hiddenType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto weightType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  if (!hiddenType || hiddenType.getRank() != 3 || !weightType ||
+      weightType.getRank() != 2) {
+    op.getOperation()->emitWarning()
+        << "topk_router_gpt expects hidden_states [B, S, H] and "
+           "router_weight [E, H]";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  if (op.getNumOperands() == 3) {
+    auto biasType =
+        llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
+    if (!biasType || biasType.getRank() != 1) {
+      op.getOperation()->emitWarning()
+          << "topk_router_gpt bias must be a 1D tensor [E]";
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+  }
+
+  SmallVector<Type> resultTypes;
+  if (op.getNumResults() == 2) {
+    for (auto type : op.getResultTypes()) {
+      resultTypes.push_back(type);
+    }
+  } else if (op.getNumResults() == 1) {
+    auto tupleType = llvm::dyn_cast<mlir::TupleType>(op.getResult(0).getType());
+    if (!tupleType || tupleType.size() != 2) {
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+    for (auto elemType : tupleType.getTypes()) {
+      resultTypes.push_back(elemType);
+    }
+  } else {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto indicesType = llvm::dyn_cast<RankedTensorType>(resultTypes[0]);
+  auto scoresType = llvm::dyn_cast<RankedTensorType>(resultTypes[1]);
+  if (!indicesType || !scoresType || indicesType.getRank() != 3 ||
+      scoresType.getRank() != 3) {
+    op.getOperation()->emitWarning()
+        << "topk_router_gpt results must be [B, S, K]";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t bDim = hiddenType.getShape()[0];
+  int64_t sDim = hiddenType.getShape()[1];
+  int64_t hDim = hiddenType.getShape()[2];
+  int64_t eDim = weightType.getShape()[0];
+  int64_t kDim = indicesType.getShape()[2];
+
+  if (hDim != weightType.getShape()[1]) {
+    op.getOperation()->emitWarning()
+        << "topk_router_gpt hidden_states H (" << hDim
+        << ") does not match router_weight H (" << weightType.getShape()[1]
+        << ")";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  mlir::sdy::OpShardingRuleBuilder builder(op.getOperandTypes(),
+                                           TypeRange(resultTypes),
+                                           op.getContext(), std::nullopt);
+
+  SmallVector<int64_t> bFactor(op.getNumOperands(), mlir::sdy::kNullDim);
+  bFactor[0] = 0;
+  builder.addFactor(bFactor, {0, 0}, bDim, mlir::sdy::FactorType::kPassThrough);
+
+  SmallVector<int64_t> sFactor(op.getNumOperands(), mlir::sdy::kNullDim);
+  sFactor[0] = 1;
+  builder.addFactor(sFactor, {1, 1}, sDim, mlir::sdy::FactorType::kPassThrough);
+
+  SmallVector<int64_t> hFactor(op.getNumOperands(), mlir::sdy::kNullDim);
+  hFactor[0] = 2;
+  hFactor[1] = 1;
+  builder.addFactor(hFactor, {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, hDim,
+                    mlir::sdy::FactorType::kReduction);
+
+  SmallVector<int64_t> eFactor(op.getNumOperands(), mlir::sdy::kNullDim);
+  eFactor[1] = 0;
+  if (op.getNumOperands() == 3) {
+    eFactor[2] = 0;
+  }
+  builder.addFactor(eFactor, {mlir::sdy::kNullDim, mlir::sdy::kNullDim}, eDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  SmallVector<int64_t> kFactor(op.getNumOperands(), mlir::sdy::kNullDim);
+  builder.addFactor(kFactor, {2, 2}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  return builder.build();
 }
 
 // Sharding rule for sparse_matmul used in MoE (Mixture of Experts) models.
@@ -650,6 +770,100 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// all_to_all_dispatch_metadata sharding rule
+// Operands:
+//   [0] input [B, 1, S, H]
+//   [1] indices [B, 1, S, K]
+//   [2] scores [B, 1, S, K]
+//   [3] mapping [1, 1, E, D]
+// Results:
+//   [0] dispatched [1, B*D, S, H]
+//   [1] metadata_indices [1, B*D, S, K]
+//   [2] metadata_scores [1, B*D, S, K]
+static mlir::sdy::OpShardingRuleAttr
+getAllToAllDispatchMetadataShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 4) {
+    op.getOperation()->emitWarning()
+        << "all_to_all_dispatch_metadata expects 4 operands, got "
+        << op.getNumOperands();
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto inputType = llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto indicesType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto scoresType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
+  auto mappingType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(3).getType());
+
+  if (!inputType || inputType.getRank() != 4 || !indicesType ||
+      indicesType.getRank() != 4 || !scoresType || scoresType.getRank() != 4 ||
+      !mappingType || mappingType.getRank() != 4) {
+    op.getOperation()->emitWarning()
+        << "all_to_all_dispatch_metadata expects 4D operands";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  SmallVector<Type> resultTypes;
+  if (op.getNumResults() == 3) {
+    for (auto type : op.getResultTypes()) {
+      resultTypes.push_back(type);
+    }
+  } else if (op.getNumResults() == 1) {
+    auto tupleType = llvm::dyn_cast<mlir::TupleType>(op.getResult(0).getType());
+    if (!tupleType || tupleType.size() != 3) {
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+    for (auto elemType : tupleType.getTypes()) {
+      resultTypes.push_back(elemType);
+    }
+  } else {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t bDim = inputType.getShape()[0];
+  int64_t sDim = inputType.getShape()[2];
+  int64_t hDim = inputType.getShape()[3];
+  int64_t kDim = indicesType.getShape()[3];
+  int64_t eDim = mappingType.getShape()[2];
+  int64_t dDim = mappingType.getShape()[3];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op.getOperandTypes(),
+                                           TypeRange(resultTypes),
+                                           op.getContext(), std::nullopt);
+
+  builder.addFactor(
+      {0, 0, 0, mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, bDim,
+      mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+  builder.addFactor({2, 2, 2, mlir::sdy::kNullDim}, {2, 2, 2}, sDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+  builder.addFactor(
+      {3, mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      {3, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, hDim,
+      mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+  builder.addFactor({mlir::sdy::kNullDim, 3, 3, mlir::sdy::kNullDim},
+                    {mlir::sdy::kNullDim, 3, 3}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 2},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, eDim,
+      mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 3},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, dDim,
+      mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  return builder.build();
+}
+
 // =====================================================================
 // all_to_all_combine sharding rule
 // =====================================================================
@@ -746,6 +960,179 @@ getAllToAllCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
                     {mlir::sdy::kNullDim}, dDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
+
+  return builder.build();
+}
+
+// moe_gpt sharding rule
+// Input:
+//   [0] hidden [1, B*D, S, H]
+//   [1] indices [1, B*D, S, K]
+//   [2] scores [1, B*D, S, K]
+//   [3] mapping [1, 1, E, D]
+//   [4] gate_up_proj [E, H, 2I]
+//   [5] gate_up_bias [E, 2I]
+//   [6] down_proj [E, I, H]
+//   [7] down_proj_bias [E, H]
+// Results:
+//   [0] combine_metadata [1, 1, E, D]           (replicated metadata bundle)
+//   [1] bundled_indices [1, B*D, S, K]          (forwarded to combine)
+//   [2] bundled_scores [1, B*D, S, K]           (forwarded to combine)
+//   [3] auxiliary_scores [1, B*D, S, K]         (placeholder bundle slot)
+//   [4] expert_output [E, S, B*D, H]
+static mlir::sdy::OpShardingRuleAttr
+getMoeGptShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 8) {
+    op.getOperation()->emitWarning() << "moe_gpt expects 8 operands";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto hiddenType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto indicesType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto scoresType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
+  auto mappingType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(3).getType());
+  auto gateUpType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(4).getType());
+  auto gateUpBiasType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(5).getType());
+  auto downType = llvm::dyn_cast<RankedTensorType>(op.getOperand(6).getType());
+  auto downBiasType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(7).getType());
+
+  SmallVector<Type> resultTypes;
+  if (op.getNumResults() == 5) {
+    for (auto type : op.getResultTypes()) {
+      resultTypes.push_back(type);
+    }
+  } else if (op.getNumResults() == 1) {
+    auto tupleType = llvm::dyn_cast<mlir::TupleType>(op.getResult(0).getType());
+    if (!tupleType || tupleType.size() != 5) {
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+    for (auto elemType : tupleType.getTypes()) {
+      resultTypes.push_back(elemType);
+    }
+  } else {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto combineMetadataType = llvm::dyn_cast<RankedTensorType>(resultTypes[0]);
+  auto bundledIndicesType = llvm::dyn_cast<RankedTensorType>(resultTypes[1]);
+  auto bundledScoresType = llvm::dyn_cast<RankedTensorType>(resultTypes[2]);
+  auto auxiliaryScoresType = llvm::dyn_cast<RankedTensorType>(resultTypes[3]);
+  auto expertOutputType = llvm::dyn_cast<RankedTensorType>(resultTypes[4]);
+
+  if (!hiddenType || hiddenType.getRank() != 4 || !indicesType ||
+      indicesType.getRank() != 4 || !scoresType || scoresType.getRank() != 4 ||
+      !mappingType || mappingType.getRank() != 4 || !gateUpType ||
+      gateUpType.getRank() != 3 || !gateUpBiasType ||
+      gateUpBiasType.getRank() != 2 || !downType || downType.getRank() != 3 ||
+      !downBiasType || downBiasType.getRank() != 2 || !combineMetadataType ||
+      combineMetadataType.getRank() != 4 || !bundledIndicesType ||
+      bundledIndicesType.getRank() != 4 || !bundledScoresType ||
+      bundledScoresType.getRank() != 4 || !auxiliaryScoresType ||
+      auxiliaryScoresType.getRank() != 4 || !expertOutputType ||
+      expertOutputType.getRank() != 4) {
+    op.getOperation()->emitWarning() << "moe_gpt expects ranked decode tensors";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t eDim = mappingType.getShape()[2];
+  int64_t bdDim = hiddenType.getShape()[1];
+  int64_t sDim = hiddenType.getShape()[2];
+  int64_t hiddenInputDim = hiddenType.getShape()[3];
+  int64_t kDim = indicesType.getShape()[3];
+  int64_t dDim = mappingType.getShape()[3];
+  int64_t gateIntermediateDim = gateUpType.getShape()[2];
+  int64_t intermediateDim = downType.getShape()[1];
+  int64_t hiddenOutputDim = downType.getShape()[2];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op.getOperandTypes(),
+                                           TypeRange(resultTypes),
+                                           op.getContext(), std::nullopt);
+
+  // Expert sharding propagates through the expert weight tensors into the final
+  // expert-major activation output only. The mapping bundle remains replicated.
+  builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim, 0, 0, 0, 0},
+                    {mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim, 0},
+                    eDim, mlir::sdy::FactorType::kPassThrough);
+
+  builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, 2, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim},
+                    {2, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                    eDim, mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor(
+      {3, mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 1,
+       mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+       mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      hiddenInputDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim, 2, 1},
+                    {mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim, 3},
+                    hiddenOutputDim, mlir::sdy::FactorType::kPassThrough);
+
+  builder.addFactor({1, 1, 1, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim},
+                    {mlir::sdy::kNullDim, 1, 1, 1, 2}, bdDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor({2, 2, 2, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim},
+                    {mlir::sdy::kNullDim, 2, 2, 2, 1}, sDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor({mlir::sdy::kNullDim, 3, 3, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                    {mlir::sdy::kNullDim, 3, 3, 3, mlir::sdy::kNullDim}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, 3, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim},
+                    {3, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                    dDim, mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+       mlir::sdy::kNullDim, 2, 1, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+       mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      gateIntermediateDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+       mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 1,
+       mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+       mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      intermediateDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
 
   return builder.build();
 }
@@ -927,6 +1314,120 @@ getMoeExpertTokenRemapShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// selective_reduce_combine sharding rule
+// Input:
+//   [0] expert_output [E, B*D, S, H] or [E, S, B*D, H]
+//   [1] metadata_indices [1, B*D, S, K]
+//   [2] metadata_scores [1, B*D, S, K]
+//   [3] combine_metadata [1, 1, E, D]
+// Result:
+//   [0] combined [K, B, S, H] or [K, S, B, H]
+static mlir::sdy::OpShardingRuleAttr
+getSelectiveReduceCombineShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 4 || op.getNumResults() != 1) {
+    op.getOperation()->emitWarning()
+        << "selective_reduce_combine expects 4 operands and 1 result";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto expertOutType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto metadataIndicesType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto metadataScoresType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(2).getType());
+  auto combineMetadataType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(3).getType());
+  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+
+  if (!expertOutType || expertOutType.getRank() != 4 || !metadataIndicesType ||
+      metadataIndicesType.getRank() != 4 || !metadataScoresType ||
+      metadataScoresType.getRank() != 4 || !combineMetadataType ||
+      combineMetadataType.getRank() != 4 || !resultType ||
+      resultType.getRank() != 4) {
+    op.getOperation()->emitWarning()
+        << "selective_reduce_combine expects 4D tensors";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  mlir::DictionaryAttr frontendAttrs =
+      mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+          op->getDiscardableAttr("mhlo.frontend_attributes"));
+  int64_t outputShardDim = 2;
+  if (frontendAttrs) {
+    if (auto attr = frontendAttrs.getAs<mlir::StringAttr>("output_shard_dim")) {
+      if (attr.getValue().getAsInteger(10, outputShardDim)) {
+        return mlir::sdy::OpShardingRuleAttr();
+      }
+    }
+  }
+
+  if (outputShardDim != 1 && outputShardDim != 2) {
+    op.getOperation()->emitWarning()
+        << "selective_reduce_combine output_shard_dim must be 1 or 2, got "
+        << outputShardDim;
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  int64_t inputSDim = outputShardDim == 1 ? 2 : 1;
+  int64_t inputBDDim = outputShardDim == 1 ? 1 : 2;
+  int64_t resultSDim = outputShardDim == 1 ? 2 : 1;
+  int64_t resultBDDim = outputShardDim == 1 ? 1 : 2;
+
+  int64_t eDim = expertOutType.getShape()[0];
+  int64_t bdDim = expertOutType.getShape()[inputBDDim];
+  int64_t sDim = expertOutType.getShape()[inputSDim];
+  int64_t hDim = expertOutType.getShape()[3];
+  int64_t kDim = metadataIndicesType.getShape()[3];
+  int64_t dDim = combineMetadataType.getShape()[3];
+  int64_t eTotalDim = combineMetadataType.getShape()[2];
+  int64_t bDim = resultType.getShape()[resultBDDim];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  builder.addFactor(
+      {0, mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim}, eDim, mlir::sdy::FactorType::kPassThrough);
+
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 2},
+      {mlir::sdy::kNullDim}, eTotalDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  builder.addFactor(
+      {3, mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim}, {3},
+      hDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  builder.addFactor({mlir::sdy::kNullDim, 3, 3, mlir::sdy::kNullDim}, {0}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor({inputSDim, 2, 2, mlir::sdy::kNullDim}, {resultSDim}, sDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  // BD (input) and B (result) are different sizes because the CCL combine
+  // reduces BD=B*D → B internally. Keep BD as input-only (replicated) and
+  // add a separate PassThrough factor for the result B dimension so SDY
+  // propagates the batch sharding without inserting an explicit all_slice.
+  builder.addFactor({inputBDDim, 1, 1, mlir::sdy::kNullDim},
+                    {mlir::sdy::kNullDim}, bdDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  builder.addFactor({mlir::sdy::kNullDim, mlir::sdy::kNullDim,
+                     mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+                    {resultBDDim}, bDim, mlir::sdy::FactorType::kPassThrough);
+
+  builder.addFactor(
+      {mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim, 3},
+      {mlir::sdy::kNullDim}, dDim, mlir::sdy::FactorType::kNeedReplication,
+      /*isBlocked=*/true);
+
+  return builder.build();
+}
+
 struct StablehloCustomCallShardingModel
     : public mlir::sdy::ShardingRuleOpInterface::ExternalModel<
           StablehloCustomCallShardingModel, ::mlir::stablehlo::CustomCallOp> {
@@ -967,10 +1468,16 @@ private:
           {pagedSdpaDecodeTargetName, getPagedAttentionShardingRule},
           {pagedUpdateCacheTargetName, getPagedAttentionShardingRule},
           {pagedFillCacheTargetName, getPagedAttentionShardingRule},
+          {topkRouterGptTargetName, getTopKRouterGPTShardingRule},
           {sparseMatmulTargetName, getSparseMatmulShardingRule},
           {allToAllDispatchTargetName, getAllToAllDispatchShardingRule},
+          {allToAllDispatchMetadataTargetName,
+           getAllToAllDispatchMetadataShardingRule},
           {allToAllCombineTargetName, getAllToAllCombineShardingRule},
+          {moeGptTargetName, getMoeGptShardingRule},
           {moeExpertTokenRemapTargetName, getMoeExpertTokenRemapShardingRule},
+          {selectiveReduceCombineTargetName,
+           getSelectiveReduceCombineShardingRule},
       };
 };
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5850,6 +5850,120 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 }
 
 //===----------------------------------------------------------------------===//
+// MoeGPTDecodeOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::MoeGPTDecodeOp::verify() {
+  RankedTensorType hiddenType = getHiddenStates().getType();
+  RankedTensorType indicesType = getTopkIndices().getType();
+  RankedTensorType scoresType = getTopkScores().getType();
+  RankedTensorType dispatchMappingType = getDispatchMapping().getType();
+  RankedTensorType moeGptMappingType = getMoeGptMapping().getType();
+  RankedTensorType gateUpType = getGateUpProj().getType();
+  RankedTensorType gateUpBiasType = getGateUpProjBias().getType();
+  RankedTensorType downType = getDownProj().getType();
+  RankedTensorType downBiasType = getDownProjBias().getType();
+  RankedTensorType resultType = getResult().getType();
+  int64_t numDevices = static_cast<int64_t>(getNumDevices());
+  int64_t clusterAxis = static_cast<int64_t>(getClusterAxis());
+  int64_t numExperts = static_cast<int64_t>(getNumExperts());
+  int64_t numExpertsPerTok = static_cast<int64_t>(getNumExpertsPerTok());
+  int64_t intermediateSize = static_cast<int64_t>(getIntermediateSize());
+
+  if (hiddenType.getRank() != 3) {
+    return emitOpError("hidden_states must be a 3D tensor [B, S, H]");
+  }
+  if (indicesType.getRank() != 3 || scoresType.getRank() != 3) {
+    return emitOpError("topk tensors must be 3D [B, S, K]");
+  }
+  if (dispatchMappingType.getRank() != 4 || moeGptMappingType.getRank() != 4) {
+    return emitOpError(
+        "dispatch_mapping and moe_gpt_mapping must be 4D tensors [1, 1, E, "
+        "D]");
+  }
+  if (dispatchMappingType.getShape()[0] != 1 ||
+      dispatchMappingType.getShape()[1] != 1 ||
+      moeGptMappingType.getShape()[0] != 1 ||
+      moeGptMappingType.getShape()[1] != 1) {
+    return emitOpError(
+        "dispatch_mapping and moe_gpt_mapping leading dimensions must be 1");
+  }
+  if (gateUpType.getRank() != 3 || gateUpBiasType.getRank() != 2) {
+    return emitOpError("gate_up tensors must be [E, H, 2I] and [E, 2I]");
+  }
+  if (downType.getRank() != 3 || downBiasType.getRank() != 2) {
+    return emitOpError("down tensors must be [E, I, H] and [E, H]");
+  }
+  if (resultType.getRank() != 3) {
+    return emitOpError("result must be a 3D tensor [B, S, H]");
+  }
+
+  if (numDevices <= 0) {
+    return emitOpError("num_devices must be positive");
+  }
+  if (clusterAxis < 0 || clusterAxis > 1) {
+    return emitOpError("cluster_axis must be 0 or 1");
+  }
+  if (numExperts <= 0 || numExpertsPerTok <= 0 || intermediateSize <= 0) {
+    return emitOpError("num_experts, num_experts_per_tok, and "
+                       "intermediate_size must be positive");
+  }
+  if (hiddenType.getShape()[1] != 1) {
+    return emitOpError(
+        "moe_gpt_decode currently expects decode inputs with S=1");
+  }
+
+  if (indicesType.getShape() != scoresType.getShape()) {
+    return emitOpError("topk_indices and topk_scores must have the same shape");
+  }
+  if (indicesType.getShape()[0] != hiddenType.getShape()[0] ||
+      indicesType.getShape()[1] != hiddenType.getShape()[1] ||
+      indicesType.getShape()[2] != numExpertsPerTok) {
+    return emitOpError("topk tensors must have shape [B, S, K]");
+  }
+
+  if (dispatchMappingType.getShape() != moeGptMappingType.getShape()) {
+    return emitOpError(
+        "dispatch_mapping and moe_gpt_mapping must have the same shape");
+  }
+  if (dispatchMappingType.getShape()[2] != numExperts ||
+      moeGptMappingType.getShape()[2] != numExperts) {
+    return emitOpError("mapping E dimensions must match num_experts");
+  }
+  if (dispatchMappingType.getShape()[3] != numDevices ||
+      moeGptMappingType.getShape()[3] != numDevices) {
+    return emitOpError("mapping D dimensions must match num_devices");
+  }
+  if (gateUpType.getShape()[0] != numExperts ||
+      gateUpBiasType.getShape()[0] != numExperts ||
+      downType.getShape()[0] != numExperts ||
+      downBiasType.getShape()[0] != numExperts) {
+    return emitOpError("expert parameter tensors must agree on num_experts");
+  }
+
+  int64_t hiddenSize = hiddenType.getShape()[2];
+  if (gateUpType.getShape()[1] != hiddenSize ||
+      downType.getShape()[2] != hiddenSize ||
+      downBiasType.getShape()[1] != hiddenSize) {
+    return emitOpError("hidden dimension must match expert parameter tensors");
+  }
+  if (downType.getShape()[1] != intermediateSize) {
+    return emitOpError(
+        "down_proj intermediate dimension must match intermediate_size");
+  }
+  if (gateUpType.getShape()[2] != intermediateSize * 2 ||
+      gateUpBiasType.getShape()[1] != intermediateSize * 2) {
+    return emitOpError(
+        "gate_up tensors must encode a fused [gate, up] projection");
+  }
+  if (resultType.getShape() != hiddenType.getShape()) {
+    return emitOpError("result must have the same shape as hidden_states");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CumSumOp
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_gpt_oss_decode.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_gpt_oss_decode.mlir
@@ -1,0 +1,31 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --legalize-stablehlo-composite-to-ttir -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module @gpt_oss_decode_composite_tests attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  // CHECK-LABEL: func.func @moe_gpt_decode
+  // CHECK: %[[RESULT:.*]] = "ttir.moe_gpt_decode"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8)
+  // CHECK-SAME: alpha =
+  // CHECK-SAME: cluster_axis = 1 : i64
+  // CHECK-SAME: intermediate_size = 128 : i64
+  // CHECK-SAME: limit =
+  // CHECK-SAME: num_devices = 2 : i64
+  // CHECK-SAME: num_experts = 8 : i64
+  // CHECK-SAME: num_experts_per_tok = 2 : i64
+  func.func @moe_gpt_decode(%arg0: tensor<4x1x128xbf16>, %arg1: tensor<4x1x2xi64>, %arg2: tensor<4x1x2xbf16>, %arg3: tensor<1x1x8x2xi64>, %arg4: tensor<1x1x8x2xi64>, %arg5: tensor<8x128x256xbf16>, %arg6: tensor<8x256xbf16>, %arg7: tensor<8x128x128xbf16>, %arg8: tensor<8x128xbf16>) -> tensor<4x1x128xbf16> {
+    // CHECK: return %[[RESULT]] : tensor<4x1x128xbf16>
+    %0 = stablehlo.composite "tenstorrent.moe_gpt_decode" %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8 {composite_attributes = {num_devices = 2 : i64, cluster_axis = 1 : i64, num_experts = 8 : i64, num_experts_per_tok = 2 : i64, intermediate_size = 128 : i64, alpha = 1.702000e+00 : f32, limit = 5.000000e+00 : f32}, decomposition = @tenstorrent.moe_gpt_decode.impl} : (tensor<4x1x128xbf16>, tensor<4x1x2xi64>, tensor<4x1x2xbf16>, tensor<1x1x8x2xi64>, tensor<1x1x8x2xi64>, tensor<8x128x256xbf16>, tensor<8x256xbf16>, tensor<8x128x128xbf16>, tensor<8x128xbf16>) -> tensor<4x1x128xbf16>
+    return %0 : tensor<4x1x128xbf16>
+  }
+
+  func.func private @tenstorrent.moe_gpt_decode.impl(%arg0: tensor<4x1x128xbf16>, %arg1: tensor<4x1x2xi64>, %arg2: tensor<4x1x2xbf16>, %arg3: tensor<1x1x8x2xi64>, %arg4: tensor<1x1x8x2xi64>, %arg5: tensor<8x128x256xbf16>, %arg6: tensor<8x256xbf16>, %arg7: tensor<8x128x128xbf16>, %arg8: tensor<8x128xbf16>) -> tensor<4x1x128xbf16> {
+    %hidden4d = stablehlo.reshape %arg0 : (tensor<4x1x128xbf16>) -> tensor<4x1x1x128xbf16>
+    %indices4d = stablehlo.reshape %arg1 : (tensor<4x1x2xi64>) -> tensor<4x1x1x2xi64>
+    %scores4d = stablehlo.reshape %arg2 : (tensor<4x1x2xbf16>) -> tensor<4x1x1x2xbf16>
+    %0:3 = stablehlo.custom_call @tt.all_to_all_dispatch_metadata(%hidden4d, %indices4d, %scores4d, %arg3) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2"}} : (tensor<4x1x1x128xbf16>, tensor<4x1x1x2xi64>, tensor<4x1x1x2xbf16>, tensor<1x1x8x2xi64>) -> (tensor<1x8x1x128xbf16>, tensor<1x8x1x2xi64>, tensor<1x8x1x2xbf16>)
+    %1:5 = stablehlo.custom_call @tt.moe_gpt(%0#0, %0#1, %0#2, %arg4, %arg5, %arg6, %arg7, %arg8) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2", num_experts_per_tok = "2"}} : (tensor<1x8x1x128xbf16>, tensor<1x8x1x2xi64>, tensor<1x8x1x2xbf16>, tensor<1x1x8x2xi64>, tensor<8x128x256xbf16>, tensor<8x256xbf16>, tensor<8x128x128xbf16>, tensor<8x128xbf16>) -> (tensor<1x1x8x2xi64>, tensor<1x8x1x2xi64>, tensor<1x8x1x2xbf16>, tensor<1x8x1x2xbf16>, tensor<8x1x8x128xbf16>)
+    %2 = stablehlo.custom_call @tt.selective_reduce_combine(%1#4, %1#1, %1#2, %1#0) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2", num_experts_per_tok = "2", output_shard_dim = "2"}} : (tensor<8x1x8x128xbf16>, tensor<1x8x1x2xi64>, tensor<1x8x1x2xbf16>, tensor<1x1x8x2xi64>) -> tensor<2x1x4x128xbf16>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<4x1x128xbf16>
+    return %cst : tensor<4x1x128xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/gpt_oss_decode_ops.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/gpt_oss_decode_ops.mlir
@@ -1,0 +1,60 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt -split-input-file --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// =====================================================================
+// topk_router_gpt: batch factor is passthrough, so no collectives are needed
+// =====================================================================
+module @TopkRouter_BatchPassthrough attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<4x1x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "hidden"}, %arg1: tensor<8x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "weight"}, %arg2: tensor<8xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "bias"}) -> (tensor<4x1x2xi64>, tensor<4x1x2xbf16>) {
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK-NOT: stablehlo.all_reduce
+    // CHECK: stablehlo.custom_call @tt.topk_router_gpt
+    %0:2 = stablehlo.custom_call @tt.topk_router_gpt(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {k = "2"}} : (tensor<4x1x128xbf16>, tensor<8x128xbf16>, tensor<8xbf16>) -> (tensor<4x1x2xi64>, tensor<4x1x2xbf16>)
+    return %0#0, %0#1 : tensor<4x1x2xi64>, tensor<4x1x2xbf16>
+  }
+}
+
+// -----
+
+// =====================================================================
+// all_to_all_dispatch_metadata: H is blocked, so all_gather is inserted
+// =====================================================================
+module @DispatchMetadata_BlocksH attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2x1x1x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,1,1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "hidden"}, %arg1: tensor<2x1x1x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "indices"}, %arg2: tensor<2x1x1x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "scores"}, %arg3: tensor<1x1x8x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "mapping"}) -> (tensor<1x4x1x128xbf16>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>) {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.all_to_all_dispatch_metadata
+    %0:3 = stablehlo.custom_call @tt.all_to_all_dispatch_metadata(%arg0, %arg1, %arg2, %arg3) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2"}} : (tensor<2x1x1x128xbf16>, tensor<2x1x1x2xi64>, tensor<2x1x1x2xbf16>, tensor<1x1x8x2xi64>) -> (tensor<1x4x1x128xbf16>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x4x1x128xbf16>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>
+  }
+}
+
+// -----
+
+// =====================================================================
+// moe_gpt: hidden input H is blocked, so all_gather is inserted
+// =====================================================================
+module @MoeGpt_BlocksInputH attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x4x1x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {\22_axis_0\22}]>"}, mhlo.sharding = "{devices=[1,1,1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "hidden"}, %arg1: tensor<1x4x1x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "indices"}, %arg2: tensor<1x4x1x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "scores"}, %arg3: tensor<1x1x8x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "mapping"}, %arg4: tensor<8x128x256xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "gate_up"}, %arg5: tensor<8x256xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "gate_up_bias"}, %arg6: tensor<8x128x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "down"}, %arg7: tensor<8x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "down_bias"}) -> tensor<8x1x4x128xbf16> {
+    // CHECK: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.moe_gpt
+    %0:5 = stablehlo.custom_call @tt.moe_gpt(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2", num_experts_per_tok = "2"}} : (tensor<1x4x1x128xbf16>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>, tensor<1x1x8x2xi64>, tensor<8x128x256xbf16>, tensor<8x256xbf16>, tensor<8x128x128xbf16>, tensor<8x128xbf16>) -> (tensor<1x1x8x2xi64>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>, tensor<1x4x1x2xbf16>, tensor<8x1x4x128xbf16>)
+    return %0#4 : tensor<8x1x4x128xbf16>
+  }
+}
+
+// -----
+
+// =====================================================================
+// selective_reduce_combine: E factor is passthrough, so EP sharding propagates
+// =====================================================================
+module @SelectiveReduceCombine_EPPassthrough attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<8x1x4x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}, {}, {}]>"}, mhlo.sharding = "{devices=[2,1,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "expert_output"}, %arg1: tensor<1x4x1x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "metadata_indices"}, %arg2: tensor<1x4x1x2xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "metadata_scores"}, %arg3: tensor<1x1x8x2xi64> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {}, {}, {}]>"}, ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "combine_metadata"}) -> tensor<2x1x2x128xbf16> {
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK-NOT: stablehlo.all_reduce
+    // CHECK: stablehlo.custom_call @tt.selective_reduce_combine
+    %0 = stablehlo.custom_call @tt.selective_reduce_combine(%arg0, %arg1, %arg2, %arg3) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", num_devices = "2", num_experts_per_tok = "2", output_shard_dim = "2"}} : (tensor<8x1x4x128xbf16>, tensor<1x4x1x2xi64>, tensor<1x4x1x2xbf16>, tensor<1x1x8x2xi64>) -> tensor<2x1x2x128xbf16>
+    return %0 : tensor<2x1x2x128xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4166)

### Problem description
The GPT-OSS fused decode pipeline (dispatch_metadata -> moe_gpt ->  selective_reduce_combine) needs a TTIR op and composite legalization path so tt-MLIR can recognize the StableHLO composite emitted by the tt-xla frontend and lower it through the standard TTIR -> TTNN flow.

### What's changed
    - TTIROps.td: Define MoeGPTDecodeOp with 9 tensor operands and 7 attributes (num_devices, cluster_axis, num_experts, etc.)
    - TTIROps.cpp: Add verify() with full shape/attribute validation
    - StableHLOLegalizeCompositePass: Register "tenstorrent.moe_gpt_decode" composite name for automatic legalization
    - RegisterCustomShardingRule: Add sharding propagation rules for the new op and its constituent custom calls (all_to_all_dispatch_metadata,  moe_gpt, selective_reduce_combine)
    - Tests: Add MLIR lit tests for composite legalization and op verification

### Checklist
- [ ] New/Existing tests provide coverage for changes
