### PR TITLE
Fix conv3d opModel

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -5325,7 +5325,7 @@ struct Conv3dSpecs {
   ::ttnn::TensorSpec inputSpec;
   ::ttnn::TensorSpec weightSpec;
   std::optional<::ttnn::TensorSpec> biasSpec;
-  ::ttnn::experimental::prim::Conv3dConfig config;
+  std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
   ::tt::tt_metal::DataType dtype;
   uint32_t outputChannels;
   std::array<uint32_t, 3> kernelSize;
@@ -5376,30 +5376,32 @@ llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
     biasSpec = biasSpecExp.get();
   }
 
-  // Initialize Conv3dConfig with base values
-  ::ttnn::experimental::prim::Conv3dConfig config;
+  std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
 
   // Apply Conv3dConfig overrides if provided
   if (conv3dConfig.has_value()) {
+    config.emplace();
     if (conv3dConfig->getWeightsDtype()) {
-      config.weights_dtype =
+      config->weights_dtype =
           conversion::getDataType(*conv3dConfig->getWeightsDtype());
     }
     if (conv3dConfig->getTOutBlock()) {
-      config.T_out_block = *conv3dConfig->getTOutBlock();
+      config->T_out_block = *conv3dConfig->getTOutBlock();
     }
     if (conv3dConfig->getWOutBlock()) {
-      config.W_out_block = *conv3dConfig->getWOutBlock();
+      config->W_out_block = *conv3dConfig->getWOutBlock();
     }
     if (conv3dConfig->getHOutBlock()) {
-      config.H_out_block = *conv3dConfig->getHOutBlock();
+      config->H_out_block = *conv3dConfig->getHOutBlock();
     }
     if (conv3dConfig->getCOutBlock()) {
-      config.C_out_block = *conv3dConfig->getCOutBlock();
+      config->C_out_block = *conv3dConfig->getCOutBlock();
     }
     if (conv3dConfig->getCInBlock()) {
-      config.C_in_block = *conv3dConfig->getCInBlock();
+      config->C_in_block = *conv3dConfig->getCInBlock();
     }
+    config->compute_with_storage_grid_size =
+        device->compute_with_storage_grid_size();
   }
 
   // Get output dtype in this order: explicit outputDtype → outputLayout →
@@ -5411,9 +5413,6 @@ llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
   if (!dtype) {
     dtype = detail::getNullableDataType(outputLayout);
   }
-
-  config.compute_with_storage_grid_size =
-      device->compute_with_storage_grid_size();
 
   std::optional<::ttnn::DeviceComputeKernelConfig>
       deviceComputeKernelConfigConverted =

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -3119,20 +3119,20 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(std::make_tuple(
         // tt-metal Conv3d expects input in [N, D, H, W, C] format (channels
         // LAST)
-        detail::TestTensor{{1, 5, 10, 10, 3}, // [N, D, H, W, C]
+        detail::TestTensor{{1, 5, 10, 10, 32}, // [N, D, H, W, C]
                            TensorMemoryLayout::Interleaved,
                            BufferType::DRAM},
         // Weight must be 2D: [kD*kH*kW*C_in, C_out] where C_in is input
-        // channels patch_size = 3*3*3*3 = 81, out_channels = 64 (multiple of
+        // channels patch_size = 3*3*3*32 = 864, out_channels = 64 (multiple of
         // 32)
         detail::TestTensor{
-            {81, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
+            {864, 64}, TensorMemoryLayout::Interleaved, BufferType::DRAM},
         // Output dims: D_out=(5-3)/1+1=3, H_out=(10-3)/1+1=8,
         // W_out=(10-3)/1+1=8
         detail::TestTensor{{1, 3, 8, 8, 64}, // [N, D_out, H_out, W_out, C_out]
                            TensorMemoryLayout::Interleaved,
                            BufferType::DRAM},
-        3, 64, 1, 5, 10, 10, llvm::SmallVector<int32_t>{3, 3, 3},
+        32, 64, 1, 5, 10, 10, llvm::SmallVector<int32_t>{3, 3, 3},
         llvm::SmallVector<int32_t>{1, 1, 1},
         llvm::SmallVector<int32_t>{0, 0, 0}, 1, "zeros",
         detail::ExpectedResult{true})));

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2976,10 +2976,10 @@ TEST_F(OpModelBase, conv2dInterfaceComputeKernelConfig) {
 }
 
 TEST_F(OpModelBase, Conv3dInterface) {
-  llvm::SmallVector<int64_t> inputShape = {1, 5, 10, 10, 3}; // [N, D, H, W, C]
+  llvm::SmallVector<int64_t> inputShape = {1, 5, 10, 10, 32}; // [N, D, H, W, C]
   // Weight must be 2D: [kD*kH*kW*C_in/groups, C_out]
-  // patch_size = 3*3*3*3 = 81, out_channels = 64 (multiple of 32)
-  llvm::SmallVector<int64_t> weightShape = {81, 64};
+  // patch_size = 3*3*3*32 = 864, out_channels = 64 (multiple of 32)
+  llvm::SmallVector<int64_t> weightShape = {864, 64};
   // Output dims: D_out=(5-3)/1+1=3, H_out=(10-3)/1+1=8, W_out=(10-3)/1+1=8
   llvm::SmallVector<int64_t> outputShape = {
       1, 3, 8, 8, 64}; // [N, D_out, H_out, W_out, C_out]
@@ -3008,7 +3008,7 @@ TEST_F(OpModelBase, Conv3dInterface) {
       weight,                  // Weight tensor
       nullptr,                 // Bias tensor (optional)
       deviceOp,                // Device operation
-      3,                       // Input channels
+      32,                      // Input channels
       64,                      // Output channels (must be multiple of 32)
       1,                       // Batch size
       5,                       // Input depth


### PR DESCRIPTION
### Problem description
Conv3d config became optional in tt-metal. If no config is passed, no default value is needed. Op model was still creating empty config for conv3d that caused mismatch between actual execution and op model.

### What's changed
Made conv3d config optional in op model.
