### PR TITLE
update cache patter for transformers <= 5.2.0 and > 5.2.0 compat

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5706,11 +5706,12 @@ public:
     RankedTensorType updatesType =
         mlir::cast<RankedTensorType>(updates.getType());
 
-    // If the cachePositions tensor has more than one element we assume it
-    // represents a set of arranged indices (0, cachePositions.size), so we
-    // replace it with FillCacheOp. If the tensor has only one element, we
-    // assume it represents the update index for UpateCacheOp.
-    if (cacheUpdateInputShape[0] != 1) {
+    // If the update seq_len > 1 we use FillCacheOp (prefill). If not, we use
+    // UpdateCacheOp (single-token decode). We use the update tensor's sequence
+    // dim rather than the block arg shape because the block arg may be a scalar
+    // cumulative_length (shape [1]) even when filling multiple positions.
+    int64_t cacheUpdateSeqLen = updatesType.getShape()[2];
+    if (cacheUpdateSeqLen != 1) {
       // Fill cache requires that each batch is filled separately. So, we will
       // insert a FillCacheOp for each batch. This requires slicing out each
       // batch.
@@ -5872,7 +5873,8 @@ private:
       if (!effectively1D) {
         continue;
       }
-      if (ttmlir::utils::volume(argTensorShape) == cacheUpdateSize) {
+      if (ttmlir::utils::volume(argTensorShape) == cacheUpdateSize ||
+          ttmlir::utils::volume(argTensorShape) == 1) {
         // We found the cachePositions input tensor.
         return blockArg;
       }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/kv_cache_fusing.mlir
@@ -46,6 +46,53 @@ module @scatter_fill_cache{
   }
 }
 
+// Test case with a FillCache scatter op pattern where the position input is a
+// scalar cumulative_length (tensor<1xi64>, volume 1) but updates has S>1.
+// This models the transformers >5.2.0 pattern and verifies that fill vs update
+// is decided by the updates tensor seq_len, not the position tensor volume.
+module @scatter_fill_cache_cumulative_length {
+  func.func @fill_cache_cumulative_length(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<1xi64>, %arg2: tensor<1x8x15x128xbf16>) -> tensor<1x8x64x128xbf16> {
+    // CHECK-NOT: ttir.scatter
+    // CHECK-NOT: ttir.update_cache
+    // CHECK: %[[RET:[0-9]+]] = "ttir.fill_cache"(%arg0, %arg2) <{batch_offset = 0 : i32}> : (tensor<1x8x64x128xbf16>, tensor<1x8x15x128xbf16>) -> tensor<1x8x64x128xbf16>
+    // CHECK: return %[[RET]] : tensor<1x8x64x128xbf16>
+
+    %0 = stablehlo.constant() <{value = dense<0> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %1 = stablehlo.constant() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %2 = stablehlo.constant() <{value = dense<0> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %3 = stablehlo.constant() <{value = dense<1> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %4 = stablehlo.constant() <{value = dense<0> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %5 = stablehlo.constant() <{value = dense<1> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %6 = stablehlo.iota dim = 0 : tensor<128xi64>
+    %8 = stablehlo.multiply %6, %5 : tensor<128xi64>
+    %10 = stablehlo.add %8, %4 : tensor<128xi64>
+    %11 = stablehlo.iota dim = 0 : tensor<8xi64>
+    %13 = stablehlo.multiply %11, %3 : tensor<8xi64>
+    %15 = stablehlo.add %13, %2 : tensor<8xi64>
+    %16 = stablehlo.iota dim = 0 : tensor<1xi64>
+    %18 = stablehlo.multiply %16, %1 : tensor<1xi64>
+    %20 = stablehlo.add %18, %0 : tensor<1xi64>
+    %22 = stablehlo.reshape %20 : (tensor<1xi64>) -> tensor<1x1x1x1xi64>
+    %24 = stablehlo.broadcast_in_dim %22, dims = [0, 1, 2, 3] : (tensor<1x1x1x1xi64>) -> tensor<1x8x15x128xi64>
+    %26 = stablehlo.reshape %24 : (tensor<1x8x15x128xi64>) -> tensor<1x8x15x128x1xi64>
+    %28 = stablehlo.reshape %15 : (tensor<8xi64>) -> tensor<1x8x1x1xi64>
+    %30 = stablehlo.broadcast_in_dim %28, dims = [0, 1, 2, 3] : (tensor<1x8x1x1xi64>) -> tensor<1x8x15x128xi64>
+    %32 = stablehlo.reshape %30 : (tensor<1x8x15x128xi64>) -> tensor<1x8x15x128x1xi64>
+    %34 = stablehlo.reshape %arg1 : (tensor<1xi64>) -> tensor<1x1x1x1xi64>
+    %36 = stablehlo.broadcast_in_dim %34, dims = [0, 1, 2, 3] : (tensor<1x1x1x1xi64>) -> tensor<1x8x15x128xi64>
+    %38 = stablehlo.reshape %36 : (tensor<1x8x15x128xi64>) -> tensor<1x8x15x128x1xi64>
+    %40 = stablehlo.reshape %10 : (tensor<128xi64>) -> tensor<1x1x1x128xi64>
+    %42 = stablehlo.broadcast_in_dim %40, dims = [0, 1, 2, 3] : (tensor<1x1x1x128xi64>) -> tensor<1x8x15x128xi64>
+    %44 = stablehlo.reshape %42 : (tensor<1x8x15x128xi64>) -> tensor<1x8x15x128x1xi64>
+    %46 = stablehlo.concatenate %26, %32, %38, %44, dim = 4 : (tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>) -> tensor<1x8x15x128x4xi64>
+    %48 = "stablehlo.scatter"(%arg0, %46, %arg2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [], inserted_window_dims = [0, 1, 2, 3], scatter_dims_to_operand_dims = [0, 1, 2, 3], index_vector_dim = 4>, unique_indices = false}> ({
+    ^bb0(%arg3: tensor<bf16>, %arg4: tensor<bf16>):
+      stablehlo.return %arg4 : tensor<bf16>
+    }) : (tensor<1x8x64x128xbf16>, tensor<1x8x15x128x4xi64>, tensor<1x8x15x128xbf16>) -> tensor<1x8x64x128xbf16>
+    return %48 : tensor<1x8x64x128xbf16>
+  }
+}
+
 // Test case with a UpdateCache scatter op pattern
 module @scatter_update_cache{
   func.func @update_cache(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<1xi64>, %arg2: tensor<1x8x1x128xbf16>) -> tensor<1x8x64x128xbf16> {


### PR DESCRIPTION
### Ticket

### Problem description
transformers<=5.2.0 uses a `cache_positions` tensor to update/fill cache and we use the size of that tensor to determine if the  `stablehlo.scatter` was updating or filling the cache, `if |cache_positions| > 1` that's a fill cache, `if == 1` then it's an update cache. transformers>5.2.0 has deprecated the `cache_position tensor` and now uses a `cummulative_length` tensor that is always of size one (where to start the update/fill) causing the pattern matcher to not convert the scatter op into a fill/update_cache op.

### What's changed
Use the update's seq_len dim instead. If the update's seq_len >= 1 it's a fill_cache and if == 1 then it's a update_cache. This change is compatible with transformers<=5.2.0 and transformers>5.2.0

### Checklist
- [x] New/Existing tests provide coverage for changes
