### PR TITLE
[d2m] tag intermediate scratch allocs with d2m.blocking_maps

### DIFF
--- a/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
+++ b/lib/Dialect/D2M/Transforms/ElementwiseFusion.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/PatternMatch.h"
@@ -542,6 +543,16 @@ static GenericOp createFusedGeneric(OpOperand *fusedOperand, GenericOp producer,
   }
   rewriter.setInsertionPointToEnd(&fusedBlock);
   rewriter.create<YieldOp>(fusedOp.getLoc(), fusedYields);
+
+  // Tag inner linalg.generic ops with their output blocking map so that the
+  // allocator's reblocking can derive the correct shape for intermediate
+  // buffers that have no associated generic operand.
+  for (Operation &op : fusedBlock) {
+    if (auto linalgOp = dyn_cast<linalg::LinalgOp>(&op)) {
+      AffineMap outputMap = linalgOp.getIndexingMapsArray().back();
+      op.setAttr("d2m.blocking_map", AffineMapAttr::get(outputMap));
+    }
+  }
 
   return fusedOp;
 }

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -57,6 +57,31 @@ static bool needsScratch(GenericOp genericOp) {
   return linalgCount > 1;
 }
 
+// Transfer d2m.blocking_map attributes from inner linalg ops (set during
+// elementwise fusion) to their output memref.alloc ops, so that the allocator
+// can read the map directly from the alloc.
+static void transferBlockingMaps(GenericOp genericOp) {
+  if (genericOp.getNumRegions() == 0) {
+    return;
+  }
+  for (Operation &op : genericOp.getRegion(0).front()) {
+    auto linalgOp = dyn_cast<linalg::GenericOp>(&op);
+    if (!linalgOp) {
+      continue;
+    }
+    auto blockingMap = linalgOp->getAttr("d2m.blocking_map");
+    if (!blockingMap) {
+      continue;
+    }
+    for (OpOperand &init : linalgOp.getDpsInitsMutable()) {
+      if (auto allocOp = init.get().getDefiningOp<memref::AllocOp>()) {
+        allocOp->setAttr("d2m.blocking_map", blockingMap);
+      }
+    }
+    linalgOp->removeAttr("d2m.blocking_map");
+  }
+}
+
 // Add a scratch buffer inside a single d2m.generic op's region
 // (post-bufferization). Creates a memref.alloc + scratch_init at the start of
 // the region body.
@@ -124,6 +149,7 @@ class D2MInsertScratchBuffers
         [&](GenericOp genericOp) { genericsToProcess.push_back(genericOp); });
 
     for (GenericOp genericOp : genericsToProcess) {
+      transferBlockingMaps(genericOp);
       addScratchToGeneric(genericOp);
     }
   }

--- a/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
@@ -1,0 +1,62 @@
+// RUN: ttmlir-opt --ttcore-register-device --d2m-insert-scratch-buffers --d2m-generic-apply-interchange --d2m-generate-outer-loops %s | FileCheck %s
+
+#l1 = #ttcore.memory_space<l1>
+#parallel = #ttcore.iterator_type<parallel>
+
+!tile_f32 = !ttcore.tile<32x32, f32>
+!memref_tiled = memref<1x1x4x4x!tile_f32, #ttcore.shard<16384x4096, 1>, #l1>
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// d2m.blocking_map on inner linalg ops (set by elementwise fusion) should
+// transfer to the output memref.alloc in InsertScratchBuffers and survive
+// through ApplyInterchange + GenerateOuterLoops down to the allocator.
+
+// CHECK-LABEL: func.func @blocking_map_transfers_to_alloc
+// CHECK: d2m.generic
+// CHECK: memref.alloc() {alignment = 64 : i64, d2m.blocking_map = #map} : memref<4x4x!ttcore.tile<32x32, f32>>
+func.func @blocking_map_transfers_to_alloc(%arg0: !memref_tiled, %arg1: !memref_tiled) {
+  %out = memref.alloc() : !memref_tiled
+  d2m.generic {
+    block_factors = [1, 1], grid = #ttcore.grid<1x1>,
+    indexing_maps = [#map, #map, #map],
+    iterator_types = [#parallel, #parallel],
+    threads = [#d2m.thread<unified>]
+  }
+  ins(%arg0, %arg1 : !memref_tiled, !memref_tiled)
+  outs(%out : !memref_tiled) {
+  ^unified0:
+    %block0 = d2m.block_index(0) : index
+    %block1 = d2m.block_index(1) : index
+    %e0 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    %e1 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    %intermediate = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]
+    }
+    ins(%e0, %e1 : memref<4x4x!tile_f32>, memref<4x4x!tile_f32>)
+    outs(%intermediate : memref<4x4x!tile_f32>)
+    attrs = {d2m.blocking_map = #map} {
+    ^bb0(%in0: !tile_f32, %in1: !tile_f32, %unused: !tile_f32):
+      %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
+      linalg.yield %s : !tile_f32
+    }
+    %e3 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]
+    }
+    ins(%intermediate, %e0 : memref<4x4x!tile_f32>, memref<4x4x!tile_f32>)
+    outs(%e3 : memref<4x4x!tile_f32>)
+    attrs = {d2m.blocking_map = #map} {
+    ^bb0(%in0: !tile_f32, %in1: !tile_f32, %unused: !tile_f32):
+      %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
+      linalg.yield %s : !tile_f32
+    }
+    %stored = d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+  }
+  return
+}


### PR DESCRIPTION
Tag intermediate `memref.allocs` (not backed by `d2m.generic` operands) within fused `d2m.generics` with an appropriate affine map to assist the Allocator when reblocking.
