### PR TITLE
[EraseInverseOps] Support reshape commute through distributed_rms_norm

### DIFF
--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/RMSNormCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/RMSNormCommutePatterns.cpp
@@ -92,9 +92,177 @@ private:
 } // namespace
 
 template <CommuteDirection commuteDirection>
+class TTIRCommuteReshapeThroughDistributedRMSNorm
+    : public TTIRCommuteOpRewritePattern<ReshapeOp, DistributedRMSNormOp,
+                                         commuteDirection> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ReshapeOp, DistributedRMSNormOp,
+      commuteDirection>::TTIRCommuteOpRewritePattern;
+
+  // Consider the following IR pseudocode:
+  //
+  // %0 = distributed_rms_norm(%input, %weight, %residual) {cluster_axis, eps}
+  // %1 = reshape(%0) <{shape = [...]}>
+  //
+  // This method will transform this into:
+  //
+  // %a = reshape(%input) <{shape = [...]}>
+  // %b = reshape(%residual) <{shape = [...]}>   (only if residual is present)
+  // %c = distributed_rms_norm(%a, %weight, %b) {cluster_axis, eps}
+  //
+  // The reshape is moved above distributed_rms_norm. Weight is shaped by the
+  // normalized (last) dimension and is not reshaped. The residual must track
+  // the input shape, so it is reshaped alongside. The key constraint is that
+  // the last dimension (normalization dimension) must remain unchanged by the
+  // reshape.
+  void performCommuteUpwardsRewrite(DistributedRMSNormOp op,
+                                    ReshapeOp reshapeUser,
+                                    PatternRewriter &rewriter) const override {
+    auto inputType = cast<RankedTensorType>(op.getInput().getType());
+    auto outputReshapeType = cast<RankedTensorType>(reshapeUser.getType());
+    ArrayRef<int64_t> newShape = outputReshapeType.getShape();
+    SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
+
+    auto newInputType = RankedTensorType::get(
+        newShape, inputType.getElementType(), inputType.getEncoding());
+    auto newInputReshape = rewriter.create<ReshapeOp>(
+        op.getLoc(), newInputType, op.getInput(),
+        rewriter.getI32ArrayAttr(newShapeI32));
+
+    Value newResidual = nullptr;
+    if (op.getResidual()) {
+      auto residualType = cast<RankedTensorType>(op.getResidual().getType());
+      auto newResidualType = RankedTensorType::get(
+          newShape, residualType.getElementType(), residualType.getEncoding());
+      newResidual = rewriter.create<ReshapeOp>(
+          op.getLoc(), newResidualType, op.getResidual(),
+          rewriter.getI32ArrayAttr(newShapeI32));
+    }
+
+    auto newDistributedRmsNorm = rewriter.create<DistributedRMSNormOp>(
+        op.getLoc(), outputReshapeType, newInputReshape.getResult(),
+        op.getWeight(), newResidual, op.getClusterAxisAttr(),
+        op.getEpsilonAttr());
+
+    // All users must be identical TMs. We must not reference `reshapeUser`
+    // during/after replacements, as it will be erased on its turn.
+    SmallVector<Operation *> users(op->getUsers());
+    assert(llvm::all_of(users,
+                        [&](Operation *user) {
+                          return checkIdenticalTms(reshapeUser, user);
+                        }) &&
+           "isCommuteUpwardsViable/Favorable should have ensured all users "
+           "are identical TMs");
+
+    for (auto *user : users) {
+      rewriter.replaceOp(user, newDistributedRmsNorm.getResult());
+    }
+  }
+
+  // Consider the following IR pseudocode:
+  //
+  // %a = reshape(%orig_input) <{shape = [...]}>
+  // %0 = distributed_rms_norm(%a, %weight, %residual) {cluster_axis, eps}
+  //
+  // This method will transform this into:
+  //
+  // %r = reshape(%residual) <{shape = inverse}>  (only if residual is present)
+  // %0 = distributed_rms_norm(%orig_input, %weight, %r) {cluster_axis, eps}
+  // %1 = reshape(%0) <{shape = [...]}>
+  //
+  // The reshape on the input operand is moved below distributed_rms_norm. The
+  // last dimension (normalization dim) must be preserved by the reshape. The
+  // residual, if present, is reshaped inversely so it continues to match the
+  // input shape fed to distributed_rms_norm.
+  void
+  performCommuteDownwardsRewrite(DistributedRMSNormOp op,
+                                 ReshapeOp reshapeOperand,
+                                 PatternRewriter &rewriter) const override {
+    auto origInput = reshapeOperand.getInput();
+    auto origInputType = cast<RankedTensorType>(origInput.getType());
+    ArrayRef<int64_t> origInputShape = origInputType.getShape();
+    SmallVector<int32_t> origInputShapeI32(origInputShape.begin(),
+                                           origInputShape.end());
+
+    Value newResidual = nullptr;
+    if (op.getResidual()) {
+      auto residualType = cast<RankedTensorType>(op.getResidual().getType());
+      auto newResidualType = RankedTensorType::get(
+          origInputShape, residualType.getElementType(),
+          residualType.getEncoding());
+      newResidual = rewriter.create<ReshapeOp>(
+          op.getLoc(), newResidualType, op.getResidual(),
+          rewriter.getI32ArrayAttr(origInputShapeI32));
+    }
+
+    auto newOpType = RankedTensorType::get(origInputShape,
+                                           origInputType.getElementType(),
+                                           origInputType.getEncoding());
+    auto newDistributedRmsNorm = rewriter.create<DistributedRMSNormOp>(
+        op.getLoc(), newOpType, origInput, op.getWeight(), newResidual,
+        op.getClusterAxisAttr(), op.getEpsilonAttr());
+
+    auto originalType = cast<RankedTensorType>(op.getType());
+    ArrayRef<int64_t> originalShape = originalType.getShape();
+    SmallVector<int32_t> reshapeTargetShape(originalShape.begin(),
+                                            originalShape.end());
+    auto newReshape = rewriter.create<ReshapeOp>(
+        reshapeOperand->getLoc(), op.getType(),
+        newDistributedRmsNorm.getResult(),
+        rewriter.getI32ArrayAttr(reshapeTargetShape));
+
+    rewriter.replaceOp(op, newReshape.getResult());
+  }
+
+private:
+  bool
+  isCommuteUpwardsViable(DistributedRMSNormOp op,
+                         ReshapeOp reshapeUser) const override {
+    // Distributed RMSNorm normalizes along the last dim; it must be preserved
+    // by the reshape for the commute to be semantically valid.
+    return utils::preservesDim(reshapeUser, -1);
+  }
+
+  bool
+  isCommuteUpwardsFavorable(DistributedRMSNormOp op,
+                            ReshapeOp reshapeUser) const override {
+    // Favorable if all users are identical reshapes — moving the reshape
+    // above distributed_rms_norm collapses all of them onto the input and may
+    // allow further cancellation via other commute patterns.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+
+  bool
+  isCommuteDownwardsViable(DistributedRMSNormOp op,
+                           ReshapeOp reshapeOperand) const override {
+    // Only commute when the reshape is on the input operand: moving a reshape
+    // that feeds the weight (normalized shape) or residual downwards would
+    // change the semantics.
+    if (op.getInput() != reshapeOperand.getResult()) {
+      return false;
+    }
+    // The last dim (normalization dim) must be preserved across the reshape.
+    return utils::preservesDim(reshapeOperand, -1);
+  }
+
+  bool
+  isCommuteDownwardsFavorable(DistributedRMSNormOp op,
+                              ReshapeOp reshapeOperand) const override {
+    // distributed_rms_norm typically has a single consumer, so commuting a
+    // reshape below it does not duplicate the op — always favorable when
+    // viable.
+    return true;
+  }
+};
+
+template <CommuteDirection commuteDirection>
 void populateRMSNormCommutePatterns(MLIRContext *ctx,
                                     RewritePatternSet &patterns) {
   patterns.add<TTIRCommuteReshapeThroughRMSNorm<commuteDirection>>(ctx);
+  patterns.add<TTIRCommuteReshapeThroughDistributedRMSNorm<commuteDirection>>(
+      ctx);
 }
 
 template void populateRMSNormCommutePatterns<CommuteDirection::UPWARDS>(

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_distributed_rms_norm.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_distributed_rms_norm.mlir
@@ -1,0 +1,44 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=true enable-commute-upwards=false" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+    // Basic case: the input reshape is pushed below distributed_rms_norm, so
+    // distributed_rms_norm runs at the un-reshaped (smaller-rank) shape and an
+    // output reshape is added afterward.
+    func.func @test_reshape_distributed_rms_norm_commute_down(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>) -> tensor<32x1x2048xbf16> {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_commute_down
+        // CHECK: "ttir.distributed_rms_norm"(%arg0, %arg1)
+        // CHECK-SAME: (tensor<32x2048xbf16>, tensor<2048xbf16>) -> tensor<32x2048xbf16>
+        // CHECK: "ttir.reshape"
+        // CHECK-SAME: -> tensor<32x1x2048xbf16>
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>) -> tensor<32x1x2048xbf16>
+        return %1 : tensor<32x1x2048xbf16>
+    }
+
+    // Case with residual: commute down adds an inverse reshape on the residual
+    // so it continues to match the input shape fed to distributed_rms_norm.
+    func.func @test_reshape_distributed_rms_norm_commute_down_with_residual(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>, %arg2: tensor<32x1x2048xbf16>) -> tensor<32x1x2048xbf16> {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_commute_down_with_residual
+        // CHECK: "ttir.reshape"(%arg2)
+        // CHECK-SAME: -> tensor<32x2048xbf16>
+        // CHECK: "ttir.distributed_rms_norm"(%arg0, %arg1, %{{.+}})
+        // CHECK-SAME: -> tensor<32x2048xbf16>
+        // CHECK: "ttir.reshape"
+        // CHECK-SAME: -> tensor<32x1x2048xbf16>
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1, %arg2) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>, tensor<32x1x2048xbf16>) -> tensor<32x1x2048xbf16>
+        return %1 : tensor<32x1x2048xbf16>
+    }
+
+    // Negative case: reshape changes the last dimension. Should NOT commute down
+    // because the normalization dim would change.
+    func.func @test_reshape_distributed_rms_norm_down_last_dim_changes(%arg0: tensor<1x32x64xbf16>, %arg1: tensor<2048xbf16>) -> tensor<1x2048xbf16> {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_down_last_dim_changes
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.distributed_rms_norm"
+        %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 2048 : i32]}> : (tensor<1x32x64xbf16>) -> tensor<1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<1x2048xbf16>, tensor<2048xbf16>) -> tensor<1x2048xbf16>
+        return %1 : tensor<1x2048xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_distributed_rms_norm.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_distributed_rms_norm.mlir
@@ -1,0 +1,72 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=true enable-commute-downwards=false" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+    // Basic case: inverse reshapes around distributed_rms_norm are eliminated.
+    // reshape(32x2048 -> 32x1x2048) -> distributed_rms_norm -> reshape(32x1x2048 -> 32x2048)
+    // The reshape pair should be folded away.
+    func.func @test_reshape_distributed_rms_norm_inverse_reshape_upwards(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>) -> tensor<32x2048xbf16> {
+        // CHECK: "ttir.distributed_rms_norm"(%arg0, %arg1)
+        // CHECK-SAME: (tensor<32x2048xbf16>, tensor<2048xbf16>) -> tensor<32x2048xbf16>
+        // CHECK-NOT: "ttir.reshape"
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>) -> tensor<32x1x2048xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16>) -> tensor<32x2048xbf16>
+        return %2 : tensor<32x2048xbf16>
+    }
+
+    // Case with residual: both input and residual must be reshaped when the
+    // reshape commutes above distributed_rms_norm.
+    func.func @test_reshape_distributed_rms_norm_with_residual(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>, %arg2: tensor<32x2048xbf16>) -> tensor<32x2048xbf16> {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_with_residual
+        // CHECK: "ttir.distributed_rms_norm"(%arg0, %arg1, %arg2)
+        // CHECK-SAME: (tensor<32x2048xbf16>, tensor<2048xbf16>, tensor<32x2048xbf16>) -> tensor<32x2048xbf16>
+        // CHECK-NOT: "ttir.reshape"
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.reshape"(%arg2) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %2 = "ttir.distributed_rms_norm"(%0, %arg1, %1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 1>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>, tensor<32x1x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %3 = "ttir.reshape"(%2) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16>) -> tensor<32x2048xbf16>
+        return %3 : tensor<32x2048xbf16>
+    }
+
+    // Case with multiple identical reshape users - all should be replaced.
+    func.func @test_reshape_distributed_rms_norm_multiple_identical_users(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>) -> (tensor<32x2048xbf16>, tensor<32x2048xbf16>) {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_multiple_identical_users
+        // CHECK: "ttir.distributed_rms_norm"(%arg0, %arg1)
+        // CHECK-SAME: (tensor<32x2048xbf16>, tensor<2048xbf16>) -> tensor<32x2048xbf16>
+        // CHECK-NOT: "ttir.reshape"
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>) -> tensor<32x1x2048xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16>) -> tensor<32x2048xbf16>
+        %3 = "ttir.reshape"(%1) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16>) -> tensor<32x2048xbf16>
+        return %2, %3 : tensor<32x2048xbf16>, tensor<32x2048xbf16>
+    }
+
+    // Negative case: reshape changes the last dimension (normalization dim).
+    // Should NOT commute because the last dim is different.
+    func.func @test_reshape_distributed_rms_norm_last_dim_changes(%arg0: tensor<1x32x64xbf16>, %arg1: tensor<2048xbf16>) -> tensor<1x32x64xbf16> {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_last_dim_changes
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.distributed_rms_norm"
+        // CHECK: "ttir.reshape"
+        %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 2048 : i32]}> : (tensor<1x32x64xbf16>) -> tensor<1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<1x2048xbf16>, tensor<2048xbf16>) -> tensor<1x2048xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 64 : i32]}> : (tensor<1x2048xbf16>) -> tensor<1x32x64xbf16>
+        return %2 : tensor<1x32x64xbf16>
+    }
+
+    // Negative case: distributed_rms_norm has a non-reshape user.
+    // Should NOT commute because not all users are identical reshapes.
+    func.func @test_reshape_distributed_rms_norm_non_reshape_user(%arg0: tensor<32x2048xbf16>, %arg1: tensor<2048xbf16>) -> (tensor<32x2048xbf16>, tensor<32x1x2048xbf16>) {
+        // CHECK-LABEL: @test_reshape_distributed_rms_norm_non_reshape_user
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.distributed_rms_norm"
+        // CHECK: "ttir.reshape"
+        // CHECK: "ttir.relu"
+        %0 = "ttir.reshape"(%arg0) <{shape = [32 : i32, 1 : i32, 2048 : i32]}> : (tensor<32x2048xbf16>) -> tensor<32x1x2048xbf16>
+        %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{cluster_axis = 1 : ui32, epsilon = 9.99999974E-6 : f32, operandSegmentSizes = array<i32: 1, 1, 0>}> : (tensor<32x1x2048xbf16>, tensor<2048xbf16>) -> tensor<32x1x2048xbf16>
+        %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 2048 : i32]}> : (tensor<32x1x2048xbf16>) -> tensor<32x2048xbf16>
+        %3 = "ttir.relu"(%1) : (tensor<32x1x2048xbf16>) -> tensor<32x1x2048xbf16>
+        return %2, %3 : tensor<32x2048xbf16>, tensor<32x1x2048xbf16>
+    }
+}


### PR DESCRIPTION
### Ticket
N/A — follow-up to the distributed_rms_norm support landing via #7878

### Problem description
The EraseInverseOps pass has commute patterns for the existing `ttir.rms_norm` op but not for the newer `ttir.distributed_rms_norm`. Once distributed_rms_norm starts appearing in the graph (after the composite-to-distributed fusion in #7878 lands) inverse reshapes around it will stay in place and block downstream cancellation opportunities.

### What's changed
Added a new `TTIRCommuteReshapeThroughDistributedRMSNorm` pattern alongside the existing RMSNorm pattern:

- **Upwards commute**: a reshape user above `distributed_rms_norm` is moved above the op. The last (normalization) dimension must be preserved by the reshape. When `residual` is present (it tracks the input shape), it is reshaped alongside the input so the verifier invariant `residual.shape == input.shape` is kept.
- **Downwards commute**: a reshape on the `input` operand is moved below `distributed_rms_norm`. The last dim must be preserved. If `residual` is present, an inverse reshape is inserted on it so it matches the pre-reshape input shape fed to `distributed_rms_norm`. Reshapes on `weight` or `residual` operands are intentionally not commuted because they would change op semantics.
- Registered the new pattern from `populateRMSNormCommutePatterns` so it is picked up in both upwards and downwards directions.

The existing `ttir.rms_norm` pattern is left unchanged.

### Tests
New FileCheck lit tests covering both directions:
- `test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/commute_reshape_distributed_rms_norm.mlir`
- `test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteDownwards/commute_reshape_distributed_rms_norm.mlir`

Cases include: basic inverse reshape pair, with/without residual, multiple identical reshape users, non-reshape user (negative), last-dim-changing reshape (negative).

### Verified locally
- Incremental build of `MLIRTTIREraseInverseOps` from clean: green.
- Both new lit tests pass locally via `ttmlir-opt` + `FileCheck`.
- End-to-end `test_llama_3_1_70b_tp` (1-layer, bs=32, llmbox 8xWormhole) passes with the change, same PCC (0.9974) as the baseline. Note: `ttir.distributed_rms_norm` does not yet appear in the llama 70b IR on this tt-mlir base because the composite-to-distributed fusion (#7878) is not merged — so this PR is forward-compatible groundwork rather than an observable change in that flow today.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [ ] Depends on #7878 for end-to-end exercise

---

_Note: this draft PR was opened by Claude Code on behalf of @odjuricic as part of an autonomous task._