### PR TITLE
[Optimizer] Fix conv2d shard layout and concat mixed-input handling

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -288,6 +288,11 @@ private:
   bool evictUntil(int64_t pos, const ScheduleData &data,
                   std::function<bool()> shouldStop);
 
+  /// Evict a specific live value: spill to DRAM, update tracker, insert
+  /// reshards for already-processed consumers. Used by evictUntil and by
+  /// sibling-operand eviction paths.
+  void evictValue(Value victim, int64_t pos, const ScheduleData &data);
+
   /// Insert a ToMemoryConfigOp before an already-processed consumer to
   /// convert the DRAM spill output back to the consumer's expected L1 layout.
   void insertReshardForConsumer(Operation *consumer, unsigned operandIdx,

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h
@@ -46,6 +46,11 @@ struct Conv2dRuleBook : OpRuleBook {
   /// Tiebreaker: prefer lower act_block_h_override.
   bool preferCandidate(Operation *op, const BeamCandidate &a,
                        const BeamCandidate &b) const override;
+
+  /// Reject output hints that would mix sharding types with the input.
+  bool isValidOutputHintForInputs(
+      const OpConfig &hint,
+      llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const override;
 };
 
 /// Set L1Full slice config on all Conv2d ops before validation.

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -652,6 +652,53 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
+void L1SpillManagement<MemoryTracker>::evictValue(Value victim, int64_t pos,
+                                                  const ScheduleData &data) {
+  liveValues.erase(victim);
+  Operation *victimOp = victim.getDefiningOp();
+  uint64_t freedBytes = memoryTracker.getTensorSize(victim);
+
+  // Save original L1 layout before spilling.
+  auto tensorType = mlir::cast<RankedTensorType>(victim.getType());
+  TTNNLayoutAttr originalL1Layout =
+      mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "    EVICT: {0} (L1: {1} bytes)", ttmlir::opToString(victimOp),
+               freedBytes);
+  observer_->onEviction(victimOp, pos, freedBytes);
+
+  spillToDram(victim);
+  memoryTracker.removeTensorFromSizes(victim);
+  markEvictedAndRebuild(victim);
+
+  // Insert reshards for already-processed consumers instead of cascade
+  // revalidation. This preserves downstream ops' sharded layouts.
+  if (originalL1Layout.hasL1BufferType()) {
+    for (Operation *consumer : collectDownstreamConsumers(victimOp)) {
+      auto posIt = data.positionMap.find(consumer);
+      if (posIt == data.positionMap.end() || posIt->second >= pos) {
+        continue;
+      }
+      if (!mlir::dyn_cast<OpModel>(consumer)) {
+        continue;
+      }
+      if (isa<ToLayoutOp>(consumer)) {
+        continue;
+      }
+      for (unsigned i = 0; i < consumer->getNumOperands(); ++i) {
+        Value operand = consumer->getOperand(i);
+        Operation *defOp = operand.getDefiningOp();
+        if (isa_and_nonnull<ToMemoryConfigOp>(defOp) &&
+            defOp->getOperand(0) == victim) {
+          insertReshardForConsumer(consumer, i, originalL1Layout);
+        }
+      }
+    }
+  }
+}
+
+template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::evictUntil(
     int64_t pos, const ScheduleData &data, std::function<bool()> shouldStop) {
   while (!shouldStop() && !liveValues.empty()) {
@@ -659,48 +706,7 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
     if (!victim) {
       break;
     }
-
-    Operation *victimOp = victim.getDefiningOp();
-    uint64_t freedBytes = memoryTracker.getTensorSize(victim);
-
-    // Save original L1 layout before spilling.
-    auto tensorType = mlir::cast<RankedTensorType>(victim.getType());
-    TTNNLayoutAttr originalL1Layout =
-        mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
-
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "    EVICT: {0} (L1: {1} bytes)", ttmlir::opToString(victimOp),
-                 freedBytes);
-    observer_->onEviction(victimOp, pos, freedBytes);
-
-    spillToDram(victim);
-    memoryTracker.removeTensorFromSizes(victim);
-    markEvictedAndRebuild(victim);
-
-    // Insert reshards for already-processed consumers instead of cascade
-    // revalidation. This preserves downstream ops' sharded layouts.
-    if (originalL1Layout.hasL1BufferType()) {
-      for (Operation *consumer : collectDownstreamConsumers(victimOp)) {
-        auto posIt = data.positionMap.find(consumer);
-        if (posIt == data.positionMap.end() || posIt->second >= pos) {
-          continue;
-        }
-        if (!mlir::dyn_cast<OpModel>(consumer)) {
-          continue;
-        }
-        if (isa<ToLayoutOp>(consumer)) {
-          continue;
-        }
-        for (unsigned i = 0; i < consumer->getNumOperands(); ++i) {
-          Value operand = consumer->getOperand(i);
-          Operation *defOp = operand.getDefiningOp();
-          if (isa_and_nonnull<ToMemoryConfigOp>(defOp) &&
-              defOp->getOperand(0) == victim) {
-            insertReshardForConsumer(consumer, i, originalL1Layout);
-          }
-        }
-      }
-    }
+    evictValue(victim, pos, data);
   }
   return shouldStop();
 }
@@ -812,6 +818,37 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
     memoryTracker.logState();
     return freshL1;
+  }
+
+  // If validation failed with a backend constraint error (not OOM) after
+  // partial eviction, some ops (e.g. concat) require homogeneous input
+  // layouts and now see a mix of DRAM (spilled) and L1 (still live) inputs.
+  // Spill all remaining L1 operands of the op to DRAM so the op sees
+  // homogeneous DRAM inputs, then fall through to demoteToDram to also
+  // put the output in DRAM. We intentionally do NOT validate with the
+  // original (possibly sharded) output config after sibling spill:
+  // tt-metal concat does not reject interleaved inputs paired with a
+  // sharded output memory config at validation time, but runtime will
+  // crash with a JIT kernel build failure
+  // (https://github.com/tenstorrent/tt-metal/issues/41469). Keeping the
+  // op all-DRAM avoids that runtime bug.
+  if (freshResult.status !=
+      op_constraint_validation::ValidationStatus::OutOfMemoryError) {
+    // Collect L1 operands that need spilling (can't mutate liveValues
+    // while iterating op operands via liveSet).
+    llvm::SmallVector<Value> toEvict;
+    for (Value operand : op->getOperands()) {
+      if (liveValues.count(operand)) {
+        toEvict.push_back(operand);
+      }
+    }
+    for (Value victim : toEvict) {
+      TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                   "    SPILL_SIBLING_OPERAND: evicting {0} to DRAM to "
+                   "resolve backend constraint failure for {1}",
+                   ttmlir::opToString(victim.getDefiningOp()), op->getName());
+      evictValue(victim, pos, data);
+    }
   }
 
   demoteToDram(op);
@@ -1090,7 +1127,8 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
     }
     TTNNLayoutAttr dramLayout =
         layoutAttr.withBufferType(BufferType::DRAM)
-            .withMemoryLayout(TensorMemoryLayout::Interleaved);
+            .withMemoryLayout(TensorMemoryLayout::Interleaved)
+            .withTensorShape(tensorType.getShape());
     RankedTensorType newType =
         utils::RankedTensorTypeFactory::create(tensorType, dramLayout);
     opResult.setType(newType);
@@ -1214,9 +1252,19 @@ void L1SpillManagement<MemoryTracker>::spillToDram(Value result,
   }
 
   // Create DRAM interleaved layout.
+  // Use withTensorShape to recompute the memref dimensions from the full tensor
+  // shape. A plain withBufferType(DRAM) would preserve the per-core shard
+  // dimensions in the memref, producing an incorrect layout (e.g., 32x4 tiles
+  // instead of 2048x4 for a 65536x128 tensor that was height-sharded on 64
+  // cores).
   TTNNLayoutAttr dramLayout =
       layoutAttr.withBufferType(BufferType::DRAM)
-          .withMemoryLayout(TensorMemoryLayout::Interleaved);
+          .withMemoryLayout(TensorMemoryLayout::Interleaved)
+          .withTensorShape(tensorType.getShape());
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "    SPILL_TO_DRAM: {0}, new layout: {1}",
+               ttmlir::opToString(defOp), dramLayout);
+
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(tensorType, dramLayout);
 

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -669,9 +669,12 @@ void MemoryLayoutPropagation::applyInputLayoutFilter(
                      candidates.end());
     // Guarantee at least one interleaved candidate remains.
     if (candidates.empty()) {
+      auto tensorType =
+          mlir::cast<RankedTensorType>(op->getOperand(operandIdx).getType());
       InputCandidate ic;
       ic.layout = currentLayout.withBufferType(BufferType::DRAM)
-                      .withMemoryLayout(TensorMemoryLayout::Interleaved);
+                      .withMemoryLayout(TensorMemoryLayout::Interleaved)
+                      .withTensorShape(tensorType.getShape());
       ic.producerCandidateIndex = 0;
       ic.isReshard = true;
       candidates.push_back(ic);
@@ -1198,7 +1201,8 @@ MemoryLayoutPropagation::getDRAMInterleavedFallback(Operation *op) {
     return nullptr;
   }
   return currentLayout.withBufferType(BufferType::DRAM)
-      .withMemoryLayout(TensorMemoryLayout::Interleaved);
+      .withMemoryLayout(TensorMemoryLayout::Interleaved)
+      .withTensorShape(tensorType.getShape());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1226,7 +1230,8 @@ void MemoryLayoutPropagation::insertReturnDramSpills() {
 
       TTNNLayoutAttr dramLayout =
           layout.withBufferType(BufferType::DRAM)
-              .withMemoryLayout(TensorMemoryLayout::Interleaved);
+              .withMemoryLayout(TensorMemoryLayout::Interleaved)
+              .withTensorShape(tensorType.getShape());
       insertReshardOp(returnOp, i, dramLayout);
 
       // insertReshardOp places the new op right before returnOp. Move it to

--- a/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ConvRules.cpp
@@ -5,15 +5,40 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/ConvRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Conv2dConfigParams.h"
 #include "ttmlir/Support/Logger.h"
-#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn {
 
 OutputHints Conv2dRuleBook::getOutputHints(
     Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
   // Conv2d configs carry Conv2dConfig tied to output hint.
-  return OutputHints{legalConfigs, {}};
+  // Embed the output shard layout into the conv2d config so that the tt-metal
+  // runtime respects it when choosing a kernel variant. Only propagate for
+  // sharded outputs; shard_layout is not applicable (and rejected by the
+  // backend) for interleaved DRAM/L1 outputs.
+  std::vector<OpConfig> configs = legalConfigs;
+  for (auto &config : configs) {
+    assert(config.outputLayout &&
+           "Conv2d legal config must have output layout");
+    auto ml = config.outputLayout.getMemLayout();
+    assert(ml &&
+           "Conv2d legal config must have memory layout in output layout");
+    if (!isShardedMemoryLayout(ml.getValue())) {
+      continue;
+    }
+
+    auto *attrs = std::get_if<Conv2dAttrs>(&config.opSpecificAttrs);
+    assert(attrs && "Conv2d legal config must have Conv2dAttrs");
+    assert(attrs->conv2dConfig.has_value() &&
+           "Conv2d legal config must have conv2d config");
+
+    Conv2dConfigParams params(attrs->conv2dConfig.value());
+    params.shardLayout = ml.getValue();
+    attrs->conv2dConfig =
+        params.buildConv2dConfigAttr(config.outputLayout.getContext());
+  }
+  return OutputHints{configs, {}};
 }
 
 void Conv2dRuleBook::applyOpSpecificAttrs(
@@ -76,6 +101,29 @@ bool Conv2dRuleBook::preferCandidate(Operation *op, const BeamCandidate &a,
     return abhA > abhB;
   }
   return OpRuleBook::preferCandidate(op, a, b);
+}
+
+bool Conv2dRuleBook::isValidOutputHintForInputs(
+    const OpConfig &hint, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const {
+  if (inputLayouts.empty() || !hint.outputLayout) {
+    return true;
+  }
+
+  auto inputML = inputLayouts[0].getMemLayout();
+  auto outputML = hint.outputLayout.getMemLayout();
+  if (!inputML || !outputML) {
+    return true;
+  }
+
+  // If both input and output are sharded, require matching sharding type.
+  // Mixing sharding types (e.g. HS input -> BS output) forces costly reshards
+  // and can cascade into DRAM fallbacks at downstream concat ops.
+  if (isShardedMemoryLayout(inputML.getValue()) &&
+      isShardedMemoryLayout(outputML.getValue())) {
+    return inputML.getValue() == outputML.getValue();
+  }
+
+  return true;
 }
 
 void applyConvSliceConfig(ModuleOp moduleOp) {

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/OperationValidationAndFallback.cpp
@@ -563,6 +563,13 @@ createFallbackTransforms(TTNNLayoutAttr originalLayout,
 
         if (targetBufferType != result.getBufferType()) {
           result = result.withBufferType(targetBufferType);
+          // Recompute memref dimensions for DRAM: withBufferType(DRAM) sets
+          // grid to 1x1 but preserves the old per-core shard shape in the
+          // memref, producing incorrect dimensions for formerly-sharded
+          // layouts.
+          if (targetBufferType == BufferType::DRAM) {
+            result = result.withTensorShape(tensorShape);
+          }
         }
 
         fallbackLayoutsSet.insert(result);
@@ -697,13 +704,15 @@ testFallbackCombination(Operation *op, const OpConfig &originalConfig,
                         const std::vector<TTNNLayoutAttr> &inputLayouts) {
 
   // For all fallbacks, constrain output layout to be DRAM Interleaved.
+  // Use withTensorShape to recompute memref dimensions from the full tensor
+  // shape — withBufferType(DRAM) alone preserves per-core shard dimensions.
   OpConfig testConfig = originalConfig;
   if (testConfig.outputLayout) {
-    testConfig.outputLayout = originalConfig.outputLayout;
+    auto tensorType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
     testConfig.outputLayout =
-        testConfig.outputLayout.withBufferType(BufferType::DRAM);
-    testConfig.outputLayout = testConfig.outputLayout.withMemoryLayout(
-        TensorMemoryLayout::Interleaved);
+        testConfig.outputLayout.withBufferType(BufferType::DRAM)
+            .withMemoryLayout(TensorMemoryLayout::Interleaved)
+            .withTensorShape(tensorType.getShape());
   }
 
   return op_constraint_validation::validateOperation(op, inputLayouts,


### PR DESCRIPTION
## Summary

Two related optimizer fixes that address CNN model perf regressions and segformer compilation failure:

**1. Conv2d shard layout propagation to tt-metal runtime**

When the greedy optimizer chooses a sharded output layout for conv2d, embed the shard layout into the \`Conv2dConfig\`'s \`shard_layout\` field in \`getOutputHints\`. Without this, the tt-metal runtime's auto-shard heuristic picks a different (often slower) shard type when the input is later spilled to DRAM. Fixes a 4x regression on 128x128 spatial conv2d ops (876μs → 224μs, matching legacy).

Additional fixes:
- \`withBufferType(DRAM)\` memref dimensions: append \`.withTensorShape()\` at all call sites converting sharded L1 layouts to DRAM interleaved (6 sites across \`MemoryLayoutPropagation\`, \`L1SpillManagement\`, \`OperationValidationAndFallback\`). Previously the per-core shard dimensions leaked into the DRAM memref (e.g., \`memref<32x4>\` instead of \`memref<2048x4>\`).
- Add same-shard-type constraint for conv2d via \`Conv2dRuleBook::isValidOutputHintForInputs\` to prevent costly HS→BS reshards.

**2. Sibling-operand spill for backend constraint failures**

When L1 spill management evicts one concat operand to DRAM under CB-fragmentation pressure, the concat fails validation with a structural constraint error (\"All tensors must be sharded or all must be interleaved\") because the remaining operands are still L1 sharded.

In \`handleFragmentation\`, after partial eviction, distinguish OOM errors from backend constraint errors via \`ValidationResult\`'s status enum. On non-OOM failure, spill all remaining L1 operands of the op to DRAM, then fall through to \`demoteToDram\` so the op runs all-DRAM. Intentionally do not keep a sharded output after sibling spill to avoid a known runtime bug (https://github.com/tenstorrent/tt-metal/issues/41469).

Refactor: extract \`evictValue\` helper from \`evictUntil\` so both the farthest-use eviction loop and the sibling-operand path share the same tracker-rebuild + consumer-reshard bookkeeping.

## Test plan

- [x] UNet compiles and runs successfully on n150 silicon
- [x] Segformer compiles and runs successfully on n150 silicon (previously aborted with compiler error)
- [x] CNN perf benchmark on n150 non-shared runner vs April 15 nightly baseline:
  - resnet: **+26%**
  - unet: **+18%**
  - vovnet: **+17%**
  - efficientnet: **+7%**
  - segformer: **+26%**
  - mobilenetv2: neutral
- [x] Full CI pipeline on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)