### PR TITLE
Metal uplift fix

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=90c914ef258b5cc92ad172f3604b784ec77253ca
+ARG TT_METAL_DEPENDENCIES_COMMIT=a1d692ace7962299d9ac8218fddb2dffab53c761
 
 # Install dependencies
 RUN <<EOT

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=a1d692ace7962299d9ac8218fddb2dffab53c761
+ARG TT_METAL_DEPENDENCIES_COMMIT=feae59c12b17381fe8e0a4fdb6a0b89dbcf07d53
 
 # Install dependencies
 RUN <<EOT


### PR DESCRIPTION
## Summary

- Bumps `TT_METAL_DEPENDENCIES_COMMIT` in `.github/Dockerfile.base` to [`a1d692ac`](https://github.com/tenstorrent/tt-metal/commit/a1d692ace7962299d9ac8218fddb2dffab53c761) (branch [`vzeljkovic/mlir_uplift`](https://github.com/tenstorrent/tt-metal/tree/vzeljkovic/mlir_uplift))
- Fixes a `NameError: name 'experimental' is not defined` crash that occurs at `import ttnn` time, breaking tt-xla CI tests
- Root cause: `ttnn/ttnn/__init__.py` line 516 used a bare `experimental` local name that was never defined; the fix uses `sys.modules["ttnn.experimental"]` consistent with the rest of the file
- Introduced in tenstorrent/tt-metal#41589

## Test plan

- [ ] tt-xla CI passes `import ttnn` in the "Test ttnn package" step
- [ ] Benchmark/LLM tests no longer fail with `NameError` on `tracy.signpost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- xla-validate -->
---
### tt-xla Validation

**Base (tt-xla branch):** `vzeljkovic/xla-validate-pr-8012` (pins this PR's HEAD `c3b5645e`)

| Test Suite | Run | Status |
|------------|-----|--------|
| perf-benchmark (all archs) | [Run #24566197044](https://github.com/tenstorrent/tt-xla/actions/runs/24566197044) | :hourglass: in_progress |
<!-- /xla-validate -->
