### PR TITLE
Multihost API - Get Worker Debug Stats

### DIFF
--- a/runtime/include/tt/runtime/debug.h
+++ b/runtime/include/tt/runtime/debug.h
@@ -189,6 +189,7 @@ public:
   std::int64_t getStat(const std::string &stat) const;
   void removeStat(const std::string &stat);
   void clear();
+  DebugStatsMap getAllStats() const;
   std::string toString() const;
 #else
   static constexpr Stats get() { return Stats(); }
@@ -196,6 +197,7 @@ public:
   inline std::int64_t getStat(const std::string &) const { return 0; }
   inline void removeStat(const std::string &) const {}
   constexpr void clear() const {}
+  inline DebugStatsMap getAllStats() const { return {}; }
   inline std::string toString() const { return "DebugStats Disabled"; }
 #endif
 

--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -17,6 +17,8 @@ public:
   static uint64_t buildSetMemoryLogLevelCommand(
       ::flatbuffers::FlatBufferBuilder &fbb,
       const ::tt::runtime::MemoryLogLevel &memoryLogLevel);
+  static uint64_t
+  buildGetWorkerDebugStatsCommand(::flatbuffers::FlatBufferBuilder &fbb);
 
   static uint64_t buildConfigureRuntimeContextCommand(
       ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -87,6 +87,7 @@ public:
 
   // Runtime APIs
   void setMemoryLogLevel(const MemoryLogLevel &logLevel);
+  WorkerDebugStats getWorkerDebugStats();
 
   SystemDesc getCurrentSystemDesc(
       std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType =
@@ -215,6 +216,9 @@ private:
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 
   void handleSetMemoryLogLevelResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+  void handleGetWorkerDebugStatsResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -11,6 +11,7 @@ namespace tt::runtime::distributed {
 
 void launchDistributedRuntime(const DistributedOptions &options = {});
 void shutdownDistributedRuntime();
+WorkerDebugStats getWorkerDebugStats();
 
 void setMemoryLogLevel(const MemoryLogLevel &logLevel);
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -20,6 +20,9 @@ table SetMemoryLogLevelCommand {
   memory_log_level: tt.runtime.flatbuffer.MemoryLogLevel;
 }
 
+table GetWorkerDebugStatsCommand {
+}
+
 table GetSystemDescCommand {
   device: tt.target.DeviceRef;
   dispatch_core_type: tt.runtime.flatbuffer.DispatchCoreType = null;
@@ -172,6 +175,7 @@ table ClearProgramCacheCommand{
 union CommandType {
   ConfigureRuntimeContextCommand,
   SetMemoryLogLevelCommand,
+  GetWorkerDebugStatsCommand,
   GetSystemDescCommand,
   SetFabricConfigCommand,
   GetNumAvailableDevicesCommand,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -22,6 +22,7 @@ table DebugStatEntry {
 }
 
 table GetWorkerDebugStatsResponse {
+  hostname: string;
   stats: [DebugStatEntry];
 }
 

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -16,6 +16,15 @@ table ConfigureRuntimeContextResponse {
 table SetMemoryLogLevelResponse {
 }
 
+table DebugStatEntry {
+  key: string;
+  value: int64;
+}
+
+table GetWorkerDebugStatsResponse {
+  stats: [DebugStatEntry];
+}
+
 table GetSystemDescResponse {
   system_desc: [ubyte]; // size-prefixed SystemDescRoot buffer
 }
@@ -122,6 +131,7 @@ union ResponseType {
   ErrorResponse,
   ConfigureRuntimeContextResponse,
   SetMemoryLogLevelResponse,
+  GetWorkerDebugStatsResponse,
   GetSystemDescResponse,
   SetFabricConfigResponse,
   GetNumAvailableDevicesResponse,

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -68,6 +68,10 @@ private:
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::SetMemoryLogLevelCommand
               *command);
+  void execute(
+      uint64_t commandId,
+      const ::tt::runtime::distributed::flatbuffer::GetWorkerDebugStatsCommand
+          *command);
 
   void
   execute(uint64_t commandId,

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -22,7 +22,7 @@ public:
                                  uint64_t commandId);
   static void buildGetWorkerDebugStatsResponse(
       ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
-      const DebugStatsMap &stats);
+      const std::string &hostname, const DebugStatsMap &stats);
 
   static void
   buildConfigureRuntimeContextResponse(::flatbuffers::FlatBufferBuilder &fbb,

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -20,6 +20,9 @@ public:
   static void
   buildSetMemoryLogLevelResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                  uint64_t commandId);
+  static void buildGetWorkerDebugStatsResponse(
+      ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+      const DebugStatsMap &stats);
 
   static void
   buildConfigureRuntimeContextResponse(::flatbuffers::FlatBufferBuilder &fbb,

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -48,6 +48,7 @@ SystemDesc getCurrentSystemDesc(
 
 void launchDistributedRuntime(const DistributedOptions &options = {});
 void shutdownDistributedRuntime();
+WorkerDebugStats getWorkerDebugStats();
 
 // Creates host tensor with a view of the input data (the buffer of the tensor
 // is on the host and it was borrowed from an external buffer which is

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -11,9 +11,9 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <variant>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #pragma clang diagnostic push
@@ -419,6 +419,8 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
       : detail::RuntimeCheckedObjectImpl(handle, runtime), data(data),
         event(eventHandle.value_or(nullptr), runtime),
         globalId(nextTensorGlobalId()) {}
+
+  ~Tensor();
 
   void setGlobalId(std::uint64_t id) { globalId = id; }
   std::uint64_t getGlobalId() const { return globalId; }

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -42,7 +42,12 @@ using MemoryBlockTable =
     std::vector<std::unordered_map<std::string, std::string>>;
 
 using DebugStatsMap = std::unordered_map<std::string, std::int64_t>;
-using WorkerDebugStats = std::vector<DebugStatsMap>;
+
+struct WorkerDebugStatsEntry {
+  std::string hostname;
+  DebugStatsMap stats;
+};
+using WorkerDebugStats = std::vector<WorkerDebugStatsEntry>;
 
 enum class MemoryBufferType {
   DRAM,

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -420,8 +420,6 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
         event(eventHandle.value_or(nullptr), runtime),
         globalId(nextTensorGlobalId()) {}
 
-  ~Tensor();
-
   void setGlobalId(std::uint64_t id) { globalId = id; }
   std::uint64_t getGlobalId() const { return globalId; }
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -6,11 +6,14 @@
 #define TT_RUNTIME_TYPES_H
 
 #include <cassert>
+#include <cstdint>
 #include <filesystem>
 #include <map>
 #include <memory>
 #include <optional>
 #include <variant>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #pragma clang diagnostic push
@@ -37,6 +40,9 @@ MemoryBlockTable is a list of memory blocks in the following format:
 */
 using MemoryBlockTable =
     std::vector<std::unordered_map<std::string, std::string>>;
+
+using DebugStatsMap = std::unordered_map<std::string, std::int64_t>;
+using WorkerDebugStats = std::vector<DebugStatsMap>;
 
 enum class MemoryBufferType {
   DRAM,

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -69,6 +69,11 @@ void Stats::clear() {
   counters.clear();
 }
 
+DebugStatsMap Stats::getAllStats() const {
+  std::shared_lock<std::shared_mutex> lock(countersMutex);
+  return counters;
+}
+
 std::string Stats::toString() const {
   std::shared_lock<std::shared_mutex> lock(countersMutex);
 

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt/runtime/types.h"
-#include "tt/runtime/debug.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/utils.h"
@@ -208,17 +207,7 @@ std::uint32_t Device::nextDeviceGlobalId() {
 
 std::uint64_t Tensor::nextTensorGlobalId() {
   static std::atomic<std::uint64_t> globalId = 0;
-  std::uint64_t id = globalId.fetch_add(1, std::memory_order_relaxed);
-  ::tt::runtime::debug::Stats::get().incrementStat("tensor_allocations");
-  ::tt::runtime::debug::Stats::get().incrementStat("allocate_" +
-                                                   std::to_string(id));
-  return id;
-}
-
-Tensor::~Tensor() {
-  ::tt::runtime::debug::Stats::get().incrementStat("tensor_deallocations");
-  ::tt::runtime::debug::Stats::get().incrementStat("deallocate_" +
-                                                   std::to_string(globalId));
+  return globalId.fetch_add(1, std::memory_order_relaxed);
 }
 
 std::uint64_t GlobalSemaphore::nextGlobalSemaphoreGlobalId() {

--- a/runtime/lib/common/types.cpp
+++ b/runtime/lib/common/types.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt/runtime/types.h"
+#include "tt/runtime/debug.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/utils.h"
@@ -207,7 +208,17 @@ std::uint32_t Device::nextDeviceGlobalId() {
 
 std::uint64_t Tensor::nextTensorGlobalId() {
   static std::atomic<std::uint64_t> globalId = 0;
-  return globalId.fetch_add(1, std::memory_order_relaxed);
+  std::uint64_t id = globalId.fetch_add(1, std::memory_order_relaxed);
+  ::tt::runtime::debug::Stats::get().incrementStat("tensor_allocations");
+  ::tt::runtime::debug::Stats::get().incrementStat("allocate_" +
+                                                   std::to_string(id));
+  return id;
+}
+
+Tensor::~Tensor() {
+  ::tt::runtime::debug::Stats::get().incrementStat("tensor_deallocations");
+  ::tt::runtime::debug::Stats::get().incrementStat("deallocate_" +
+                                                   std::to_string(globalId));
 }
 
 std::uint64_t GlobalSemaphore::nextGlobalSemaphoreGlobalId() {

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -59,6 +59,16 @@ uint64_t CommandFactory::buildSetMemoryLogLevelCommand(
   return commandId;
 }
 
+uint64_t CommandFactory::buildGetWorkerDebugStatsCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId = BUILD_COMMAND(GetWorkerDebugStats, fbb);
+
+  return commandId;
+}
+
 uint64_t CommandFactory::buildConfigureRuntimeContextCommand(
     ::flatbuffers::FlatBufferBuilder &fbb, const std::string &mlirHome,
     const std::string &metalHome,

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -241,6 +241,30 @@ void Controller::setMemoryLogLevel(const MemoryLogLevel &logLevel) {
                                  std::move(commandBuilder));
 }
 
+WorkerDebugStats Controller::getWorkerDebugStats() {
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  uint64_t commandId =
+      CommandFactory::buildGetWorkerDebugStatsCommand(*commandBuilder);
+
+  auto workerDebugStatsHandle = std::make_shared<WorkerDebugStats>();
+  auto awaitingHandles = std::make_unique<std::vector<std::shared_ptr<void>>>();
+  awaitingHandles->push_back(
+      std::static_pointer_cast<void>(workerDebugStatsHandle));
+
+  auto awaitingPromise = std::make_unique<std::promise<void>>();
+  std::future<void> awaitingFuture = awaitingPromise->get_future();
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::GetWorkerDebugStatsCommand,
+      std::move(commandBuilder), std::move(awaitingHandles),
+      std::move(awaitingPromise));
+
+  awaitingFuture.wait();
+
+  return *workerDebugStatsHandle;
+}
+
 SystemDesc Controller::getCurrentSystemDesc(
     std::optional<::tt::runtime::DispatchCoreType> dispatchCoreType,
     std::optional<::tt::runtime::Device> deviceHandle) {
@@ -977,6 +1001,41 @@ void Controller::handleSetMemoryLogLevelResponse(
   debug::assertNoAwaitingState(*awaitingResponse, "SetMemoryLogLevel");
 }
 
+void Controller::handleGetWorkerDebugStatsResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+  debug::checkResponseTypes(responseBuffers,
+                            fb::ResponseType::GetWorkerDebugStatsResponse);
+
+  auto [awaitingHandles, awaitingPromise] =
+      awaitingResponse->popAwaitingState();
+
+  DEBUG_ASSERT(awaitingHandles && awaitingHandles->size() == 1,
+               "GetWorkerDebugStats: Awaiting handles must be populated and "
+               "contain exactly one handle");
+  DEBUG_ASSERT(awaitingPromise, "Awaiting promise must be populated");
+
+  std::shared_ptr<WorkerDebugStats> workerDebugStatsHandle =
+      std::static_pointer_cast<WorkerDebugStats>(awaitingHandles->at(0));
+  workerDebugStatsHandle->clear();
+  workerDebugStatsHandle->reserve(responseBuffers.size());
+
+  for (const SizedBuffer &responseBuffer : responseBuffers) {
+    const fb::GetWorkerDebugStatsResponse *response =
+        getResponse(responseBuffer)->type_as_GetWorkerDebugStatsResponse();
+
+    DebugStatsMap workerStats;
+    if (response->stats()) {
+      for (const fb::DebugStatEntry *entry : *response->stats()) {
+        workerStats[entry->key()->str()] = entry->value();
+      }
+    }
+    workerDebugStatsHandle->push_back(std::move(workerStats));
+  }
+
+  awaitingPromise->set_value();
+}
+
 void Controller::handleGetSystemDescResponse(
     const std::vector<SizedBuffer> &responseBuffers,
     std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
@@ -1523,6 +1582,10 @@ void Controller::handleResponse(
   case fb::CommandType::SetMemoryLogLevelCommand: {
     return handleSetMemoryLogLevelResponse(responseBuffers,
                                            std::move(awaitingResponse));
+  }
+  case fb::CommandType::GetWorkerDebugStatsCommand: {
+    return handleGetWorkerDebugStatsResponse(responseBuffers,
+                                             std::move(awaitingResponse));
   }
   case fb::CommandType::GetSystemDescCommand: {
     return handleGetSystemDescResponse(responseBuffers,

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -1024,13 +1024,19 @@ void Controller::handleGetWorkerDebugStatsResponse(
     const fb::GetWorkerDebugStatsResponse *response =
         getResponse(responseBuffer)->type_as_GetWorkerDebugStatsResponse();
 
+    std::string hostname;
+    if (response->hostname()) {
+      hostname = response->hostname()->str();
+    }
     DebugStatsMap workerStats;
     if (response->stats()) {
       for (const fb::DebugStatEntry *entry : *response->stats()) {
         workerStats[entry->key()->str()] = entry->value();
       }
     }
-    workerDebugStatsHandle->push_back(std::move(workerStats));
+    workerDebugStatsHandle->push_back(
+        ::tt::runtime::WorkerDebugStatsEntry{std::move(hostname),
+                                             std::move(workerStats)});
   }
 
   awaitingPromise->set_value();

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -1034,9 +1034,8 @@ void Controller::handleGetWorkerDebugStatsResponse(
         workerStats[entry->key()->str()] = entry->value();
       }
     }
-    workerDebugStatsHandle->push_back(
-        ::tt::runtime::WorkerDebugStatsEntry{std::move(hostname),
-                                             std::move(workerStats)});
+    workerDebugStatsHandle->push_back(::tt::runtime::WorkerDebugStatsEntry{
+        std::move(hostname), std::move(workerStats)});
   }
 
   awaitingPromise->set_value();

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -59,6 +59,11 @@ void shutdownDistributedRuntime() {
   ControllerSingleton::shutdown();
 }
 
+WorkerDebugStats getWorkerDebugStats() {
+  assertControllerLaunched();
+  return ControllerSingleton::get().getWorkerDebugStats();
+}
+
 void setMemoryLogLevel(const ::tt::runtime::MemoryLogLevel &memoryLogLevel) {
   assertControllerLaunched();
   ControllerSingleton::get().setMemoryLogLevel(memoryLogLevel);

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -37,15 +37,14 @@ static const fb::Command *getCommand(const SizedBuffer &command) {
   return fb::GetCommand(command.data());
 }
 
-static std::int64_t getHostnameHash() {
+static std::string getWorkerHostname() {
   std::array<char, 256> hostnameBuffer{};
   if (gethostname(hostnameBuffer.data(), hostnameBuffer.size()) != 0) {
-    return 0;
+    return {};
   }
 
   hostnameBuffer.back() = '\0';
-  return static_cast<std::int64_t>(
-      std::hash<std::string>{}(std::string(hostnameBuffer.data())));
+  return std::string(hostnameBuffer.data());
 }
 
 void CommandExecutor::connect(const std::string &host, uint16_t port) {
@@ -161,12 +160,11 @@ void CommandExecutor::execute(uint64_t commandId,
                               const fb::GetWorkerDebugStatsCommand *command) {
   (void)command;
   DebugStatsMap stats = ::tt::runtime::debug::Stats::get().getAllStats();
-  stats["__worker_hostname_hash"] = getHostnameHash();
   stats["__worker_pid"] = static_cast<std::int64_t>(getpid());
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
       buildResponse(ResponseFactory::buildGetWorkerDebugStatsResponse, commandId,
-                    stats);
+                    getWorkerHostname(), stats);
 
   responseQueue_.push(std::move(responseBuilder));
 }

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt/runtime/detail/distributed/worker/command_executor.h"
+#include "tt/runtime/debug.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/common/socket.h"
@@ -11,7 +12,9 @@
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
+#include <array>
 #include <thread>
+#include <unistd.h>
 
 namespace tt::runtime::distributed::worker {
 
@@ -32,6 +35,17 @@ static const fb::Command *getCommand(const SizedBuffer &command) {
   bool isDistributedCommand = fb::CommandBufferHasIdentifier(command.data());
   LOG_ASSERT(isDistributedCommand, "Command is not a distributed command");
   return fb::GetCommand(command.data());
+}
+
+static std::int64_t getHostnameHash() {
+  std::array<char, 256> hostnameBuffer{};
+  if (gethostname(hostnameBuffer.data(), hostnameBuffer.size()) != 0) {
+    return 0;
+  }
+
+  hostnameBuffer.back() = '\0';
+  return static_cast<std::int64_t>(
+      std::hash<std::string>{}(std::string(hostnameBuffer.data())));
 }
 
 void CommandExecutor::connect(const std::string &host, uint16_t port) {
@@ -139,6 +153,20 @@ void CommandExecutor::execute(uint64_t commandId,
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
       buildResponse(ResponseFactory::buildSetMemoryLogLevelResponse, commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
+void CommandExecutor::execute(uint64_t commandId,
+                              const fb::GetWorkerDebugStatsCommand *command) {
+  (void)command;
+  DebugStatsMap stats = ::tt::runtime::debug::Stats::get().getAllStats();
+  stats["__worker_hostname_hash"] = getHostnameHash();
+  stats["__worker_pid"] = static_cast<std::int64_t>(getpid());
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildGetWorkerDebugStatsResponse, commandId,
+                    stats);
 
   responseQueue_.push(std::move(responseBuilder));
 }
@@ -732,6 +760,10 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
   case fb::CommandType::SetMemoryLogLevelCommand: {
     return execute(command->command_id(),
                    command->type_as_SetMemoryLogLevelCommand());
+  }
+  case fb::CommandType::GetWorkerDebugStatsCommand: {
+    return execute(command->command_id(),
+                   command->type_as_GetWorkerDebugStatsCommand());
   }
   case fb::CommandType::GetSystemDescCommand: {
     return execute(command->command_id(),

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -163,8 +163,8 @@ void CommandExecutor::execute(uint64_t commandId,
   stats["__worker_pid"] = static_cast<std::int64_t>(getpid());
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
-      buildResponse(ResponseFactory::buildGetWorkerDebugStatsResponse, commandId,
-                    getWorkerHostname(), stats);
+      buildResponse(ResponseFactory::buildGetWorkerDebugStatsResponse,
+                    commandId, getWorkerHostname(), stats);
 
   responseQueue_.push(std::move(responseBuilder));
 }

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -58,7 +58,7 @@ void ResponseFactory::buildSetMemoryLogLevelResponse(
 
 void ResponseFactory::buildGetWorkerDebugStatsResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
-    const DebugStatsMap &stats) {
+    const std::string &hostname, const DebugStatsMap &stats) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
   std::vector<::flatbuffers::Offset<fb::DebugStatEntry>> entries;
@@ -67,7 +67,8 @@ void ResponseFactory::buildGetWorkerDebugStatsResponse(
     entries.push_back(fb::CreateDebugStatEntryDirect(fbb, key.c_str(), value));
   }
 
-  BUILD_RESPONSE_DIRECT(GetWorkerDebugStats, fbb, commandId, &entries);
+  BUILD_RESPONSE_DIRECT(GetWorkerDebugStats, fbb, commandId, hostname.c_str(),
+                        &entries);
 }
 
 void ResponseFactory::buildConfigureRuntimeContextResponse(

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -56,6 +56,20 @@ void ResponseFactory::buildSetMemoryLogLevelResponse(
   BUILD_RESPONSE(SetMemoryLogLevel, fbb, commandId);
 }
 
+void ResponseFactory::buildGetWorkerDebugStatsResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId,
+    const DebugStatsMap &stats) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  std::vector<::flatbuffers::Offset<fb::DebugStatEntry>> entries;
+  entries.reserve(stats.size());
+  for (const auto &[key, value] : stats) {
+    entries.push_back(fb::CreateDebugStatEntryDirect(fbb, key.c_str(), value));
+  }
+
+  BUILD_RESPONSE_DIRECT(GetWorkerDebugStats, fbb, commandId, &entries);
+}
+
 void ResponseFactory::buildConfigureRuntimeContextResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -279,6 +279,23 @@ void shutdownDistributedRuntime() {
       });
 }
 
+WorkerDebugStats getWorkerDebugStats() {
+  using RetType = WorkerDebugStats;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getWorkerDebugStats",
+                                    DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getWorkerDebugStats",
+                                    DeviceRuntime::TTMetal);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::distributed::getWorkerDebugStats();
+      });
+}
+
 Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &shape,
                                 const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -284,8 +284,7 @@ WorkerDebugStats getWorkerDebugStats() {
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType {
-        detail::fatalNotImplemented("getWorkerDebugStats",
-                                    DeviceRuntime::TTNN);
+        detail::fatalNotImplemented("getWorkerDebugStats", DeviceRuntime::TTNN);
       },
       [&]() -> RetType {
         detail::fatalNotImplemented("getWorkerDebugStats",

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -2,7 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <map>
+#include <optional>
 #include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "tt/runtime/debug.h"
 #include "tt/runtime/perf.h"

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -362,8 +362,11 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def("shutdown_distributed_runtime",
         &tt::runtime::shutdownDistributedRuntime,
         "Shutdown the distributed runtime");
+  nb::class_<tt::runtime::WorkerDebugStatsEntry>(m, "WorkerDebugStatsEntry")
+      .def_ro("hostname", &tt::runtime::WorkerDebugStatsEntry::hostname)
+      .def_ro("stats", &tt::runtime::WorkerDebugStatsEntry::stats);
   m.def("get_worker_debug_stats", &tt::runtime::getWorkerDebugStats,
-        "Get per-worker runtime debug stats");
+        "Get per-worker runtime debug stats (hostname and counter map per worker)");
   m.def(
       "create_borrowed_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -241,9 +241,12 @@ void registerRuntimeBindings(nb::module_ &m) {
            [](tt::runtime::Tensor self, tt::runtime::Layout layout) {
              return tt::runtime::hasLayout(self, layout);
            })
-      .def("get_layout", [](tt::runtime::Tensor self) {
-        return tt::runtime::getTensorLayout(self);
-      });
+      .def("get_layout",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorLayout(self);
+           })
+      .def("get_global_id",
+           [](tt::runtime::Tensor self) { return self.getGlobalId(); });
 
   nb::class_<tt::runtime::TensorRef>(m, "TensorRef")
       .def(

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -364,7 +364,13 @@ void registerRuntimeBindings(nb::module_ &m) {
         "Shutdown the distributed runtime");
   nb::class_<tt::runtime::WorkerDebugStatsEntry>(m, "WorkerDebugStatsEntry")
       .def_ro("hostname", &tt::runtime::WorkerDebugStatsEntry::hostname)
-      .def_ro("stats", &tt::runtime::WorkerDebugStatsEntry::stats);
+      .def_ro("stats", &tt::runtime::WorkerDebugStatsEntry::stats)
+      .def("__repr__", [](const tt::runtime::WorkerDebugStatsEntry &entry) {
+        std::ostringstream oss;
+        oss << "WorkerDebugStatsEntry(hostname='" << entry.hostname
+            << "', num_stats=" << entry.stats.size() << ")";
+        return oss.str();
+      });
   m.def("get_worker_debug_stats", &tt::runtime::getWorkerDebugStats,
         "Get per-worker runtime debug stats (hostname and counter map per worker)");
   m.def(

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -362,6 +362,8 @@ void registerRuntimeBindings(nb::module_ &m) {
   m.def("shutdown_distributed_runtime",
         &tt::runtime::shutdownDistributedRuntime,
         "Shutdown the distributed runtime");
+  m.def("get_worker_debug_stats", &tt::runtime::getWorkerDebugStats,
+        "Get per-worker runtime debug stats");
   m.def(
       "create_borrowed_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -370,8 +370,17 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def_ro("stats", &tt::runtime::WorkerDebugStatsEntry::stats)
       .def("__repr__", [](const tt::runtime::WorkerDebugStatsEntry &entry) {
         std::ostringstream oss;
-        oss << "WorkerDebugStatsEntry(hostname='" << entry.hostname
-            << "', num_stats=" << entry.stats.size() << ")";
+        oss << "Worker: " << entry.hostname << "\n";
+        // Sort keys for consistent output
+        std::vector<std::string> keys;
+        keys.reserve(entry.stats.size());
+        for (const auto &[key, value] : entry.stats) {
+          keys.push_back(key);
+        }
+        std::sort(keys.begin(), keys.end());
+        for (const auto &key : keys) {
+          oss << "  " << key << ": " << entry.stats.at(key) << "\n";
+        }
         return oss.str();
       });
   m.def("get_worker_debug_stats", &tt::runtime::getWorkerDebugStats,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -372,7 +372,8 @@ void registerRuntimeBindings(nb::module_ &m) {
         return oss.str();
       });
   m.def("get_worker_debug_stats", &tt::runtime::getWorkerDebugStats,
-        "Get per-worker runtime debug stats (hostname and counter map per worker)");
+        "Get per-worker runtime debug stats (hostname and counter map per "
+        "worker)");
   m.def(
       "create_borrowed_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -167,6 +167,24 @@ def test_get_num_devices():
     shutdown_distributed_runtime()
 
 
+def test_get_worker_debug_stats():
+    launch_distributed_runtime()
+
+    worker_debug_stats = ttrt.runtime.get_worker_debug_stats()
+    assert isinstance(worker_debug_stats, list)
+    assert len(worker_debug_stats) == ttrt.runtime.get_num_available_devices()
+
+    for worker_stat in worker_debug_stats:
+        assert isinstance(worker_stat.hostname, str)
+        assert worker_stat.hostname != ""
+        assert isinstance(worker_stat.stats, dict)
+        for key, value in worker_stat.stats.items():
+            assert isinstance(key, str)
+            assert isinstance(value, int)
+
+    shutdown_distributed_runtime()
+
+
 @pytest.mark.parametrize("mesh_shape", ["1x8"])
 def test_get_mesh_shape(mesh_shape):
     launch_distributed_runtime()

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -185,6 +185,45 @@ def test_get_worker_debug_stats():
     shutdown_distributed_runtime()
 
 
+def test_tensor_refcount_deallocation_asymmetry():
+    """
+    Demonstrates that controller tensor destruction via refcount
+    is NOT reflected to workers.
+
+    Expected behavior (showing the current limitation):
+    - Worker shows: tensor_allocations=N, allocate_<UID>=1
+    - Worker does NOT show: tensor_deallocations or deallocate_<UID>
+    """
+    launch_distributed_runtime()
+
+    # Create tensor in a scope and let it be destroyed by refcount
+    def create_tensor_in_scope():
+        tensor = get_runtime_tensor_from_torch(
+            torch.randn(32, 32), storage=Storage.Owned
+        )
+        global_id = tensor.get_global_id()
+        return global_id
+
+    # Tensor is created and destroyed via Python refcount when scope exits
+    global_id = create_tensor_in_scope()
+
+    # Query worker stats and print them
+    stats = ttrt.runtime.get_worker_debug_stats()
+    for worker_stat in stats:
+        print(f"\nWorker: {worker_stat.hostname}")
+        for key, value in sorted(worker_stat.stats.items()):
+            print(f"  {key}: {value}")
+
+        # Allocation is tracked on worker
+        assert worker_stat.stats.get(f"allocate_{global_id}", 0) == 1
+
+        # Deallocation is NOT tracked on worker (demonstrating the asymmetry)
+        # The tensor was destroyed on controller via refcount, but worker never received deallocation
+        assert worker_stat.stats.get(f"deallocate_{global_id}", 0) == 0
+
+    shutdown_distributed_runtime()
+
+
 @pytest.mark.parametrize("mesh_shape", ["1x8"])
 def test_get_mesh_shape(mesh_shape):
     launch_distributed_runtime()

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -172,52 +172,15 @@ def test_get_worker_debug_stats():
 
     worker_debug_stats = ttrt.runtime.get_worker_debug_stats()
     assert isinstance(worker_debug_stats, list)
-    assert len(worker_debug_stats) == ttrt.runtime.get_num_available_devices()
 
     for worker_stat in worker_debug_stats:
+        print(worker_stat)
         assert isinstance(worker_stat.hostname, str)
         assert worker_stat.hostname != ""
         assert isinstance(worker_stat.stats, dict)
         for key, value in worker_stat.stats.items():
             assert isinstance(key, str)
             assert isinstance(value, int)
-
-    shutdown_distributed_runtime()
-
-
-def test_tensor_refcount_deallocation_asymmetry():
-    """
-    Demonstrates that controller tensor destruction via refcount
-    is NOT reflected to workers.
-
-    Expected behavior (showing the current limitation):
-    - Worker shows: tensor_allocations=N, allocate_<UID>=1
-    - Worker does NOT show: tensor_deallocations or deallocate_<UID>
-    """
-    launch_distributed_runtime()
-
-    # Create tensor in a scope and let it be destroyed by refcount
-    def create_tensor_in_scope():
-        tensor = get_runtime_tensor_from_torch(
-            torch.randn(32, 32), storage=Storage.Owned
-        )
-        global_id = tensor.get_global_id()
-        return global_id
-
-    # Tensor is created and destroyed via Python refcount when scope exits
-    global_id = create_tensor_in_scope()
-
-    # Query worker stats and print them
-    stats = ttrt.runtime.get_worker_debug_stats()
-    for worker_stat in stats:
-        print(worker_stat)
-
-        # Allocation is tracked on worker
-        assert worker_stat.stats.get(f"allocate_{global_id}", 0) == 1
-
-        # Deallocation is NOT tracked on worker (demonstrating the asymmetry)
-        # The tensor was destroyed on controller via refcount, but worker never received deallocation
-        assert worker_stat.stats.get(f"deallocate_{global_id}", 0) == 0
 
     shutdown_distributed_runtime()
 

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -210,9 +210,7 @@ def test_tensor_refcount_deallocation_asymmetry():
     # Query worker stats and print them
     stats = ttrt.runtime.get_worker_debug_stats()
     for worker_stat in stats:
-        print(f"\nWorker: {worker_stat.hostname}")
-        for key, value in sorted(worker_stat.stats.items()):
-            print(f"  {key}: {value}")
+        print(worker_stat)
 
         # Allocation is tracked on worker
         assert worker_stat.stats.get(f"allocate_{global_id}", 0) == 1

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -70,6 +70,7 @@ try:
         get_op_loc_info,
         unregister_hooks,
         FabricConfig,
+        get_worker_debug_stats,
     )
 except ModuleNotFoundError:
     raise ImportError(


### PR DESCRIPTION
### Ticket
None

### Problem description
We currently have no way to introspect on the worker internals. As multihost has some worker behaviour diverging from the controller, this information gap becomes a hindrance as we cannot easily test for worker-internal mechanics. 

Current debug stats API is not suitable as debug stats is a process-local singleton, so we can query debug stats on the controller, but since the workers live on separate processes, their debug stats are inaccessible. 

### What's changed
- Introduce new multihost API getWorkerDebugStats, to mirror existing debug APIs to get debug stats. This will return a vector of WorkerDebugStatsEntry, which are hostname, DebugStatsMap (string -> i64 dictionary)


### Checklist
- [ ] Added multihost test