### PR TITLE
Support added to fix Convolution Feature Group Count

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -402,6 +402,65 @@ static mlir::LogicalResult updateShapes(MLIRContext *context,
   return mlir::success();
 }
 
+// Shardy shards the convolution's feature dim across operands but leaves
+// feature_group_count at its global value, so the local (already-reduced) input
+// feature dim is no longer divisible by it and StableHLO verification rejects
+// the op. The fix is to rescale the count from the localized types.
+// Issue: https://github.com/tenstorrent/tt-metal/issues/45396
+//
+// in_channels_per_group is invariant under sharding, so the new count follows
+// from the local LHS feature dim:
+//   in_channels_per_group = global_in_feature_dim / feature_group_count
+//   new_feature_group_count = local_in_feature_dim / in_channels_per_group
+// (depthwise conv has in_channels_per_group == 1, so the count equals the local
+// feature dim.)
+static mlir::LogicalResult
+fixConvolutionFeatureGroupCount(MLIRContext *context,
+                                mlir::ModuleOp &rootModule) {
+  mlir::WalkResult result =
+      rootModule.walk([&](mlir::stablehlo::ConvolutionOp convOp) {
+        uint64_t currentFGC = convOp.getFeatureGroupCount();
+        // A standard convolution (feature_group_count == 1) keeps a single
+        // group no matter how the feature dim is sharded, so its count never
+        // goes stale and there is nothing to recompute.
+        if (currentFGC <= 1) {
+          return WalkResult::advance();
+        }
+
+        auto lhsType =
+            mlir::cast<mlir::RankedTensorType>(convOp.getLhs().getType());
+        auto rhsType =
+            mlir::cast<mlir::RankedTensorType>(convOp.getRhs().getType());
+
+        int64_t inputFeatureDim =
+            convOp.getDimensionNumbers().getInputFeatureDimension();
+        int64_t kernelInputFeatureDim =
+            convOp.getDimensionNumbers().getKernelInputFeatureDimension();
+
+        int64_t localInputChannels = lhsType.getDimSize(inputFeatureDim);
+        int64_t inChannelsPerGroup = rhsType.getDimSize(kernelInputFeatureDim);
+
+        if (inChannelsPerGroup <= 0 ||
+            localInputChannels % inChannelsPerGroup != 0) {
+          convOp.emitError()
+              << "cannot rescale feature_group_count: local input feature dim ("
+              << localInputChannels
+              << ") not divisible by kernel input feature "
+                 "dim ("
+              << inChannelsPerGroup << ")";
+          return WalkResult::interrupt();
+        }
+
+        int64_t newFGC = localInputChannels / inChannelsPerGroup;
+        if (static_cast<int64_t>(currentFGC) != newFGC) {
+          convOp.setFeatureGroupCount(static_cast<uint64_t>(newFGC));
+        }
+        return WalkResult::advance();
+      });
+
+  return mlir::failure(result.wasInterrupted());
+}
+
 // Convert all sdy ccl ops into stablehlo ccl ops.
 static mlir::LogicalResult
 convertShardyCCLToStableHLOCCL(MLIRContext *context,
@@ -523,6 +582,14 @@ public:
         return;
       }
     });
+
+    // Shardy updates the operand shapes but not
+    // the feature_group_count attribute, so we fix it here from the local
+    // types.
+    if (failed(fixConvolutionFeatureGroupCount(context, rootModule))) {
+      signalPassFailure();
+      return;
+    }
 
     // Run conversion pattern to convert all sdy ccl operations into stablehlo
     // ccl operations

--- a/test/ttmlir/Dialect/StableHLO/global_to_local_shape/convolution_feature_group_count.mlir
+++ b/test/ttmlir/Dialect/StableHLO/global_to_local_shape/convolution_feature_group_count.mlir
@@ -1,0 +1,20 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --split-input-file --update-global-to-local-shapes -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @jit_depthwise_conv attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  sdy.mesh @mesh = <["_axis_0"=2]>
+  func.func @main(%arg0: tensor<1x64x8x8xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}]>, ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x8x8xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}, %arg1: tensor<64x1x3x3xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}, {}, {}]>, ttcore.argument_type = #ttcore.argument_type<parameter>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<32x1x3x3xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x64x6x6xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}]>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x6x6xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) {
+    %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {"_axis_0"}, {}, {}]>, <@mesh, [{"_axis_0"}, {}, {}, {}]>] out_shardings=[<@mesh, [{}, {"_axis_0"}, {}, {}]>] manual_axes={} (%arg2: tensor<1x64x8x8xf32>, %arg3: tensor<64x1x3x3xf32>) {
+      // The feature_group_count is rescaled from the global value (64) to the
+      // local value (32), and the operand/result shapes are localized.
+      // CHECK: stablehlo.convolution
+      // CHECK-SAME: feature_group_count = 32 : i64
+      // CHECK-SAME: (tensor<1x32x8x8xf32>, tensor<32x1x3x3xf32>) -> tensor<1x32x6x6xf32>
+      %1 = stablehlo.convolution(%arg2, %arg3) dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1], window = {stride = [1, 1], pad = [[0, 0], [0, 0]], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 64 : i64, sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"_axis_0"}, {}, {}]>]>} : (tensor<1x64x8x8xf32>, tensor<64x1x3x3xf32>) -> tensor<1x64x6x6xf32>
+      sdy.return %1 : tensor<1x64x6x6xf32>
+    } : (tensor<1x64x8x8xf32>, tensor<64x1x3x3xf32>) -> tensor<1x64x6x6xf32>
+    return %0 : tensor<1x64x6x6xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/45396

### Problem description
When Shardy applies tensor-parallel sharding to a grouped or depthwise `stablehlo.convolution`:

- `lhs_input_feature_dim` becomes local (global / shard factor)
- `feature_group_count` is **not** updated and stays at the global value

StableHLO verification then fails because it requires
`lhs_input_feature_dim % feature_group_count == 0` and
`in_channels_per_group = lhs_input_feature_dim / feature_group_count`.

This blocks compilation of any model that combines channel-dim TP sharding with a grouped/depthwise conv — notably the depthwise `Conv1d` inside the `GatedDeltaNet` linear-attention layers in **Qwen 3.5**.

### What's changed
After `updateShapes` runs in `UpdateGlobalToLocalShapesPass`, walk all `stablehlo.convolution` ops with `feature_group_count > 1` and recompute the attribute from the now-local operand types:

```
in_channels_per_group   = rhs_kernel_input_feature_dim         // invariant under sharding
new_feature_group_count = local_lhs_input_feature_dim / in_channels_per_group
```

For depthwise conv (`in_channels_per_group == 1`) this simplifies to
`new_feature_group_count = local_lhs_input_feature_dim`.

The pass is a no-op on:
- Non-grouped convs (`feature_group_count <= 1`)
- Convs where the values were already consistent
- Cases where `local_lhs_input_feature_dim` is not divisible by `in_channels_per_group` (guard against bad rewrites)


### Checklist
- [ ] New/Existing tests provide coverage for changes
