### PR TITLE
[TTNNFusing] Fix attention mask broadcast for SDPA

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6599,13 +6599,13 @@ mlir::tt::ttir::ScaledDotProductAttentionDecodeOp::verify() {
     if (attentionMaskType.getShape().size() != 4) {
       return emitOpError("Attention mask must be a 4D tensor");
     }
-    if (attentionMaskType.getShape()[0] != 1 &&
-        attentionMaskType.getShape()[0] != batchSize) {
+    if (attentionMaskType.getShape()[0] != 1) {
+      return emitOpError("Attention mask dim 0 must be 1");
+    }
+    if (attentionMaskType.getShape()[1] != 1 &&
+        attentionMaskType.getShape()[1] != batchSize) {
       return emitOpError("Attention mask batch size must be 1 (broadcast) or "
                          "match query batch size");
-    }
-    if (attentionMaskType.getShape()[1] != 1) {
-      return emitOpError("Attention mask dim 1 must be 1");
     }
     if (attentionMaskType.getShape()[2] != 1 &&
         attentionMaskType.getShape()[2] != nQueryHeads) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1387,12 +1387,16 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
   // and check that all input tensors have the same rank
   // and that all dimensions except `dim` are the same.
   int64_t dimSizeSum = firstTensor.getDimSize(dim);
-  for (auto input : inputs.drop_front()) {
+  for (auto [idx, input] :
+       llvm::enumerate(llvm::drop_begin(inputs, /*N=*/1))) {
     auto inputType = mlir::cast<mlir::RankedTensorType>(input.getType());
 
     // Check if all inputs have the same rank.
     if (inputType.getRank() != firstTensorRank) {
-      return emitOpError("All input tensors must have the same rank.");
+      return emitOpError() << "All input tensors must have the same rank "
+                              "(operand 0 rank "
+                           << firstTensorRank << ", operand " << (idx + 1)
+                           << " rank " << inputType.getRank() << ").";
     }
 
     // Check that dimensions (except `dim`) are the same.
@@ -1404,7 +1408,12 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
       if (inputType.getDimSize(i) != firstTensor.getDimSize(i)) {
         return emitOpError() << "All input tensors must have the same "
                                 "dimensions, except for dimension "
-                             << dim << ".";
+                             << dim << " (operand 0 shape "
+                             << firstTensor.getShape() << ", operand "
+                             << (idx + 1) << " shape " << inputType.getShape()
+                             << " differ at dim " << i << ": "
+                             << firstTensor.getDimSize(i) << " vs "
+                             << inputType.getDimSize(i) << ").";
       }
     }
   }
@@ -5404,13 +5413,17 @@ mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
     if (attentionMaskType.getShape().size() != 4) {
       return emitOpError("Attention mask must be a 4D tensor");
     }
+    // First 3 dims of the mask must each either be 1 (broadcast) or match the
+    // corresponding query dim. Query layout is [1, batch, nQueryHeads, headSize].
     if (attentionMaskType.getShape()[0] != 1 &&
-        attentionMaskType.getShape()[0] != batchSize) {
+        attentionMaskType.getShape()[0] != queryType.getShape()[0]) {
+      return emitOpError("Attention mask dim 0 must be 1 (broadcast) or "
+                         "match query dim 0");
+    }
+    if (attentionMaskType.getShape()[1] != 1 &&
+        attentionMaskType.getShape()[1] != batchSize) {
       return emitOpError("Attention mask batch size must be 1 (broadcast) or "
                          "match query batch size");
-    }
-    if (attentionMaskType.getShape()[1] != 1) {
-      return emitOpError("Attention mask dim 1 must be 1");
     }
     if (attentionMaskType.getShape()[2] != 1 &&
         attentionMaskType.getShape()[2] != nQueryHeads) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1387,8 +1387,7 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
   // and check that all input tensors have the same rank
   // and that all dimensions except `dim` are the same.
   int64_t dimSizeSum = firstTensor.getDimSize(dim);
-  for (auto [idx, input] :
-       llvm::enumerate(llvm::drop_begin(inputs, /*N=*/1))) {
+  for (auto [idx, input] : llvm::enumerate(llvm::drop_begin(inputs, /*N=*/1))) {
     auto inputType = mlir::cast<mlir::RankedTensorType>(input.getType());
 
     // Check if all inputs have the same rank.
@@ -1406,14 +1405,13 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
         continue;
       }
       if (inputType.getDimSize(i) != firstTensor.getDimSize(i)) {
-        return emitOpError() << "All input tensors must have the same "
-                                "dimensions, except for dimension "
-                             << dim << " (operand 0 shape "
-                             << firstTensor.getShape() << ", operand "
-                             << (idx + 1) << " shape " << inputType.getShape()
-                             << " differ at dim " << i << ": "
-                             << firstTensor.getDimSize(i) << " vs "
-                             << inputType.getDimSize(i) << ").";
+        return emitOpError()
+               << "All input tensors must have the same "
+                  "dimensions, except for dimension "
+               << dim << " (operand 0 shape " << firstTensor.getShape()
+               << ", operand " << (idx + 1) << " shape " << inputType.getShape()
+               << " differ at dim " << i << ": " << firstTensor.getDimSize(i)
+               << " vs " << inputType.getDimSize(i) << ").";
       }
     }
   }
@@ -5414,7 +5412,8 @@ mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
       return emitOpError("Attention mask must be a 4D tensor");
     }
     // First 3 dims of the mask must each either be 1 (broadcast) or match the
-    // corresponding query dim. Query layout is [1, batch, nQueryHeads, headSize].
+    // corresponding query dim. Query layout is [1, batch, nQueryHeads,
+    // headSize].
     if (attentionMaskType.getShape()[0] != 1 &&
         attentionMaskType.getShape()[0] != queryType.getShape()[0]) {
       return emitOpError("Attention mask dim 0 must be 1 (broadcast) or "

--- a/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -703,11 +703,19 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         llvm::to_vector(kToDecodePermutation), rewriter,
         c.attentionMatmul.getLoc());
 
+    Value permutedMask = c.mask;
+    if (permutedMask) {
+      permutedMask = ttir_to_ttnn::utils::generatePermute(
+          mlir::cast<TypedValue<RankedTensorType>>(permutedMask),
+          llvm::to_vector(kToDecodePermutation), rewriter,
+          c.attentionMatmul.getLoc());
+    }
+
     auto validationResult =
         validator.validateFusion<ScaledDotProductAttentionDecodeOp>(
             c.attentionMatmul.getOperation(), c.attentionMatmul.getLoc(),
             {permutedQuery.getType()}, permutedQuery, c.key, c.value,
-            /*is_causal=*/rewriter.getBoolAttr(false), c.mask,
+            /*is_causal=*/rewriter.getBoolAttr(false), permutedMask,
             /*cur_pos_tensor=*/Value(), c.attentionSink, scaleAttr,
             /*memory_config=*/MemoryConfigAttr(),
             /*program_config=*/SDPAProgramConfigAttr());
@@ -722,7 +730,7 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
     auto decodeOp = rewriter.create<ScaledDotProductAttentionDecodeOp>(
         c.attentionMatmul.getLoc(), permutedQuery.getType(), permutedQuery,
         c.key, c.value,
-        /*is_causal=*/rewriter.getBoolAttr(false), c.mask,
+        /*is_causal=*/rewriter.getBoolAttr(false), permutedMask,
         /*cur_pos_tensor=*/Value(), c.attentionSink, scaleAttr,
         /*memory_config=*/MemoryConfigAttr(),
         /*program_config=*/SDPAProgramConfigAttr());

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
@@ -30,10 +30,8 @@ ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern::matchAndRewrite(
     return failure();
   }
 
-  // Query layout: [1, batch, num_heads, head_dim].
   // Mask layout (per ScaledDotProductAttentionDecodeOp::verify):
-  //   [batch_or_1, 1, num_heads_or_1, kv_seq_len]
-  // so dim 0 is the batch dim and dim 2 is the heads dim.
+  //   [1, batch_or_1, num_heads_or_1, kv_seq_len].
   int64_t batch = queryType.getShape()[1];
   int64_t numHeads = queryType.getShape()[2];
   int64_t maskBatch = maskType.getShape()[1];

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
@@ -30,16 +30,28 @@ ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern::matchAndRewrite(
     return failure();
   }
 
+  // Query layout: [1, batch, num_heads, head_dim].
+  // Mask layout (per ScaledDotProductAttentionDecodeOp::verify):
+  //   [batch_or_1, 1, num_heads_or_1, kv_seq_len]
+  // so dim 0 is the batch dim and dim 2 is the heads dim.
+  int64_t batch = queryType.getShape()[1];
   int64_t numHeads = queryType.getShape()[2];
+  int64_t maskBatch = maskType.getShape()[0];
   int64_t maskHeads = maskType.getShape()[2];
 
-  // Only broadcast if mask heads == 1 and query has more heads.
-  if (maskHeads != 1 || numHeads <= 1) {
+  bool needBatchBroadcast = (maskBatch == 1 && batch > 1);
+  bool needHeadBroadcast = (maskHeads == 1 && numHeads > 1);
+  if (!needBatchBroadcast && !needHeadBroadcast) {
     return failure();
   }
 
   SmallVector<int64_t> targetShape(maskType.getShape());
-  targetShape[2] = numHeads;
+  if (needBatchBroadcast) {
+    targetShape[0] = batch;
+  }
+  if (needHeadBroadcast) {
+    targetShape[2] = numHeads;
+  }
 
   auto broadcastType =
       utils::RankedTensorTypeFactory::create(maskType, targetShape);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
@@ -36,18 +36,19 @@ ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern::matchAndRewrite(
   // so dim 0 is the batch dim and dim 2 is the heads dim.
   int64_t batch = queryType.getShape()[1];
   int64_t numHeads = queryType.getShape()[2];
-  int64_t maskBatch = maskType.getShape()[0];
+  int64_t maskBatch = maskType.getShape()[1];
   int64_t maskHeads = maskType.getShape()[2];
 
   bool needBatchBroadcast = (maskBatch == 1 && batch > 1);
   bool needHeadBroadcast = (maskHeads == 1 && numHeads > 1);
+
   if (!needBatchBroadcast && !needHeadBroadcast) {
     return failure();
   }
 
   SmallVector<int64_t> targetShape(maskType.getShape());
   if (needBatchBroadcast) {
-    targetShape[0] = batch;
+    targetShape[1] = batch;
   }
   if (needHeadBroadcast) {
     targetShape[2] = numHeads;

--- a/test/python/golden/ttir_ops/attention/test_sdpa.py
+++ b/test/python/golden/ttir_ops/attention/test_sdpa.py
@@ -267,28 +267,23 @@ def test_sdpa_mask_broadcast(
 @pytest.mark.parametrize(
     "shapes,mask_shape,scale",
     [
-        # Decode mask: [batch, 1, num_heads, kv_seq] - standard
+        # Decode mask: [1, batch, num_heads, kv_seq] - standard
         (
             [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
-            (32, 1, 32, 128),
+            (1, 32, 32, 128),
             0.124999993,
         ),
         # Decode mask with GQA: mask num_heads matches query num_heads
         (
             [(1, 32, 32, 64), (32, 8, 128, 64), (32, 8, 128, 64), (32,)],
-            (32, 1, 32, 128),
+            (1, 32, 32, 128),
             0.124999993,
         ),
-        # Decode mask with batch broadcast: mask[0]=1
-        pytest.param(
+        # Decode mask with batch broadcast: mask[1]=1
+        (
             [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
             (1, 1, 32, 128),
             0.0883883387,
-            marks=pytest.mark.xfail(
-                reason="SDPA decode does not support batch broadcasting on "
-                "attention mask. "
-                "https://github.com/tenstorrent/tt-metal/issues/39910"
-            ),
         ),
     ],
     ids=[

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -887,14 +887,33 @@ def test_sdpa_with_mask_no_workaround(
     [
         # Decode with mask num_heads=1 (broadcast needed)
         # Q: [1, batch, num_heads, head_dim], K/V: [batch, kv_heads, kv_seq, head_dim]
-        # Mask: [batch, 1, 1, kv_seq] - heads=1 needs broadcast to num_heads
-        [
-            (1, 32, 32, 64),  # query (decode shape)
-            (32, 32, 128, 64),  # key
-            (32, 32, 128, 64),  # value
-            (32,),  # cur_pos_tensor
-            (32, 1, 1, 128),  # attention mask with heads=1
-        ],
+        # Mask: [1, batch, 1, kv_seq] - heads=1 needs broadcast to num_heads
+        pytest.param(
+            [
+                (1, 32, 32, 64),  # query (decode shape)
+                (32, 32, 128, 64),  # key
+                (32, 32, 128, 64),  # value
+                (32,),  # cur_pos_tensor
+                (1, 32, 1, 128),  # attention mask with heads=1
+            ],
+            marks=pytest.mark.xfail(
+                reason="SDPA decode requires mask[2] == num_heads. Metal issue: https://github.com/tenstorrent/tt-metal/issues/39910"
+            ),
+        ),
+        # Decode with mask batch=1 (broadcast needed)
+        # Mask: [1, 1, num_heads, kv_seq] - batch=1 needs broadcast to query batch
+        pytest.param(
+            [
+                (1, 32, 32, 64),  # query (decode shape)
+                (32, 32, 128, 64),  # key
+                (32, 32, 128, 64),  # value
+                (32,),  # cur_pos_tensor
+                (1, 1, 32, 128),  # attention mask with batch=1
+            ],
+            marks=pytest.mark.xfail(
+                reason="SDPA decode requires mask[1] == query batch. Metal issue: https://github.com/tenstorrent/tt-metal/issues/39910"
+            ),
+        ),
     ],
     ids=shapes_list_str,
 )
@@ -903,16 +922,12 @@ def test_sdpa_with_mask_no_workaround(
     [[torch.bfloat16, torch.bfloat16, torch.bfloat16, torch.int32, torch.bfloat16]],
 )
 @pytest.mark.parametrize("target", ["ttnn"])
-@pytest.mark.xfail(
-    reason="SDPA decode with mask num_heads=1 fails without workaround. "
-    "tt-metal requires mask[2] == num_heads and does not support implicit broadcast."
-)
 def test_sdpa_decode_mask_broadcast_no_workaround(
     shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
 ):
     """
-    Test that SDPA decode with mask num_heads=1 fails without the workaround.
-    tt-metal requires mask[2] == num_heads for decode.
+    Test that SDPA decode with a mask requiring batch or num_heads broadcast
+    fails without the workaround.
     """
     batch = shapes[0][1]
     kv_seq = shapes[1][2]

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
@@ -180,11 +180,11 @@ module @test_sdpa_workaround attributes {} {
     %query: tensor<1x32x32x64xbf16>,
     %key: tensor<32x32x128x64xbf16>,
     %value: tensor<32x32x128x64xbf16>,
-    %mask: tensor<32x1x1x128xbf16>
+    %mask: tensor<1x32x1x128xbf16>
   ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_workaround_broadcast_mask_heads
 
-    // Mask should be broadcast from [32, 1, 1, 128] to [32, 1, 32, 128]
+    // Mask should be broadcast from [1, 32, 1, 128] to [1, 32, 32, 128]
     // CHECK: %[[BROADCAST_MASK:[0-9]+]] = "ttnn.repeat"(%arg3)
     // CHECK-SAME: repeat_dims = #ttnn.shape<1x1x32x1>
 
@@ -195,7 +195,7 @@ module @test_sdpa_workaround attributes {} {
       is_causal = false,
       scale = 0.125 : f32
     }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
-         tensor<32x32x128x64xbf16>, tensor<32x1x1x128xbf16>)
+         tensor<32x32x128x64xbf16>, tensor<1x32x1x128xbf16>)
       -> tensor<1x32x32x64xbf16>
     return %result : tensor<1x32x32x64xbf16>
   }
@@ -205,7 +205,7 @@ module @test_sdpa_workaround attributes {} {
     %query: tensor<1x32x32x64xbf16>,
     %key: tensor<32x32x128x64xbf16>,
     %value: tensor<32x32x128x64xbf16>,
-    %mask: tensor<32x1x32x128xbf16>
+    %mask: tensor<1x32x32x128xbf16>
   ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_no_workaround_mask_heads_match
 
@@ -218,7 +218,7 @@ module @test_sdpa_workaround attributes {} {
       is_causal = false,
       scale = 0.125 : f32
     }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
-         tensor<32x32x128x64xbf16>, tensor<32x1x32x128xbf16>)
+         tensor<32x32x128x64xbf16>, tensor<1x32x32x128xbf16>)
       -> tensor<1x32x32x64xbf16>
     return %result : tensor<1x32x32x64xbf16>
   }

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
@@ -11,9 +11,9 @@ module {
         return %0 : tensor<1x8x12x32xbf16>
     }
 
-    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<8x1x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
+    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<1x8x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
         // CHECK: "ttnn.scaled_dot_product_attention_decode"
-        %0 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
+        %0 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<1x8x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
         return %0 : tensor<1x8x12x32xbf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
@@ -9,9 +9,9 @@ module {
         return %1 : tensor<1x8x12x32xbf16>
     }
 
-    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<8x1x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
+    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<1x8x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
         // CHECK: "ttnn.scaled_dot_product_attention_decode"
-        %1 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
+        %1 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<1x8x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
         return %1 : tensor<1x8x12x32xbf16>
     }
 }

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1752,6 +1752,7 @@ def sdpa_decode_golden(
         Query:  [1, batch, num_heads, head_dim]
         Key:    [batch, num_kv_heads, seq_len, head_dim]
         Value:  [batch, num_kv_heads, seq_len, head_dim]
+        Mask:   [1, batch_or_1, num_heads_or_1, seq_len]
         Output: [1, batch, num_heads, head_dim]
     """
     # Query: [1, B, H, D] -> [B, H, 1, D]
@@ -1774,9 +1775,9 @@ def sdpa_decode_golden(
     qk = torch.matmul(q, k.transpose(-2, -1))
 
     # Add attention mask (before scaling, matching tt-metal)
-    # Mask is in decode layout [B, 1, H, S], permute to [B, H, 1, S] to match qk
+    # Mask is in decode layout [1, B, H, S], permute to [B, H, 1, S] to match qk
     if attention_mask is not None:
-        qk = torch.add(qk, attention_mask.float().transpose(1, 2))
+        qk = torch.add(qk, attention_mask.float().permute(1, 2, 0, 3))
 
     # Scale AFTER masking (tt-metal fuses scale into exp)
     if scale is not None:


### PR DESCRIPTION
### Ticket
[xla pcc issue](https://github.com/tenstorrent/tt-xla/issues/4206)
[known metal sdpa issue](https://github.com/tenstorrent/tt-metal/issues/39910)

### Problem description
Even though pcc on prefill is good, outputs for multichip LLMs are mostly bad, like in [this nightly run](https://github.com/tenstorrent/tt-xla/actions/runs/24642681050/job/72084379748). This is especially present in galaxy llama and gpt oss.

### What's changed
The root cause is attention_mask broadcasting in the decode sdpa op. 

Without checking and asserting shape, device ops assumes that it has same batch and num_heads as Q. When provided with tensor of batch_size 1 instead, it still reads rest of the data in expected size. When these are all 0, and KV cache has 0 on future places,  it might not look that bad with outputs repeating sensible frequent words, but if something else is already written there output can be completely random. 

Output for the first user was always ok as it was the only one with correct attention_mask. The fix was needed only for decode, so pcc that we calculate on prefill will not be affected.

Some perf drop is expected, but it will be back once we support `is_causal` and `sliding_window` built-in masks.

It should not change pcc of any model as we measure it today because we check only first user prefill, and this is fixing decode for non-first tokens. 

### Checklist
- [x] [perf benchmark on llmbox](https://github.com/tenstorrent/tt-xla/actions/runs/24664607317/job/72120802836) - mlir change only (gpt oss still expected to be weird)
- [x] [perf benchmark on galaxy](https://github.com/tenstorrent/tt-xla/actions/runs/24666905318/job/72129144995) - with [xla fix for gpt oss](https://github.com/tenstorrent/tt-xla/pull/4316)
- [x] [perf benchmark n150](https://github.com/tenstorrent/tt-xla/actions/runs/24710067795)
