### PR TITLE
[Optimizer] Add RmsNormRuleBook with sharded-input scoring override

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -114,10 +114,15 @@ struct BeamCandidate {
 };
 
 /// Score a backend validation result. Per-op customization via TypeSwitch.
+/// `inputLayouts` is the full per-operand input layout set for this candidate
+/// (or empty if the op has no inputs); passed through to
+/// `OpRuleBook::adjustScore` so per-op overrides can inspect and make
+/// decisions based on input layouts.
 LayoutScore
 scoreCandidate(Operation *op, const OpConfig &config,
                const op_constraint_validation::ValidationResult &result,
-               bool requiresReshard);
+               bool requiresReshard,
+               llvm::ArrayRef<TTNNLayoutAttr> inputLayouts = {});
 
 /// Op-specific tiebreaker when two candidates have equal LayoutScores.
 /// Returns true if candidate a is preferred over b.

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -5,9 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_LAYOUTFILTERUTILS_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_LAYOUTFILTERUTILS_H
 
+#include "ttmlir/Dialect/TTCore/Utils/CoreRangeSet.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
 
+#include <algorithm>
+#include <limits>
 #include <vector>
 
 namespace mlir::tt::ttnn::layout_filter_utils {
@@ -24,6 +27,42 @@ inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   return !(ml && ml.getValue() == TensorMemoryLayout::WidthSharded);
 }
 
+/// Whether a sharded layout's core grid forms a full rectangular bounding
+/// box (num_cores == bbox_num_cores). Interleaved layouts return true.
+inline bool isFullBboxSharded(TTNNLayoutAttr layout) {
+  auto ml = layout.getMemLayout();
+  if (!isShardedMemoryLayout(ml.getValue())) {
+    return true;
+  }
+
+  auto grid = layout.getGrid();
+  mlir::AffineMap mapping = grid.getVirtToPhysicalMap();
+  assert(mapping &&
+         "sharded layout must have a grid with a virt-to-phys mapping");
+
+  auto ranges =
+      mlir::tt::ttcore::utils::toCoreRangeSet(grid.getShape(), mapping);
+  if (ranges.empty()) {
+    return false;
+  }
+
+  int32_t minX = std::numeric_limits<int32_t>::max();
+  int32_t minY = std::numeric_limits<int32_t>::max();
+  int32_t maxX = std::numeric_limits<int32_t>::min();
+  int32_t maxY = std::numeric_limits<int32_t>::min();
+  int64_t numCores = 0;
+  for (const auto &[loc, size] : ranges) {
+    numCores += static_cast<int64_t>(size[0]) * static_cast<int64_t>(size[1]);
+    minX = std::min(minX, loc[0]);
+    minY = std::min(minY, loc[1]);
+    maxX = std::max(maxX, loc[0] + size[0] - 1);
+    maxY = std::max(maxY, loc[1] + size[1] - 1);
+  }
+  int64_t bboxCores = static_cast<int64_t>(maxX - minX + 1) *
+                      static_cast<int64_t>(maxY - minY + 1);
+  return numCores == bboxCores;
+}
+
 /// Allow only a specific sharding type (plus interleaved). Returns a filter
 /// function that rejects sharded layouts whose type doesn't match.
 inline LayoutFilterFn
@@ -37,17 +76,14 @@ allowOnlyShardingType(TensorMemoryLayout allowedSharding) {
   };
 }
 
-/// Filter legalConfigs to only include non-sharded (DRAM or L1-interleaved).
+/// Filter legalConfigs by an output-layout predicate. Configs with a NULL
+/// output layout are always kept (NULL hint means "backend picks"). Keeps any
+/// config whose output layout passes `keep`.
 inline std::vector<OpConfig>
-filterNonSharded(const std::vector<OpConfig> &legalConfigs) {
+filterConfigs(const std::vector<OpConfig> &legalConfigs, LayoutFilterFn keep) {
   std::vector<OpConfig> result;
   for (const auto &config : legalConfigs) {
-    if (!config.outputLayout) {
-      result.push_back(config);
-      continue;
-    }
-    auto memLayout = config.outputLayout.getMemLayout();
-    if (!memLayout || !isShardedMemoryLayout(memLayout.getValue())) {
+    if (!config.outputLayout || keep(config.outputLayout)) {
       result.push_back(config);
     }
   }
@@ -57,7 +93,13 @@ filterNonSharded(const std::vector<OpConfig> &legalConfigs) {
 /// Non-sharded output hints (common pattern for many ops).
 inline OutputHints
 nonShardedOutputHints(const std::vector<OpConfig> &legalConfigs) {
-  return OutputHints{filterNonSharded(legalConfigs), {}};
+  return OutputHints{filterConfigs(legalConfigs, rejectAllSharded), {}};
+}
+
+/// All non-width-sharded output hints (interleaved + block/height sharded).
+inline OutputHints
+nonWidthShardedOutputHints(const std::vector<OpConfig> &legalConfigs) {
+  return OutputHints{filterConfigs(legalConfigs, rejectWidthSharded), {}};
 }
 
 /// NULL-hint-only output (backend decides from inputs, no fallbacks).

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_NORMALIZATIONRULES_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_NORMALIZATIONRULES_H
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+
+namespace mlir::tt::ttnn {
+
+//===----------------------------------------------------------------------===//
+// Normalization ops: RMSNorm (LayerNorm has the same kernel dispatch logic
+// and could share rules in a follow-up).
+//
+// Kernel dispatch (layernorm_device_operation.cpp:16-22):
+//   input.is_sharded() ? LayerNormShardedProgramFactory
+//                      : LayerNormMultiCoreProgramFactory
+//
+// The sharded kernel's validator enforces
+// (layernorm_device_operation.cpp:148-173):
+//   - input cannot be HEIGHT_SHARDED
+//   - shard grid must be a full rectangular bounding box
+//     (shard_spec.grid.num_cores() == bbox_num_cores)
+//   - output must also be sharded (not height sharded)
+//
+// Without an input filter, partial-grid sharded candidates reach op-model
+// validation and fail with TT_FATAL. The filter prunes them early.
+//===----------------------------------------------------------------------===//
+
+struct RmsNormRuleBook : OpRuleBook {
+
+  /// RMSNormOp: operand 0 (activation) must be interleaved OR full-bbox
+  /// block/width sharded. Height-sharded inputs and partial-bbox sharded inputs
+  /// are rejected because the sharded layernorm kernel doesn't support them.
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+
+  /// adjustScore reflects kernel-dispatch reality: the generic scorer derives
+  /// `coreCount` from the output layout, but for rms_norm with interleaved
+  /// input the kernel runs single- or few-core (parallelism = NC*Ht of input)
+  /// regardless of how the output is sharded. With sharded input, the sharded
+  /// kernel uses input->grid->volume cores. Without this adjustment, an
+  /// interleaved-input candidate with a high-core sharded output beats a
+  /// sharded-input candidate with a low-core sharded output, even though the
+  /// sharded-input candidate is the strictly faster runtime path.
+  ///
+  /// The adjustment also intentionally lets a reshard-bearing candidate win
+  /// over a no-reshard alternative when the reshard produces a full-bbox
+  /// sharded input: the generic LayoutScore lexicographic order ranks
+  /// `requiresReshard=false` above `coreCount`, which blocks sharded-input
+  /// candidates whose only cost vs an interleaved-input peer is the inserted
+  /// reshard. For rms_norm the kernel speedup (~3x+ on decode shapes)
+  /// dominates the reshard cost, so `requiresReshard` is cleared on
+  /// sharded-input candidates to prefer the better-parallelized path.
+  LayoutScore adjustScore(Operation *op, LayoutScore base,
+                          const OpConfig &config,
+                          llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                          bool requiresReshard) const override;
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_NORMALIZATIONRULES_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -79,6 +79,16 @@ struct OpRuleBook {
   /// Default: prefer more sharded inputs (fewer DRAM/L1-interleaved reads).
   virtual bool preferCandidate(Operation *op, const BeamCandidate &a,
                                const BeamCandidate &b) const;
+
+  /// Adjust a candidate's LayoutScore after the base scorer computed it.
+  /// Receives the output config, all operand input
+  /// layouts, and the reshard flag.
+  virtual LayoutScore adjustScore(Operation *op, LayoutScore base,
+                                  const OpConfig &config,
+                                  llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                                  bool requiresReshard) const {
+    return base;
+  }
 };
 
 /// Direct lookup: maps an op to its RuleBook via OperationName.

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -143,7 +143,8 @@ std::optional<BeamCandidate> MemoryLayoutPropagation::evaluateHint(
     BeamCandidate candidate;
     candidate.configHint =
         OpConfig(result.getFirstActualOutputLayout(), hint.opSpecificAttrs);
-    candidate.score = scoreCandidate(op, hint, result, anyReshard);
+    candidate.score =
+        scoreCandidate(op, hint, result, anyReshard, inputLayouts);
     candidate.score.inputDramBytes = computeInputDramBytes(inputLayouts);
     candidate.validationResult = result;
     candidate.inputLayouts = inputLayouts;

--- a/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
@@ -59,7 +59,8 @@ bool LayoutScore::operator==(const LayoutScore &other) const {
 LayoutScore
 scoreCandidate(Operation *op, const OpConfig &config,
                const op_constraint_validation::ValidationResult &result,
-               bool requiresReshard) {
+               bool requiresReshard,
+               llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) {
   LayoutScore score;
   score.requiresReshard = requiresReshard;
   score.outputL1Usage = result.outputL1Usage;
@@ -67,7 +68,8 @@ scoreCandidate(Operation *op, const OpConfig &config,
   TTNNLayoutAttr layout = result.getFirstActualOutputLayout();
   if (!layout) {
     // No layout returned; treat as DRAM fallback.
-    return score;
+    return getRuleBook(op).adjustScore(op, score, config, inputLayouts,
+                                       requiresReshard);
   }
 
   score.isL1 = layout.hasL1BufferType();
@@ -83,7 +85,8 @@ scoreCandidate(Operation *op, const OpConfig &config,
     }
   }
 
-  return score;
+  return getRuleBook(op).adjustScore(op, score, config, inputLayouts,
+                                     requiresReshard);
 }
 
 bool preferCandidate(Operation *op, const BeamCandidate &a,

--- a/lib/Dialect/TTNN/Analysis/OpRules/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/OpRules/CMakeLists.txt
@@ -3,6 +3,7 @@ set(OPRULES_SRCS
     DataMovementRules.cpp
     EmbeddingRules.cpp
     MatmulRules.cpp
+    NormalizationRules.cpp
     OpRuleBook.cpp
     TransformerRules.cpp
     TypecastRules.cpp

--- a/lib/Dialect/TTNN/Analysis/OpRules/NormalizationRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/NormalizationRules.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::tt::ttnn {
+
+namespace {
+
+/// Input operand's tile-height: the total number of tile rows across all
+/// leading (batch/channel) dims times the tile-aligned height of the
+/// last-two-dim row. Computed as `NC * Ht`, where `NC` is the product of all
+/// dims except the last two and `Ht = ceil(H / TILE_HEIGHT)`. Kernels that
+/// parallelize by distributing tile rows across cores are capped by this
+/// count regardless of how the output tensor is sharded.
+int64_t inputOperandTileHeight(Operation *op, unsigned operandIdx) {
+  auto opType =
+      mlir::cast<mlir::RankedTensorType>(op->getOperand(operandIdx).getType());
+  assert(opType && "expected ranked tensor operand");
+
+  auto shape = opType.getShape();
+  constexpr int64_t kTileHeight = 32;
+  int64_t ht = shape.size() >= 2
+                   ? llvm::divideCeil(shape[shape.size() - 2], kTileHeight)
+                   : 1;
+  int64_t nc = 1;
+  for (size_t i = 0; i + 2 < shape.size(); ++i) {
+    nc *= shape[i];
+  }
+  return nc * ht;
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// RmsNormRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+RmsNormRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Only operand 0 (activation) gates kernel dispatch. Gamma (operand 1) and
+  // beta (operand 2) are small 1D tensors; leave them unconstrained.
+  if (operandIdx != 0) {
+    return nullptr;
+  }
+
+  return [](TTNNLayoutAttr layout) -> bool {
+    auto ml = layout.getMemLayout();
+    if (!ml) {
+      return true; // no mem layout info — accept
+    }
+
+    auto value = ml.getValue();
+
+    // Interleaved is always accepted.
+    if (!isShardedMemoryLayout(value)) {
+      return true;
+    }
+
+    // Height-sharded is explicitly rejected by the sharded layernorm kernel
+    // (layernorm_device_operation.cpp:151).
+    if (value == TensorMemoryLayout::HeightSharded) {
+      return false;
+    }
+
+    // Block- and width-sharded are accepted, provided the grid is a full
+    // rectangular bbox.
+    return layout_filter_utils::isFullBboxSharded(layout);
+  };
+}
+
+LayoutScore RmsNormRuleBook::adjustScore(
+    Operation *op, LayoutScore base, const OpConfig &config,
+    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts, bool requiresReshard) const {
+  // Only operand 0 (activation) gates rms_norm kernel dispatch.
+  if (inputLayouts.empty() || !inputLayouts[0]) {
+    return base;
+  }
+  TTNNLayoutAttr operand0Layout = inputLayouts[0];
+  auto ml = operand0Layout.getMemLayout();
+
+  if (isShardedMemoryLayout(ml.getValue())) {
+    // Sharded-input path: the sharded layernorm kernel parallelizes across
+    // the input shard grid. The output-derived `coreCount` already typically
+    // matches (kernel writes to the same grid), but force it to the input
+    // grid's volume for ops where output sharding might differ. Also clear
+    // `requiresReshard` — the 3x+ kernel speedup over the interleaved variant
+    // dominates the few-µs reshard cost on decode-shape tensors.
+    base.coreCount =
+        static_cast<int64_t>(operand0Layout.getGrid().getGridVolume());
+    base.requiresReshard = false;
+  } else {
+    // Interleaved-input path: `LayerNormMultiCoreProgramFactory` parallelizes
+    // by tile-row count. Override the output-derived coreCount with the
+    // input operand's tile height so the comparison reflects kernel reality,
+    // not output distribution.
+    base.coreCount = inputOperandTileHeight(op, /*operandIdx=*/0);
+  }
+  return base;
+}
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/EmbeddingRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
@@ -75,6 +76,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static TypecastRuleBook typecast;
   static RotaryEmbeddingRuleBook rotaryEmbedding;
   static SplitQKVRuleBook splitQKV;
+  static RmsNormRuleBook rmsNorm;
 
   static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
   static std::once_flag initFlag;
@@ -107,6 +109,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(RotaryEmbeddingOp::getOperationName(), &rotaryEmbedding);
     reg(RotaryEmbeddingLlamaOp::getOperationName(), &rotaryEmbedding);
     reg(SplitQueryKeyValueAndSplitHeadsOp::getOperationName(), &splitQKV);
+    reg(RMSNormOp::getOperationName(), &rmsNorm);
   });
   auto it = registry.find(op->getName());
   return it != registry.end() ? *it->second : defaultRules;


### PR DESCRIPTION
## Summary
- Adds `OpRuleBook::adjustScore` hook so per-op rules can rewrite a candidate's `LayoutScore` after base scoring, with access to the output `OpConfig`, all input layouts, and the `requiresReshard` flag.
- Adds `RmsNormRuleBook` with an input layout filter (rejects height-sharded and partial-bbox sharded operand-0 inputs) and an `adjustScore` override that makes rms_norm score candidates based on kernel-dispatch reality instead of output sharding.
- Adds `isFullBboxSharded` helper in `LayoutFilterUtils.h` — checks whether a sharded layout's core grid forms a full rectangular bounding box (required by the sharded layernorm kernel's TT_FATAL at `layernorm_device_operation.cpp:173`).

## Why

The generic `LayoutScore` derives `coreCount` from the output layout, but sharding-gated kernels (layernorm/rms_norm) key their parallelism off the **input** layout:
- sharded input → `LayerNormShardedProgramFactory`, uses `input.grid.volume` cores (full-bbox required)
- interleaved input → `LayerNormMultiCoreProgramFactory`, tile-row-parallel (parallelism = `NC*Ht` of input shape)

Previously the lexicographic `LayoutScore` order ranked `requiresReshard=false` above `coreCount`, so an interleaved-input candidate with a high-core sharded **output** beat a sharded-input candidate with a reshard — even though the latter is the strictly faster kernel path. The 2D decode-shape case was the worst: kernel actually ran on 1 core despite the output being `width_sharded/1x45`.

`RmsNormRuleBook::adjustScore` fixes this by:
1. On sharded input: set `coreCount = input.grid.volume` and clear `requiresReshard` (kernel speedup dominates ~5–10 µs reshard cost on decode-shape tensors).
2. On interleaved input: set `coreCount = NC * Ht` of the input shape (the real kernel parallelism, capped by `split_work_to_cores`).

The filter prunes sharded candidates the kernel would reject at op-model validation, saving compile time.

## Test plan

- [x] gpt_oss_20b_decode_2lyr recompile: all 5 rms_norms on sharded input
- [x] tt-xla perf benchmark (n150, LLMs): 0 regressions, 7 improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)