### PR TITLE
[Optimizer] Bail out of emitting matmul program config when fuse_batch=false

### DIFF
--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -267,6 +267,16 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   }
   int64_t maxSubblockSize = getMaxSubblockSize(computeConfig);
 
+  // Batched matmul (fuse_batch=false, i.e. in1 has a non-unit batch dim):
+  // sharded outputs hit a hang with the mcast program configs
+  // (https://github.com/tenstorrent/tt-metal/issues/42572), so we opt out
+  // of emitting any program config here and let tt-metal's runtime auto-picker
+  // choose. Once the issue is resolved, op itself would reject such configs
+  // and we can remove the fuse_batch check here.
+  if (!fuseBatch) {
+    return std::nullopt;
+  }
+
   if (outputMemLayout == TensorMemoryLayout::BlockSharded) {
     return generateMatmul2DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,
                                          fusedActivation, maxSubblockSize,


### PR DESCRIPTION
## Summary
- For matmul / linear where input B has a non-unit batch dim (`fuse_batch = false`), skip emitting a `MatmulMultiCoreReuseMultiCast{1D,2D}ProgramConfig` with a sharded output and let tt-metal's runtime auto-picker choose instead.

## Why
Emitting the mcast program config with a sharded output on a batched matmul hits a hang inside tt-metal — tracked in https://github.com/tenstorrent/tt-metal/issues/42572. The safest fix on the compiler side is to fall back to no explicit config for this case; the runtime picks a working configuration on its own.

Once the upstream issue lands, the op itself will reject the invalid configs and this guard can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)