### PR TITLE
[d2m] rand lowering

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -829,6 +829,40 @@ def D2M_TileFillOp : D2M_GenericRegionComputeOp<"tile_fill"> {
     }];
 }
 
+def D2M_TileRandOp : D2M_GenericRegionComputeOp<"tile_rand"> {
+    let summary = "D2M Rand Tile Op";
+    let description = [{
+        The `tile_rand` operation creates a tile filled with random float values
+        drawn from a uniform distribution over the range [from, from + scale).
+
+        Attributes:
+          - `seed` (UI32): Seed passed to `rand_tile_init` to initialize the PRNG.
+          - `from` (F32): Lower bound of the uniform distribution (inclusive).
+          - `scale` (F32): Width of the uniform distribution (must be > 0).
+
+        Lowers to `ttkernel.rand_tile_init(seed)` + `ttkernel.rand_tile(dst_idx,
+        from_bits, scale_bits)` where the `from`/`scale` parameters are the
+        bit-cast f32 values.
+    }];
+
+    let arguments = (ins DefaultValuedAttr<UI32Attr, "0">:$seed,
+                         DefaultValuedAttr<F32Attr, "0.0">:$from,
+                         DefaultValuedAttr<F32Attr, "1.0">:$scale);
+    let results = (outs TTCore_Tile:$result);
+
+    let assemblyFormat = [{
+        `(` `)` attr-dict `:` type($result)
+    }];
+
+    let extraClassDeclaration = [{
+        // This operation doesn't load from DST (it generates a new tile).
+        mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
+          return {};
+        }
+        bool getDstRegInPlace() { return false; }
+    }];
+}
+
 def D2M_BlockMaskOp : D2M_GenericRegionComputeOp<"block_mask",
   [ DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -2412,6 +2412,40 @@ def TTKernel_FillTileIntOp : TTKernel_SFPUOp<"fill_tile_int", [TTKernel_UnaryOpT
     }];
 }
 
+def TTKernel_RandTileInitOp : TTKernel_InitOp<"rand_tile_init"> {
+    let summary = "Init function for rand_tile operation. Refer to documentation for any init function.";
+    let description = [{
+      Initializes the PRNG seed for the SFPU. Must be run before rand_tile.
+    }];
+
+    let arguments = (ins IndexLike:$seed);
+
+    let assemblyFormat = [{
+      `(` $seed `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_RandTileOp : TTKernel_SFPUOp<"rand_tile", [TTKernel_UnaryOpTrait]> {
+    let summary = "Rand tile operation";
+    let description = [{
+      Performs element-wise rand on each element of a tile in DST register at
+      index tile_index. That is each element is overwritten with a randomly
+      generated float in the range [from, from + scale).
+
+      `from` and `scale` are passed as the uint32_t bit pattern of their
+      corresponding f32 values. The DST register buffer must be in acquired
+      state via *tile_regs_acquire* call.
+    }];
+
+    let arguments = (ins IndexLike:$tile_index,
+                         IndexLike:$from,
+                         IndexLike:$scale);
+
+    let assemblyFormat = [{
+      `(` $tile_index `,` $from `,` $scale `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 def TTKernel_SigmoidTileInitOp : TTKernel_InitOp<"sigmoid_tile_init"> {
     let summary = "Short init function which configures compute unit for execution of sigmoid_tile.";
     let description = [{

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -189,6 +189,8 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"power_binary_tile_init",                         {"api/compute/eltwise_binary_sfpu.h", ""}},
         {"power_tile",                                     {"api/compute/compute_kernel_api.h", ""}},
         {"power_tile_init",                                {"api/compute/compute_kernel_api.h", ""}},
+        {"rand_tile",                                      {"api/compute/eltwise_unary/rand.h", ""}},
+        {"rand_tile_init",                                 {"api/compute/eltwise_unary/rand.h", ""}},
         {"recip_tile",                                     {"api/compute/eltwise_unary/recip.h", ""}},
         {"recip_tile_init",                                {"api/compute/eltwise_unary/recip.h", ""}},
         {"reduce_init",                                    {"api/compute/reduce.h", ""}},

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -27,6 +27,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -1618,6 +1619,71 @@ public:
     return success();
   }
 };
+
+// Lower `d2m.tile_rand` to `ttkernel.rand_tile_init(seed)` + `rand_tile`.
+// `from`/`scale` are the uint32 bit patterns of the f32 attributes (see
+// tt_metal/hw/inc/api/compute/eltwise_unary/rand.h). Mirrors ttnn::rand's
+// per-core seed perturbation at runtime via my_logical_{x,y}_, hoisted above
+// the tile loop so each core's PRNG advances across tiles.
+class D2MTileRandRewriter : public OpConversionPattern<d2m::TileRandOp> {
+public:
+  using OpConversionPattern<d2m::TileRandOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::TileRandOp op, d2m::TileRandOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Value dstIdx = getDstIdxFromResult(op.getResult());
+    ensureDominatesInsertionPoint(rewriter, dstIdx);
+
+    Location loc = op->getLoc();
+    Value outCB = getOutCB(rewriter, op);
+    auto insertionPoint = rewriter.getInsertionPoint();
+
+    // Hoist HW startup and rand_tile_init above the tile loop.
+    setInsertionPointAfterOperands(rewriter, {outCB}, /*allowHoisting*/ true);
+    rewriter.create<ttkernel::ComputeKernelHWStartupOp>(loc, outCB, nullptr,
+                                                        outCB);
+
+    // Build an i32 constant from a raw 32-bit pattern without going through a
+    // `uint32_t -> int32_t` cast (which is impl-defined for values with the
+    // high bit set). This matters for seeds/f32 bit-patterns/hash primes.
+    auto i32Ty = rewriter.getI32Type();
+    auto i32FromBits = [&](uint32_t bits) -> Value {
+      return rewriter
+          .create<arith::ConstantOp>(
+              loc, i32Ty,
+              rewriter.getIntegerAttr(i32Ty, llvm::APInt(/*numBits=*/32, bits)))
+          .getResult();
+    };
+
+    // Per-core seed: user_seed XOR (x*C1) XOR (y*C2) with hash-prime
+    // constants, giving distinct streams per core even when seed=0.
+    Value userSeed = i32FromBits(op.getSeed());
+    Value logicalX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+    Value logicalY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
+    Value xI32 = rewriter.create<arith::IndexCastOp>(loc, i32Ty, logicalX);
+    Value yI32 = rewriter.create<arith::IndexCastOp>(loc, i32Ty, logicalY);
+    Value mulX =
+        rewriter.create<arith::MulIOp>(loc, xI32, i32FromBits(0x9E3779B1u));
+    Value mulY =
+        rewriter.create<arith::MulIOp>(loc, yI32, i32FromBits(0x85EBCA77u));
+    Value seedWithX = rewriter.create<arith::XOrIOp>(loc, userSeed, mulX);
+    Value effSeed = rewriter.create<arith::XOrIOp>(loc, seedWithX, mulY);
+    rewriter.create<ttkernel::RandTileInitOp>(loc, effSeed);
+    rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+
+    Value fromVal =
+        i32FromBits(llvm::bit_cast<uint32_t>(op.getFrom().convertToFloat()));
+    Value scaleVal =
+        i32FromBits(llvm::bit_cast<uint32_t>(op.getScale().convertToFloat()));
+
+    rewriter.create<ttkernel::RandTileOp>(loc, dstIdx, fromVal, scaleVal);
+
+    rewriter.replaceOp(op, dstIdx);
+    return success();
+  }
+};
+
 class D2MExperimentalFillArangeTileRewriter
     : public OpConversionPattern<d2m::FillArangeTileOp> {
 public:
@@ -2695,6 +2761,7 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MTilizeUntilizeRewriter<d2m::TileTilizeBlockOp, ttkernel::ExperimentalTilizeBlockOp>,
                ttkernel::D2MTilizeUntilizeRewriter<d2m::TileUntilizeBlockOp, ttkernel::ExperimentalPackUntilizeBlockOp>,
                ttkernel::D2MTileFillRewriter,
+               ttkernel::D2MTileRandRewriter,
                ttkernel::D2MWriteRowMaskTileRewriter,
                ttkernel::D2MWriteColMaskTileRewriter,
                ttkernel::D2MExperimentalFillArangeTileRewriter,

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1644,38 +1644,42 @@ public:
     rewriter.create<ttkernel::ComputeKernelHWStartupOp>(loc, outCB, nullptr,
                                                         outCB);
 
-    // Build an i32 constant from a raw 32-bit pattern without going through a
-    // `uint32_t -> int32_t` cast (which is impl-defined for values with the
-    // high bit set). This matters for seeds/f32 bit-patterns/hash primes.
+    // LLK takes uint32 seed / uint32 bit-cast of f32 from/scale; materialize
+    // as i32 constants carrying the raw 32-bit pattern.
     auto i32Ty = rewriter.getI32Type();
-    auto i32FromBits = [&](uint32_t bits) -> Value {
+    auto i32FromBits = [&](llvm::APInt bits) -> Value {
+      assert(bits.getBitWidth() == 32);
       return rewriter
-          .create<arith::ConstantOp>(
-              loc, i32Ty,
-              rewriter.getIntegerAttr(i32Ty, llvm::APInt(/*numBits=*/32, bits)))
+          .create<arith::ConstantOp>(loc, i32Ty,
+                                     rewriter.getIntegerAttr(i32Ty, bits))
           .getResult();
     };
 
-    // Per-core seed: user_seed XOR (x*C1) XOR (y*C2) with hash-prime
-    // constants, giving distinct streams per core even when seed=0.
-    Value userSeed = i32FromBits(op.getSeed());
+    // Per-core seed perturbation (mirrors ttnn::rand): mix the core's
+    // logical coords into the user seed so each core gets a distinct stream,
+    // even when seed=0.
+    //   effective_seed = user_seed ^ (x * kPrimeX) ^ (y * kPrimeY)
+    // where x, y are `my_logical_{x,y}` and kPrime* are distinct odd 32-bit
+    // hash primes (kPrimeX = phi * 2^32) used to spread small, structured
+    // coordinates across the full 32-bit range before XOR-folding.
+    constexpr uint32_t kPrimeX = 0x9E3779B1u;
+    constexpr uint32_t kPrimeY = 0x85EBCA77u;
+    Value userSeed = i32FromBits(llvm::APInt(32, op.getSeed()));
+    Value primeX = i32FromBits(llvm::APInt(32, kPrimeX));
+    Value primeY = i32FromBits(llvm::APInt(32, kPrimeY));
     Value logicalX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
     Value logicalY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
     Value xI32 = rewriter.create<arith::IndexCastOp>(loc, i32Ty, logicalX);
     Value yI32 = rewriter.create<arith::IndexCastOp>(loc, i32Ty, logicalY);
-    Value mulX =
-        rewriter.create<arith::MulIOp>(loc, xI32, i32FromBits(0x9E3779B1u));
-    Value mulY =
-        rewriter.create<arith::MulIOp>(loc, yI32, i32FromBits(0x85EBCA77u));
+    Value mulX = rewriter.create<arith::MulIOp>(loc, xI32, primeX);
+    Value mulY = rewriter.create<arith::MulIOp>(loc, yI32, primeY);
     Value seedWithX = rewriter.create<arith::XOrIOp>(loc, userSeed, mulX);
     Value effSeed = rewriter.create<arith::XOrIOp>(loc, seedWithX, mulY);
     rewriter.create<ttkernel::RandTileInitOp>(loc, effSeed);
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
-    Value fromVal =
-        i32FromBits(llvm::bit_cast<uint32_t>(op.getFrom().convertToFloat()));
-    Value scaleVal =
-        i32FromBits(llvm::bit_cast<uint32_t>(op.getScale().convertToFloat()));
+    Value fromVal = i32FromBits(op.getFrom().bitcastToAPInt());
+    Value scaleVal = i32FromBits(op.getScale().bitcastToAPInt());
 
     rewriter.create<ttkernel::RandTileOp>(loc, dstIdx, fromVal, scaleVal);
 

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -2538,8 +2538,9 @@ public:
 };
 
 /// Lowers `ttir.rand` to a `d2m.generic` of `d2m.tile_rand` tiles, mapping
-/// `[low, high)` to the kernel's `[from, from + scale)` form. Non-f32
-/// dtypes are generated in f32 and chained through a `ttir.typecast`.
+/// `[low, high)` to the kernel's `[from, from + scale)` form. Non-f32 outputs
+/// are generated in f32 and then cast via a second `d2m.generic` wrapping
+/// `d2m.tile_typecast`.
 class D2MRandOpRewriter : public OpConversionPattern<ttir::RandOp>,
                           D2MNamedRewriterCommon {
 public:
@@ -2567,8 +2568,8 @@ public:
           op, "ttir.rand requires high > low for TTMetal lowering");
     }
 
-    // `rand_tile` only produces f32 reliably; for other dtypes, rand in f32
-    // and chain a `ttir.typecast` (lowered later in this pass).
+    // `rand_tile` only produces f32 reliably; other dtypes rand in f32 and
+    // then get cast via `buildTypecastGeneric` below.
     Type f32Ty = rewriter.getF32Type();
     const bool needsCast = finalElemType != f32Ty;
     RankedTensorType randResultType =
@@ -2576,17 +2577,39 @@ public:
                                           finalResultType.getEncoding())
                   : finalResultType;
 
+    auto seedAttr = op.getSeedAttr();
+    auto fromAttr = rewriter.getF32FloatAttr(low);
+    auto scaleAttr = rewriter.getF32FloatAttr(scale);
+
+    mlir::Value randResult = buildRandGeneric(rewriter, loc, randResultType,
+                                              seedAttr, fromAttr, scaleAttr);
+
+    mlir::Value result =
+        needsCast
+            ? buildTypecastGeneric(rewriter, loc, randResult, finalResultType)
+            : randResult;
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  /// Fills a fresh `randResultType` tensor with `d2m.tile_rand` tiles.
+  /// Returns the un-layouted logical result.
+  mlir::Value buildRandGeneric(ConversionPatternRewriter &rewriter,
+                               Location loc, RankedTensorType randResultType,
+                               mlir::IntegerAttr seedAttr,
+                               mlir::FloatAttr fromAttr,
+                               mlir::FloatAttr scaleAttr) const {
     SmallVector<Value> origInputs;
     SmallVector<Value> origOutputs =
         createDpsOutputs(loc, rewriter, {randResultType});
     auto [inputs, outputs] = toLayoutOperandsAndResults(
         rewriter, {origInputs, origOutputs}, /*tiled*/ true);
     assert(outputs.size() == 1);
-    Value output = outputs[0];
 
     const std::size_t physicalRank =
-        ttcore::getDeviceLayout(output).getRank() / 2;
-
+        ttcore::getDeviceLayout(outputs[0]).getRank() / 2;
     SmallVector<AffineMap> indexingMaps =
         getIdentityAffineMapsArray(rewriter, 1, physicalRank);
     auto parallel = ttcore::IteratorTypeAttr::get(
@@ -2597,10 +2620,6 @@ public:
         loc, inputs, outputs, /*additionalArgs=*/ValueRange(),
         rewriter.getAffineMapArrayAttr(indexingMaps),
         rewriter.getArrayAttr(iteratorTypes));
-
-    auto seedAttr = op.getSeedAttr();
-    auto fromAttr = rewriter.getF32FloatAttr(low);
-    auto scaleAttr = rewriter.getF32FloatAttr(scale);
 
     withD2MGenericRegion(
         rewriter, loc, generic, inputs, outputs,
@@ -2632,16 +2651,67 @@ public:
           return {linalgGeneric.getResult(0)};
         });
 
-    mlir::Value result =
-        unLayoutResult(rewriter, generic->getResult(0), randResultType)
-            ->getResult(0);
+    return unLayoutResult(rewriter, generic->getResult(0), randResultType)
+        ->getResult(0);
+  }
 
-    if (needsCast) {
-      result = rewriter.create<ttir::TypecastOp>(loc, finalResultType, result);
-    }
+  /// Casts `input` elementwise to `resultType` via `d2m.tile_typecast`.
+  /// Emitted inline instead of going through `ttir.typecast` so we don't
+  /// rely on the conversion driver revisiting a freshly-created op.
+  mlir::Value buildTypecastGeneric(ConversionPatternRewriter &rewriter,
+                                   Location loc, mlir::Value input,
+                                   RankedTensorType resultType) const {
+    SmallVector<Value> origInputs{input};
+    SmallVector<Value> origOutputs =
+        createDpsOutputs(loc, rewriter, {resultType});
+    auto [inputs, outputs] = toLayoutOperandsAndResults(
+        rewriter, {origInputs, origOutputs}, /*tiled*/ true);
+    assert(inputs.size() == 1 && outputs.size() == 1);
 
-    rewriter.replaceOp(op, result);
-    return success();
+    const std::size_t physicalRank =
+        ttcore::getDeviceLayout(outputs[0]).getRank() / 2;
+    SmallVector<AffineMap> indexingMaps =
+        getIdentityAffineMapsArray(rewriter, 2, physicalRank);
+    auto parallel = ttcore::IteratorTypeAttr::get(
+        rewriter.getContext(), ttcore::IteratorType::Parallel);
+    SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, inputs, outputs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
+
+    withD2MGenericRegion(
+        rewriter, loc, generic, inputs, outputs,
+        [&](mlir::ArrayRef<mlir::Value> blockArgs) -> SmallVector<Value> {
+          SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
+              iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);
+
+          auto linalgGeneric = rewriter.create<mlir::linalg::GenericOp>(
+              loc,
+              llvm::to_vector(
+                  mlir::ValueRange(blockArgs.take_back(1)).getTypes()),
+              /*inputs=*/blockArgs.take_front(1),
+              /*outs=*/blockArgs.take_back(1), indexingMaps,
+              linalgIteratorTypes,
+              [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
+                  mlir::ValueRange bbArgs) {
+                auto outShardTy =
+                    mlir::cast<RankedTensorType>(blockArgs.back().getType());
+                auto outTileTy =
+                    mlir::cast<ttcore::TileType>(outShardTy.getElementType());
+                mlir::Value casted = bbBuilder
+                                         .create<d2m::TileTypecastOp>(
+                                             bbLoc, outTileTy, bbArgs.front())
+                                         .getResult();
+                bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, casted);
+              });
+
+          return {linalgGeneric.getResult(0)};
+        });
+
+    return unLayoutResult(rewriter, generic->getResult(0), resultType)
+        ->getResult(0);
   }
 };
 

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -2537,6 +2537,114 @@ public:
   }
 };
 
+/// Lowers `ttir.rand` to a `d2m.generic` of `d2m.tile_rand` tiles, mapping
+/// `[low, high)` to the kernel's `[from, from + scale)` form. Non-f32
+/// dtypes are generated in f32 and chained through a `ttir.typecast`.
+class D2MRandOpRewriter : public OpConversionPattern<ttir::RandOp>,
+                          D2MNamedRewriterCommon {
+public:
+  D2MRandOpRewriter(const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
+                    ttcore::MemorySpace defaultInputMemSpace,
+                    ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
+                    bool collapseTensors, bool enableMulticastInference)
+      : OpConversionPattern<ttir::RandOp>(typeConverter, ctx),
+        D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
+                               ttnnMode, collapseTensors,
+                               enableMulticastInference) {}
+
+  LogicalResult
+  matchAndRewrite(ttir::RandOp op, ttir::RandOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    RankedTensorType finalResultType = op.getResult().getType();
+    Type finalElemType = finalResultType.getElementType();
+
+    const float low = op.getLow().convertToFloat();
+    const float high = op.getHigh().convertToFloat();
+    const float scale = high - low;
+    if (scale <= 0.0f) {
+      return rewriter.notifyMatchFailure(
+          op, "ttir.rand requires high > low for TTMetal lowering");
+    }
+
+    // `rand_tile` only produces f32 reliably; for other dtypes, rand in f32
+    // and chain a `ttir.typecast` (lowered later in this pass).
+    Type f32Ty = rewriter.getF32Type();
+    const bool needsCast = finalElemType != f32Ty;
+    RankedTensorType randResultType =
+        needsCast ? RankedTensorType::get(finalResultType.getShape(), f32Ty,
+                                          finalResultType.getEncoding())
+                  : finalResultType;
+
+    SmallVector<Value> origInputs;
+    SmallVector<Value> origOutputs =
+        createDpsOutputs(loc, rewriter, {randResultType});
+    auto [inputs, outputs] = toLayoutOperandsAndResults(
+        rewriter, {origInputs, origOutputs}, /*tiled*/ true);
+    assert(outputs.size() == 1);
+    Value output = outputs[0];
+
+    const std::size_t physicalRank =
+        ttcore::getDeviceLayout(output).getRank() / 2;
+
+    SmallVector<AffineMap> indexingMaps =
+        getIdentityAffineMapsArray(rewriter, 1, physicalRank);
+    auto parallel = ttcore::IteratorTypeAttr::get(
+        rewriter.getContext(), ttcore::IteratorType::Parallel);
+    SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, inputs, outputs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
+
+    auto seedAttr = op.getSeedAttr();
+    auto fromAttr = rewriter.getF32FloatAttr(low);
+    auto scaleAttr = rewriter.getF32FloatAttr(scale);
+
+    withD2MGenericRegion(
+        rewriter, loc, generic, inputs, outputs,
+        [&](mlir::ArrayRef<mlir::Value> blockArgs) -> SmallVector<Value> {
+          SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
+              iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);
+
+          auto linalgGeneric = rewriter.create<mlir::linalg::GenericOp>(
+              loc,
+              llvm::to_vector(
+                  mlir::ValueRange(blockArgs.take_back(1)).getTypes()),
+              /*inputs=*/ValueRange{},
+              /*outs=*/blockArgs.take_back(1), indexingMaps,
+              linalgIteratorTypes,
+              [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
+                  mlir::ValueRange) {
+                auto shardTy =
+                    mlir::cast<RankedTensorType>(blockArgs.back().getType());
+                auto tType =
+                    mlir::cast<ttcore::TileType>(shardTy.getElementType());
+                mlir::Value yieldTile =
+                    bbBuilder
+                        .create<d2m::TileRandOp>(bbLoc, tType, seedAttr,
+                                                 fromAttr, scaleAttr)
+                        .getResult();
+                bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yieldTile);
+              });
+
+          return {linalgGeneric.getResult(0)};
+        });
+
+    mlir::Value result =
+        unLayoutResult(rewriter, generic->getResult(0), randResultType)
+            ->getResult(0);
+
+    if (needsCast) {
+      result = rewriter.create<ttir::TypecastOp>(loc, finalResultType, result);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 class D2MArangeOpRewriter : public OpConversionPattern<ttir::ArangeOp>,
                             D2MNamedRewriterCommon {
 public:
@@ -3591,6 +3699,11 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
 
   // Arange.
   patterns.add<D2MArangeOpRewriter>(typeConverter, ctx, defaultInputMemSpace,
+    defaultOutputMemSpace, ttnnMode,
+    collapseTensors, enableMulticastInference);
+
+  // Rand.
+  patterns.add<D2MRandOpRewriter>(typeConverter, ctx, defaultInputMemSpace,
     defaultOutputMemSpace, ttnnMode,
     collapseTensors, enableMulticastInference);
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1367,6 +1367,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::RoundingTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SeluTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SeluTileOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::RandTileInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::RandTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::RsqrtTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::RsqrtTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SqrtTileInitOp>,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -793,7 +793,17 @@ void EmptyOp::getEffects(
   auto dtype = getDtype();
   auto outputType = getResult().getType().getElementType();
 
-  if (dtype != outputType) {
+  // Normalize both sides so that pre/post `ttir-element-type-normalization`
+  // IR (e.g. signless i32 vs. signed si32) is treated as equivalent.
+  auto normalizedDtype = mlir::tt::ttcore::toTTMLIRSupportedDataType(dtype);
+  auto normalizedOutput =
+      mlir::tt::ttcore::toTTMLIRSupportedDataType(outputType);
+  if (!normalizedDtype || !normalizedOutput) {
+    return emitOpError() << "unsupported dtype or output element type [dtype = "
+                         << dtype << ", output tensor type = " << outputType
+                         << "].";
+  }
+  if (normalizedDtype != normalizedOutput) {
     return emitOpError()
            << "dtype does not match with output tensor type [dtype = " << dtype
            << ", output tensor type = " << outputType << "].";

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -793,17 +793,7 @@ void EmptyOp::getEffects(
   auto dtype = getDtype();
   auto outputType = getResult().getType().getElementType();
 
-  // Normalize both sides so that pre/post `ttir-element-type-normalization`
-  // IR (e.g. signless i32 vs. signed si32) is treated as equivalent.
-  auto normalizedDtype = mlir::tt::ttcore::toTTMLIRSupportedDataType(dtype);
-  auto normalizedOutput =
-      mlir::tt::ttcore::toTTMLIRSupportedDataType(outputType);
-  if (!normalizedDtype || !normalizedOutput) {
-    return emitOpError() << "unsupported dtype or output element type [dtype = "
-                         << dtype << ", output tensor type = " << outputType
-                         << "].";
-  }
-  if (normalizedDtype != normalizedOutput) {
+  if (dtype != outputType) {
     return emitOpError()
            << "dtype does not match with output tensor type [dtype = " << dtype
            << ", output tensor type = " << outputType << "].";

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -142,6 +142,41 @@ private:
   }
 };
 
+// `ttir.rand` carries its output element type as a `TypeAttr` (`$dtype`),
+// which `UniformTypeRewriter` doesn't touch. Normalize it through the same
+// `TypeConverter` used for tensor element types so the attribute tracks the
+// rewritten result type (e.g. signless `i32` -> signed `si32`).
+class RandOpAttrRewriter : public mlir::OpRewritePattern<tt::ttir::RandOp> {
+public:
+  using mlir::OpRewritePattern<tt::ttir::RandOp>::OpRewritePattern;
+
+  RandOpAttrRewriter(const mlir::TypeConverter &converter,
+                     mlir::MLIRContext *ctx)
+      : OpRewritePattern(ctx), converter(converter) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(tt::ttir::RandOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Type dtype = op.getDtype();
+    auto dtypeTensor = mlir::RankedTensorType::get({1}, dtype);
+    auto normalizedTensor = mlir::dyn_cast_or_null<mlir::RankedTensorType>(
+        converter.convertType(dtypeTensor));
+    if (!normalizedTensor) {
+      return failure();
+    }
+    mlir::Type normalized = normalizedTensor.getElementType();
+    if (normalized == dtype) {
+      return failure();
+    }
+    rewriter.modifyOpInPlace(
+        op, [&]() { op.setDtypeAttr(mlir::TypeAttr::get(normalized)); });
+    return success();
+  }
+
+private:
+  mlir::TypeConverter converter;
+};
+
 struct ElementTypeNormalization
     : public impl::ElementTypeNormalizationBase<ElementTypeNormalization> {
   using impl::ElementTypeNormalizationBase<
@@ -159,6 +194,7 @@ struct ElementTypeNormalization
     config.enableFolding(false);
     patterns.add<UniformTypeRewriter>(converter, &getContext());
     patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
+    patterns.add<RandOpAttrRewriter>(converter, &getContext());
     if (failed(mlir::applyPatternsGreedily(getOperation(), std::move(patterns),
                                            config))) {
       signalPassFailure();

--- a/test/python/golden/test_metal_rand.py
+++ b/test/python/golden/test_metal_rand.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# End-to-end tests for ttir.rand on TTMetal. The SFPU PRNG isn't
+# torch-matchable, so instead of a golden check we validate range,
+# non-degeneracy, seed reproducibility, and seed sensitivity. Non-f32 dtypes
+# lower as f32 rand + tile_typecast, so this also covers that path.
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+import torch
+
+from conftest import get_request_kwargs
+from test_utils import shape_str
+
+from builder.base.builder_utils import get_artifact_dir
+from builder.ttir.ttir_builder import TTIRBuilder
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
+from builder.base.builder_runtime import execute_fb
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+# ----------------------------- Harness helpers -----------------------------
+
+
+def _run_rand_and_capture(
+    shape: Tuple[int, int],
+    dtype: torch.dtype,
+    low: float,
+    high: float,
+    seed: int,
+    request,
+    device,
+    test_suffix: str = "",
+) -> torch.Tensor:
+    """Compile+execute a single ``ttir.rand`` and return its device output,
+    cast to f32. Uses low-level APIs so we can grab the runtime tensor."""
+
+    def module(builder: TTIRBuilder):
+        @builder.func([], [])
+        def rand_fn(
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.rand(
+                list(shape),
+                dtype,
+                low=low,
+                high=high,
+                seed=seed,
+                unit_attrs=unit_attrs,
+            )
+
+    kwargs = get_request_kwargs(request)
+    test_base = kwargs["test_base"]
+    if test_suffix:
+        test_base = f"{test_base}__{test_suffix}"
+    output_root = kwargs["output_root"]
+    system_desc_path = kwargs["system_desc_path"]
+
+    artifact_dir = get_artifact_dir(
+        output_root, "TTIRBuilder", test_base, make_dir=True
+    )
+
+    (
+        builder,
+        compiled_bin,
+        io_goldens,
+        intermediate_goldens,
+    ) = compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=system_desc_path,
+        artifact_dir=artifact_dir,
+        target="ttmetal",
+        save_artifacts=False,
+    )
+
+    # disable_golden=False to get tensors back; check_* off since HW PRNG
+    # doesn't match torch.
+    _golden_report, output_tensors = execute_fb(
+        compiled_bin,
+        input_output_goldens=io_goldens,
+        intermediate_goldens=intermediate_goldens,
+        disable_golden=False,
+        device=device,
+        check_pcc=False,
+        check_atol=False,
+        check_rtol=False,
+        save_artifacts=False,
+        artifact_dir=artifact_dir,
+        bypass_ops=builder._bypass_ops,
+    )
+
+    assert output_tensors, "execute_fb returned no output tensors"
+    program_outputs: Dict[str, Dict[int, torch.Tensor]] = output_tensors["program_0"]
+    device_out = program_outputs["device_output_0"]
+    assert (
+        len(device_out) == 1
+    ), f"expected single-shard output, got {len(device_out)} shards"
+    return device_out[0].to(torch.float32)
+
+
+def _assert_uniform_in_range(
+    t: torch.Tensor,
+    shape: Tuple[int, int],
+    low: float,
+    high: float,
+    *,
+    bounds_eps: float = 1e-3,
+    mean_tol_frac: float = 0.15,
+    min_unique: int = 32,
+) -> None:
+    """Loose sanity check that ``t`` looks like ``Uniform[low, high)``.
+    Catches obvious regressions, not PRNG quality."""
+    assert torch.is_tensor(t), f"expected tensor, got {type(t)!r}"
+    assert tuple(t.shape) == shape, f"shape mismatch: {tuple(t.shape)} vs {shape}"
+    assert not torch.isnan(t).any(), "output contains NaNs"
+    assert not torch.isinf(t).any(), "output contains infs"
+
+    # Small eps on both sides to tolerate bf16/f32 rounding at the bounds.
+    t_min = float(t.min().item())
+    t_max = float(t.max().item())
+    assert t_min >= low - bounds_eps, f"min {t_min} below low {low} (eps={bounds_eps})"
+    assert (
+        t_max <= high + bounds_eps
+    ), f"max {t_max} above high {high} (eps={bounds_eps})"
+
+    t_std = float(t.std().item())
+    assert t_std > 0.0, "output tensor is constant (std == 0)"
+
+    # Absolute floor, not a ratio: bf16 caps at ~256 values per narrow range.
+    numel = t.numel()
+    if numel >= 1024:
+        unique = int(torch.unique(t).numel())
+        assert (
+            unique >= min_unique
+        ), f"too few unique values: {unique} < {min_unique} (numel={numel})"
+
+    # Absolute band vs. an iid-uniform σ check; SFPU rand has a ~5% small-N bias.
+    span = high - low
+    expected_mean = 0.5 * (low + high)
+    empirical_mean = float(t.mean().item())
+    diff = abs(empirical_mean - expected_mean)
+    tol = mean_tol_frac * span
+    assert diff <= tol, (
+        f"empirical mean {empirical_mean:.4f} too far from expected "
+        f"{expected_mean:.4f} (|diff|={diff:.4f}, allowed={tol:.4f})"
+    )
+
+
+# --------------------------------- Tests ----------------------------------
+
+
+_RAND_SHAPES = [(32, 32), (128, 128), (64, 128)]
+
+
+@pytest.mark.parametrize("shape", _RAND_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.bfloat16],
+    ids=["f32", "bf16"],
+)
+@pytest.mark.parametrize(
+    "low,high,seed",
+    [
+        (0.0, 1.0, 0),
+        (-1.0, 1.0, 42),
+        (2.0, 5.0, 1337),
+    ],
+    ids=["uniform01", "signed_unit", "range_2to5"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_rand(
+    shape,
+    dtype: torch.dtype,
+    low: float,
+    high: float,
+    seed: int,
+    target: str,
+    request,
+    device,
+):
+    """End-to-end ``ttir.rand``; validates range and non-degeneracy."""
+    out = _run_rand_and_capture(
+        shape, dtype, low, high, seed, request, device, test_suffix="main"
+    )
+
+    # bf16 quantizes to ~2^-7, so loosen the bounds check.
+    bounds_eps = 5e-3 if dtype == torch.bfloat16 else 1e-4
+    _assert_uniform_in_range(out, shape, low, high, bounds_eps=bounds_eps)
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_rand_reproducibility(target: str, request, device):
+    """Same seed must produce bit-identical output across independent runs."""
+    shape = (64, 64)
+    dtype = torch.float32
+    low, high, seed = -0.5, 0.5, 12345
+
+    run_a = _run_rand_and_capture(
+        shape, dtype, low, high, seed, request, device, test_suffix="repro_a"
+    )
+    run_b = _run_rand_and_capture(
+        shape, dtype, low, high, seed, request, device, test_suffix="repro_b"
+    )
+
+    _assert_uniform_in_range(run_a, shape, low, high)
+    _assert_uniform_in_range(run_b, shape, low, high)
+    assert torch.equal(run_a, run_b), (
+        "two runs with identical seed produced different tensors "
+        f"(max abs diff = {float((run_a - run_b).abs().max()):.6f})"
+    )
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_rand_different_seeds_differ(target: str, request, device):
+    """Distinct seeds must produce meaningfully different tensors."""
+    shape = (64, 64)
+    dtype = torch.float32
+    low, high = 0.0, 1.0
+
+    run_a = _run_rand_and_capture(
+        shape, dtype, low, high, 1, request, device, test_suffix="seed_a"
+    )
+    run_b = _run_rand_and_capture(
+        shape, dtype, low, high, 2, request, device, test_suffix="seed_b"
+    )
+
+    _assert_uniform_in_range(run_a, shape, low, high)
+    _assert_uniform_in_range(run_b, shape, low, high)
+
+    assert not torch.equal(run_a, run_b), "different seeds produced identical tensors"
+    diff_frac = float((run_a != run_b).float().mean())
+    assert diff_frac > 0.5, (
+        f"different seeds produced near-identical tensors: only {diff_frac:.4f} "
+        "of elements differ"
+    )
+
+
+@pytest.mark.parametrize("shape", _RAND_SHAPES, ids=shape_str)
+@pytest.mark.parametrize(
+    "int_dtype",
+    [torch.int32],
+    ids=["i32"],
+)
+@pytest.mark.parametrize(
+    "low,high,seed",
+    [
+        (0.0, 128.0, 0),
+        (-64.0, 64.0, 42),
+        (10.0, 100.0, 1337),
+    ],
+    ids=["pos128", "signed64", "range_10to100"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_rand_int(
+    shape,
+    int_dtype: torch.dtype,
+    low: float,
+    high: float,
+    seed: int,
+    target: str,
+    request,
+    device,
+):
+    """Integer ``ttir.rand`` (lowered via f32 rand + tile_typecast); check
+    outputs are exact integers in [floor(low), ceil(high))."""
+    out = _run_rand_and_capture(
+        shape, int_dtype, low, high, seed, request, device, test_suffix="int"
+    )
+
+    assert tuple(out.shape) == shape, f"shape mismatch: {tuple(out.shape)} vs {shape}"
+    assert not torch.isnan(out).any(), "int rand output contains NaNs"
+    assert not torch.isinf(out).any(), "int rand output contains infs"
+
+    fractional = out - torch.floor(out)
+    assert float(fractional.abs().max()) == 0.0, (
+        f"int rand produced non-integer values (max fractional part = "
+        f"{float(fractional.abs().max())})"
+    )
+
+    int_lo = math.floor(low)
+    int_hi_excl = math.ceil(high)
+    t_min = int(out.min().item())
+    t_max = int(out.max().item())
+    assert t_min >= int_lo, f"int rand min {t_min} below low {int_lo}"
+    assert t_max < int_hi_excl, f"int rand max {t_max} >= high {int_hi_excl}"
+
+    unique = int(torch.unique(out).numel())
+    possible = int_hi_excl - int_lo
+    expected_floor = max(2, min(possible, 8))
+    assert unique >= expected_floor, (
+        f"int rand produced too few distinct values: {unique} "
+        f"(expected at least {expected_floor} over range [{int_lo}, {int_hi_excl}))"
+    )
+
+
+@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_rand_unary(
+    shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    """Compose rand with a unary op for multi-op pipeline coverage."""
+    from builder.base.builder_apis import compile_and_execute_ttir
+
+    def module(builder: TTIRBuilder):
+        @builder.func([], [])
+        def rand_abs(
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            r = builder.rand(
+                list(shape), dtype, low=-1.0, high=1.0, seed=7, unit_attrs=unit_attrs
+            )
+            return builder.abs(r, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        disable_golden=True,
+    )
+
+    out = _run_rand_and_capture(
+        shape, dtype, -1.0, 1.0, 7, request, device, test_suffix="unary_rand_only"
+    )
+    bounds_eps = 5e-3 if dtype == torch.bfloat16 else 1e-4
+    _assert_uniform_in_range(out, shape, -1.0, 1.0, bounds_eps=bounds_eps)

--- a/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/named_to_generic.mlir
@@ -460,4 +460,37 @@ module {
     %0 = "ttir.logical_xor"(%lhs, %rhs) : (!ttype, !ttype) -> !ttype
     return %0 : !ttype
   }
+
+  // CHECK-LABEL: func @named_rand
+  func.func @named_rand() -> !ttype {
+    // f32 rand: single d2m.generic + d2m.tile_rand, no cast.
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel"]
+    // CHECK: d2m.tile_rand
+    // CHECK-NOT: d2m.tile_typecast
+    %0 = "ttir.rand"() <{dtype = f32, high = 1.000000e+00 : f32, low = 0.000000e+00 : f32, seed = 0 : ui32, size = [128 : i32, 96 : i32]}> : () -> !ttype
+    return %0 : !ttype
+  }
+
+  // CHECK-LABEL: func @named_rand_bf16
+  func.func @named_rand_bf16() -> tensor<128x96xbf16> {
+    // bf16 rand: f32 d2m.tile_rand followed by a d2m.tile_typecast to bf16.
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: d2m.tile_rand
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: d2m.tile_typecast
+    %0 = "ttir.rand"() <{dtype = bf16, high = 1.000000e+00 : f32, low = 0.000000e+00 : f32, seed = 0 : ui32, size = [128 : i32, 96 : i32]}> : () -> tensor<128x96xbf16>
+    return %0 : tensor<128x96xbf16>
+  }
+
+  // CHECK-LABEL: func @named_rand_i32
+  func.func @named_rand_i32() -> tensor<128x96xi32> {
+    // i32 rand: f32 d2m.tile_rand followed by a d2m.tile_typecast to i32.
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: d2m.tile_rand
+    // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel]
+    // CHECK: d2m.tile_typecast
+    %0 = "ttir.rand"() <{dtype = i32, high = 1.280000e+02 : f32, low = 0.000000e+00 : f32, seed = 0 : ui32, size = [128 : i32, 96 : i32]}> : () -> tensor<128x96xi32>
+    return %0 : tensor<128x96xi32>
+  }
 }

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -144,3 +144,12 @@ func.func @constant_bf16() -> tensor<32x32xbf16> {
   %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
   return %0 : tensor<32x32xbf16>
 }
+
+// `ttir.rand`'s `dtype` attribute is rewritten alongside the result type.
+func.func @rand_i32() -> tensor<32x32xi32> {
+  // CHECK: "ttir.rand"
+  // CHECK-SAME: dtype = si32
+  // CHECK-SAME: -> tensor<32x32xsi32>
+  %0 = "ttir.rand"() <{dtype = i32, high = 1.000000e+02 : f32, low = 0.000000e+00 : f32, seed = 0 : ui32, size = [32 : i32, 32 : i32]}> : () -> tensor<32x32xi32>
+  return %0 : tensor<32x32xi32>
+}


### PR DESCRIPTION
### Problem description
Need to support `ttir.rand` in d2m for sampling graphs in models

### What's changed
- Added lowering thru ttmetal pipeline for `ttir.rand` including typecasting rand from `f32` to output dtype if a different dtype is specified. Also had each core use their grid position + seed to produce different values across different tiles following ttnn protocol.
- Updated element type normalization to normalize both the dtype and the attribute because it was causing errors with `i32` and `si32` mismatch
- Added lit tests for different dtypes for rand
- Added builder test file for metal rand including special harnesses for checking rand produces random values

### Checklist
- [ ] New/Existing tests provide coverage for changes
