### PR TITLE
Add ttnn.sampling op for fused non-greedy LLM sampling

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3121,6 +3121,39 @@ def TTIR_SortOp : TTIR_NamedOp<"sort"> {
   let hasVerifier = 1;
 }
 
+def TTIR_SamplingOp : TTIR_NamedOp<"sampling"> {
+  let summary = "Sampling operation.";
+  let description = [{
+    Performs fused top-k + top-p + multinomial sampling on pre-filtered
+    candidate logits. Takes the top-k values and their global vocab indices
+    (from a prior topk stage), per-request top-k, top-p, temperature
+    parameters, and an optional random seed. Returns one sampled global
+    token index per request.
+
+    Inputs:
+      - `input_values`: Pre-filtered candidate logit values [batch, candidates] bf16
+      - `input_indices`: Global vocab indices for each candidate [batch, candidates] int32
+      - `k`: Per-request top-k values [batch] uint32
+      - `p`: Per-request top-p values [batch] bf16
+      - `temp`: Per-request temperature values [batch] bf16
+      - `seed`: Optional random seed (uint32 scalar attribute)
+
+    Output:
+      - `result`: Sampled global token indices [batch] int32
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input_values,
+                       AnyRankedTensor:$input_indices,
+                       AnyRankedTensor:$k,
+                       AnyRankedTensor:$p,
+                       AnyRankedTensor:$temp,
+                       OptionalAttr<UI32Attr>:$seed);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 def TTIR_TransposeOp : TTIR_NamedOp<"transpose", [TTIR_TensorManipulation]> {
     let summary = "Tensor transpose operation.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4021,13 +4021,13 @@ def TTNN_SamplingOp : TTNN_Op<"sampling"> {
     Inputs:
       - `input_values`: Pre-filtered candidate logit values [batch, candidates] bf16, TILE layout
       - `input_indices`: Global vocab indices for each candidate [batch, candidates] int32, ROW_MAJOR
-      - `k`: Per-request top-k values [32] uint32, ROW_MAJOR
-      - `p`: Per-request top-p values [32] bf16, ROW_MAJOR
-      - `temp`: Per-request temperature values [32] bf16, ROW_MAJOR
+      - `k`: Per-request top-k values [batch] uint32, ROW_MAJOR
+      - `p`: Per-request top-p values [batch] bf16, ROW_MAJOR
+      - `temp`: Per-request temperature values [batch] bf16, ROW_MAJOR
       - `seed`: Optional random seed (uint32 scalar attribute)
 
     Output:
-      - `result`: Sampled global token indices [1, 1, 1, batch] uint32, ROW_MAJOR
+      - `result`: Sampled global token indices [batch] int32, ROW_MAJOR
   }];
 
   let arguments = (ins AnyRankedTensor:$input_values,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4041,7 +4041,7 @@ def TTNN_SamplingOp : TTNN_Op<"sampling"> {
 
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-      return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds(getOperation());
+      return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds();
     }
   }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -4012,6 +4012,42 @@ def TTNN_AggregateTensorOp : TTNN_Op<"aggregate_tensor"> {
   let results = (outs AnyRankedTensor:$result);
 }
 
+def TTNN_SamplingOp : TTNN_Op<"sampling"> {
+  let summary = "Sampling operation.";
+  let description = [{
+    Performs fused top-k + top-p + multinomial sampling on pre-filtered
+    candidate logits using the ttnn::sampling kernel.
+
+    Inputs:
+      - `input_values`: Pre-filtered candidate logit values [batch, candidates] bf16, TILE layout
+      - `input_indices`: Global vocab indices for each candidate [batch, candidates] int32, ROW_MAJOR
+      - `k`: Per-request top-k values [32] uint32, ROW_MAJOR
+      - `p`: Per-request top-p values [32] bf16, ROW_MAJOR
+      - `temp`: Per-request temperature values [32] bf16, ROW_MAJOR
+      - `seed`: Optional random seed (uint32 scalar attribute)
+
+    Output:
+      - `result`: Sampled global token indices [1, 1, 1, batch] uint32, ROW_MAJOR
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input_values,
+                       AnyRankedTensor:$input_indices,
+                       AnyRankedTensor:$k,
+                       AnyRankedTensor:$p,
+                       AnyRankedTensor:$temp,
+                       OptionalAttr<UI32Attr>:$seed);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds(getOperation());
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def TTNN_TopKOp : TTNN_Op<"topk", [TTNN_MemoryConfigOpInterface]> {
   let summary = "Top-K selection operation.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -296,6 +296,9 @@ public:
   static TTNNOperandsWorkarounds
   createPagedFillCacheOpOperandsWorkarounds(Operation *op);
 
+  static TTNNOperandsWorkarounds
+  createSamplingOpOperandsWorkarounds(Operation *op);
+
   // Create workarounds for binary op operands.
   static TTNNOperandsWorkarounds
   createBinaryOpOperandsWorkarounds(mlir::Operation *op);

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -296,8 +296,7 @@ public:
   static TTNNOperandsWorkarounds
   createPagedFillCacheOpOperandsWorkarounds(Operation *op);
 
-  static TTNNOperandsWorkarounds
-  createSamplingOpOperandsWorkarounds(Operation *op);
+  static TTNNOperandsWorkarounds createSamplingOpOperandsWorkarounds();
 
   // Create workarounds for binary op operands.
   static TTNNOperandsWorkarounds

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -92,6 +92,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
+#include "ttnn/operations/reduction/sampling/sampling.hpp"
 #include "ttnn/operations/reduction/topk/topk.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
 #include "ttnn/operations/transformer/sdpa/sdpa.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1973,6 +1973,34 @@ struct OpModel<TopKOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// SamplingOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<SamplingOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(ttcore::GridAttr deviceGrid,
+                   llvm::ArrayRef<int64_t> inputValuesShape,
+                   TTNNLayoutAttr inputValuesLayout,
+                   llvm::ArrayRef<int64_t> inputIndicesShape,
+                   TTNNLayoutAttr inputIndicesLayout,
+                   llvm::ArrayRef<int64_t> kShape, TTNNLayoutAttr kLayout,
+                   llvm::ArrayRef<int64_t> pShape, TTNNLayoutAttr pLayout,
+                   llvm::ArrayRef<int64_t> tempShape, TTNNLayoutAttr tempLayout,
+                   std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputValuesShape,
+               TTNNLayoutAttr inputValuesLayout,
+               llvm::ArrayRef<int64_t> inputIndicesShape,
+               TTNNLayoutAttr inputIndicesLayout,
+               llvm::ArrayRef<int64_t> kShape, TTNNLayoutAttr kLayout,
+               llvm::ArrayRef<int64_t> pShape, TTNNLayoutAttr pLayout,
+               llvm::ArrayRef<int64_t> tempShape, TTNNLayoutAttr tempLayout,
+               std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // MeshPartitionOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/reduction.fbs
+++ b/include/ttmlir/Target/TTNN/operations/reduction.fbs
@@ -46,6 +46,16 @@ table TopKOp {
   outputs: [tt.target.ttnn.TensorRef];
 }
 
+table SamplingOp {
+  input_values: tt.target.ttnn.TensorRef;
+  input_indices: tt.target.ttnn.TensorRef;
+  k: tt.target.ttnn.TensorRef;
+  p: tt.target.ttnn.TensorRef;
+  temp: tt.target.ttnn.TensorRef;
+  seed: uint32 = null;
+  out: tt.target.ttnn.TensorRef;
+}
+
 table TopKRouterGptOp {
   input: tt.target.ttnn.TensorRef;
   weight: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -121,6 +121,7 @@ union OpType {
   RMSNormPreAllGatherOp,
   RMSNormOp,
   ReshapeOp,
+  SamplingOp,
   ScaledDotProductAttentionOp,
   ScaledDotProductAttentionDecodeOp,
   ScatterOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7362,6 +7362,67 @@ public:
     return success();
   }
 };
+
+class StableHLOSamplingConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
+    if (funcName != "tt.sampling") {
+      return failure();
+    }
+
+    if (adaptor.getOperands().size() != 5 || srcOp.getResults().size() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "Sampling op must have exactly five operands and one result. "
+                 "Got " +
+                     std::to_string(adaptor.getOperands().size()) +
+                     " operands and " +
+                     std::to_string(srcOp.getResults().size()) + " results.");
+    }
+
+    Value inputValues = adaptor.getOperands()[0];
+    Value inputIndices = adaptor.getOperands()[1];
+    Value k = adaptor.getOperands()[2];
+    Value p = adaptor.getOperands()[3];
+    Value temp = adaptor.getOperands()[4];
+
+    // Parse optional seed from frontend attributes.
+    std::optional<uint32_t> seed;
+    mlir::DictionaryAttr frontendAttributes =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (frontendAttributes) {
+      auto seedStringAttr = frontendAttributes.getAs<mlir::StringAttr>("seed");
+      if (seedStringAttr) {
+        uint32_t seedVal;
+        if (seedStringAttr.getValue().getAsInteger(10, seedVal)) {
+          return rewriter.notifyMatchFailure(srcOp,
+                                             "Failed to parse seed attribute.");
+        }
+        seed = seedVal;
+      }
+    }
+
+    auto resultType =
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
+    mlir::IntegerAttr seedAttr;
+    if (seed.has_value()) {
+      seedAttr = rewriter.getIntegerAttr(
+          rewriter.getIntegerType(32, /*isSigned=*/false), seed.value());
+    }
+
+    rewriter.replaceOpWithNewOp<ttir::SamplingOp>(
+        srcOp, resultType, inputValues, inputIndices, k, p, temp, seedAttr);
+
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -8292,6 +8353,7 @@ static void addCacheOpsConversionPattern(MLIRContext *ctx,
   patterns.add<StableHLOUpdateCacheConversionPattern>(typeConverter, ctx);
   patterns.add<StableHLOPagedUpdateCacheConversionPattern>(typeConverter, ctx);
   patterns.add<StableHLOPagedFillCacheConversionPattern>(typeConverter, ctx);
+  patterns.add<StableHLOSamplingConversionPattern>(typeConverter, ctx);
 }
 
 static void

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -778,6 +778,22 @@ public:
     return success();
   }
 };
+
+class SamplingOpConversionPattern
+    : public OpConversionPattern<ttir::SamplingOp> {
+public:
+  using OpConversionPattern<ttir::SamplingOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::SamplingOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::SamplingOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInputValues(), adaptor.getInputIndices(), adaptor.getK(),
+        adaptor.getP(), adaptor.getTemp(), adaptor.getSeedAttr());
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -3839,6 +3855,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            UpdateCacheOpConversionPattern,
            PagedFillCacheOpConversionPattern,
            PagedUpdateCacheOpConversionPattern,
+           SamplingOpConversionPattern,
            FillCacheOpConversionPattern,
            ScatterOpConversionPattern,
            GatherOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -5109,6 +5109,33 @@ public:
     return success();
   }
 };
+
+class TTNNToEmitCSamplingOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::SamplingOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::SamplingOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::SamplingOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::SamplingOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputValues()),
+        emitter.emit(srcOp.getInputIndices()),
+        emitter.emit(srcOp.getK()),
+        emitter.emit(srcOp.getP()),
+        emitter.emit(srcOp.getTemp()),
+        emitter.emit(srcOp.getSeed()),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
 } // namespace
 
 namespace mlir::tt {
@@ -5248,7 +5275,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
            RepeatInterleaveOpConversionPattern, SliceStaticOpConversionPattern,
            SliceDynamicOpConversionPattern, SortOpConversionPattern,
            PermuteOpConversionPattern, PadOpConversionPattern,
-           TTNNToEmitCTopKOpConversionPattern, GatherOpConversionPattern>(
+           TTNNToEmitCTopKOpConversionPattern,
+           TTNNToEmitCSamplingOpConversionPattern, GatherOpConversionPattern>(
           typeConverter, ctx);
 
   // Quantization ops.

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4608,6 +4608,32 @@ public:
     return success();
   }
 };
+
+class SamplingOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<tt::ttnn::SamplingOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      tt::ttnn::SamplingOp>::TTNNToEmitPyBaseOpConversionPattern;
+  LogicalResult
+  matchAndRewrite(tt::ttnn::SamplingOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<tt::ttnn::SamplingOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputValues()),
+        emitter.emit(srcOp.getInputIndices()),
+        emitter.emit(srcOp.getK()),
+        emitter.emit(srcOp.getP()),
+        emitter.emit(srcOp.getTemp()),
+        emitter.emit(srcOp.getSeed(), "seed"),
+    };
+
+    emitter.replaceOp(*this, args);
+    return success();
+  }
+};
 } // namespace
 
 namespace mlir::tt {
@@ -4855,6 +4881,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<FillCacheOpConversionPattern>(typeConverter, ctx);
   patterns.add<UpdateCacheOpConversionPattern>(typeConverter, ctx);
   patterns.add<PagedUpdateCacheOpConversionPattern>(typeConverter, ctx);
+  patterns.add<SamplingOpConversionPattern>(typeConverter, ctx);
 
   // Quantization ops.
   //

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5230,6 +5230,30 @@ void mlir::tt::ttir::UpdateCacheOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// SamplingOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::SamplingOp::verify() {
+  auto inputValuesType = getInputValues().getType();
+  auto inputIndicesType = getInputIndices().getType();
+
+  if (inputValuesType.getRank() < 2) {
+    return emitOpError("input_values must have at least 2 dimensions");
+  }
+
+  if (inputIndicesType.getRank() < 2) {
+    return emitOpError("input_indices must have at least 2 dimensions");
+  }
+
+  if (inputValuesType.getShape() != inputIndicesType.getShape()) {
+    return emitOpError(
+        "input_values and input_indices must have the same shape");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // FillCacheOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -5236,18 +5236,42 @@ void mlir::tt::ttir::UpdateCacheOp::getCanonicalizationPatterns(
 ::mlir::LogicalResult mlir::tt::ttir::SamplingOp::verify() {
   auto inputValuesType = getInputValues().getType();
   auto inputIndicesType = getInputIndices().getType();
+  auto kType = getK().getType();
+  auto pType = getP().getType();
+  auto tempType = getTemp().getType();
+  auto resultType = getResult().getType();
 
-  if (inputValuesType.getRank() < 2) {
-    return emitOpError("input_values must have at least 2 dimensions");
+  if (inputValuesType.getRank() != 2) {
+    return emitOpError("input_values must be 2D [batch, candidates]");
   }
-
-  if (inputIndicesType.getRank() < 2) {
-    return emitOpError("input_indices must have at least 2 dimensions");
+  if (inputIndicesType.getRank() != 2) {
+    return emitOpError("input_indices must be 2D [batch, candidates]");
   }
-
   if (inputValuesType.getShape() != inputIndicesType.getShape()) {
     return emitOpError(
         "input_values and input_indices must have the same shape");
+  }
+
+  int64_t batch = inputValuesType.getShape()[0];
+
+  // k, p, temp must be 1D with the same batch dimension.
+  for (auto [tensor, name] :
+       llvm::zip(std::array<mlir::RankedTensorType, 3>{kType, pType, tempType},
+                 std::array<llvm::StringRef, 3>{"k", "p", "temp"})) {
+    if (tensor.getRank() != 1) {
+      return emitOpError() << name << " must be 1D [batch]";
+    }
+    if (tensor.getShape()[0] != batch) {
+      return emitOpError() << name << " batch dimension ("
+                           << tensor.getShape()[0]
+                           << ") must match input_values batch (" << batch
+                           << ")";
+    }
+  }
+
+  // Result must be 1D [batch].
+  if (resultType.getRank() != 1 || resultType.getShape()[0] != batch) {
+    return emitOpError("result must be 1D [batch]");
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3857,18 +3857,42 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 ::mlir::LogicalResult SamplingOp::verify() {
   auto inputValuesType = getInputValues().getType();
   auto inputIndicesType = getInputIndices().getType();
+  auto kType = getK().getType();
+  auto pType = getP().getType();
+  auto tempType = getTemp().getType();
+  auto resultType = getResult().getType();
 
-  if (inputValuesType.getRank() < 2) {
-    return emitOpError("input_values must have at least 2 dimensions");
+  if (inputValuesType.getRank() != 2) {
+    return emitOpError("input_values must be 2D [batch, candidates]");
   }
-
-  if (inputIndicesType.getRank() < 2) {
-    return emitOpError("input_indices must have at least 2 dimensions");
+  if (inputIndicesType.getRank() != 2) {
+    return emitOpError("input_indices must be 2D [batch, candidates]");
   }
-
   if (inputValuesType.getShape() != inputIndicesType.getShape()) {
     return emitOpError(
         "input_values and input_indices must have the same shape");
+  }
+
+  int64_t batch = inputValuesType.getShape()[0];
+
+  // k, p, temp must be 1D with the same batch dimension.
+  for (auto [tensor, name] :
+       llvm::zip(std::array<mlir::RankedTensorType, 3>{kType, pType, tempType},
+                 std::array<llvm::StringRef, 3>{"k", "p", "temp"})) {
+    if (tensor.getRank() != 1) {
+      return emitOpError() << name << " must be 1D [batch]";
+    }
+    if (tensor.getShape()[0] != batch) {
+      return emitOpError() << name << " batch dimension ("
+                           << tensor.getShape()[0]
+                           << ") must match input_values batch (" << batch
+                           << ")";
+    }
+  }
+
+  // Result must be 1D [batch].
+  if (resultType.getRank() != 1 || resultType.getShape()[0] != batch) {
+    return emitOpError("result must be 1D [batch]");
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3851,6 +3851,30 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// SamplingOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult SamplingOp::verify() {
+  auto inputValuesType = getInputValues().getType();
+  auto inputIndicesType = getInputIndices().getType();
+
+  if (inputValuesType.getRank() < 2) {
+    return emitOpError("input_values must have at least 2 dimensions");
+  }
+
+  if (inputIndicesType.getRank() < 2) {
+    return emitOpError("input_indices must have at least 2 dimensions");
+  }
+
+  if (inputValuesType.getShape() != inputIndicesType.getShape()) {
+    return emitOpError(
+        "input_values and input_indices must have the same shape");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // FillCacheOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -468,19 +468,20 @@ TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(
 
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds() {
-  // ttnn::sampling kernel requires ROW_MAJOR layout for index/param tensors.
-  // temp: bf16 ROW_MAJOR
+  // ttnn::sampling kernel requires ROW_MAJOR layout for index/param tensors
+  // and produces a ROW_MAJOR output. Declare both so the pass inserts
+  // to_layout ops to reconcile with neighbours.
   TTNNOperandWorkarounds empty;
   TTNNOperandWorkarounds rowMajor;
   rowMajor.tensorLayoutWorkaround = Layout::RowMajor;
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addInputOperandWorkaround(empty)    // input_values
-      .addInputOperandWorkaround(rowMajor) // input_indices
-      .addInputOperandWorkaround(rowMajor) // k
-      .addInputOperandWorkaround(rowMajor) // p
-      .addInputOperandWorkaround(rowMajor) // temp
-      .addOutputOperandWorkaround(empty);  // result
+      .addInputOperandWorkaround(empty)      // input_values
+      .addInputOperandWorkaround(rowMajor)   // input_indices
+      .addInputOperandWorkaround(rowMajor)   // k
+      .addInputOperandWorkaround(rowMajor)   // p
+      .addInputOperandWorkaround(rowMajor)   // temp
+      .addOutputOperandWorkaround(rowMajor); // result
 }
 
 TTNNOperandsWorkarounds

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -467,12 +467,8 @@ TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(
 }
 
 TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds(
-    Operation *op) {
-  // input_values: bf16 TILE (no workaround needed)
-  // input_indices: int32 ROW_MAJOR
-  // k: uint32 ROW_MAJOR
-  // p: bf16 ROW_MAJOR
+TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds() {
+  // ttnn::sampling kernel requires ROW_MAJOR layout for index/param tensors.
   // temp: bf16 ROW_MAJOR
   TTNNOperandWorkarounds empty;
   TTNNOperandWorkarounds rowMajor;

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -467,6 +467,27 @@ TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(
 }
 
 TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds(
+    Operation *op) {
+  // input_values: bf16 TILE (no workaround needed)
+  // input_indices: int32 ROW_MAJOR
+  // k: uint32 ROW_MAJOR
+  // p: bf16 ROW_MAJOR
+  // temp: bf16 ROW_MAJOR
+  TTNNOperandWorkarounds empty;
+  TTNNOperandWorkarounds rowMajor;
+  rowMajor.tensorLayoutWorkaround = Layout::RowMajor;
+
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(empty)    // input_values
+      .addInputOperandWorkaround(rowMajor) // input_indices
+      .addInputOperandWorkaround(rowMajor) // k
+      .addInputOperandWorkaround(rowMajor) // p
+      .addInputOperandWorkaround(rowMajor) // temp
+      .addOutputOperandWorkaround(empty);  // result
+}
+
+TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createPagedFillCacheOpOperandsWorkarounds(
     Operation *op) {
   TTNNOperandWorkarounds nullWorkarounds;

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3635,6 +3635,24 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       batchIdxShape, batchIdxLayout, opConfig.outputLayout);
 }
 //===----------------------------------------------------------------------===//
+// SamplingOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+SamplingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // WriteTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3641,15 +3641,33 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+  assert(inputs.size() == 5);
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpConstraints, *this,
+      deviceGrid, getInputValues().getType().getShape(), inputs[0],
+      getInputIndices().getType().getShape(), inputs[1],
+      getK().getType().getShape(), inputs[2], getP().getType().getShape(),
+      inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 SamplingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+  assert(inputs.size() == 5);
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpRuntime, *this,
+      getInputValues().getType().getShape(), inputs[0],
+      getInputIndices().getType().getShape(), inputs[1],
+      getK().getType().getShape(), inputs[2], getP().getType().getShape(),
+      inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -8340,13 +8340,22 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
+  // ttnn::sampling kernel expects 4D [N, C, H, W] with N*C*H==32. Runtime
+  // reshapes 2D [batch, candidates] -> [1, 1, batch, candidates] before
+  // dispatch; mirror that here so constraint queries see the kernel-expected
+  // shape.
+  llvm::SmallVector<int64_t, 4> values4D = {1, 1, inputValuesShape[0],
+                                            inputValuesShape[1]};
+  llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
+                                             inputIndicesShape[1]};
+
   auto valuesSpecExp =
-      detail::convertToTensorSpec(device, inputValuesShape, inputValuesLayout);
+      detail::convertToTensorSpec(device, values4D, inputValuesLayout);
   if (!valuesSpecExp) {
     return valuesSpecExp.takeError();
   }
-  auto indicesSpecExp = detail::convertToTensorSpec(device, inputIndicesShape,
-                                                    inputIndicesLayout);
+  auto indicesSpecExp =
+      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout);
   if (!indicesSpecExp) {
     return indicesSpecExp.takeError();
   }
@@ -8395,13 +8404,19 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
+  // See getOpConstraints: reshape 2D -> 4D to match runtime dispatch.
+  llvm::SmallVector<int64_t, 4> values4D = {1, 1, inputValuesShape[0],
+                                            inputValuesShape[1]};
+  llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
+                                             inputIndicesShape[1]};
+
   auto valuesSpecExp =
-      detail::convertToTensorSpec(device, inputValuesShape, inputValuesLayout);
+      detail::convertToTensorSpec(device, values4D, inputValuesLayout);
   if (!valuesSpecExp) {
     return valuesSpecExp.takeError();
   }
-  auto indicesSpecExp = detail::convertToTensorSpec(device, inputIndicesShape,
-                                                    inputIndicesLayout);
+  auto indicesSpecExp =
+      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout);
   if (!indicesSpecExp) {
     return indicesSpecExp.takeError();
   }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -8325,6 +8325,118 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// SamplingOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputValuesShape,
+    TTNNLayoutAttr inputValuesLayout, llvm::ArrayRef<int64_t> inputIndicesShape,
+    TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+    TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+    TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+    TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto valuesSpecExp =
+      detail::convertToTensorSpec(device, inputValuesShape, inputValuesLayout);
+  if (!valuesSpecExp) {
+    return valuesSpecExp.takeError();
+  }
+  auto indicesSpecExp = detail::convertToTensorSpec(device, inputIndicesShape,
+                                                    inputIndicesLayout);
+  if (!indicesSpecExp) {
+    return indicesSpecExp.takeError();
+  }
+  auto kSpecExp = detail::convertToTensorSpec(device, kShape, kLayout);
+  if (!kSpecExp) {
+    return kSpecExp.takeError();
+  }
+  auto pSpecExp = detail::convertToTensorSpec(device, pShape, pLayout);
+  if (!pSpecExp) {
+    return pSpecExp.takeError();
+  }
+  auto tempSpecExp = detail::convertToTensorSpec(device, tempShape, tempLayout);
+  if (!tempSpecExp) {
+    return tempSpecExp.takeError();
+  }
+
+  // Extract TensorSpecs before lambda capture (Expected is not copyable).
+  ::ttnn::TensorSpec valuesSpec = valuesSpecExp.get();
+  ::ttnn::TensorSpec indicesSpec = indicesSpecExp.get();
+  ::ttnn::TensorSpec kSpec = kSpecExp.get();
+  ::ttnn::TensorSpec pSpec = pSpecExp.get();
+  ::ttnn::TensorSpec tempSpec = tempSpecExp.get();
+
+  auto samplingQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS(::ttnn::sampling, device, valuesSpec,
+                                indicesSpec, kSpec, pSpec, tempSpec, seed,
+                                std::nullopt, std::nullopt);
+  };
+
+  return operation::getOpConstraints(inputValuesLayout.getContext(), deviceGrid,
+                                     samplingQuery);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
+    llvm::ArrayRef<int64_t> inputIndicesShape,
+    TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+    TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+    TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+    TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto valuesSpecExp =
+      detail::convertToTensorSpec(device, inputValuesShape, inputValuesLayout);
+  if (!valuesSpecExp) {
+    return valuesSpecExp.takeError();
+  }
+  auto indicesSpecExp = detail::convertToTensorSpec(device, inputIndicesShape,
+                                                    inputIndicesLayout);
+  if (!indicesSpecExp) {
+    return indicesSpecExp.takeError();
+  }
+  auto kSpecExp = detail::convertToTensorSpec(device, kShape, kLayout);
+  if (!kSpecExp) {
+    return kSpecExp.takeError();
+  }
+  auto pSpecExp = detail::convertToTensorSpec(device, pShape, pLayout);
+  if (!pSpecExp) {
+    return pSpecExp.takeError();
+  }
+  auto tempSpecExp = detail::convertToTensorSpec(device, tempShape, tempLayout);
+  if (!tempSpecExp) {
+    return tempSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec valuesSpec = valuesSpecExp.get();
+  ::ttnn::TensorSpec indicesSpec = indicesSpecExp.get();
+  ::ttnn::TensorSpec kSpec = kSpecExp.get();
+  ::ttnn::TensorSpec pSpec = pSpecExp.get();
+  ::ttnn::TensorSpec tempSpec = tempSpecExp.get();
+
+  auto samplingQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttnn::sampling, device, valuesSpec, indicesSpec,
+                            kSpec, pSpec, tempSpec, seed, std::nullopt,
+                            std::nullopt);
+  };
+
+  return operation::getOpRuntime(samplingQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // MeshPartitionOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3973,6 +3973,31 @@ createOp(FlatbufferObjectCache &cache, TopKOp op) {
       (memoryConfig ? toFlatbuffer(cache, memoryConfig.value()) : 0), &outputs);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::SamplingOp>
+createOp(FlatbufferObjectCache &cache, SamplingOp op) {
+  auto inputValues = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInputValues()));
+  auto inputIndices = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInputIndices()));
+  auto k = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getK()));
+  auto p = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getP()));
+  auto temp = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getTemp()));
+  auto output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  ::flatbuffers::Optional<uint32_t> seed;
+  if (op.getSeed().has_value()) {
+    seed = op.getSeed().value();
+  }
+
+  return ::tt::target::ttnn::CreateSamplingOp(
+      *cache.fbb, inputValues, inputIndices, k, p, temp, seed, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::TopKRouterGptOp>
 createOp(FlatbufferObjectCache &cache, TopKRouterGptOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
@@ -4567,6 +4592,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
       pagedFillCacheOp) {
     return createOperation(cache, createOp(cache, pagedFillCacheOp),
                            debugString, locInfo);
+  }
+  if (auto samplingOp = dyn_cast<SamplingOp>(op); samplingOp) {
+    return createOperation(cache, createOp(cache, samplingOp), debugString,
+                           locInfo);
   }
   if (auto permuteOp = dyn_cast<PermuteOp>(op); permuteOp) {
     return createOperation(cache, createOp(cache, permuteOp), debugString,

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -60,6 +60,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
+#include "ttnn/operations/reduction/sampling/sampling.hpp"
 #include "ttnn/operations/reduction/topk/topk.hpp"
 #include "ttnn/operations/trace.hpp"
 #include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/argmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/prod.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/reduction/sampling.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/topk.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/topk_router_gpt.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_serialization/dump_tensor.cpp

--- a/runtime/lib/ttnn/operations/reduction/sampling.cpp
+++ b/runtime/lib/ttnn/operations/reduction/sampling.cpp
@@ -37,25 +37,19 @@ void run(const ::tt::target::ttnn::SamplingOp *op, ProgramContext &context) {
         ::ttnn::reshape(inputIndices, ::ttnn::Shape({1, 1, batch, candidates}));
   }
 
-  // Ensure correct layouts: input_values must be TILE, others ROW_MAJOR.
-  // The compiler workarounds pass requests these layouts but they may not
-  // always be applied (e.g. when the layout pass optimizes them away).
-  if (inputIndices.layout() != ::ttnn::Layout::ROW_MAJOR) {
-    inputIndices = ::ttnn::to_layout(inputIndices, ::ttnn::Layout::ROW_MAJOR,
-                                     std::nullopt, std::nullopt);
-  }
-  if (k.layout() != ::ttnn::Layout::ROW_MAJOR) {
-    k = ::ttnn::to_layout(k, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
-                          std::nullopt);
-  }
-  if (p.layout() != ::ttnn::Layout::ROW_MAJOR) {
-    p = ::ttnn::to_layout(p, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
-                          std::nullopt);
-  }
-  if (temp.layout() != ::ttnn::Layout::ROW_MAJOR) {
-    temp = ::ttnn::to_layout(temp, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
-                             std::nullopt);
-  }
+  // Workarounds pass requests ROW_MAJOR for index/param tensors but may be
+  // skipped when the layout pass optimizes them away. Enforce defensively.
+  auto toRowMajor = [](::ttnn::Tensor t) -> ::ttnn::Tensor {
+    if (t.layout() != ::ttnn::Layout::ROW_MAJOR) {
+      return ::ttnn::to_layout(t, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
+                               std::nullopt);
+    }
+    return t;
+  };
+  inputIndices = toRowMajor(inputIndices);
+  k = toRowMajor(k);
+  p = toRowMajor(p);
+  temp = toRowMajor(temp);
 
   // Kernel requires k as UINT32.
   if (k.dtype() != ::tt::tt_metal::DataType::UINT32) {

--- a/runtime/lib/ttnn/operations/reduction/sampling.cpp
+++ b/runtime/lib/ttnn/operations/reduction/sampling.cpp
@@ -25,12 +25,18 @@ void run(const ::tt::target::ttnn::SamplingOp *op, ProgramContext &context) {
     seed = op->seed().value();
   }
 
-  // ttnn::sampling kernel expects 4D input [N, C, H, W] where N*C*H == 32.
-  // The compiler passes 2D [batch, candidates]. Reshape to 4D.
+  // ttnn::sampling kernel expects 4D input [N, C, H, W] where N*C*H == 32
+  // (the kernel uses a fixed 32-user batch). The compiler always pads the
+  // batch dimension to 32 before calling this op, so batch == 32 here.
+  // Reshape 2D [batch, candidates] → [1, 1, batch, candidates] to satisfy
+  // the 4D requirement.
   auto inputShape = inputValues.logical_shape();
   if (inputShape.rank() == 2) {
     uint32_t batch = inputShape[0];
     uint32_t candidates = inputShape[1];
+    TT_FATAL(batch == 32,
+             "ttnn::sampling requires batch == 32 (N*C*H == 32), got batch={}",
+             batch);
     inputValues =
         ::ttnn::reshape(inputValues, ::ttnn::Shape({1, 1, batch, candidates}));
     inputIndices =

--- a/runtime/lib/ttnn/operations/reduction/sampling.cpp
+++ b/runtime/lib/ttnn/operations/reduction/sampling.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/reduction/sampling.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::reduction::sampling {
+void run(const ::tt::target::ttnn::SamplingOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  ::ttnn::Tensor inputValues =
+      tensorPool.getTTNNTensorAndValidate(op->input_values());
+  ::ttnn::Tensor inputIndices =
+      tensorPool.getTTNNTensorAndValidate(op->input_indices());
+  ::ttnn::Tensor k = tensorPool.getTTNNTensorAndValidate(op->k());
+  ::ttnn::Tensor p = tensorPool.getTTNNTensorAndValidate(op->p());
+  ::ttnn::Tensor temp = tensorPool.getTTNNTensorAndValidate(op->temp());
+
+  std::optional<uint32_t> seed;
+  if (op->seed().has_value()) {
+    seed = op->seed().value();
+  }
+
+  // ttnn::sampling kernel expects 4D input [N, C, H, W] where N*C*H == 32.
+  // The compiler passes 2D [batch, candidates]. Reshape to 4D.
+  auto inputShape = inputValues.logical_shape();
+  if (inputShape.rank() == 2) {
+    uint32_t batch = inputShape[0];
+    uint32_t candidates = inputShape[1];
+    inputValues =
+        ::ttnn::reshape(inputValues, ::ttnn::Shape({1, 1, batch, candidates}));
+    inputIndices =
+        ::ttnn::reshape(inputIndices, ::ttnn::Shape({1, 1, batch, candidates}));
+  }
+
+  // Ensure correct layouts: input_values must be TILE, others ROW_MAJOR.
+  // The compiler workarounds pass requests these layouts but they may not
+  // always be applied (e.g. when the layout pass optimizes them away).
+  if (inputIndices.layout() != ::ttnn::Layout::ROW_MAJOR) {
+    inputIndices = ::ttnn::to_layout(inputIndices, ::ttnn::Layout::ROW_MAJOR,
+                                     std::nullopt, std::nullopt);
+  }
+  if (k.layout() != ::ttnn::Layout::ROW_MAJOR) {
+    k = ::ttnn::to_layout(k, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
+                          std::nullopt);
+  }
+  if (p.layout() != ::ttnn::Layout::ROW_MAJOR) {
+    p = ::ttnn::to_layout(p, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
+                          std::nullopt);
+  }
+  if (temp.layout() != ::ttnn::Layout::ROW_MAJOR) {
+    temp = ::ttnn::to_layout(temp, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
+                             std::nullopt);
+  }
+
+  // Kernel requires k as UINT32.
+  if (k.dtype() != ::tt::tt_metal::DataType::UINT32) {
+    k = ::ttnn::typecast(k, ::tt::tt_metal::DataType::UINT32);
+  }
+
+  ::ttnn::Tensor output =
+      ::ttnn::sampling(inputValues, inputIndices, k, p, temp, seed);
+
+  // Reshape output from [1, 1, 1, batch] to match expected 1D output shape.
+  auto outShape = output.logical_shape();
+  if (outShape.rank() == 4 && outShape[0] == 1 && outShape[1] == 1 &&
+      outShape[2] == 1) {
+    output = ::ttnn::reshape(output, ::ttnn::Shape({outShape[3]}));
+  }
+
+  // ttnn::sampling returns UINT32. Typecast to INT32 to match compiler type.
+  if (output.dtype() == ::tt::tt_metal::DataType::UINT32) {
+    output = ::ttnn::typecast(output, ::tt::tt_metal::DataType::INT32);
+  }
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
+}
+} // namespace tt::runtime::ttnn::operations::reduction::sampling

--- a/runtime/lib/ttnn/operations/reduction/sampling.h
+++ b/runtime/lib/ttnn/operations/reduction/sampling.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_SAMPLING_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_SAMPLING_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::reduction::sampling {
+void run(const ::tt::target::ttnn::SamplingOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::reduction::sampling
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_REDUCTION_SAMPLING_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -94,6 +94,7 @@
 #include "operations/reduction/cumsum.h"
 #include "operations/reduction/prod.h"
 #include "operations/reduction/reduction.h"
+#include "operations/reduction/sampling.h"
 #include "operations/reduction/topk.h"
 #include "operations/reduction/topk_router_gpt.h"
 #include "operations/tensor_serialization/dump_tensor.h"
@@ -534,6 +535,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::PagedFillCacheOp: {
     return operations::kv_cache::run(op->type_as_PagedFillCacheOp(),
                                      getContext());
+  }
+  case ::tt::target::ttnn::OpType::SamplingOp: {
+    return operations::reduction::sampling::run(op->type_as_SamplingOp(),
+                                                getContext());
   }
   case ::tt::target::ttnn::OpType::UpsampleOp: {
     return operations::pool::run(op->type_as_UpsampleOp(), getContext());

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1298,6 +1298,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_PagedUpdateCacheOp()->cache();
     break;
   }
+  case ::tt::target::ttnn::OpType::SamplingOp: {
+    tensorRef = opContext.type_as_SamplingOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::PointToPointOp: {
     tensorRef = opContext.type_as_PointToPointOp()->out();
     break;
@@ -1837,6 +1841,14 @@ getOpInputRefs(OpContext opContextHandle,
                   opContext.type_as_PagedUpdateCacheOp()->input(),
                   opContext.type_as_PagedUpdateCacheOp()->update_index(),
                   opContext.type_as_PagedUpdateCacheOp()->page_table()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::SamplingOp: {
+    tensorRefs = {opContext.type_as_SamplingOp()->input_values(),
+                  opContext.type_as_SamplingOp()->input_indices(),
+                  opContext.type_as_SamplingOp()->k(),
+                  opContext.type_as_SamplingOp()->p(),
+                  opContext.type_as_SamplingOp()->temp()};
     break;
   }
   case ::tt::target::ttnn::OpType::FillCacheOp: {

--- a/test/python/golden/test_ttnn_ops.py
+++ b/test/python/golden/test_ttnn_ops.py
@@ -259,6 +259,63 @@ def test_gather(
 
 
 @pytest.mark.parametrize(
+    "candidates,vocab_size",
+    [
+        (128, 128256),  # Llama-3.x
+        (64, 50272),  # OPT-125M
+    ],
+    ids=["llama", "opt"],
+)
+def test_sampling(
+    candidates: int,
+    vocab_size: int,
+    request,
+    device,
+):
+    """Builder test for ttnn.sampling: fused top-k/p multinomial sampling.
+
+    Verifies that the op compiles and returns global token indices in the
+    valid range [0, vocab_size) for each of the 32 users.
+    """
+    batch = 32
+
+    def module(builder: TTNNBuilder):
+        @builder.func(
+            [(batch, candidates), (batch, candidates), (batch,), (batch,), (batch,)],
+            [torch.bfloat16, torch.int32, torch.uint32, torch.bfloat16, torch.bfloat16],
+        )
+        def sampling_fn(
+            vals: Operand,
+            idx: Operand,
+            k: Operand,
+            p: Operand,
+            temp: Operand,
+            builder: TTNNBuilder,
+        ):
+            # Override index tensor with valid global vocab positions.
+            valid_indices = torch.stack(
+                [torch.randperm(vocab_size)[:candidates] for _ in range(batch)]
+            ).to(torch.int32)
+            valid_k = torch.full((batch,), candidates, dtype=torch.uint32)
+            valid_p = torch.ones(batch, dtype=torch.bfloat16)
+            valid_temp = torch.full((batch,), 1.667, dtype=torch.bfloat16)
+            builder.set_goldens(
+                {idx: valid_indices, k: valid_k, p: valid_p, temp: valid_temp}, {}
+            )
+            return builder.sampling(vals, idx, k, p, temp)
+
+    # Sampling is stochastic (multinomial); CPU golden cannot be matched
+    # element-wise. Skip PCC to verify only compile+device-execute succeed.
+    kwargs = get_request_kwargs(request)
+    kwargs["check_pcc"] = False
+    compile_and_execute_ttnn(
+        module,
+        **kwargs,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
     "test_shape",
     [
         (1, 32, 32, 32),

--- a/test/ttmlir/Conversion/StableHLOToTTIR/sampling_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/sampling_op.mlir
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module attributes {} {
+
+  // Test: stablehlo custom_call "tt.sampling" → ttir.sampling, with seed.
+  // CHECK-LABEL: func.func @sampling_with_seed
+  func.func @sampling_with_seed(
+      %arg0: tensor<1x32xbf16>,
+      %arg1: tensor<1x32xi32>,
+      %arg2: tensor<1xui32>,
+      %arg3: tensor<1xbf16>,
+      %arg4: tensor<1xbf16>) -> tensor<1xi32> {
+    // CHECK: "ttir.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4)
+    // CHECK-SAME: seed = 42 : ui32
+    // CHECK-SAME: -> tensor<1xi32>
+    %0 = stablehlo.custom_call @tt.sampling(%arg0, %arg1, %arg2, %arg3, %arg4) {
+        api_version = 0 : i32,
+        mhlo.frontend_attributes = {seed = "42"}
+    } : (tensor<1x32xbf16>, tensor<1x32xi32>, tensor<1xui32>, tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xi32>
+    return %0 : tensor<1xi32>
+  }
+
+  // Test: stablehlo custom_call "tt.sampling" → ttir.sampling, without seed.
+  // CHECK-LABEL: func.func @sampling_no_seed
+  func.func @sampling_no_seed(
+      %arg0: tensor<4x64xbf16>,
+      %arg1: tensor<4x64xi32>,
+      %arg2: tensor<4xui32>,
+      %arg3: tensor<4xbf16>,
+      %arg4: tensor<4xbf16>) -> tensor<4xi32> {
+    // CHECK: "ttir.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4)
+    // CHECK-NOT: seed
+    // CHECK-SAME: -> tensor<4xi32>
+    %0 = stablehlo.custom_call @tt.sampling(%arg0, %arg1, %arg2, %arg3, %arg4) {
+        api_version = 0 : i32
+    } : (tensor<4x64xbf16>, tensor<4x64xi32>, tensor<4xui32>, tensor<4xbf16>, tensor<4xbf16>) -> tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+
+}

--- a/test/ttmlir/Dialect/TTIR/reduction/sampling_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduction/sampling_tests_positive.mlir
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt %s | FileCheck %s
+
+// Verify basic sampling operation (batch=1, 32 candidates).
+module {
+  func.func @sampling_basic(
+      %arg0: tensor<1x32xbf16>,
+      %arg1: tensor<1x32xi32>,
+      %arg2: tensor<1xui32>,
+      %arg3: tensor<1xbf16>,
+      %arg4: tensor<1xbf16>) -> tensor<1xi32> {
+    // CHECK: "ttir.sampling"
+    // CHECK-SAME: (tensor<1x32xbf16>, tensor<1x32xi32>, tensor<1xui32>, tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xi32>
+    %0 = "ttir.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4)
+        : (tensor<1x32xbf16>, tensor<1x32xi32>, tensor<1xui32>, tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xi32>
+    return %0 : tensor<1xi32>
+  }
+}
+
+// -----
+
+// Verify sampling with optional seed attribute.
+module {
+  func.func @sampling_with_seed(
+      %arg0: tensor<4x128xbf16>,
+      %arg1: tensor<4x128xi32>,
+      %arg2: tensor<4xui32>,
+      %arg3: tensor<4xbf16>,
+      %arg4: tensor<4xbf16>) -> tensor<4xi32> {
+    // CHECK: "ttir.sampling"
+    // CHECK-SAME: seed = 42 : ui32
+    %0 = "ttir.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4) <{seed = 42 : ui32}>
+        : (tensor<4x128xbf16>, tensor<4x128xi32>, tensor<4xui32>, tensor<4xbf16>, tensor<4xbf16>) -> tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#dram = #ttnn.buffer_type<dram>
+// Row-major layouts — workaround should convert index/param tensors to ROW_MAJOR
+// (they typically arrive in TILE layout after prior ops).
+#ttnn_layout_vals_tile  = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_idx_tile   = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout_k_tile     = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+#ttnn_layout_p_tile     = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_out        = #ttnn.ttnn_layout<(d0) -> (d0), <1x1>, memref<1xsi32, #dram>, <interleaved>>
+
+module attributes {} {
+
+  // Verify that index/param tensors in TILE layout are converted to ROW_MAJOR.
+  // input_values stays in TILE (no workaround needed for values tensor).
+  func.func @sampling_tile_inputs_get_row_major(
+      %arg0: tensor<1x32xbf16, #ttnn_layout_vals_tile>,
+      %arg1: tensor<1x32xi32, #ttnn_layout_idx_tile>,
+      %arg2: tensor<1xui32, #ttnn_layout_k_tile>,
+      %arg3: tensor<1xbf16, #ttnn_layout_p_tile>,
+      %arg4: tensor<1xbf16, #ttnn_layout_p_tile>)
+      -> tensor<1xi32, #ttnn_layout_out> {
+    // CHECK-LABEL: func.func @sampling_tile_inputs_get_row_major
+    // CHECK: %[[IDX:.*]] = "ttnn.to_layout"(%arg1)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: %[[K:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: %[[P:.*]] = "ttnn.to_layout"(%arg3)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: %[[T:.*]] = "ttnn.to_layout"(%arg4)
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: "ttnn.sampling"(%arg0, %[[IDX]], %[[K]], %[[P]], %[[T]])
+    %0 = "ttnn.sampling"(%arg0, %arg1, %arg2, %arg3, %arg4)
+        : (tensor<1x32xbf16, #ttnn_layout_vals_tile>,
+           tensor<1x32xi32, #ttnn_layout_idx_tile>,
+           tensor<1xui32, #ttnn_layout_k_tile>,
+           tensor<1xbf16, #ttnn_layout_p_tile>,
+           tensor<1xbf16, #ttnn_layout_p_tile>)
+        -> tensor<1xi32, #ttnn_layout_out>
+    return %0 : tensor<1xi32, #ttnn_layout_out>
+  }
+
+}

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6480,4 +6480,81 @@ TEST_F(OpModelBase, PagedFlashMultiLatentAttentionDecodeOpInterface) {
   }
 }
 
+//===----------------------------------------------------------------------===//
+// SamplingOp
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpModelBase, SamplingOp) {
+  // Typical vLLM non-greedy sampling shapes: batch=32, candidates=128
+  const int64_t batch = 32;
+  const int64_t candidates = 128;
+
+  llvm::SmallVector<int64_t> valuesShape = {batch, candidates};
+  llvm::SmallVector<int64_t> indicesShape = {batch, candidates};
+  llvm::SmallVector<int64_t> paramShape = {batch}; // k, p, temp
+  llvm::SmallVector<int64_t> outputShape = {batch};
+
+  auto gridAttr = ttcore::GridAttr::get(&context);
+  auto tensorMemoryLayoutAttr =
+      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
+
+  // Build TTNNLayoutAttrs matching the kernel's expected tensor contracts.
+  auto bf16TileType = ttcore::TileType::get(builder.getBF16Type());
+  auto si32TileType = ttcore::TileType::get(builder.getIntegerType(32, true));
+  auto ui32TileType = ttcore::TileType::get(builder.getIntegerType(32, false));
+
+  auto valuesLayout =
+      TTNNLayoutAttr::get(&context, valuesShape, bf16TileType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+  auto indicesLayout =
+      TTNNLayoutAttr::get(&context, indicesShape, si32TileType,
+                          BufferType::DRAM, gridAttr, tensorMemoryLayoutAttr);
+  auto kLayout =
+      TTNNLayoutAttr::get(&context, paramShape, ui32TileType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+  auto paramLayout =
+      TTNNLayoutAttr::get(&context, paramShape, bf16TileType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+  auto outputLayout =
+      TTNNLayoutAttr::get(&context, outputShape, si32TileType, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
+
+  auto inputValues = createEmptyTensor(valuesShape, bf16TileType, valuesLayout);
+  auto inputIndices =
+      createEmptyTensor(indicesShape, si32TileType, indicesLayout);
+  auto k = createEmptyTensor(paramShape, ui32TileType, kLayout);
+  auto p = createEmptyTensor(paramShape, bf16TileType, paramLayout);
+  auto temp = createEmptyTensor(paramShape, bf16TileType, paramLayout);
+
+  auto outputType =
+      createRankedTensorType(outputShape, si32TileType, outputLayout);
+
+  auto samplingOp =
+      builder.create<SamplingOp>(builder.getUnknownLoc(), outputType,
+                                 inputValues, inputIndices, k, p, temp,
+                                 /*seed=*/mlir::IntegerAttr{});
+
+  samplingOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
+
+  auto constraintsExp = getOpConstraints(samplingOp.getOperation());
+  if (constraintsExp) {
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+        constraintsExp.get();
+    EXPECT_GE(cbSize, 0);
+    EXPECT_GE(l1PeakSize, 0);
+    EXPECT_GT(outputSize, 0);
+  } else {
+    FAIL() << "Missing L1 constraints for SamplingOp; Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = getOpRuntime(samplingOp.getOperation());
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0u);
+  } else {
+    FAIL() << "Runtime test failed for SamplingOp; Error="
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 } // namespace mlir::tt::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6498,36 +6498,37 @@ TEST_F(OpModelBase, SamplingOp) {
   auto tensorMemoryLayoutAttr =
       TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved);
 
-  // Build TTNNLayoutAttrs matching the kernel's expected tensor contracts.
+  // Build TTNNLayoutAttrs matching the kernel's expected tensor contracts
+  // post-workaround: input_values is TILE, index/param/result tensors are
+  // ROW_MAJOR (the sampling kernel rejects TILE for indices/k/p/temp).
   auto bf16TileType = ttcore::TileType::get(builder.getBF16Type());
-  auto si32TileType = ttcore::TileType::get(builder.getIntegerType(32, true));
-  auto ui32TileType = ttcore::TileType::get(builder.getIntegerType(32, false));
+  auto bf16Type = builder.getBF16Type();
+  auto si32Type = builder.getIntegerType(32, true);
+  auto ui32Type = builder.getIntegerType(32, false);
 
   auto valuesLayout =
       TTNNLayoutAttr::get(&context, valuesShape, bf16TileType, BufferType::DRAM,
                           gridAttr, tensorMemoryLayoutAttr);
   auto indicesLayout =
-      TTNNLayoutAttr::get(&context, indicesShape, si32TileType,
-                          BufferType::DRAM, gridAttr, tensorMemoryLayoutAttr);
+      TTNNLayoutAttr::get(&context, indicesShape, si32Type, BufferType::DRAM,
+                          gridAttr, tensorMemoryLayoutAttr);
   auto kLayout =
-      TTNNLayoutAttr::get(&context, paramShape, ui32TileType, BufferType::DRAM,
+      TTNNLayoutAttr::get(&context, paramShape, ui32Type, BufferType::DRAM,
                           gridAttr, tensorMemoryLayoutAttr);
   auto paramLayout =
-      TTNNLayoutAttr::get(&context, paramShape, bf16TileType, BufferType::DRAM,
+      TTNNLayoutAttr::get(&context, paramShape, bf16Type, BufferType::DRAM,
                           gridAttr, tensorMemoryLayoutAttr);
   auto outputLayout =
-      TTNNLayoutAttr::get(&context, outputShape, si32TileType, BufferType::DRAM,
+      TTNNLayoutAttr::get(&context, outputShape, si32Type, BufferType::DRAM,
                           gridAttr, tensorMemoryLayoutAttr);
 
   auto inputValues = createEmptyTensor(valuesShape, bf16TileType, valuesLayout);
-  auto inputIndices =
-      createEmptyTensor(indicesShape, si32TileType, indicesLayout);
-  auto k = createEmptyTensor(paramShape, ui32TileType, kLayout);
-  auto p = createEmptyTensor(paramShape, bf16TileType, paramLayout);
-  auto temp = createEmptyTensor(paramShape, bf16TileType, paramLayout);
+  auto inputIndices = createEmptyTensor(indicesShape, si32Type, indicesLayout);
+  auto k = createEmptyTensor(paramShape, ui32Type, kLayout);
+  auto p = createEmptyTensor(paramShape, bf16Type, paramLayout);
+  auto temp = createEmptyTensor(paramShape, bf16Type, paramLayout);
 
-  auto outputType =
-      createRankedTensorType(outputShape, si32TileType, outputLayout);
+  auto outputType = createRankedTensorType(outputShape, si32Type, outputLayout);
 
   auto samplingOp =
       builder.create<SamplingOp>(builder.getUnknownLoc(), outputType,
@@ -6542,7 +6543,10 @@ TEST_F(OpModelBase, SamplingOp) {
         constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
-    EXPECT_GT(outputSize, 0);
+    // outputSize is l1_output_buffer_per_core; ttnn::sampling's signature
+    // has no memory_config parameter, so we can't place output in L1 and
+    // this is expected to be 0.
+    EXPECT_GE(outputSize, 0);
   } else {
     FAIL() << "Missing L1 constraints for SamplingOp; Error="
            << llvm::toString(constraintsExp.takeError());

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -9747,6 +9747,73 @@ class TTNNBuilder(Builder):
 
         return gather_module, gather_builder
 
+    @tag(ttnn.SamplingOp)
+    def sampling(
+        self,
+        input_values: Operand,
+        input_indices: Operand,
+        k: Operand,
+        p: Operand,
+        temp: Operand,
+        seed: Optional[int] = None,
+        loc: Optional[str] = None,
+    ) -> OpResult:
+        """Fused top-k + top-p + multinomial sampling on pre-filtered candidates.
+
+        Args:
+            input_values: Candidate logit values [batch=32, candidates] bf16.
+            input_indices: Global vocab indices for candidates [batch=32, candidates] int32.
+            k: Per-request top-k values [batch=32] uint32.
+            p: Per-request top-p values [batch=32] bf16.
+            temp: Per-request temperature values [batch=32] bf16 (1/temperature).
+            seed: Optional random seed for reproducibility.
+        Returns:
+            Sampled global token indices [batch=32] int32.
+        """
+        ttnn_op = self.get_opview_from_method(TTNNBuilder.sampling)
+
+        vals_t = self._get_golden_tensor(input_values).float()
+        idx_t = self._get_golden_tensor(input_indices)
+        temp_t = self._get_golden_tensor(temp).float()
+
+        batch = vals_t.shape[0]
+        temperature = temp_t.clamp(min=1e-6).unsqueeze(-1)
+        scaled = torch.div(vals_t, temperature)
+        probs = torch.softmax(scaled, dim=-1)
+        sampled_local = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        golden_output = (
+            torch.gather(idx_t, 1, sampled_local.unsqueeze(-1))
+            .squeeze(-1)
+            .to(torch.int32)
+        )
+
+        result_shape = [batch]
+        mlir_output_type = self._get_type_from_torch_dtype(torch.int32)
+        result = self.create_ttnn_tensor(result_shape, mlir_output_type)
+
+        seed_attr = None
+        if seed is not None:
+            seed_attr = IntegerAttr.get(IntegerType.get_unsigned(32), seed)
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = ttnn_op(
+            result,
+            input_values,
+            input_indices,
+            k,
+            p,
+            temp,
+            seed=seed_attr,
+            loc=loc,
+        )
+        op_result = op.result
+        self._set_golden_tensor(op_result, golden_output)
+        return op_result
+
     ############### ttnn.AllGatherOp ###############
 
     @tag(ttnn.AllGatherOp)

--- a/tools/builder/ttnn/ttnn_builder.py
+++ b/tools/builder/ttnn/ttnn_builder.py
@@ -9772,28 +9772,31 @@ class TTNNBuilder(Builder):
         """
         ttnn_op = self.get_opview_from_method(TTNNBuilder.sampling)
 
-        vals_t = self._get_golden_tensor(input_values).float()
-        idx_t = self._get_golden_tensor(input_indices)
-        temp_t = self._get_golden_tensor(temp).float()
-
-        batch = vals_t.shape[0]
-        temperature = temp_t.clamp(min=1e-6).unsqueeze(-1)
-        scaled = torch.div(vals_t, temperature)
-        probs = torch.softmax(scaled, dim=-1)
-        sampled_local = torch.multinomial(probs, num_samples=1).squeeze(-1)
-        golden_output = (
-            torch.gather(idx_t, 1, sampled_local.unsqueeze(-1))
-            .squeeze(-1)
-            .to(torch.int32)
-        )
-
-        result_shape = [batch]
         mlir_output_type = self._get_type_from_torch_dtype(torch.int32)
-        result = self.create_ttnn_tensor(result_shape, mlir_output_type)
+
+        vals_golden = self._get_golden_tensor(input_values)
+        idx_golden = self._get_golden_tensor(input_indices)
+        k_golden = self._get_golden_tensor(k)
+        p_golden = self._get_golden_tensor(p)
+        temp_golden = self._get_golden_tensor(temp)
 
         seed_attr = None
         if seed is not None:
             seed_attr = IntegerAttr.get(IntegerType.get_unsigned(32), seed)
+
+        op_golden_function = get_golden_function(ttnn_op)
+        golden_output = op_golden_function(
+            vals_golden,
+            idx_golden,
+            k_golden,
+            p_golden,
+            temp_golden,
+            seed_attr,
+            mlir_output_type,
+        )
+
+        batch = vals_golden.shape[0]
+        result = self.create_ttnn_tensor([batch], mlir_output_type)
 
         if loc is None:
             loc = self._get_location()

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4848,6 +4848,33 @@ def ttir_topk_router_gpt_golden(
     return expert_indices, expert_weights
 
 
+def ttnn_sampling_golden(
+    input_values: GoldenMapTensor,
+    input_indices: GoldenMapTensor,
+    _k: GoldenMapTensor,
+    _p: GoldenMapTensor,
+    temp: GoldenMapTensor,
+    _seed: Optional[IntegerAttr],
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    """CPU golden for ttnn.sampling (fused top-k/p + multinomial).
+
+    Inputs are already pre-filtered candidates, so k/p are unused on the
+    CPU side. The device kernel is stochastic with hardware RNG that
+    cannot be mirrored on CPU, so callers should disable PCC comparison.
+    """
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    temperature = temp.float().clamp(min=1e-6).unsqueeze(-1)
+    scaled = torch.div(input_values.float(), temperature)
+    probs = torch.softmax(scaled, dim=-1)
+    sampled_local = torch.multinomial(probs, num_samples=1).squeeze(-1)
+    return (
+        torch.gather(input_indices, 1, sampled_local.unsqueeze(-1))
+        .squeeze(-1)
+        .to(output_dtype)
+    )
+
+
 ################ StableHLO Op Golden Functions ###############
 
 
@@ -7454,6 +7481,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.AggregateTensorOp: ttnn_aggregate_tensor_golden,
     ttnn.AllGatherOp: ttnn_all_gather_golden,
     ttnn.GatherOp: ttir_gather_golden,
+    ttnn.SamplingOp: ttnn_sampling_golden,
     ttnn.AllReduceAsyncOp: ttir_all_reduce_golden,
     ttnn.ReduceScatterOp: ttnn_reduce_scatter_golden,
     # ----- DEBUG OPS -----


### PR DESCRIPTION
## Ticket

tenstorrent/tt-xla#3940

## Problem

Non-greedy (temperature > 0) LLM inference on TT device was significantly slower than greedy. The sampling path (softmax → top-k filtering → top-p filtering → multinomial sampling) ran as separate compiled ops over a pre-filtered candidate set of ~128 tokens. Each op incurs program dispatch overhead and separate kernel launches.

The `ttnn::sampling` hardware kernel fuses all of these into a single call: softmax + top-k masking + top-p masking + multinomial selection. Exposing it through the compiler stack eliminates those intermediate kernel launches.

## What's changed

Wires the existing `ttnn::sampling` hardware kernel end-to-end through the tt-mlir compiler and runtime:

**Compiler:**
- Add `ttir.sampling` op to the TTIR dialect with verifier (inputs: candidate logit values, global vocab indices, per-request k/p/temp tensors, optional seed; output: sampled global token index per request)
- Add `ttnn.sampling` op to the TTNN dialect with layout workarounds (TILE for input values, ROW_MAJOR for index/param tensors and for the output — kernel produces ROW_MAJOR, so the workaround pass now inserts an explicit `ttnn.to_layout` after the op rather than having the runtime silently convert)
- Lower `stablehlo.custom_call "tt.sampling"` → `ttir.sampling` → `ttnn.sampling` through the standard conversion pipeline; optional seed parsed from `mhlo.frontend_attributes`
- Flatbuffer serialization via `reduction.fbs`

**Runtime:**
- `runtime/lib/ttnn/operations/reduction/sampling.cpp`: dispatch `SamplingOp` to `::ttnn::sampling` with required shape/layout/dtype workarounds (2D→4D reshape for batch=32 kernel requirement, defensive ROW_MAJOR enforcement, int32→uint32 k typecast, uint32→int32 output typecast)
- Wire into `program_executor.cpp` dispatch table and `runtime.cpp`

**OpModel:**
- Full `OpModel<SamplingOp>` template specialization in `TTNNOpModel.cpp` (5-tensor `convertToTensorSpec` + `QUERY_OP_CONSTRAINTS/RUNTIME(::ttnn::sampling, ...)`)
- `TTNNOpModelInterface.cpp` wires `SamplingOp::getOpConstraints/getOpRuntime` to the `OpModel` (replacing the `MissingMetalDefinition` stubs)

**Tests:**
- `test/ttmlir/Conversion/StableHLOToTTIR/sampling_op.mlir`: custom_call lowering with and without seed
- `test/ttmlir/Dialect/TTIR/reduction/sampling_tests_positive.mlir`: TTIR op round-trip
- `test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sampling_workaround.mlir`: TILE → ROW_MAJOR layout conversion for index/param tensors
- `test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp`: `OpModelBase.SamplingOp` unit test (batch=32, candidates=128)
- `tools/builder/ttnn/ttnn_builder.py` + `test/python/golden/test_ttnn_ops.py`: `TTNNBuilder.sampling()` method and `test_sampling` parametrized over Llama-3.x and OPT-125M vocab sizes (PCC check disabled because multinomial sampling is stochastic; test verifies compile + device execute succeed end-to-end)

## Results

Drops non-greedy sampler from ~34ms to ~20ms in llama cases.

Measured on Blackhole (single device, batch=1, bfp8, opt-level-0):

| Model | Non-greedy before | Non-greedy with ttnn.sampling |
|---|---|---|
| Llama 3.1-8B | 9.2 tok/s | **10.8 tok/s (+17%)** |
| Llama 3.2-1B | 14.0 tok/s | **17.2 tok/s (+23%)** |
| OPT-125M | 33.5 tok/s | **40.1 tok/s (+20%)** |

The baseline (9.2/14.0/33.5) already includes a separate tt-xla change (tenstorrent/tt-xla#4334) that replaces full-vocab sort with chunked topk. Combined improvement vs the original sort-based baseline (4.6/5.5/12.9 tok/s) is 2-3x. Output quality verified on Llama 3.1-8B and 3.2-1B.

Further throughput improvements are in progress: pre-padding the logit batch to 32 before the topk stage removes extra padding ops at the sampling layer and is expected to add another ~17%.

## Checklist

- [x] ttnn.sampling op wired end-to-end through compiler and runtime
- [x] OpModel implemented with unit test
- [x] Builder API method + builder test added
- [x] MLIR lit tests added (conversion, TTIR dialect, workarounds)
- [x] Throughput improvement verified on 3 models
