### PR TITLE
[TTIRToD2M] Workaround for ND (>2D) implicit broadcast crash in elementwise lowering

### DIFF
--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -811,6 +811,69 @@ private:
       std::is_same_v<ConcreteOp, ttir::LessThanOp> ||
       std::is_same_v<ConcreteOp, ttir::LessEqualOp>;
 
+  // Build outer (per-shard) implicit-broadcast indexing maps in `physicalRank`,
+  // by comparing each input's physical shard shape (in tiles) to the output's.
+  //
+  // The d2m.generic / linalg.generic iteration domain is `physicalRank`, which
+  // for TTNN-encoded operands may be smaller than the logical rank because the
+  // TTNN layout collapses leading dims into a 2D physical memref. Building the
+  // indexing maps in physical rank (instead of the logical output rank) keeps
+  // the indexing-map domain in lock-step with the iteration domain regardless
+  // of whether the layout collapses dims.
+  //
+  // Per physical dim:
+  //   - input dim == output dim         -> identity dim expr
+  //   - input dim == 1 && output dim > 1 -> constant 0 (broadcast)
+  //   - any other mismatch              -> assertion failure
+  //
+  // In-tile broadcasts (TileBcastType::{Row, Col, Scalar}) are computed
+  // independently from the original logical shapes via `getImplicitBcastInfo`
+  // and applied inside the d2m.generic body via `d2m.tile_bcast`.
+  static SmallVector<mlir::AffineMap> buildPhysicalImplicitBcastIndexingMaps(
+      mlir::OpBuilder &builder, mlir::ArrayRef<Value> physicalInputs,
+      Value physicalOutput, std::size_t physicalRank) {
+    auto getShardTiles = [](Value v) -> mlir::ArrayRef<int64_t> {
+      auto tensorType = mlir::cast<mlir::RankedTensorType>(v.getType());
+      auto layout =
+          mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
+      return layout.getShardShape(tensorType);
+    };
+
+    mlir::ArrayRef<int64_t> outShard = getShardTiles(physicalOutput);
+    TT_assertv(outShard.size() == physicalRank,
+               "output shard rank ({}) must equal physicalRank ({})",
+               outShard.size(), physicalRank);
+
+    SmallVector<mlir::AffineMap> maps;
+    maps.reserve(physicalInputs.size() + 1);
+
+    for (Value input : physicalInputs) {
+      mlir::ArrayRef<int64_t> inShard = getShardTiles(input);
+      TT_assertv(inShard.size() == physicalRank,
+                 "input shard rank ({}) must equal physicalRank ({})",
+                 inShard.size(), physicalRank);
+
+      SmallVector<mlir::AffineExpr> exprs;
+      exprs.reserve(physicalRank);
+      for (std::size_t d = 0; d < physicalRank; ++d) {
+        if (inShard[d] == outShard[d]) {
+          exprs.push_back(builder.getAffineDimExpr(d));
+        } else {
+          TT_assertv(inShard[d] == 1,
+                     "incompatible implicit bcast in physical dim {} "
+                     "(input={}, output={})",
+                     d, inShard[d], outShard[d]);
+          exprs.push_back(builder.getAffineConstantExpr(0));
+        }
+      }
+      maps.push_back(AffineMap::get(physicalRank, /*symbolCount=*/0, exprs,
+                                    builder.getContext()));
+    }
+
+    maps.push_back(builder.getMultiDimIdentityMap(physicalRank));
+    return maps;
+  }
+
   static std::pair<SmallVector<mlir::AffineMap>,
                    SmallVector<d2m::TileBcastType>>
   getImplicitBcastInfo(mlir::OpBuilder &builder, ArrayRef<Value> inputs,
@@ -1002,18 +1065,25 @@ private:
         createDpsOutputs(loc, rewriter, {op.getResult().getType()});
     SmallVector<Value> origInputs = adaptor.getOperands();
 
-    SmallVector<mlir::AffineMap> bcastIndexingMaps;
+    // Compute logical-shape-derived bcast info. Only `tileBcastTypes` (used
+    // for in-tile broadcasting via d2m.tile_bcast) and the `isImplicitBcast`
+    // flag are consumed from this; the logical-rank affine maps are not used
+    // to construct the d2m.generic, because they would not match the physical
+    // (possibly collapsed) iteration domain. See
+    // `buildPhysicalImplicitBcastIndexingMaps` below.
+    SmallVector<mlir::AffineMap> logicalBcastMaps;
     SmallVector<d2m::TileBcastType> tileBcastTypes;
-    std::tie(bcastIndexingMaps, tileBcastTypes) =
+    std::tie(logicalBcastMaps, tileBcastTypes) =
         getImplicitBcastInfo(rewriter, origInputs, origOutputs);
 
     // Implicit bcast if tile-level bcast exists or any input indexing map is
     // not identity.
     const bool isImplicitBcast =
-        !bcastIndexingMaps.empty() &&
-        llvm::any_of(ArrayRef<mlir::AffineMap>(bcastIndexingMaps)
+        !logicalBcastMaps.empty() &&
+        llvm::any_of(ArrayRef<mlir::AffineMap>(logicalBcastMaps)
                          .take_front(origInputs.size()),
                      [](mlir::AffineMap map) { return !map.isIdentity(); });
+
     auto [inputs, outputs] =
         toLayoutOperandsAndResults(rewriter, {origInputs, origOutputs},
                                    /*tiled*/ true, isImplicitBcast);
@@ -1024,13 +1094,29 @@ private:
     const std::size_t physicalRank =
         ttcore::getDeviceLayout(outputs[0]).getRank() / 2;
 
-    auto indexingMaps =
+    // Build indexing maps in the *physical* iteration domain. For implicit
+    // broadcasts we cannot reuse the logical-rank maps from
+    // `getImplicitBcastInfo` because TTNN-encoded operands may collapse leading
+    // logical dims into a 2D physical layout, leaving the logical-rank maps
+    // (e.g. 4D) misaligned with the physical iteration domain (e.g. 2D). The
+    // physical-rank maps below are derived from per-operand physical shard
+    // shape comparison and stay correct regardless of layout collapse.
+    SmallVector<mlir::AffineMap> indexingMaps =
         isImplicitBcast
-            ? bcastIndexingMaps
+            ? buildPhysicalImplicitBcastIndexingMaps(rewriter, inputs,
+                                                     outputs[0], physicalRank)
             : getAffineMapsArray(rewriter, numOperands, physicalRank);
 
     SmallVector<mlir::Attribute> iteratorTypes =
         getIteratorTypesArray(rewriter, physicalRank);
+
+    // Invariant required by getMulticastGridDims and downstream code: the
+    // domain of every indexing map must match the size of iteratorTypes.
+    assert(llvm::all_of(indexingMaps,
+                        [&](mlir::AffineMap m) {
+                          return m.getNumDims() == iteratorTypes.size();
+                        }) &&
+           "indexing map domain rank must match iterator types count");
 
     // Create 'd2m.generic' accepting 'op's operands.
     auto generic = rewriter.create<d2m::GenericOp>(
@@ -1054,11 +1140,13 @@ private:
             generic, inputIndices, mcastGridDims);
         ArrayRef<Value> blockArgs(blockArgsVec);
 
-        // Create 'linalg.generic' accepting 'blockArgs'.
-        auto linalgIndexingMaps =
-            isImplicitBcast
-                ? bcastIndexingMaps
-                : getAffineMapsArray(rewriter, numOperands, physicalRank);
+        // Create 'linalg.generic' accepting 'blockArgs'. The inner per-shard
+        // tile iteration domain has the same rank as the d2m.generic outer
+        // iteration domain (both `physicalRank`), and the same
+        // shard-shape-derived broadcast pattern applies (broadcast inputs read
+        // their single shard tile across the output's tile iteration). Reuse
+        // the physical-rank maps to keep the two ranks/domains in sync.
+        auto linalgIndexingMaps = indexingMaps;
 
         SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
             iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -832,14 +832,20 @@ private:
   static SmallVector<mlir::AffineMap> buildPhysicalImplicitBcastIndexingMaps(
       mlir::OpBuilder &builder, mlir::ArrayRef<Value> physicalInputs,
       Value physicalOutput, std::size_t physicalRank) {
-    auto getShardTiles = [](Value v) -> mlir::ArrayRef<int64_t> {
+    // Return an owning SmallVector rather than ArrayRef: even though the
+    // current MetalLayoutAttr::getShardShape implementation returns a slice
+    // backed by the MLIR type's stable storage, the interface contract
+    // returns ArrayRef<int64_t> and a future implementation could return a
+    // view into a temporary container, which would dangle. Copying once per
+    // operand is cheap and removes that footgun.
+    auto getShardTiles = [](Value v) -> SmallVector<int64_t> {
       auto tensorType = mlir::cast<mlir::RankedTensorType>(v.getType());
       auto layout =
           mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
-      return layout.getShardShape(tensorType);
+      return SmallVector<int64_t>(layout.getShardShape(tensorType));
     };
 
-    mlir::ArrayRef<int64_t> outShard = getShardTiles(physicalOutput);
+    SmallVector<int64_t> outShard = getShardTiles(physicalOutput);
     TT_assertv(outShard.size() == physicalRank,
                "output shard rank ({}) must equal physicalRank ({})",
                outShard.size(), physicalRank);
@@ -848,7 +854,7 @@ private:
     maps.reserve(physicalInputs.size() + 1);
 
     for (Value input : physicalInputs) {
-      mlir::ArrayRef<int64_t> inShard = getShardTiles(input);
+      SmallVector<int64_t> inShard = getShardTiles(input);
       TT_assertv(inShard.size() == physicalRank,
                  "input shard rank ({}) must equal physicalRank ({})",
                  inShard.size(), physicalRank);
@@ -1112,11 +1118,15 @@ private:
 
     // Invariant required by getMulticastGridDims and downstream code: the
     // domain of every indexing map must match the size of iteratorTypes.
-    assert(llvm::all_of(indexingMaps,
-                        [&](mlir::AffineMap m) {
-                          return m.getNumDims() == iteratorTypes.size();
-                        }) &&
-           "indexing map domain rank must match iterator types count");
+    // Use TT_assertv (always-on) instead of assert so a violation aborts
+    // with a clear diagnostic in release builds rather than crashing later
+    // with an out-of-bounds read into iteratorTypes.
+    for (auto [i, m] : llvm::enumerate(indexingMaps)) {
+      TT_assertv(m.getNumDims() == iteratorTypes.size(),
+                 "indexing map #{} domain rank ({}) must match iterator "
+                 "types count ({})",
+                 i, m.getNumDims(), iteratorTypes.size());
+    }
 
     // Create 'd2m.generic' accepting 'op's operands.
     auto generic = rewriter.create<d2m::GenericOp>(

--- a/test/ttmlir/Conversion/TTIRToD2M/nd_implicit_bcast.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/nd_implicit_bcast.mlir
@@ -1,0 +1,150 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m="ttnn-mode=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// CHECK-DAG: #[[MAP_ID:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: #[[MAP_COL_BCAST:.+]] = affine_map<(d0, d1) -> (d0, 0)>
+
+// Verify that TTIRToD2M correctly lowers elementwise ops with implicit
+// broadcasts whose logical operand rank (>2) is greater than the physical
+// post-collapse rank (=2 for the standard TTNN layout).
+//
+// The d2m.generic / linalg.generic indexing maps must be built in the
+// (collapsed) physical iteration domain, derived from per-operand physical
+// shard-tile-shape comparison. In-tile broadcasts are still expressed via
+// d2m.tile_bcast inside the body.
+
+#dram = #ttnn.buffer_type<dram>
+
+// 4D operand layouts that all collapse to a 2D physical memref:
+//   1x1x32x128 -> physical (32, 128) -> tiles (1, 4)   "_full"
+//   1x1x32x1   -> physical (32, 1)   -> tiles (1, 1)   "_col_bcast"
+//   1x1x1x128  -> physical (1, 128)  -> tiles (1, 4)   "_row_bcast"
+//   1x1x1x1    -> physical (1, 1)    -> tiles (1, 1)   "_scalar_bcast"
+#layout4d_full        = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout4d_col_bcast   = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout4d_row_bcast   = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout4d_scalar_bcast = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+
+  // ND implicit row broadcast (input is 1 along the second-to-last logical
+  // dim): physical shard tiles match output (1,4 vs 1,4), so the outer
+  // indexing map is identity and only an in-tile row broadcast is needed.
+  // CHECK-LABEL: func.func @nd4_row_bcast
+  func.func @nd4_row_bcast(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: d2m.generic
+    // CHECK-SAME: indexing_maps = [#[[MAP_ID]], #[[MAP_ID]], #[[MAP_ID]]]
+    // CHECK-SAME: iterator_types = [#parallel, #parallel]
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type row>}>
+    // CHECK: d2m.tile_add
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %0 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // ND implicit col broadcast (input is 1 along the last logical dim):
+  // physical shard tiles differ (1,1 vs 1,4), so the outer indexing map
+  // broadcasts on physical dim 1, plus an in-tile col broadcast.
+  // CHECK-LABEL: func.func @nd4_col_bcast
+  func.func @nd4_col_bcast(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: d2m.generic
+    // CHECK-SAME: indexing_maps = [#[[MAP_ID]], #[[MAP_COL_BCAST]], #[[MAP_ID]]]
+    // CHECK-SAME: iterator_types = [#parallel, #parallel]
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK: d2m.tile_add
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %0 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // ND implicit scalar broadcast (input is 1 in all dims): physical shard
+  // tiles differ on the last dim (1,1 vs 1,4), in-tile broadcast is scalar.
+  // CHECK-LABEL: func.func @nd4_scalar_bcast
+  func.func @nd4_scalar_bcast(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x1x1xbf16, #layout4d_scalar_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type scalar>}>
+    // CHECK: d2m.tile_add
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x1x1xbf16, #layout4d_scalar_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %0 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // Dual ND broadcast: one input row-bcast, one input col-bcast.
+  // CHECK-LABEL: func.func @nd4_dual_bcast
+  func.func @nd4_dual_bcast(
+      %arg0: tensor<1x1x1x128xbf16, #layout4d_row_bcast>,
+      %arg1: tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: d2m.generic
+    // CHECK: linalg.generic
+    // CHECK-DAG: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type row>}>
+    // CHECK-DAG: "d2m.tile_bcast"(%{{.*}}) <{bcast_type = #d2m<tile_bcast_type col>}>
+    // CHECK: d2m.tile_add
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x1x128xbf16, #layout4d_row_bcast>, tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %0 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // ND chain that previously crashed in TTIRToD2M::getMulticastGridDims when
+  // the d2m-fusing pass pulled it into a d2m_subgraph. With the physical-rank
+  // indexing-map fix it lowers to two d2m.generic ops (one per ttir op).
+  // CHECK-LABEL: func.func @nd4_bcast_chain
+  func.func @nd4_bcast_chain(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x32x1xbf16, #layout4d_col_bcast>,
+      %arg2: tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK-COUNT-2: d2m.generic
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    %1 = "ttir.multiply"(%0, %arg2) : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %1 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+}
+
+// ----- Original gpt-oss-20b subgraph regression (reduced) -----
+//
+// Reproducer for the original error reported by the gpt-oss-20b subgraph: a
+// chain of `ttir.gt` (comparison) and `ttir.logical_and` (logical) ops with
+// 4D logical operands that all collapse to a 2D physical TTNN layout. The
+// pre-fix TTIRToD2M produced 4D logical-rank indexing maps but a 2D physical
+// iteration domain, leading to an index-out-of-bounds crash inside
+// getMulticastGridDims when looking up iteratorTypes[iterDimPos]. Both the
+// comparison-op (`isComparisonOp`) and the logical-op (NEZ-decomposition)
+// codepaths in `createComputeRegion` go through the same indexing-map
+// construction, so this test covers both ops in addition to the
+// arithmetic ones above.
+
+#dram2 = #ttnn.buffer_type<dram>
+#layout38 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram2>, <interleaved>>
+#layout41 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, si32>, #dram2>, <interleaved>>
+#layout65 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram2>, <interleaved>>
+#layout67 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram2>, <interleaved>>
+
+module {
+  // CHECK-LABEL: func.func private @d2m_subgraph
+  func.func private @d2m_subgraph(
+      %arg0: tensor<1x1x1x128xsi32, #layout41>,
+      %arg1: tensor<1x1x17x1xsi32,  #layout65>,
+      %arg2: tensor<1x1x1x1xbf16,   #layout38>,
+      %arg3: tensor<1x1x17x128xbf16,#layout67>)
+      -> tensor<1x1x17x128xbf16, #layout67> {
+    // Three elementwise ops, each lowered to its own d2m.generic.
+    // CHECK-COUNT-3: d2m.generic
+    %0 = "ttir.gt"(%arg0, %arg1)
+        : (tensor<1x1x1x128xsi32, #layout41>,
+           tensor<1x1x17x1xsi32,  #layout65>)
+        -> tensor<1x1x17x128xbf16, #layout67>
+    %1 = "ttir.logical_and"(%arg2, %0)
+        : (tensor<1x1x1x1xbf16,   #layout38>,
+           tensor<1x1x17x128xbf16,#layout67>)
+        -> tensor<1x1x17x128xbf16, #layout67>
+    %2 = "ttir.logical_and"(%1, %arg3)
+        : (tensor<1x1x17x128xbf16,#layout67>,
+           tensor<1x1x17x128xbf16,#layout67>)
+        -> tensor<1x1x17x128xbf16, #layout67>
+    return %2 : tensor<1x1x17x128xbf16, #layout67>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/dispatch_d2m/d2m_fusing_nd_bcast.mlir
+++ b/test/ttmlir/Dialect/TTNN/dispatch_d2m/d2m_fusing_nd_bcast.mlir
@@ -1,0 +1,76 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-wrap-device-module --ttnn-d2m-fusing %s | FileCheck %s
+
+// Verify that the TTNN d2m-fusing pass DOES fuse elementwise ops with
+// implicit broadcasts on >2D operands into a d2m_subgraph. The TTIRToD2M
+// elementwise rewriter builds the d2m.generic indexing maps in the physical
+// (post-layout-collapse) iteration domain, so >2D logical broadcasts that
+// collapse to 2D physical layouts are fully supported (the broadcast is
+// expressed as either an outer per-shard-tile broadcast in the indexing map
+// or an in-tile broadcast via d2m.tile_bcast).
+
+#l1 = #ttnn.buffer_type<l1>
+#layout4d_full = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout4d_col_bcast = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout4d_row_bcast = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout3d_full = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout3d_col_bcast = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x8x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#layout2d_row = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+
+module {
+
+  // 4D chain with implicit broadcast on the trailing dim of one operand and
+  // on a leading dim of another. Both ops should be fused into a single
+  // d2m_subgraph (the broadcasts are handled at lower levels).
+  // CHECK-LABEL: func.func @nd4_bcast_chain_fused
+  func.func @nd4_bcast_chain_fused(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x32x1xbf16, #layout4d_col_bcast>,
+      %arg2: tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: ttnn.d2m_subgraph
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.multiply"
+    %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x32x1xbf16, #layout4d_col_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    %1 = "ttnn.multiply"(%0, %arg2) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x1x128xbf16, #layout4d_row_bcast>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %1 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // 3D chain with implicit broadcast: also fused.
+  // CHECK-LABEL: func.func @nd3_bcast_chain_fused
+  func.func @nd3_bcast_chain_fused(
+      %arg0: tensor<1x32x128xbf16, #layout3d_full>,
+      %arg1: tensor<1x32x1xbf16, #layout3d_col_bcast>) -> tensor<1x32x128xbf16, #layout3d_full> {
+    // CHECK: ttnn.d2m_subgraph
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.multiply"
+    %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x32x128xbf16, #layout3d_full>, tensor<1x32x1xbf16, #layout3d_col_bcast>) -> tensor<1x32x128xbf16, #layout3d_full>
+    %1 = "ttnn.multiply"(%0, %arg0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x32x128xbf16, #layout3d_full>, tensor<1x32x128xbf16, #layout3d_full>) -> tensor<1x32x128xbf16, #layout3d_full>
+    return %1 : tensor<1x32x128xbf16, #layout3d_full>
+  }
+
+  // 4D chain WITHOUT broadcasts: all operands match output shape. Should also
+  // still be fused into a d2m_subgraph.
+  // CHECK-LABEL: func.func @nd4_no_bcast_still_fused
+  func.func @nd4_no_bcast_still_fused(
+      %arg0: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg1: tensor<1x1x32x128xbf16, #layout4d_full>,
+      %arg2: tensor<1x1x32x128xbf16, #layout4d_full>) -> tensor<1x1x32x128xbf16, #layout4d_full> {
+    // CHECK: ttnn.d2m_subgraph
+    %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x32x128xbf16, #layout4d_full>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    %1 = "ttnn.multiply"(%0, %arg2) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<1x1x32x128xbf16, #layout4d_full>, tensor<1x1x32x128xbf16, #layout4d_full>) -> tensor<1x1x32x128xbf16, #layout4d_full>
+    return %1 : tensor<1x1x32x128xbf16, #layout4d_full>
+  }
+
+  // 2D chain WITH implicit broadcast: still fused (covered the regression
+  // baseline before/after the ND fix).
+  // CHECK-LABEL: func.func @nd2_bcast_still_fused
+  func.func @nd2_bcast_still_fused(
+      %arg0: tensor<64x256xbf16, #layout2d>,
+      %arg1: tensor<1x256xbf16, #layout2d_row>,
+      %arg2: tensor<64x256xbf16, #layout2d>) -> tensor<64x256xbf16, #layout2d> {
+    // CHECK: ttnn.d2m_subgraph
+    %0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x256xbf16, #layout2d>, tensor<1x256xbf16, #layout2d_row>) -> tensor<64x256xbf16, #layout2d>
+    %1 = "ttnn.multiply"(%0, %arg2) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x256xbf16, #layout2d>, tensor<64x256xbf16, #layout2d>) -> tensor<64x256xbf16, #layout2d>
+    return %1 : tensor<64x256xbf16, #layout2d>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/d2m_greedy_optimizer_nd_bcast.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/d2m_greedy_optimizer_nd_bcast.mlir
@@ -1,0 +1,33 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 enable-d2m-fusing-pass=true" --mlir-print-local-scope -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// End-to-end regression: a TTIR graph with implicit ND broadcasts in an
+// elementwise chain used to crash the full ttir-to-ttnn-backend-pipeline
+// (with optimization-level=2 and enable-d2m-fusing-pass=true) inside
+// TTIRToD2M::getMulticastGridDims when the d2m-fusing pass pulled the chain
+// into a d2m_subgraph.
+//
+// The fix builds the d2m.generic / linalg.generic indexing maps in the
+// physical (post-layout-collapse) iteration domain (derived from per-operand
+// physical shard-tile-shape comparison), so the broadcast-needing ND ops can
+// stay inside the d2m_subgraph and the pipeline runs to completion all the
+// way down to ttnn.generic compiled kernels.
+
+module {
+  func.func @nd4_bcast_chain(
+      %arg0: tensor<1x1x32x128xbf16>,
+      %arg1: tensor<1x1x32x1xbf16>,
+      %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x1x32x128xbf16> {
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<1x1x32x128xbf16>, tensor<1x1x32x1xbf16>) -> tensor<1x1x32x128xbf16>
+    %1 = "ttir.multiply"(%0, %arg2) : (tensor<1x1x32x128xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x1x32x128xbf16>
+    return %1 : tensor<1x1x32x128xbf16>
+  }
+}
+
+// CHECK: func.func @nd4_bcast_chain
+// The implicit broadcasted ops should be fused via the d2m path and compiled
+// to ttnn.generic kernels rather than left as native ttnn.add / ttnn.multiply.
+// CHECK-NOT: "ttnn.add"
+// CHECK-NOT: "ttnn.multiply"
+// CHECK: "ttnn.generic"


### PR DESCRIPTION
## Summary

Fix a crash in `TTIRToD2M` when lowering elementwise ops whose operands have a **logical rank greater than the physical (post-collapse) rank** under the TTNN layout (e.g. a `1x1xHxW` tensor whose `ttnn.ttnn_layout` collapses the leading dims into a 2D physical memref).

The crash showed up while running a subgraph through the `ttir-to-d2m` (`ttnn-mode=true`) path, e.g.:

```mlir
%0 = "ttir.gt"(%arg0, %arg1)
    : (tensor<1x1x1x128xsi32, #ttnn_layout41>,
       tensor<1x1x17x1xsi32,  #ttnn_layout65>)
    -> tensor<1x1x17x128xbf16, #ttnn_layout67>
```

…aborted with an index-out-of-bounds inside `TTIRToD2M.cpp::getMulticastGridDims` at the `iteratorTypes[iterDimPos]` lookup.

## Root cause

`TTIRToD2MNamedRewriter::matchAndRewrite` was building the `d2m.generic` / `linalg.generic` indexing maps from `getImplicitBcastInfo`, which derives them from the **logical output rank** (e.g. 4 for `1x1x32x128`). However, the iteration domain (`physicalRank = getDeviceLayout(outputs[0]).getRank() / 2`) is the **physical post-collapse rank** (typically 2 for the standard interleaved TTNN layout). The two ranks must be equal: every `AffineDimExpr` produced by the indexing maps is later indexed into `iteratorTypes` (whose size is `physicalRank`) by `getMulticastGridDims`. With 4D maps and a 2D `iteratorTypes` array, dims `d2`/`d3` walked off the end of the array and crashed.

This only worked previously for the 2D-logical case where logical rank already matched physical rank.

## Fix

Add a new helper `buildPhysicalImplicitBcastIndexingMaps` that constructs implicit-broadcast indexing maps in the **physical iteration domain**, by comparing each input's physical shard tile shape against the output's physical shard tile shape:

- input dim == output dim → identity dim expr
- input dim == 1 && output dim > 1 → constant 0 (broadcast)
- any other mismatch → assertion failure

`matchAndRewrite` now uses these physical-rank maps for both the outer `d2m.generic` and the inner `linalg.generic`, so the indexing-map domain is always in lock-step with `iteratorTypes`. The logical-rank result of `getImplicitBcastInfo` is now only used for:

- `tileBcastTypes` — to drive the in-tile `d2m.tile_bcast` (Row / Col / Scalar) inside the compute body, which is independent of layout collapse.
- the `isImplicitBcast` flag.

A debug `assert` is added right after the maps are built to validate the `indexingMap.getNumDims() == iteratorTypes.size()` invariant.

## Scope / known limitation

This is a **localized temp workaround**. It correctly handles the `1x1xHxW` case (and lower-rank cases that collapse to ≤2D physical), where the leading logical dims are all 1 and the per-shard physical shape captures the broadcast pattern.

It does **not** yet handle true `NxCxHxW` (N, C > 1) inputs — under the current TTNN layout collapse, multiple non-trivial leading logical dims fold into the same physical row index with strides that the simple shard-shape comparison cannot recover. A proper implementation will follow as a separate change by @wenbinlyuTT.

The change is gated behind `isImplicitBcast` and only differs from the previous code path on operands whose logical rank exceeds the physical rank, so 2D-logical implicit-broadcast behavior is preserved.

## Tests

Three new lit tests were added:

- `test/ttmlir/Conversion/TTIRToD2M/nd_implicit_bcast.mlir` — direct `--ttir-to-d2m="ttnn-mode=true"` lowering coverage for 4D logical operands collapsing to 2D physical layouts:
  - `nd4_row_bcast` — row-broadcast input, identity outer maps + in-tile `tile_bcast row`.
  - `nd4_col_bcast` — col-broadcast input, outer map broadcasts on physical dim 1 + in-tile `tile_bcast col`.
  - `nd4_scalar_bcast` — fully-broadcast input + in-tile `tile_bcast scalar`.
  - `nd4_dual_bcast` — row-broadcast and col-broadcast on two inputs.
  - `nd4_bcast_chain` — 2-op chain that previously crashed via the `d2m-fusing` pass; now lowers to 2 `d2m.generic` ops.
  - `d2m_subgraph` — reduced reproducer chaining `ttir.gt` (comparison-op codepath) and two `ttir.logical_and` (NEZ-decomposition codepath), with mixed `si32`/`bf16` dtypes.

- `test/ttmlir/Dialect/TTNN/dispatch_d2m/d2m_fusing_nd_bcast.mlir` — verifies that the `--ttnn-d2m-fusing` pass still fuses 4D and 3D elementwise chains with implicit broadcasts into a single `ttnn.d2m_subgraph`, plus a 2D regression baseline.

- `test/ttmlir/Dialect/TTNN/optimizer/d2m_greedy_optimizer_nd_bcast.mlir` (`REQUIRES: opmodel`) — end-to-end regression: a 4D implicit-broadcast chain that used to crash the full `--ttir-to-ttnn-backend-pipeline` (`optimization-level=2 enable-d2m-fusing-pass=true`) all the way down to `ttnn.generic` kernels.
