### PR TITLE
[d2m/optimizer][ttnn.jit] Remove Layouts from Intermediates

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -525,17 +525,30 @@ def TTIRCPUBooleanNarrowing : Pass<"ttir-cpu-boolean-narrowing", "::mlir::Module
 def TTIRStripIntermediateTTNNLayouts : Pass<"ttir-strip-intermediate-ttnn-layouts", "::mlir::ModuleOp"> {
   let summary = "Strip TTNN layouts from intermediate tensors.";
   let description = [{
-    This pass removes TTNN layouts from tensors which are intermediates ops. In the TTIRToTTMetal pipeline, optimal
-    layouts are inferred and applied to all intermediates. If layouts already exist prior to this, the effect will be a reshard:
+    This pass removes TTNN layouts from tensors which are 'intermediate' ops. In the TTIRToTTMetal pipeline, optimal
+    layouts are inferred and applied to all intermediates. If layouts already exist prior to this, the effect will be a reshard from the original layout to the optimal layout and back which is not wanted.
+    This pass runs before TTIRToTTMetal pipeline and after TTNNToTTIR pass to ensure there are no existing layouts on intermediates.
 
-      original layout -> optimal layout -> original layout
-
-    This pass runs before TTIRToTTMetal pipeline and after
-    TTNNToTTIR pass to ensure there are no existing layouts on intermediates.
+    Layouts are preserved on:
+      - function arguments and returned values
+      - results of `ttir.to_layout` ops and its init (ttir.empty op)
+    Every other TTIR result with a `ttnn_layout` encoding is stripped.
 
     Example:
-
-    TODO: Add example
+    Before:
+      func.func @f(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
+        %0 = "ttir.abs"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+        %1 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+        %2 = ttir.to_layout %0, %1 : tensor<32x32xbf16, #ttnn_layout> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+        return %2 : tensor<32x32xbf16, #ttnn_layout>
+      }
+    After:
+      func.func @f(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
+        %0 = "ttir.abs"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16> // no ttnn_layout encoding
+        %1 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+        %2 = ttir.to_layout %0, %1 : tensor<32x32xbf16> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+        return %2 : tensor<32x32xbf16, #ttnn_layout>
+      }
   }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -522,4 +522,21 @@ def TTIRCPUBooleanNarrowing : Pass<"ttir-cpu-boolean-narrowing", "::mlir::Module
   }];
 }
 
+def TTIRStripIntermediateTTNNLayouts : Pass<"ttir-strip-intermediate-ttnn-layouts", "::mlir::ModuleOp"> {
+  let summary = "Strip TTNN layouts from intermediate tensors.";
+  let description = [{
+    This pass removes TTNN layouts from tensors which are intermediates ops. In the TTIRToTTMetal pipeline, optimal
+    layouts are inferred and applied to all intermediates. If layouts already exist prior to this, the effect will be a reshard:
+
+      original layout -> optimal layout -> original layout
+
+    This pass runs before TTIRToTTMetal pipeline and after
+    TTNNToTTIR pass to ensure there are no existing layouts on intermediates.
+
+    Example:
+
+    TODO: Add example
+  }];
+}
+
 #endif

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         QuantDequantConversion.cpp
         ReductionForceKeepDim.cpp
         RankNormalization.cpp
+        StripIntermediateTTNNLayouts.cpp
         Transforms.cpp
         TTIRFusing.cpp
         MultiDeviceTensorAnnotation.cpp

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -23,45 +23,26 @@ namespace {
 // arguments, return operands, and any ToLayout op results.
 static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
   llvm::DenseSet<Value> preserved;
-  llvm::SmallVector<Value> frontier;
-
-  // Add value `v` to the preserved set if not already present, and enqueue it
-  // on the propagation frontier so its DPS-init operands (if any) get visited.
-  auto markPreserved = [&](Value v) {
-    if (preserved.insert(v).second) {
-      frontier.push_back(v);
-    }
-  };
 
   for (BlockArgument arg : funcOp.getArguments()) {
-    markPreserved(arg);
+    preserved.insert(arg);
   }
 
   for (Block &block : funcOp.getBody()) {
     if (auto returnOp = mlir::dyn_cast<func::ReturnOp>(block.getTerminator())) {
       for (Value returnedValue : returnOp.getOperands()) {
-        markPreserved(returnedValue);
+        preserved.insert(returnedValue);
       }
     }
+    // We need to respect the ttnn layout of any to_layout op, so preserve the
+    // ttnn layout on the to_layout op and
+    // its init (empty op)
     for (ttir::ToLayoutOp toLayoutOp : block.getOps<ttir::ToLayoutOp>()) {
       for (Value result : toLayoutOp.getResults()) {
-        markPreserved(result);
+        preserved.insert(result);
       }
-    }
-  }
-
-  // For any preserved value defined by a DPS op, the
-  // verifier requires the op's DPS init operands to
-  // have the same type as the result (including the ttnn_layout encoding).
-  // Stripping the layout from such an init operand while keeping its result
-  // encoded would produce an invalid op, so we propagate preservation backward
-  // by checking the DPS init operands of DPS ops.
-  while (!frontier.empty()) {
-    Value v = frontier.pop_back_val();
-    if (auto dpsOp = mlir::dyn_cast_if_present<DestinationStyleOpInterface>(
-            v.getDefiningOp())) {
-      for (Value init : dpsOp.getDpsInits()) {
-        markPreserved(init);
+      for (Value init : toLayoutOp.getDpsInits()) {
+        preserved.insert(init);
       }
     }
   }

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_TTIRSTRIPINTERMEDIATETTNNLAYOUTS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+class TTIRStripIntermediateTTNNLayouts
+    : public impl::TTIRStripIntermediateTTNNLayoutsBase<
+          TTIRStripIntermediateTTNNLayouts> {
+public:
+  using impl::TTIRStripIntermediateTTNNLayoutsBase<
+      TTIRStripIntermediateTTNNLayouts>::TTIRStripIntermediateTTNNLayoutsBase;
+
+  void runOnOperation() final {
+    // TODO:
+    //   1. For each func::FuncOp in the module:
+    //        a. collectPreservedValues(funcOp, preserved)
+    //        b. funcOp.walk([&](Operation *op) {
+    //             stripIntermediateResultTypes(op, preserved);
+    //           });
+    //   2. signalPassFailure() on any error.
+
+    ModuleOp module = getOperation();
+    module->walk([&](func::FuncOp func) {
+
+    });
+  };
+}
+
+} // namespace
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -19,14 +19,14 @@ namespace mlir::tt::ttir {
 
 namespace {
 
-// collect all values that are preserved from the function arguments, return
-// operands, and DPS init operands
+// collect all values that should be preserved.  These include the function
+// arguments, return operands, and any DPS init operands of DPS ops.
 static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
   llvm::DenseSet<Value> preserved;
   llvm::SmallVector<Value> frontier;
 
-  // Add `v` to the preserved set if not already present, and enqueue it on
-  // the propagation frontier so its DPS-init operands (if any) get visited.
+  // Add value `v` to the preserved set if not already present, and enqueue it
+  // on the propagation frontier so its DPS-init operands (if any) get visited.
   auto markPreserved = [&](Value v) {
     if (preserved.insert(v).second) {
       frontier.push_back(v);
@@ -38,33 +38,31 @@ static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
   }
 
   for (Block &block : funcOp.getBody()) {
-    auto returnOp = mlir::dyn_cast<func::ReturnOp>(block.getTerminator());
-    if (!returnOp) {
-      continue;
+    if (auto returnOp = mlir::dyn_cast<func::ReturnOp>(block.getTerminator())) {
+      for (Value returnedValue : returnOp.getOperands()) {
+        markPreserved(returnedValue);
+      }
     }
-    for (Value returnedValue : returnOp.getOperands()) {
-      markPreserved(returnedValue);
+    for (ttir::ToLayoutOp toLayoutOp : block.getOps<ttir::ToLayoutOp>()) {
+      for (Value result : toLayoutOp.getResults()) {
+        markPreserved(result);
+      }
     }
   }
 
   // For any preserved value defined by a DPS op, the
-  // DestinationStyleOpInterface verifier requires the op's DPS init operands to
-  // share their result's type (including the ttnn_layout encoding). Stripping
-  // such an init operand while keeping its result encoded would produce an
-  // invalid op, so we propagate preservation backward through DPS init
-  // operands.
+  // verifier requires the op's DPS init operands to
+  // have the same type as the result (including the ttnn_layout encoding).
+  // Stripping the layout from such an init operand while keeping its result
+  // encoded would produce an invalid op, so we propagate preservation backward
+  // by checking the DPS init operands of DPS ops.
   while (!frontier.empty()) {
     Value v = frontier.pop_back_val();
-    Operation *defOp = v.getDefiningOp();
-    if (!defOp) {
-      continue;
-    }
-    auto dps = mlir::dyn_cast<DestinationStyleOpInterface>(defOp);
-    if (!dps) {
-      continue;
-    }
-    for (Value init : dps.getDpsInits()) {
-      markPreserved(init);
+    if (auto dpsOp = mlir::dyn_cast_if_present<DestinationStyleOpInterface>(
+            v.getDefiningOp())) {
+      for (Value init : dpsOp.getDpsInits()) {
+        markPreserved(init);
+      }
     }
   }
 
@@ -102,17 +100,18 @@ public:
             continue;
           }
 
-          auto rt = mlir::dyn_cast<RankedTensorType>(result.getType());
-          if (!rt) {
+          auto rankedTensor =
+              mlir::dyn_cast<RankedTensorType>(result.getType());
+          if (!rankedTensor) {
             continue;
           }
 
-          RankedTensorType stripped = stripTTNNLayout(rt);
-          if (stripped == rt) {
+          RankedTensorType strippedTensorType = stripTTNNLayout(rankedTensor);
+          if (strippedTensorType == rankedTensor) {
             continue;
           }
 
-          result.setType(stripped);
+          result.setType(strippedTensorType);
         }
       });
     });

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -5,7 +5,13 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir::tt::ttir {
 
@@ -13,6 +19,105 @@ namespace mlir::tt::ttir {
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
+
+// Flip to true to enable verbose tracing on llvm::errs(). When false, all
+// debug prints below are dead-code-eliminated by the optimizer because the
+// guard is constexpr.
+static constexpr bool kDebug = false;
+
+// collect all values that are preserved from the function arguments, return
+// operands, and DPS init operands
+static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
+  if (kDebug) {
+    llvm::errs() << "[strip-layouts] collectPreservedValues: entering func @"
+                 << funcOp.getName() << "\n";
+  }
+
+  llvm::DenseSet<Value> preserved;
+  llvm::SmallVector<Value> frontier;
+
+  // Add `v` to the preserved set if not already present, and enqueue it on
+  // the propagation frontier so its DPS-init operands (if any) get visited.
+  auto markPreserved = [&](Value v, llvm::StringRef reason) {
+    bool inserted = preserved.insert(v).second;
+    if (inserted) {
+      if (kDebug) {
+        llvm::errs() << "[strip-layouts]   preserving (" << reason
+                     << ") : " << v.getType() << "\n";
+      }
+      frontier.push_back(v);
+    }
+  };
+
+  for (BlockArgument arg : funcOp.getArguments()) {
+    markPreserved(arg, "func arg");
+  }
+
+  for (Block &block : funcOp.getBody()) {
+    auto returnOp = mlir::dyn_cast<func::ReturnOp>(block.getTerminator());
+    if (!returnOp) {
+      if (kDebug) {
+        llvm::errs() << "[strip-layouts]   block terminator is not "
+                        "func.return; skipping\n";
+      }
+      continue;
+    }
+    for (Value returnedValue : returnOp.getOperands()) {
+      markPreserved(returnedValue, "return operand");
+    }
+  }
+
+  // For any preserved value defined by a DPS op, the
+  // DestinationStyleOpInterface verifier requires the op's DPS init operands to
+  // share their result's type (including the ttnn_layout encoding). Stripping
+  // such an init operand while keeping its result encoded would produce an
+  // invalid op, so we propagate preservation backward through DPS init
+  // operands.
+  while (!frontier.empty()) {
+    Value v = frontier.pop_back_val();
+    Operation *defOp = v.getDefiningOp();
+    if (!defOp) {
+      continue;
+    }
+    auto dps = mlir::dyn_cast<DestinationStyleOpInterface>(defOp);
+    if (!dps) {
+      continue;
+    }
+    for (Value init : dps.getDpsInits()) {
+      markPreserved(init, "DPS init of preserved op");
+    }
+  }
+
+  if (kDebug) {
+    llvm::errs() << "[strip-layouts] collectPreservedValues: returning "
+                 << preserved.size() << " preserved values from func @"
+                 << funcOp.getName() << "\n";
+  }
+  return preserved;
+}
+
+// return a new RankedTensorType with the ttnn layout removed
+static RankedTensorType stripTTNNLayout(RankedTensorType tensorType) {
+  if (kDebug) {
+    llvm::errs() << "[strip-layouts] stripTTNNLayout: input type = "
+                 << tensorType << "\n";
+  }
+
+  if (!mlir::isa_and_nonnull<ttnn::TTNNLayoutAttr>(tensorType.getEncoding())) {
+    if (kDebug) {
+      llvm::errs() << "[strip-layouts]   no ttnn_layout encoding; "
+                      "returning input unchanged\n";
+    }
+    return tensorType;
+  }
+
+  RankedTensorType stripped =
+      RankedTensorType::get(tensorType.getShape(), tensorType.getElementType());
+  if (kDebug) {
+    llvm::errs() << "[strip-layouts]   stripped to: " << stripped << "\n";
+  }
+  return stripped;
+}
 
 class TTIRStripIntermediateTTNNLayouts
     : public impl::TTIRStripIntermediateTTNNLayoutsBase<
@@ -22,20 +127,64 @@ public:
       TTIRStripIntermediateTTNNLayouts>::TTIRStripIntermediateTTNNLayoutsBase;
 
   void runOnOperation() final {
-    // TODO:
-    //   1. For each func::FuncOp in the module:
-    //        a. collectPreservedValues(funcOp, preserved)
-    //        b. funcOp.walk([&](Operation *op) {
-    //             stripIntermediateResultTypes(op, preserved);
-    //           });
-    //   2. signalPassFailure() on any error.
+    if (kDebug) {
+      llvm::errs()
+          << "[strip-layouts] runOnOperation: starting pass on module\n";
+    }
 
-    ModuleOp module = getOperation();
-    module->walk([&](func::FuncOp func) {
+    ModuleOp moduleOp = getOperation();
+    moduleOp.walk([&](func::FuncOp func) {
+      if (kDebug) {
+        llvm::errs() << "[strip-layouts] visiting func @" << func.getName()
+                     << "\n";
+      }
 
+      llvm::DenseSet<Value> preservedValues = collectPreservedValues(func);
+
+      func.walk([&](Operation *op) {
+        for (Value result : op->getResults()) {
+          if (preservedValues.contains(result)) {
+            if (kDebug) {
+              llvm::errs() << "[strip-layouts]   skip (preserved): "
+                           << op->getName()
+                           << " result type = " << result.getType() << "\n";
+            }
+            continue;
+          }
+
+          auto rt = mlir::dyn_cast<RankedTensorType>(result.getType());
+          if (!rt) {
+            if (kDebug) {
+              llvm::errs() << "[strip-layouts]   skip (non-tensor): "
+                           << op->getName()
+                           << " result type = " << result.getType() << "\n";
+            }
+            continue;
+          }
+
+          RankedTensorType stripped = stripTTNNLayout(rt);
+          if (stripped == rt) {
+            if (kDebug) {
+              llvm::errs() << "[strip-layouts]   skip (no change): "
+                           << op->getName() << " result type = " << rt << "\n";
+            }
+            continue;
+          }
+
+          if (kDebug) {
+            llvm::errs() << "[strip-layouts]   rewriting " << op->getName()
+                         << " result : " << rt << " -> " << stripped << "\n";
+          }
+          result.setType(stripped);
+        }
+      });
     });
-  };
-}
+
+    if (kDebug) {
+      llvm::errs() << "[strip-layouts] runOnOperation: done\n";
+    }
+  }
+};
 
 } // namespace
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -11,7 +11,6 @@
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace mlir::tt::ttir {
 
@@ -20,50 +19,31 @@ namespace mlir::tt::ttir {
 
 namespace {
 
-// Flip to true to enable verbose tracing on llvm::errs(). When false, all
-// debug prints below are dead-code-eliminated by the optimizer because the
-// guard is constexpr.
-static constexpr bool kDebug = false;
-
 // collect all values that are preserved from the function arguments, return
 // operands, and DPS init operands
 static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
-  if (kDebug) {
-    llvm::errs() << "[strip-layouts] collectPreservedValues: entering func @"
-                 << funcOp.getName() << "\n";
-  }
-
   llvm::DenseSet<Value> preserved;
   llvm::SmallVector<Value> frontier;
 
   // Add `v` to the preserved set if not already present, and enqueue it on
   // the propagation frontier so its DPS-init operands (if any) get visited.
-  auto markPreserved = [&](Value v, llvm::StringRef reason) {
-    bool inserted = preserved.insert(v).second;
-    if (inserted) {
-      if (kDebug) {
-        llvm::errs() << "[strip-layouts]   preserving (" << reason
-                     << ") : " << v.getType() << "\n";
-      }
+  auto markPreserved = [&](Value v) {
+    if (preserved.insert(v).second) {
       frontier.push_back(v);
     }
   };
 
   for (BlockArgument arg : funcOp.getArguments()) {
-    markPreserved(arg, "func arg");
+    markPreserved(arg);
   }
 
   for (Block &block : funcOp.getBody()) {
     auto returnOp = mlir::dyn_cast<func::ReturnOp>(block.getTerminator());
     if (!returnOp) {
-      if (kDebug) {
-        llvm::errs() << "[strip-layouts]   block terminator is not "
-                        "func.return; skipping\n";
-      }
       continue;
     }
     for (Value returnedValue : returnOp.getOperands()) {
-      markPreserved(returnedValue, "return operand");
+      markPreserved(returnedValue);
     }
   }
 
@@ -84,39 +64,21 @@ static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
       continue;
     }
     for (Value init : dps.getDpsInits()) {
-      markPreserved(init, "DPS init of preserved op");
+      markPreserved(init);
     }
   }
 
-  if (kDebug) {
-    llvm::errs() << "[strip-layouts] collectPreservedValues: returning "
-                 << preserved.size() << " preserved values from func @"
-                 << funcOp.getName() << "\n";
-  }
   return preserved;
 }
 
 // return a new RankedTensorType with the ttnn layout removed
 static RankedTensorType stripTTNNLayout(RankedTensorType tensorType) {
-  if (kDebug) {
-    llvm::errs() << "[strip-layouts] stripTTNNLayout: input type = "
-                 << tensorType << "\n";
-  }
-
   if (!mlir::isa_and_nonnull<ttnn::TTNNLayoutAttr>(tensorType.getEncoding())) {
-    if (kDebug) {
-      llvm::errs() << "[strip-layouts]   no ttnn_layout encoding; "
-                      "returning input unchanged\n";
-    }
     return tensorType;
   }
 
-  RankedTensorType stripped =
-      RankedTensorType::get(tensorType.getShape(), tensorType.getElementType());
-  if (kDebug) {
-    llvm::errs() << "[strip-layouts]   stripped to: " << stripped << "\n";
-  }
-  return stripped;
+  return RankedTensorType::get(tensorType.getShape(),
+                               tensorType.getElementType());
 }
 
 class TTIRStripIntermediateTTNNLayouts
@@ -127,62 +89,33 @@ public:
       TTIRStripIntermediateTTNNLayouts>::TTIRStripIntermediateTTNNLayoutsBase;
 
   void runOnOperation() final {
-    if (kDebug) {
-      llvm::errs()
-          << "[strip-layouts] runOnOperation: starting pass on module\n";
-    }
-
     ModuleOp moduleOp = getOperation();
     moduleOp.walk([&](func::FuncOp func) {
-      if (kDebug) {
-        llvm::errs() << "[strip-layouts] visiting func @" << func.getName()
-                     << "\n";
-      }
-
       llvm::DenseSet<Value> preservedValues = collectPreservedValues(func);
 
       func.walk([&](Operation *op) {
+        if (!isa<TTIRDialect>(op->getDialect())) {
+          return;
+        }
         for (Value result : op->getResults()) {
           if (preservedValues.contains(result)) {
-            if (kDebug) {
-              llvm::errs() << "[strip-layouts]   skip (preserved): "
-                           << op->getName()
-                           << " result type = " << result.getType() << "\n";
-            }
             continue;
           }
 
           auto rt = mlir::dyn_cast<RankedTensorType>(result.getType());
           if (!rt) {
-            if (kDebug) {
-              llvm::errs() << "[strip-layouts]   skip (non-tensor): "
-                           << op->getName()
-                           << " result type = " << result.getType() << "\n";
-            }
             continue;
           }
 
           RankedTensorType stripped = stripTTNNLayout(rt);
           if (stripped == rt) {
-            if (kDebug) {
-              llvm::errs() << "[strip-layouts]   skip (no change): "
-                           << op->getName() << " result type = " << rt << "\n";
-            }
             continue;
           }
 
-          if (kDebug) {
-            llvm::errs() << "[strip-layouts]   rewriting " << op->getName()
-                         << " result : " << rt << " -> " << stripped << "\n";
-          }
           result.setType(stripped);
         }
       });
     });
-
-    if (kDebug) {
-      llvm::errs() << "[strip-layouts] runOnOperation: done\n";
-    }
   }
 };
 

--- a/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
+++ b/lib/Dialect/TTIR/Transforms/StripIntermediateTTNNLayouts.cpp
@@ -20,7 +20,7 @@ namespace mlir::tt::ttir {
 namespace {
 
 // collect all values that should be preserved.  These include the function
-// arguments, return operands, and any DPS init operands of DPS ops.
+// arguments, return operands, and any ToLayout op results.
 static llvm::DenseSet<Value> collectPreservedValues(func::FuncOp funcOp) {
   llvm::DenseSet<Value> preserved;
   llvm::SmallVector<Value> frontier;

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -613,7 +613,6 @@ void createTTNNCommonToEmitPyPipeline(
 
 void createTTNNPipelineD2MPass(OpPassManager &pm,
                                const TTNNPipelineD2MPassOptions &options) {
-  // TODO(vtang): pass to strip intermediate layouts.
   pm.addPass(tt::createConvertTTNNToTTIRPass());
   pm.addPass(mlir::tt::ttir::createTTIRStripIntermediateTTNNLayouts());
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -615,7 +615,7 @@ void createTTNNPipelineD2MPass(OpPassManager &pm,
                                const TTNNPipelineD2MPassOptions &options) {
   // TODO(vtang): pass to strip intermediate layouts.
   pm.addPass(tt::createConvertTTNNToTTIRPass());
-  // pm.addPass(strip layouts pass)
+  pm.addPass(mlir::tt::ttir::createTTIRStripIntermediateTTNNLayouts());
 
   // Can't use createTTIRToTTMetalPipeline because TTCoreWrapDeviceModulePass
   // only works on top-level modules (doesn't run module has a parent op).

--- a/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
@@ -59,13 +59,9 @@ func.func @strip_eltwise_unary_chain(%arg0: tensor<32x32xbf16, #ttnn_layout>)
   return %4 : tensor<32x32xbf16, #ttnn_layout>
 }
 
-// DPS init operands of preserved DestinationStyleOpInterface ops must also be
-// preserved, since their type is coupled to the result type by the verifier.
-// In this case, %1 (ttir.empty) is the DPS init of %2 (ttir.to_layout),
-// so %1's encoding must survive even though %1 is an intermediate.
-// Only %0 (ttir.abs result) should have its encoding stripped.
-// CHECK-LABEL: func.func @strip_with_to_layout_dps
-func.func @strip_with_to_layout_dps(
+// DPS init operands of toLayout ops must also be preserved, since their type is coupled to the result type by the verifier.
+// CHECK-LABEL: func.func @strip_with_to_layout
+func.func @strip_with_to_layout(
     %arg0: tensor<32x32xbf16, #ttnn_layout>)
     -> tensor<32x32xbf16, #ttnn_layout> {
   // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
@@ -84,4 +80,41 @@ func.func @strip_with_to_layout_dps(
         -> tensor<32x32xbf16, #ttnn_layout>
   // CHECK: return %[[TO]] : tensor<32x32xbf16, #ttnn_layout>
   return %2 : tensor<32x32xbf16, #ttnn_layout>
+}
+
+// Two (empty, to_layout) sequences in series.
+// CHECK-LABEL: func.func @strip_with_two_to_layouts
+func.func @strip_with_two_to_layouts(
+    %arg0: tensor<32x32xbf16, #ttnn_layout>,
+    %arg1: tensor<32x32xbf16, #ttnn_layout>)
+    -> tensor<32x32xbf16, #ttnn_layout> {
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %arg1)
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %0 = "ttir.add"(%arg0, %arg1)
+      : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[E1:.*]] = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  %1 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[T1:.*]] = ttir.to_layout %[[ADD]], %[[E1]]
+  // CHECK-SAME: : tensor<32x32xbf16> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+  %2 = ttir.to_layout %0, %1
+      : tensor<32x32xbf16, #ttnn_layout>
+        into tensor<32x32xbf16, #ttnn_layout>
+        -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[MUL:.*]] = "ttir.multiply"(%[[T1]], %arg0)
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %3 = "ttir.multiply"(%2, %arg0)
+      : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[E2:.*]] = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  %4 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[T2:.*]] = ttir.to_layout %[[MUL]], %[[E2]]
+  // CHECK-SAME: : tensor<32x32xbf16> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+  %5 = ttir.to_layout %3, %4
+      : tensor<32x32xbf16, #ttnn_layout>
+        into tensor<32x32xbf16, #ttnn_layout>
+        -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: return %[[T2]] : tensor<32x32xbf16, #ttnn_layout>
+  return %5 : tensor<32x32xbf16, #ttnn_layout>
 }

--- a/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
@@ -5,7 +5,6 @@
                                   memref<1x1x!ttcore.tile<32x32, bf16>, #dram>,
                                   <interleaved>>
 
-// Intermediate result has its ttnn_layout stripped; args/return-feeder preserved.
 // CHECK-LABEL: func.func @strip_single_intermediate
 func.func @strip_single_intermediate(
     %arg0: tensor<32x32xbf16, #ttnn_layout>,
@@ -27,7 +26,6 @@ func.func @strip_single_intermediate(
   return %1 : tensor<32x32xbf16, #ttnn_layout>
 }
 
-// Five-op unary chain: every intermediate is stripped; only the return-feeder keeps its encoding.
 // CHECK-LABEL: func.func @strip_eltwise_unary_chain
 func.func @strip_eltwise_unary_chain(%arg0: tensor<32x32xbf16, #ttnn_layout>)
     -> tensor<32x32xbf16, #ttnn_layout> {

--- a/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir
@@ -1,0 +1,89 @@
+// RUN: ttmlir-opt --ttir-strip-intermediate-ttnn-layouts %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>,
+                                  memref<1x1x!ttcore.tile<32x32, bf16>, #dram>,
+                                  <interleaved>>
+
+// Intermediate result has its ttnn_layout stripped; args/return-feeder preserved.
+// CHECK-LABEL: func.func @strip_single_intermediate
+func.func @strip_single_intermediate(
+    %arg0: tensor<32x32xbf16, #ttnn_layout>,
+    %arg1: tensor<32x32xbf16, #ttnn_layout>)
+    -> tensor<32x32xbf16, #ttnn_layout> {
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>)
+  // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[ADD:.*]] = "ttir.add"(%arg0, %arg1)
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %0 = "ttir.add"(%arg0, %arg1)
+      : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[MUL:.*]] = "ttir.multiply"(%[[ADD]], %arg0)
+  // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout>
+  %1 = "ttir.multiply"(%0, %arg0)
+      : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: return %[[MUL]] : tensor<32x32xbf16, #ttnn_layout>
+  return %1 : tensor<32x32xbf16, #ttnn_layout>
+}
+
+// Five-op unary chain: every intermediate is stripped; only the return-feeder keeps its encoding.
+// CHECK-LABEL: func.func @strip_eltwise_unary_chain
+func.func @strip_eltwise_unary_chain(%arg0: tensor<32x32xbf16, #ttnn_layout>)
+    -> tensor<32x32xbf16, #ttnn_layout> {
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[ABS:.*]] = "ttir.abs"(%arg0)
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %0 = "ttir.abs"(%arg0)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[NEG:.*]] = "ttir.neg"(%[[ABS]])
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %1 = "ttir.neg"(%0)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[EXP:.*]] = "ttir.exp"(%[[NEG]])
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %2 = "ttir.exp"(%1)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[SIG:.*]] = "ttir.sigmoid"(%[[EXP]])
+  // CHECK-SAME: -> tensor<32x32xbf16>{{$}}
+  %3 = "ttir.sigmoid"(%2)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[TANH:.*]] = "ttir.tanh"(%[[SIG]])
+  // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout>
+  %4 = "ttir.tanh"(%3)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: return %[[TANH]] : tensor<32x32xbf16, #ttnn_layout>
+  return %4 : tensor<32x32xbf16, #ttnn_layout>
+}
+
+// DPS init operands of preserved DestinationStyleOpInterface ops must also be
+// preserved, since their type is coupled to the result type by the verifier.
+// In this case, %1 (ttir.empty) is the DPS init of %2 (ttir.to_layout),
+// so %1's encoding must survive even though %1 is an intermediate.
+// Only %0 (ttir.abs result) should have its encoding stripped.
+// CHECK-LABEL: func.func @strip_with_to_layout_dps
+func.func @strip_with_to_layout_dps(
+    %arg0: tensor<32x32xbf16, #ttnn_layout>)
+    -> tensor<32x32xbf16, #ttnn_layout> {
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[ABS:.*]] = "ttir.abs"(%arg0)
+  // CHECK-SAME: (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16>{{$}}
+  %0 = "ttir.abs"(%arg0)
+      : (tensor<32x32xbf16, #ttnn_layout>)
+      -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[EMPTY:.*]] = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  %1 = ttir.empty() : tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: %[[TO:.*]] = ttir.to_layout %[[ABS]], %[[EMPTY]]
+  // CHECK-SAME: : tensor<32x32xbf16> into tensor<32x32xbf16, #ttnn_layout> -> tensor<32x32xbf16, #ttnn_layout>
+  %2 = ttir.to_layout %0, %1
+      : tensor<32x32xbf16, #ttnn_layout>
+        into tensor<32x32xbf16, #ttnn_layout>
+        -> tensor<32x32xbf16, #ttnn_layout>
+  // CHECK: return %[[TO]] : tensor<32x32xbf16, #ttnn_layout>
+  return %2 : tensor<32x32xbf16, #ttnn_layout>
+}


### PR DESCRIPTION
### Ticket
#7160 

### Problem description
In the `TTIRToTTMetal` pipeline, optimal layouts are inferred and applied to all intermediates. If layouts already exist prior to this, the effect will be a reshard from the original selected layout -> optimal layout and back. This is not wanted. 

### What's changed
- Add pass `TTIRStripIntermediateTTNNLayouts` (name to be finalized) after `ConvertTTNNToTTIRPass` in `createTTNNPipelineD2MPass`
- Walks each function and strips the ttnn_layout encoding from a tensor result iff:
  - it is produced by a TTIR op,
  - it is not a function argument, and
  - it is not consumed by a return op.

### Checklist
- [x] New/Existing tests provide coverage for changes
- Added test `test/ttmlir/Dialect/TTIR/Transforms/strip_intermediate_ttnn_layouts.mlir`
