### PR TITLE
[d2m] int32 dtype support for min, max and sum reductions

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -618,67 +618,84 @@ def D2M_TileWhereOp : D2M_GenericRegionComputeTernaryDstOp<"tile_where", D2M_Til
 def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Sum Op";
   let description = [{
-        The `tile_reduce_sum` operation computes the sum of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- sum<dims>(A * B, C)
+        The `tile_reduce_sum` operation computes the sum of the input tile A over the
+        specified reduction dim(s), accumulating into C: `result <- sum<dims>(A * B, C)`.
+        The scaler B is required for float element types and must be absent for integer
+        (i32) element types, which lower through the SFPU and do not use a scaler.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       TTCore_Tile:$b,
+                       Optional<TTCore_Tile>:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      return {2};
+      // $c is always the last operand; its physical index depends on
+      // whether the optional $b scaler is present.
+      return {static_cast<int64_t>(getNumOperands() - 1)};
     }
     bool getDstRegInPlace() {
       return true;
     }
   }];
+
+  let hasVerifier = 1;
 }
 
 def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Max Op";
   let description = [{
-        The `tile_reduce_max` operation computes the max of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- max<dims>(A * B, C)
+        The `tile_reduce_max` operation computes the max of the input tile A over the
+        specified reduction dim(s), accumulating into C: `result <- max<dims>(A * B, C)`.
+        The scaler B is required for float element types and must be absent for integer
+        (i32) element types, which lower through the SFPU and do not use a scaler.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       TTCore_Tile:$b,
+                       Optional<TTCore_Tile>:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      return {2};
+      return {static_cast<int64_t>(getNumOperands() - 1)};
     }
     bool getDstRegInPlace() {
       return true;
     }
   }];
+
+  let hasVerifier = 1;
 }
 
 def D2M_TileReduceMeanOp : D2M_GenericRegionComputeOp<"tile_reduce_mean", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Mean Op";
   let description = [{
-        The `tile_reduce_mean` operation computes the mean of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- avg<dims>(A * B, C)
+        The `tile_reduce_mean` operation computes the mean of the input tile A over the
+        specified reduction dim(s), accumulating into C: `result <- avg<dims>(A * B, C)`.
+        The scaler B encodes 1/N and is required for float element types; it must be
+        absent for integer (i32) element types.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       TTCore_Tile:$b,
+                       Optional<TTCore_Tile>:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      return {2};
+      return {static_cast<int64_t>(getNumOperands() - 1)};
     }
     bool getDstRegInPlace() {
       return true;
     }
   }];
+
+  let hasVerifier = 1;
 }
 
 // TODO(#5968): fusion w/ implicit bcast causes multiple failure scenarios.

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -618,23 +618,19 @@ def D2M_TileWhereOp : D2M_GenericRegionComputeTernaryDstOp<"tile_where", D2M_Til
 def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Sum Op";
   let description = [{
-        The `tile_reduce_sum` operation computes the sum of the input tile A over the
-        specified reduction dim(s), accumulating into C: `result <- sum<dims>(A * B, C)`.
-        The scaler B is required for float element types and must be absent for integer
-        (i32) element types, which lower through the SFPU and do not use a scaler.
+        The `tile_reduce_sum` operation computes the sum of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- sum<dims>(A * B, C).
+        Valid only for float element types; integer sum reductions use `tile_sfpu_reduce_sum` instead.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       Optional<TTCore_Tile>:$b,
+                       TTCore_Tile:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      // $c is always the last operand; its physical index depends on
-      // whether the optional $b scaler is present.
-      return {static_cast<int64_t>(getNumOperands() - 1)};
+      return {2};
     }
     bool getDstRegInPlace() {
       return true;
@@ -647,21 +643,19 @@ def D2M_TileReduceSumOp : D2M_GenericRegionComputeOp<"tile_reduce_sum", D2M_Tile
 def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Max Op";
   let description = [{
-        The `tile_reduce_max` operation computes the max of the input tile A over the
-        specified reduction dim(s), accumulating into C: `result <- max<dims>(A * B, C)`.
-        The scaler B is required for float element types and must be absent for integer
-        (i32) element types, which lower through the SFPU and do not use a scaler.
+        The `tile_reduce_max` operation computes the max of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- max<dims>(A * B, C).
+        Valid only for float element types; integer max reductions use `tile_sfpu_reduce_max` instead.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       Optional<TTCore_Tile>:$b,
+                       TTCore_Tile:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      return {static_cast<int64_t>(getNumOperands() - 1)};
+      return {2};
     }
     bool getDstRegInPlace() {
       return true;
@@ -674,24 +668,84 @@ def D2M_TileReduceMaxOp : D2M_GenericRegionComputeOp<"tile_reduce_max", D2M_Tile
 def D2M_TileReduceMeanOp : D2M_GenericRegionComputeOp<"tile_reduce_mean", D2M_TileComputeOpTraitBundle> {
   let summary = "D2M Tile Reduce Mean Op";
   let description = [{
-        The `tile_reduce_mean` operation computes the mean of the input tile A over the
-        specified reduction dim(s), accumulating into C: `result <- avg<dims>(A * B, C)`.
-        The scaler B encodes 1/N and is required for float element types; it must be
-        absent for integer (i32) element types.
+        The `tile_reduce_mean` operation computes the mean of all elements in the input A element-wise multiplied by B and input C over the specified reduction dim(s): result <- avg<dims>(A * B, C).
+        Valid only for float element types; integer mean reduction is not supported yet.
     }];
 
   let arguments = (ins TTCore_Tile:$a,
-                       Optional<TTCore_Tile>:$b,
+                       TTCore_Tile:$b,
                        TTCore_Tile:$c,
                        D2M_ReduceDimAttr:$reduce_dim);
   let results = (outs TTCore_Tile:$result);
 
   let extraClassDeclaration = [{
     mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
-      return {static_cast<int64_t>(getNumOperands() - 1)};
+      return {2};
     }
     bool getDstRegInPlace() {
       return true;
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def D2M_TileSFPUReduceSumOp : D2M_GenericRegionComputeOp<"tile_sfpu_reduce_sum", D2M_TileComputeOpTraitBundle> {
+  let summary = "D2M Tile SFPU Reduce Sum Op";
+  let description = [{
+        The `tile_sfpu_reduce_sum` operation computes the sum of the input A over the specified reduction dim(s), accumulating into C: result <- sum<dims>(A, C).
+        Valid only for integer element types; float sum reductions use `tile_reduce_sum` instead.
+
+        `dst_scratch_index` is populated by `d2m-insert-dst-register-access`
+        (see `getNumDstScratchSlices`) and is -1 before the pass runs.
+    }];
+
+  let arguments = (ins TTCore_Tile:$a,
+                       TTCore_Tile:$c,
+                       D2M_ReduceDimAttr:$reduce_dim,
+                       DefaultValuedAttr<I64Attr, "-1">:$dst_scratch_index);
+  let results = (outs TTCore_Tile:$result);
+
+  let extraClassDeclaration = [{
+    mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
+      return {1};
+    }
+    bool getDstRegInPlace() {
+      return true;
+    }
+    int64_t getNumDstScratchSlices() {
+      return 1;
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def D2M_TileSFPUReduceMaxOp : D2M_GenericRegionComputeOp<"tile_sfpu_reduce_max", D2M_TileComputeOpTraitBundle> {
+  let summary = "D2M Tile SFPU Reduce Max Op";
+  let description = [{
+        The `tile_sfpu_reduce_max` operation computes the max of the input A over the specified reduction dim(s), accumulating into C: result <- max<dims>(A, C).
+        Valid only for integer element types; float max reductions use `tile_reduce_max` instead.
+
+        `dst_scratch_index` is populated by `d2m-insert-dst-register-access`
+        (see `getNumDstScratchSlices`) and is -1 before the pass runs.
+    }];
+
+  let arguments = (ins TTCore_Tile:$a,
+                       TTCore_Tile:$c,
+                       D2M_ReduceDimAttr:$reduce_dim,
+                       DefaultValuedAttr<I64Attr, "-1">:$dst_scratch_index);
+  let results = (outs TTCore_Tile:$result);
+
+  let extraClassDeclaration = [{
+    mlir::SmallVector<int64_t> getOperandsLoadFromDstRegister() {
+      return {1};
+    }
+    bool getDstRegInPlace() {
+      return true;
+    }
+    int64_t getNumDstScratchSlices() {
+      return 1;
     }
   }];
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
@@ -196,9 +196,10 @@ def D2M_OperandLoadStoreRegisterOpInterface : OpInterface<"OperandLoadStoreRegis
     InterfaceMethod<
       /*desc=*/[{
         Returns the number of DST scratch slices this op needs beyond its
-        operand/output slices. The insert-dst-register-access pass reserves
-        this many slices from the DST allocator and records their indices on
-        the op (e.g. via `dst_scratch_index`) for the lowering to consume.
+        operand/output slices. Only 0 or 1 are supported today: when 1, the
+        insert-dst-register-access pass reserves a slice from the DST
+        allocator and records its index on the op via `dst_scratch_index`
+        for the lowering to consume.
       }],
       /*retTy=*/"int64_t",
       /*methodName=*/"getNumDstScratchSlices",

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsInterfaces.td
@@ -193,6 +193,19 @@ def D2M_OperandLoadStoreRegisterOpInterface : OpInterface<"OperandLoadStoreRegis
         return false;
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the number of DST scratch slices this op needs beyond its
+        operand/output slices. The insert-dst-register-access pass reserves
+        this many slices from the DST allocator and records their indices on
+        the op (e.g. via `dst_scratch_index`) for the lowering to consume.
+      }],
+      /*retTy=*/"int64_t",
+      /*methodName=*/"getNumDstScratchSlices",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return 0;"
+    >,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -661,6 +661,9 @@ def TTKernel_SFPUReduceInitOp : TTKernel_InitOp<"sfpu_reduce_init"> {
       Unlike reduce_init this call carries no CB/DST operands: it only
       configures the SFPU for the given PoolType and DataFormat.
 
+      Only Sum/Max reductions over Int32 tiles are supported today; the
+      verifier enforces this.
+
       Lowers to: sfpu_reduce_init<PoolType, DataFormat>().
     }];
 
@@ -670,6 +673,8 @@ def TTKernel_SFPUReduceInitOp : TTKernel_InitOp<"sfpu_reduce_init"> {
     let assemblyFormat = [{
       `(` $reduce_type `,` $data_format `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let hasVerifier = 1;
 }
 
 def TTKernel_SFPUReduceTileOp : TTKernel_SFPUOp<"sfpu_reduce"> {
@@ -683,11 +688,9 @@ def TTKernel_SFPUReduceTileOp : TTKernel_SFPUOp<"sfpu_reduce"> {
 
       Only 32x32 tile dimensions are supported.
 
-      Supports PoolType::{SUM, AVG, MAX, MIN} for REDUCE_COL, and
-      PoolType::{SUM, MAX} for REDUCE_ROW (sfpu_reduce currently does not
-      support MIN across rows).
-
-      Supported data formats are Float32, Int32, UInt32, UInt16, Float16_b.
+      Only Sum/Max reductions over Int32 tiles are supported today, and
+      reduce_dim must be Row or Col (Scalar must be decomposed into Col + Row
+      by the caller); the verifier enforces these constraints.
 
       Lowers to: sfpu_reduce<PoolType, DataFormat, ReduceDim>(dst_index).
     }];
@@ -700,6 +703,8 @@ def TTKernel_SFPUReduceTileOp : TTKernel_SFPUOp<"sfpu_reduce"> {
     let assemblyFormat = [{
       `(` $dst_index `,` $reduce_type `,` $data_format `,` $reduce_dim `)` attr-dict `:` functional-type(operands, results)
     }];
+
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -654,6 +654,54 @@ def TTKernel_ReduceTileOp : TTKernel_FPUOp<"reduce_tile", [TTKernel_TernaryOpTra
     }];
 }
 
+def TTKernel_SFPUReduceInitOp : TTKernel_InitOp<"sfpu_reduce_init"> {
+    let summary = "Init for sfpu_reduce.";
+    let description = [{
+      Initializes the SFPU reduce kernel. Must be called before sfpu_reduce.
+      Unlike reduce_init this call carries no CB/DST operands: it only
+      configures the SFPU for the given PoolType and DataFormat.
+
+      Lowers to: sfpu_reduce_init<PoolType, DataFormat>().
+    }];
+
+    let arguments = (ins TTKernel_ReduceTypeAttr:$reduce_type,
+                         TTCore_DataTypeAttr:$data_format);
+
+    let assemblyFormat = [{
+      `(` $reduce_type `,` $data_format `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_SFPUReduceTileOp : TTKernel_SFPUOp<"sfpu_reduce"> {
+    let summary = "SFPU reduce operation on a tile in DST.";
+    let description = [{
+      Performs an intra-tile reduction on the tile at index `dst_index` in the
+      DST register using the SFPU path. The input tile must already be loaded
+      into DST (e.g. via copy_tile). The reduction is performed in-place on
+      that DST slot, writing the result into the first row (REDUCE_COL) or
+      first column (REDUCE_ROW) of the same tile.
+
+      Only 32x32 tile dimensions are supported.
+
+      Supports PoolType::{SUM, AVG, MAX, MIN} for REDUCE_COL, and
+      PoolType::{SUM, MAX} for REDUCE_ROW (sfpu_reduce currently does not
+      support MIN across rows).
+
+      Supported data formats are Float32, Int32, UInt32, UInt16, Float16_b.
+
+      Lowers to: sfpu_reduce<PoolType, DataFormat, ReduceDim>(dst_index).
+    }];
+
+    let arguments = (ins IndexLike:$dst_index,
+                         TTKernel_ReduceTypeAttr:$reduce_type,
+                         TTCore_DataTypeAttr:$data_format,
+                         TTKernel_ReduceDimAttr:$reduce_dim);
+
+    let assemblyFormat = [{
+      `(` $dst_index `,` $reduce_type `,` $data_format `,` $reduce_dim `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel SFPU operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_padding_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_padding_llks.h
@@ -97,10 +97,12 @@ inline void _write_col_mask_to_l1_(volatile T *ptr, uint32_t validCols,
 // 2-byte elements (2048 B/tile).
 
 constexpr uint16_t ONE_BF16 = 0x3F80; // 1.0 in bfloat16
+constexpr uint32_t ONE_I32 = 1;       // integer 1
 
 template <DataFormat df = DataFormat::Float32>
 ALWI void write_row_mask_tile(uint32_t validRows, uint32_t cb_id) {
-  static_assert(df == DataFormat::Float32 || df == DataFormat::Float16_b,
+  static_assert(df == DataFormat::Float32 || df == DataFormat::Float16_b ||
+                    df == DataFormat::Int32,
                 "write_row_mask_tile: unsupported DataFormat");
 #ifdef TRISC_UNPACK
   uint32_t write_addr = (get_local_cb_interface(cb_id).fifo_rd_ptr) << 4;
@@ -112,13 +114,18 @@ ALWI void write_row_mask_tile(uint32_t validRows, uint32_t cb_id) {
     volatile tt_l1_ptr uint16_t *ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t *>(write_addr);
     _write_row_mask_to_l1_(ptr, validRows, ONE_BF16);
+  } else if constexpr (df == DataFormat::Int32) {
+    volatile tt_l1_ptr uint32_t *ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t *>(write_addr);
+    _write_row_mask_to_l1_(ptr, validRows, ONE_I32);
   }
 #endif
 }
 
 template <DataFormat df = DataFormat::Float32>
 ALWI void write_col_mask_tile(uint32_t validCols, uint32_t cb_id) {
-  static_assert(df == DataFormat::Float32 || df == DataFormat::Float16_b,
+  static_assert(df == DataFormat::Float32 || df == DataFormat::Float16_b ||
+                    df == DataFormat::Int32,
                 "write_col_mask_tile: unsupported DataFormat");
 #ifdef TRISC_UNPACK
   uint32_t write_addr = (get_local_cb_interface(cb_id).fifo_rd_ptr) << 4;
@@ -130,6 +137,10 @@ ALWI void write_col_mask_tile(uint32_t validCols, uint32_t cb_id) {
     volatile tt_l1_ptr uint16_t *ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t *>(write_addr);
     _write_col_mask_to_l1_(ptr, validCols, ONE_BF16);
+  } else if constexpr (df == DataFormat::Int32) {
+    volatile tt_l1_ptr uint32_t *ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t *>(write_addr);
+    _write_col_mask_to_l1_(ptr, validCols, ONE_I32);
   }
 #endif
 }

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -204,6 +204,8 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"rsqrt_tile_init",                                {"api/compute/eltwise_unary/rsqrt.h", ""}},
         {"selu_tile",                                      {"api/compute/eltwise_unary/selu.h", ""}},
         {"selu_tile_init",                                 {"api/compute/eltwise_unary/selu.h", ""}},
+        {"sfpu_reduce",                                    {"api/compute/compute_kernel_api.h", ""}},
+        {"sfpu_reduce_init",                               {"api/compute/compute_kernel_api.h", ""}},
         {"sigmoid_tile",                                   {"api/compute/compute_kernel_api.h", ""}},
         {"sigmoid_tile_init",                              {"api/compute/compute_kernel_api.h", ""}},
         {"sign_tile",                                      {"api/compute/compute_kernel_api.h", ""}},

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -799,7 +799,16 @@ public:
     } else {
       static_assert(arity == 3 && !ttmlir::utils::always_false<ConcreteOp>(),
                     "FPUOp must be unary, binary or ternary");
-      assert(op->getNumOperands() == 3u);
+      // TileReduce{Sum,Max,Mean} have an optional scaler `$b` that is absent
+      // for integer reductions (which lower through the SFPU path), so they
+      // may legitimately present with only 2 operands.
+      if constexpr (std::is_same_v<ConcreteOp, d2m::TileReduceSumOp> ||
+                    std::is_same_v<ConcreteOp, d2m::TileReduceMaxOp> ||
+                    std::is_same_v<ConcreteOp, d2m::TileReduceMeanOp>) {
+        assert(op->getNumOperands() == 2u || op->getNumOperands() == 3u);
+      } else {
+        assert(op->getNumOperands() == 3u);
+      }
     }
 
     if constexpr (std::is_same_v<ConcreteOp, d2m::TileMatmulOp>) {
@@ -910,21 +919,36 @@ public:
         break;
       }
 
+      // Int tile reduce goes through SFPU (FPU reduce_tile is float-only).
+      const auto inTileType = mlir::cast<ttcore::TileType>(op.getA().getType());
+      const bool isIntReduce =
+          mlir::isa<IntegerType>(inTileType.getElementType());
+
       auto insertionPoint = rewriter.getInsertionPoint();
       auto cbA = getCB(rewriter, op.getA());
-      auto cbB = getCB(rewriter, op.getB());
       auto outCB = getOutCB(rewriter, op);
-      setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
-                                     /*allowHoisting*/ true);
-      rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), cbA,
-                                                          cbB, outCB);
-      rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-      rewriter.create<ttkernel::ReduceInitOp>(op->getLoc(), cbA, cbB, outCB,
-                                              reduce_type, kernel_reduce_dim);
-      rewriter.create<ttkernel::ReduceTileOp>(
-          op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(),
-          adaptor.getC(), reduce_type, kernel_reduce_dim);
-      rewriter.create<ttkernel::ReduceUninitOp>(op->getLoc());
+      Value cIdx = adaptor.getC();
+
+      if (isIntReduce) {
+        if (failed(lowerIntTileReduce(
+                op, adaptor, rewriter, reduce_type, kernel_reduce_dim,
+                inTileType.getDataType(), cbA, outCB, cIdx, insertionPoint))) {
+          return failure();
+        }
+      } else {
+        auto cbB = getCB(rewriter, op.getB());
+        setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
+                                       /*allowHoisting*/ true);
+        rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), cbA,
+                                                            cbB, outCB);
+        rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+        rewriter.create<ttkernel::ReduceInitOp>(op->getLoc(), cbA, cbB, outCB,
+                                                reduce_type, kernel_reduce_dim);
+        rewriter.create<ttkernel::ReduceTileOp>(
+            op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(), cIdx,
+            reduce_type, kernel_reduce_dim);
+        rewriter.create<ttkernel::ReduceUninitOp>(op->getLoc());
+      }
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileBcastOp>) {
       ttkernel::BcastType bcastType = ttkernel::BcastType::None;
       switch (op.getBcastType()) {
@@ -961,6 +985,93 @@ public:
     }
 
     rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  // Lower int32 TileReduce{Sum,Max} via SFPU sfpu_reduce.
+  //
+  // sfpu_reduce is intra-tile only, so seed DST[cIdx] with the pool identity
+  // once (hoisted), then per iter: copy input into scratch DST[cIdx + 1],
+  // sfpu_reduce it, accumulate into DST[cIdx] with the matching int binary op.
+  // REDUCE_SCALAR is unsupported; RC is decomposed into Col + Row.
+  LogicalResult lowerIntTileReduce(ConcreteOp op,
+                                   typename ConcreteOp::Adaptor adaptor,
+                                   ConversionPatternRewriter &rewriter,
+                                   ttkernel::ReduceType reduceType,
+                                   ttkernel::ReduceDim kernelReduceDim,
+                                   ttcore::DataType dataFormat, Value cbA,
+                                   Value outCB, Value cIdx,
+                                   Block::iterator insertionPoint) const {
+    // cIdx is defined inside the scf loops, so re-materialize a constant
+    // copy for use at the hoisted init point.
+    auto cIdxConst = cIdx.template getDefiningOp<arith::ConstantOp>();
+    if (!cIdxConst) {
+      return op->emitOpError(
+          "int tile reduce expects C operand's DST index to be a "
+          "compile-time constant; got a non-constant value");
+    }
+    int64_t cIdxVal = mlir::cast<IntegerAttr>(cIdxConst.getValue()).getInt();
+
+    int32_t identityInt = 0;
+    switch (reduceType) {
+    case ttkernel::ReduceType::Sum:
+      break;
+    case ttkernel::ReduceType::Max:
+      identityInt = std::numeric_limits<int32_t>::min();
+      break;
+    case ttkernel::ReduceType::Avg:
+      return op->emitOpError("int tile reduce mean is not yet supported");
+    }
+
+    setInsertionPointAfterOperands(rewriter, {cbA, outCB},
+                                   /*allowHoisting*/ true);
+    rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), cbA, outCB);
+    Value hoistedCIdx =
+        rewriter.create<arith::ConstantIndexOp>(op->getLoc(), cIdxVal);
+    Value identityVal = rewriter.create<arith::ConstantOp>(
+        op->getLoc(), rewriter.getI32Type(),
+        rewriter.getI32IntegerAttr(identityInt));
+    rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
+    rewriter.create<ttkernel::FillTileIntOp>(op->getLoc(), hoistedCIdx,
+                                             identityVal);
+
+    rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+
+    // tempIdx = cIdx + 1; only one DST slot is reserved for the reduction,
+    // so the adjacent slot is free scratch.
+    auto one = rewriter.create<arith::ConstantIndexOp>(op->getLoc(), 1);
+    Value tempIdx = rewriter.create<arith::AddIOp>(op->getLoc(), cIdx, one);
+
+    rewriter.create<ttkernel::CopyTileInitOp>(op->getLoc(), cbA);
+    rewriter.create<ttkernel::CopyTileOp>(op->getLoc(), cbA, adaptor.getA(),
+                                          tempIdx);
+    rewriter.create<ttkernel::SFPUReduceInitOp>(op->getLoc(), reduceType,
+                                                dataFormat);
+    SmallVector<ttkernel::ReduceDim> sfpuDims =
+        (kernelReduceDim == ttkernel::ReduceDim::Scalar)
+            ? SmallVector<ttkernel::ReduceDim>{ttkernel::ReduceDim::Col,
+                                               ttkernel::ReduceDim::Row}
+            : SmallVector<ttkernel::ReduceDim>{kernelReduceDim};
+    for (ttkernel::ReduceDim dim : sfpuDims) {
+      rewriter.create<ttkernel::SFPUReduceTileOp>(op->getLoc(), tempIdx,
+                                                  reduceType, dataFormat, dim);
+    }
+
+    switch (reduceType) {
+    case ttkernel::ReduceType::Sum:
+      rewriter.create<ttkernel::AddIntTileInitOp>(op->getLoc());
+      rewriter.create<ttkernel::AddIntTileOp>(op->getLoc(), tempIdx, cIdx, cIdx,
+                                              dataFormat);
+      break;
+    case ttkernel::ReduceType::Max:
+      rewriter.create<ttkernel::BinaryMaxInt32TileInitOp>(op->getLoc());
+      rewriter.create<ttkernel::BinaryMaxInt32TileOp>(op->getLoc(), tempIdx,
+                                                      cIdx, cIdx);
+      break;
+    case ttkernel::ReduceType::Avg:
+      llvm_unreachable("Avg handled by early return above");
+    }
     return success();
   }
 };

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -799,16 +799,7 @@ public:
     } else {
       static_assert(arity == 3 && !ttmlir::utils::always_false<ConcreteOp>(),
                     "FPUOp must be unary, binary or ternary");
-      // TileReduce{Sum,Max,Mean} have an optional scaler `$b` that is absent
-      // for integer reductions (which lower through the SFPU path), so they
-      // may legitimately present with only 2 operands.
-      if constexpr (std::is_same_v<ConcreteOp, d2m::TileReduceSumOp> ||
-                    std::is_same_v<ConcreteOp, d2m::TileReduceMaxOp> ||
-                    std::is_same_v<ConcreteOp, d2m::TileReduceMeanOp>) {
-        assert(op->getNumOperands() == 2u || op->getNumOperands() == 3u);
-      } else {
-        assert(op->getNumOperands() == 3u);
-      }
+      assert(op->getNumOperands() == 3u);
     }
 
     if constexpr (std::is_same_v<ConcreteOp, d2m::TileMatmulOp>) {
@@ -919,36 +910,21 @@ public:
         break;
       }
 
-      // Int tile reduce goes through SFPU (FPU reduce_tile is float-only).
-      const auto inTileType = mlir::cast<ttcore::TileType>(op.getA().getType());
-      const bool isIntReduce =
-          mlir::isa<IntegerType>(inTileType.getElementType());
-
       auto insertionPoint = rewriter.getInsertionPoint();
       auto cbA = getCB(rewriter, op.getA());
+      auto cbB = getCB(rewriter, op.getB());
       auto outCB = getOutCB(rewriter, op);
-      Value cIdx = adaptor.getC();
-
-      if (isIntReduce) {
-        if (failed(lowerIntTileReduce(
-                op, adaptor, rewriter, reduce_type, kernel_reduce_dim,
-                inTileType.getDataType(), cbA, outCB, cIdx, insertionPoint))) {
-          return failure();
-        }
-      } else {
-        auto cbB = getCB(rewriter, op.getB());
-        setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
-                                       /*allowHoisting*/ true);
-        rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), cbA,
-                                                            cbB, outCB);
-        rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
-        rewriter.create<ttkernel::ReduceInitOp>(op->getLoc(), cbA, cbB, outCB,
-                                                reduce_type, kernel_reduce_dim);
-        rewriter.create<ttkernel::ReduceTileOp>(
-            op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(), cIdx,
-            reduce_type, kernel_reduce_dim);
-        rewriter.create<ttkernel::ReduceUninitOp>(op->getLoc());
-      }
+      setInsertionPointAfterOperands(rewriter, {cbA, cbB, outCB},
+                                     /*allowHoisting*/ true);
+      rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), cbA,
+                                                          cbB, outCB);
+      rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+      rewriter.create<ttkernel::ReduceInitOp>(op->getLoc(), cbA, cbB, outCB,
+                                              reduce_type, kernel_reduce_dim);
+      rewriter.create<ttkernel::ReduceTileOp>(
+          op->getLoc(), cbA, cbB, adaptor.getA(), adaptor.getB(),
+          adaptor.getC(), reduce_type, kernel_reduce_dim);
+      rewriter.create<ttkernel::ReduceUninitOp>(op->getLoc());
     } else if constexpr (std::is_same_v<ConcreteOp, d2m::TileBcastOp>) {
       ttkernel::BcastType bcastType = ttkernel::BcastType::None;
       switch (op.getBcastType()) {
@@ -987,42 +963,66 @@ public:
     rewriter.eraseOp(op);
     return success();
   }
+};
 
-private:
-  // Lower int32 TileReduce{Sum,Max} via SFPU sfpu_reduce.
-  //
-  // sfpu_reduce is intra-tile only, so seed DST[cIdx] with the pool identity
-  // once (hoisted), then per iter: copy input into scratch DST[cIdx + 1],
-  // sfpu_reduce it, accumulate into DST[cIdx] with the matching int binary op.
-  // REDUCE_SCALAR is unsupported; RC is decomposed into Col + Row.
-  LogicalResult lowerIntTileReduce(ConcreteOp op,
-                                   typename ConcreteOp::Adaptor adaptor,
-                                   ConversionPatternRewriter &rewriter,
-                                   ttkernel::ReduceType reduceType,
-                                   ttkernel::ReduceDim kernelReduceDim,
-                                   ttcore::DataType dataFormat, Value cbA,
-                                   Value outCB, Value cIdx,
-                                   Block::iterator insertionPoint) const {
+// Lowers integer tile reductions via SFPU `sfpu_reduce` (intra-tile only):
+// seed DST[cIdx] with the pool identity once, then per iter stage the input
+// into DST[scratchIdx], sfpu_reduce it, and combine into DST[cIdx] with an
+// int binary op. scratchIdx comes from `dst_scratch_index` reserved by
+// `d2m-insert-dst-register-access`. RC decomposes into Col + Row.
+template <typename ConcreteOp>
+class D2MSFPUReduceRewriter : public OpConversionPattern<ConcreteOp> {
+public:
+  using OpConversionPattern<ConcreteOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ConcreteOp op, typename ConcreteOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    static_assert(std::is_same_v<ConcreteOp, d2m::TileSFPUReduceSumOp> ||
+                      std::is_same_v<ConcreteOp, d2m::TileSFPUReduceMaxOp>,
+                  "D2MSFPUReduceRewriter supports only int tile_sfpu_reduce_*");
+
+    ttkernel::ReduceType reduceType =
+        std::is_same_v<ConcreteOp, d2m::TileSFPUReduceSumOp>
+            ? ttkernel::ReduceType::Sum
+            : ttkernel::ReduceType::Max;
+
+    ttkernel::ReduceDim kernelReduceDim;
+    switch (op.getReduceDim()) {
+    case d2m::ReduceDim::C:
+      kernelReduceDim = ttkernel::ReduceDim::Col;
+      break;
+    case d2m::ReduceDim::R:
+      kernelReduceDim = ttkernel::ReduceDim::Row;
+      break;
+    case d2m::ReduceDim::RC:
+      kernelReduceDim = ttkernel::ReduceDim::Scalar;
+      break;
+    }
+
+    // i32 element type is enforced by the op verifier; fill_tile_int and
+    // binary_max_int32_tile below rely on that invariant.
+    const auto inTileType = mlir::cast<ttcore::TileType>(op.getA().getType());
+    ttcore::DataType dataFormat = inTileType.getDataType();
+
+    auto insertionPoint = rewriter.getInsertionPoint();
+    Value cbA = getCB(rewriter, op.getA());
+    Value outCB = getOutCB(rewriter, op);
+    Value cIdx = adaptor.getC();
+
     // cIdx is defined inside the scf loops, so re-materialize a constant
     // copy for use at the hoisted init point.
     auto cIdxConst = cIdx.template getDefiningOp<arith::ConstantOp>();
     if (!cIdxConst) {
       return op->emitOpError(
-          "int tile reduce expects C operand's DST index to be a "
+          "tile_sfpu_reduce_* expects C operand's DST index to be a "
           "compile-time constant; got a non-constant value");
     }
     int64_t cIdxVal = mlir::cast<IntegerAttr>(cIdxConst.getValue()).getInt();
 
-    int32_t identityInt = 0;
-    switch (reduceType) {
-    case ttkernel::ReduceType::Sum:
-      break;
-    case ttkernel::ReduceType::Max:
-      identityInt = std::numeric_limits<int32_t>::min();
-      break;
-    case ttkernel::ReduceType::Avg:
-      return op->emitOpError("int tile reduce mean is not yet supported");
-    }
+    int32_t identityInt = (reduceType == ttkernel::ReduceType::Max)
+                              ? std::numeric_limits<int32_t>::min()
+                              : 0;
 
     setInsertionPointAfterOperands(rewriter, {cbA, outCB},
                                    /*allowHoisting*/ true);
@@ -1038,10 +1038,13 @@ private:
 
     rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
 
-    // tempIdx = cIdx + 1; only one DST slot is reserved for the reduction,
-    // so the adjacent slot is free scratch.
-    auto one = rewriter.create<arith::ConstantIndexOp>(op->getLoc(), 1);
-    Value tempIdx = rewriter.create<arith::AddIOp>(op->getLoc(), cIdx, one);
+    int64_t scratchIdxVal = op.getDstScratchIndex();
+    if (scratchIdxVal < 0) {
+      return op->emitOpError("dst_scratch_index must be set by "
+                             "d2m-insert-dst-register-access before lowering");
+    }
+    Value tempIdx =
+        rewriter.create<arith::ConstantIndexOp>(op->getLoc(), scratchIdxVal);
 
     rewriter.create<ttkernel::CopyTileInitOp>(op->getLoc(), cbA);
     rewriter.create<ttkernel::CopyTileOp>(op->getLoc(), cbA, adaptor.getA(),
@@ -1058,20 +1061,17 @@ private:
                                                   reduceType, dataFormat, dim);
     }
 
-    switch (reduceType) {
-    case ttkernel::ReduceType::Sum:
+    if constexpr (std::is_same_v<ConcreteOp, d2m::TileSFPUReduceSumOp>) {
       rewriter.create<ttkernel::AddIntTileInitOp>(op->getLoc());
       rewriter.create<ttkernel::AddIntTileOp>(op->getLoc(), tempIdx, cIdx, cIdx,
                                               dataFormat);
-      break;
-    case ttkernel::ReduceType::Max:
+    } else {
       rewriter.create<ttkernel::BinaryMaxInt32TileInitOp>(op->getLoc());
       rewriter.create<ttkernel::BinaryMaxInt32TileOp>(op->getLoc(), tempIdx,
                                                       cIdx, cIdx);
-      break;
-    case ttkernel::ReduceType::Avg:
-      llvm_unreachable("Avg handled by early return above");
     }
+
+    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -2823,10 +2823,14 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MFPUOpsRewriter<d2m::TileMatmulOp>,
                ttkernel::D2MFPUOpsRewriter<d2m::TileMatmulBlockOp>,
 
-               // Reductions FPU.
+               // Reductions FPU (float).
                ttkernel::D2MFPUOpsRewriter<d2m::TileReduceSumOp>,
                ttkernel::D2MFPUOpsRewriter<d2m::TileReduceMaxOp>,
                ttkernel::D2MFPUOpsRewriter<d2m::TileReduceMeanOp>,
+
+               // Reductions SFPU (integer).
+               ttkernel::D2MSFPUReduceRewriter<d2m::TileSFPUReduceSumOp>,
+               ttkernel::D2MSFPUReduceRewriter<d2m::TileSFPUReduceMaxOp>,
 
                // Elementwise SFPU Unary.
                ttkernel::D2MSFPUOpsRewriter<d2m::TileAbsOp>,

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1005,38 +1005,37 @@ public:
     const auto inTileType = mlir::cast<ttcore::TileType>(op.getA().getType());
     ttcore::DataType dataFormat = inTileType.getDataType();
 
-    auto insertionPoint = rewriter.getInsertionPoint();
     Value cbA = getCB(rewriter, op.getA());
     Value outCB = getOutCB(rewriter, op);
     Value cIdx = adaptor.getC();
 
     // cIdx is defined inside the scf loops, so re-materialize a constant
     // copy for use at the hoisted init point.
-    auto cIdxConst = cIdx.template getDefiningOp<arith::ConstantOp>();
-    if (!cIdxConst) {
+    std::optional<int64_t> cIdxVal = getConstantIntValue(cIdx);
+    if (!cIdxVal) {
       return op->emitOpError(
           "tile_sfpu_reduce_* expects C operand's DST index to be a "
           "compile-time constant; got a non-constant value");
     }
-    int64_t cIdxVal = mlir::cast<IntegerAttr>(cIdxConst.getValue()).getInt();
 
     int32_t identityInt = (reduceType == ttkernel::ReduceType::Max)
                               ? std::numeric_limits<int32_t>::min()
                               : 0;
 
-    setInsertionPointAfterOperands(rewriter, {cbA, outCB},
-                                   /*allowHoisting*/ true);
-    rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), cbA, outCB);
-    Value hoistedCIdx =
-        rewriter.create<arith::ConstantIndexOp>(op->getLoc(), cIdxVal);
-    Value identityVal = rewriter.create<arith::ConstantOp>(
-        op->getLoc(), rewriter.getI32Type(),
-        rewriter.getI32IntegerAttr(identityInt));
-    rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
-    rewriter.create<ttkernel::FillTileIntOp>(op->getLoc(), hoistedCIdx,
-                                             identityVal);
-
-    rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      setInsertionPointAfterOperands(rewriter, {cbA, outCB},
+                                     /*allowHoisting*/ true);
+      rewriter.create<ttkernel::InitSFPUOp>(op->getLoc(), cbA, outCB);
+      Value hoistedCIdx =
+          rewriter.create<arith::ConstantIndexOp>(op->getLoc(), *cIdxVal);
+      Value identityVal = rewriter.create<arith::ConstantOp>(
+          op->getLoc(), rewriter.getI32Type(),
+          rewriter.getI32IntegerAttr(identityInt));
+      rewriter.create<ttkernel::FillTileInitOp>(op->getLoc());
+      rewriter.create<ttkernel::FillTileIntOp>(op->getLoc(), hoistedCIdx,
+                                               identityVal);
+    }
 
     int64_t scratchIdxVal = op.getDstScratchIndex();
     if (scratchIdxVal < 0) {

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -649,8 +649,8 @@ protected:
         ttcore::TileType::getDefaultShape(), elementType, encoding);
 
     assert(mlir::isa<mlir::FloatType>(elementType) &&
-           "createScaler: only float element types are supported; int "
-           "reductions lower without a scaler (b operand is optional)");
+           "createScaler is float-only; integer reductions lower via "
+           "tile_sfpu_reduce_* which take no scaler");
     mlir::Attribute fillAttr =
         mlir::FloatAttr::get(rewriter.getF32Type(), fillValue);
 
@@ -1509,16 +1509,19 @@ private:
 } // namespace
 
 // D2MNamedTileReduceRewriter lowers tile C/R reductions (the last two
-// physical iterator dims) via tile_reduce_{sum,max,mean}, optionally with a
-// scaler tile broadcast across the lhs (e.g. 1/N for mean).
+// physical iterator dims) via tile_reduce_{sum,max,mean} for float element
+// types (with a broadcast scaler tile encoding e.g. 1/N for mean) and via
+// tile_sfpu_reduce_{sum,max} for integer element types (no scaler, SFPU
+// lowering). `IntTileOp` may be `void` to indicate the int path is not
+// supported (e.g. mean).
 namespace {
-template <typename ConcreteOp, typename TileOp>
+template <typename ConcreteOp, typename FloatTileOp, typename IntTileOp = void>
 class D2MNamedTileReduceRewriter final
     : public mlir::OpConversionPattern<ConcreteOp>,
       D2MNamedRewriterCommon {
 
 public:
-  D2MNamedTileReduceRewriter<ConcreteOp, TileOp>(
+  D2MNamedTileReduceRewriter<ConcreteOp, FloatTileOp, IntTileOp>(
       const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
       ttcore::MemorySpace defaultInputMemSpace,
       ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
@@ -1529,16 +1532,18 @@ public:
                                enableMulticastInference) {}
 
 private:
+  static constexpr bool kIntSupported = !std::is_void_v<IntTileOp>;
+
   // Return the identity OOB fill value for this reduction's tile op.
   // Padded elements must not affect the reduction result.
   static constexpr ttcore::OOBVal getReductionOOBVal() {
-    if constexpr (std::is_same_v<TileOp, d2m::TileReduceMaxOp>) {
+    if constexpr (std::is_same_v<FloatTileOp, d2m::TileReduceMaxOp>) {
       return ttcore::OOBVal::NegInf;
-    } else if constexpr (std::is_same_v<TileOp, d2m::TileReduceSumOp> ||
-                         std::is_same_v<TileOp, d2m::TileReduceMeanOp>) {
+    } else if constexpr (std::is_same_v<FloatTileOp, d2m::TileReduceSumOp> ||
+                         std::is_same_v<FloatTileOp, d2m::TileReduceMeanOp>) {
       return ttcore::OOBVal::Zero;
     } else {
-      static_assert(ttmlir::utils::always_false<TileOp>(),
+      static_assert(ttmlir::utils::always_false<FloatTileOp>(),
                     "Unhandled reduction TileOp");
     }
   }
@@ -1558,10 +1563,15 @@ private:
         mlir::cast<RankedTensorType>(origInputs.front().getType());
     // Float reductions multiply A by a broadcast scaler tile inside
     // tile_reduce_*. Integer reductions lower through the SFPU, which
-    // ignores the scaler entirely, so we skip building it and emit the
-    // d2m.tile_reduce_* op with the optional $b operand absent.
-    const bool hasScaler =
+    // ignores the scaler entirely, so we emit tile_sfpu_reduce_* without a
+    // scaler operand.
+    const bool isFloat =
         mlir::isa<mlir::FloatType>(inputTensorType.getElementType());
+    if (!isFloat && !kIntSupported) {
+      return rewriter.notifyMatchFailure(
+          op, "integer tile reduction is not supported for this op");
+    }
+    const bool hasScaler = isFloat;
     SmallVector<mlir::Value> newInputs(origInputs.begin(), origInputs.end());
     if (hasScaler) {
       newInputs.emplace_back(this->createScaler(rewriter, loc, inputTensorType,
@@ -1633,11 +1643,21 @@ private:
                 mlir::ValueRange bbArgs) {
               // bbArgs layout: [A, (scaler if hasScaler,) outputInit...].
               mlir::Value aArg = bbArgs.front();
-              mlir::Value bArg = hasScaler ? bbArgs[1] : mlir::Value();
               mlir::Value cArg = bbArgs[numInputs];
               mlir::Type resultType = cArg.getType();
-              mlir::Value yield = bbBuilder.create<TileOp>(
-                  loc, resultType, aArg, bArg, cArg, reduceDimAttr);
+              mlir::Value yield;
+              if (hasScaler) {
+                mlir::Value bArg = bbArgs[1];
+                yield = bbBuilder.create<FloatTileOp>(
+                    loc, resultType, aArg, bArg, cArg, reduceDimAttr);
+              } else {
+                if constexpr (kIntSupported) {
+                  yield = bbBuilder.create<IntTileOp>(loc, resultType, aArg,
+                                                      cArg, reduceDimAttr);
+                } else {
+                  llvm_unreachable("int path guarded against at entry");
+                }
+              }
               bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
             });
 
@@ -3740,10 +3760,11 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MNamedAccumReductionRewriter<ttir::MaxOp,  d2m::TileMaximumOp>,
     D2MNamedAccumReductionRewriter<ttir::MinOp,  d2m::TileMinimumOp>,
     D2MNamedAccumReductionRewriter<ttir::MeanOp, d2m::TileAddOp>,
-    // Inner (tile C/R) reductions: tile_reduce_*.
-    D2MNamedTileReduceRewriter<ttir::MaxOp,  d2m::TileReduceMaxOp>,
+    // Inner (tile C/R) reductions: tile_reduce_* (float) /
+    // tile_sfpu_reduce_* (integer). Mean has no integer variant.
+    D2MNamedTileReduceRewriter<ttir::MaxOp,  d2m::TileReduceMaxOp, d2m::TileSFPUReduceMaxOp>,
     D2MNamedTileReduceRewriter<ttir::MeanOp, d2m::TileReduceMeanOp>,
-    D2MNamedTileReduceRewriter<ttir::SumOp,  d2m::TileReduceSumOp>,
+    D2MNamedTileReduceRewriter<ttir::SumOp,  d2m::TileReduceSumOp, d2m::TileSFPUReduceSumOp>,
     // Data movement.
     D2MNamedElementwiseRewriter<ttir::TypecastOp,        d2m::TileTypecastOp>,
     // Tensor manipulation/View ops.

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -52,7 +52,8 @@ protected:
         enableMulticastInference(enableMulticastInference) {}
 
   /// Attributes required to lower any `TTIR_ReductionOp` to D2M (used by both
-  /// `D2MNamedOuterReductionRewriter` and `D2MNamedInnerReductionRewriter`).
+  /// `D2MNamedAccumReductionRewriter` and
+  /// `D2MNamedTileReduceRewriter`).
   /// Call once at the start of each match; downstream code assumes `dim_arg` is
   /// present and `keep_dim` is true. Valid indices inside `dim_arg` are
   /// enforced by the TTIR op verifier.
@@ -648,7 +649,8 @@ protected:
         ttcore::TileType::getDefaultShape(), elementType, encoding);
 
     assert(mlir::isa<mlir::FloatType>(elementType) &&
-           "tile reductions only support float element types");
+           "createScaler: only float element types are supported; int "
+           "reductions lower without a scaler (b operand is optional)");
     mlir::Attribute fillAttr =
         mlir::FloatAttr::get(rewriter.getF32Type(), fillValue);
 
@@ -1130,16 +1132,18 @@ private:
 
 // ----------------------------------------------------------------------------
 //
-// D2MNamedOuterReductionRewriter: outer logical-dimension reductions require
-// explicit accumulation into the output buffer via d2m.generic with reduction
-// iterators and remote load/store.
+// D2MNamedAccumReductionRewriter: outer logical-dim reductions
+// lowered by accumulating full-tile binary ops (tile_add / tile_maximum /
+// tile_minimum) across the reduction dim via d2m.generic with reduction
+// iterators. Inner (tile C/R) reductions use the sibling
+// D2MNamedTileReduceRewriter instead.
 namespace {
 template <typename ConcreteOp, typename TileAccumulateOp>
-class D2MNamedOuterReductionRewriter final
+class D2MNamedAccumReductionRewriter final
     : public mlir::OpConversionPattern<ConcreteOp>,
       D2MNamedRewriterCommon {
 public:
-  D2MNamedOuterReductionRewriter(const TypeConverter &typeConverter,
+  D2MNamedAccumReductionRewriter(const TypeConverter &typeConverter,
                                  mlir::MLIRContext *ctx,
                                  ttcore::MemorySpace defaultInputMemSpace,
                                  ttcore::MemorySpace defaultOutputMemSpace,
@@ -1504,18 +1508,17 @@ private:
 };
 } // namespace
 
-// D2MNamedInnerReductionRewriter: tile C/R reductions (last two physical
-// iterator dims), similar to the elementwise group except ops whose tiled
-// counterparts need a scaler (e.g. 1/N for mean)—a single filled tile
-// broadcast across the lhs indexing space.
+// D2MNamedTileReduceRewriter lowers tile C/R reductions (the last two
+// physical iterator dims) via tile_reduce_{sum,max,mean}, optionally with a
+// scaler tile broadcast across the lhs (e.g. 1/N for mean).
 namespace {
 template <typename ConcreteOp, typename TileOp>
-class D2MNamedInnerReductionRewriter final
+class D2MNamedTileReduceRewriter final
     : public mlir::OpConversionPattern<ConcreteOp>,
       D2MNamedRewriterCommon {
 
 public:
-  D2MNamedInnerReductionRewriter<ConcreteOp, TileOp>(
+  D2MNamedTileReduceRewriter<ConcreteOp, TileOp>(
       const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
       ttcore::MemorySpace defaultInputMemSpace,
       ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
@@ -1551,13 +1554,19 @@ private:
     auto origInputs = adaptor.getOperands();
     auto origOutputs =
         createDpsOutputs(loc, rewriter, {op.getResult().getType()});
-    SmallVector<mlir::Value> newInputs(origInputs.begin(), origInputs.end());
-    newInputs.emplace_back(this->createScaler(
-        rewriter, loc,
-        mlir::cast<mlir::RankedTensorType>(origInputs.front().getType()),
-        getScaleValue(op)));
     auto inputTensorType =
         mlir::cast<RankedTensorType>(origInputs.front().getType());
+    // Float reductions multiply A by a broadcast scaler tile inside
+    // tile_reduce_*. Integer reductions lower through the SFPU, which
+    // ignores the scaler entirely, so we skip building it and emit the
+    // d2m.tile_reduce_* op with the optional $b operand absent.
+    const bool hasScaler =
+        mlir::isa<mlir::FloatType>(inputTensorType.getElementType());
+    SmallVector<mlir::Value> newInputs(origInputs.begin(), origInputs.end());
+    if (hasScaler) {
+      newInputs.emplace_back(this->createScaler(rewriter, loc, inputTensorType,
+                                                getScaleValue(op)));
+    }
     bool noCollapse = (inputTensorType.getRank() > 2);
 
     auto [inputs, outputs] = toLayoutOperandsAndResults(
@@ -1573,7 +1582,7 @@ private:
     assertPhysicalIteratorRankForReduction(physicalRank);
 
     SmallVector<mlir::AffineMap> indexingMaps =
-        getAffineMapsArray(rewriter, op, numOperands, physicalRank);
+        getAffineMapsArray(rewriter, op, numOperands, physicalRank, hasScaler);
     SmallVector<mlir::Attribute> iteratorTypes =
         getIteratorTypesArray(rewriter, op, physicalRank);
 
@@ -1601,21 +1610,15 @@ private:
 
         // Create 'linalg.generic' accepting 'blockArgs'.
 
-        SmallVector<mlir::AffineMap> linalgIndexingMaps =
-            getAffineMapsArray(rewriter, op, numOperands, physicalRank);
+        SmallVector<mlir::AffineMap> linalgIndexingMaps = getAffineMapsArray(
+            rewriter, op, numOperands, physicalRank, hasScaler);
         SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
             iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);
 
         // Propagate attributes.
 
-        SmallVector<mlir::NamedAttribute> attributes;
-        {
-          // Propagate 'dim_arg' as 'ReduceDim'.
-          attributes.emplace_back(
-              d2m::ReduceDimAttr::getMnemonic(),
-              d2m::ReduceDimAttr::get(ctx,
-                                      dimArgAsReduceDim(op, physicalRank)));
-        }
+        auto reduceDimAttr =
+            d2m::ReduceDimAttr::get(ctx, dimArgAsReduceDim(op, physicalRank));
 
         auto linalgGeneric = rewriter.create<mlir::linalg::GenericOp>(
             loc,
@@ -1628,10 +1631,13 @@ private:
             linalgIteratorTypes,
             [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
                 mlir::ValueRange bbArgs) {
+              // bbArgs layout: [A, (scaler if hasScaler,) outputInit...].
+              mlir::Value aArg = bbArgs.front();
+              mlir::Value bArg = hasScaler ? bbArgs[1] : mlir::Value();
+              mlir::Value cArg = bbArgs[numInputs];
+              mlir::Type resultType = cArg.getType();
               mlir::Value yield = bbBuilder.create<TileOp>(
-                  loc,
-                  /* resultTypes */ bbArgs.take_back(numOutputs).getTypes(),
-                  /* operands */ bbArgs, attributes);
+                  loc, resultType, aArg, bArg, cArg, reduceDimAttr);
               bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
             });
 
@@ -1665,7 +1671,7 @@ private:
 
   static SmallVector<mlir::AffineMap>
   getAffineMapsArray(mlir::OpBuilder &builder, ConcreteOp op, std::size_t arity,
-                     std::size_t rank) {
+                     std::size_t rank, bool hasScaler) {
     mlir::ArrayAttr dimArg = getDimArg(op);
 
     mlir::AffineExpr zero =
@@ -1677,12 +1683,18 @@ private:
         accumulator.setResult(index, zero);
       }
     });
-    SmallVector<mlir::AffineMap> maps(arity - 2,
+    // Final two (or one, if no scaler) maps are special: the scaler is
+    // broadcast from a single tile via a zeros map, and the output uses the
+    // accumulator map. All earlier inputs use the identity map.
+    const std::size_t numIdentity = arity - 1 - (hasScaler ? 1 : 0);
+    SmallVector<mlir::AffineMap> maps(numIdentity,
                                       builder.getMultiDimIdentityMap(rank));
-    std::array<mlir::AffineExpr, 2> zeros{zero, zero};
-    maps.emplace_back(mlir::AffineMap::get(/* dimCount */ rank,
-                                           /* symbolCount */ 0, zeros,
-                                           builder.getContext()));
+    if (hasScaler) {
+      std::array<mlir::AffineExpr, 2> zeros{zero, zero};
+      maps.emplace_back(mlir::AffineMap::get(/* dimCount */ rank,
+                                             /* symbolCount */ 0, zeros,
+                                             builder.getContext()));
+    }
     maps.emplace_back(accumulator.getAffineMap());
 
     return maps;
@@ -1727,7 +1739,7 @@ private:
 
   /// Map `dim_arg` to a `ReduceDim` over the last two (tile C/R) dimensions.
   /// Outer-only reductions should have matched
-  /// `D2MNamedOuterReductionRewriter`.
+  /// `D2MNamedAccumReductionRewriter`.
   static d2m::ReduceDim dimArgAsReduceDim(ConcreteOp op, std::size_t rank) {
     SmallVector<bool> dims(rank, false);
     forAllDims(rank, getDimArg(op),
@@ -1746,9 +1758,9 @@ private:
       return d2m::ReduceDim::R;
     }
     llvm_unreachable(
-        "D2MNamedInnerReductionRewriter: dim_arg does not reduce tile C or R "
-        "(last two physical iterator dims). For reductions over outer logical "
-        "dims, D2MNamedOuterReductionRewriter must match "
+        "D2MNamedTileReduceRewriter: dim_arg does not reduce tile "
+        "C or R (last two physical iterator dims). For reductions over outer "
+        "logical dims, D2MNamedAccumReductionRewriter must match "
         "before this pattern since it has higher benefit.");
   }
 
@@ -3723,15 +3735,15 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
     D2MNamedElementwiseRewriter<ttir::GreaterEqualOp,    d2m::TileGezOp>,
     D2MNamedElementwiseRewriter<ttir::LessThanOp,        d2m::TileLtzOp>,
     D2MNamedElementwiseRewriter<ttir::LessEqualOp,       d2m::TileLezOp>,
-    // Named outer-dimension reductions.
-    D2MNamedOuterReductionRewriter<ttir::SumOp,          d2m::TileAddOp>,
-    D2MNamedOuterReductionRewriter<ttir::MaxOp,          d2m::TileMaximumOp>,
-    D2MNamedOuterReductionRewriter<ttir::MinOp,          d2m::TileMinimumOp>,
-    D2MNamedOuterReductionRewriter<ttir::MeanOp,         d2m::TileAddOp>,
-    // Named inner (tile C/R) reductions.
-    D2MNamedInnerReductionRewriter<ttir::MaxOp,          d2m::TileReduceMaxOp>,
-    D2MNamedInnerReductionRewriter<ttir::MeanOp,         d2m::TileReduceMeanOp>,
-    D2MNamedInnerReductionRewriter<ttir::SumOp,          d2m::TileReduceSumOp>,
+    // Outer-dim (and integer) reductions: accumulate full-tile binary ops.
+    D2MNamedAccumReductionRewriter<ttir::SumOp,  d2m::TileAddOp>,
+    D2MNamedAccumReductionRewriter<ttir::MaxOp,  d2m::TileMaximumOp>,
+    D2MNamedAccumReductionRewriter<ttir::MinOp,  d2m::TileMinimumOp>,
+    D2MNamedAccumReductionRewriter<ttir::MeanOp, d2m::TileAddOp>,
+    // Inner (tile C/R) reductions: tile_reduce_*.
+    D2MNamedTileReduceRewriter<ttir::MaxOp,  d2m::TileReduceMaxOp>,
+    D2MNamedTileReduceRewriter<ttir::MeanOp, d2m::TileReduceMeanOp>,
+    D2MNamedTileReduceRewriter<ttir::SumOp,  d2m::TileReduceSumOp>,
     // Data movement.
     D2MNamedElementwiseRewriter<ttir::TypecastOp,        d2m::TileTypecastOp>,
     // Tensor manipulation/View ops.

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -289,6 +289,24 @@ public:
       template_args.push_back(emitc::OpaqueAttr::get(
           op.getContext(), op.getFullFp32() ? "true" : "false"));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::SFPUReduceInitOp>) {
+      // sfpu_reduce_init<PoolType, DataFormat>()
+      SmallVector<Attribute, 2> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(), getReduceType(op.getReduceType())));
+      template_args.push_back(
+          datatypeToDataformatEnumNameOpaqueAttr(builder, op.getDataFormat()));
+      return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::SFPUReduceTileOp>) {
+      // sfpu_reduce<PoolType, DataFormat, ReduceDim>(dst_index)
+      SmallVector<Attribute, 3> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(), getReduceType(op.getReduceType())));
+      template_args.push_back(
+          datatypeToDataformatEnumNameOpaqueAttr(builder, op.getDataFormat()));
+      template_args.push_back(emitc::OpaqueAttr::get(
+          op.getContext(), getReduceDim(op.getReduceDim())));
+      return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::UnaryBcastInitOp> ||
                          std::is_same_v<SourceOp, ttkernel::UnaryBcastTileOp>) {
       SmallVector<Attribute, 1> template_args;
@@ -1361,6 +1379,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReduceInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReduceTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReduceUninitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::SFPUReduceInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::SFPUReduceTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReluTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReluTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ReluTileI32Op>,

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1618,6 +1618,46 @@ mlir::LogicalResult TileClampScalarOp::verify() {
   return success();
 }
 
+// Shared helper: `$b` (the scaler tile) is required for float-typed
+// reductions and must be absent for integer (i32) reductions which lower
+// through the SFPU path.
+template <typename OpTy>
+static mlir::LogicalResult verifyTileReduceScalerPresence(OpTy op) {
+  auto tileType = mlir::cast<mlir::tt::ttcore::TileType>(op.getA().getType());
+  mlir::Type elemType = tileType.getElementType();
+  const bool hasScaler = static_cast<bool>(op.getB());
+
+  if (mlir::isa<mlir::FloatType>(elemType)) {
+    if (!hasScaler) {
+      return op.emitOpError(
+          "requires the scaler operand `b` to be present for float element "
+          "types");
+    }
+  } else if (mlir::isa<mlir::IntegerType>(elemType)) {
+    if (hasScaler) {
+      return op.emitOpError(
+          "must not have the scaler operand `b` for integer element types "
+          "(int reductions lower through the SFPU path which ignores the "
+          "scaler)");
+    }
+  } else {
+    return op.emitOpError("unsupported element type for tile reduction");
+  }
+  return mlir::success();
+}
+
+mlir::LogicalResult TileReduceSumOp::verify() {
+  return verifyTileReduceScalerPresence(*this);
+}
+
+mlir::LogicalResult TileReduceMaxOp::verify() {
+  return verifyTileReduceScalerPresence(*this);
+}
+
+mlir::LogicalResult TileReduceMeanOp::verify() {
+  return verifyTileReduceScalerPresence(*this);
+}
+
 mlir::LogicalResult TileTilizeBlockOp::verify() {
   if (llvm::isa<mlir::tt::ttcore::TileType>(
           getElemType(getInput().getType()))) {

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1618,46 +1618,6 @@ mlir::LogicalResult TileClampScalarOp::verify() {
   return success();
 }
 
-// Shared helper: `$b` (the scaler tile) is required for float-typed
-// reductions and must be absent for integer (i32) reductions which lower
-// through the SFPU path.
-template <typename OpTy>
-static mlir::LogicalResult verifyTileReduceScalerPresence(OpTy op) {
-  auto tileType = mlir::cast<mlir::tt::ttcore::TileType>(op.getA().getType());
-  mlir::Type elemType = tileType.getElementType();
-  const bool hasScaler = static_cast<bool>(op.getB());
-
-  if (mlir::isa<mlir::FloatType>(elemType)) {
-    if (!hasScaler) {
-      return op.emitOpError(
-          "requires the scaler operand `b` to be present for float element "
-          "types");
-    }
-  } else if (mlir::isa<mlir::IntegerType>(elemType)) {
-    if (hasScaler) {
-      return op.emitOpError(
-          "must not have the scaler operand `b` for integer element types "
-          "(int reductions lower through the SFPU path which ignores the "
-          "scaler)");
-    }
-  } else {
-    return op.emitOpError("unsupported element type for tile reduction");
-  }
-  return mlir::success();
-}
-
-mlir::LogicalResult TileReduceSumOp::verify() {
-  return verifyTileReduceScalerPresence(*this);
-}
-
-mlir::LogicalResult TileReduceMaxOp::verify() {
-  return verifyTileReduceScalerPresence(*this);
-}
-
-mlir::LogicalResult TileReduceMeanOp::verify() {
-  return verifyTileReduceScalerPresence(*this);
-}
-
 mlir::LogicalResult TileTilizeBlockOp::verify() {
   if (llvm::isa<mlir::tt::ttcore::TileType>(
           getElemType(getInput().getType()))) {
@@ -1785,6 +1745,59 @@ void TileUntilizeBlockOp::getEffects(
                        true, mlir::SideEffects::DefaultResource::get());
   effects.emplace_back(mlir::MemoryEffects::Write::get(), &getOutputMutable(),
                        0, true, mlir::SideEffects::DefaultResource::get());
+}
+
+// Verifier helpers for tile reduction ops.
+//
+// FPU (`tile_reduce_*`) ops require all float operands because they lower to
+// the `reduce_tile` kernel, which is float-only. Integer reductions must use
+// the matching `tile_sfpu_reduce_*` op instead.
+namespace {
+template <typename OpT>
+static mlir::LogicalResult verifyFPUTileReduce(OpT op) {
+  auto isFloatTile = [](mlir::Value v) {
+    return mlir::isa<mlir::FloatType>(
+        mlir::cast<mlir::tt::ttcore::TileType>(v.getType()).getElementType());
+  };
+  if (!isFloatTile(op.getA()) || !isFloatTile(op.getB()) ||
+      !isFloatTile(op.getC())) {
+    return op.emitOpError("requires float tile element types; use the matching "
+                          "tile_sfpu_reduce_* op for integer reductions");
+  }
+  return mlir::success();
+}
+
+template <typename OpT>
+static mlir::LogicalResult verifySFPUTileReduce(OpT op) {
+  // The SFPU reduce lowering uses i32-only TTKernel ops (fill_tile_int,
+  // binary_max_int32_tile, add_int_tile), so restrict this op to i32 tiles.
+  auto isI32Tile = [](mlir::Value v) {
+    auto intType = mlir::dyn_cast<mlir::IntegerType>(
+        mlir::cast<mlir::tt::ttcore::TileType>(v.getType()).getElementType());
+    return intType && intType.getWidth() == 32;
+  };
+  if (!isI32Tile(op.getA()) || !isI32Tile(op.getC())) {
+    return op.emitOpError("requires 32-bit integer tile element types; use "
+                          "the matching tile_reduce_* op for float reductions");
+  }
+  return mlir::success();
+}
+} // namespace
+
+mlir::LogicalResult TileReduceSumOp::verify() {
+  return verifyFPUTileReduce(*this);
+}
+mlir::LogicalResult TileReduceMaxOp::verify() {
+  return verifyFPUTileReduce(*this);
+}
+mlir::LogicalResult TileReduceMeanOp::verify() {
+  return verifyFPUTileReduce(*this);
+}
+mlir::LogicalResult TileSFPUReduceSumOp::verify() {
+  return verifySFPUTileReduce(*this);
+}
+mlir::LogicalResult TileSFPUReduceMaxOp::verify() {
+  return verifySFPUTileReduce(*this);
 }
 
 template <typename Pred>

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1769,16 +1769,18 @@ static mlir::LogicalResult verifyFPUTileReduce(OpT op) {
 
 template <typename OpT>
 static mlir::LogicalResult verifySFPUTileReduce(OpT op) {
-  // The SFPU reduce lowering uses i32-only TTKernel ops (fill_tile_int,
-  // binary_max_int32_tile, add_int_tile), so restrict this op to i32 tiles.
-  auto isI32Tile = [](mlir::Value v) {
-    auto intType = mlir::dyn_cast<mlir::IntegerType>(
-        mlir::cast<mlir::tt::ttcore::TileType>(v.getType()).getElementType());
-    return intType && intType.getWidth() == 32;
+  // The SFPU reduce lowering uses signed i32-only TTKernel ops
+  // (fill_tile_int, binary_max_int32_tile, add_int_tile), so restrict this
+  // op to signed i32 tiles.
+  auto isSI32Tile = [](mlir::Value v) {
+    return mlir::cast<mlir::tt::ttcore::TileType>(v.getType())
+        .getElementType()
+        .isSignedInteger(32);
   };
-  if (!isI32Tile(op.getA()) || !isI32Tile(op.getC())) {
-    return op.emitOpError("requires 32-bit integer tile element types; use "
-                          "the matching tile_reduce_* op for float reductions");
+  if (!isSI32Tile(op.getA()) || !isSI32Tile(op.getC())) {
+    return op.emitOpError("requires signed 32-bit integer tile element types; "
+                          "use the matching tile_reduce_* op for float "
+                          "reductions");
   }
   return mlir::success();
 }

--- a/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeMasking.cpp
@@ -31,20 +31,52 @@ struct BoundsInterval {
   Value end;
 };
 
-static double getFillValueAsDouble(ttcore::OOBVal oobVal) {
-  switch (oobVal) {
-  case ttcore::OOBVal::Undef:
-    return 0.0;
-  case ttcore::OOBVal::Zero:
-    return 0.0;
-  case ttcore::OOBVal::One:
-    return 1.0;
-  case ttcore::OOBVal::Inf:
-    return std::numeric_limits<double>::infinity();
-  case ttcore::OOBVal::NegInf:
-    return -std::numeric_limits<double>::infinity();
+// Build an element-typed OOB fill attribute. For integer types, Inf/NegInf
+// are saturated to the representable min/max of the type.
+static TypedAttr getFillValueAttr(Builder &builder, Type elemType,
+                                  ttcore::OOBVal oobVal) {
+  if (auto floatTy = dyn_cast<FloatType>(elemType)) {
+    double v = 0.0;
+    switch (oobVal) {
+    case ttcore::OOBVal::Undef:
+    case ttcore::OOBVal::Zero:
+      v = 0.0;
+      break;
+    case ttcore::OOBVal::One:
+      v = 1.0;
+      break;
+    case ttcore::OOBVal::Inf:
+      v = std::numeric_limits<double>::infinity();
+      break;
+    case ttcore::OOBVal::NegInf:
+      v = -std::numeric_limits<double>::infinity();
+      break;
+    }
+    return builder.getFloatAttr(floatTy, v);
   }
-  return 0.0;
+  if (auto intTy = dyn_cast<IntegerType>(elemType)) {
+    unsigned w = intTy.getWidth();
+    bool isUnsigned = intTy.isUnsigned();
+    APInt v(w, 0);
+    switch (oobVal) {
+    case ttcore::OOBVal::Undef:
+    case ttcore::OOBVal::Zero:
+      break;
+    case ttcore::OOBVal::One:
+      v = APInt(w, 1);
+      break;
+    case ttcore::OOBVal::Inf:
+      v = isUnsigned ? APInt::getMaxValue(w) : APInt::getSignedMaxValue(w);
+      break;
+    case ttcore::OOBVal::NegInf:
+      v = isUnsigned ? APInt(w, 0) : APInt::getSignedMinValue(w);
+      break;
+    }
+    // arith.constant requires signless int types; TileFillOp accepts any
+    // integer so this is safe for the downstream use.
+    return builder.getIntegerAttr(IntegerType::get(builder.getContext(), w), v);
+  }
+  llvm_unreachable("unsupported element type for OOB fill");
 }
 
 /// Decompose BlockMaskOp with multi-core support.
@@ -189,9 +221,9 @@ struct DecomposeBlockMaskPattern : OpRewritePattern<BlockMaskOp> {
     Value zeroIdx = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value oneIdx = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
-    double fillValueDouble = getFillValueAsDouble(fillOOBVal);
-    Value fillScalar = rewriter.create<arith::ConstantOp>(
-        loc, elemType, rewriter.getFloatAttr(elemType, fillValueDouble));
+    TypedAttr fillAttr = getFillValueAttr(rewriter, elemType, fillOOBVal);
+    Value fillScalar =
+        rewriter.create<arith::ConstantOp>(loc, fillAttr.getType(), fillAttr);
 
     // Get this core's coordinates.
     Value coreY = rewriter.create<CoreIndexOp>(

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -34,6 +34,26 @@ namespace mlir::tt::d2m {
 
 namespace {
 
+// True iff `op` is any tile-level reduction op (FPU or SFPU variant).
+static bool isTileReductionOp(Operation *op) {
+  return mlir::isa<d2m::TileReduceMaxOp, d2m::TileReduceSumOp,
+                   d2m::TileReduceMeanOp, d2m::TileSFPUReduceMaxOp,
+                   d2m::TileSFPUReduceSumOp>(op);
+}
+
+// Stamp a pass-allocated scratch slice onto the op's `dst_scratch_index`
+// attribute for the TTKernel lowering to consume. Only supports ops that
+// need exactly one scratch slice today.
+static void setDstScratchIndex(OperandLoadStoreRegisterOpInterface computeOp,
+                               int scratchSlice) {
+  assert(computeOp.getNumDstScratchSlices() == 1 &&
+         "setDstScratchIndex supports exactly one scratch slice");
+  Operation *op = computeOp.getOperation();
+  op->setAttr("dst_scratch_index",
+              mlir::IntegerAttr::get(
+                  mlir::IntegerType::get(op->getContext(), 64), scratchSlice));
+}
+
 struct OperationTypes {
   bool hasComputeOps = false;
   bool hasLinalgGeneric = false;
@@ -871,16 +891,10 @@ public:
           if (dstRegInPlace || rhsIsScalar) {
             bool isUnaryOp = computeOp->getNumOperands() == 1;
             bool isTileMatmul = mlir::isa<d2m::TileMatmulOp>(computeOp);
-            bool isReduction = mlir::isa<d2m::TileReduceMaxOp>(computeOp) ||
-                               mlir::isa<d2m::TileReduceSumOp>(computeOp) ||
-                               mlir::isa<d2m::TileReduceMeanOp>(computeOp);
-            assert(
-                (isUnaryOp || isTileMatmul || isReduction || rhsIsScalar) &&
-                "Only unary ops, tile matmul, reductions, and tile+scalar ops "
-                "supported for destination register in place, multi-operand "
-                "ops "
-                "would reference wrong tile, but those ops should be setting "
-                "output tile.");
+            bool isReduction = isTileReductionOp(computeOp);
+            assert((isUnaryOp || isTileMatmul || isReduction || rhsIsScalar) &&
+                   "in-place DST only supported for unary, tile matmul, "
+                   "reductions, and tile+scalar ops");
             dstSlice = getInPlaceDstSlice(computeOp);
           } else if (numLoads >= 2) {
             // SFPU binary/ternary ops: output overwrites first operand's slot
@@ -906,12 +920,10 @@ public:
           if (dstRegInPlace || rhsIsScalar) {
             bool isUnaryOp = computeOp->getNumOperands() == 1;
             bool isTileMatmul = mlir::isa<d2m::TileMatmulOp>(computeOp);
-            bool isReduction = mlir::isa<d2m::TileReduceMaxOp>(computeOp) ||
-                               mlir::isa<d2m::TileReduceSumOp>(computeOp);
-            assert(
-                (isUnaryOp || isTileMatmul || isReduction || rhsIsScalar) &&
-                "Only unary ops, tile matmul, reductions, and tile+scalar ops "
-                "supported for destination register in place.");
+            bool isReduction = isTileReductionOp(computeOp);
+            assert((isUnaryOp || isTileMatmul || isReduction || rhsIsScalar) &&
+                   "in-place DST only supported for unary, tile matmul, "
+                   "reductions, and tile+scalar ops");
             dstSlice = getInPlaceDstSlice(computeOp);
           } else if (numLoads >= 2) {
             // SFPU binary/ternary ops: output overwrites first operand's slot.
@@ -960,6 +972,12 @@ public:
             dstIntermediates[computeOp] = {dstSlice, outermostInnerComputeLoop};
           }
         }
+      }
+
+      // Reserve any extra DST scratch slices the op declares via the
+      // interface so they don't collide with operand/output slots.
+      for (int64_t i = 0, n = computeOp.getNumDstScratchSlices(); i < n; ++i) {
+        setDstScratchIndex(computeOp, dstSliceAllocationState.allocate());
       }
     });
     return {copyInfos, dstIntermediates};
@@ -2005,6 +2023,13 @@ public:
           dstIntermediates[computeOp] = {allocatedIndex,
                                          outermostInnerComputeLoop};
         }
+      }
+
+      // Reserve any extra DST scratch slices the op declares via the
+      // interface so they don't collide with operand/output slots. No
+      // deallocate: the slot is logically owned by the op for its lifetime.
+      for (int64_t i = 0, n = computeOp.getNumDstScratchSlices(); i < n; ++i) {
+        setDstScratchIndex(computeOp, dstStackAllocator.allocate());
       }
     });
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess.cpp
@@ -976,6 +976,9 @@ public:
 
       // Reserve any extra DST scratch slices the op declares via the
       // interface so they don't collide with operand/output slots.
+      // TODO(https://github.com/tenstorrent/tt-mlir/issues/8081): scratch
+      // becomes the new `getCurrSliceIndex()`; safe today but a future
+      // in-region fusion would trip it.
       for (int64_t i = 0, n = computeOp.getNumDstScratchSlices(); i < n; ++i) {
         setDstScratchIndex(computeOp, dstSliceAllocationState.allocate());
       }
@@ -2028,6 +2031,9 @@ public:
       // Reserve any extra DST scratch slices the op declares via the
       // interface so they don't collide with operand/output slots. No
       // deallocate: the slot is logically owned by the op for its lifetime.
+      // TODO(https://github.com/tenstorrent/tt-mlir/issues/8081): scratch
+      // lands on `inputStack`; safe today but a future in-region fusion
+      // would trip `deallocateAllButFirstInput()`.
       for (int64_t i = 0, n = computeOp.getNumDstScratchSlices(); i < n; ++i) {
         setDstScratchIndex(computeOp, dstStackAllocator.allocate());
       }

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -256,6 +256,43 @@ static ::mlir::LogicalResult verifyPackUntilizeDims(Operation *op,
   return success();
 }
 
+// The D2M pipeline today only exercises sfpu_reduce for signed int32
+// reductions (the float path goes through reduce_tile). Restrict these ops to
+// Int32 until we grow coverage for other data formats.
+static bool isSFPUReduceTypeSupported(ttkernel::ReduceType rt) {
+  return rt == ttkernel::ReduceType::Sum || rt == ttkernel::ReduceType::Max;
+}
+static bool isSFPUReduceDataFormatSupported(ttcore::DataType dt) {
+  return dt == ttcore::DataType::Int32;
+}
+
+::mlir::LogicalResult SFPUReduceInitOp::verify() {
+  if (!isSFPUReduceTypeSupported(getReduceType())) {
+    return emitOpError("sfpu_reduce only supports reduce_type Sum or Max");
+  }
+  if (!isSFPUReduceDataFormatSupported(getDataFormat())) {
+    return emitOpError("sfpu_reduce only supports data_format Int32");
+  }
+  return success();
+}
+
+::mlir::LogicalResult SFPUReduceTileOp::verify() {
+  if (!isSFPUReduceTypeSupported(getReduceType())) {
+    return emitOpError("sfpu_reduce only supports reduce_type Sum or Max");
+  }
+  if (!isSFPUReduceDataFormatSupported(getDataFormat())) {
+    return emitOpError("sfpu_reduce only supports data_format Int32");
+  }
+  // The sfpu_reduce kernel only performs intra-tile reductions along a single
+  // dim (Row or Col). Scalar reductions must be decomposed into Col + Row by
+  // the caller.
+  if (getReduceDim() == ttkernel::ReduceDim::Scalar) {
+    return emitOpError("sfpu_reduce does not support reduce_dim Scalar; "
+                       "decompose into Col + Row");
+  }
+  return success();
+}
+
 ::mlir::LogicalResult DPrintOp::verify() {
   StringRef fmt = getFmt();
   size_t numFormatSpecifiers = fmt.count("{}");

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -19,51 +19,68 @@ pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
 
 
-def _sum_atol(shape, dtype):
-    per_elem_tol = 0.01 if dtype == torch.bfloat16 else 0.0005
-    return math.prod(shape) * per_elem_tol
-
-
-def _max_atol(dtype):
-    return 0.01 if dtype == torch.bfloat16 else 0.0
-
-
-def _mean_atol(shape, dim_arg, dtype):
-    per_elem_tol = 0.01 if dtype == torch.bfloat16 else 0.0005
-    reduction_size = math.prod(shape[d] for d in dim_arg)
-    return math.prod(shape) * per_elem_tol / reduction_size
+_INTEGER_DTYPES = (torch.int32,)
+_REDUCE_TYPES = ["sum", "max", "min", "mean"]
+_INT_REDUCE_TYPES = ["sum", "max", "min"]
+_FLOAT_DTYPES = [torch.float32, torch.bfloat16]
+_INT_DTYPES = [torch.int32]
+_DTYPE_IDS = {torch.float32: "f32", torch.bfloat16: "bf16", torch.int32: "i32"}
+_KEEP_DIMS = [True, False]
 
 
 def _reduction_atol(reduce_type: str, shape, dim_arg, dtype):
+    if dtype in _INTEGER_DTYPES:
+        return 0.0
+    per_elem_tol = 0.01 if dtype == torch.bfloat16 else 0.0005
     if reduce_type == "sum":
-        return _sum_atol(shape, dtype)
+        return math.prod(shape) * per_elem_tol
     if reduce_type == "mean":
-        return _mean_atol(shape, dim_arg, dtype)
+        reduction_size = math.prod(shape[d] for d in dim_arg)
+        return math.prod(shape) * per_elem_tol / reduction_size
     if reduce_type in ("max", "min"):
-        return _max_atol(dtype)
+        return 0.01 if dtype == torch.bfloat16 else 0.0
     raise ValueError(f"Unsupported reduce_type: {reduce_type}")
 
 
-_REDUCE_TYPES = ["sum", "max", "min", "mean"]
+# Int range small enough that reductions won't overflow int32.
+def _int_input_range(reduce_type: str, shape, dim_arg):
+    if reduce_type != "sum":
+        return -10_000, 10_000
+    reduction_size = max(1, math.prod(shape[d] for d in dim_arg))
+    bound = min(10_000, max(1, (2**31 - 1) // (8 * reduction_size)))
+    return -bound, bound
 
-_3D_OUTER_REDUCE = {
-    combo: _REDUCE_TYPES[i % len(_REDUCE_TYPES)]
-    for i, combo in enumerate(
-        (b, m, n) for b in [2, 3, 8, 16, 64] for m in [1, 2, 4, 8] for n in [1, 2, 8]
-    )
-}
 
-_4D_OUTER_REDUCE = {
-    combo: _REDUCE_TYPES[i % len(_REDUCE_TYPES)]
-    for i, combo in enumerate(
-        (a, b, m, n, d)
-        for a in [2, 3, 4, 8, 16, 32, 64]
-        for b in [2, 4, 8]
-        for m in [2]
-        for n in [4]
-        for d in [0, 1]
-    )
-}
+# Cycle reduce_type/dtype/keep_dim independently across shape/dim combos so
+# each combo gets exactly one variant (vs. full cross product).
+def _cycled_reduction_params(
+    combos,
+    *,
+    reduce_types=_REDUCE_TYPES,
+    dtypes=_FLOAT_DTYPES,
+    keep_dims=_KEEP_DIMS,
+):
+    def pick(options, i):
+        return options[i % len(options)]
+
+    params = []
+    for i, combo in enumerate(combos):
+        reduce_type = pick(reduce_types, i)
+        dtype = pick(dtypes, i)
+        keep_dim = pick(keep_dims, i)
+        ids = "-".join(
+            "_".join(map(str, x)) if isinstance(x, list) else str(x) for x in combo
+        )
+        params.append(
+            pytest.param(
+                *combo,
+                reduce_type,
+                dtype,
+                keep_dim,
+                id=f"{ids}-{reduce_type}-{_DTYPE_IDS[dtype]}-keep{int(keep_dim)}",
+            )
+        )
+    return params
 
 
 def create_reductions_constrained_inputs(
@@ -74,75 +91,122 @@ def create_reductions_constrained_inputs(
         def reductions_constrained_inputs(
             in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
         ):
-            in_tensor = torch.randn(input_shape, dtype=dtype)
-            if dtype == torch.float32:
-                # Simulate TF32 truncation in the golden computation
-                # TF32 has 10 bits mantissa vs FP32's 23 bits = ~3 decimal digits precision
-                scale = 2**13  # Roughly equivalent to TF32 precision
-                in_tensor = (in_tensor * scale).round() / scale
+            if dtype in _INTEGER_DTYPES:
+                lo, hi = _int_input_range(reduce_type, input_shape, dim_arg)
+                # torch.randint's high is exclusive.
+                in_tensor = torch.randint(lo, hi + 1, input_shape, dtype=dtype)
+            else:
+                in_tensor = torch.randn(input_shape, dtype=dtype)
+                if dtype == torch.float32:
+                    # Round golden to ~TF32 precision (10 mantissa bits).
+                    scale = 2**13
+                    in_tensor = (in_tensor * scale).round() / scale
             builder.set_goldens(inputs={in0: in_tensor})
-            if reduce_type == "sum":
-                return builder.sum(in0, dim_arg=dim_arg, keep_dim=keep_dim)
-            elif reduce_type == "max":
-                return builder.max(
-                    in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
-                )
-            elif reduce_type == "mean":
-                return builder.mean(in0, dim_arg=dim_arg, keep_dim=keep_dim)
-            elif reduce_type == "min":
-                return builder.min(
-                    in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
-                )
+
+            kwargs = {"dim_arg": dim_arg, "keep_dim": keep_dim}
+            if reduce_type in ("max", "min"):
+                kwargs["unit_attrs"] = unit_attrs
+            return getattr(builder, reduce_type)(in0, **kwargs)
 
     return module
 
 
-@pytest.mark.parametrize("m", [4, 8, 16])
-@pytest.mark.parametrize("n", [2, 4, 8])
-@pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
+_2D_SHAPE_DIM_COMBOS = [
+    (m, n, dim_arg)
+    for m in [4, 8, 16]
+    for n in [2, 4, 8]
+    for dim_arg in [[0], [1], [0, 1]]
+]
+
+
+@pytest.mark.parametrize(
+    "m,n,dim_arg,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_2D_SHAPE_DIM_COMBOS),
+)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_sum(
+def test_reduce_2d(
     m: int,
     n: int,
     dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
     keep_dim: bool,
     target: str,
-    dtype: torch.dtype,
     request,
     device,
 ):
     tile_size = 32
-    shape = (
-        m * tile_size,
-        n * tile_size,
-    )
+    shape = (m * tile_size, n * tile_size)
 
     compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "sum", dim_arg, keep_dim, dtype),
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim, dtype
+        ),
         target=target,
         **get_request_kwargs(request),
         device=device,
-        atol=_sum_atol(shape, dtype),
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
     )
 
 
-@pytest.mark.parametrize("b", [1, 2])
-@pytest.mark.parametrize("m", [4, 8])
-@pytest.mark.parametrize("n", [2, 4])
-@pytest.mark.parametrize("dim_arg", [[1], [2], [1, 2]])
-@pytest.mark.parametrize("keep_dim", [True, False])
+# Non-tile-aligned shapes exercise OOB padding (0 for sum, +/- inf for
+# max/min) so padded elements don't corrupt the reduction.
+_2D_UNALIGNED_COMBOS = [
+    (shape, dim_arg)
+    for shape in [(100, 50), (37, 61), (50, 100), (129, 65), (1, 501)]
+    for dim_arg in [[0], [1], [0, 1]]
+]
+
+
+@pytest.mark.parametrize(
+    "shape,dim_arg,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_2D_UNALIGNED_COMBOS),
+)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_sum_3d(
+def test_reduce_2d_unaligned(
+    shape: tuple,
+    dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
+    keep_dim: bool,
+    target: str,
+    request,
+    device,
+):
+    compile_and_execute_ttir(
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim, dtype
+        ),
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
+    )
+
+
+_3D_INNER_COMBOS = [
+    (b, m, n, dim_arg)
+    for b in [1, 2]
+    for m in [4, 8]
+    for n in [2, 4]
+    for dim_arg in [[1], [2], [1, 2]]
+]
+
+
+@pytest.mark.parametrize(
+    "b,m,n,dim_arg,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_3D_INNER_COMBOS),
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_reduce_3d_inner(
     b: int,
     m: int,
     n: int,
     dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
     keep_dim: bool,
     target: str,
-    dtype: torch.dtype,
     request,
     device,
 ):
@@ -152,36 +216,39 @@ def test_sum_3d(
         )
 
     tile_size = 32
-    shape = (
-        b,
-        m * tile_size,
-        n * tile_size,
-    )
+    shape = (b, m * tile_size, n * tile_size)
 
     compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "sum", dim_arg, keep_dim, dtype),
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim, dtype
+        ),
         target=target,
         **get_request_kwargs(request),
         device=device,
-        atol=_sum_atol(shape, dtype),
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
     )
 
 
-@pytest.mark.parametrize("b", [2, 3, 8, 16, 64])
-@pytest.mark.parametrize("m", [1, 2, 4, 8])
-@pytest.mark.parametrize("n", [1, 2, 8])
-@pytest.mark.parametrize("dim_arg", [[0]])
-@pytest.mark.parametrize("keep_dim", [True])
+# Outer (batch dim) reductions go through the D2M accumulation rewriter
+# instead of per-tile tile_reduce.
+_3D_OUTER_COMBOS = [
+    (b, m, n) for b in [2, 3, 8, 16, 64] for m in [1, 2, 4, 8] for n in [1, 2, 8]
+]
+
+
+@pytest.mark.parametrize(
+    "b,m,n,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_3D_OUTER_COMBOS, keep_dims=[True]),
+)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 def test_reduce_outer_3d(
     b: int,
     m: int,
     n: int,
-    dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
     keep_dim: bool,
     target: str,
-    dtype: torch.dtype,
     request,
     device,
 ):
@@ -193,13 +260,53 @@ def test_reduce_outer_3d(
             "all-reduce is missing, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
         )
 
-    reduce_type = _3D_OUTER_REDUCE[(b, m, n)]
     tile_size = 32
-    shape = (
-        b,
-        m * tile_size,
-        n * tile_size,
+    shape = (b, m * tile_size, n * tile_size)
+
+    compile_and_execute_ttir(
+        create_reductions_constrained_inputs(shape, reduce_type, [0], keep_dim, dtype),
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        atol=_reduction_atol(reduce_type, shape, [0], dtype),
     )
+
+
+_4D_INNER_COMBOS = [
+    (a, b, m, n, dim_arg)
+    for a in [1, 2]
+    for b in [1, 2]
+    for m in [4, 8]
+    for n in [2, 4]
+    for dim_arg in [[2], [3], [2, 3]]
+]
+
+
+@pytest.mark.parametrize(
+    "a,b,m,n,dim_arg,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_4D_INNER_COMBOS),
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_reduce_4d_inner(
+    a: int,
+    b: int,
+    m: int,
+    n: int,
+    dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
+    keep_dim: bool,
+    target: str,
+    request,
+    device,
+):
+    if len(dim_arg) >= 2 and not keep_dim:
+        pytest.skip(
+            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
+        )
+
+    tile_size = 32
+    shape = (a, b, m * tile_size, n * tile_size)
 
     compile_and_execute_ttir(
         create_reductions_constrained_inputs(
@@ -212,34 +319,39 @@ def test_reduce_outer_3d(
     )
 
 
-@pytest.mark.parametrize("a", [2, 3, 4, 8, 16, 32, 64])
-@pytest.mark.parametrize("b", [2, 4, 8])
-@pytest.mark.parametrize("m", [2])
-@pytest.mark.parametrize("n", [4])
-@pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True])
+_4D_OUTER_COMBOS = [
+    (a, b, dim_arg)
+    for a in [2, 3, 4, 8, 16, 32, 64]
+    for b in [2, 4, 8]
+    for dim_arg in [0, 1]
+]
+
+
+@pytest.mark.parametrize(
+    "a,b,reduce_dim,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(_4D_OUTER_COMBOS, keep_dims=[True]),
+)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
 def test_reduce_outer_4d(
     a: int,
     b: int,
-    m: int,
-    n: int,
-    dim_arg: List[int],
+    reduce_dim: int,
+    reduce_type: str,
+    dtype: torch.dtype,
     keep_dim: bool,
     target: str,
-    dtype: torch.dtype,
     request,
     device,
     system_desc,
 ):
+    m, n = 2, 4
     total_tiles = a * b * m * n
-    if dim_arg == [0] and total_tiles >= 128:
+    if reduce_dim == 0 and total_tiles >= 128:
         pytest.xfail(
             f"Outer dim 0 reduction incorrect when total input tiles ({total_tiles}) >= 128: "
             "block factor analysis splits the reduction dim, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
         )
-    if dim_arg == [1] and a == 3 and b == 4:
+    if reduce_dim == 1 and a == 3 and b == 4:
         pytest.xfail(
             "Outer dim 1 reduction incorrect for a=3, b=4: block factor "
             "analysis splits the reduction dim due to odd batch size, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
@@ -250,14 +362,39 @@ def test_reduce_outer_4d(
     if dim_arg == [1] and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
         pytest.skip("L1 OOM on non-square grid (see #8079)")
 
-    reduce_type = _4D_OUTER_REDUCE[(a, b, m, n, dim_arg[0])]
     tile_size = 32
-    shape = (
-        a,
-        b,
-        m * tile_size,
-        n * tile_size,
+    shape = (a, b, m * tile_size, n * tile_size)
+
+    compile_and_execute_ttir(
+        create_reductions_constrained_inputs(
+            shape, reduce_type, [reduce_dim], keep_dim, dtype
+        ),
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        atol=_reduction_atol(reduce_type, shape, [reduce_dim], dtype),
     )
+
+
+# Int32 reductions: inner via SFPU reduce (tile_reduce_* is float-only),
+# outer via the D2M accumulation rewriter. Mean is float-only.
+
+
+@pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
+@pytest.mark.parametrize("keep_dim", [True, False])
+@pytest.mark.parametrize("reduce_type", _INT_REDUCE_TYPES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("dtype", [torch.int32], ids=["i32"])
+def test_reduce_i32_2d(
+    dim_arg: List[int],
+    keep_dim: bool,
+    reduce_type: str,
+    target: str,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    shape = (4 * 32, 2 * 32)
 
     compile_and_execute_ttir(
         create_reductions_constrained_inputs(
@@ -270,326 +407,115 @@ def test_reduce_outer_4d(
     )
 
 
-@pytest.mark.parametrize("a", [1, 2])
-@pytest.mark.parametrize("b", [1, 2])
-@pytest.mark.parametrize("m", [4, 8])
-@pytest.mark.parametrize("n", [2, 4])
-@pytest.mark.parametrize("dim_arg", [[2], [3], [2, 3]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_sum_4d(
-    a: int,
-    b: int,
-    m: int,
-    n: int,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    if len(dim_arg) >= 2 and not keep_dim:
-        pytest.skip(
-            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
-        )
-
-    tile_size = 32
-    shape = (
-        a,
-        b,
-        m * tile_size,
-        n * tile_size,
-    )
-
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "sum", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_sum_atol(shape, dtype),
-    )
-
-
-@pytest.mark.parametrize("m", [4, 8, 16])
-@pytest.mark.parametrize("n", [2, 4, 8])
-@pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_max(
-    m: int,
-    n: int,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    tile_size = 32
-    shape = (
-        m * tile_size,
-        n * tile_size,
-    )
-
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "max", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_max_atol(dtype),
-    )
-
-
-# Unaligned shapes: dimensions that are NOT multiples of the tile size (32).
-# These exercise the OOB padding fill values — sum needs zero-fill and max
-# needs neg-inf fill so that padded elements don't corrupt the reduction.
+_2D_UNALIGNED_INT_COMBOS = [
+    (shape, dim_arg)
+    for shape in [(100, 50), (37, 61), (50, 100), (129, 65), (1, 501)]
+    for dim_arg in [[0], [1], [0, 1]]
+]
 
 
 @pytest.mark.parametrize(
-    "shape",
-    [(100, 50), (37, 61), (50, 100), (129, 65)],
+    "shape,dim_arg,reduce_type,dtype,keep_dim",
+    _cycled_reduction_params(
+        _2D_UNALIGNED_INT_COMBOS,
+        reduce_types=_INT_REDUCE_TYPES,
+        dtypes=_INT_DTYPES,
+    ),
 )
-@pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_sum_unaligned(
+def test_reduce_i32_2d_unaligned(
     shape: tuple,
     dim_arg: List[int],
+    reduce_type: str,
+    dtype: torch.dtype,
     keep_dim: bool,
     target: str,
-    dtype: torch.dtype,
     request,
     device,
 ):
     compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "sum", dim_arg, keep_dim, dtype),
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim, dtype
+        ),
         target=target,
         **get_request_kwargs(request),
         device=device,
-        atol=_sum_atol(shape, dtype),
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
     )
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [(100, 50), (37, 61), (50, 100), (129, 65)],
-)
-@pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_max_unaligned(
-    shape: tuple,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "max", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_max_atol(dtype),
-    )
-
-
-@pytest.mark.parametrize("m", [4, 8, 16])
-@pytest.mark.parametrize("n", [2, 4, 8])
-@pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_mean(
-    m: int,
-    n: int,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    tile_size = 32
-    shape = (
-        m * tile_size,
-        n * tile_size,
-    )
-
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "mean", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_mean_atol(shape, dim_arg, dtype),
-    )
-
-
-@pytest.mark.parametrize("b", [1, 2])
-@pytest.mark.parametrize("m", [4, 8])
-@pytest.mark.parametrize("n", [2, 4])
 @pytest.mark.parametrize("dim_arg", [[1], [2], [1, 2]])
-@pytest.mark.parametrize("keep_dim", [True, False])
+@pytest.mark.parametrize("reduce_type", _INT_REDUCE_TYPES)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_mean_3d(
+@pytest.mark.parametrize("dtype", [torch.int32], ids=["i32"])
+def test_reduce_i32_3d_inner(
+    dim_arg: List[int],
+    reduce_type: str,
+    target: str,
+    dtype: torch.dtype,
+    request,
+    device,
+):
+    # keep_dim is pinned to True to avoid the reshape-after-reduce issue
+    # (#6377) that affects multi-dim inner reductions.
+    shape = (2, 4 * 32, 2 * 32)
+
+    compile_and_execute_ttir(
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim=True, dtype=dtype
+        ),
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
+    )
+
+
+@pytest.mark.parametrize("b", [2, 8])
+@pytest.mark.parametrize("reduce_type", _INT_REDUCE_TYPES)
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("dtype", [torch.int32], ids=["i32"])
+def test_reduce_i32_outer_3d(
     b: int,
-    m: int,
-    n: int,
-    dim_arg: List[int],
-    keep_dim: bool,
+    reduce_type: str,
     target: str,
     dtype: torch.dtype,
     request,
     device,
 ):
-    if len(dim_arg) >= 2 and not keep_dim:
-        pytest.skip(
-            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
-        )
-
-    tile_size = 32
-    shape = (
-        b,
-        m * tile_size,
-        n * tile_size,
-    )
+    shape = (b, 2 * 32, 2 * 32)
 
     compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "mean", dim_arg, keep_dim, dtype),
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg=[0], keep_dim=True, dtype=dtype
+        ),
         target=target,
         **get_request_kwargs(request),
         device=device,
-        atol=_mean_atol(shape, dim_arg, dtype),
+        atol=_reduction_atol(reduce_type, shape, [0], dtype),
     )
 
 
-@pytest.mark.parametrize("a", [1, 2])
-@pytest.mark.parametrize("b", [1, 2])
-@pytest.mark.parametrize("m", [4, 8])
-@pytest.mark.parametrize("n", [2, 4])
-@pytest.mark.parametrize("dim_arg", [[2], [3], [2, 3]])
-@pytest.mark.parametrize("keep_dim", [True, False])
+@pytest.mark.parametrize("dim_arg", [[2], [3]])
+@pytest.mark.parametrize("reduce_type", _INT_REDUCE_TYPES)
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_mean_4d(
-    a: int,
-    b: int,
-    m: int,
-    n: int,
+@pytest.mark.parametrize("dtype", [torch.int32], ids=["i32"])
+def test_reduce_i32_4d_inner(
     dim_arg: List[int],
-    keep_dim: bool,
+    reduce_type: str,
     target: str,
     dtype: torch.dtype,
     request,
     device,
 ):
-    if len(dim_arg) >= 2 and not keep_dim:
-        pytest.skip(
-            "keep_dim=False not supported for multi-dim reductions on inner 2 dims because the reshape after the reduction is unsupported due to noc issue: https://github.com/tenstorrent/tt-mlir/issues/6377"
-        )
-
-    tile_size = 32
-    shape = (
-        a,
-        b,
-        m * tile_size,
-        n * tile_size,
-    )
+    shape = (2, 2, 4 * 32, 2 * 32)
 
     compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "mean", dim_arg, keep_dim, dtype),
+        create_reductions_constrained_inputs(
+            shape, reduce_type, dim_arg, keep_dim=True, dtype=dtype
+        ),
         target=target,
         **get_request_kwargs(request),
         device=device,
-        atol=_mean_atol(shape, dim_arg, dtype),
-    )
-
-
-@pytest.mark.parametrize(
-    "shape",
-    [(100, 50), (37, 61), (50, 100), (129, 65)],
-)
-@pytest.mark.parametrize("dim_arg", [[0], [1], [0, 1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_mean_unaligned(
-    shape: tuple,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "mean", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_mean_atol(shape, dim_arg, dtype),
-    )
-
-
-@pytest.mark.parametrize("m", [4, 8, 16])
-@pytest.mark.parametrize("n", [2, 4, 8])
-@pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_min(
-    m: int,
-    n: int,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    tile_size = 32
-    shape = (
-        m * tile_size,
-        n * tile_size,
-    )
-
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "min", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_max_atol(dtype),
-    )
-
-
-@pytest.mark.parametrize(
-    "shape",
-    [(100, 50), (37, 61), (50, 100), (129, 65)],
-)
-@pytest.mark.parametrize("dim_arg", [[0], [1]])
-@pytest.mark.parametrize("keep_dim", [True, False])
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
-def test_min_unaligned(
-    shape: tuple,
-    dim_arg: List[int],
-    keep_dim: bool,
-    target: str,
-    dtype: torch.dtype,
-    request,
-    device,
-):
-    compile_and_execute_ttir(
-        create_reductions_constrained_inputs(shape, "min", dim_arg, keep_dim, dtype),
-        target=target,
-        **get_request_kwargs(request),
-        device=device,
-        atol=_max_atol(dtype),
+        atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
     )

--- a/test/python/golden/test_metal_reductions.py
+++ b/test/python/golden/test_metal_reductions.py
@@ -356,10 +356,10 @@ def test_reduce_outer_4d(
             "Outer dim 1 reduction incorrect for a=3, b=4: block factor "
             "analysis splits the reduction dim due to odd batch size, issue here: https://github.com/tenstorrent/tt-mlir/issues/7895"
         )
-    # TODO(#8079): (a=3, b=8, dim_arg=[1]) fails on p150 with L1 OOM on the
+    # TODO(#8079): (a=3, b=8, reduce_dim=1) fails on p150 with L1 OOM on the
     # non-square 10x13 grid. Re-enable once grid selection handles non-square
     # grids without inflating per-core L1.
-    if dim_arg == [1] and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
+    if reduce_dim == 1 and a == 3 and b == 8 and get_board_id(system_desc) == "p150":
         pytest.skip("L1 OOM on non-square grid (see #8079)")
 
     tile_size = 32

--- a/test/ttmlir/Conversion/D2MToTTKernel/reduce_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/reduce_ops.mlir
@@ -1,0 +1,153 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttmetal-fe-pipeline --ttir-to-ttmetal-me-pipeline --convert-d2m-to-ttkernel %s | FileCheck %s
+
+// Float reductions lower via the FPU reduce_tile kernel (3-operand form
+// with a scaler tile materialized by tile_fill).
+
+!ttype_f32 = tensor<128x96xf32>
+// CHECK-LABEL: func.func @test_sum_f32
+func.func @test_sum_f32(%in: !ttype_f32) -> (tensor<128x1xf32>) {
+  // CHECK: ttkernel.fill_tile
+  // CHECK: ttkernel.reduce_init
+  // CHECK: ttkernel.reduce_tile
+  %0 = "ttir.sum"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_f32) -> tensor<128x1xf32>
+  return %0 : tensor<128x1xf32>
+}
+
+// -----
+
+!ttype_f32 = tensor<128x96xf32>
+// CHECK-LABEL: func.func @test_max_f32
+func.func @test_max_f32(%in: !ttype_f32) -> (tensor<128x1xf32>) {
+  // CHECK: ttkernel.fill_tile
+  // CHECK: ttkernel.reduce_init
+  // CHECK: ttkernel.reduce_tile
+  %0 = "ttir.max"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_f32) -> tensor<128x1xf32>
+  return %0 : tensor<128x1xf32>
+}
+
+// -----
+
+!ttype_f32 = tensor<128x96xf32>
+// CHECK-LABEL: func.func @test_mean_f32
+func.func @test_mean_f32(%in: !ttype_f32) -> (tensor<128x1xf32>) {
+  // CHECK: ttkernel.fill_tile
+  // CHECK: ttkernel.reduce_init
+  // CHECK: ttkernel.reduce_tile
+  %0 = "ttir.mean"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_f32) -> tensor<128x1xf32>
+  return %0 : tensor<128x1xf32>
+}
+
+// -----
+
+// Integer reductions lower via the SFPU sfpu_reduce kernel (no scaler tile,
+// identity seed + accumulator for inter-tile accumulation).
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_sum_i32
+func.func @test_sum_i32(%in: !ttype_i32) -> (tensor<128x1xsi32>) {
+  // CHECK-NOT: ttkernel.reduce_tile
+  // Identity (0) is seeded into DST via fill_tile_int.
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce
+  // Accumulator across tiles uses add_int_tile for sum.
+  // CHECK: ttkernel.add_int_tile_init
+  // CHECK: ttkernel.add_int_tile(
+  %0 = "ttir.sum"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<128x1xsi32>
+  return %0 : tensor<128x1xsi32>
+}
+
+// -----
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_max_i32
+func.func @test_max_i32(%in: !ttype_i32) -> (tensor<128x1xsi32>) {
+  // CHECK-NOT: ttkernel.reduce_tile
+  // Identity (INT_MIN) is seeded into DST via fill_tile_int.
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce
+  // Accumulator across tiles uses binary_max_int32_tile for max.
+  // CHECK: ttkernel.binary_max_int32_tile_init
+  // CHECK: ttkernel.binary_max_int32_tile(
+  %0 = "ttir.max"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<128x1xsi32>
+  return %0 : tensor<128x1xsi32>
+}
+
+// -----
+
+// i32 sum reducing the second-to-last dim exercises reduce_dim C.
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_sum_i32_C
+func.func @test_sum_i32_C(%in: !ttype_i32) -> (tensor<1x96xsi32>) {
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_sum>, <{{.*}}>, <reduce_dim_col>)
+  // CHECK: ttkernel.add_int_tile(
+  %0 = "ttir.sum"(%in) <{dim_arg = [-2 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<1x96xsi32>
+  return %0 : tensor<1x96xsi32>
+}
+
+// -----
+
+// i32 max reducing the last dim exercises reduce_dim R.
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_max_i32_R
+func.func @test_max_i32_R(%in: !ttype_i32) -> (tensor<128x1xsi32>) {
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_max>, <{{.*}}>, <reduce_dim_row>)
+  // CHECK: ttkernel.binary_max_int32_tile(
+  %0 = "ttir.max"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<128x1xsi32>
+  return %0 : tensor<128x1xsi32>
+}
+
+// -----
+
+// i32 reduce over both inner dims (RC) → the SFPU rewriter decomposes
+// ReduceDim::Scalar into two sfpu_reduce kernels (Col then Row).
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_sum_i32_RC
+func.func @test_sum_i32_RC(%in: !ttype_i32) -> (tensor<1x1xsi32>) {
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_sum>, <{{.*}}>, <reduce_dim_col>)
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_sum>, <{{.*}}>, <reduce_dim_row>)
+  // CHECK: ttkernel.add_int_tile(
+  %0 = "ttir.sum"(%in) <{dim_arg = [-2 : i32, -1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<1x1xsi32>
+  return %0 : tensor<1x1xsi32>
+}
+
+// -----
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_max_i32_RC
+func.func @test_max_i32_RC(%in: !ttype_i32) -> (tensor<1x1xsi32>) {
+  // CHECK: ttkernel.fill_tile_int
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_max>, <{{.*}}>, <reduce_dim_col>)
+  // CHECK: ttkernel.sfpu_reduce({{.*}}, <reduce_max>, <{{.*}}>, <reduce_dim_row>)
+  // CHECK: ttkernel.binary_max_int32_tile(
+  %0 = "ttir.max"(%in) <{dim_arg = [-2 : i32, -1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<1x1xsi32>
+  return %0 : tensor<1x1xsi32>
+}
+
+// -----
+
+// i32 min decomposes to neg → max → neg, so we still see the SFPU reduce_max
+// sequence, surrounded by negative int tile ops.
+
+!ttype_i32 = tensor<128x96xsi32>
+// CHECK-LABEL: func.func @test_min_i32
+func.func @test_min_i32(%in: !ttype_i32) -> (tensor<128x1xsi32>) {
+  // CHECK: ttkernel.negative_tile_int32
+  // CHECK: ttkernel.sfpu_reduce_init
+  // CHECK: ttkernel.sfpu_reduce
+  // CHECK: ttkernel.binary_max_int32_tile(
+  // CHECK: ttkernel.negative_tile_int32
+  %0 = "ttir.min"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<128x1xsi32>
+  return %0 : tensor<128x1xsi32>
+}

--- a/test/ttmlir/Conversion/TTIRToD2M/reduction_i32.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/reduction_i32.mlir
@@ -1,0 +1,82 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-decompose-min-reduction --ttir-to-d2m --d2m-materialize-view-returns -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Integer reductions lower to the SFPU tile_sfpu_reduce_* ops (no scaler tile).
+
+module {
+
+  // i32 sum on last dim → d2m.tile_sfpu_reduce_sum with reduce_dim R; no scaler tile_fill.
+  // CHECK-LABEL: func @sum_i32_reduce_R
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #reduction]
+  // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "reduction"]
+  // CHECK: d2m.tile_sfpu_reduce_sum{{.+}}d2m<reduce_dim R>
+  // CHECK-NOT: d2m.tile_reduce_sum
+  func.func @sum_i32_reduce_R(%arg: tensor<128x96xsi32>) -> tensor<128x1xsi32> {
+    %0 = "ttir.sum"(%arg) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<128x96xsi32>) -> tensor<128x1xsi32>
+    return %0 : tensor<128x1xsi32>
+  }
+
+  // i32 sum on second-to-last dim → reduce_dim C.
+  // CHECK-LABEL: func @sum_i32_reduce_C
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.tile_sfpu_reduce_sum{{.+}}d2m<reduce_dim C>
+  func.func @sum_i32_reduce_C(%arg: tensor<128x96xsi32>) -> tensor<1x96xsi32> {
+    %0 = "ttir.sum"(%arg) <{dim_arg = [-2 : i32], keep_dim = true}> : (tensor<128x96xsi32>) -> tensor<1x96xsi32>
+    return %0 : tensor<1x96xsi32>
+  }
+
+  // i32 max on last dim → d2m.tile_sfpu_reduce_max.
+  // CHECK-LABEL: func @max_i32_reduce_R
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.tile_sfpu_reduce_max{{.+}}d2m<reduce_dim R>
+  // CHECK-NOT: d2m.tile_reduce_max
+  func.func @max_i32_reduce_R(%arg: tensor<128x96xsi32>) -> tensor<128x1xsi32> {
+    %0 = "ttir.max"(%arg) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<128x96xsi32>) -> tensor<128x1xsi32>
+    return %0 : tensor<128x1xsi32>
+  }
+
+  // i32 min decomposes to neg → max → neg via --ttir-decompose-min-reduction,
+  // so we still end up with an SFPU max reduce surrounded by tile_negative.
+  // CHECK-LABEL: func @min_i32_reduce_R
+  // CHECK: d2m.tile_negative
+  // CHECK: d2m.tile_sfpu_reduce_max{{.+}}d2m<reduce_dim R>
+  // CHECK: d2m.tile_negative
+  func.func @min_i32_reduce_R(%arg: tensor<128x96xsi32>) -> tensor<128x1xsi32> {
+    %0 = "ttir.min"(%arg) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<128x96xsi32>) -> tensor<128x1xsi32>
+    return %0 : tensor<128x1xsi32>
+  }
+
+  // 3D i32 sum reducing last dim (R): tensor<32x1x8192xsi32> -> tensor<32x1x1xsi32>
+  // CHECK-LABEL: func @sum_i32_3d_reduce_last
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
+  // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "parallel", "reduction"]
+  // CHECK: d2m.tile_sfpu_reduce_sum{{.+}}d2m<reduce_dim R>
+  func.func @sum_i32_3d_reduce_last(%arg0: tensor<32x1x8192xsi32>) -> tensor<32x1x1xsi32> {
+    %0 = "ttir.sum"(%arg0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x1x8192xsi32>) -> tensor<32x1x1xsi32>
+    return %0 : tensor<32x1x1xsi32>
+  }
+
+  // 3D i32 sum reducing both inner dims (RC): tensor<32x128x96xsi32> -> tensor<32x1x1xsi32>
+  // CHECK-LABEL: func @sum_i32_3d_reduce_both_inner
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #reduction, #reduction]
+  // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "reduction", "reduction"]
+  // CHECK: d2m.tile_sfpu_reduce_sum{{.+}}d2m<reduce_dim RC>
+  func.func @sum_i32_3d_reduce_both_inner(%arg0: tensor<32x128x96xsi32>) -> tensor<32x1x1xsi32> {
+    %0 = "ttir.sum"(%arg0) <{dim_arg = [1 : i32, 2 : i32], keep_dim = true}> : (tensor<32x128x96xsi32>) -> tensor<32x1x1xsi32>
+    return %0 : tensor<32x1x1xsi32>
+  }
+
+  // 3D i32 max reducing second-to-last dim (C).
+  // CHECK-LABEL: func @max_i32_3d_reduce_C
+  // CHECK-NOT: d2m.tile_fill
+  // CHECK: d2m.generic{{.+}}iterator_types = [#parallel, #reduction, #parallel]
+  // CHECK: linalg.generic{{.+}}iterator_types = ["parallel", "reduction", "parallel"]
+  // CHECK: d2m.tile_sfpu_reduce_max{{.+}}d2m<reduce_dim C>
+  func.func @max_i32_3d_reduce_C(%arg0: tensor<32x8192x1xsi32>) -> tensor<32x1x1xsi32> {
+    %0 = "ttir.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<32x8192x1xsi32>) -> tensor<32x1x1xsi32>
+    return %0 : tensor<32x1x1xsi32>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/generic/generic_region_ops.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_region_ops.mlir
@@ -39,6 +39,66 @@ func.func @reduce_max(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> t
     return %1 : tensor<64x128xf32>
   }
 
+func.func @sfpu_reduce_sum(%arg0: tensor<64x128xsi32>) -> tensor<64x128xsi32> {
+    %0 = d2m.empty() : tensor<64x128xsi32>
+    %1 = "d2m.generic"(%arg0, %0) <{
+        block_factors = [1, 1],
+        grid = #ttcore.grid<1x1>,
+        indexing_maps = [#map, #map],
+        iterator_types = [#parallel, #parallel],
+        threads = [#d2m.thread<compute>],
+        operandSegmentSizes = array<i32: 1, 1, 0>
+        }> ({
+        ^bb0:
+            %cb2 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+            %cb3 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+            %arg2 = d2m.wait %cb2 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+            %arg4 = d2m.reserve %cb3 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+            %result = linalg.generic {
+                indexing_maps = [#map, #map],
+                iterator_types = ["parallel", "parallel"]}
+                ins(%arg2: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>)
+                outs(%arg4: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>) {
+                ^bb0(%a: !ttcore.tile<32x32, si32>, %c: !ttcore.tile<32x32, si32>):
+                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_sum"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{reduce_dim = #d2m<reduce_dim R>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    %4 = "d2m.tile_sfpu_reduce_sum" (%a, %c) {reduce_dim = #d2m<reduce_dim R>} : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    linalg.yield %4: !ttcore.tile<32x32, si32>
+            } -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+        d2m.yield %0 : (tensor<64x128xsi32>)
+        }) : (tensor<64x128xsi32>, tensor<64x128xsi32>) -> tensor<64x128xsi32>
+    return %1 : tensor<64x128xsi32>
+  }
+
+func.func @sfpu_reduce_max(%arg0: tensor<64x128xsi32>) -> tensor<64x128xsi32> {
+    %0 = d2m.empty() : tensor<64x128xsi32>
+    %1 = "d2m.generic"(%arg0, %0) <{
+        block_factors = [1, 1],
+        grid = #ttcore.grid<1x1>,
+        indexing_maps = [#map, #map],
+        iterator_types = [#parallel, #parallel],
+        threads = [#d2m.thread<compute>],
+        operandSegmentSizes = array<i32: 1, 1, 0>
+        }> ({
+        ^bb0:
+            %cb2 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+            %cb3 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+            %arg2 = d2m.wait %cb2 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+            %arg4 = d2m.reserve %cb3 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+            %result = linalg.generic {
+                indexing_maps = [#map, #map],
+                iterator_types = ["parallel", "parallel"]}
+                ins(%arg2: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>)
+                outs(%arg4: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>) {
+                ^bb0(%a: !ttcore.tile<32x32, si32>, %c: !ttcore.tile<32x32, si32>):
+                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_max"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{reduce_dim = #d2m<reduce_dim C>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    %4 = "d2m.tile_sfpu_reduce_max" (%a, %c) {reduce_dim = #d2m<reduce_dim C>} : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    linalg.yield %4: !ttcore.tile<32x32, si32>
+            } -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+        d2m.yield %0 : (tensor<64x128xsi32>)
+        }) : (tensor<64x128xsi32>, tensor<64x128xsi32>) -> tensor<64x128xsi32>
+    return %1 : tensor<64x128xsi32>
+  }
+
 func.func @reduce_mean(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     %0 = d2m.empty() : tensor<64x128xf32>
     %1 = "d2m.generic"(%arg0, %arg1, %0) <{

--- a/test/ttmlir/Dialect/D2M/generic/generic_region_ops.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_region_ops.mlir
@@ -60,7 +60,7 @@ func.func @sfpu_reduce_sum(%arg0: tensor<64x128xsi32>) -> tensor<64x128xsi32> {
                 ins(%arg2: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>)
                 outs(%arg4: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>) {
                 ^bb0(%a: !ttcore.tile<32x32, si32>, %c: !ttcore.tile<32x32, si32>):
-                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_sum"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{reduce_dim = #d2m<reduce_dim R>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_sum"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{dst_scratch_index = -1 : i64, reduce_dim = #d2m<reduce_dim R>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
                     %4 = "d2m.tile_sfpu_reduce_sum" (%a, %c) {reduce_dim = #d2m<reduce_dim R>} : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
                     linalg.yield %4: !ttcore.tile<32x32, si32>
             } -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
@@ -90,7 +90,7 @@ func.func @sfpu_reduce_max(%arg0: tensor<64x128xsi32>) -> tensor<64x128xsi32> {
                 ins(%arg2: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>)
                 outs(%arg4: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>) {
                 ^bb0(%a: !ttcore.tile<32x32, si32>, %c: !ttcore.tile<32x32, si32>):
-                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_max"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{reduce_dim = #d2m<reduce_dim C>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                    // CHECK: %{{[0-9]+}} = "d2m.tile_sfpu_reduce_max"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{dst_scratch_index = -1 : i64, reduce_dim = #d2m<reduce_dim C>}> : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
                     %4 = "d2m.tile_sfpu_reduce_max" (%a, %c) {reduce_dim = #d2m<reduce_dim C>} : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
                     linalg.yield %4: !ttcore.tile<32x32, si32>
             } -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>

--- a/test/ttmlir/Dialect/D2M/generic/generic_region_ops_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_region_ops_negative.mlir
@@ -75,3 +75,81 @@ func.func @reduce_mean_missing_dim(%arg0: tensor<64x128xf32>, %arg1: tensor<64x1
       }) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#l1_alias = #ttcore.memory_space<l1>
+
+// FPU tile_reduce_* ops are float-only; using an integer tile must fail verification.
+func.func @reduce_sum_rejects_int(%arg0: tensor<64x128xsi32>, %arg1: tensor<64x128xsi32>) -> tensor<64x128xsi32> {
+  %0 = d2m.empty() : tensor<64x128xsi32>
+  %1 = "d2m.generic"(%arg0, %arg1, %0) <{
+      block_factors = [1, 1],
+      grid = #ttcore.grid<1x1>,
+      indexing_maps = [#map, #map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<compute>],
+      operandSegmentSizes = array<i32: 2, 1, 0>
+      }> ({
+      ^bb0:
+          %cb0 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+          %cb1 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+          %cb2 = d2m.get_cb(2) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>>
+          %arg2 = d2m.wait %cb0 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+          %arg3 = d2m.wait %cb1 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+          %arg4 = d2m.reserve %cb2 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>
+          linalg.generic {
+              indexing_maps = [#map, #map, #map],
+              iterator_types = ["parallel", "parallel"]
+              }
+              ins(%arg2, %arg3: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>, tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>)
+              outs(%arg4: tensor<2x4x!ttcore.tile<32x32, si32>, #l1_alias>) {
+              ^bb0(%a: !ttcore.tile<32x32, si32>, %b: !ttcore.tile<32x32, si32>, %c: !ttcore.tile<32x32, si32>):
+                  // CHECK: error: 'd2m.tile_reduce_sum' op requires float tile element types
+                  %4 = "d2m.tile_reduce_sum" (%a, %b, %c) {reduce_dim = #d2m<reduce_dim R>} : (!ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>, !ttcore.tile<32x32, si32>) -> !ttcore.tile<32x32, si32>
+                  linalg.yield %4: !ttcore.tile<32x32, si32>
+              }
+      d2m.yield %0 : (tensor<64x128xsi32>)
+      }) : (tensor<64x128xsi32>, tensor<64x128xsi32>, tensor<64x128xsi32>) -> tensor<64x128xsi32>
+  return %1 : tensor<64x128xsi32>
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #ttcore.iterator_type<parallel>
+#l1_alias = #ttcore.memory_space<l1>
+
+// SFPU tile_sfpu_reduce_* ops are integer-only; using a float tile must fail verification.
+func.func @sfpu_reduce_max_rejects_float(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = d2m.empty() : tensor<64x128xf32>
+  %1 = "d2m.generic"(%arg0, %0) <{
+      block_factors = [1, 1],
+      grid = #ttcore.grid<1x1>,
+      indexing_maps = [#map, #map],
+      iterator_types = [#parallel, #parallel],
+      threads = [#d2m.thread<compute>],
+      operandSegmentSizes = array<i32: 1, 1, 0>
+      }> ({
+      ^bb0:
+          %cb0 = d2m.get_cb(0) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>>
+          %cb1 = d2m.get_cb(1) : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>>
+          %arg2 = d2m.wait %cb0 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>
+          %arg4 = d2m.reserve %cb1 : !d2m.cb<tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>> -> tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>
+          linalg.generic {
+              indexing_maps = [#map, #map],
+              iterator_types = ["parallel", "parallel"]
+              }
+              ins(%arg2: tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>)
+              outs(%arg4: tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>) {
+              ^bb0(%a: !ttcore.tile<32x32, f32>, %c: !ttcore.tile<32x32, f32>):
+                  // CHECK: error: 'd2m.tile_sfpu_reduce_max' op requires 32-bit integer tile element types
+                  %4 = "d2m.tile_sfpu_reduce_max" (%a, %c) {reduce_dim = #d2m<reduce_dim R>} : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+                  linalg.yield %4: !ttcore.tile<32x32, f32>
+              }
+      d2m.yield %0 : (tensor<64x128xf32>)
+      }) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}

--- a/test/ttmlir/Dialect/D2M/generic/generic_region_ops_negative.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/generic_region_ops_negative.mlir
@@ -145,7 +145,7 @@ func.func @sfpu_reduce_max_rejects_float(%arg0: tensor<64x128xf32>) -> tensor<64
               ins(%arg2: tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>)
               outs(%arg4: tensor<2x4x!ttcore.tile<32x32, f32>, #l1_alias>) {
               ^bb0(%a: !ttcore.tile<32x32, f32>, %c: !ttcore.tile<32x32, f32>):
-                  // CHECK: error: 'd2m.tile_sfpu_reduce_max' op requires 32-bit integer tile element types
+                  // CHECK: error: 'd2m.tile_sfpu_reduce_max' op requires signed 32-bit integer tile element types
                   %4 = "d2m.tile_sfpu_reduce_max" (%a, %c) {reduce_dim = #d2m<reduce_dim R>} : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
                   linalg.yield %4: !ttcore.tile<32x32, f32>
               }


### PR DESCRIPTION
### Problem description
Need this for llms as there's an i32 sum.

### What's changed
- Added ttkernel ops for `sfpu_reduce` and `sfpu_reduce_init` and d2m ops for reducing integers since they go down the sfpu path, not fpu.
- Add handling for int32 for writing padding in experimental llks
- Integer handling in `decomposeMasking.cpp`
- Added builder tests for i32 including unaligned. Also adding deterministic cycling between attrs like keep_dim, dtype, reduce_dim to not bloat test suite
- Added lit tests for all extensions to reductions

### Checklist
- [ ] New/Existing tests provide coverage for changes
