### PR TITLE
[StableHLO] Handle GatherOp in complex-data-type-conversion pass

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -337,53 +337,6 @@ public:
   }
 };
 
-// Rewrites stablehlo::GatherOp on complex tensors: operand/result become
-// ...x2xf32 and slice_sizes gains a trailing 2 (gather full real+imag pair).
-class ComplexGatherOpConversionPattern
-    : public OpConversionPattern<mlir::stablehlo::GatherOp> {
-  using OpConversionPattern<mlir::stablehlo::GatherOp>::OpConversionPattern;
-
-public:
-  LogicalResult matchAndRewrite(
-      mlir::stablehlo::GatherOp op,
-      OpConversionPattern<mlir::stablehlo::GatherOp>::OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
-    auto origResultType =
-        mlir::dyn_cast<RankedTensorType>(op.getResult().getType());
-    if (!origResultType ||
-        !mlir::isa<mlir::ComplexType>(origResultType.getElementType())) {
-      return failure();
-    }
-
-    auto newResultType = mlir::cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getResult().getType()));
-
-    auto origOperandType =
-        mlir::cast<RankedTensorType>(op.getOperand().getType());
-
-    SmallVector<int64_t> newSliceSizes(op.getSliceSizes().begin(),
-                                       op.getSliceSizes().end());
-    newSliceSizes.push_back(2);
-
-    auto dimNums = op.getDimensionNumbersAttr();
-    SmallVector<int64_t> newOffsetDims(dimNums.getOffsetDims().begin(),
-                                       dimNums.getOffsetDims().end());
-    // Pre-conversion rank indexes the trailing real/imag dim (size 2) appended
-    // after lowering (e.g. 512x24 complex -> 512x24x2xf32).
-    newOffsetDims.push_back(origOperandType.getRank());
-    auto newDimNums = mlir::stablehlo::GatherDimensionNumbersAttr::get(
-        rewriter.getContext(), newOffsetDims, dimNums.getCollapsedSliceDims(),
-        dimNums.getOperandBatchingDims(), dimNums.getStartIndicesBatchingDims(),
-        dimNums.getStartIndexMap(), dimNums.getIndexVectorDim());
-
-    rewriter.replaceOpWithNewOp<mlir::stablehlo::GatherOp>(
-        op, newResultType, adaptor.getOperand(), adaptor.getStartIndices(),
-        newDimNums, rewriter.getDenseI64ArrayAttr(newSliceSizes),
-        op.getIndicesAreSortedAttr());
-    return success();
-  }
-};
-
 // Rewrites stablehlo::SliceOp with complex-typed tensor results by appending
 // a full-range slice (0:2:1) for the trailing real/imag dimension.
 class ComplexSliceOpConversionPattern
@@ -553,8 +506,8 @@ struct StableHLOComplexDataTypeConversionPass
     target.addDynamicallyLegalOp<
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::GatherOp,
-        mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp,
-        mlir::stablehlo::GatherOp>(isNotComplexType);
+        mlir::stablehlo::ConcatenateOp,
+        mlir::stablehlo::BroadcastInDimOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
                         mlir::stablehlo::ImagOp>();

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -214,6 +214,53 @@ public:
 };
 } // namespace
 
+// Rewrites stablehlo::GatherOp with a complex-typed result by:
+//   1. Appending 2 to slice_sizes (gather the full float-pair trailing dim).
+//   2. Appending the new trailing result dimension index to offset_dims.
+namespace {
+class ComplexGatherOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::GatherOp> {
+  using OpConversionPattern<mlir::stablehlo::GatherOp>::OpConversionPattern;
+
+public:
+  LogicalResult matchAndRewrite(
+      mlir::stablehlo::GatherOp op,
+      OpConversionPattern<mlir::stablehlo::GatherOp>::OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto newResultType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+    // If the type converter did not change the result type, the operand is not
+    // complex-typed and this pattern does not apply.
+    if (newResultType == op.getResult().getType()) {
+      return failure();
+    }
+
+    // Append 2 to slice_sizes: the new trailing float-pair dim is fully
+    // gathered
+    SmallVector<int64_t> newSliceSizes(op.getSliceSizes().begin(),
+                                       op.getSliceSizes().end());
+    newSliceSizes.push_back(2);
+
+    // The new trailing result dim is an offset dim (not batch or collapsed)
+    auto dimNums = op.getDimensionNumbers();
+    SmallVector<int64_t> newOffsetDims(dimNums.getOffsetDims().begin(),
+                                       dimNums.getOffsetDims().end());
+    newOffsetDims.push_back(newResultType.getRank() - 1);
+
+    auto newDimNums = mlir::stablehlo::GatherDimensionNumbersAttr::get(
+        rewriter.getContext(), newOffsetDims, dimNums.getCollapsedSliceDims(),
+        dimNums.getOperandBatchingDims(), dimNums.getStartIndicesBatchingDims(),
+        dimNums.getStartIndexMap(), dimNums.getIndexVectorDim());
+
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::GatherOp>(
+        op, newResultType, adaptor.getOperand(), adaptor.getStartIndices(),
+        newDimNums, rewriter.getDenseI64ArrayAttr(newSliceSizes),
+        op.getIndicesAreSorted());
+    return success();
+  }
+};
+} // namespace
+
 // Rewrites ops that produce complex-typed tensors to operate on the equivalent
 // unpacked real representation (trailing dim of size 2).
 namespace {
@@ -506,8 +553,8 @@ struct StableHLOComplexDataTypeConversionPass
     target.addDynamicallyLegalOp<
         mlir::stablehlo::ConstantOp, mlir::stablehlo::ReshapeOp,
         mlir::stablehlo::SliceOp, mlir::stablehlo::GatherOp,
-        mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp>(
-        isNotComplexType);
+        mlir::stablehlo::ConcatenateOp, mlir::stablehlo::BroadcastInDimOp,
+        mlir::stablehlo::GatherOp>(isNotComplexType);
 
     target.addIllegalOp<mlir::stablehlo::ComplexOp, mlir::stablehlo::RealOp,
                         mlir::stablehlo::ImagOp>();

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/pixtral_rope.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/pixtral_rope.mlir
@@ -1,0 +1,66 @@
+// RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion -o %t %s
+// RUN: FileCheck %s --input-file=%t
+// REQUIRES: stablehlo
+
+// Pixtral/Mistral-Small vision encoder 2D RoPE pattern.
+//
+// freqs_cis is a (H x W x head_dim/2) complex position cache gathered by
+// flattened (H*W) patch position indices before being applied to Q and K.
+//
+// This test verifies that GatherOp on a complex-typed operand is correctly
+// converted by the stablehlo-complex-data-type-conversion pass:
+//   - operand: tensor<110x110x32xcomplex<f32>> -> tensor<110x110x32x2xf32>
+//   - slice_sizes: [1, 1, 32] -> [1, 1, 32, 2]
+//   - offset_dims: [1]        -> [1, 2]
+//   - result:  tensor<12100x32xcomplex<f32>>  -> tensor<12100x32x2xf32>
+
+// CHECK-LABEL: func.func @pixtral_rope_gather(
+// CHECK-SAME:    %arg0: tensor<110x110x32x2xf32>
+func.func @pixtral_rope_gather(
+    %freqs_cis: tensor<110x110x32xcomplex<f32>>,
+    %positions: tensor<12100x2xi64>,
+    %xq: tensor<1x12100x16x64xf32>
+) -> tensor<1x12100x16x64xf32> {
+  // Gather freqs_cis at all 12100 patch positions -> tensor<12100x32xcomplex<f32>>
+  // CHECK: stablehlo.gather
+  // CHECK-SAME: offset_dims = [1, 2]
+  // CHECK-SAME: slice_sizes = array<i64: 1, 1, 32, 2>
+  // CHECK-SAME: (tensor<110x110x32x2xf32>, tensor<12100x2xi64>) -> tensor<12100x32x2xf32>
+  %0 = "stablehlo.gather"(%freqs_cis, %positions) {
+    dimension_numbers = #stablehlo.gather<
+      offset_dims = [1],
+      collapsed_slice_dims = [0, 1],
+      start_index_map = [0, 1],
+      index_vector_dim = 1
+    >,
+    slice_sizes = array<i64: 1, 1, 32>,
+    indices_are_sorted = false
+  } : (tensor<110x110x32xcomplex<f32>>, tensor<12100x2xi64>) -> tensor<12100x32xcomplex<f32>>
+
+  // Reshape and broadcast for Q/K application: [12100x32] -> [1x12100x16x32]
+  // CHECK: stablehlo.reshape
+  // CHECK-SAME: (tensor<12100x32x2xf32>) -> tensor<1x12100x1x32x2xf32>
+  %1 = stablehlo.reshape %0 : (tensor<12100x32xcomplex<f32>>) -> tensor<1x12100x1x32xcomplex<f32>>
+  // CHECK: stablehlo.broadcast_in_dim
+  // CHECK-SAME: dims = [0, 1, 2, 3, 4]
+  // CHECK-SAME: (tensor<1x12100x1x32x2xf32>) -> tensor<1x12100x16x32x2xf32>
+  %freqs_bc = stablehlo.broadcast_in_dim %1, dims = [0, 1, 2, 3] : (tensor<1x12100x1x32xcomplex<f32>>) -> tensor<1x12100x16x32xcomplex<f32>>
+
+  // Build complex Q from interleaved real/imag pairs
+  %xq_r = stablehlo.reshape %xq : (tensor<1x12100x16x64xf32>) -> tensor<1x12100x16x32x2xf32>
+  %xq_re_s = stablehlo.slice %xq_r [0:1, 0:12100, 0:16, 0:32, 0:1] : (tensor<1x12100x16x32x2xf32>) -> tensor<1x12100x16x32x1xf32>
+  %xq_re = stablehlo.reshape %xq_re_s : (tensor<1x12100x16x32x1xf32>) -> tensor<1x12100x16x32xf32>
+  %xq_im_s = stablehlo.slice %xq_r [0:1, 0:12100, 0:16, 0:32, 1:2] : (tensor<1x12100x16x32x2xf32>) -> tensor<1x12100x16x32x1xf32>
+  %xq_im = stablehlo.reshape %xq_im_s : (tensor<1x12100x16x32x1xf32>) -> tensor<1x12100x16x32xf32>
+  %xq_complex = stablehlo.complex %xq_re, %xq_im : tensor<1x12100x16x32xcomplex<f32>>
+
+  // Apply rotation: complex multiply then extract real/imag
+  %rotated = stablehlo.multiply %xq_complex, %freqs_bc : tensor<1x12100x16x32xcomplex<f32>>
+  %out_re = stablehlo.real %rotated : (tensor<1x12100x16x32xcomplex<f32>>) -> tensor<1x12100x16x32xf32>
+  %out_re_s = stablehlo.reshape %out_re : (tensor<1x12100x16x32xf32>) -> tensor<1x12100x16x32x1xf32>
+  %out_im = stablehlo.imag %rotated : (tensor<1x12100x16x32xcomplex<f32>>) -> tensor<1x12100x16x32xf32>
+  %out_im_s = stablehlo.reshape %out_im : (tensor<1x12100x16x32xf32>) -> tensor<1x12100x16x32x1xf32>
+  %out_cat = stablehlo.concatenate %out_re_s, %out_im_s, dim = 4 : (tensor<1x12100x16x32x1xf32>, tensor<1x12100x16x32x1xf32>) -> tensor<1x12100x16x32x2xf32>
+  %out = stablehlo.reshape %out_cat : (tensor<1x12100x16x32x2xf32>) -> tensor<1x12100x16x64xf32>
+  return %out : tensor<1x12100x16x64xf32>
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The stablehlo-complex-data-type-conversion pass was missing a conversion pattern for GatherOp, causing an unresolved materialization error when models gather from a complex-typed tensor (e.g. Pixtral/Mistral-Small vision encoder where freqs_cis is a 2D RoPE position cache of shape [H x W x head_dim/2 xcomplex<f32>] indexed by flattened patch positions).

The pass converted function argument types (complex -> float-pair) but had no pattern for GatherOp, so the framework inserted an unrealized unrealized_conversion_cast from the converted float-pair type back to complex that could never be resolved:

  loc("reshape.677"): error: failed to legalize unresolved materialization
  from ('tensor<12100x32xcomplex<f32>>') to ('tensor<12100x32x2xf32>')
  that remained live after conversion

Fix: add ComplexGatherOpConversionPattern that updates:
  1. slice_sizes — appends 2 for the new trailing float-pair dimension
  2. offset_dims — appends the new trailing result dimension index

Also registers GatherOp as dynamically legal (illegal when complex) and adds a test function covering the exact Pixtral RoPE gather pattern (freqs_cis: 110x110x32 complex, positions: 12100x2).

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
