### PR TITLE
Revert "[OpModel] Introduce opModelExempt and ASSIGN_OR_RETURN macro (#7925)"

### DIFF
--- a/docs/src/ttnn-op-constraints.md
+++ b/docs/src/ttnn-op-constraints.md
@@ -147,17 +147,9 @@ llvm::Expected<OpConstraints>
 OpModel<YourOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid,
     // operation-specific parameters
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
   #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::distributed::MeshDevice *device =
-      SingletonDeviceContext::getInstance().getDevice();
-
-  // 1. Convert inputs to TensorSpecs using ASSIGN_OR_RETURN.
-  //    This macro unwraps llvm::Expected and returns the error
-  //    on failure, avoiding repetitive error-checking boilerplate.
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  // 1. Perform necessary conversions, create Tensor objects, etc.
 
   // 2. Create query closure
   // Here the ultimate goal is to enable the optimizer to call the
@@ -173,13 +165,12 @@ OpModel<YourOp>::getOpConstraints(
   //      inputs are expected to match the invoke function of the
   //      op in metal.
   auto yourOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::yourOp, device, inputSpec,
-        /* other converted parameters */);
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::yourOp, device, /* other converted parameters */);
   };
 
   // 3. Call getOpConstraints and pass the callable.
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
+  return operation::getOpConstraints(getContext(), deviceGrid,
                                      yourOpQuery);
 #else
   return OpConstraints{};
@@ -189,19 +180,13 @@ OpModel<YourOp>::getOpConstraints(
 llvm::Expected<size_t>
 OpModel<YourOp>::getOpRuntime(
     // operation-specific parameters
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::distributed::MeshDevice *device =
-      SingletonDeviceContext::getInstance().getDevice();
-
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-
+  // Similar to the previous function.
+  // Create query closure
   auto yourOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::yourOp, device, inputSpec,
-        /* other converted parameters */);
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::yourOp, device, /* other converted parameters */);
   };
 
   return operation::getOpRuntime(yourOpQuery);
@@ -341,36 +326,45 @@ INSTANTIATE_TEST_SUITE_P(
 
 ## Key Considerations
 
-### Operations Not Supported by OpModel
+### Error handling: Operations Not Supported
+For operations that cannot support these APIs, use the provided error helpers in `TTNNOpModelInterface.cpp`.
+We're keeping track of such ops in [this issue](https://github.com/tenstorrent/tt-mlir/issues/4392).
+So please either update the issue or add comments to it.
 
-If an operation does not need OpModel support (e.g., it has no metal backend
-implementation, requires multi-device support, or simply doesn't benefit from
-constraint analysis), mark it with the `OpModelExempt` trait in its TableGen
-definition:
+```cpp
+llvm::Expected<op_model::OpConstraints>
+YourOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return detail::issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::/*..*/);
+}
 
-```tablegen
-def TTNN_YourOp : TTNN_Op<"your_op", [OpModelExempt]> {
-  // ...
+llvm::Expected<size_t>
+YourOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                     const OpConfig &opConfig) {
+  return detail::issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::/*..*/);
 }
 ```
 
-The `OpModelExempt` trait prevents the base op class from adding
-`DeclareOpInterfaceMethods<TTNN_OpModelInterface>`, so no stub
-implementation in `TTNNOpModelInterface.cpp` is needed.
-
-We're keeping track of ops that lack OpModel support in
-[this issue](https://github.com/tenstorrent/tt-mlir/issues/4392).
-Please either update the issue or add comments to it when exempting an op.
+Available error reasons:
+- `NeedsMemoryIO`: Operation requires memory I/O during trace capture
+- `MissingMetalDefinition`: Metal backend implementation is missing
+- `NeedsMultiDevice`: Operation requires multi-device support
+- `NoNeedForConstraintAPI`: Operation doesn't benefit from constraint analysis
+- `ArchitecturalMismatch`: Mismatch in Operation's definition in metal and mlir
 
 ### Device Grid Validation
 
-Validate the device worker grid before proceeding using the
-`ASSIGN_OR_RETURN` macro (defined in `ttmlir/OpModel/TTNN/TTNNOpModel.h`)
-combined with `detail::getValidatedDeviceGrid`:
+Validate the device worker grid before proceeding:
 
 ```cpp
-ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-    detail::getValidatedDeviceGrid(op.getOperation()));
+llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+if (!check) {
+  return check.takeError();
+}
+ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 ```
 
 ### Caching

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
@@ -43,35 +43,23 @@ def TTNN_Dialect : Dialect {
 }
 
 //===----------------------------------------------------------------------===//
-// TTNN traits definition for OpModel.
-//===----------------------------------------------------------------------===//
-
-// Returns [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ...>] when
-// OpModelExempt is absent from traits, or [] when present.
-class IfOpModelRequired<list<Trait> traits> {
-  list<Trait> value = !if(!empty(!filter(t, traits, !eq(t, OpModelExempt))),
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface,
-        ["getOpConstraints", "getOpRuntime"]>], []);
-}
-
-//===----------------------------------------------------------------------===//
 // Base TTNN operation definition.
 //===----------------------------------------------------------------------===//
 
 class TTNN_Op<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [Pure, CheckTileTypeTrait, TTNN_WorkaroundInterface] #
-        IfOpModelRequired<traits>.value # traits>;
+        Op<TTNN_Dialect, mnemonic, [Pure, CheckTileTypeTrait, TTNN_WorkaroundInterface,
+        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
 
 class TTNN_InplaceOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemWrite]>, TTNN_WorkaroundInterface] #
-        IfOpModelRequired<traits>.value # traits>;
+        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemWrite]>, TTNN_WorkaroundInterface,
+        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
 
 class TTNN_MemFreeOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemFree]>, TTNN_WorkaroundInterface] #
-        IfOpModelRequired<traits>.value # traits>;
+        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemFree]>, TTNN_WorkaroundInterface,
+        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
 
 class TTNN_MemoryEffectOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, TTNN_WorkaroundInterface] #
-        IfOpModelRequired<traits>.value # traits>;
+        Op<TTNN_Dialect, mnemonic, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, TTNN_WorkaroundInterface,
+        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -23,7 +23,7 @@ include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/CommonAttrConstraints.td"
 
-def TTNN_GetDeviceOp : TTNN_Op<"get_device", [TTCore_DuplicateConstEvalTrait, OpModelExempt]> {
+def TTNN_GetDeviceOp : TTNN_Op<"get_device", [TTCore_DuplicateConstEvalTrait]> {
     let summary = "Get Device op.";
     let description = [{
       This op returns a submesh carved out from the parent runtime device.
@@ -122,7 +122,7 @@ def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
     let hasVerifier = 1;
 }
 
-def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
+def TTNN_ToDeviceOp : TTNN_Op<"to_device"> {
     let summary = "ToDevice op.";
     let description = [{
       This op sends the input tensor to the given device with the given memory config.
@@ -134,7 +134,7 @@ def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
     let results = (outs AnyRankedTensor:$result);
 }
 
-def TTNN_FromDeviceOp : TTNN_Op<"from_device", [OpModelExempt]> {
+def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
     let summary = "FromDevice op.";
     let description = [{
       This op retrieves the input tensor from the given device.
@@ -1581,7 +1581,7 @@ def TTNN_MatmulOp : TTNN_Op<"matmul", [TTNN_ComputeKernelConfigOpInterface]> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
-def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul", [OpModelExempt]> {
+def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul"> {
     let summary = "Sparse block matrix multiplication with sparsity mask.";
     let description = [{
       The `sparse_matmul` operation performs batched matrix multiplication where
@@ -1632,7 +1632,7 @@ def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul", [OpModelExempt]> {
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch", [OpModelExempt]> {
+def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch"> {
     let summary = "Dispatch tokens to expert devices for MoE computation.";
     let description = [{
       Routes tokens to devices holding their selected experts via all-to-all
@@ -1657,7 +1657,7 @@ def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch", [OpModelExempt]> {
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata", [OpModelExempt]> {
+def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata"> {
     let summary = "Dispatch tokens with metadata to expert devices for MoE computation.";
     let description = [{
       Routes tokens along with expert scores to devices holding their selected
@@ -1704,7 +1704,7 @@ def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata", [O
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine", [OpModelExempt]> {
+def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine"> {
     let summary = "Combine expert outputs back to original token positions.";
     let description = [{
       Inverse of dispatch: gathers expert computation results from expert devices
@@ -1731,7 +1731,7 @@ def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine", [OpModelExempt]> {
     let hasVerifier = 1;
 }
 
-def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine", [OpModelExempt]> {
+def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine"> {
     let summary = "Reduce and combine phase of the MoE pipeline.";
     let description = [{
       Takes dense blocks of expert-computed tokens from the MoE compute kernel,
@@ -1754,7 +1754,7 @@ def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine", [OpModel
     let hasVerifier = 1;
 }
 
-def TTNN_MoeExpertTokenRemapOp : TTNN_Op<"moe_expert_token_remap", [OpModelExempt]> {
+def TTNN_MoeExpertTokenRemapOp : TTNN_Op<"moe_expert_token_remap"> {
     let summary = "Remap global expert routing to local device experts with sparsity.";
     let description = [{
       Converts global expert routing scores to local per-device expert mapping
@@ -2386,7 +2386,7 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_MemoryC
 }
 
 def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
-    [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
+    [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Distributed RMS normalization with all-gather op.";
     let description = [{
       Fused distributed RMS normalization operation across mesh devices.
@@ -2509,7 +2509,7 @@ def TTNN_RMSNormPreAllGatherOp :  TTNN_Op<"rms_norm_pre_all_gather",
 }
 
 def TTNN_DistributedLayerNormOp : TTNN_Op<"distributed_layer_norm",
-    [AttrSizedOperandSegments, OpModelExempt]> {
+    [AttrSizedOperandSegments]> {
     let summary = "Distributed layer normalization with all-gather op.";
     let description = [{
       Intermediate TTNN op for distributed layer normalization across mesh devices.
@@ -2973,7 +2973,7 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
     let hasVerifier = 1;
 }
 
-def TTNN_AllocOp : TTNN_Op<"alloc", [TTCore_CreationOpTrait, OpModelExempt]> {
+def TTNN_AllocOp : TTNN_Op<"alloc", [TTCore_CreationOpTrait]> {
     let summary = "Alloc op.";
     let description = [{
       Tensor Alloc operation
@@ -3055,7 +3055,7 @@ def TTNN_GatherOp : TTNN_Op<"gather", [TTNN_MemoryConfigOpInterface]> {
     }];
 }
 
-def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
+def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface]> {
     let summary = "All gather op.";
     let description = [{
         Tensor All Gather operation
@@ -3078,7 +3078,7 @@ def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface, OpMod
 
 def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
     [TTNN_MemoryConfigOpInterface,
-     TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
+     TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Reduce scatter op.";
     let description = [{
         Tensor Reduce Scatter operation
@@ -3101,7 +3101,7 @@ def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
     let hasFolder = 1;
 }
 
-def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
+def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface]> {
     let summary = "All reduce op.";
     let description = [{
         Tensor All Reduce operation
@@ -3122,7 +3122,7 @@ def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface, OpMod
     let hasFolder = 1;
 }
 
-def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
+def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInterface]> {
     let summary = "Asynchronous all reduce op.";
     let description = [{
         Asynchronous all-reduce collective communication operation. Performs a
@@ -3144,7 +3144,7 @@ def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInter
     let hasVerifier = 1;
 }
 
-def TTNN_MeshShardOp: TTNN_Op<"mesh_shard", [OpModelExempt]> {
+def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {
     let summary = "Mesh shard op.";
     let description = [{
         Tensor Mesh Shard operation
@@ -3372,7 +3372,7 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
     let hasVerifier = 1;
 }
 
-def TTNN_PointToPointOp: TTNN_Op<"point_to_point", [OpModelExempt]> {
+def TTNN_PointToPointOp: TTNN_Op<"point_to_point"> {
   let summary = "Point To Point operation.";
   let description = [{
     Performs point-to-point communication by copying a tensor shard from one device to another
@@ -3394,7 +3394,7 @@ def TTNN_PointToPointOp: TTNN_Op<"point_to_point", [OpModelExempt]> {
   let hasVerifier = 1;
 }
 
-def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor", [OpModelExempt]> {
+def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor"> {
   let summary = "Write tensor op.";
   let description = [{
     Copies host_tensor data into device_tensor through cq_id.
@@ -3414,7 +3414,7 @@ def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor", [OpModelExempt]> {
   let hasVerifier = 1;
 }
 
-def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture", [OpModelExempt]> {
+def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture"> {
   let summary = "Begin trace capture.";
   let description = [{
     Begins trace capture. Returns a scalar tensor containing the trace id.
@@ -3433,7 +3433,7 @@ def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture", [OpMod
   let hasVerifier = 1;
 }
 
-def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture", [OpModelExempt]> {
+def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture"> {
   let summary = "End trace capture.";
   let description = [{
     Ends trace capture for the given trace id. Consumes a scalar tensor containing the trace id.
@@ -3453,7 +3453,7 @@ def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture", [OpModelEx
   let hasVerifier = 1;
 }
 
-def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace", [OpModelExempt]> {
+def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace"> {
   let summary = "Execute trace.";
   let description = [{
     Executes the captured trace. Consumes a scalar tensor containing the trace id.
@@ -3474,7 +3474,7 @@ def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace", [OpModelExempt]> 
   let hasVerifier = 1;
 }
 
-def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace", [OpModelExempt]> {
+def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace"> {
   let summary = "Capture or execute trace.";
   let description = [{
     Captures or executes the trace. Will have read/write memory effects on the cached trace data.
@@ -3500,7 +3500,7 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
   let hasVerifier = 1;
 }
 
-def TTNN_GenericOp : TTNN_Op<"generic", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, MemoryEffects<[MemRead, MemWrite]>, TTCore_NonCacheableTrait, OpModelExempt]> {
+def TTNN_GenericOp : TTNN_Op<"generic", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, MemoryEffects<[MemRead, MemWrite]>, TTCore_NonCacheableTrait]> {
     let summary = "Generic operation.";
     let description = [{
       Generic operation capable of running a program with custom kernels. Each kernel is described with a
@@ -3662,7 +3662,7 @@ def TTNN_NLPConcatHeadsOp : TTNN_Op<"nlp_concat_heads", [TTNN_MemoryConfigOpInte
   let hasVerifier = 1;
 }
 
-def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor", [OpModelExempt]> {
+def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
   let summary = "Saves a tensor to disk in the TTNN binary format";
   let description = [{
     Saves a tensor to disk in the TTNN binary format. Files must use the `.tensorbin` extension.
@@ -3702,7 +3702,7 @@ def NLPCreateQKVHeadsDecodeOp : TTNN_Op<"nlp_create_qkv_heads_decode", [TTNN_Mem
   let hasVerifier = 1;
 }
 
-def TTNN_LoadTensorOp : TTNN_Op<"load_tensor", [OpModelExempt]> {
+def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
   let summary = "Loads a tensor from disk";
   let description = [{
     Loads a tensor from disk, optionally placing it directly on a device.
@@ -3942,7 +3942,7 @@ def TTNN_AssignOp : TTNN_Op<"assign", [TTNN_MemoryConfigOpInterface, TTNN_DtypeO
     let hasVerifier = 1;
 }
 
-def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor", [OpModelExempt]> {
+def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor"> {
   let summary = "Distribute tensor across mesh devices";
   let description = [{
     Distributes a host-side tensor across multiple devices in a mesh
@@ -3978,7 +3978,7 @@ def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor", [OpModelExempt]> {
   let results = (outs AnyRankedTensor:$result); // Distributed tensor
 }
 
-def TTNN_AggregateTensorOp : TTNN_Op<"aggregate_tensor", [OpModelExempt]> {
+def TTNN_AggregateTensorOp : TTNN_Op<"aggregate_tensor"> {
   let summary = "Aggregate distributed tensor back to host";
   let description = [{
     Aggregates a multi-device tensor back into a single host-side tensor
@@ -4078,7 +4078,7 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
   let hasVerifier = 1;
 }
 
-def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [OpModelExempt]> {
+def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore"> {
     let summary = "Create global semaphore op.";
     let description = [{
       Creates a global semaphore with the specified core range and initial value.
@@ -4108,7 +4108,7 @@ def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [OpModelEx
     let results = (outs TTNN_GlobalSemaphore:$result);
 }
 
-def TTNN_ResetGlobalSemaphoreOp : TTNN_Op<"reset_global_semaphore", [OpModelExempt]> {
+def TTNN_ResetGlobalSemaphoreOp : TTNN_Op<"reset_global_semaphore"> {
     let summary = "Reset global semaphore op.";
     let description = [{
       Resets a global semaphore to the specified value.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -53,11 +53,6 @@ public:
 template <typename ConcreteType>
 class CanExecuteOnHostTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, CanExecuteOnHostTrait> {};
-
-// Marker trait to exempt an op from implementing the OpModel interface.
-template <typename ConcreteType>
-class OpModelExempt
-    : public mlir::OpTrait::TraitBase<ConcreteType, OpModelExempt> {};
 } // namespace mlir::tt::ttnn
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -24,12 +24,4 @@ def CanExecuteOnHostTrait : NativeOpTrait<"CanExecuteOnHostTrait">
   let cppNamespace = "::mlir::tt::ttnn";
 }
 
-// Trait to exempt an op from implementing the OpModel interface.
-// Ops tagged with this trait will not have DeclareOpInterfaceMethods<TTNN_OpModelInterface>
-// added by the base op classes (TTNN_Op, TTNN_InplaceOp, etc.).
-def OpModelExempt : NativeOpTrait<"OpModelExempt">
-{
-  let cppNamespace = "::mlir::tt::ttnn";
-}
-
 #endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNN_TRAITS_TD

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -12,32 +12,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
-// Unwrap an llvm::Expected<T> expression: on success assign the value to `lhs`,
-// on failure propagate the error by returning it from the enclosing function.
-//
-// `lhs` may be either an existing l-value or a new variable declaration
-// (e.g. `Foo foo`). The macro expands to a single statement of the form
-// `lhs = (...);` so it is safe to use inside unbraced `if`/`else`/`for`/`while`
-// bodies. Implementation uses Clang's statement-expression extension
-// (`({ ... })`) — required because the unwrapped value must escape the macro's
-// scope while still allowing an early `return` on the error path. tt-mlir is
-// a clang-only build (see top-level CMakeLists.txt); porting to GCC would
-// need a parallel definition that silences -Wpedantic the same way.
-// clang-format off
-#define TTMLIR_CONCAT_IMPL_(a, b) a##b
-#define TTMLIR_CONCAT_(a, b) TTMLIR_CONCAT_IMPL_(a, b)
-#define ASSIGN_OR_RETURN(lhs, expr)                                            \
-  _Pragma("clang diagnostic push")                                             \
-  _Pragma("clang diagnostic ignored \"-Wgnu-statement-expression-from-macro-expansion\"") \
-  lhs = ({                                                                     \
-    auto TTMLIR_CONCAT_(_tt_expected_, __LINE__) = (expr);                     \
-    if (!TTMLIR_CONCAT_(_tt_expected_, __LINE__))                              \
-      return TTMLIR_CONCAT_(_tt_expected_, __LINE__).takeError();              \
-    std::move(TTMLIR_CONCAT_(_tt_expected_, __LINE__).get());                  \
-  });                                                                          \
-  _Pragma("clang diagnostic pop")
-// clang-format on
-
 namespace mlir::tt::ttnn::op_model {
 
 // Checks if the tensor layout is legal for the given tensor shape.

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/OpModel/TTNN/D2MOpCostModel.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -85,14 +86,6 @@ llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
   return op_model::Device::getDeviceConstraints(deviceAttr.getWorkerGrid());
 }
 
-llvm::Expected<ttcore::GridAttr> getValidatedDeviceGrid(mlir::Operation *op) {
-  auto check = checkDeviceWorkerGrid(op);
-  if (!check) {
-    return check.takeError();
-  }
-  return ttcore::lookupDevice(op).getWorkerGrid();
-}
-
 llvm::SmallVector<int64_t>
 convertArrayAttrToSmallVec(mlir::ArrayAttr arrayAttr) {
   llvm::SmallVector<int64_t> result;
@@ -118,8 +111,12 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
       inputs[0], opConfig.outputLayout);
@@ -147,8 +144,12 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = op.getLhs().getType().getShape();
   const auto inputShapeB = op.getRhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   ttcore::DataTypeAttr opDtypeAttr = nullptr;
   if (auto dtypeOp = mlir::dyn_cast<TTNNDtypeOpInterface>(op.getOperation())) {
@@ -184,8 +185,12 @@ getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
@@ -214,8 +219,12 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
       inputs[0], detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
@@ -242,8 +251,12 @@ getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -278,8 +291,12 @@ getMaxPool2dWithIndicesOpConstraints(OpT op,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -314,8 +331,12 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   const mlir::tt::ttnn::ShapeAttr shape = op.getShape();
   const std::optional<mlir::tt::ttcore::DataType> dtype = op.getDtype();
@@ -337,8 +358,12 @@ getQuantizationOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto scaleShape = op.getScale().getType().getShape();
   const auto zeroPointShape = op.getZeroPoint().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(op.getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -901,8 +926,12 @@ LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, deviceGrid,
@@ -1094,8 +1123,12 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
@@ -1119,6 +1152,11 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
   if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
@@ -1141,8 +1179,12 @@ GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
   const auto indexShape = getIndex().getType().getShape();
@@ -1195,8 +1237,12 @@ GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getLhs().getType().getShape();
   const auto inputShapeB = getRhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GeluBackwardOp>::getOpConstraints, getOperation(),
@@ -1264,8 +1310,12 @@ PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getLhs().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PowScalarOp>::getOpConstraints, *this, deviceGrid,
@@ -1535,8 +1585,12 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, deviceGrid,
       inputShape, inputs[0], getDimension(), getNumericStable(),
@@ -1568,8 +1622,12 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ReshapeOp>::getOpConstraints, *this, deviceGrid,
@@ -1600,8 +1658,12 @@ SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, deviceGrid,
@@ -1637,8 +1699,12 @@ SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto beginsShape = getBegins().getType().getShape();
   const auto endsShape = getEnds().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, deviceGrid,
@@ -1673,8 +1739,12 @@ BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, deviceGrid,
@@ -1704,8 +1774,12 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<TypecastOp>::getOpConstraints, *this, deviceGrid,
@@ -1737,8 +1811,13 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, deviceGrid,
@@ -1770,8 +1849,12 @@ ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, deviceGrid,
@@ -1791,6 +1874,60 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// GetDeviceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+GetDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+GetDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// FromDeviceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+FromDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+}
+
+llvm::Expected<size_t>
+FromDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+}
+
+//===----------------------------------------------------------------------===//
+// ToDeviceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ToDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+}
+
+llvm::Expected<size_t>
+ToDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+}
+
+//===----------------------------------------------------------------------===//
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -1806,8 +1943,12 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     inputShapes.push_back(inputType.getShape());
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConcatOp>::getOpConstraints, *this, deviceGrid,
@@ -1842,8 +1983,12 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<TransposeOp>::getOpConstraints, *this, deviceGrid,
@@ -1873,8 +2018,12 @@ CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<CumSumOp>::getOpConstraints, *this, deviceGrid,
@@ -1902,8 +2051,12 @@ ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -2014,8 +2167,12 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
          "4, 5, or 6 input tensors");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
       unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2041,6 +2198,11 @@ llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
   assert(inputs.size() >= 3 && inputs.size() <= 6 &&
          "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
          "4, 5, or 6 input tensors");
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
       unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2142,8 +2304,12 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2170,6 +2336,11 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
   assert(inputs.size() >= 4 && inputs.size() <= 7 &&
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2269,8 +2440,12 @@ llvm::Expected<op_model::OpConstraints>
 PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
       unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
@@ -2290,6 +2465,11 @@ PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
   PagedFlashMultiLatentAttentionDecodeArgs args =
       unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
 
@@ -2315,8 +2495,12 @@ ScaledDotProductAttentionOp::getOpConstraints(
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto queryShape = getQuery().getType().getShape();
   const auto keyShape = getKey().getType().getShape();
@@ -2350,6 +2534,11 @@ llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 5 &&
          "ttnn::scaled_dot_product_attention can have 3 to 5 input tensors");
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
 
   const auto queryShape = getQuery().getType().getShape();
   const auto keyShape = getKey().getType().getShape();
@@ -2388,8 +2577,13 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 4);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
   auto sinShape = getSinCache().getType().getShape();
@@ -2428,8 +2622,13 @@ RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
@@ -2467,8 +2666,13 @@ NLPCreateQKVHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto inputShape = getInput().getType().getShape();
 
@@ -2515,8 +2719,13 @@ NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
@@ -2544,8 +2753,13 @@ NLPConcatHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
   uint32_t numHeads = getNumHeads();
@@ -2574,8 +2788,12 @@ llvm::Expected<op_model::OpConstraints>
 SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto inputShape = getInputTensor().getType().getShape();
 
@@ -2622,8 +2840,12 @@ RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatInterleaveOp>::getOpConstraints, *this,
@@ -2654,8 +2876,12 @@ RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatOp>::getOpConstraints, *this, deviceGrid,
@@ -2685,8 +2911,12 @@ PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PadOp>::getOpConstraints, *this, deviceGrid, inputShape,
@@ -2717,8 +2947,12 @@ SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SortOp>::getOpConstraints, *this, deviceGrid,
@@ -2749,8 +2983,12 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, deviceGrid,
@@ -2781,8 +3019,12 @@ ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ProdOp>::getOpConstraints, *this, deviceGrid,
@@ -2842,8 +3084,12 @@ RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outScaleShape = getOutScale().getType().getShape();
   const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RequantizeOp>::getOpConstraints, *this, deviceGrid,
@@ -2916,8 +3162,12 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
@@ -2986,8 +3236,12 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     }
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
@@ -3019,6 +3273,111 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// SparseMatmulOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+SparseMatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+SparseMatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// AllToAllDispatchOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllToAllDispatchOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllToAllDispatchOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// AllToAllDispatchMetadataOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllToAllDispatchMetadataOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t> AllToAllDispatchMetadataOp::getOpRuntime(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// AllToAllCombineOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllToAllCombineOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllToAllCombineOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// SelectiveReduceCombineOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+SelectiveReduceCombineOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t> SelectiveReduceCombineOp::getOpRuntime(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// MoeExpertTokenRemapOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> MoeExpertTokenRemapOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+MoeExpertTokenRemapOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3027,8 +3386,12 @@ TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
@@ -3079,6 +3442,24 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// AllocOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllocOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllocOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3086,8 +3467,12 @@ llvm::Expected<op_model::OpConstraints>
 FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 2);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3119,8 +3504,12 @@ llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
   assert(inputs.size() == 3);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3151,8 +3540,12 @@ PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3197,8 +3590,12 @@ PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3238,6 +3635,24 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       batchIdxShape, batchIdxLayout, opConfig.outputLayout);
 }
 //===----------------------------------------------------------------------===//
+// WriteTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+WriteTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+WriteTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3276,8 +3691,12 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
@@ -3334,8 +3753,12 @@ Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<Conv3dOp>::getOpConstraints, *this, deviceGrid,
@@ -3410,8 +3833,12 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   // If a conv config has been specified, use that. If not, read the op property
   Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
@@ -3460,8 +3887,12 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -3493,8 +3924,12 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -3525,8 +3960,12 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -3557,8 +3996,12 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dBiasOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -3668,8 +4111,12 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3720,8 +4167,12 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
          "usage of this op with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3797,8 +4248,12 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3837,6 +4292,25 @@ RMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// DistributedRMSNormOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+// DistributedRMSNormOp is a fused CCL operation that requires multi-device
+// support and is not supported in the op model.
+
+llvm::Expected<op_model::OpConstraints> DistributedRMSNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
+}
+
+llvm::Expected<size_t>
+DistributedRMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
+}
+
+//===----------------------------------------------------------------------===//
 // RMSNormPreAllGatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3863,8 +4337,14 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+
+  if (!check) {
+    return check.takeError();
+  }
+
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3891,6 +4371,27 @@ RMSNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, getDtype(), getUse_2dCoreGrid(),
       opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
+// DistributedLayerNormOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+// DistributedLayerNormOp decomposes into multiple ops (CCL + layer norm), and
+// there is no equivalent fused op in the TTNN library, so op model is not
+// supported.
+
+llvm::Expected<op_model::OpConstraints>
+DistributedLayerNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
+}
+
+llvm::Expected<size_t>
+DistributedLayerNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3928,8 +4429,12 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -3993,8 +4498,12 @@ unpackLayerNormPreAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4058,8 +4567,12 @@ unpackLayerNormPostAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
   const auto statsShape = getStats().getType().getShape();
@@ -4134,8 +4647,12 @@ llvm::Expected<op_model::OpConstraints>
 GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(!inputs.empty() && "GroupNormOp requires at least input layout");
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4179,8 +4696,12 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, deviceGrid,
@@ -4210,8 +4731,12 @@ ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, deviceGrid,
@@ -4243,8 +4768,12 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PermuteOp>::getOpConstraints, *this, deviceGrid,
@@ -4275,8 +4804,12 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<UpsampleOp>::getOpConstraints, *this, deviceGrid,
@@ -4308,8 +4841,12 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, deviceGrid,
@@ -4342,8 +4879,12 @@ EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto weightShape = getWeight().getType().getShape();
   const auto inGradientShape = getInGradient().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
@@ -4380,8 +4921,12 @@ EmptyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const mlir::tt::ttnn::Layout layout = getLayoutAttr().getValue();
   const mlir::tt::ttnn::MemoryConfigAttr memoryConfig = getMemoryConfigAttr();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints, *this,
       deviceGrid, shape, dtype, layout, memoryConfig, opConfig.outputLayout);
@@ -4468,8 +5013,12 @@ llvm::Expected<op_model::OpConstraints>
 FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const mlir::tt::ttnn::ShapeAttr shape = getShape();
   const mlir::Attribute fillValue = getFillValue();
@@ -4492,6 +5041,44 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// AllGatherOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+// AllGatherOp and ReduceScatterOp are not supported, since they have been
+// removed from metal. See
+// https://github.com/tenstorrent/tt-metal/commit/1ccd1c6480
+llvm::Expected<op_model::OpConstraints>
+AllGatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// ReduceScatterOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ReduceScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+ReduceScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -4502,8 +5089,12 @@ MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, deviceGrid,
@@ -4523,6 +5114,62 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// PointToPointOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+// PointToPointOp is not supported rn. The reason is that the metal definition
+// requires semaphore and multi-device, which is not available at the moment.
+llvm::Expected<op_model::OpConstraints>
+PointToPointOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
+}
+
+llvm::Expected<size_t>
+PointToPointOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
+}
+
+//===----------------------------------------------------------------------===//
+// AllReduceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllReduceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllReduceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// AllReduceAsyncOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AllReduceAsyncOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AllReduceAsyncOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -4531,8 +5178,12 @@ ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConstantOp>::getOpConstraints, *this, deviceGrid,
@@ -4555,8 +5206,12 @@ RandOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints, *this,
@@ -4582,8 +5237,12 @@ DropoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<DropoutOp>::getOpConstraints, *this, deviceGrid,
@@ -4605,6 +5264,150 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// MeshShardOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+MeshShardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+MeshShardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// GenericOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+GenericOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+GenericOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// BeginTraceCaptureOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+BeginTraceCaptureOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+BeginTraceCaptureOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// EndTraceCaptureOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+EndTraceCaptureOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+EndTraceCaptureOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// ExecuteTraceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ExecuteTraceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+ExecuteTraceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// CaptureOrExecuteTraceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+CaptureOrExecuteTraceOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+CaptureOrExecuteTraceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// DumpTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+DumpTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+DumpTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// LoadTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+LoadTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+LoadTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -4615,8 +5418,12 @@ GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, deviceGrid,
@@ -4643,8 +5450,12 @@ llvm::Expected<op_model::OpConstraints>
 AssignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4662,6 +5473,42 @@ AssignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime, *this,
       inputShape, inputs[0], getMemoryConfig(), getDtype());
+}
+
+//===----------------------------------------------------------------------===//
+// DistributeTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+DistributeTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+DistributeTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
+// AggregateTensorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+AggregateTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+AggregateTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4857,8 +5704,12 @@ llvm::Expected<op_model::OpConstraints>
 TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-                   detail::getValidatedDeviceGrid(getOperation()));
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
   const auto inputShape = getInputTensor().getType().getShape();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
@@ -4876,4 +5727,40 @@ TopKOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
       opConfig.outputLayout);
 }
+//===----------------------------------------------------------------------===//
+// CreateGlobalSemaphoreOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+CreateGlobalSemaphoreOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+CreateGlobalSemaphoreOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+//===----------------------------------------------------------------------===//
+// ResetGlobalSemaphoreOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+ResetGlobalSemaphoreOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
+llvm::Expected<size_t>
+ResetGlobalSemaphoreOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -7,7 +7,6 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/OpModelError.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Support/Logger.h"
@@ -173,17 +172,6 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   // Check that operation supports OpModel interface.
   auto backend = mlir::dyn_cast<OpModel>(op);
   if (!backend) {
-    // Ops marked with the OpModelExempt trait deliberately do not implement
-    // the OpModel interface (e.g. CCL/multi-device, trace, generic, or other
-    // ops without a metal-side definition). The optimizer relies on observing
-    // a NotImplemented result for such ops so it can fall back gracefully
-    // (e.g. evict L1 state) instead of treating the op as analyzable.
-    if (op->hasTrait<OpModelExempt>()) {
-      return ValidationResult::notImplemented(
-          (llvm::Twine("OpModel interface not implemented for op ") +
-           op->getName().getStringRef() + " (OpModelExempt)")
-              .str());
-    }
     llvm::reportFatalInternalError(llvm::Twine("Backend constraints are not "
                                                "implemented for op ")
                                        .concat(op->getName().getStringRef()));

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -635,9 +635,12 @@ llvm::Expected<::ttnn::TensorSpec> getPrepareConv2dWeightsOpOutputTensorSpec(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> inputDtype =
       detail::getNullableDataType(inputLayout);
@@ -729,9 +732,12 @@ getPrepareConv2dBiasOpOutputTensorSpec(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> inputDtype =
       detail::getNullableDataType(inputLayout);
@@ -831,9 +837,12 @@ llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto query = [=]() {
@@ -858,9 +867,12 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto query = [=]() {
@@ -884,9 +896,12 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   bool fastApproxMode = true;
 
@@ -913,9 +928,12 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   bool fastApproxMode = true;
 
@@ -976,9 +994,12 @@ llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Add default parameters
   int32_t vectorMode =
@@ -1007,9 +1028,12 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Add default parameters
   int32_t vectorMode =
@@ -1040,9 +1064,12 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto leakyReluOpQuery = [=]() {
@@ -1065,9 +1092,12 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto leakyReluOpQuery = [=]() {
@@ -1096,13 +1126,19 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -1135,13 +1171,19 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -1171,13 +1213,19 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1205,13 +1253,19 @@ llvm::Expected<size_t> BinaryCompositeOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1268,13 +1322,19 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1301,13 +1361,19 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1337,9 +1403,12 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
@@ -1378,9 +1447,12 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
@@ -1423,17 +1495,26 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecC,
-      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
+  auto inputSpecCExp =
+      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC);
+  if (!inputSpecCExp) {
+    return inputSpecCExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecC = inputSpecCExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1462,17 +1543,26 @@ llvm::Expected<size_t> TernaryEltwiseOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecC,
-      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
+  auto inputSpecCExp =
+      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC);
+  if (!inputSpecCExp) {
+    return inputSpecCExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecC = inputSpecCExp.get();
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1506,9 +1596,12 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
@@ -1544,9 +1637,12 @@ llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
@@ -1637,9 +1733,12 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto softmaxOpQuery = [=]() {
@@ -1663,9 +1762,12 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto softmaxOpQuery = [=]() {
@@ -1695,17 +1797,26 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec indexSpec,
-      detail::convertToTensorSpec(device, indexShape, indexLayout));
+  auto indexSpecExp =
+      detail::convertToTensorSpec(device, indexShape, indexLayout);
+  if (!indexSpecExp) {
+    return indexSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec sourceSpec,
-      detail::convertToTensorSpec(device, sourceShape, sourceLayout));
+  auto sourceSpecExp =
+      detail::convertToTensorSpec(device, sourceShape, sourceLayout);
+  if (!sourceSpecExp) {
+    return sourceSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec sourceSpec = sourceSpecExp.get();
 
   // Convert optReduction to ScatterReductionType enum
   auto optReductionType = conversion::getScatterReductionType(optReduction);
@@ -1735,17 +1846,26 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec indexSpec,
-      detail::convertToTensorSpec(device, indexShape, indexLayout));
+  auto indexSpecExp =
+      detail::convertToTensorSpec(device, indexShape, indexLayout);
+  if (!indexSpecExp) {
+    return indexSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec sourceSpec,
-      detail::convertToTensorSpec(device, sourceShape, sourceLayout));
+  auto sourceSpecExp =
+      detail::convertToTensorSpec(device, sourceShape, sourceLayout);
+  if (!sourceSpecExp) {
+    return sourceSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec sourceSpec = sourceSpecExp.get();
 
   auto optReductionType = conversion::getScatterReductionType(optReduction);
 
@@ -1774,9 +1894,12 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto reshapeOpQuery = [=]() {
@@ -1799,9 +1922,12 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto reshapeOpQuery = [=]() {
@@ -1828,9 +1954,12 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // convert arrays
   ::ttsl::SmallVector<int> beginsVec =
@@ -1867,9 +1996,12 @@ llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert arrays
   ::ttsl::SmallVector<int> beginsVec =
@@ -1910,9 +2042,12 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // It is not possible to use the dynamic version of slice in tt-metal since
   // the validity of the op depends on the actual data that is stored in the
@@ -1956,9 +2091,12 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // It is not possible to use the dynamic version of slice in tt-metal since
   // the validity of the op depends on the actual data that is stored in the
@@ -2002,9 +2140,12 @@ llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto bitcastOpQuery = [=]() {
@@ -2027,9 +2168,12 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto bitcastOpQuery = [=]() {
@@ -2055,9 +2199,12 @@ llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto typecastOpQuery = [=]() {
@@ -2080,9 +2227,12 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto typecastOpQuery = [=]() {
@@ -2108,9 +2258,12 @@ llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> dtype;
   if (outputDtype) {
@@ -2140,9 +2293,12 @@ llvm::Expected<size_t> OpModel<ToLayoutOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> dtype;
   if (outputDtype) {
@@ -2176,9 +2332,12 @@ llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
@@ -2200,9 +2359,12 @@ llvm::Expected<size_t> OpModel<ToMemoryConfigOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
@@ -2233,10 +2395,12 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
 
   std::vector<::ttnn::TensorSpec> inputSpecs;
   for (size_t i = 0; i < numInputs; ++i) {
-    ASSIGN_OR_RETURN(
-        auto _push_tmp,
-        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]));
-    inputSpecs.push_back(std::move(_push_tmp));
+    auto inputSpecExp =
+        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]);
+    if (!inputSpecExp) {
+      return inputSpecExp.takeError();
+    }
+    inputSpecs.push_back(inputSpecExp.get());
   }
 
   // Create query closure
@@ -2265,10 +2429,12 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 
   std::vector<::ttnn::TensorSpec> inputSpecs;
   for (size_t i = 0; i < numInputs; ++i) {
-    ASSIGN_OR_RETURN(
-        auto _push_tmp,
-        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]));
-    inputSpecs.push_back(std::move(_push_tmp));
+    auto inputSpecExp =
+        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]);
+    if (!inputSpecExp) {
+      return inputSpecExp.takeError();
+    }
+    inputSpecs.push_back(inputSpecExp.get());
   }
 
   // Create query closure
@@ -2294,9 +2460,12 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto transposeOpQuery = [=]() {
@@ -2320,9 +2489,12 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto transposeOpQuery = [=]() {
@@ -2349,9 +2521,12 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
   if (dtype) {
@@ -2381,9 +2556,12 @@ OpModel<CumSumOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
   if (dtype) {
@@ -2414,9 +2592,12 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
@@ -2440,9 +2621,12 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
@@ -2480,14 +2664,24 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2544,14 +2738,24 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2611,17 +2815,30 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2672,17 +2889,30 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2738,14 +2968,24 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> valueSpec =
       detail::convertToOptionalTensorSpec(device, valueShape, valueLayout);
@@ -2798,14 +3038,24 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> valueSpec =
       detail::convertToOptionalTensorSpec(device, valueShape, valueLayout);
@@ -2859,14 +3109,24 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2909,14 +3169,24 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec querySpec,
-      detail::convertToTensorSpec(device, queryShape, queryLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
-                   detail::convertToTensorSpec(device, keyShape, keyLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec valueSpec,
-      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  auto querySpecExp =
+      detail::convertToTensorSpec(device, queryShape, queryLayout);
+  if (!querySpecExp) {
+    return querySpecExp.takeError();
+  }
+  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
+  if (!keySpecExp) {
+    return keySpecExp.takeError();
+  }
+  auto valueSpecExp =
+      detail::convertToTensorSpec(device, valueShape, valueLayout);
+  if (!valueSpecExp) {
+    return valueSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec querySpec = querySpecExp.get();
+  ::ttnn::TensorSpec keySpec = keySpecExp.get();
+  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2957,16 +3227,29 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
-                   detail::convertToTensorSpec(device, cosShape, cosLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
-                   detail::convertToTensorSpec(device, sinShape, sinLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec transMatSpec,
-      detail::convertToTensorSpec(device, transMatShape, transMatLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
+  if (!cosSpecExp) {
+    return cosSpecExp.takeError();
+  }
+  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
+  if (!sinSpecExp) {
+    return sinSpecExp.takeError();
+  }
+  auto transMatSpecExp =
+      detail::convertToTensorSpec(device, transMatShape, transMatLayout);
+  if (!transMatSpecExp) {
+    return transMatSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
+  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
+  ::ttnn::TensorSpec transMatSpec = transMatSpecExp.get();
 
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding_llama,
@@ -2992,16 +3275,28 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
-                   detail::convertToTensorSpec(device, cosShape, cosLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
-                   detail::convertToTensorSpec(device, sinShape, sinLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec transMatSpec,
-      detail::convertToTensorSpec(device, transMatShape, transMatLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
+  if (!cosSpecExp) {
+    return cosSpecExp.takeError();
+  }
+  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
+  if (!sinSpecExp) {
+    return sinSpecExp.takeError();
+  }
+  auto transMatSpecExp =
+      detail::convertToTensorSpec(device, transMatShape, transMatLayout);
+  if (!transMatSpecExp) {
+    return transMatSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
+  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
+  ::ttnn::TensorSpec transMatSpec = transMatSpecExp.get();
 
   // Create query closure
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
@@ -3031,13 +3326,26 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
-                   detail::convertToTensorSpec(device, cosShape, cosLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
-                   detail::convertToTensorSpec(device, sinShape, sinLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
+  if (!cosSpecExp) {
+    return cosSpecExp.takeError();
+  }
+
+  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
+  if (!sinSpecExp) {
+    return sinSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
+  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
 
   auto rotaryEmbeddingOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding, device,
@@ -3061,13 +3369,26 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
-                   detail::convertToTensorSpec(device, cosShape, cosLayout));
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
-                   detail::convertToTensorSpec(device, sinShape, sinLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
+  if (!cosSpecExp) {
+    return cosSpecExp.takeError();
+  }
+
+  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
+  if (!sinSpecExp) {
+    return sinSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
+  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
 
   // Create query closure
   auto rotaryEmbeddingOpQuery = [=]() {
@@ -3097,15 +3418,23 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
   std::optional<::ttnn::TensorSpec> batchOffsetSpec = std::nullopt;
   if (batchOffsetShape && batchOffsetLayout) {
-    ASSIGN_OR_RETURN(batchOffsetSpec, detail::convertToTensorSpec(
-                                          device, batchOffsetShape.value(),
-                                          batchOffsetLayout.value()));
+    auto batchOffsetSpecExp = detail::convertToTensorSpec(
+        device, batchOffsetShape.value(), batchOffsetLayout.value());
+    if (!batchOffsetSpecExp) {
+      return batchOffsetSpecExp.takeError();
+    }
+    batchOffsetSpec = batchOffsetSpecExp.get();
   }
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
@@ -3136,15 +3465,23 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
   std::optional<::ttnn::TensorSpec> batchOffsetSpec = std::nullopt;
   if (batchOffsetShape && batchOffsetLayout) {
-    ASSIGN_OR_RETURN(batchOffsetSpec, detail::convertToTensorSpec(
-                                          device, batchOffsetShape.value(),
-                                          batchOffsetLayout.value()));
+    auto batchOffsetSpecExp = detail::convertToTensorSpec(
+        device, batchOffsetShape.value(), batchOffsetLayout.value());
+    if (!batchOffsetSpecExp) {
+      return batchOffsetSpecExp.takeError();
+    }
+    batchOffsetSpec = batchOffsetSpecExp.get();
   }
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
@@ -3178,15 +3515,21 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> inputKVSpec = std::nullopt;
   if (inputKVShape && inputKVLayout) {
-    ASSIGN_OR_RETURN(inputKVSpec,
-                     detail::convertToTensorSpec(device, inputKVShape.value(),
-                                                 inputKVLayout.value()));
+    auto inputKVSpecExp = detail::convertToTensorSpec(
+        device, inputKVShape.value(), inputKVLayout.value());
+    if (!inputKVSpecExp) {
+      return inputKVSpecExp.takeError();
+    }
+    inputKVSpec = inputKVSpecExp.get();
   }
 
   // Create query closure
@@ -3214,15 +3557,21 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> inputKVSpec = std::nullopt;
   if (inputKVShape && inputKVLayout) {
-    ASSIGN_OR_RETURN(inputKVSpec,
-                     detail::convertToTensorSpec(device, inputKVShape.value(),
-                                                 inputKVLayout.value()));
+    auto inputKVSpecExp = detail::convertToTensorSpec(
+        device, inputKVShape.value(), inputKVLayout.value());
+    if (!inputKVSpecExp) {
+      return inputKVSpecExp.takeError();
+    }
+    inputKVSpec = inputKVSpecExp.get();
   }
 
   // Create query closure
@@ -3249,9 +3598,12 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
@@ -3275,9 +3627,12 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
@@ -3303,9 +3658,12 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // tt-metal's nlp_concat_heads_decode infers on_subcoregrids from the input
   // shard grid: if the CoreRangeSet has multiple ranges or doesn't start at
@@ -3345,9 +3703,12 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Pass sub_core_grids when the input shard grid would trigger subcoregrids
   // (see getOpConstraints above for rationale).
@@ -3387,9 +3748,12 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
@@ -3412,9 +3776,12 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
@@ -3440,9 +3807,12 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert repeats to ttnn::Shape
   ::ttnn::Shape repeatShape = conversion::getShape(repeats);
@@ -3475,9 +3845,12 @@ llvm::Expected<size_t> OpModel<RepeatOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert repeats to SmallVector<uint32_t> to use overload with memory_config
   ::ttsl::SmallVector<uint32_t> repeatVec;
@@ -3542,9 +3915,12 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
@@ -3571,9 +3947,12 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
@@ -3602,9 +3981,12 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto sortOpQuery = [=]() {
@@ -3627,9 +4009,12 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto sortOpQuery = [=]() {
@@ -3658,16 +4043,25 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
-                   detail::convertToTensorSpec(device, biasShape, biasLayout));
+  auto biasSpecExp = detail::convertToTensorSpec(device, biasShape, biasLayout);
+  if (!biasSpecExp) {
+    return biasSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec biasSpec = biasSpecExp.get();
 
   auto topKRouterGptQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_router_gpt, device,
@@ -3690,16 +4084,25 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
-                   detail::convertToTensorSpec(device, biasShape, biasLayout));
+  auto biasSpecExp = detail::convertToTensorSpec(device, biasShape, biasLayout);
+  if (!biasSpecExp) {
+    return biasSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec biasSpec = biasSpecExp.get();
 
   auto topKRouterGptQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::experimental::topk_router_gpt, device,
@@ -3723,9 +4126,12 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto argMaxOpQuery = [=]() {
@@ -3750,9 +4156,12 @@ OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto argMaxOpQuery = [=]() {
@@ -3778,9 +4187,12 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto prodOpQuery = [=]() {
@@ -3810,17 +4222,26 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec scaleSpec,
-      detail::convertToTensorSpec(device, scaleShape, scaleLayout));
+  auto scaleSpecExp =
+      detail::convertToTensorSpec(device, scaleShape, scaleLayout);
+  if (!scaleSpecExp) {
+    return scaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec scaleSpec = scaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec zeroPointSpec,
-      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
+  auto zeroPointSpecExp =
+      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout);
+  if (!zeroPointSpecExp) {
+    return zeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec zeroPointSpec = zeroPointSpecExp.get();
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -3859,17 +4280,26 @@ llvm::Expected<size_t> QuantizationOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec scaleSpec,
-      detail::convertToTensorSpec(device, scaleShape, scaleLayout));
+  auto scaleSpecExp =
+      detail::convertToTensorSpec(device, scaleShape, scaleLayout);
+  if (!scaleSpecExp) {
+    return scaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec scaleSpec = scaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec zeroPointSpec,
-      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
+  auto zeroPointSpecExp =
+      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout);
+  if (!zeroPointSpecExp) {
+    return zeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec zeroPointSpec = zeroPointSpecExp.get();
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -3915,25 +4345,40 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inScaleSpec,
-      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout));
+  auto inScaleSpecExp =
+      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout);
+  if (!inScaleSpecExp) {
+    return inScaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inScaleSpec = inScaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inZeroPointSpec,
-      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout));
+  auto inZeroPointSpecExp =
+      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout);
+  if (!inZeroPointSpecExp) {
+    return inZeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inZeroPointSpec = inZeroPointSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec outScaleSpec,
-      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout));
+  auto outScaleSpecExp =
+      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout);
+  if (!outScaleSpecExp) {
+    return outScaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec outScaleSpec = outScaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec outZeroPointSpec,
-                   detail::convertToTensorSpec(device, outZeroPointShape,
-                                               outZeroPointLayout));
+  auto outZeroPointSpecExp = detail::convertToTensorSpec(
+      device, outZeroPointShape, outZeroPointLayout);
+  if (!outZeroPointSpecExp) {
+    return outZeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec outZeroPointSpec = outZeroPointSpecExp.get();
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -3974,25 +4419,40 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inScaleSpec,
-      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout));
+  auto inScaleSpecExp =
+      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout);
+  if (!inScaleSpecExp) {
+    return inScaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inScaleSpec = inScaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inZeroPointSpec,
-      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout));
+  auto inZeroPointSpecExp =
+      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout);
+  if (!inZeroPointSpecExp) {
+    return inZeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inZeroPointSpec = inZeroPointSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec outScaleSpec,
-      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout));
+  auto outScaleSpecExp =
+      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout);
+  if (!outScaleSpecExp) {
+    return outScaleSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec outScaleSpec = outScaleSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec outZeroPointSpec,
-                   detail::convertToTensorSpec(device, outZeroPointShape,
-                                               outZeroPointLayout));
+  auto outZeroPointSpecExp = detail::convertToTensorSpec(
+      device, outZeroPointShape, outZeroPointLayout);
+  if (!outZeroPointSpecExp) {
+    return outZeroPointSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec outZeroPointSpec = outZeroPointSpecExp.get();
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -4034,13 +4494,19 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::Tensor> biasTensor;
   if (biasShape && biasLayout) {
@@ -4095,13 +4561,19 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::Tensor> biasTensor;
   if (biasShape && biasLayout) {
@@ -4147,13 +4619,19 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -4198,13 +4676,19 @@ llvm::Expected<size_t> OpModel<MatmulOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecA,
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
+  auto inputSpecAExp =
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
+  if (!inputSpecAExp) {
+    return inputSpecAExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpecB,
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
+  auto inputSpecBExp =
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
+  if (!inputSpecBExp) {
+    return inputSpecBExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -4242,9 +4726,12 @@ OpModel<DeallocateOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto deallocateOpQuery = [=]() {
@@ -4269,13 +4756,19 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   auto fillCacheOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::fill_cache, device, cacheSpec,
@@ -4297,13 +4790,19 @@ llvm::Expected<size_t> OpModel<FillCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   auto fillCacheOpQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::fill_cache, device, cacheSpec, inputSpec,
@@ -4329,13 +4828,19 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // TODO(#1510): modify the ttnn::update_cache to take a tensor for
   // updateIndex.
@@ -4374,13 +4879,19 @@ llvm::Expected<size_t> OpModel<UpdateCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // TODO(#1510): modify the ttnn::update_cache to take a tensor for
   // updateIndex.
@@ -4415,23 +4926,35 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec updateIndexSpec,
-      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout));
+  auto updateIndexSpecExp =
+      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout);
+  if (!updateIndexSpecExp) {
+    return updateIndexSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec updateIndexSpec = updateIndexSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> pageTableSpec;
   if (pageTableShape && pageTableLayout) {
-    ASSIGN_OR_RETURN(
-        pageTableSpec,
-        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
+    auto pageTableSpecExp =
+        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout);
+    if (!pageTableSpecExp) {
+      return pageTableSpecExp.takeError();
+    }
+    pageTableSpec = pageTableSpecExp.get();
   }
 
   std::vector<uint32_t> emptyUpdateIndex = {};
@@ -4461,23 +4984,35 @@ llvm::Expected<size_t> OpModel<PagedUpdateCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec updateIndexSpec,
-      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout));
+  auto updateIndexSpecExp =
+      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout);
+  if (!updateIndexSpecExp) {
+    return updateIndexSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec updateIndexSpec = updateIndexSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> pageTableSpec;
   if (pageTableShape && pageTableLayout) {
-    ASSIGN_OR_RETURN(
-        pageTableSpec,
-        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
+    auto pageTableSpecExp =
+        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout);
+    if (!pageTableSpecExp) {
+      return pageTableSpecExp.takeError();
+    }
+    pageTableSpec = pageTableSpecExp.get();
   }
 
   std::vector<uint32_t> emptyUpdateIndex = {};
@@ -4508,23 +5043,35 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> batchIdxSpec;
   if (batchIdxShape && batchIdxLayout) {
-    ASSIGN_OR_RETURN(
-        batchIdxSpec,
-        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
+    auto batchIdxSpecExp =
+        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout);
+    if (!batchIdxSpecExp) {
+      return batchIdxSpecExp.takeError();
+    }
+    batchIdxSpec = batchIdxSpecExp.get();
   }
 
   auto pagedFillCacheOpQuery = [=]() {
@@ -4551,23 +5098,35 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec cacheSpec,
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
+  auto cacheSpecExp =
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
+  if (!cacheSpecExp) {
+    return cacheSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec pageTableSpec,
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
+  auto pageTableSpecExp =
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
+  if (!pageTableSpecExp) {
+    return pageTableSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> batchIdxSpec;
   if (batchIdxShape && batchIdxLayout) {
-    ASSIGN_OR_RETURN(
-        batchIdxSpec,
-        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
+    auto batchIdxSpecExp =
+        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout);
+    if (!batchIdxSpecExp) {
+      return batchIdxSpecExp.takeError();
+    }
+    batchIdxSpec = batchIdxSpecExp.get();
   }
 
   auto pagedFillCacheOpQuery = [=]() {
@@ -4632,9 +5191,12 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -4717,9 +5279,12 @@ llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -4788,20 +5353,30 @@ llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
     TTNNLayoutAttr outputLayout) {
 
   // Convert input layout to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert weight layout to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
   // Convert bias if present
   std::optional<::ttnn::TensorSpec> biasSpec;
   if (biasShape && biasLayout) {
-    ASSIGN_OR_RETURN(
-        biasSpec, detail::convertToTensorSpec(device, *biasShape, *biasLayout));
+    auto biasSpecExp =
+        detail::convertToTensorSpec(device, *biasShape, *biasLayout);
+    if (!biasSpecExp) {
+      return biasSpecExp.takeError();
+    }
+    biasSpec = biasSpecExp.get();
   }
 
   std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
@@ -5002,9 +5577,12 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5084,9 +5662,12 @@ llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5381,9 +5962,12 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto maxPool2DQuery = [=]() {
@@ -5428,9 +6012,12 @@ llvm::Expected<size_t> OpModel<MaxPool2dOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto maxPool2DQuery = [=]() {
@@ -5480,9 +6067,12 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
@@ -5528,9 +6118,12 @@ llvm::Expected<size_t> OpModel<MaxPool2dWithIndicesOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
@@ -5579,9 +6172,12 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // default values for the variables that are received by the op's invoke
   // method in tt-metal but do not exist in the op's definition in TTNNOps.td:
@@ -5632,9 +6228,12 @@ llvm::Expected<size_t> OpModel<AvgPool2dOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // default values for the variables that are received by the op's invoke
   // method in tt-metal but do not exist in the op's definition in TTNNOps.td:
@@ -5677,9 +6276,12 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType;
   if (dtype.has_value()) {
@@ -5710,9 +6312,12 @@ llvm::Expected<size_t> OpModel<GlobalAvgPool2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType;
   if (dtype.has_value()) {
@@ -5754,9 +6359,12 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -5808,9 +6416,12 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -5867,9 +6478,12 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -5920,9 +6534,12 @@ llvm::Expected<size_t> OpModel<BatchNormTrainingOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -5975,9 +6592,12 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6019,9 +6639,12 @@ llvm::Expected<size_t> OpModel<RMSNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6160,9 +6783,12 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6198,9 +6824,12 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6242,9 +6871,12 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6286,9 +6918,12 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6336,13 +6971,19 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec statsSpec,
-      detail::convertToTensorSpec(device, statsShape, statsLayout));
+  auto statsSpecExp =
+      detail::convertToTensorSpec(device, statsShape, statsLayout);
+  if (!statsSpecExp) {
+    return statsSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6378,13 +7019,19 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec statsSpec,
-      detail::convertToTensorSpec(device, statsShape, statsLayout));
+  auto statsSpecExp =
+      detail::convertToTensorSpec(device, statsShape, statsLayout);
+  if (!statsSpecExp) {
+    return statsSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6426,9 +7073,12 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> inputMaskSpec =
       detail::convertToOptionalTensorSpec(device, inputMaskShape,
@@ -6482,9 +7132,12 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   std::optional<::ttnn::TensorSpec> inputMaskSpec =
       detail::convertToOptionalTensorSpec(device, inputMaskShape,
@@ -6550,9 +7203,12 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   auto memConfig = detail::getNullableMemoryConfig(outputLayout);
   auto minVariant = clampAttrToVariant(min);
@@ -6578,9 +7234,12 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   auto memConfig = detail::getNullableMemoryConfig(outputLayout);
   auto minVariant = clampAttrToVariant(min);
@@ -6610,15 +7269,24 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec minSpec,
-                   detail::convertToTensorSpec(device, minShape, minLayout));
+  auto minSpecExp = detail::convertToTensorSpec(device, minShape, minLayout);
+  if (!minSpecExp) {
+    return minSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec minSpec = minSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
-                   detail::convertToTensorSpec(device, maxShape, maxLayout));
+  auto maxSpecExp = detail::convertToTensorSpec(device, maxShape, maxLayout);
+  if (!maxSpecExp) {
+    return maxSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec maxSpec = maxSpecExp.get();
 
   // Create query closure
   auto clampTensorQuery = [=]() {
@@ -6644,15 +7312,24 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec minSpec,
-                   detail::convertToTensorSpec(device, minShape, minLayout));
+  auto minSpecExp = detail::convertToTensorSpec(device, minShape, minLayout);
+  if (!minSpecExp) {
+    return minSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec minSpec = minSpecExp.get();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
-                   detail::convertToTensorSpec(device, maxShape, maxLayout));
+  auto maxSpecExp = detail::convertToTensorSpec(device, maxShape, maxLayout);
+  if (!maxSpecExp) {
+    return maxSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec maxSpec = maxSpecExp.get();
 
   // Create query closure
   auto clampTensorQuery = [=]() {
@@ -6683,9 +7360,12 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
 
   float defaultedPadValue = padValue.convertToFloat();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto permuteQuery = [=]() {
@@ -6716,9 +7396,12 @@ llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
   // Convert float
   float defaultedPadValue = padValue.convertToFloat();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto permuteQuery = [=]() {
@@ -6762,9 +7445,12 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
     return llvm::createStringError("Invalid scaleFactor");
   }
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto upsampleQuery = [=]() {
@@ -6807,9 +7493,12 @@ llvm::Expected<size_t> OpModel<UpsampleOp>::getOpRuntime(
     return llvm::createStringError("Invalid scaleFactor");
   }
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto upsampleQuery = [=]() {
@@ -6839,13 +7528,19 @@ llvm::Expected<EmbeddingOpArgs> getEmbeddingOpArgs(
     ::tt::tt_metal::distributed::MeshDevice *device,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout) {
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
   return EmbeddingOpArgs{inputSpec, weightSpec};
 }
@@ -6949,17 +7644,26 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inGradientSpec,
-      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
+  auto inGradientSpecExp =
+      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout);
+  if (!inGradientSpecExp) {
+    return inGradientSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inGradientSpec = inGradientSpecExp.get();
 
   auto embeddingBackwardOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -6985,17 +7689,26 @@ OpModel<mlir::tt::ttnn::EmbeddingBackwardOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec weightSpec,
-      detail::convertToTensorSpec(device, weightShape, weightLayout));
+  auto weightSpecExp =
+      detail::convertToTensorSpec(device, weightShape, weightLayout);
+  if (!weightSpecExp) {
+    return weightSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inGradientSpec,
-      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
+  auto inGradientSpecExp =
+      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout);
+  if (!inGradientSpecExp) {
+    return inGradientSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inGradientSpec = inGradientSpecExp.get();
 
   auto embeddingBackwardOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
@@ -7022,12 +7735,19 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec indexSpec,
-      detail::convertToTensorSpec(device, indexShape, indexLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto indexSpecExp =
+      detail::convertToTensorSpec(device, indexShape, indexLayout);
+  if (!indexSpecExp) {
+    return indexSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
 
   auto gatherOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -7052,12 +7772,19 @@ llvm::Expected<size_t> OpModel<GatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec indexSpec,
-      detail::convertToTensorSpec(device, indexShape, indexLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto indexSpecExp =
+      detail::convertToTensorSpec(device, indexShape, indexLayout);
+  if (!indexSpecExp) {
+    return indexSpecExp.takeError();
+  }
+
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
 
   auto gatherOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
@@ -7278,9 +8005,12 @@ OpModel<mlir::tt::ttnn::DropoutOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   float probVal = prob.convertToFloat();
   float scaleVal = scale.convertToFloat();
@@ -7308,9 +8038,12 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::DropoutOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   float probVal = prob.convertToFloat();
   float scaleVal = scale.convertToFloat();
@@ -7456,9 +8189,12 @@ OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert output memory config
   ::tt::tt_metal::MemoryConfig metalMemConfig =
@@ -7492,9 +8228,12 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert output memory config
   ::tt::tt_metal::MemoryConfig metalMemConfig =
@@ -7532,9 +8271,12 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto topKQuery = [=]() {
@@ -7560,9 +8302,12 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto topKQuery = [=]() {
@@ -7592,9 +8337,12 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto meshPartitionOpQuery = [=]() {
@@ -7618,9 +8366,12 @@ llvm::Expected<size_t> OpModel<MeshPartitionOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  ASSIGN_OR_RETURN(
-      ::ttnn::TensorSpec inputSpec,
-      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Create query closure
   auto meshPartitionOpQuery = [=]() {

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -11,7 +11,6 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -249,13 +248,7 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
 }
 
 // Test ValidationStatus::NotImplemented
-// AllocOp carries the OpModelExempt trait and therefore does not implement
-// the OpModel interface. validateOperation must surface this as a
-// NotImplemented ValidationResult so the optimizer can fall back gracefully
-// (see GreedyMemoryLayoutPropagation / L1SpillManagement, which both branch
-// on result.isNotImplemented()). Regressing this contract — e.g. by removing
-// the OpModelExempt special case in OpConstraintValidation::validateConstraints
-// — would crash the optimizer at runtime via reportFatalInternalError.
+// AllocOp returns MissingMetalDefinition which maps to NotImplemented
 TEST_F(OpConstraintValidationTest, ValidationStatusNotImplemented) {
   llvm::SmallVector<int64_t> tensorShape = {1, 1, 32, 32};
   auto layout = createTiledLayout(tensorShape, BufferType::L1,
@@ -281,89 +274,6 @@ TEST_F(OpConstraintValidationTest, ValidationStatusNotImplemented) {
   EXPECT_TRUE(result.isError());
   EXPECT_FALSE(result.isSuccess());
   EXPECT_FALSE(result.errorMessage.empty());
-}
-
-// Regression test for "OpModelExempt -> NotImplemented" optimizer contract.
-//
-// Background: ops that opt out of the OpModel interface via the OpModelExempt
-// trait (e.g. CCL ops, trace ops, host/alloc ops, GetDeviceOp...) do not
-// implement TTNN_OpModelInterface at all. The optimizer's L1 spill / memory
-// layout propagation passes call op_constraint_validation::validateOperation
-// on every op in the IR and rely on observing isNotImplemented() for ops
-// they cannot analyze, so they can fall back (e.g. evict L1) instead of
-// taking layout decisions on bogus data.
-//
-// Before the OpModelExempt change, these ops had explicit stub
-// getOpConstraints / getOpRuntime overrides returning OpNotSupportedError,
-// which validateOperation translated to NotImplemented via handleAllErrors.
-// After OpModelExempt removed those stubs, dyn_cast<OpModel>(op) returns
-// nullptr for exempt ops and the original code path called
-// llvm::reportFatalInternalError, crashing the compiler.
-//
-// This test asserts the contract using two independent OpModelExempt ops:
-//   - GetDeviceOp: a trivial OpModelExempt op with no tensor inputs.
-//   - AllocOp:    an OpModelExempt op with a tensor result.
-// Both must be observed as NotImplemented (never crash, never silently
-// succeed). If someone removes the OpModelExempt fallback in
-// validateConstraints, both calls will hit reportFatalInternalError and
-// abort this test process.
-TEST_F(OpConstraintValidationTest,
-       OpModelExemptOpsReturnNotImplementedNotFatal) {
-  // Sanity: the trait-driven contract we are asserting.
-  static_assert(GetDeviceOp::hasTrait<OpModelExempt>(),
-                "GetDeviceOp must carry the OpModelExempt trait for this "
-                "regression test to be meaningful.");
-  static_assert(AllocOp::hasTrait<OpModelExempt>(),
-                "AllocOp must carry the OpModelExempt trait for this "
-                "regression test to be meaningful.");
-
-  // GetDeviceOp: zero tensor inputs, just produces a device value.
-  auto getDeviceOp = builder.create<GetDeviceOp>(
-      builder.getUnknownLoc(), builder.getType<DeviceType>(),
-      MeshShapeAttr::get(&context, 1, 1), MeshOffsetAttr::get(&context, 0, 0));
-
-  // Ensure the op truly does not implement the OpModel interface.
-  ASSERT_FALSE(mlir::isa<OpModel>(getDeviceOp.getOperation()))
-      << "GetDeviceOp unexpectedly implements OpModel; the OpModelExempt -> "
-         "NotImplemented fallback would never be exercised by this test.";
-
-  OpConfig config = createTestConfig();
-  auto getDeviceResult = op_constraint_validation::validateOperation(
-      getDeviceOp, /*inputLayouts=*/{}, config);
-
-  EXPECT_TRUE(getDeviceResult.isNotImplemented())
-      << "OpModelExempt op (GetDeviceOp) must surface NotImplemented to "
-         "preserve the optimizer fallback path. Status="
-      << op_constraint_validation::validationStatusToString(
-             getDeviceResult.status)
-             .str();
-  EXPECT_FALSE(getDeviceResult.isSuccess());
-  EXPECT_FALSE(getDeviceResult.errorMessage.empty());
-
-  // AllocOp: same contract via a second exempt op with different shape.
-  llvm::SmallVector<int64_t> tensorShape = {1, 1, 32, 32};
-  auto layout = createTiledLayout(tensorShape, BufferType::L1,
-                                  TensorMemoryLayout::Interleaved);
-  auto tensorType =
-      mlir::RankedTensorType::get(tensorShape, builder.getBF16Type(), layout);
-  auto allocOp = builder.create<AllocOp>(
-      builder.getUnknownLoc(), tensorType, builder.getI64IntegerAttr(0),
-      builder.getI64IntegerAttr(2048),
-      BufferTypeAttr::get(&context, BufferType::L1));
-
-  ASSERT_FALSE(mlir::isa<OpModel>(allocOp.getOperation()))
-      << "AllocOp unexpectedly implements OpModel; the OpModelExempt -> "
-         "NotImplemented fallback would never be exercised by this test.";
-
-  auto allocLayouts = ttnn::utils::extractInputLayouts(allocOp);
-  auto allocResult = op_constraint_validation::validateOperation(
-      allocOp, allocLayouts, config);
-
-  EXPECT_TRUE(allocResult.isNotImplemented())
-      << "OpModelExempt op (AllocOp) must surface NotImplemented to preserve "
-         "the optimizer fallback path. Status="
-      << op_constraint_validation::validationStatusToString(allocResult.status)
-             .str();
 }
 
 // Test ValidationStatus::MetalBackendError


### PR DESCRIPTION
## Summary

Reverts #7925.

This commit causes an L1 circular-buffer / tensor clash at runtime in tt-xla when running `qwen_3_8b` in tensor-parallel mode. The crash occurs inside `rms_norm` / `LayerNormDeviceOperation` during the warmup phase:

```
TT_THROW: Statically allocated circular buffers in program 67311 clash with L1 buffers
on core range [(x=0,y=0) - (x=7,y=7)].
L1 buffer allocated at 245536 and static circular buffer region ends at 675104
```

Tracked in issue: #8065

## Test plan

- [x] `pytest -svv tests/benchmark/test_llms.py::test_qwen_3_8b_tp` passes after revert
- [ ] Existing OpModel tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)