### PR TITLE
Paged sdpa p150 core grid setting

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3781,7 +3781,8 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
                        Optional<AnyRankedTensor>:$cur_pos_tensor,
                        Optional<AnyRankedTensor>:$attention_sink,
                        OptionalAttr<F32Attr>:$scale,
-                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                       OptionalAttr<TTNN_CoreCoordAttr>:$core_grid);
 
   let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -750,21 +750,22 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<TTNNLayoutAttr> curPosTensorLayout,
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
-      std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+      std::optional<llvm::APFloat> scale, std::optional<CoreCoordAttr> coreGrid,
+      TTNNLayoutAttr outputLayout);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-               llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-               llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-               llvm::ArrayRef<int64_t> pageTableShape,
-               TTNNLayoutAttr pageTableLayout, bool isCausal,
-               std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-               std::optional<TTNNLayoutAttr> attentionMaskLayout,
-               std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-               std::optional<TTNNLayoutAttr> curPosTensorLayout,
-               std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-               std::optional<TTNNLayoutAttr> attentionSinkLayout,
-               std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale, std::optional<CoreCoordAttr> coreGrid,
+      TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -117,6 +117,7 @@ table PagedScaledDotProductAttentionDecodeOp {
   scale: float = null;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
+  core_grid: tt.target.ttnn.CoreCoord;
 }
 
 table PagedFlashMultiLatentAttentionDecodeOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3402,7 +3402,8 @@ public:
         adaptor.getPageTable(), adaptor.getIsCausal(),
         adaptor.getAttentionMask(), adaptor.getCurPosTensor(),
         adaptor.getAttentionSink(), adaptor.getScaleAttr(),
-        /*memory_config=*/nullptr);
+        /*memory_config=*/nullptr,
+        /*core_grid=*/nullptr);
     return success();
   }
 };

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2240,6 +2240,7 @@ struct PagedScaledDotProductAttentionDecodeArgs {
   std::optional<llvm::SmallVector<int64_t>> attentionSinkShape = std::nullopt;
   std::optional<TTNNLayoutAttr> attentionSinkLayout = std::nullopt;
   std::optional<llvm::APFloat> scale = std::nullopt;
+  std::optional<CoreCoordAttr> coreGrid = std::nullopt;
 };
 
 static PagedScaledDotProductAttentionDecodeArgs
@@ -2260,6 +2261,7 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   ret.pageTableLayout = inputs[3];
   ret.isCausal = op.getIsCausal();
   ret.scale = op.getScale();
+  ret.coreGrid = op.getCoreGrid();
 
   TypedValue<RankedTensorType> attentionMask = op.getAttentionMask();
   TypedValue<RankedTensorType> curPosTensor = op.getCurPosTensor();
@@ -2304,15 +2306,20 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
-
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
+  ttcore::GridAttr deviceGrid;
+  if (pagedSdpaArgs.coreGrid) {
+    deviceGrid = ttcore::GridAttr::get(
+        getContext(), {static_cast<int64_t>(pagedSdpaArgs.coreGrid->getX()),
+                       static_cast<int64_t>(pagedSdpaArgs.coreGrid->getY())});
+  } else {
+    llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+    if (!check) {
+      return check.takeError();
+    }
+    deviceGrid = ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  }
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<
@@ -2324,7 +2331,7 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
       pagedSdpaArgs.attentionMaskShape, pagedSdpaArgs.attentionMaskLayout,
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
-      pagedSdpaArgs.scale, opConfig.outputLayout);
+      pagedSdpaArgs.scale, pagedSdpaArgs.coreGrid, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2337,13 +2344,14 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
+  if (!pagedSdpaArgs.coreGrid) {
+    llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+    if (!check) {
+      return check.takeError();
+    }
+  }
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime,
@@ -2354,7 +2362,7 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
       pagedSdpaArgs.attentionMaskShape, pagedSdpaArgs.attentionMaskLayout,
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
-      pagedSdpaArgs.scale, opConfig.outputLayout);
+      pagedSdpaArgs.scale, pagedSdpaArgs.coreGrid, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -568,6 +568,41 @@ private:
   }
 };
 
+class PagedSDPADecodeP150CoreGridWorkaround
+    : public OpRewritePattern<ttnn::PagedScaledDotProductAttentionDecodeOp> {
+  // Paged SDPA decode crashes with TT_FATAL: Output spatial index 32 out of
+  // bounds (max 32) when batch=32 and num_kv_heads=8 on Blackhole. tt-metal
+  // issue: https://github.com/tenstorrent/tt-metal/issues/40978
+public:
+  using OpRewritePattern<
+      ttnn::PagedScaledDotProductAttentionDecodeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::PagedScaledDotProductAttentionDecodeOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getCoreGrid()) {
+      return failure();
+    }
+
+    ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(op);
+    if (chipDesc.getArch().getValue() != ttcore::Arch::Blackhole) {
+      return failure();
+    }
+
+    ttcore::DeviceAttr device = ttcore::lookupDevice(op);
+    for (int64_t dim : device.getMeshShape()) {
+      if (dim != 1) {
+        return failure();
+      }
+    }
+
+    rewriter.modifyOpInPlace(op, [&]() {
+      op->setAttr("core_grid", ttnn::CoreCoordAttr::get(rewriter.getContext(),
+                                                        /*x=*/8, /*y=*/8));
+    });
+    return success();
+  }
+};
+
 // Pass to apply workarounds to the operands of TTNN operations.
 class TTNNWorkarounds : public impl::TTNNWorkaroundsBase<TTNNWorkarounds> {
 public:
@@ -577,7 +612,7 @@ public:
     if (decompositionWorkaroundsEnabled) {
       RewritePatternSet patterns(&getContext());
       patterns.add<
-          TTNNAllReduceWorkarounds,
+          PagedSDPADecodeP150CoreGridWorkaround, TTNNAllReduceWorkarounds,
           workarounds::decomposition::TTNNAllGatherWorkarounds,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2809,7 +2809,8 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+    std::optional<llvm::APFloat> scale, std::optional<CoreCoordAttr> coreGrid,
+    TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2852,6 +2853,17 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
 
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = std::nullopt;
+  if (coreGrid) {
+    sdpaProgramConfig.emplace();
+    sdpaProgramConfig->compute_with_storage_grid_size =
+        ::tt::tt_metal::CoreCoord{coreGrid->getX(), coreGrid->getY()};
+    sdpaProgramConfig->q_chunk_size = 0;
+    sdpaProgramConfig->k_chunk_size = 0;
+    sdpaProgramConfig->max_cores_per_head_batch =
+        coreGrid->getX() * coreGrid->getY();
+  }
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -2859,8 +2871,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         /*slidingWindowSize=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout), sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
@@ -2884,7 +2895,8 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+    std::optional<llvm::APFloat> scale, std::optional<CoreCoordAttr> coreGrid,
+    TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2929,6 +2941,17 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
   std::optional<uint32_t> slidingWindowSize = std::nullopt;
+  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
+      sdpaProgramConfig = std::nullopt;
+  if (coreGrid) {
+    sdpaProgramConfig.emplace();
+    sdpaProgramConfig->compute_with_storage_grid_size =
+        ::tt::tt_metal::CoreCoord{coreGrid->getX(), coreGrid->getY()};
+    sdpaProgramConfig->q_chunk_size = 0;
+    sdpaProgramConfig->k_chunk_size = 0;
+    sdpaProgramConfig->max_cores_per_head_batch =
+        coreGrid->getX() * coreGrid->getY();
+  }
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
@@ -2936,7 +2959,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        /*program_config=*/std::nullopt,
+        sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3281,6 +3281,12 @@ createOp(FlatbufferObjectCache &cache,
                  ? std::make_optional(op.getScale().value().convertToFloat())
                  : std::nullopt);
   auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
+  const ::tt::target::ttnn::CoreCoord *coreGridPtr = nullptr;
+  ::tt::target::ttnn::CoreCoord coreGridVal;
+  if (auto coreGridAttr = op.getCoreGrid()) {
+    coreGridVal = toFlatbuffer(cache, *coreGridAttr);
+    coreGridPtr = &coreGridVal;
+  }
 
   auto out =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
@@ -3289,7 +3295,7 @@ createOp(FlatbufferObjectCache &cache,
 
   return ::tt::target::ttnn::CreatePagedScaledDotProductAttentionDecodeOp(
       *cache.fbb, query, key, value, pageTable, isCausal, attentionMask,
-      curPosTensor, attentionSink, scale, out, memoryConfig);
+      curPosTensor, attentionSink, scale, out, memoryConfig, coreGridPtr);
 }
 
 ::flatbuffers::Offset<

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -67,6 +67,7 @@ static void runPagedScaledDotProductAttentionDecodeOp(
     programConfig->q_chunk_size = 0;
     programConfig->k_chunk_size = 0;
     programConfig->compute_with_storage_grid_size = computeGrid;
+    programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
   }
 
   ::ttnn::Tensor out =

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -42,7 +42,10 @@ static void runPagedScaledDotProductAttentionDecodeOp(
 
   std::optional<float> scale = op->scale();
   std::optional<uint32_t> slidingWindowSize = std::nullopt;
-  const auto computeGrid = query.device()->compute_with_storage_grid_size();
+  auto computeGrid = query.device()->compute_with_storage_grid_size();
+  if (op->core_grid()) {
+    computeGrid = ::tt::runtime::ttnn::utils::toTTNNCoreCoord(*op->core_grid());
+  }
 
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       programConfig = std::nullopt;
@@ -59,6 +62,11 @@ static void runPagedScaledDotProductAttentionDecodeOp(
     programConfig->compute_with_storage_grid_size = computeGrid;
     programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
     programConfig->exp_approx_mode = false;
+  } else if (op->core_grid()) {
+    programConfig.emplace();
+    programConfig->q_chunk_size = 0;
+    programConfig->k_chunk_size = 0;
+    programConfig->compute_with_storage_grid_size = computeGrid;
   }
 
   ::ttnn::Tensor out =

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6579,7 +6579,7 @@ protected:
             valueShape, valueLayout, pageTableShape, pageTableLayout, isCausal,
             attentionMaskShape, attentionMaskLayout, curPosTensorShape,
             curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
-            outputLayout);
+            /*coreGrid=*/std::nullopt, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2178,7 +2178,8 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
           /*cur_pos_tensor=*/curPos,
           /*attention_sink=*/nullptr,
           /*scale=*/builder.getF32FloatAttr(0.125f),
-          /*memory_config=*/nullptr);
+          /*memory_config=*/nullptr,
+          /*core_grid=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/7703

### Problem description
Paged SDPA decode crashes with `TT_FATAL: Output spatial index 32 out of bounds (max 32)` on Blackhole.

### What's changed
Exposed core grid attribute to PagedScaledDotProductAttentionDecodeOp and added workaround to set it to 8x8 grid on Blackhole single chip.