### PR TITLE
Implement constant folding for unary eltwise ops

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -335,6 +335,8 @@ def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs", [TTIR_Idempotence]> {
         -x if x < 0
       }
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_CbrtOp: TTIR_ElementwiseUnaryOp<"cbrt"> {
@@ -368,6 +370,8 @@ def TTIR_CbrtOp: TTIR_ElementwiseUnaryOp<"cbrt"> {
 
       Mathematical definition: cbrt(x) = ∛x = x^(1/3)
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil", [TTIR_Idempotence]> {
@@ -405,6 +409,8 @@ def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil", [TTIR_Idempotence]> {
 
       Mathematical definition: ceil(x) = ⌈x⌉ = min{n ∈ ℤ | n ≥ x}
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_CosOp: TTIR_ElementwiseUnaryOp<"cos"> {
@@ -424,6 +430,8 @@ def TTIR_CosOp: TTIR_ElementwiseUnaryOp<"cos"> {
       // [[0.9601, 0.5403, -0.9553, -0.1365], ... ]
       ```
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_AcosOp: TTIR_ElementwiseUnaryOp<"acos"> {
@@ -479,6 +487,8 @@ def TTIR_FloorOp: TTIR_ElementwiseUnaryOp<"floor", [TTIR_Idempotence]> {
 
       Mathematical definition: floor(x) = ⌊x⌋ = max{n ∈ ℤ | n ≤ x}
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_FracOp: TTIR_ElementwiseUnaryOp<"frac"> {
@@ -539,6 +549,8 @@ def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite"> {
 
       Mathematical definition: isfinite(x) = x ∈ ℝ
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not"> {
@@ -560,6 +572,8 @@ def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not"> {
 
       Mathematical definition: logical_not(x) = !x
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [TTIR_Involution]> {
@@ -588,6 +602,8 @@ def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [TTIR_Involution]
 
       Mathematical definition: bitwise_not(x) = ~x
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_MishOp: TTIR_ElementwiseUnaryOp<"mish"> {
@@ -657,6 +673,8 @@ def TTIR_TanOp: TTIR_ElementwiseUnaryOp<"tan"> {
 
       Mathematical definition: tan(x) = sin(x) / cos(x)
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_AtanOp: TTIR_ElementwiseUnaryOp<"atan"> {
@@ -686,6 +704,8 @@ def TTIR_AtanOp: TTIR_ElementwiseUnaryOp<"atan"> {
 
       Mathematical definition: atan(x) = tan⁻¹(x), where the result is in the range [-π/2, π/2]
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_TanhOp: TTIR_ElementwiseUnaryOp<"tanh"> {
@@ -731,6 +751,8 @@ def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal", [TTIR_Involution]>
 
       Mathematical definition: reciprocal(x) = 1 / x
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu", [TTIR_Idempotence]> {
@@ -798,6 +820,8 @@ def TTIR_RsqrtOp : TTIR_ElementwiseUnaryOp<"rsqrt"> {
 
       Mathematical definition: rsqrt(x) = 1 / sqrt(x)
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_SigmoidOp: TTIR_ElementwiseUnaryOp<"sigmoid"> {
@@ -917,6 +941,8 @@ def TTIR_SignOp: TTIR_ElementwiseUnaryOp<"sign", [TTIR_Idempotence]> {
         -1 if x < 0
       }
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_SignbitOp: TTIR_ElementwiseUnaryOp<"signbit"> {
@@ -944,6 +970,8 @@ def TTIR_SinOp: TTIR_ElementwiseUnaryOp<"sin"> {
       // [[0.9601, 0.5403, -0.3, 4.5], ... ]
       ```
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_AsinOp: TTIR_ElementwiseUnaryOp<"asin"> {
@@ -1017,6 +1045,8 @@ def TTIR_SqrtOp : TTIR_ElementwiseUnaryOp<"sqrt"> {
 
       Mathematical definition: sqrt(x) = √x
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_SquareOp : TTIR_ElementwiseUnaryOp<"square"> {
@@ -1121,6 +1151,8 @@ def TTIR_LogOp: TTIR_ElementwiseUnaryOp<"log"> {
 
       Mathematical definition: log(x) = ln(x), where ln is the natural logarithm
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_Log1pOp: TTIR_ElementwiseUnaryOp<"log1p"> {
@@ -1152,6 +1184,8 @@ def TTIR_Log1pOp: TTIR_ElementwiseUnaryOp<"log1p"> {
 
       Mathematical definition: log1p(x) = ln(1 + x)
       }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_Expm1Op: TTIR_ElementwiseUnaryOp<"expm1"> {
@@ -1184,6 +1218,8 @@ def TTIR_Expm1Op: TTIR_ElementwiseUnaryOp<"expm1"> {
 
     Mathematical definition: expm1(x) = e^x - 1
   }];
+
+  let hasFolder = 1;
 }
 
 def TTIR_ExpOp: TTIR_ElementwiseUnaryOp<"exp"> {
@@ -1205,6 +1241,8 @@ def TTIR_ExpOp: TTIR_ElementwiseUnaryOp<"exp"> {
 
       Mathematical definition: exp(x) = e^x
     }];
+
+    let hasFolder = 1;
 }
 
 def TTIR_Exp2Op: TTIR_ElementwiseUnaryOp<"exp2"> {
@@ -4728,6 +4766,8 @@ def TTIR_ClampScalarOp : TTIR_NamedOp<"clamp_scalar", [TTIR_ElementwiseUnary]> {
     let hasVerifier = 1;
 
     let hasCanonicalizer = 1;
+
+    let hasFolder = 1;
 }
 
 def TTIR_ClampTensorOp : TTIR_NamedOp<"clamp_tensor"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -142,6 +143,121 @@ constantFoldTM(mlir::Operation *op, mlir::Attribute inputAttr, Fun indexMap) {
   }
   return nullptr;
 }
+
+// Wrapper to avoid repetitive writing of template arguments of constFoldCastOp.
+template <
+    class AttrElementT, class TargetAttrElementT,
+    class ElementValueT = typename AttrElementT::ValueType,
+    class TargetElementValueT = typename TargetAttrElementT::ValueType,
+    class CalculationT = function_ref<TargetElementValueT(ElementValueT, bool)>>
+Attribute foldCast(ArrayRef<Attribute> operands, Type resType,
+                   CalculationT &&calculate) {
+  return mlir::constFoldCastOp<AttrElementT, TargetAttrElementT, ElementValueT,
+                               TargetElementValueT, void, CalculationT>(
+      operands, resType, std::forward<CalculationT>(calculate));
+}
+
+// Helper to perform constant folding of elementwise unary operators. `floatMap`
+// and `intMap` should perform a unary operation on `APFloat` and `APInt` values
+// respectively.
+template <typename Operator, typename FloatMap, typename IntMap,
+          bool isConditional = false,
+          typename FoldAdaptor = typename Operator::FoldAdaptor>
+static ::mlir::OpFoldResult
+constantFoldEltwiseUnary(Operator op, FoldAdaptor adaptor, FloatMap floatMap,
+                         IntMap intMap) {
+  auto input =
+      mlir::dyn_cast_if_present<mlir::ElementsAttr>(adaptor.getInput());
+  if (!input) {
+    return nullptr;
+  }
+  if (!input.isSplat() && !shouldFold(op)) {
+    return nullptr;
+  }
+
+  // Allow the caller to pass nullptr if they want to fold only one of float or
+  // integer types.
+  if constexpr (!std::is_same_v<FloatMap, std::nullptr_t>) {
+    if (op.getType().getElementType().isFloat()) {
+      if constexpr (isConditional) {
+        return mlir::constFoldUnaryOpConditional<mlir::FloatAttr, mlir::APFloat,
+                                                 void>(adaptor.getOperands(),
+                                                       floatMap);
+      } else {
+        return mlir::constFoldUnaryOp<mlir::FloatAttr, mlir::APFloat, void>(
+            adaptor.getOperands(), floatMap);
+      }
+    }
+  }
+
+  if constexpr (!std::is_same_v<IntMap, std::nullptr_t>) {
+    if (op.getType().getElementType().isInteger()) {
+      if constexpr (isConditional) {
+        return mlir::constFoldUnaryOpConditional<mlir::IntegerAttr, mlir::APInt,
+                                                 void>(adaptor.getOperands(),
+                                                       intMap);
+      } else {
+        return mlir::constFoldUnaryOp<mlir::IntegerAttr, mlir::APInt, void>(
+            adaptor.getOperands(), intMap);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+// Helper to perform constant folding of elementwise unary operators. `floatMap`
+// and `intMap` should perform a unary operation on `APFloat` and `APInt` values
+// respectively and return a std::optional.
+template <typename Operator, typename FloatMap, typename IntMap,
+          typename FoldAdaptor = typename Operator::FoldAdaptor>
+static ::mlir::OpFoldResult
+constantFoldEltwiseUnaryConditional(Operator op, FoldAdaptor adaptor,
+                                    FloatMap floatMap, IntMap intMap) {
+  return constantFoldEltwiseUnary<Operator, FloatMap, IntMap,
+                                  /*isConditional=*/true, FoldAdaptor>(
+      op, adaptor, floatMap, intMap);
+}
+
+// Callable that maps a C++ float function over an APFloat by converting it to
+// f32 and back to the original type. This allows folding with non standard
+// float types like bf16 using functions from C++ standard library.
+template <typename Fun>
+class ApplyToAPFloat {
+public:
+  explicit ApplyToAPFloat(Fun fn) : fn{fn} {}
+  llvm::APFloat operator()(const llvm::APFloat &value) const {
+    // If the input is already a float32, apply the function directly.
+    if (&value.getSemantics() == &llvm::APFloat::IEEEsingle()) {
+      float nativeFloat = value.convertToFloat();
+      float result = fn(nativeFloat);
+      return llvm::APFloat(result);
+    }
+
+    // Else, convert to float32, apply the function, and convert back.
+    // Note that we don't support f64, so this won't lower precision.
+    llvm::APFloat floatVal = value;
+    bool losesInfo{};
+    floatVal.convert(llvm::APFloat::IEEEsingle(),
+                     llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+
+    float nativeFloat = floatVal.convertToFloat();
+    float result = fn(nativeFloat);
+
+    llvm::APFloat finalResult(result);
+    finalResult.convert(value.getSemantics(),
+                        llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+    return finalResult;
+  }
+
+private:
+  Fun fn;
+};
+
+// Deduction guide to avoid having to write the template parameter at the
+// call site.
+template <typename Fun>
+ApplyToAPFloat(Fun) -> ApplyToAPFloat<Fun>;
 
 //===----------------------------------------------------------------------===//
 // AddOp
@@ -508,6 +624,51 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
   }
 
   return success();
+}
+
+// ClampScalarOp folder
+::mlir::OpFoldResult mlir::tt::ttir::ClampScalarOp::fold(FoldAdaptor adaptor) {
+  // We use double here since `min` and `max` attributes are f32 or i32 and
+  // every f32 and i32 value can be exactly represented as a double.
+  double min{}, max{};
+  if (auto floatMin = mlir::dyn_cast<mlir::FloatAttr>(getMin())) {
+    min = floatMin.getValueAsDouble();
+  } else if (auto intMin = mlir::dyn_cast<mlir::IntegerAttr>(getMin())) {
+    min = static_cast<double>(intMin.getInt());
+  } else {
+    return nullptr;
+  }
+  if (auto floatMax = mlir::dyn_cast<mlir::FloatAttr>(getMax())) {
+    max = floatMax.getValueAsDouble();
+  } else if (auto intMax = mlir::dyn_cast<mlir::IntegerAttr>(getMax())) {
+    max = static_cast<double>(intMax.getInt());
+  } else {
+    return nullptr;
+  }
+
+  auto clampFloat = ApplyToAPFloat([min = static_cast<float>(min),
+                                    max = static_cast<float>(max)](float val) {
+    return std::clamp(val, min, max);
+  });
+
+  auto intType = mlir::dyn_cast<mlir::IntegerType>(getType().getElementType());
+  bool isUnsigned = intType && intType.isUnsignedInteger();
+  // If not int, just create the width large enough to create lambda closure
+  // parameters without error.
+  auto width = intType ? intType.getWidth() : 64;
+
+  auto clampInt =
+      [isUnsigned,
+       min = llvm::APInt(width, static_cast<uint64_t>(min), !isUnsigned),
+       max = llvm::APInt(width, static_cast<uint64_t>(max), !isUnsigned)](
+          llvm::APInt val) {
+        if (isUnsigned) {
+          return llvm::APIntOps::umax(llvm::APIntOps::umin(val, max), min);
+        }
+        return llvm::APIntOps::smax(llvm::APIntOps::smin(val, max), min);
+      };
+
+  return constantFoldEltwiseUnary(*this, adaptor, clampFloat, clampInt);
 }
 
 // ClampScalarOp canonicalization
@@ -974,30 +1135,8 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 
 // NegOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::NegOp::fold(FoldAdaptor adaptor) {
-  Attribute attr = adaptor.getInput();
-  if (!attr) {
-    return nullptr;
-  }
-  if (!shouldFold(*this)) {
-    return nullptr;
-  }
-
-  if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr)) {
-    Type elementType = denseAttr.getElementType();
-    if (elementType.isInteger()) {
-      return denseAttr.mapValues(elementType,
-                                 [](const APInt &val) { return -val; });
-    }
-    if (elementType.isFloat()) {
-      return denseAttr.mapValues(elementType, [](const llvm::APFloat &val) {
-        // Negate the float and reinterpret its raw bits as an integer for
-        // DenseElementsAttr's internal storage.
-        return (-val).bitcastToAPInt();
-      });
-    }
-  }
-
-  return nullptr;
+  auto neg = std::negate<>();
+  return constantFoldEltwiseUnary(*this, adaptor, neg, neg);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3317,8 +3456,7 @@ constantFoldTypecast(mlir::tt::ttir::TypecastOp op,
 
   if (inputElementType.isFloat()) {
     if (auto targetType = mlir::dyn_cast<FloatType>(outputElementType)) {
-      return constFoldCastOp<mlir::FloatAttr, mlir::FloatAttr, llvm::APFloat,
-                             llvm::APFloat, void>(
+      return foldCast<mlir::FloatAttr, mlir::FloatAttr>(
           adaptor.getOperands(), outputType,
           [targetType](llvm::APFloat value, bool &castStatus) -> llvm::APFloat {
             bool losesInfo{};
@@ -3331,8 +3469,7 @@ constantFoldTypecast(mlir::tt::ttir::TypecastOp op,
     }
 
     if (auto targetType = mlir::dyn_cast<IntegerType>(outputElementType)) {
-      return constFoldCastOp<mlir::FloatAttr, mlir::IntegerAttr, llvm::APFloat,
-                             llvm::APInt, void>(
+      return foldCast<mlir::FloatAttr, mlir::IntegerAttr>(
           adaptor.getOperands(), outputType,
           [targetType](const llvm::APFloat &value,
                        bool &castStatus) -> llvm::APInt {
@@ -3349,8 +3486,7 @@ constantFoldTypecast(mlir::tt::ttir::TypecastOp op,
 
   if (auto sourceType = mlir::dyn_cast<mlir::IntegerType>(inputElementType)) {
     if (auto targetType = mlir::dyn_cast<FloatType>(outputElementType)) {
-      return constFoldCastOp<mlir::IntegerAttr, mlir::FloatAttr, llvm::APInt,
-                             llvm::APFloat, void>(
+      return foldCast<mlir::IntegerAttr, mlir::FloatAttr>(
           adaptor.getOperands(), outputType,
           [sourceType, targetType](const llvm::APInt &value,
                                    bool &castStatus) -> llvm::APFloat {
@@ -3366,8 +3502,7 @@ constantFoldTypecast(mlir::tt::ttir::TypecastOp op,
     }
 
     if (auto targetType = mlir::dyn_cast<IntegerType>(outputElementType)) {
-      return constFoldCastOp<mlir::IntegerAttr, mlir::IntegerAttr, llvm::APInt,
-                             llvm::APInt, void>(
+      return foldCast<mlir::IntegerAttr, mlir::IntegerAttr>(
           adaptor.getOperands(), outputType,
           [sourceType, targetType](const llvm::APInt &value,
                                    bool &castStatus) -> llvm::APInt {
@@ -7321,6 +7456,241 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// AbsOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::AbsOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(
+      *this, adaptor, [](const llvm::APFloat &x) { return llvm::abs(x); },
+      [](const llvm::APInt &x) { return x.abs(); });
+}
+
+//===----------------------------------------------------------------------===//
+// AtanOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::AtanOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::atanf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// BitwiseNotOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::BitwiseNotOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(
+      *this, adaptor,
+      [](const llvm::APFloat &x) {
+        // APFloat doesn't support bitwise not, so we bitcast it to APInt
+        // and back.
+        return llvm::APFloat(x.getSemantics(), ~x.bitcastToAPInt());
+      },
+      [](const llvm::APInt &x) { return ~x; });
+}
+
+//===----------------------------------------------------------------------===//
+// CbrtOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::CbrtOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::cbrtf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// CeilOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::CeilOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::ceilf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// CosOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::CosOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::cosf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// ExpOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::ExpOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::expf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Expm1Op
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::Expm1Op::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::expm1f),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// FloorOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::FloorOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::floorf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// IsFiniteOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::IsFiniteOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(
+      *this, adaptor,
+      [](const llvm::APFloat &x) {
+        return x.isFinite() ? llvm::APFloat::getOne(x.getSemantics())
+                            : llvm::APFloat::getZero(x.getSemantics());
+      },
+      nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// LogOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::LogOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::logf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Log1pOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::Log1pOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::log1pf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalNotOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::LogicalNotOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(
+      *this, adaptor,
+      [](const llvm::APFloat &x) {
+        return llvm::APFloat(x.getSemantics(), x.isZero() ? 1 : 0);
+      },
+      [](const llvm::APInt &x) {
+        return llvm::APInt(x.getBitWidth(), x.isZero() ? 1 : 0,
+                           /*isSigned=*/false);
+      });
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// ReciprocalOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::ReciprocalOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnaryConditional(
+      *this, adaptor,
+      [](const llvm::APFloat &x) -> std::optional<llvm::APFloat> {
+        llvm::APFloat result = llvm::APFloat(1.0f) / x;
+        if (result.isFinite()) {
+          return result;
+        }
+        // Don't fold if the result is inf because runtime doesn't support
+        // it fully.
+        return {};
+      },
+      nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// RsqrtOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::RsqrtOp::fold(FoldAdaptor adaptor) {
+  auto rsqrt = ApplyToAPFloat([](float x) { return 1.0f / ::sqrtf(x); });
+  return constantFoldEltwiseUnaryConditional(
+      *this, adaptor,
+      [rsqrt](const llvm::APFloat &x) -> std::optional<llvm::APFloat> {
+        if (x.isZero()) {
+          // Don't fold if the result is inf because runtime doesn't support
+          // it fully.
+          return {};
+        }
+        return rsqrt(x);
+      },
+      nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// SignOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::SignOp::fold(FoldAdaptor adaptor) {
+  auto intType = mlir::dyn_cast<mlir::IntegerType>(getType().getElementType());
+  bool isUnsigned = intType && intType.isUnsignedInteger();
+  return constantFoldEltwiseUnary(
+      *this, adaptor,
+      [](const llvm::APFloat &x) {
+        if (x.isZero()) {
+          return llvm::APFloat::getZero(x.getSemantics());
+        }
+        if (x.isNegative()) {
+          return llvm::APFloat::getOne(x.getSemantics(), /*Negative=*/true);
+        }
+        if (x.isNaN()) {
+          return x;
+        }
+        // x is positive.
+        return llvm::APFloat::getOne(x.getSemantics());
+      },
+      [isUnsigned](const llvm::APInt &x) {
+        if (x.isZero()) {
+          return llvm::APInt::getZero(x.getBitWidth());
+        }
+        if (isUnsigned || x.isStrictlyPositive()) {
+          return llvm::APInt(x.getBitWidth(), 1);
+        }
+        return llvm::APInt(x.getBitWidth(), -1, true);
+      });
+}
+
+//===----------------------------------------------------------------------===//
+// SinOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::SinOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::sinf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// SqrtOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::SqrtOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::sqrtf),
+                                  nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// TanOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult mlir::tt::ttir::TanOp::fold(FoldAdaptor adaptor) {
+  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::tanf),
+                                  nullptr);
 }
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -161,13 +161,12 @@ Attribute foldCast(ArrayRef<Attribute> operands, Type resType,
 // and `intMap` should perform a unary operation on `APFloat` and `APInt` values
 // respectively.
 template <typename Operator, typename FloatMap, typename IntMap,
-          bool isConditional = false,
           typename FoldAdaptor = typename Operator::FoldAdaptor>
 static ::mlir::OpFoldResult
 constantFoldEltwiseUnary(Operator op, FoldAdaptor adaptor, FloatMap floatMap,
                          IntMap intMap) {
-  auto input =
-      mlir::dyn_cast_if_present<mlir::ElementsAttr>(adaptor.getInput());
+  mlir::DenseElementsAttr input =
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(adaptor.getInput());
   if (!input) {
     return nullptr;
   }
@@ -178,45 +177,38 @@ constantFoldEltwiseUnary(Operator op, FoldAdaptor adaptor, FloatMap floatMap,
   // Allow the caller to pass nullptr if they want to fold only one of float or
   // integer types.
   if constexpr (!std::is_same_v<FloatMap, std::nullptr_t>) {
-    if (op.getType().getElementType().isFloat()) {
-      if constexpr (isConditional) {
-        return mlir::constFoldUnaryOpConditional<mlir::FloatAttr, mlir::APFloat,
-                                                 void>(adaptor.getOperands(),
-                                                       floatMap);
-      } else {
-        return mlir::constFoldUnaryOp<mlir::FloatAttr, mlir::APFloat, void>(
-            adaptor.getOperands(), floatMap);
+    if (input.getElementType().isFloat()) {
+      if (input.isSplat()) {
+        auto splatValue = input.getSplatValue<llvm::APFloat>();
+        auto result = floatMap(splatValue);
+        return mlir::SplatElementsAttr::get(input.getType(), result);
       }
+      llvm::SmallVector<llvm::APFloat> results;
+      results.reserve(input.getNumElements());
+      for (auto value : input.getValues<llvm::APFloat>()) {
+        results.push_back(floatMap(value));
+      }
+      return mlir::DenseElementsAttr::get(input.getType(), results);
     }
   }
 
   if constexpr (!std::is_same_v<IntMap, std::nullptr_t>) {
-    if (op.getType().getElementType().isInteger()) {
-      if constexpr (isConditional) {
-        return mlir::constFoldUnaryOpConditional<mlir::IntegerAttr, mlir::APInt,
-                                                 void>(adaptor.getOperands(),
-                                                       intMap);
-      } else {
-        return mlir::constFoldUnaryOp<mlir::IntegerAttr, mlir::APInt, void>(
-            adaptor.getOperands(), intMap);
+    if (input.getElementType().isInteger()) {
+      if (input.isSplat()) {
+        auto splatValue = input.getSplatValue<llvm::APInt>();
+        auto result = intMap(splatValue);
+        return mlir::SplatElementsAttr::get(input.getType(), result);
       }
+      llvm::SmallVector<llvm::APInt> results;
+      results.reserve(input.getNumElements());
+      for (auto value : input.getValues<llvm::APInt>()) {
+        results.push_back(intMap(value));
+      }
+      return mlir::DenseElementsAttr::get(input.getType(), results);
     }
   }
 
   return nullptr;
-}
-
-// Helper to perform constant folding of elementwise unary operators. `floatMap`
-// and `intMap` should perform a unary operation on `APFloat` and `APInt` values
-// respectively and return a std::optional.
-template <typename Operator, typename FloatMap, typename IntMap,
-          typename FoldAdaptor = typename Operator::FoldAdaptor>
-static ::mlir::OpFoldResult
-constantFoldEltwiseUnaryConditional(Operator op, FoldAdaptor adaptor,
-                                    FloatMap floatMap, IntMap intMap) {
-  return constantFoldEltwiseUnary<Operator, FloatMap, IntMap,
-                                  /*isConditional=*/true, FoldAdaptor>(
-      op, adaptor, floatMap, intMap);
 }
 
 // Callable that maps a C++ float function over an APFloat by converting it to
@@ -7598,17 +7590,40 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 // ReciprocalOp
 //===----------------------------------------------------------------------===//
 
+static bool noneZero(mlir::Attribute attr) {
+  if (auto elementsAttr = mlir::dyn_cast_if_present<mlir::ElementsAttr>(attr)) {
+    if (elementsAttr.getElementType().isFloat()) {
+      if (elementsAttr.isSplat()) {
+        return !elementsAttr.getSplatValue<llvm::APFloat>().isZero();
+      }
+      auto begin = elementsAttr.value_begin<llvm::APFloat>();
+      auto end = elementsAttr.value_end<llvm::APFloat>();
+      return std::none_of(begin, end, [](const llvm::APFloat &value) {
+        return value.isZero();
+      });
+    }
+    if (elementsAttr.getElementType().isInteger()) {
+      if (elementsAttr.isSplat()) {
+        return !elementsAttr.getSplatValue<llvm::APInt>().isZero();
+      }
+      auto begin = elementsAttr.value_begin<llvm::APInt>();
+      auto end = elementsAttr.value_end<llvm::APInt>();
+      return std::none_of(
+          begin, end, [](const llvm::APInt &value) { return value.isZero(); });
+    }
+  }
+  return false;
+}
+
 ::mlir::OpFoldResult mlir::tt::ttir::ReciprocalOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnaryConditional(
+  if (!noneZero(adaptor.getInput())) {
+    // Don't fold if the result is inf because runtime doesn't support it fully.
+    return nullptr;
+  }
+  return constantFoldEltwiseUnary(
       *this, adaptor,
-      [](const llvm::APFloat &x) -> std::optional<llvm::APFloat> {
-        llvm::APFloat result = llvm::APFloat::getOne(x.getSemantics()) / x;
-        if (result.isFinite()) {
-          return result;
-        }
-        // Don't fold if the result is inf because runtime doesn't support
-        // it fully.
-        return {};
+      [](const llvm::APFloat &x) {
+        return llvm::APFloat::getOne(x.getSemantics()) / x;
       },
       nullptr);
 }
@@ -7618,18 +7633,12 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::RsqrtOp::fold(FoldAdaptor adaptor) {
+  if (!noneZero(adaptor.getInput())) {
+    // Don't fold if the result is inf because runtime doesn't support it fully.
+    return nullptr;
+  }
   auto rsqrt = ApplyToAPFloat([](float x) { return 1.0f / ::sqrtf(x); });
-  return constantFoldEltwiseUnaryConditional(
-      *this, adaptor,
-      [rsqrt](const llvm::APFloat &x) -> std::optional<llvm::APFloat> {
-        if (x.isZero()) {
-          // Don't fold if the result is inf because runtime doesn't support
-          // it fully.
-          return {};
-        }
-        return rsqrt(x);
-      },
-      nullptr);
+  return constantFoldEltwiseUnary(*this, adaptor, rsqrt, nullptr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -620,47 +620,49 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
 
 // ClampScalarOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ClampScalarOp::fold(FoldAdaptor adaptor) {
-  // We use double here since `min` and `max` attributes are f32 or i32 and
-  // every f32 and i32 value can be exactly represented as a double.
-  double min{}, max{};
-  if (auto floatMin = mlir::dyn_cast<mlir::FloatAttr>(getMin())) {
-    min = floatMin.getValueAsDouble();
-  } else if (auto intMin = mlir::dyn_cast<mlir::IntegerAttr>(getMin())) {
-    min = static_cast<double>(intMin.getInt());
-  } else {
-    return nullptr;
-  }
-  if (auto floatMax = mlir::dyn_cast<mlir::FloatAttr>(getMax())) {
-    max = floatMax.getValueAsDouble();
-  } else if (auto intMax = mlir::dyn_cast<mlir::IntegerAttr>(getMax())) {
-    max = static_cast<double>(intMax.getInt());
-  } else {
+  auto input =
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(adaptor.getInput());
+  if (!input) {
     return nullptr;
   }
 
-  auto clampFloat = ApplyToAPFloat([min = static_cast<float>(min),
-                                    max = static_cast<float>(max)](float val) {
-    return std::clamp(val, min, max);
-  });
+  if (auto floatType =
+          mlir::dyn_cast<mlir::FloatType>(input.getElementType())) {
+    auto min = ttmlir::utils::attributeToAPFloat(getMin());
+    auto max = ttmlir::utils::attributeToAPFloat(getMax());
+    if (&floatType.getFloatSemantics() != &llvm::APFloat::IEEEsingle()) {
+      bool losesInfo{};
+      min.convert(floatType.getFloatSemantics(),
+                  llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+      max.convert(floatType.getFloatSemantics(),
+                  llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+    }
+    return constantFoldEltwiseUnary(
+        *this, adaptor,
+        [min, max](const llvm::APFloat &val) {
+          return std::clamp(val, min, max);
+        },
+        nullptr);
+  }
 
-  auto intType = mlir::dyn_cast<mlir::IntegerType>(getType().getElementType());
-  bool isUnsigned = intType && intType.isUnsignedInteger();
-  // If not int, just create the width large enough to create lambda closure
-  // parameters without error.
-  auto width = intType ? intType.getWidth() : 64;
+  if (auto intType =
+          mlir::dyn_cast<mlir::IntegerType>(input.getElementType())) {
+    double minDouble = ttmlir::utils::attributeToDouble(getMin());
+    double maxDouble = ttmlir::utils::attributeToDouble(getMax());
+    auto min = llvm::APInt(intType.getWidth(), static_cast<int64_t>(minDouble));
+    auto max = llvm::APInt(intType.getWidth(), static_cast<int64_t>(maxDouble));
+    bool isUnsigned = intType.isUnsigned();
+    return constantFoldEltwiseUnary(
+        *this, adaptor, nullptr,
+        [min, max, isUnsigned](const llvm::APInt &val) {
+          if (isUnsigned) {
+            return llvm::APIntOps::umax(min, llvm::APIntOps::umin(val, max));
+          }
+          return llvm::APIntOps::smax(min, llvm::APIntOps::smin(val, max));
+        });
+  }
 
-  auto clampInt =
-      [isUnsigned,
-       min = llvm::APInt(width, static_cast<uint64_t>(min), !isUnsigned),
-       max = llvm::APInt(width, static_cast<uint64_t>(max), !isUnsigned)](
-          llvm::APInt val) {
-        if (isUnsigned) {
-          return llvm::APIntOps::umax(llvm::APIntOps::umin(val, max), min);
-        }
-        return llvm::APIntOps::smax(llvm::APIntOps::smin(val, max), min);
-      };
-
-  return constantFoldEltwiseUnary(*this, adaptor, clampFloat, clampInt);
+  return nullptr;
 }
 
 // ClampScalarOp canonicalization

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -201,6 +201,7 @@ static ::mlir::Attribute constantFoldEltwiseUnaryInt(mlir::Operation *op,
   }
 
   if (op->getOperand(0).getType() != op->getResult(0).getType()) {
+    // Avoid implicit type conversion in folders since it does not happen often.
     return nullptr;
   }
   if (!input.isSplat() && !shouldFold(op)) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7592,7 +7592,6 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
         return llvm::APInt(x.getBitWidth(), x.isZero() ? 1 : 0,
                            /*isSigned=*/false);
       });
-  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -7603,7 +7602,7 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
   return constantFoldEltwiseUnaryConditional(
       *this, adaptor,
       [](const llvm::APFloat &x) -> std::optional<llvm::APFloat> {
-        llvm::APFloat result = llvm::APFloat(1.0f) / x;
+        llvm::APFloat result = llvm::APFloat::getOne(x.getSemantics()) / x;
         if (result.isFinite()) {
           return result;
         }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1144,16 +1144,6 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
-// NegOp
-//===----------------------------------------------------------------------===//
-
-// NegOp folder
-::mlir::OpFoldResult mlir::tt::ttir::NegOp::fold(FoldAdaptor adaptor) {
-  auto neg = std::negate<>();
-  return constantFoldEltwiseUnary(*this, adaptor.getInput(), neg, neg);
-}
-
-//===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
 
@@ -7599,6 +7589,16 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
         return llvm::APInt(x.getBitWidth(), x.isZero() ? 1 : 0,
                            /*isSigned=*/false);
       });
+}
+
+//===----------------------------------------------------------------------===//
+// NegOp
+//===----------------------------------------------------------------------===//
+
+// NegOp folder
+::mlir::OpFoldResult mlir::tt::ttir::NegOp::fold(FoldAdaptor adaptor) {
+  auto neg = std::negate<>();
+  return constantFoldEltwiseUnary(*this, adaptor.getInput(), neg, neg);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -157,57 +157,70 @@ Attribute foldCast(ArrayRef<Attribute> operands, Type resType,
       operands, resType, std::forward<CalculationT>(calculate));
 }
 
-// Helper to perform constant folding of elementwise unary operators. `floatMap`
-// and `intMap` should perform a unary operation on `APFloat` and `APInt` values
-// respectively.
-template <typename Operator, typename FloatMap, typename IntMap,
-          typename FoldAdaptor = typename Operator::FoldAdaptor>
-static ::mlir::OpFoldResult
-constantFoldEltwiseUnary(Operator op, FoldAdaptor adaptor, FloatMap floatMap,
-                         IntMap intMap) {
+// Helper to perform constant folding of elementwise unary operators when
+// element type is float. `floatMap` should perform a unary operation on
+// `APFloat` values respectively.
+template <typename Fun>
+static ::mlir::Attribute
+constantFoldEltwiseUnaryFloat(mlir::Operation *op, mlir::Attribute inputAttr,
+                              Fun floatMap) {
   mlir::DenseElementsAttr input =
-      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(adaptor.getInput());
-  if (!input) {
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(inputAttr);
+  if (!input || !input.getElementType().isFloat()) {
     return nullptr;
   }
   if (!input.isSplat() && !shouldFold(op)) {
     return nullptr;
   }
 
-  // Allow the caller to pass nullptr if they want to fold only one of float or
-  // integer types.
-  if constexpr (!std::is_same_v<FloatMap, std::nullptr_t>) {
-    if (input.getElementType().isFloat()) {
-      if (input.isSplat()) {
-        auto splatValue = input.getSplatValue<llvm::APFloat>();
-        auto result = floatMap(splatValue);
-        return mlir::SplatElementsAttr::get(input.getType(), result);
-      }
-      llvm::SmallVector<llvm::APFloat> results;
-      results.reserve(input.getNumElements());
-      for (auto value : input.getValues<llvm::APFloat>()) {
-        results.push_back(floatMap(value));
-      }
-      return mlir::DenseElementsAttr::get(input.getType(), results);
-    }
+  return input.mapValues(input.getElementType(),
+                         [floatMap](const llvm::APFloat &value) {
+                           llvm::APFloat result = floatMap(value);
+                           // `mapValues` expects the lambda to return an APInt,
+                           // so we reinterpret the bits of the APFloat result
+                           // as an APInt before returning.
+                           return result.bitcastToAPInt();
+                         });
+}
+
+// Helper to perform constant folding of elementwise unary operators when
+// element type is integer. `intMap` should perform a unary operation on `APInt`
+// values respectively.
+template <typename Fun>
+static ::mlir::Attribute constantFoldEltwiseUnaryInt(mlir::Operation *op,
+                                                     mlir::Attribute inputAttr,
+                                                     Fun intMap) {
+  mlir::DenseElementsAttr input =
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(inputAttr);
+  if (!input || !input.getElementType().isInteger()) {
+    return nullptr;
+  }
+  if (!input.isSplat() && !shouldFold(op)) {
+    return nullptr;
   }
 
-  if constexpr (!std::is_same_v<IntMap, std::nullptr_t>) {
-    if (input.getElementType().isInteger()) {
-      if (input.isSplat()) {
-        auto splatValue = input.getSplatValue<llvm::APInt>();
-        auto result = intMap(splatValue);
-        return mlir::SplatElementsAttr::get(input.getType(), result);
-      }
-      llvm::SmallVector<llvm::APInt> results;
-      results.reserve(input.getNumElements());
-      for (auto value : input.getValues<llvm::APInt>()) {
-        results.push_back(intMap(value));
-      }
-      return mlir::DenseElementsAttr::get(input.getType(), results);
-    }
+  return input.mapValues(input.getElementType(), intMap);
+}
+
+// Helper to perform constant folding of elementwise unary operators. `floatMap`
+// and `intMap` should perform a unary operation on `APFloat` and `APInt` values
+// respectively.
+template <typename FloatMap, typename IntMap>
+static ::mlir::OpFoldResult
+constantFoldEltwiseUnary(mlir::Operation *op, mlir::Attribute inputAttr,
+                         FloatMap floatMap, IntMap intMap) {
+  mlir::DenseElementsAttr input =
+      mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(inputAttr);
+  if (!input) {
+    return nullptr;
   }
 
+  if (input.getElementType().isFloat()) {
+    return constantFoldEltwiseUnaryFloat(op, inputAttr, floatMap);
+  }
+  if (input.getElementType().isInteger()) {
+    return constantFoldEltwiseUnaryInt(op, inputAttr, intMap);
+  }
   return nullptr;
 }
 
@@ -637,12 +650,10 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
       max.convert(floatType.getFloatSemantics(),
                   llvm::APFloat::rmNearestTiesToEven, &losesInfo);
     }
-    return constantFoldEltwiseUnary(
-        *this, adaptor,
-        [min, max](const llvm::APFloat &val) {
-          return std::clamp(val, min, max);
-        },
-        nullptr);
+    return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                         [min, max](const llvm::APFloat &val) {
+                                           return std::clamp(val, min, max);
+                                         });
   }
 
   if (auto intType =
@@ -652,8 +663,8 @@ void mlir::tt::ttir::LogicalOrOp::getCanonicalizationPatterns(
     auto min = llvm::APInt(intType.getWidth(), static_cast<int64_t>(minDouble));
     auto max = llvm::APInt(intType.getWidth(), static_cast<int64_t>(maxDouble));
     bool isUnsigned = intType.isUnsigned();
-    return constantFoldEltwiseUnary(
-        *this, adaptor, nullptr,
+    return constantFoldEltwiseUnaryInt(
+        *this, adaptor.getInput(),
         [min, max, isUnsigned](const llvm::APInt &val) {
           if (isUnsigned) {
             return llvm::APIntOps::umax(min, llvm::APIntOps::umin(val, max));
@@ -1130,7 +1141,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 // NegOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::NegOp::fold(FoldAdaptor adaptor) {
   auto neg = std::negate<>();
-  return constantFoldEltwiseUnary(*this, adaptor, neg, neg);
+  return constantFoldEltwiseUnary(*this, adaptor.getInput(), neg, neg);
 }
 
 //===----------------------------------------------------------------------===//
@@ -7458,7 +7469,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 
 ::mlir::OpFoldResult mlir::tt::ttir::AbsOp::fold(FoldAdaptor adaptor) {
   return constantFoldEltwiseUnary(
-      *this, adaptor, [](const llvm::APFloat &x) { return llvm::abs(x); },
+      *this, adaptor.getInput(),
+      [](const llvm::APFloat &x) { return llvm::abs(x); },
       [](const llvm::APInt &x) { return x.abs(); });
 }
 
@@ -7467,8 +7479,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::AtanOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::atanf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::atanf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7476,14 +7488,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::BitwiseNotOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(
-      *this, adaptor,
-      [](const llvm::APFloat &x) {
-        // APFloat doesn't support bitwise not, so we bitcast it to APInt
-        // and back.
-        return llvm::APFloat(x.getSemantics(), ~x.bitcastToAPInt());
-      },
-      [](const llvm::APInt &x) { return ~x; });
+  return constantFoldEltwiseUnaryInt(*this, adaptor.getInput(),
+                                     [](const llvm::APInt &x) { return ~x; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -7491,8 +7497,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::CbrtOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::cbrtf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::cbrtf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7500,8 +7506,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::CeilOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::ceilf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::ceilf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7509,8 +7515,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::CosOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::cosf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::cosf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7518,8 +7524,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::ExpOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::expf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::expf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7527,8 +7533,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::Expm1Op::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::expm1f),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::expm1f));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7536,8 +7542,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::FloorOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::floorf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::floorf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7545,13 +7551,11 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::IsFiniteOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(
-      *this, adaptor,
-      [](const llvm::APFloat &x) {
+  return constantFoldEltwiseUnaryFloat(
+      *this, adaptor.getInput(), [](const llvm::APFloat &x) {
         return x.isFinite() ? llvm::APFloat::getOne(x.getSemantics())
                             : llvm::APFloat::getZero(x.getSemantics());
-      },
-      nullptr);
+      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -7559,8 +7563,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::LogOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::logf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::logf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7568,8 +7572,8 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::Log1pOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::log1pf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::log1pf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7578,7 +7582,7 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 
 ::mlir::OpFoldResult mlir::tt::ttir::LogicalNotOp::fold(FoldAdaptor adaptor) {
   return constantFoldEltwiseUnary(
-      *this, adaptor,
+      *this, adaptor.getInput(),
       [](const llvm::APFloat &x) {
         return llvm::APFloat(x.getSemantics(), x.isZero() ? 1 : 0);
       },
@@ -7598,20 +7602,15 @@ static bool noneZero(mlir::Attribute attr) {
       if (elementsAttr.isSplat()) {
         return !elementsAttr.getSplatValue<llvm::APFloat>().isZero();
       }
-      auto begin = elementsAttr.value_begin<llvm::APFloat>();
-      auto end = elementsAttr.value_end<llvm::APFloat>();
-      return std::none_of(begin, end, [](const llvm::APFloat &value) {
-        return value.isZero();
-      });
+      return llvm::none_of(elementsAttr.getValues<llvm::APFloat>(),
+                           std::mem_fn(&llvm::APFloat::isZero));
     }
     if (elementsAttr.getElementType().isInteger()) {
       if (elementsAttr.isSplat()) {
         return !elementsAttr.getSplatValue<llvm::APInt>().isZero();
       }
-      auto begin = elementsAttr.value_begin<llvm::APInt>();
-      auto end = elementsAttr.value_end<llvm::APInt>();
-      return std::none_of(
-          begin, end, [](const llvm::APInt &value) { return value.isZero(); });
+      return llvm::none_of(elementsAttr.getValues<llvm::APInt>(),
+                           std::mem_fn(&llvm::APInt::isZero));
     }
   }
   return false;
@@ -7622,12 +7621,10 @@ static bool noneZero(mlir::Attribute attr) {
     // Don't fold if the result is inf because runtime doesn't support it fully.
     return nullptr;
   }
-  return constantFoldEltwiseUnary(
-      *this, adaptor,
-      [](const llvm::APFloat &x) {
+  return constantFoldEltwiseUnaryFloat(
+      *this, adaptor.getInput(), [](const llvm::APFloat &x) {
         return llvm::APFloat::getOne(x.getSemantics()) / x;
-      },
-      nullptr);
+      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -7640,7 +7637,7 @@ static bool noneZero(mlir::Attribute attr) {
     return nullptr;
   }
   auto rsqrt = ApplyToAPFloat([](float x) { return 1.0f / ::sqrtf(x); });
-  return constantFoldEltwiseUnary(*this, adaptor, rsqrt, nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(), rsqrt);
 }
 
 //===----------------------------------------------------------------------===//
@@ -7651,7 +7648,7 @@ static bool noneZero(mlir::Attribute attr) {
   auto intType = mlir::dyn_cast<mlir::IntegerType>(getType().getElementType());
   bool isUnsigned = intType && intType.isUnsignedInteger();
   return constantFoldEltwiseUnary(
-      *this, adaptor,
+      *this, adaptor.getInput(),
       [](const llvm::APFloat &x) {
         if (x.isZero()) {
           return llvm::APFloat::getZero(x.getSemantics());
@@ -7681,8 +7678,8 @@ static bool noneZero(mlir::Attribute attr) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::SinOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::sinf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::sinf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7690,8 +7687,8 @@ static bool noneZero(mlir::Attribute attr) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::SqrtOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::sqrtf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::sqrtf));
 }
 
 //===----------------------------------------------------------------------===//
@@ -7699,8 +7696,8 @@ static bool noneZero(mlir::Attribute attr) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::OpFoldResult mlir::tt::ttir::TanOp::fold(FoldAdaptor adaptor) {
-  return constantFoldEltwiseUnary(*this, adaptor, ApplyToAPFloat(::tanf),
-                                  nullptr);
+  return constantFoldEltwiseUnaryFloat(*this, adaptor.getInput(),
+                                       ApplyToAPFloat(::tanf));
 }
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -169,6 +169,10 @@ constantFoldEltwiseUnaryFloat(mlir::Operation *op, mlir::Attribute inputAttr,
   if (!input || !input.getElementType().isFloat()) {
     return nullptr;
   }
+
+  if (op->getOperand(0).getType() != op->getResult(0).getType()) {
+    return nullptr;
+  }
   if (!input.isSplat() && !shouldFold(op)) {
     return nullptr;
   }
@@ -193,6 +197,10 @@ static ::mlir::Attribute constantFoldEltwiseUnaryInt(mlir::Operation *op,
   mlir::DenseElementsAttr input =
       mlir::dyn_cast_if_present<mlir::DenseElementsAttr>(inputAttr);
   if (!input || !input.getElementType().isInteger()) {
+    return nullptr;
+  }
+
+  if (op->getOperand(0).getType() != op->getResult(0).getType()) {
     return nullptr;
   }
   if (!input.isSplat() && !shouldFold(op)) {

--- a/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
@@ -69,6 +69,26 @@ module {
     return %1 : tensor<64x64xbf16>
   }
 
+  func.func @abs_int_to_float_no_fold() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @abs_int_to_float_no_fold
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = -2
+    // CHECK: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = -2 : i32}> : () -> tensor<64x64xsi32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xsi32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @abs_float_to_int_no_fold() -> tensor<64x64xsi32> {
+    // CHECK-LABEL: func.func @abs_float_to_int_no_fold
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = -2.000000e+00
+    // CHECK: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = -2.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xf32>) -> tensor<64x64xsi32>
+    return %1 : tensor<64x64xsi32>
+  }
+
   func.func @atan0() -> tensor<32xf32> {
     // CHECK-LABEL: func.func @atan0
     // CHECK: "ttir.zeros"

--- a/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
@@ -107,15 +107,6 @@ module {
     return %1 : tensor<64x64xsi32>
   }
 
-  func.func @bitwise_not_float() -> tensor<64x64xf32> {
-    // CHECK-LABEL: func.func @bitwise_not_float
-    // CHECK: "ttir.zeros"
-    // CHECK-NOT: "ttir.bitwise_not"
-    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0xffffffff : f32}> : () -> tensor<64x64xf32>
-    %1 = "ttir.bitwise_not"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
-    return %1 : tensor<64x64xf32>
-  }
-
   func.func @cbrt_float() -> tensor<64x64xf32> {
     // CHECK-LABEL: func.func @cbrt_float
     // CHECK: "ttir.full"

--- a/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
@@ -1,0 +1,375 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  func.func @abs_float_positive() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @abs_float_positive
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 4.000000e+00
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 4.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @abs_float_negative() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @abs_float_negative
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 4.000000e+00
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = -4.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @abs_float_zero() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @abs_float_zero
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @abs_int_positive() -> tensor<64x64xsi32> {
+    // CHECK-LABEL: func.func @abs_int_positive
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 2
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 2 : i32}> : () -> tensor<64x64xsi32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xsi32>) -> tensor<64x64xsi32>
+    return %1 : tensor<64x64xsi32>
+  }
+
+  func.func @abs_int_negative() -> tensor<64x64xsi32> {
+    // CHECK-LABEL: func.func @abs_int_negative
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 2
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = -2 : i32}> : () -> tensor<64x64xsi32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xsi32>) -> tensor<64x64xsi32>
+    return %1 : tensor<64x64xsi32>
+  }
+
+  func.func @abs_int_zero() -> tensor<64x64xsi32> {
+    // CHECK-LABEL: func.func @abs_int_zero
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xsi32>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xsi32>) -> tensor<64x64xsi32>
+    return %1 : tensor<64x64xsi32>
+  }
+
+  func.func @abs_bf() -> tensor<64x64xbf16> {
+    // CHECK-LABEL: func.func @abs_bf
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 4.000000e+00
+    // CHECK-NOT: "ttir.abs"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = -4.000000e+00 : f32}> : () -> tensor<64x64xbf16>
+    %1 = "ttir.abs"(%0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %1 : tensor<64x64xbf16>
+  }
+
+  func.func @atan0() -> tensor<32xf32> {
+    // CHECK-LABEL: func.func @atan0
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.atan"
+    %0 = "ttir.zeros"() <{shape = array<i32: 32>}> : () -> tensor<32xf32>
+    %1 = "ttir.atan"(%0) : (tensor<32xf32>) -> tensor<32xf32>
+    return %1 : tensor<32xf32>
+  }
+
+  func.func @atan1() -> tensor<32xf32> {
+    // CHECK-LABEL: func.func @atan1
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 0.7853981{{[0-9]*(e+00)?}} : f32
+    // CHECK-NOT: "ttir.atan"
+    %0 = "ttir.ones"() <{shape = array<i32: 32>}> : () -> tensor<32xf32>
+    %1 = "ttir.atan"(%0) : (tensor<32xf32>) -> tensor<32xf32>
+    return %1 : tensor<32xf32>
+  }
+
+  func.func @atan_bf() -> tensor<64x64xbf16> {
+    // CHECK-LABEL: func.func @atan_bf
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.atan"
+    %0 = "ttir.zeros"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xbf16>
+    %1 = "ttir.atan"(%0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %1 : tensor<64x64xbf16>
+  }
+
+  func.func @bitwise_not_int() -> tensor<64x64xsi32> {
+    // CHECK-LABEL: func.func @bitwise_not_int
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 31
+    // CHECK-NOT: "ttir.bitwise_not"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0xFFFFFFE0 : i32}> : () -> tensor<64x64xsi32>
+    %1 = "ttir.bitwise_not"(%0) : (tensor<64x64xsi32>) -> tensor<64x64xsi32>
+    return %1 : tensor<64x64xsi32>
+  }
+
+  func.func @bitwise_not_float() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @bitwise_not_float
+    // CHECK: "ttir.zeros"
+    // CHECK-NOT: "ttir.bitwise_not"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 0xffffffff : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.bitwise_not"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @cbrt_float() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @cbrt_float
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 2.000000e+00
+    // CHECK-NOT: "ttir.cbrt"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 8.000000e+00 : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.cbrt"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @ceil_float() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @ceil_float
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 2.000000e+00
+    // CHECK-NOT: "ttir.ceil"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.200000e+00 : f32}> : () -> tensor<64x64xf32>
+    %1 = "ttir.ceil"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @ceil_bf_same() -> tensor<64x64xbf16> {
+    // CHECK-LABEL: func.func @ceil_bf_same
+    // CHECK: "ttir.full"
+    // CHECK-SAME: fill_value = 2.000000e+00
+    // CHECK-NOT: "ttir.ceil"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 2.000000e+00 : f32}> : () -> tensor<64x64xbf16>
+    %1 = "ttir.ceil"(%0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %1 : tensor<64x64xbf16>
+  }
+
+  func.func @floor_bf() -> tensor<64x64xbf16> {
+    // CHECK-LABEL: func.func @floor_bf
+    // CHECK: "ttir.ones"
+    // CHECK-NOT: "ttir.floor"
+    %0 = "ttir.full"() <{shape = array<i32: 64, 64>, fill_value = 1.800000e+00 : f32}> : () -> tensor<64x64xbf16>
+    %1 = "ttir.floor"(%0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %1 : tensor<64x64xbf16>
+  }
+
+  func.func @floor_float_same() -> tensor<64x64xf32> {
+    // CHECK-LABEL: func.func @floor_float
+    // CHECK: "ttir.ones"
+    // CHECK-NOT: "ttir.floor"
+    %0 = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
+    %1 = "ttir.floor"(%0) : (tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+
+  func.func @clamp_scalar_uint() -> tensor<1x8xui8> {
+    // CHECK-LABEL: func.func @clamp_scalar_uint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[\[}}2, 2, 2, 3, 4, 5, 5, 5]]>
+    // CHECK-NOT: "ttir.clamp_scalar"
+    %0 = "ttir.constant"() <{value = dense<[[0, 1, 2, 3, 4, 5, 6, 255]]> : tensor<1x8xui8>}> : () -> tensor<1x8xui8>
+    %1 = "ttir.clamp_scalar"(%0) <{min = 2.000000e+00 : f32, max = 5.000000e+00 : f32}> : (tensor<1x8xui8>) -> tensor<1x8xui8>
+    return %1 : tensor<1x8xui8>
+  }
+
+  func.func @clamp_scalar_sint() -> tensor<1x8xsi32> {
+    // CHECK-LABEL: func.func @clamp_scalar_sint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[\[}}2, 2, 2, 3, 4, 5, 5, 2]]>
+    // CHECK-NOT: "ttir.clamp_scalar"
+    %0 = "ttir.constant"() <{value = dense<[[0, 1, 2, 3, 4, 5, 6, -1]]> : tensor<1x8xsi32>}> : () -> tensor<1x8xsi32>
+    %1 = "ttir.clamp_scalar"(%0) <{min = 2 : i32, max = 5 : i32}> : (tensor<1x8xsi32>) -> tensor<1x8xsi32>
+    return %1 : tensor<1x8xsi32>
+  }
+
+  func.func @clamp_scalar_bf() -> tensor<1x7xbf16> {
+    // CHECK-LABEL: func.func @clamp_scalar_bf
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[\[}}2.000000e+00, 2.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 5.000000e+00]]>
+    // CHECK-NOT: "ttir.clamp_scalar"
+    %0 = "ttir.constant"() <{value = dense<[[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<1x7xbf16>}> : () -> tensor<1x7xbf16>
+    %1 = "ttir.clamp_scalar"(%0) <{min = 2 : i32, max = 5 : i32}> : (tensor<1x7xbf16>) -> tensor<1x7xbf16>
+    return %1 : tensor<1x7xbf16>
+  }
+
+  func.func @cos() -> tensor<2xf32> {
+    // CHECK-LABEL: func.func @cos
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[}}1.0000{{[0-9]*(e\+00)?}}, -0.12884{{[0-9]*(e\+00)?}}]>
+    // CHECK-NOT: "ttir.cos"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 1.7]> : tensor<2xf32>}> : () -> tensor<2xf32>
+    %1 = "ttir.cos"(%0) : (tensor<2xf32>) -> tensor<2xf32>
+    return %1 : tensor<2xf32>
+  }
+
+  func.func @exp() -> tensor<2xf32> {
+    // CHECK-LABEL: func.func @exp
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[}}2.7182{{[0-9]*(e\+00)?}}, 12.182{{[0-9]*(e\+00)?}}]>
+    // CHECK-NOT: "ttir.exp"
+    %0 = "ttir.constant"() <{value = dense<[1.0, 2.5]> : tensor<2xf32>}> : () -> tensor<2xf32>
+    %1 = "ttir.exp"(%0) : (tensor<2xf32>) -> tensor<2xf32>
+    return %1 : tensor<2xf32>
+  }
+
+  func.func @expm1() -> tensor<5xf32> {
+    // CHECK-LABEL: func.func @expm1
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[}}0.0000{{[0-9]*(e\+00)?}}, 1.7182{{[0-9]*(e\+00)?}}, 1.0000{{[0-9]*[eE]}}-10, 1.0000{{[0-9]*[eE]-0?}}7, 1.0000{{[0-9]*[eE]-0?}}5]>
+    // CHECK-NOT: "ttir.expm1"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 1.0, 1.0e-10, 1.0e-7, 1.0e-5]> : tensor<5xf32>}> : () -> tensor<5xf32>
+    %1 = "ttir.expm1"(%0) : (tensor<5xf32>) -> tensor<5xf32>
+    return %1 : tensor<5xf32>
+  }
+
+  func.func @isfinite() -> tensor<5xf32> {
+    // CHECK-LABEL: func.func @isfinite
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00]>
+    // CHECK-NOT: "ttir.isfinite"
+    // %0 = [1, inf, -inf, qNaN, -2.33]
+    %0 = "ttir.constant"() <{value = dense<[1.0, 0x7F800000, 0xFF800000, 0xFFC00001, -2.33]> : tensor<5xf32>}> : () -> tensor<5xf32>
+    %1 = "ttir.isfinite"(%0) : (tensor<5xf32>) -> tensor<5xf32>
+    return %1 : tensor<5xf32>
+  }
+
+  func.func @log1p() -> tensor<3xf32> {
+    // CHECK-LABEL: func.func @log1p
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[0.000000e+00, 0.69314{{[0-9]*(e\+00)?}}, 2.000000e+00]>
+    // CHECK-NOT: "ttir.log1p"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 1.0, 6.3890562]> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %1 = "ttir.log1p"(%0) : (tensor<3xf32>) -> tensor<3xf32>
+    return %1 : tensor<3xf32>
+  }
+
+  func.func @log() -> tensor<3xf32> {
+    // CHECK-LABEL: func.func @log
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[0.000000e+00, 0.69314{{[0-9]*(e\+00)?}}, 2.000000e+00]>
+    // CHECK-NOT: "ttir.log"
+    %0 = "ttir.constant"() <{value = dense<[1.0, 2.0, 7.3890562]> : tensor<3xf32>}> : () -> tensor<3xf32>
+    %1 = "ttir.log"(%0) : (tensor<3xf32>) -> tensor<3xf32>
+    return %1 : tensor<3xf32>
+  }
+
+  func.func @logical_not_zero() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @logical_not_zero
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00]>
+    // CHECK-NOT: "ttir.logical_not"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 1.0, -2.0, 0.0]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.logical_not"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @reciprocal() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @reciprocal
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 5.000000e-01, -2.500000e-01, 2.000000e+00]>
+    // CHECK-NOT: "ttir.reciprocal"
+    %0 = "ttir.constant"() <{value = dense<[1.0, 2.0, -4.0, 0.5]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.reciprocal"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @reciprocal_no_fold() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @reciprocal_no_fold
+    // CHECK: "ttir.zeros"
+    // CHECK: "ttir.reciprocal"
+    %0 = "ttir.zeros"() <{shape = array<i32: 4>}> : () -> tensor<4xf32>
+    %1 = "ttir.reciprocal"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @rsqrt() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @rsqrt
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 5.000000e-01, 2.500000e-01, 2.000000e+00]>
+    // CHECK-NOT: "ttir.rsqrt"
+    %0 = "ttir.constant"() <{value = dense<[1.0, 4.0, 16.0, 0.25]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.rsqrt"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @rsqrt_no_fold() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @rsqrt_no_fold
+    // CHECK: "ttir.zeros"
+    // CHECK: "ttir.rsqrt"
+    %0 = "ttir.zeros"() <{shape = array<i32: 4>}> : () -> tensor<4xf32>
+    %1 = "ttir.rsqrt"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @sign_float() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @sign_float
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[-1.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]>
+    // CHECK-NOT: "ttir.sign"
+    %0 = "ttir.constant"() <{value = dense<[-4.0, 0.0, 0.5, 3.0]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.sign"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @sign_bf() -> tensor<4xbf16> {
+    // CHECK-LABEL: func.func @sign_bf
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[-1.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]>
+    // CHECK-NOT: "ttir.sign"
+    %0 = "ttir.constant"() <{value = dense<[-4.0, 0.0, 0.5, 3.0]> : tensor<4xf32>}> : () -> tensor<4xbf16>
+    %1 = "ttir.sign"(%0) : (tensor<4xbf16>) -> tensor<4xbf16>
+    return %1 : tensor<4xbf16>
+  }
+
+  func.func @sign_sint() -> tensor<4xsi32> {
+    // CHECK-LABEL: func.func @sign_sint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[-1, 0, 1, 1]>
+    // CHECK-NOT: "ttir.sign"
+    %0 = "ttir.constant"() <{value = dense<[-4, 0, 1, 3]> : tensor<4xsi32>}> : () -> tensor<4xsi32>
+    %1 = "ttir.sign"(%0) : (tensor<4xsi32>) -> tensor<4xsi32>
+    return %1 : tensor<4xsi32>
+  }
+
+  func.func @sign_uint() -> tensor<4xui8> {
+    // CHECK-LABEL: func.func @sign_uint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[0, 0, 1, 1]>
+    // CHECK-NOT: "ttir.sign"
+    %0 = "ttir.constant"() <{value = dense<[0, 0, 1, 255]> : tensor<4xui8>}> : () -> tensor<4xui8>
+    %1 = "ttir.sign"(%0) : (tensor<4xui8>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
+  }
+
+  func.func @sin() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @sin
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[0.000000e+00, 5.000000e-01, -5.000000e-01, 1.000000e+00]>
+    // CHECK-NOT: "ttir.sin"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 0.5235988, -0.5235988, 1.5707963]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.sin"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @sqrt() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @sqrt
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1.000000e+00, 2.000000e+00, 4.000000e+00, 5.000000e-01]>
+    // CHECK-NOT: "ttir.sqrt"
+    %0 = "ttir.constant"() <{value = dense<[1.0, 4.0, 16.0, 0.25]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.sqrt"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+
+  func.func @tan() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @tan
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[0.000000e+00, 1.000000e+00, -1.000000e+00, 5.000000e-01]>
+    // CHECK-NOT: "ttir.tan"
+    %0 = "ttir.constant"() <{value = dense<[0.0, 0.7853982, -0.7853982, 0.4636476]> : tensor<4xf32>}> : () -> tensor<4xf32>
+    %1 = "ttir.tan"(%0) : (tensor<4xf32>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
@@ -156,7 +156,7 @@ module {
   }
 
   func.func @floor_float_same() -> tensor<64x64xf32> {
-    // CHECK-LABEL: func.func @floor_float
+    // CHECK-LABEL: func.func @floor_float_same
     // CHECK: "ttir.ones"
     // CHECK-NOT: "ttir.floor"
     %0 = "ttir.ones"() <{shape = array<i32: 64, 64>}> : () -> tensor<64x64xf32>
@@ -318,7 +318,7 @@ module {
     // CHECK: "ttir.constant"
     // CHECK-SAME: value = dense<[-1.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]>
     // CHECK-NOT: "ttir.sign"
-    %0 = "ttir.constant"() <{value = dense<[-4.0, 0.0, 0.5, 3.0]> : tensor<4xf32>}> : () -> tensor<4xbf16>
+    %0 = "ttir.constant"() <{value = dense<[-4.0, 0.0, 0.5, 3.0]> : tensor<4xbf16>}> : () -> tensor<4xbf16>
     %1 = "ttir.sign"(%0) : (tensor<4xbf16>) -> tensor<4xbf16>
     return %1 : tensor<4xbf16>
   }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/eltwise_unary_op_fold_tests.mlir
@@ -194,6 +194,16 @@ module {
     return %1 : tensor<1x7xbf16>
   }
 
+  func.func @clamp_scalar_f32() -> tensor<1x7xf32> {
+    // CHECK-LABEL: func.func @clamp_scalar_f32
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<{{\[\[}}2.000000e+00, 2.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 5.000000e+00]]>
+    // CHECK-NOT: "ttir.clamp_scalar"
+    %0 = "ttir.constant"() <{value = dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]> : tensor<1x7xf32>}> : () -> tensor<1x7xf32>
+    %1 = "ttir.clamp_scalar"(%0) <{min = 2 : i32, max = 5 : i32}> : (tensor<1x7xf32>) -> tensor<1x7xf32>
+    return %1 : tensor<1x7xf32>
+  }
+
   func.func @cos() -> tensor<2xf32> {
     // CHECK-LABEL: func.func @cos
     // CHECK: "ttir.constant"
@@ -255,14 +265,34 @@ module {
     return %1 : tensor<3xf32>
   }
 
-  func.func @logical_not_zero() -> tensor<4xf32> {
-    // CHECK-LABEL: func.func @logical_not_zero
+  func.func @logical_not_float() -> tensor<4xf32> {
+    // CHECK-LABEL: func.func @logical_not_float
     // CHECK: "ttir.constant"
     // CHECK-SAME: value = dense<[1.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00]>
     // CHECK-NOT: "ttir.logical_not"
     %0 = "ttir.constant"() <{value = dense<[0.0, 1.0, -2.0, 0.0]> : tensor<4xf32>}> : () -> tensor<4xf32>
     %1 = "ttir.logical_not"(%0) : (tensor<4xf32>) -> tensor<4xf32>
     return %1 : tensor<4xf32>
+  }
+
+  func.func @logical_not_sint() -> tensor<4xsi32> {
+    // CHECK-LABEL: func.func @logical_not_sint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1, 0, 0, 1]>
+    // CHECK-NOT: "ttir.logical_not"
+    %0 = "ttir.constant"() <{value = dense<[0, 1, -2, 0]> : tensor<4xsi32>}> : () -> tensor<4xsi32>
+    %1 = "ttir.logical_not"(%0) : (tensor<4xsi32>) -> tensor<4xsi32>
+    return %1 : tensor<4xsi32>
+  }
+
+  func.func @logical_not_uint() -> tensor<4xui8> {
+    // CHECK-LABEL: func.func @logical_not_uint
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<[1, 0, 0, 1]>
+    // CHECK-NOT: "ttir.logical_not"
+    %0 = "ttir.constant"() <{value = dense<[0, 1, 255, 0]> : tensor<4xui8>}> : () -> tensor<4xui8>
+    %1 = "ttir.logical_not"(%0) : (tensor<4xui8>) -> tensor<4xui8>
+    return %1 : tensor<4xui8>
   }
 
   func.func @reciprocal() -> tensor<4xf32> {


### PR DESCRIPTION
### Ticket
Closes #8075 

### Problem description
We want to have constant folding of elementwise unary ops.

### What's changed
Implement generic functions for folding of eltwise unary ops.
Implement folders.
Update NegOp folders to use the new generic.
Slightly improve TypecastOp implementation.
Add tests for new folders.

### Checklist
- [x] New/Existing tests provide coverage for changes

<!-- xla-validate -->
---
### tt-xla Validation

**Base (uplifted):** `5b85073695`

| Test Suite | Run | Status |
|------------|-----|--------|
| full-mlir-uplift-qualification.json | [Run #25171503203](https://github.com/tenstorrent/tt-xla/actions/runs/25171503203) | :white_check_mark: passed |
<!-- /xla-validate -->


