### PR TITLE
Add slice_static workaround when circular buffer > L1 size

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
@@ -14,7 +14,9 @@ namespace mlir::tt::ttnn::workarounds::decomposition {
 
 // tt-metal's slice op fails when the circular buffer for the last output
 // dimension exceeds L1 memory (check: output_shape[-1] * elem_size * 2 >
-// l1_size). This pattern decomposes such a slice into permute -> slice ->
+// l1_size). A factor of 2 is used because of double-buffering: the reader and
+// writer work simultaneously on the same CB.
+// This pattern decomposes such a slice into permute -> slice ->
 // permute, swapping the last dimension with a smaller-output dimension so
 // the CB fits in L1.
 class SliceStaticOpRewritePattern

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_SLICESTATICOPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_SLICESTATICOPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// tt-metal's slice op fails when the circular buffer for the last output
+// dimension exceeds L1 memory (check: output_shape[-1] * elem_size * 2 >
+// l1_size). This pattern decomposes such a slice into permute -> slice ->
+// permute, swapping the last dimension with a smaller-output dimension so
+// the CB fits in L1.
+class SliceStaticOpRewritePattern
+    : public OpRewritePattern<ttnn::SliceStaticOp> {
+public:
+  using OpRewritePattern<ttnn::SliceStaticOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::SliceStaticOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_SLICESTATICOPREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -56,6 +56,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.cpp
         Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp
         Workarounds/Decomposition/ScatterOpRewritePattern.cpp
+        Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
         Workarounds/Decomposition/ScaledDotProductAttentionDecodeAttentionSinkRewritePattern.cpp
         Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
         Workarounds/Decomposition/ScaledDotProductAttentionPadTileDimsRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+LogicalResult
+SliceStaticOpRewritePattern::matchAndRewrite(ttnn::SliceStaticOp srcOp,
+                                             PatternRewriter &rewriter) const {
+
+  RankedTensorType outputType = srcOp.getResult().getType();
+  RankedTensorType inputType =
+      mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+
+  int64_t rank = outputType.getRank();
+  if (rank < 2) {
+    return failure();
+  }
+
+  llvm::ArrayRef<int64_t> outputShape = outputType.getShape();
+
+  // Compute circular buffer row bytes for the output's last dimension.
+  mlir::Type elementType = inputType.getElementType();
+  uint64_t elemSizeBytes = ttcore::getElementSizeBytes(elementType);
+  uint64_t rowBytes =
+      static_cast<uint64_t>(outputShape[rank - 1]) * elemSizeBytes;
+
+  // Get usable L1 size from the chip descriptor.
+  ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(srcOp);
+  uint64_t l1UsableSize = chipDesc.getUsableL1Size();
+
+  // CB needs two buffers (double buffering), so check rowBytes * 2.
+  if (rowBytes * 2 <= l1UsableSize) {
+    return failure();
+  }
+
+  // Find a dimension (other than the last) whose output size fits in L1 when
+  // placed last. Prefer closer-to-last dimensions first.
+  int64_t swapDim = -1;
+  for (int64_t d = rank - 2; d >= 0; --d) {
+    if (static_cast<uint64_t>(outputShape[d]) * elemSizeBytes * 2 <=
+        l1UsableSize) {
+      swapDim = d;
+      break;
+    }
+  }
+
+  if (swapDim < 0) {
+    // No dimension found that would bring CB within L1 — cannot apply.
+    return failure();
+  }
+
+  // Build permutation that swaps swapDim and the last dimension.
+  llvm::SmallVector<int64_t> permutation =
+      llvm::to_vector(llvm::seq<int64_t>(rank));
+  std::swap(permutation[swapDim], permutation[rank - 1]);
+
+  // Compute the permuted input type.
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  llvm::SmallVector<int64_t> permutedInputShape =
+      ttmlir::utils::applyPermutation(inputShape, permutation);
+  RankedTensorType permutedInputType =
+      utils::RankedTensorTypeFactory::create(inputType, permutedInputShape);
+
+  // Forward permute: move the smaller dimension to the last position.
+  auto forwardPermute = rewriter.create<ttnn::PermuteOp>(
+      ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_permute"),
+      permutedInputType, srcOp.getInput(),
+      rewriter.getDenseI64ArrayAttr(permutation),
+      /*memory_config=*/ttnn::MemoryConfigAttr(),
+      /*pad_value=*/mlir::FloatAttr());
+
+  // Remap begins/ends/steps: new_attr[d] = old_attr[permutation[d]] because
+  // after permutation, new dimension d corresponds to old dimension
+  // permutation[d].
+  auto extractI32s = [](mlir::ArrayAttr attr) {
+    llvm::SmallVector<int32_t> v;
+    for (mlir::Attribute a : attr) {
+      v.push_back(
+          static_cast<int32_t>(mlir::cast<mlir::IntegerAttr>(a).getInt()));
+    }
+    return v;
+  };
+  auto begins = extractI32s(srcOp.getBegins());
+  auto ends = extractI32s(srcOp.getEnds());
+  auto steps = extractI32s(srcOp.getStep());
+
+  llvm::SmallVector<int32_t> newBegins(rank), newEnds(rank), newSteps(rank);
+  for (int64_t d = 0; d < rank; ++d) {
+    newBegins[d] = begins[permutation[d]];
+    newEnds[d] = ends[permutation[d]];
+    newSteps[d] = steps[permutation[d]];
+  }
+
+  // Compute the permuted output type.
+  llvm::SmallVector<int64_t> permutedOutputShape =
+      ttmlir::utils::applyPermutation(outputShape, permutation);
+  RankedTensorType permutedOutputType =
+      utils::RankedTensorTypeFactory::create(outputType, permutedOutputShape);
+
+  // Slice on the permuted input.
+  auto sliceOp = rewriter.create<ttnn::SliceStaticOp>(
+      ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_slice"),
+      permutedOutputType, forwardPermute, rewriter.getI32ArrayAttr(newBegins),
+      rewriter.getI32ArrayAttr(newEnds), rewriter.getI32ArrayAttr(newSteps));
+
+  // Inverse permute: restore the original dimension order.
+  llvm::SmallVector<int64_t> inversePermutation =
+      ttmlir::utils::inversePermutation(permutation);
+
+  auto inversePermute = rewriter.replaceOpWithNewOp<ttnn::PermuteOp>(
+      srcOp, outputType, sliceOp,
+      rewriter.getDenseI64ArrayAttr(inversePermutation),
+      /*memory_config=*/ttnn::MemoryConfigAttr(),
+      /*pad_value=*/mlir::FloatAttr());
+  inversePermute->setLoc(ttmlir::utils::appendLocationSuffix(
+      inversePermute.getLoc(), "_permuteInverse"));
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.cpp
@@ -25,8 +25,7 @@ SliceStaticOpRewritePattern::matchAndRewrite(ttnn::SliceStaticOp srcOp,
                                              PatternRewriter &rewriter) const {
 
   RankedTensorType outputType = srcOp.getResult().getType();
-  RankedTensorType inputType =
-      mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+  RankedTensorType inputType = srcOp.getInput().getType();
 
   int64_t rank = outputType.getRank();
   if (rank < 2) {

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -35,6 +35,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadTileDimsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScatterOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SliceStaticOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/SplitQueryKeyValueAndSplitHeadsOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/TopKRouterGptDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.h"
@@ -616,7 +617,9 @@ public:
           workarounds::decomposition::ReduceScatterConfigRewritePattern,
           workarounds::decomposition::TopKRouterGptDecompositionRewritePattern,
           workarounds::decomposition::
-              AllToAllDispatchMetadataDrainCoreRewritePattern>(&getContext());
+              AllToAllDispatchMetadataDrainCoreRewritePattern,
+          workarounds::decomposition::SliceStaticOpRewritePattern>(
+          &getContext());
       patterns.add<workarounds::decomposition::LinearOpRewritePattern>(
           &getContext(), /*benefit=*/2);
       patterns

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -998,3 +998,60 @@ def test_prod_last_dim_padding_no_workaround(
         target=target,
         pipeline_options=["disable-workarounds=true"],
     )
+
+
+@pytest.mark.parametrize(
+    "input_shape,begins,ends,step,output_shape",
+    [
+        # output last dim 258112: row_bytes * 2 = 258112 * 4 * 2 = 2064896 > ~1498112 (WH usable L1)
+        # Without the workaround, the circular buffer allocation exceeds L1 and crashes.
+        (
+            (6, 3, 258112),
+            [0, 2, 0],
+            [6, 3, 258112],
+            [1, 1, 1],
+            (6, 1, 258112),
+        ),
+    ],
+    ids=["3d_last_dim_258112"],
+)
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+@pytest.mark.parametrize("target", ["ttnn"])
+@pytest.mark.xfail(
+    reason="SliceStaticOpL1CBRewritePattern: output last dim 258112 causes circular "
+    "buffer allocation to exceed L1. Metal issue: https://github.com/tenstorrent/tt-metal/issues/42882"
+)
+def test_slice_l1_cb_workaround_disabled(
+    input_shape: Shape,
+    begins: List[int],
+    ends: List[int],
+    step: List[int],
+    output_shape: Shape,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    """
+    Test slice with the L1 circular buffer workaround disabled.
+    Workaround: SliceStaticOpL1CBRewritePattern - decomposes into
+    permute -> slice_static -> permute when output last dim exceeds L1.
+    Trigger condition: output_last_dim * sizeof(dtype) * 2 > usable_l1.
+    """
+
+    def module(builder: TTIRBuilder):
+        @builder.func([input_shape], [dtype])
+        def slice_l1_cb_no_workaround(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.slice(in0, begins, ends, step, unit_attrs=unit_attrs)
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=["enable-decomposition-workaround-pass=false"],
+    )

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_static_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_static_workaround.mlir
@@ -1,0 +1,49 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#dram = #ttnn.buffer_type<dram>
+#layout_258112 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<6x8066x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_64 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<6x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+module {
+  // Test: output last dim (258112) causes circular buffer to exceed L1.
+  func.func @slice_cb_exceeds_l1(
+      %arg0: tensor<6x3x258112xf32, #layout_258112>)
+      -> tensor<6x1x258112xf32, #layout_258112> {
+    // CHECK-LABEL: func.func @slice_cb_exceeds_l1
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 1>
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 2 : i32]
+    // CHECK-SAME: ends = [6 : i32, 258112 : i32, 3 : i32]
+    // CHECK-SAME: step = [1 : i32, 1 : i32, 1 : i32]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 1>
+    %0 = "ttnn.slice_static"(%arg0)
+        <{begins = [0 : i32, 2 : i32, 0 : i32],
+          ends   = [6 : i32, 3 : i32, 258112 : i32],
+          step   = [1 : i32, 1 : i32, 1 : i32]}>
+        : (tensor<6x3x258112xf32, #layout_258112>)
+       -> tensor<6x1x258112xf32, #layout_258112>
+    return %0 : tensor<6x1x258112xf32, #layout_258112>
+  }
+
+  // Test: output last dim (64) keeps circular buffer within L1 — no decomposition.
+  func.func @slice_cb_fits_l1(
+      %arg0: tensor<6x3x64xf32, #layout_64>)
+      -> tensor<6x1x64xf32, #layout_64> {
+    // CHECK-LABEL: func.func @slice_cb_fits_l1
+    // CHECK-NOT: "ttnn.permute"
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 2 : i32, 0 : i32]
+    // CHECK-SAME: ends = [6 : i32, 3 : i32, 64 : i32]
+    // CHECK-SAME: step = [1 : i32, 1 : i32, 1 : i32]
+    %0 = "ttnn.slice_static"(%arg0)
+        <{begins = [0 : i32, 2 : i32, 0 : i32],
+          ends   = [6 : i32, 3 : i32, 64 : i32],
+          step   = [1 : i32, 1 : i32, 1 : i32]}>
+        : (tensor<6x3x64xf32, #layout_64>)
+       -> tensor<6x1x64xf32, #layout_64>
+    return %0 : tensor<6x1x64xf32, #layout_64>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/42882

### Problem description
One of the customer models fails during the following slice static operation:
```
%23 = "ttnn.slice_static"(%22) <{begins = [0 : i32, 2 : i32, 0 : i32], ends = [6 : i32, 3 : i32, 258112 : i32], step = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<6x3x258112xf32, #ttnn_layout1>) -> tensor<6x1x258112xf32, #ttnn_layout1> loc(#loc21)
```

The reason for failure is that circular buffer size needs to be smaller than L1 size. The following equality is not met:
`output_shape[-1] * input.element_size (= # of bytes) * 2 (double-buffering) < L1 size` This comes from tt-metal:

```
    const ttnn::Shape& output_shape = output.padded_shape();
    const uint32_t unpadded_row_size_bytes = output_shape[-1] * input.element_size();
    const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
```

In broader terms, the last dimension of the tensor being sliced determines the circular buffer page sizes. So if last dimension is little, there will be smaller chunks. If the last dimension is bigger, there are bigger chunks. In this failing case, the chunks are too big to write into L1. 

### What's changed
Added slice_static workaround which permutes the last dimension with one that wouldn't exceed L1 size, operates the slice on the permuted tensor, then permutes back to original orientation. 

By permuting, the size of the data being stored in total does not change. However, the chunk size decreases whilst the number of chunks increases. 

### Checklist
- [X] New/Existing tests provide coverage for changes
