### PR TITLE
Use 'pow_tensor' instead of 'pow_scalar' if 'scalar(exponent) < 0`

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -693,6 +693,19 @@ private:
     return {};
   }
 
+  // Helper function to check if exponent is negative.
+  // Negative constant exponents are handled by the pow_tensor op, as
+  // pow_scalar does not support negative exponents.
+  static bool isNegativeConstant(mlir::Attribute attr) {
+    if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(attr)) {
+      return floatAttr.getValueAsDouble() < 0.0;
+    }
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
+      return intAttr.getValue().isNegative();
+    }
+    return false;
+  }
+
 public:
   using OpConversionPattern<ttir::PowOp>::OpConversionPattern;
 
@@ -700,7 +713,7 @@ public:
   matchAndRewrite(ttir::PowOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     mlir::Attribute exponent = getConstantAttr(adaptor.getRhs());
-    if (exponent) {
+    if (exponent && !isNegativeConstant(exponent)) {
       rewriter.replaceOpWithNewOp<ttnn::PowScalarOp>(
           op, this->getTypeConverter()->convertType(op.getType()),
           adaptor.getLhs(), exponent);

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/pow/simple_pow.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/pow/simple_pow.mlir
@@ -29,4 +29,29 @@ module attributes {} {
     %1 = "ttir.pow"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xi32>) -> tensor<64x128xf32>
     return %1 : tensor<64x128xf32>
   }
+
+  // Negative float exponent must fall back to pow_tensor, because
+  // ttnn.pow_scalar's verifier rejects negative exponents.
+  func.func @power_scalar_negative_float(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    %0 = "ttir.constant"() <{value = dense<-2.0> : tensor<64x128xf32>}> : () -> tensor<64x128xf32>
+    // CHECK-LABEL: func.func @power_scalar_negative_float
+    // CHECK-NOT: "ttnn.pow_scalar"
+    // CHECK: "ttnn.pow_tensor"
+    // CHECK-SAME: tensor<64x128xf32
+    // CHECK-SAME: -> tensor<64x128xf32
+    %1 = "ttir.pow"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+
+  // Negative integer exponent must also fall back to pow_tensor.
+  func.func @power_scalar_negative_integer(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    %0 = "ttir.constant"() <{value = dense<-3> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
+    // CHECK-LABEL: func.func @power_scalar_negative_integer
+    // CHECK-NOT: "ttnn.pow_scalar"
+    // CHECK: "ttnn.pow_tensor"
+    // CHECK-SAME: tensor<64x128xf32
+    // CHECK-SAME: -> tensor<64x128xf32
+    %1 = "ttir.pow"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xi32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
'ttnn.pow_scalar' doesn't support negative exponents.

### What's changed
Added a guard against negative exponents and proceeded with 'pow_tensor' in that case.

### Checklist
- [ ] New/Existing tests provide coverage for changes
