### PR TITLE
[L1SpillManagement] Fix DistributedRMSNormOp input spilled to DRAM

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <queue>
 
 namespace mlir::tt::ttnn {
@@ -934,6 +935,36 @@ void L1SpillManagement<MemoryTracker>::run() {
     Operation *op = data.schedule[pos];
 
     processDeadTensors(pos, data);
+
+    // ToLayoutOp with L1 output: workaround-inserted and always immediately
+    // consumed by the target op. MemoryLayoutPropagation skips these, so
+    // output_l1_usage is never set and pre-decomposition OpModel is inaccurate.
+    // Use Belady to evict other live tensors if needed to create room, but do
+    // not add the output to liveValues — it is not a long-lived L1 tenant and
+    // will be gone (or dead) before any subsequent eviction decision matters.
+    // Being absent from liveValues also means evictAllFromL1 (e.g. triggered by
+    // DistributedRMSNormOp's isNotImplemented) cannot spill it.
+    if (isa<ToLayoutOp>(op)) {
+      auto resultType =
+          mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+      auto lo =
+          mlir::dyn_cast_or_null<TTNNLayoutAttr>(resultType.getEncoding());
+      assert(lo && "ToLayoutOp result must have TTNNLayoutAttr encoding");
+      if (lo.hasL1BufferType()) {
+        uint64_t derivedL1 =
+            utils::getPerCoreL1Usage(lo, lo.getGrid().getGridVolume());
+        TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                     "  [pos={0}] L1_TOLAYOUT: {1}, derivedL1={2} bytes, "
+                     "occupied={3}/{4}",
+                     pos, ttmlir::opToString(op), derivedL1,
+                     memoryTracker.getOccupiedL1(), l1BudgetPerCore);
+        // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
+        // itself which is yet to be decomposed.
+        ensureFitsL1(op, pos, data, derivedL1, /*cbPeakUsage=*/0, derivedL1);
+        continue;
+      }
+      // DRAM ToLayoutOp: fall through to standard processing.
+    }
 
     // Ops with L1 output annotation get full processing.
     // DRAM-output ops (no annotation) still need CB overlap checking against

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/TensorLayouts.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/D2MOptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
@@ -1201,12 +1202,13 @@ MemoryLayoutPropagation::getDRAMInterleavedFallback(Operation *op) {
   if (!currentLayout) {
     return nullptr;
   }
-  // Don't override a memory_config pinned by an earlier pass.
-  if (auto memConfigOp = mlir::dyn_cast<TTNNMemoryConfigOpInterface>(op)) {
-    if (memConfigOp.getMemoryConfigAttr()) {
-      return currentLayout;
-    }
+
+  // If the op already has an L1 layout it was pinned by an earlier pass
+  // (workaround or lowering) that knows what the backend kernel requires.
+  if (currentLayout.hasL1BufferType()) {
+    return currentLayout;
   }
+
   return currentLayout.withBufferType(BufferType::DRAM)
       .withMemoryLayout(TensorMemoryLayout::Interleaved)
       .withTensorShape(tensorType.getShape());

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1584,7 +1584,7 @@ createOp(FlatbufferObjectCache &cache, DistributedRMSNormOp op) {
         static_cast<uint8_t>(op.getSubDeviceId().value()));
   }
 
-  auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfig()).value_or(0);
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
   auto numLinks = toFlatbuffer(cache, op.getNumLinks());
   auto topology = toFlatbuffer(cache, op.getTopology());
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_ttir_l1_input.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_ttir_l1_input.mlir
@@ -1,0 +1,42 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt \
+// RUN:   --ttir-to-ttnn-backend-pipeline="optimization-level=2 mock-system-desc-arch=wormhole_b0 mesh-shape=1,2" \
+// RUN:   -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// TTIR-level test: starting from ttir.relu → ttir.distributed_rms_norm,
+// verify that after the full TTIR→TTNN pipeline (workaround + greedy
+// optimizer including L1SpillManagement) the relu output is converted to
+// L1 width-sharded before reaching distributed_rms_norm with no
+// intermediate DRAM spill on the input path.
+
+// CHECK-LABEL: func.func @main
+// relu → to_memory_config(L1 width-sharded) → distributed_rms_norm.
+// Verify no DRAM spill appears before the L1 conversion and none between
+// the L1 conversion and distributed_rms_norm (i.e. the input is never
+// bounced through DRAM on its way to the fused kernel).
+// CHECK: "ttnn.relu"
+// CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
+// CHECK: "ttnn.to_memory_config"{{.*}}#l1{{.*}}width_sharded
+// CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
+// CHECK: "ttnn.distributed_rms_norm"
+
+module @test_ttir_rms_l1_input attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
+  func.func @main(
+      %arg0: tensor<1x1x32x128xbf16> {ttcore.argument_type = #ttcore.argument_type<input>,
+                                       ttcore.shard_status = #ttcore.shard_status<unsharded>},
+      %arg1: tensor<128xbf16>        {ttcore.argument_type = #ttcore.argument_type<parameter>,
+                                       ttcore.shard_status = #ttcore.shard_status<unsharded>}
+  ) -> (tensor<1x1x32x128xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    // relu produces an L1 tensor that is tracked in liveValues by
+    // L1SpillManagement. The workaround converts it to L1 width-sharded via a
+    // ToLayoutOp (pre-decomposition) / to_memory_config (post-decomposition).
+    %0 = "ttir.relu"(%arg0) : (tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    %1 = "ttir.distributed_rms_norm"(%0, %arg1) <{
+        cluster_axis = 1 : ui32,
+        epsilon = 1.000000e-05 : f32,
+        operandSegmentSizes = array<i32: 1, 1, 0>
+    }> : (tensor<1x1x32x128xbf16>, tensor<128xbf16>) -> tensor<1x1x32x128xbf16>
+    return %1 : tensor<1x1x32x128xbf16>
+  }
+}


### PR DESCRIPTION
The fused_rms_minimal kernel asserts that its input tensor is sharded in L1. Three issues prevented this from working end-to-end:

1. L1SpillManagement (L1SpillManagement.cpp): DistributedRMSNormOp returns isNotImplemented() from OpModel, triggering evictAllFromL1. The workaround pass inserts a ToLayoutOp to width-shard the input into L1, but L1SpillManagement was tracking it in liveValues and evicting it before the op ran. Fix: intercept ToLayoutOps with L1 output before the main Belady loop — call ensureFitsL1 (Belady-optimal room-making) then continue without adding the output to liveValues. Being absent from liveValues makes it immune to any subsequent evictAllFromL1.

2. MemoryLayoutPropagation fallback (MemoryLayoutPropagation.cpp): getDRAMInterleavedFallback unconditionally rewrote the output to DRAM interleaved for ops with no valid OpModel candidates. For ops whose output was already pinned to L1 by an earlier workaround or lowering pass (e.g. DistributedRMSNormOp with L1 width-sharded memory_config), this left memory_config out of sync with the result type and failed verifyTTNNMemoryConfigInterface. Fix: if the current layout is already L1, preserve it instead of forcing DRAM.

3. Flatbuffer serialization (TTNNToFlatbuffer.cpp): DistributedRMSNormOp was serializing memory_config via a raw toFlatbuffer() call that could emit 0 for optional configs. Switch to getMemoryConfigIfNeeded(), consistent with other ops.

