### PR TITLE
PagedUpdate|FillCacheOp validation in BeamSearch

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.h
@@ -57,8 +57,6 @@ class LegalOpLayoutAnalysis
 public:
   LegalOpLayoutAnalysis(Operation *op) : TTNNAnalysis(op) {}
 
-  static bool isValidAnalysisTarget(mlir::Operation *op);
-
 private:
   void analysisImplementation() override;
   bool applyOverrides() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -10,7 +10,8 @@
 namespace mlir::tt::ttnn {
 
 //===----------------------------------------------------------------------===//
-// Transformer ops: SDPA, PagedSDPA, NLPConcatHeadsDecode, ConcatenateHeads
+// Transformer ops: SDPA, PagedSDPA, NLPConcatHeadsDecode, ConcatenateHeads,
+//                  (Paged)UpdateCache, (Paged)FillCache
 //
 // Output hints:
 //   SDPA/PagedSDPA/NLPConcatHeadsDecode: NULL hint only.
@@ -66,6 +67,12 @@ struct SplitQKVRuleBook : OpRuleBook {
   OutputHints
   getOutputHints(Operation *op,
                  const std::vector<OpConfig> &legalConfigs) const override;
+};
+
+/// PagedUpdateCache constraint: the fill-value (operand 1) must be L1
+/// height-sharded.
+struct PagedUpdateCacheRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -75,6 +75,20 @@ struct PagedUpdateCacheRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
+/// FillCache / PagedFillCache constraint: the cache buffer (operand 0) is
+/// modified in-place and must remain in DRAM interleaved storage. If the
+/// beam search picks an L1 layout, the optimizer inserts a to_memory_config
+/// that copies the cache into a temporary L1 buffer; the in-place fill writes
+/// then go to that scratch copy and are silently discarded, leaving the real
+/// DRAM cache uninitialized.
+struct FillCacheRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+};
+
+struct PagedFillCacheRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+};
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_TRANSFORMERRULES_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -44,10 +44,11 @@ def TTNNWorkarounds : Pass<"ttnn-workaround", "::mlir::ModuleOp"> {
              "ttnn-enable-decomposition-workaround-pass",
              "bool", /*default=*/"true",
              "TTNN Decompsition Workarounds Pass">,
-      Option<"optimizerEnabled",
-             "ttnn-is-optimizer-enabled",
-             "bool", /*default=*/"false",
-             "flag specifying if optimizer is enabled">,
+      Option<"optimizationLevel",
+             "ttnn-optimization-level",
+             "int", /*default=*/"0",
+             "Optimization level forwarded from the pipeline; controls which "
+             "workarounds are active.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
@@ -6,13 +6,43 @@
 #define TTMLIR_DIALECT_TTNN_UTILS_OPTIMIZERUTILS_H
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
+#include "mlir/IR/Operation.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <vector>
 
 namespace mlir::tt::ttnn::optimizer_utils {
+
+/// Returns true if the op produces a ranked tensor result that the layout
+/// optimizer can assign a memory layout to.
+inline bool opHasTensorResult(mlir::Operation *op) {
+  if (op->getNumResults() == 0) {
+    return false;
+  }
+  if (!llvm::isa<mlir::RankedTensorType>(op->getResult(0).getType())) {
+    return false;
+  }
+  if (llvm::isa<EmptyOp>(op)) {
+    return false;
+  }
+  return true;
+}
+
+/// Returns true for in-place ops with no tensor result that still need
+/// input layout validation and upstream reshard propagation in the beam search.
+inline bool isSinkOp(mlir::Operation *op) {
+  return llvm::isa<FillCacheOp, PagedUpdateCacheOp>(op);
+}
+
+/// Returns true if this op should participate in the greedy beam search —
+/// either because it produces a tensor output (normal path) or because it
+/// is a sink that drives upstream input layout decisions.
+inline bool isBeamSearchTarget(mlir::Operation *op) {
+  return opHasTensorResult(op) || isSinkOp(op);
+}
 
 // Create affine maps that translate a virtual grid layout to a physical
 // grid layout and vice versa for a single device based on the specified tensor

--- a/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
@@ -137,18 +137,6 @@ bool incompatibleWithOverride(
 }
 
 // Skip operations that don't have nontrivial output tensors.
-bool LegalOpLayoutAnalysis::isValidAnalysisTarget(Operation *op) {
-  if (op->getNumResults() == 0) {
-    return false;
-  }
-  if (!llvm::isa<mlir::RankedTensorType>(op->getResult(0).getType())) {
-    return false;
-  }
-  if (llvm::isa<mlir::tt::ttnn::EmptyOp>(op)) {
-    return false;
-  }
-  return true;
-}
 
 void LegalOpLayoutAnalysis::fillTTNNLayoutAttrs(TTNNLayoutAttr baseLayout) {
   Type scalarElementType = baseLayout.getScalarElementType();

--- a/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalOpLayoutAnalysis.cpp
@@ -136,8 +136,6 @@ bool incompatibleWithOverride(
   return false;
 }
 
-// Skip operations that don't have nontrivial output tensors.
-
 void LegalOpLayoutAnalysis::fillTTNNLayoutAttrs(TTNNLayoutAttr baseLayout) {
   Type scalarElementType = baseLayout.getScalarElementType();
 

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -15,6 +15,7 @@
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/D2MOptimizerUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
@@ -300,7 +301,7 @@ void MemoryLayoutPropagation::run() {
   size_t opIndex = 0;
   // Forward pass: propagate layouts in scheduled (IR) order.
   func->walk([&](Operation *op) {
-    if (!LegalOpLayoutAnalysis::isValidAnalysisTarget(op)) {
+    if (!optimizer_utils::isBeamSearchTarget(op)) {
       return;
     }
     // Skip ops that don't implement the OpModel interface (e.g.,
@@ -348,16 +349,24 @@ void MemoryLayoutPropagation::run() {
     beamState[op] = processOp(op);
 
     if (!beamState[op].empty()) {
-      TTMLIR_DEBUG(
-          ttmlir::LogComponent::GreedyOptimizer,
-          "[op {0}] -> chosen: bufType={1}, memLayout={2}, "
-          "coreCount={3}, isSharded={4}, isL1={5}, reshard={6} "
-          "outputLayout={7}",
-          opIndex, beamState[op][0].configHint.outputLayout.getBufferType(),
-          beamState[op][0].configHint.outputLayout.getMemLayout(),
-          beamState[op][0].score.coreCount, beamState[op][0].score.isSharded,
-          beamState[op][0].score.isL1, beamState[op][0].score.requiresReshard,
-          beamState[op][0].configHint.outputLayout);
+      const auto &chosen = beamState[op][0];
+      if (chosen.configHint.outputLayout) {
+        TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                     "[op {0}] -> chosen: bufType={1}, memLayout={2}, "
+                     "coreCount={3}, isSharded={4}, isL1={5}, reshard={6} "
+                     "outputLayout={7}",
+                     opIndex, chosen.configHint.outputLayout.getBufferType(),
+                     chosen.configHint.outputLayout.getMemLayout(),
+                     chosen.score.coreCount, chosen.score.isSharded,
+                     chosen.score.isL1, chosen.score.requiresReshard,
+                     chosen.configHint.outputLayout);
+      } else {
+        TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                     "[op {0}] -> chosen (sink): <no output layout> "
+                     "coreCount={1}, reshard={2}",
+                     opIndex, chosen.score.coreCount,
+                     chosen.score.requiresReshard);
+      }
     }
     ++opIndex;
   });
@@ -542,15 +551,22 @@ MemoryLayoutPropagation::processOp(Operation *op) {
   // Log all kept beam candidates for this op.
   for (size_t ci = 0; ci < candidates.size(); ++ci) {
     [[maybe_unused]] const auto &c = candidates[ci];
-    TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                 "  BEAM[{0}] {1}: outBuf={2} outMem={3} "
-                 "score(L1={4},sharded={5},dramIn={6},reshard={7},"
-                 "cores={8},l1use={9}) inputs=[{10}]",
-                 ci, op->getName(), c.configHint.outputLayout.getBufferType(),
-                 c.configHint.outputLayout.getMemLayout(), c.score.isL1,
-                 c.score.isSharded, c.score.inputDramBytes,
-                 c.score.requiresReshard, c.score.coreCount,
-                 c.score.outputL1Usage, formatInputLayouts(c.inputLayouts));
+    if (c.configHint.outputLayout) {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "  BEAM[{0}] {1}: outBuf={2} outMem={3} "
+                   "score(L1={4},sharded={5},dramIn={6},reshard={7},"
+                   "cores={8},l1use={9}) inputs=[{10}]",
+                   ci, op->getName(), c.configHint.outputLayout.getBufferType(),
+                   c.configHint.outputLayout.getMemLayout(), c.score.isL1,
+                   c.score.isSharded, c.score.inputDramBytes,
+                   c.score.requiresReshard, c.score.coreCount,
+                   c.score.outputL1Usage, formatInputLayouts(c.inputLayouts));
+    } else {
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "  BEAM[{0}] {1}: <no output> reshard={2} inputs=[{3}]", ci,
+                   op->getName(), c.score.requiresReshard,
+                   formatInputLayouts(c.inputLayouts));
+    }
   }
 
   bool usedDramFallback = false;
@@ -736,17 +752,19 @@ void MemoryLayoutPropagation::addReshardCandidates(
   // reshard grids larger than the output tile count are wasteful — the op can't
   // produce a sharded output on more cores than it has tiles.
   int64_t maxGridVolume = std::numeric_limits<int64_t>::max();
-  auto outputType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
-  auto outputLayout =
-      mlir::dyn_cast_or_null<TTNNLayoutAttr>(outputType.getEncoding());
-  if (outputLayout &&
-      mlir::isa<ttcore::TileType>(outputLayout.getElementType())) {
-    auto shape = outputType.getShape();
-    int64_t cols = (shape.back() + TILE_WIDTH - 1) / TILE_WIDTH;
-    int64_t rows =
-        (outputType.getNumElements() / shape.back() + TILE_HEIGHT - 1) /
-        TILE_HEIGHT;
-    maxGridVolume = rows * cols;
+  if (op->getNumResults() > 0) {
+    auto outputType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    auto outputLayout =
+        mlir::dyn_cast_or_null<TTNNLayoutAttr>(outputType.getEncoding());
+    if (outputLayout &&
+        mlir::isa<ttcore::TileType>(outputLayout.getElementType())) {
+      auto shape = outputType.getShape();
+      int64_t cols = (shape.back() + TILE_WIDTH - 1) / TILE_WIDTH;
+      int64_t rows =
+          (outputType.getNumElements() / shape.back() + TILE_HEIGHT - 1) /
+          TILE_HEIGHT;
+      maxGridVolume = rows * cols;
+    }
   }
 
   // Collect unique reshard layouts across all base layouts.

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -77,6 +77,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static RotaryEmbeddingRuleBook rotaryEmbedding;
   static SplitQKVRuleBook splitQKV;
   static RmsNormRuleBook rmsNorm;
+  static PagedUpdateCacheRuleBook pagedUpdateCache;
 
   static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
   static std::once_flag initFlag;
@@ -110,6 +111,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(RotaryEmbeddingLlamaOp::getOperationName(), &rotaryEmbedding);
     reg(SplitQueryKeyValueAndSplitHeadsOp::getOperationName(), &splitQKV);
     reg(RMSNormOp::getOperationName(), &rmsNorm);
+    reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
   });
   auto it = registry.find(op->getName());
   return it != registry.end() ? *it->second : defaultRules;

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -78,6 +78,8 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static SplitQKVRuleBook splitQKV;
   static RmsNormRuleBook rmsNorm;
   static PagedUpdateCacheRuleBook pagedUpdateCache;
+  static FillCacheRuleBook fillCache;
+  static PagedFillCacheRuleBook pagedFillCache;
 
   static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
   static std::once_flag initFlag;
@@ -112,6 +114,8 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(SplitQueryKeyValueAndSplitHeadsOp::getOperationName(), &splitQKV);
     reg(RMSNormOp::getOperationName(), &rmsNorm);
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
+    reg(FillCacheOp::getOperationName(), &fillCache);
+    reg(PagedFillCacheOp::getOperationName(), &pagedFillCache);
   });
   auto it = registry.find(op->getName());
   return it != registry.end() ? *it->second : defaultRules;

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -79,4 +79,24 @@ OutputHints SplitQKVRuleBook::getOutputHints(
   return layout_filter_utils::nullHintOnly();
 }
 
+//===----------------------------------------------------------------------===//
+// PagedUpdateCacheRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+PagedUpdateCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Operand 1 (fill value) must be L1 height-sharded.
+  // Reject interleaved and all other sharding types so the beam search
+  // is forced to explore HeightSharded reshard candidates. OpModel then
+  // picks the specific grid (numUsers cores) that satisfies the kernel.
+  if (operandIdx == 1) {
+    return [](TTNNLayoutAttr layout) -> bool {
+      auto ml = layout.getMemLayout();
+      return layout.hasL1BufferType() && ml &&
+             ml.getValue() == TensorMemoryLayout::HeightSharded;
+    };
+  }
+  return nullptr;
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -87,14 +87,45 @@ LayoutFilterFn
 PagedUpdateCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
   // Operand 1 (fill value) must be L1 height-sharded.
   // Reject interleaved and all other sharding types so the beam search
-  // is forced to explore HeightSharded reshard candidates. OpModel then
-  // picks the specific grid (numUsers cores) that satisfies the kernel.
+  // is forced to explore HeightSharded reshard candidates.
   if (operandIdx == 1) {
     return [](TTNNLayoutAttr layout) -> bool {
       auto ml = layout.getMemLayout();
       return layout.hasL1BufferType() && ml &&
              ml.getValue() == TensorMemoryLayout::HeightSharded;
     };
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// FillCache / PagedFillCache: cache buffer (operand 0) must stay in DRAM
+//===----------------------------------------------------------------------===//
+
+// Cache buffer: DRAM interleaved only.  These are in-place ops; the cache
+// modifications must land in the actual DRAM-resident KV cache, not in a
+// temporary L1 scratch copy that the optimizer would insert if it picks an
+// L1 layout.
+static LayoutFilterFn cacheBufferDramOnlyFilter() {
+  return [](TTNNLayoutAttr layout) -> bool {
+    auto ml = layout.getMemLayout();
+    return layout.hasDRAMBufferType() && ml &&
+           ml.getValue() == TensorMemoryLayout::Interleaved;
+  };
+}
+
+LayoutFilterFn
+FillCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  if (operandIdx == 0) {
+    return cacheBufferDramOnlyFilter();
+  }
+  return nullptr;
+}
+
+LayoutFilterFn
+PagedFillCacheRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  if (operandIdx == 0) {
+    return cacheBufferDramOnlyFilter();
   }
   return nullptr;
 }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -237,9 +237,7 @@ void createTTNNPipelineWorkaroundPass(
       options.layoutWorkaroundsEnabled,
       options.decompositionWorkaroundsEnabled};
 
-  if (options.optimizerPassEnabled) {
-    workaroundOptions.optimizerEnabled = true;
-  }
+  workaroundOptions.optimizationLevel = options.optimizationLevel;
 
   pm.addPass(createTTNNWorkarounds(workaroundOptions));
   pm.addPass(mlir::createCanonicalizerPass());

--- a/lib/Dialect/TTNN/Transforms/Fusing/FusionValidator.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/FusionValidator.cpp
@@ -27,7 +27,7 @@ FusionValidationResult FusionValidator::runValidationPipeline(ModuleOp module) {
     workaroundOptions.decompositionWorkaroundsEnabled =
         config.applyDecompositionWorkarounds;
     workaroundOptions.layoutWorkaroundsEnabled = config.applyLayoutWorkarounds;
-    workaroundOptions.optimizerEnabled = true;
+    workaroundOptions.optimizationLevel = 1;
     pm.addPass(mlir::tt::ttnn::createTTNNWorkarounds(workaroundOptions));
 
     if (failed(pm.run(module))) {

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -21,6 +21,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Utils/D2MOptimizerUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
@@ -125,7 +126,14 @@ public:
       }
 
       func->walk([&](Operation *op) {
-        if (!LegalOpLayoutAnalysis::isValidAnalysisTarget(op)) {
+        if (!optimizer_utils::opHasTensorResult(op)) {
+          // Constraint sinks (FillCacheOp, PagedUpdateCacheOp) have no tensor
+          // result but still need input layout validation. Register a
+          // null-output OpConfig so processOp can validate their input
+          // combinations and drive upstream reshards.
+          if (mlir::dyn_cast<OpModel>(op) && optimizer_utils::isSinkOp(op)) {
+            legalConfigs[op] = {OpConfig{TTNNLayoutAttr()}};
+          }
           return;
         }
         // Skip ops that don't implement the OpModel interface (e.g.,

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -24,6 +24,7 @@
 #include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/D2MOptimizerUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
@@ -273,7 +274,7 @@ public:
       }
 
       func->walk([&](Operation *op) {
-        if (!LegalOpLayoutAnalysis::isValidAnalysisTarget(op)) {
+        if (!optimizer_utils::opHasTensorResult(op)) {
           return;
         }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedUpdateCacheOpRewritePattern.cpp
@@ -14,17 +14,16 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// This rewrite pattern is used to apply a specific memory config to the input
-// tensor (fill value) of the ttnn.paged_update_cache op. The input tensor must
-// be height sharded, but in addition to that, must fit onto an exact number of
-// rows in the physical grid.
+// This rewrite pattern applies a specific memory config to the input tensor
+// (fill value) of the ttnn.paged_update_cache op. The input must be height
+// sharded, and must fit onto an exact number of rows in the physical grid.
 LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
     ttnn::PagedUpdateCacheOp op, PatternRewriter &rewriter) const {
 
   RankedTensorType inputType =
       mlir::cast<RankedTensorType>(op.getInput().getType());
 
-  // The height sharded virtual grid must me [num_users, 1]
+  // The height sharded virtual grid must be [num_users, 1]
   int64_t numUsers = inputType.getShape()[1];
   SmallVector<int64_t> virtualGridSize = {numUsers, 1};
 
@@ -34,7 +33,7 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
     inputElementType = inputTileType.getElementType();
   }
 
-  // Retrieve the phyisical grid shape for the device.
+  // Retrieve the physical grid shape for the device.
   auto physicalGrid =
       ttcore::getCurrentScopeSystemDesc(op).getChipDescs()[0].getGrid();
   // Create an affine map that translates the virtual grid layout to the
@@ -61,13 +60,12 @@ LogicalResult PagedUpdateCacheOpRewritePattern::matchAndRewrite(
   ttnn::TTNNLayoutAttr currentInputLayout =
       mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
           op.getInput().getType().getEncoding());
-  // Check that the current input layout is not identical to our desired one as
-  // we do not need to insert a ToMemoryConfigOp in this case.
+  // No-op if input already has the desired layout (e.g. optimizer set it).
   if (currentInputLayout == desiredInputLayout) {
     return failure();
   }
 
-  // Apply ToMemoryConfigOp to convert the input tensor to the desired layout.
+  // Apply ToLayoutOp to convert the input tensor to the desired layout.
   ttnn::MemoryConfigAttr inputMemoryConfig =
       ttnn::MemoryConfigAttr::get(desiredInputLayout, grid);
   RankedTensorType memoryConfigedInputType =

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -630,7 +630,8 @@ public:
           workarounds::decomposition::NLPConcatHeadsDecodeInputRewritePattern,
           workarounds::decomposition::
               SplitQueryKeyValueAndSplitHeadsOpRewritePattern,
-          workarounds::decomposition::PagedUpdateCacheOpRewritePattern,
+          // PagedUpdateCacheOpRewritePattern added below — conditionally.
+
           workarounds::decomposition::
               ScaledDotProductAttentionDecodeAttentionSinkRewritePattern,
           workarounds::decomposition::
@@ -653,6 +654,16 @@ public:
           .add<workarounds::decomposition::LinearOpOutputShapeRewritePattern>(
               &getContext(), /*benefit=*/1);
 
+      // PagedUpdateCacheOpRewritePattern is only needed below opt-level 2.
+      // At level >= 2 the greedy sharding optimizer (PagedUpdateCacheRuleBook
+      // constraint sink) drives the upstream producer to L1 height-sharded
+      // and inserts a proper ToMemoryConfigOp via beam search.
+      if (optimizationLevel < 2) {
+        patterns
+            .add<workarounds::decomposition::PagedUpdateCacheOpRewritePattern>(
+                &getContext());
+      }
+
       runRewritePatterns(std::move(patterns),
                          GreedyRewriteConfig::kNoLimit /*maxIterations*/);
     }
@@ -660,7 +671,7 @@ public:
       RewritePatternSet patterns(&getContext());
 
       std::set<mlir::StringRef> enabledOps;
-      if (optimizerEnabled) {
+      if (optimizationLevel >= 1) {
         enabledOps = enabledOpsForWorkaroundWithOptimizer;
       } else {
         enabledOps = utils::getAllTTNNDialectOps(&getContext());

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround="ttnn-is-optimizer-enabled=true" --canonicalize -o %t %s
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround="ttnn-optimization-level=1" --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Regression test: TopKOp must remain in the workaround whitelist when the

--- a/test/unittests/Optimizer/TestLegalLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLegalLayoutAnalysis.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -157,7 +158,7 @@ TEST_P(LegalLayoutAnalysisTest, LegalLayoutAnalysisVariants) {
   // Step 2: Walk function ops and their sub-ops
   module->walk([&](mlir::func::FuncOp funcOp) {
     funcOp->walk([&](mlir::Operation *op) {
-      if (!LegalOpLayoutAnalysis::isValidAnalysisTarget(op)) {
+      if (!optimizer_utils::opHasTensorResult(op)) {
         return;
       }
 


### PR DESCRIPTION

PagedUpdateCacheOp is an in-place op with no tensor result, so isValidAnalysisTarget returned false and the optimizer never validated its input layouts. The fill-value input (operand 1) must be L1 height-sharded with numUsers cores, but OperationValidationAndFallback had no way to steer upstream ops toward that layout — it could only try DRAM-output fallbacks, all of which fail the kernel's is_sharded() assertion.

- GreedyMemoryLayoutPropagation: catch `FillCacheOp` and `PagedUpdateCacheOp` and register a null-output OpConfig in legalConfigs so `processOp` validates their input layout combinations.
- MemoryLayoutPropagation::run(): widen gate via isBeamSearchTarget so both ops enter processOp and drive upstream reshards backward.

PagedUpdateCacheRuleBook: getInputLayoutFilter(operand=1) forces requireL1HeightSharded so the beam search only considers L1 HeightSharded reshard candidates for the fill value. OpModel then picks the specific {numUsers, 1} grid. A proper ToMemoryConfigOp (tracked by L1SpillManagement) is inserted instead of the old workaround ToLayoutOp.

PagedUpdateCacheOpRewritePattern: disabled (returns failure immediately). The optimizer now handles the layout constraint end-to-end.

Related https://github.com/tenstorrent/tt-mlir/issues/8030 