### PR TITLE
d2m: Revise the unpack_stall_on_pack experimental API

### DIFF
--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
@@ -11,13 +11,9 @@ namespace experimental {
 // committed to L1. Call this before unpacking data that was just packed
 // by the previous linalg.generic to guarantee L1 read-after-write ordering.
 ALWI void unpack_stall_on_pack() {
-  tile_regs_acquire();
-  tile_regs_commit();
-  tile_regs_wait();
-  tile_regs_release();
-  UNPACK(TTI_SEMWAIT(
-      p_stall::STALL_MATH | p_stall::STALL_SFPU | p_stall::STALL_SYNC,
-      semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_MAX));
+  PACK(t6_semaphore_post<>(semaphore::PACK_DONE));
+  UNPACK(t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE));
+  UNPACK(t6_semaphore_get<>(semaphore::PACK_DONE));
 }
 
 } // namespace experimental

--- a/test/python/golden/d2m/test_binary_tree.py
+++ b/test/python/golden/d2m/test_binary_tree.py
@@ -25,13 +25,12 @@ pytestmark = pytest.mark.frontend("ttir")
         (1024, 2048),
         (2048, 1024),
         (2048, 2048),
-        # (256, 256), - Issue #7539
+        (256, 256),
     ],
     ids=shape_str,
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "f32"])
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.skip_exec(("p150",), ("p300",), reason="Not supported on Blackhole")
 def test_binary_tree(shape: Shape, dtype: torch.dtype, target: str, request, device):
     """Test a binary tree of adds: add(add(arg0, arg1), add(arg2, arg3))"""
 

--- a/test/python/golden/d2m/test_composite_functions.py
+++ b/test/python/golden/d2m/test_composite_functions.py
@@ -295,7 +295,7 @@ def test_digamma(
             builder.set_goldens({x: x_tensor}, {result: output_golden})
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -340,7 +340,7 @@ def test_lgamma(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -385,7 +385,7 @@ def test_multigammaln(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -432,7 +432,7 @@ def test_polygamma(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -465,7 +465,7 @@ def test_glu_split(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -497,7 +497,7 @@ def test_reglu_split(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -529,7 +529,7 @@ def test_geglu_split(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,
@@ -561,7 +561,7 @@ def test_swiglu_split(
 
             return result
 
-    options = []
+    options = ["enable-elementwise-fusion=true"]
     compile_and_execute_ttir(
         module,
         target=target,

--- a/test/python/golden/d2m/test_eltwise_fusion.py
+++ b/test/python/golden/d2m/test_eltwise_fusion.py
@@ -610,7 +610,7 @@ def test_diamond_unary_op_fanout(
 
             return builder.div(neg_0, neg_1)
 
-    options = [grid, "enable-elementwise-fusion=true"]
+    options = [grid]
 
     compile_and_execute_ttir(
         module,

--- a/test/python/golden/d2m/test_eltwise_fusion.py
+++ b/test/python/golden/d2m/test_eltwise_fusion.py
@@ -184,7 +184,7 @@ def binary_op_builder(op_name: str, builder: TTIRBuilder):
 def test_eltwise_fuse_cosh(
     grid: str, shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     def module(builder: TTIRBuilder):
         @builder.func([shape, shape], [dtype, dtype])
@@ -261,7 +261,7 @@ def test_eltwise_sanity_check_unary_op(
                 num_inputs=1,
             )
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -316,7 +316,7 @@ def test_eltwise_fuse_unary_chain(
 
             return res_19
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -356,7 +356,7 @@ def test_eltwise_fuse_converging_unary_branches(
 
             return builder.div(branch_0_2, branch_1_2)
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -377,13 +377,10 @@ def test_eltwise_fuse_converging_unary_branches(
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.skip(
-    reason="TODO(ckaravasilisTT): reenable when binary FPU fusion is supported"
-)
 def test_eltwise_fuse_binary_reduction_tree(
     grid: str, shape: Shape, dtype: torch.dtype, target: str, request, device
 ):
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     def module(builder: TTIRBuilder):
         @builder.func([shape] * 8, [dtype] * 8)
@@ -476,7 +473,7 @@ def test_eltwise_fuse_where_simple(
 
             return builder.where(cond, true_branch, false_branch)
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -528,7 +525,7 @@ def test_eltwise_fuse_where_with_unary_chains(
 
             return out_1
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -574,7 +571,7 @@ def test_eltwise_fuse_where_with_binary_inputs(
 
             return builder.where(cond, true_branch, false_branch)
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,
@@ -613,7 +610,7 @@ def test_diamond_unary_op_fanout(
 
             return builder.div(neg_0, neg_1)
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,


### PR DESCRIPTION
### Ticket
#7574 , #7539 

### Problem description
Single tile (and some other small) test cases were failing due to the unpacker and packer not being properly synchronized.

### What's changed
This change is a more robust way of dealing with this sync using a hardware semaphore directly.
This allows us to re-enable all tests in test_composite_ops.py and test_ttir_eltwise_fusion.py (wormhole and blackhole)

### Checklist
- [X] New/Existing tests provide coverage for changes
