### PR TITLE
d2m: identify real producer in InsertSpillAndScratch

### DIFF
--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -312,38 +312,52 @@ struct GenericOperandInfo {
   unsigned operandIdx;
 };
 
-static SmallVector<ttnn::KernelCBAttr>
-createCBDescriptors(Builder &builder,
-                    const SmallVector<GenericOperandInfo> &infos,
-                    const ttcore::DeviceAttr &device,
-                    const ttnn::CoreRangeSetAttr &coreRangeSet) {
-  if (infos.empty()) {
+static ttnn::KernelCBAttr
+createCBDescriptor(Builder &builder, Value cbMemrefValue, size_t cbIndex,
+                   const ttcore::DeviceAttr &device,
+                   const ttnn::CoreRangeSetAttr &coreRangeSet,
+                   std::optional<OperandLocality> locality = std::nullopt) {
+  MLIRContext *ctx = builder.getContext();
+  auto cbMemref = mlir::cast<MemRefType>(cbMemrefValue.getType());
+  TT_assertv(mlir::isa<ttcore::TileType>(cbMemref.getElementType()),
+             "Only TileType supported.");
+  ttcore::DataType dtype =
+      ttcore::elementTypeToDataType(cbMemref.getElementType());
+  size_t pageSize = device.getMemrefCBPageSizeBytes(cbMemref);
+  size_t totalSize = device.getMemrefSizeBytes(cbMemref, pageSize, true);
+
+  ttnn::KernelCBFormatAttr cbFormat =
+      ttnn::KernelCBFormatAttr::get(ctx, cbIndex, dtype, pageSize);
+
+  ttnn::KernelCBGlobalBufferAddressOfTensorAttr globalCBIndexOfTensor;
+  if (locality && *locality == OperandLocality::L1Local) {
+    globalCBIndexOfTensor =
+        ttnn::KernelCBGlobalBufferAddressOfTensorAttr::get(ctx, cbIndex);
+  }
+
+  return ttnn::KernelCBAttr::get(ctx, totalSize, coreRangeSet, {cbFormat},
+                                 globalCBIndexOfTensor);
+}
+
+static SmallVector<ttnn::KernelCBAttr> createCBDescriptors(
+    Builder &builder, const SmallVector<GenericOperandInfo> &infos,
+    ArrayRef<Value> extraCBMemrefs, const ttcore::DeviceAttr &device,
+    const ttnn::CoreRangeSetAttr &coreRangeSet) {
+  if (infos.empty() && extraCBMemrefs.empty()) {
     llvm_unreachable("Expected circular buffers.");
   }
 
-  MLIRContext *ctx = builder.getContext();
-  SmallVector<ttnn::KernelCBAttr> cbDescriptors(infos.size());
+  SmallVector<ttnn::KernelCBAttr> cbDescriptors;
+  cbDescriptors.reserve(infos.size() + extraCBMemrefs.size());
 
   for (auto [i, info] : llvm::enumerate(infos)) {
-    auto cbMemref = mlir::cast<MemRefType>(info.cbMemref.getType());
-    TT_assertv(mlir::isa<ttcore::TileType>(cbMemref.getElementType()),
-               "Only TileType supported.");
-    ttcore::DataType dtype =
-        ttcore::elementTypeToDataType(cbMemref.getElementType());
-    size_t pageSize = device.getMemrefCBPageSizeBytes(cbMemref);
-    size_t totalSize = device.getMemrefSizeBytes(cbMemref, pageSize, true);
+    cbDescriptors.push_back(createCBDescriptor(
+        builder, info.cbMemref, i, device, coreRangeSet, info.locality));
+  }
 
-    ttnn::KernelCBFormatAttr cbFormat =
-        ttnn::KernelCBFormatAttr::get(ctx, i, dtype, pageSize);
-
-    ttnn::KernelCBGlobalBufferAddressOfTensorAttr globalCBIndexOfTensor;
-    if (info.locality == OperandLocality::L1Local) {
-      globalCBIndexOfTensor =
-          ttnn::KernelCBGlobalBufferAddressOfTensorAttr::get(ctx, i);
-    }
-
-    cbDescriptors[i] = ttnn::KernelCBAttr::get(
-        ctx, totalSize, coreRangeSet, {cbFormat}, globalCBIndexOfTensor);
+  for (Value extraCBMemref : extraCBMemrefs) {
+    cbDescriptors.push_back(createCBDescriptor(
+        builder, extraCBMemref, cbDescriptors.size(), device, coreRangeSet));
   }
 
   return cbDescriptors;
@@ -693,6 +707,7 @@ static LogicalResult convertSingleGeneric(d2m::GenericOp op,
       analyzeGenericOperands(op, valueMapping);
 
   SmallVector<Value> additionalArgs;
+  SmallVector<Value> extraCBMemrefs;
   for (Value arg : op.getAdditionalArgs()) {
     if (auto cbForOp = arg.getDefiningOp()
                            ? arg.getDefiningOp()->getAttrOfType<IntegerAttr>(
@@ -703,6 +718,10 @@ static LogicalResult convertSingleGeneric(d2m::GenericOp op,
       infos[targetIdx].cbMemref = arg;
       // The CB has its own L1 allocation (not backed by the input tensor).
       infos[targetIdx].locality = OperandLocality::L1Remote;
+    } else if (isa<MemRefType>(arg.getType())) {
+      // Standalone hoisted CBs (for example scratch backing storage) occupy CB
+      // slots but are not TTNN generic additional arguments.
+      extraCBMemrefs.push_back(arg);
     } else if (isa<ttnn::GlobalSemaphoreType>(arg.getType()) ||
                isa<RankedTensorType>(arg.getType())) {
       Value mapped = valueMapping.count(arg) ? valueMapping[arg] : arg;
@@ -719,8 +738,8 @@ static LogicalResult convertSingleGeneric(d2m::GenericOp op,
     }
   }
 
-  SmallVector<ttnn::KernelCBAttr> cbDescriptors =
-      createCBDescriptors(rewriter, infos, device, coreRangeSet);
+  SmallVector<ttnn::KernelCBAttr> cbDescriptors = createCBDescriptors(
+      rewriter, infos, extraCBMemrefs, device, coreRangeSet);
 
   SymbolTable opSymTable(op->getParentOfType<ModuleOp>());
   // Build the semaphore mapping first so createKernelDescriptors can use it.

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -31,19 +31,28 @@ static ttcore::TileType getTileType(MemRefType memrefType) {
   return mlir::dyn_cast<ttcore::TileType>(memrefType.getElementType());
 }
 
-// Find a tiled input operand and return its memref type.
-// Returns a null MemRefType if no tiled input is found.
-static MemRefType findTiledInputType(GenericOp genericOp) {
-  for (Value input : genericOp.getInputs()) {
-    auto memrefType = mlir::dyn_cast<MemRefType>(input.getType());
-    if (!memrefType) {
-      continue;
+// Find a tiled memref operand that can serve as the scratch type reference.
+// Prefer tiled inputs when present, but fall back to tiled outputs.
+// TO-DO (ckaravasilis): A better semantic criterion based on intermediate
+// analysis rather than relying on input/output.
+static MemRefType findTiledReferenceType(GenericOp genericOp) {
+  auto findTiledType = [](ValueRange values) -> MemRefType {
+    for (Value value : values) {
+      auto memrefType = mlir::dyn_cast<MemRefType>(value.getType());
+      if (!memrefType) {
+        continue;
+      }
+      if (getTileType(memrefType)) {
+        return memrefType;
+      }
     }
-    if (getTileType(memrefType)) {
-      return memrefType;
-    }
+    return MemRefType();
+  };
+
+  if (MemRefType tiledInputType = findTiledType(genericOp.getInputs())) {
+    return tiledInputType;
   }
-  return MemRefType();
+  return findTiledType(genericOp.getOutputs());
 }
 
 // Count the number of linalg.generic ops in the first region of a
@@ -133,8 +142,7 @@ static void addScratchToGeneric(GenericOp genericOp,
     return;
   }
 
-  // Find a tiled input to derive the tile type.
-  MemRefType refMemRefType = findTiledInputType(genericOp);
+  MemRefType refMemRefType = findTiledReferenceType(genericOp);
   if (!refMemRefType) {
     return;
   }

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -54,6 +54,10 @@ struct ConsumerLoopLoads {
 struct IntermediateAllocInfo {
   memref::AllocOp allocOp;
   ScratchLoopInfo *producer; // Loop nest that writes to this alloc
+  // Loads are only rewritten while the producer's definition still reaches.
+  // If a later loop writes the same allocation, that loop is the last consumer
+  // we can safely redirect to this producer's scratch slot.
+  size_t lastConsumerIndex;
   SmallVector<ConsumerLoopLoads>
       consumers; // all consumer loop nests that read from it
   SmallVector<affine::AffineStoreOp> stores; // Stores to this alloc
@@ -676,6 +680,7 @@ private:
       IntermediateAllocInfo allocInfo;
       allocInfo.allocOp = allocOp;
       allocInfo.producer = nullptr;
+      allocInfo.lastConsumerIndex = 0;
 
       Value allocResult = allocOp.getResult();
       SmallVector<SmallVector<affine::AffineStoreOp>> storesByLoop(
@@ -723,17 +728,27 @@ private:
 
         // Pick the earliest writer with a later read so in-place consumer
         // updates do not replace the true producer for this intermediate.
+        size_t firstLaterWriterIdx = scratchLoops.size();
+        for (size_t laterIdx = loopIdx + 1; laterIdx < storesByLoop.size();
+             ++laterIdx) {
+          if (!storesByLoop[laterIdx].empty()) {
+            firstLaterWriterIdx = laterIdx;
+            break;
+          }
+        }
+
         bool hasLaterConsumer =
             llvm::any_of(allocInfo.consumers, [&](const ConsumerLoopLoads &c) {
               size_t consIdx =
                   static_cast<size_t>(c.loop - scratchLoops.data());
-              return consIdx > loopIdx;
+              return consIdx > loopIdx && consIdx <= firstLaterWriterIdx;
             });
         if (!hasLaterConsumer) {
           continue;
         }
 
         allocInfo.producer = &scratchLoops[loopIdx];
+        allocInfo.lastConsumerIndex = firstLaterWriterIdx;
         allocInfo.stores = std::move(stores);
         hasSubsequentExternalConsumer = true;
         break;
@@ -801,6 +816,12 @@ private:
         if (consumerEntry.loop == allocInfo.producer) {
           continue;
         }
+        size_t consumerIdx =
+            static_cast<size_t>(consumerEntry.loop - scratchLoops.data());
+        if (consumerIdx > allocInfo.lastConsumerIndex) {
+          continue;
+        }
+
         ScratchLoopInfo &consumer = *consumerEntry.loop;
         // Use producer-aware map so that consumers with a different linalgRoot
         // step size correctly address the scratch buffer (which is laid out

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -18,6 +16,8 @@
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MINSERTSPILLANDSCRATCH
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+#include <algorithm>
 
 namespace {
 
@@ -404,7 +404,7 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
     return true;
   }
 
-  // Walk linearly through the block and rehome the operations between
+  // Walk linearly through the block and reorder the operations between
   // consecutive loop nests.
   Block *outerBlock = chains[0].chain[firstDivergentLevel]->getBlock();
   for (auto &ci : chains) {

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -19,7 +21,11 @@ namespace mlir::tt::d2m {
 
 namespace {
 
-/// Information about a loop nest with d2m.scratch_space_loop
+/// Information about one scratch_space_loop "region of compute".
+/// Records enough structural information to:
+///   1. decide whether one loop nest produces a value used by another,
+///   2. size the compiler-inserted scratch buffer, and
+///   3. build the affine indexing used to spill into scratch and reload later.
 struct ScratchLoopInfo {
   affine::AffineForOp scratchLoop; // The loop with d2m.scratch_space_loop attr
   affine::AffineForOp linalgRoot;  // The nested loop with d2m.linalg_root attr
@@ -30,12 +36,21 @@ struct ScratchLoopInfo {
 };
 
 /// A single consumer loop and the loads it contains for a given intermediate.
+/// Keep the whole list of loads because the same intermediate allocation may
+/// be read multiple times inside a later scratch_space_loop and all of those
+/// loads must be redirected to the same scratch slot once spilling is inserted.
 struct ConsumerLoopLoads {
   ScratchLoopInfo *loop;
   SmallVector<affine::AffineLoadOp> loads;
 };
 
-/// Information about an intermediate allocation that needs to become scratch
+/// Information about one intermediate allocation that should be materialized
+/// through compiler-managed scratch instead of a local memref.alloc.
+///
+/// "producer" here is intentionally the loop nest that first defines the value
+/// that must survive into a later scratch_space_loop. A later loop may both
+/// read and then update the same allocation in place, but that later write does
+/// not replace the original producer for cross-loop lifetime purposes.
 struct IntermediateAllocInfo {
   memref::AllocOp allocOp;
   ScratchLoopInfo *producer; // Loop nest that writes to this alloc
@@ -45,6 +60,10 @@ struct IntermediateAllocInfo {
 };
 
 /// Find the innermost affine.for loop with d2m.linalg_root attribute.
+///
+/// This identifies the loop where the actual elementwise/tilewise linalg-style
+/// compute begins. Scratch indexing is built from the enclosing
+/// scratch_space_loop plus this linalg_root subtree.
 static affine::AffineForOp findLinalgRootLoop(affine::AffineForOp scratchLoop) {
   affine::AffineForOp result = nullptr;
   scratchLoop.getBody()->walk([&](affine::AffineForOp forOp) {
@@ -98,8 +117,10 @@ static bool computeScratchShape(ScratchLoopInfo &info) {
   return true;
 }
 
-/// Check if a memref is an intermediate allocation (not an input/output of the
-/// generic op, but created inside the generic region)
+/// Check whether an allocation is a compiler-local intermediate of this
+/// d2m.generic.
+/// Inputs/outputs of the generic already have externally visible storage and
+/// should never be replaced by scratch slots.
 static bool isIntermediateAlloc(memref::AllocOp allocOp, GenericOp genericOp) {
   // Check if alloc is inside the generic op's region
   if (!genericOp->isProperAncestor(allocOp)) {
@@ -117,8 +138,11 @@ static bool isIntermediateAlloc(memref::AllocOp allocOp, GenericOp genericOp) {
   return true;
 }
 
-/// Check if a memref value traces back to the target allocation through
-/// subviews
+/// Check whether a memref SSA value ultimately aliases the target allocation.
+///
+/// Loads/stores often use subviews rather than the alloc result directly.
+/// Spill insertion cares about the underlying storage object, so walk
+/// through subviews and treat them as accesses to the same intermediate.
 static bool tracesToAlloc(Value memref, Value targetAlloc) {
   Value current = memref;
   while (current) {
@@ -134,7 +158,8 @@ static bool tracesToAlloc(Value memref, Value targetAlloc) {
   return false;
 }
 
-/// Collect all affine stores to a given memref within a loop nest
+/// Collect all affine stores to a given intermediate anywhere inside one
+/// scratch_space_loop nest.
 static void collectStoresInLoop(Value memref, ScratchLoopInfo &loopInfo,
                                 SmallVector<affine::AffineStoreOp> &stores) {
   loopInfo.scratchLoop.walk([&](affine::AffineStoreOp storeOp) {
@@ -144,7 +169,8 @@ static void collectStoresInLoop(Value memref, ScratchLoopInfo &loopInfo,
   });
 }
 
-/// Collect all affine loads from a given memref within a loop nest
+/// Collect all affine loads from a given intermediate anywhere inside one
+/// scratch_space_loop nest.
 static void collectLoadsInLoop(Value memref, ScratchLoopInfo &loopInfo,
                                SmallVector<affine::AffineLoadOp> &loads) {
   loopInfo.scratchLoop.walk([&](affine::AffineLoadOp loadOp) {
@@ -316,15 +342,16 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
 ///     scratch_space_loop_1 { producer }
 ///     scratch_space_loop_2 { consumer }
 ///   }
-static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
+static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
                               IRRewriter &rewriter) {
   if (scratchLoops.size() < 2) {
-    return;
+    return true;
   }
 
   struct ChainInfo {
     affine::AffineForOp scratchLoop;
-    SmallVector<scf::ForOp> chain; // outermost first
+    // The enclosing scf.for chain, ordered from outermost to innermost.
+    SmallVector<scf::ForOp> chain;
   };
 
   SmallVector<ChainInfo> chains;
@@ -340,40 +367,101 @@ static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
     chains.push_back(ci);
   }
 
+  // Every candidate must have the same number of enclosing scf.for loops.
   size_t chainLen = chains[0].chain.size();
   if (chainLen == 0) {
-    return;
+    return true;
   }
   for (auto &ci : chains) {
     if (ci.chain.size() != chainLen) {
-      return;
+      return false;
     }
   }
 
-  // Verify matching bounds/steps at each nesting level.
+  // Find the first level where the nests stop sharing the exact same loop op.
+  size_t firstDivergentLevel = chainLen;
   for (size_t level = 0; level < chainLen; ++level) {
-    auto ref = chains[0].chain[level];
+    scf::ForOp ref = chains[0].chain[level];
+    bool allMatch = true;
+    for (size_t i = 1; i < chains.size(); ++i) {
+      if (chains[i].chain[level] != ref) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) {
+      continue;
+    }
+    firstDivergentLevel = level;
+    break;
+  }
+
+  if (firstDivergentLevel == chainLen) {
+    return true;
+  }
+
+  // Walk linearly through the block and rehome the operations between
+  // consecutive loop nests.
+  Block *outerBlock = chains[0].chain[firstDivergentLevel]->getBlock();
+  for (auto &ci : chains) {
+    if (ci.chain[firstDivergentLevel]->getBlock() != outerBlock) {
+      return false;
+    }
+  }
+
+  // Put chains in source order so "chain i then chain i+1" matches the original
+  // execution order in the parent block.
+  std::sort(chains.begin(), chains.end(),
+            [](const ChainInfo &lhs, const ChainInfo &rhs) -> bool {
+              size_t level = 0;
+              while (level < lhs.chain.size() &&
+                     lhs.chain[level] == rhs.chain[level]) {
+                ++level;
+              }
+              if (level == lhs.chain.size()) {
+                return false;
+              }
+              return lhs.chain[level]->isBeforeInBlock(rhs.chain[level]);
+            });
+
+  // Verify that the divergent loops are structurally identical. Fusion here is
+  // intentionally conservative: only merge loops when they iterate over the
+  // same space with the same step so the shared loop preserves semantics.
+  for (size_t level = firstDivergentLevel; level < chainLen; ++level) {
+    scf::ForOp ref = chains[0].chain[level];
     auto refLb = getConstantIntValue(ref.getLowerBound());
     auto refUb = getConstantIntValue(ref.getUpperBound());
     auto refStep = getConstantIntValue(ref.getStep());
     if (!refLb || !refUb || !refStep) {
-      return;
+      return false;
     }
     for (size_t i = 1; i < chains.size(); ++i) {
-      auto other = chains[i].chain[level];
+      scf::ForOp other = chains[i].chain[level];
       auto lb = getConstantIntValue(other.getLowerBound());
       auto ub = getConstantIntValue(other.getUpperBound());
       auto step = getConstantIntValue(other.getStep());
       if (!lb || !ub || !step) {
-        return;
+        return false;
       }
       if (*refLb != *lb || *refUb != *ub || *refStep != *step) {
-        return;
+        return false;
       }
     }
   }
 
   // Move operations between consecutive loop nests to before the first.
+  //
+  // Source shape before fusion looks roughly like:
+  //   scf.for A
+  //   setup ops for B
+  //   scf.for B
+  //   setup ops for C
+  //   scf.for C
+  //
+  // After we create one shared outer loop, hoist the setup ops in front of the
+  // first fused chain and then splice the old loop bodies into the new shared
+  // chain.
+  //
   // These are setup ops (allocs, remote_loads, etc.) that don't depend on
   // loop IVs and need to dominate the shared loop body.
   //
@@ -382,28 +470,36 @@ static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   // chain[i]'s content, before chain[i+1]'s content). Collect these
   // separately and splice them in at the right position below.
   SmallVector<SmallVector<Operation *>> stallsAfterChain(chains.size());
-  Operation *firstOuter = chains[0].chain[0];
+  Operation *firstOuter = chains[0].chain[firstDivergentLevel];
   for (size_t i = 1; i < chains.size(); ++i) {
-    Operation *thisOuter = chains[i].chain[0];
+    Operation *thisOuter = chains[i].chain[firstDivergentLevel];
     SmallVector<Operation *> toMove;
-    for (auto it = std::next(chains[i - 1].chain[0]->getIterator());
-         &*it != thisOuter; ++it) {
-      if (isa<UnpackStallOnPackOp>(&*it)) {
-        stallsAfterChain[i - 1].push_back(&*it);
+    auto it =
+        std::next(chains[i - 1].chain[firstDivergentLevel]->getIterator());
+    auto end = outerBlock->end();
+    auto thisOuterIt = thisOuter->getIterator();
+    for (; it != end && it != thisOuterIt; ++it) {
+      Operation *op = &*it;
+      if (isa<UnpackStallOnPackOp>(op)) {
+        stallsAfterChain[i - 1].push_back(op);
       } else {
-        toMove.push_back(&*it);
+        toMove.push_back(op);
       }
+    }
+    if (it == end) {
+      return false;
     }
     for (auto *op : toMove) {
       op->moveBefore(firstOuter);
     }
   }
 
-  // Create the shared scf.for chain with matching bounds.
+  // Materialize a fresh scf.for chain with the same iteration space as the
+  // first original chain.
   rewriter.setInsertionPoint(firstOuter);
   SmallVector<scf::ForOp> shared;
-  for (size_t level = 0; level < chainLen; ++level) {
-    auto &ref = chains[0].chain[level];
+  for (size_t level = firstDivergentLevel; level < chainLen; ++level) {
+    scf::ForOp ref = chains[0].chain[level];
     auto newLoop = rewriter.create<scf::ForOp>(
         ref.getLoc(), ref.getLowerBound(), ref.getUpperBound(), ref.getStep());
     shared.push_back(newLoop);
@@ -411,17 +507,29 @@ static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   }
 
   // Move body operations from each old chain into the shared chain.
+  //
+  // Conceptually we are turning:
+  //   outerA { bodyA }
+  //   outerB { bodyB }
+  //
+  // into:
+  //   sharedOuter { bodyA; bodyB; }
+  //
+  // but we must do so level-by-level to keep nested setup/teardown ordering
+  // valid at each depth.
   for (size_t chainIdx = 0; chainIdx < chains.size(); ++chainIdx) {
     auto &ci = chains[chainIdx];
-    // Replace old IVs with shared IVs at every nesting level.
-    for (size_t level = 0; level < chainLen; ++level) {
+    // Rewrite uses of the old induction vars to the new shared IVs before
+    // moving operations.
+    for (size_t level = firstDivergentLevel; level < chainLen; ++level) {
       ci.chain[level].getInductionVar().replaceAllUsesWith(
-          shared[level].getInductionVar());
+          shared[level - firstDivergentLevel].getInductionVar());
     }
 
-    for (size_t level = 0; level < chainLen; ++level) {
+    for (size_t level = firstDivergentLevel; level < chainLen; ++level) {
+      size_t sharedLevel = level - firstDivergentLevel;
       Block *oldBody = ci.chain[level].getBody();
-      Block *sharedBody = shared[level].getBody();
+      Block *sharedBody = shared[sharedLevel].getBody();
       Operation *sharedYield = sharedBody->getTerminator();
 
       if (level + 1 < chainLen) {
@@ -453,7 +561,7 @@ static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
             preOps.push_back(&op);
           }
         }
-        Operation *innerSharedLoop = shared[level + 1].getOperation();
+        Operation *innerSharedLoop = shared[sharedLevel + 1].getOperation();
         for (auto *op : preOps) {
           op->moveBefore(innerSharedLoop);
         }
@@ -476,10 +584,12 @@ static void fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
     }
   }
 
-  // Erase old scf.for chains (outermost erases the entire chain).
+  // Erase the old divergent scf.for chains.
   for (auto &ci : chains) {
-    rewriter.eraseOp(ci.chain[0]);
+    rewriter.eraseOp(ci.chain[firstDivergentLevel]);
   }
+
+  return true;
 }
 
 /// Main pass implementation
@@ -504,6 +614,10 @@ private:
     IRRewriter rewriter(&getContext());
 
     // Step 0: Find all scratch_space_loops first (before any modifications).
+    //
+    // Gather the candidate loops up front because later rewriting may erase or
+    // re-parent surrounding structure. Skip loops already marked as processed
+    // so the pass is idempotent if it is run more than once.
     SmallVector<affine::AffineForOp> scratchSpaceLoops;
     genericOp.walk([&](affine::AffineForOp forOp) {
       if (forOp->hasAttr("d2m.scratch_space_loop") &&
@@ -520,9 +634,15 @@ private:
     // This ensures producer/consumer computations share the outer iteration
     // space, allowing the scratch buffer to be reused per outer iteration
     // rather than needing full-shard capacity.
-    fuseOuterScfLoops(scratchSpaceLoops, rewriter);
+    if (!fuseOuterScfLoops(scratchSpaceLoops, rewriter)) {
+      return success();
+    }
 
-    // Step 1: Collect full loop info.
+    // Step 1: Collect structural information for each scratch_space_loop.
+    //
+    // Only keep loops where we can identify a linalg_root and where every
+    // relevant loop bound/step is static enough to build a concrete scratch
+    // shape and affine access map.
     SmallVector<ScratchLoopInfo> scratchLoops;
     for (auto scratchLoop : scratchSpaceLoops) {
       ScratchLoopInfo info;
@@ -542,27 +662,35 @@ private:
       return success();
     }
 
-    // Step 3: Find intermediate allocations that connect the loop nests.
+    // Step 3: Find intermediate allocations that connect loop nests.
+    //
+    // Looking for the pattern:
+    //   scratch_space_loop P writes alloc A
+    //   scratch_space_loop C (later in program order) reads alloc A
     SmallVector<IntermediateAllocInfo> intermediates;
 
     genericOp.walk([&](memref::AllocOp allocOp) {
       if (!isIntermediateAlloc(allocOp, genericOp)) {
         return;
       }
-
       IntermediateAllocInfo allocInfo;
       allocInfo.allocOp = allocOp;
       allocInfo.producer = nullptr;
 
       Value allocResult = allocOp.getResult();
+      SmallVector<SmallVector<affine::AffineStoreOp>> storesByLoop(
+          scratchLoops.size());
 
       // Find which loop nests write to and read from this allocation.
-      for (auto &loopInfo : scratchLoops) {
+      // Keep per-loop stores in a side table so we can later answer: "which
+      // loop is the earliest writer whose value is consumed by a later loop?"
+      for (auto indexedLoop : llvm::enumerate(scratchLoops)) {
+        size_t loopIdx = indexedLoop.index();
+        auto &loopInfo = indexedLoop.value();
         SmallVector<affine::AffineStoreOp> stores;
         collectStoresInLoop(allocResult, loopInfo, stores);
         if (!stores.empty()) {
-          allocInfo.producer = &loopInfo;
-          allocInfo.stores = stores;
+          storesByLoop[loopIdx] = std::move(stores);
         }
 
         SmallVector<affine::AffineLoadOp> loads;
@@ -576,19 +704,39 @@ private:
       // *subsequent* scratch_space_loop (i.e., consumer index > producer
       // index). A consumer that appears before or at the same loop as the
       // producer does not require cross-loop scratch spilling.
+      // Example:
+      //   loop 0: alloc = sin(...)
+      //   loop 1: tmp = load alloc; alloc = add(tmp, ...)
+      //
+      // loop 1 both reads and writes the same alloc, but loop 0 is still the
+      // true producer of the value that must survive into loop 1. If we chose
+      // loop 1 as the producer just because it is a later writer, we would
+      // lose the real producer->consumer dependency and either spill the wrong
+      // thing or fail to spill at all.
       bool hasSubsequentExternalConsumer = false;
-      if (allocInfo.producer) {
-        size_t producerIdx =
-            static_cast<size_t>(allocInfo.producer - scratchLoops.data());
-        hasSubsequentExternalConsumer =
+      for (auto indexedStores : llvm::enumerate(storesByLoop)) {
+        size_t loopIdx = indexedStores.index();
+        auto &stores = indexedStores.value();
+        if (stores.empty()) {
+          continue;
+        }
+
+        // Pick the earliest writer with a later read so in-place consumer
+        // updates do not replace the true producer for this intermediate.
+        bool hasLaterConsumer =
             llvm::any_of(allocInfo.consumers, [&](const ConsumerLoopLoads &c) {
-              if (c.loop == allocInfo.producer) {
-                return false;
-              }
               size_t consIdx =
                   static_cast<size_t>(c.loop - scratchLoops.data());
-              return consIdx > producerIdx;
+              return consIdx > loopIdx;
             });
+        if (!hasLaterConsumer) {
+          continue;
+        }
+
+        allocInfo.producer = &scratchLoops[loopIdx];
+        allocInfo.stores = std::move(stores);
+        hasSubsequentExternalConsumer = true;
+        break;
       }
       if (hasSubsequentExternalConsumer) {
         intermediates.push_back(allocInfo);
@@ -670,7 +818,7 @@ private:
         }
       }
 
-      // Step 7: Clean up - remove subviews and old allocation if unused.
+      // Step 7: Clean up dead pieces of the original local-allocation path.
       SmallVector<memref::SubViewOp> subviews;
       for (Operation *user : allocInfo.allocOp.getResult().getUsers()) {
         if (auto subview = dyn_cast<memref::SubViewOp>(user)) {
@@ -689,7 +837,8 @@ private:
       }
     }
 
-    // Mark all scratch loops as processed.
+    // Mark all scratch loops as processed so a repeated run of this pass does
+    // not try to insert a second layer of scratch for the same loop nests.
     for (auto &info : scratchLoops) {
       info.scratchLoop->setAttr("d2m.scratch_inserted",
                                 UnitAttr::get(&getContext()));

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -100,6 +100,80 @@ func.func @two_intermediates_inplace_consumer(
 }
 
 // ---------------------------------------------------------------------------
+// Test: two scratch_space_loop nests wrapped in matching inner non-blocking
+//       scf.for loops, all of which sit inside a shared blocking scf.for
+//       (d2m.blocking_loop = 0).  The pass should:
+//         - stop climbing the parent chain at the blocking loop, so only the
+//           inner (non-blocking) scf.for is collected as a fusion candidate
+//         - fuse those inner non-blocking scf.for wrappers into one loop
+//         - leave the outer blocking scf.for untouched
+//         - insert a scratch_allocate as usual
+// ---------------------------------------------------------------------------
+
+// CHECK-LABEL: func.func @blocking_loop_inner_scf_fusion
+// CHECK:       %[[SCRATCH:.*]] = d2m.scratch_allocate {slot = 0 : i64}
+// Outer blocking loop is preserved.
+// CHECK:       scf.for
+// The two inner non-blocking scf.for wrappers are fused into one.
+// CHECK:       scf.for
+// CHECK-NOT:   scf.for
+// Both scratch nests are now tagged d2m.scratch_inserted.
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+// Outer blocking loop attribute is preserved.
+// CHECK:       } {d2m.blocking_loop = 0 : i64}
+// CHECK-NOT:   memref.alloc
+func.func @blocking_loop_inner_scf_fusion(
+    %in0  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%in0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>)
+      outs(%out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  ^unified0:
+    %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb0 = d2m.wait %cb0_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb1 = d2m.reserve %cb1_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    // Blocking loop (shared context for the whole shard tile).
+    scf.for %bi = %c0 to %c1 step %c1 {
+      // Each scratch nest is wrapped in its own matching non-blocking scf.for.
+      // Nest A: cb0 → tmp (tile_exp).
+      scf.for %k = %c0 to %c4 step %c1 {
+        affine.for %i = 0 to 2 {
+          affine.for %j = 0 to 1 {
+            %v = affine.load %cb0[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+            %r = "d2m.tile_exp"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+            affine.store %r, %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          } {d2m.linalg_root}
+        } {d2m.scratch_space_loop}
+      }
+      // Nest B: tmp → cb1 (tile_sin).
+      scf.for %k = %c0 to %c4 step %c1 {
+        affine.for %i = 0 to 2 {
+          affine.for %j = 0 to 1 {
+            %v = affine.load %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+            %r = "d2m.tile_sin"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+            affine.store %r, %cb1[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          } {d2m.linalg_root}
+        } {d2m.scratch_space_loop}
+      }
+    } {d2m.blocking_loop = 0}
+  }
+  return
+}
+
+// ---------------------------------------------------------------------------
 // Test: three scratch_space_loop nests in a linear A→B→C chain with two
 //       intermediate allocs.  Verifies that:
 //         - two scratch_allocate ops are created with slot 0 and slot 1

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -64,15 +64,15 @@ func.func @two_intermediates_inplace_consumer(
         : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
         -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
     %tmp_a = memref.alloc() {alignment = 64 : i64}
-        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // this is replaced with d2m.scratch_allocate, slot 0
     %tmp_b = memref.alloc() {alignment = 64 : i64}
-        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // this is replaced with d2m.scratch_allocate, slot 1
     // Nest A: cb0 -> tmp_a (tile_exp).
     affine.for %i = 0 to 2 {
       affine.for %j = 0 to 1 {
         %v = affine.load %cb0[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
         %r = "d2m.tile_exp"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-        affine.store %r, %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        affine.store %r, %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // put it in scratch slot 0
       } {d2m.linalg_root}
     } {d2m.scratch_space_loop}
     // Nest B: cb1 -> tmp_b (tile_sin).
@@ -80,18 +80,103 @@ func.func @two_intermediates_inplace_consumer(
       affine.for %j = 0 to 1 {
         %v = affine.load %cb1[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
         %r = "d2m.tile_sin"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // put it in scratch slot 1
       } {d2m.linalg_root}
     } {d2m.scratch_space_loop}
     // Nest C: reads BOTH tmp_a and tmp_b, updates tmp_b in place, and writes
     // the result directly to the output CB.
     affine.for %i = 0 to 2 {
       affine.for %j = 0 to 1 {
-        %va = affine.load %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
-        %vb = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %va = affine.load %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // read from scratch slot 0
+        %vb = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // read from scratch slot 1
         %r  = "d2m.tile_add"(%va, %vb)
             : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
-        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1> // put it in scratch slot 1, this will be a diff alloc
+        affine.store %r, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+  }
+  return
+}
+
+// ---------------------------------------------------------------------------
+// Test: a later consumer reads an intermediate and then overwrites that same
+//       alloc in place, followed by another consumer that reads the updated
+//       value. Verifies that only the read-before-overwrite is redirected to
+//       producer scratch; the read-after-overwrite must keep reading the
+//       original alloc so it observes the updated value.
+// ---------------------------------------------------------------------------
+
+// CHECK-LABEL: func.func @read_after_inplace_update_keeps_updated_value
+// CHECK-DAG:   %[[SCRATCH:.*]] = d2m.scratch_allocate {slot = 0 : i64} : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-DAG:   %[[TMP:.*]] = memref.alloc() {{.*}} : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+//
+// Producer nest – initial value goes to scratch.
+// CHECK:       "d2m.tile_exp"
+// CHECK:       affine.store {{.*}}, %[[SCRATCH]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+//
+// In-place update nest – reads producer scratch, then writes the updated value
+// back to the original alloc.
+// CHECK:       affine.load %[[SCRATCH]]
+// CHECK:       "d2m.tile_add"
+// CHECK:       affine.store {{.*}}, %[[TMP]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+//
+// Later consumer – must read the updated alloc, not stale producer scratch.
+// CHECK-NOT:   affine.load %[[SCRATCH]]
+// CHECK:       affine.load %[[TMP]]
+// CHECK:       "d2m.tile_abs"
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+func.func @read_after_inplace_update_keeps_updated_value(
+    %in0  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %in1  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%in0, %in1 :
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>)
+      outs(%out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  ^unified0:
+    %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb2_raw = d2m.get_cb(2) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb0 = d2m.wait %cb0_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb1 = d2m.wait %cb1_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb2 = d2m.reserve %cb2_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    // Nest A: cb0 -> tmp (tile_exp).
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %v = affine.load %cb0[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r = "d2m.tile_exp"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+        affine.store %r, %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+    // Nest B: tmp + cb1 -> tmp (tile_add), updating tmp in place.
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %a = affine.load %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %b = affine.load %cb1[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r = "d2m.tile_add"(%a, %b)
+            : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+        affine.store %r, %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+    // Nest C: reads the updated tmp value and writes directly to the output CB.
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %v = affine.load %tmp[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r = "d2m.tile_abs"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
         affine.store %r, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
       } {d2m.linalg_root}
     } {d2m.scratch_space_loop}

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -83,7 +83,8 @@ func.func @two_intermediates_inplace_consumer(
         affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
       } {d2m.linalg_root}
     } {d2m.scratch_space_loop}
-    // Nest C: reads BOTH tmp_a and tmp_b, updates tmp_b in place.
+    // Nest C: reads BOTH tmp_a and tmp_b, updates tmp_b in place, and writes
+    // the result directly to the output CB.
     affine.for %i = 0 to 2 {
       affine.for %j = 0 to 1 {
         %va = affine.load %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
@@ -91,13 +92,7 @@ func.func @two_intermediates_inplace_consumer(
         %r  = "d2m.tile_add"(%va, %vb)
             : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
         affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
-      } {d2m.linalg_root}
-    } {d2m.scratch_space_loop}
-    // Final copy to output so tmp_b remains observable after the in-place update.
-    affine.for %i = 0 to 2 {
-      affine.for %j = 0 to 1 {
-        %v = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
-        affine.store %v, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        affine.store %r, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
       } {d2m.linalg_root}
     } {d2m.scratch_space_loop}
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -13,6 +13,98 @@
 #l1 = #ttcore.memory_space<l1>
 
 // ---------------------------------------------------------------------------
+// Test: two producer nests feed a consumer nest that updates one of the
+//       producer intermediates in place. Verifies that the earlier writer is
+//       still treated as the producer for scratch insertion, even though the
+//       consumer also writes the same alloc.
+// ---------------------------------------------------------------------------
+
+// CHECK-LABEL: func.func @two_intermediates_inplace_consumer
+// CHECK-DAG:   %[[SCRATCH_A:.*]] = d2m.scratch_allocate {slot = 0 : i64} : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-DAG:   %[[SCRATCH_B:.*]] = d2m.scratch_allocate {slot = 1 : i64} : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+//
+// Nest A – tile_exp result stored to slot-0 scratch.
+// CHECK:       "d2m.tile_exp"
+// CHECK:       affine.store {{.*}}, %[[SCRATCH_A]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+//
+// Nest B – tile_sin result stored to slot-1 scratch, even though tmp_b is also
+// written later by the consumer.
+// CHECK:       "d2m.tile_sin"
+// CHECK:       affine.store {{.*}}, %[[SCRATCH_B]]
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+//
+// Nest C – loads BOTH scratch slots before updating tmp_b in place.
+// CHECK:       affine.load %[[SCRATCH_A]]
+// CHECK:       affine.load %[[SCRATCH_B]]
+// CHECK:       "d2m.tile_add"
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+func.func @two_intermediates_inplace_consumer(
+    %in0  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %in1  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%in0, %in1 :
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>)
+      outs(%out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  ^unified0:
+    %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb2_raw = d2m.get_cb(2) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb0 = d2m.wait %cb0_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb1 = d2m.wait %cb1_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb2 = d2m.reserve %cb2_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp_a = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp_b = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    // Nest A: cb0 -> tmp_a (tile_exp).
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %v = affine.load %cb0[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r = "d2m.tile_exp"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+        affine.store %r, %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+    // Nest B: cb1 -> tmp_b (tile_sin).
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %v = affine.load %cb1[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r = "d2m.tile_sin"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+    // Nest C: reads BOTH tmp_a and tmp_b, updates tmp_b in place.
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %va = affine.load %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %vb = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        %r  = "d2m.tile_add"(%va, %vb)
+            : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+        affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+    // Final copy to output so tmp_b remains observable after the in-place update.
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        %v = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        affine.store %v, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+      } {d2m.linalg_root}
+    } {d2m.scratch_space_loop}
+  }
+  return
+}
+
+// ---------------------------------------------------------------------------
 // Test: three scratch_space_loop nests in a linear A→B→C chain with two
 //       intermediate allocs.  Verifies that:
 //         - two scratch_allocate ops are created with slot 0 and slot 1

--- a/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
@@ -142,3 +142,45 @@ func.func @single_add_no_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
   }
   return
 }
+
+// Generator-style fused generic with no tiled inputs should still get scratch,
+// using the tiled output type as the reference type.
+//
+// CHECK-LABEL: func.func @generator_fused_generic_gets_scratch
+// CHECK: d2m.generic
+// CHECK: memref.alloc() : memref<1x{{[0-9]+}}x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<{{[0-9]+}}x4096, 1>, #l1>
+// CHECK-NEXT: d2m.scratch_init
+func.func @generator_fused_generic_gets_scratch() {
+  %out = memref.alloc() : !memref_tiled
+  d2m.generic {
+    block_factors = [1, 1], grid = #ttcore.grid<1x1>,
+    indexing_maps = [#map],
+    iterator_types = [#parallel, #parallel],
+    threads = [#d2m.thread<unified>]
+  }
+  ins()
+  outs(%out : !memref_tiled) {
+  ^unified0:
+    %block0 = d2m.block_index(0) : index
+    %block1 = d2m.block_index(1) : index
+    %tmp = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    linalg.generic {
+      indexing_maps = [#map],
+      iterator_types = ["parallel", "parallel"]
+    } outs(%tmp : memref<4x4x!tile_f32>) {
+    ^bb0(%unused: !tile_f32):
+      linalg.yield %unused : !tile_f32
+    }
+    %result = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
+    linalg.generic {
+      indexing_maps = [#map, #map],
+      iterator_types = ["parallel", "parallel"]
+    } ins(%tmp : memref<4x4x!tile_f32>) outs(%result : memref<4x4x!tile_f32>) {
+    ^bb0(%in: !tile_f32, %unused: !tile_f32):
+      %sum = "d2m.tile_add"(%in, %in) : (!tile_f32, !tile_f32) -> !tile_f32
+      linalg.yield %sum : !tile_f32
+    }
+    %stored = d2m.remote_store %out[%block0, %block1] %result : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+  }
+  return
+}


### PR DESCRIPTION
### Ticket
Pre-req for #8058 

### Problem description
Encountered a bug when enabling eltwise fusion for fused ops. Blocking exposed a situation wherein:
- one loop nest produced an intermediate
- a later loop nest read it
- that later loop nest also updated the same buffer in place

The old producer selection lost that relationship by letting the last writer win.  The later loop is not the "real" producer. It is a consumer that happens to re-use the same storage after reading it. If we treat loop B as the producer, we lose the real dependency from A -> B and can either spill the wrong thing or fail to spill anything.

### What's changed

During Step 0.5, make the producer/consumer nests share the same outer iteration space. Otherwise a later consumer nest may not be able to match against the matching producer from the same outer iteration.

During Step 3, keep a side table of per-loop stores `storesInLoop` that represents the candidate stores for every scratch loop so a decision can be made about which loop is the producer.

Choose the earliest loop that both
- writes the alloc
- has a later scratch_space_loop that reads the alloc.
 
Keep using that loop as the producer even if a later consumer also writes the same alloc in place.

Also added comments in the file to make it clearer to understand intent. 

### Checklist
- Added a lit test to capture the bug. 
