### PR TITLE
Support loading a flatbuffer into builder execution

### DIFF
--- a/tools/builder/README.md
+++ b/tools/builder/README.md
@@ -617,6 +617,39 @@ execute_fb(compiled_bin, input_output_goldens, intermediate_goldens, device=devi
 tt_runtime.runtime.close_mesh_device(device)
 ```
 
+## load and execute a pre-compiled flatbuffer
+
+```python
+import torch
+from builder.base.builder_runtime import execute_fb, GoldenMapTensor
+import _ttmlir_runtime as tt_runtime
+
+# Prepare your input and expected output tensors
+input0 = torch.rand([128, 128], dtype=torch.float32)
+output0 = torch.abs(input0)
+
+# Create golden tensors dictionary
+# Format: {program_index: {"input_N": GoldenMapTensor, "output_N": GoldenMapTensor}}
+input_output_goldens = {
+    0: {
+        "input_0": GoldenMapTensor({0: input0}, (1, 1)),
+        "output_0": GoldenMapTensor({0: output0}, (1, 1)),
+    }
+}
+
+tt_runtime.runtime.set_current_device_runtime(tt_runtime.runtime.DeviceRuntime.TTNN)
+mesh_options = tt_runtime.runtime.MeshDeviceOptions()
+mesh_options.dispatch_core_type = tt_runtime.runtime.DispatchCoreType.ETH
+mesh_options.mesh_shape = (1, 1)
+device = tt_runtime.runtime.open_mesh_device(mesh_options)
+
+bin = tt_runtime.binary.load_binary_from_path("abs_module.ttnn")
+
+execute_fb(bin, input_output_goldens=input_output_goldens, device=device)
+
+tt_runtime.runtime.close_mesh_device(device)
+```
+
 ## set atol/rtol
 
 ```python

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -620,7 +620,7 @@ def convert_golden_input_output_to_torch(
 
 def execute_fb(
     compiled_bin,
-    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]],
+    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]] = None,
     intermediate_goldens: Dict[str, Dict[int, GoldenMapTensor]] = None,
     pcc: float = 0.99,
     atol: float = 1e-08,
@@ -690,9 +690,13 @@ def execute_fb(
         )
 
     program_indices = range(fbb.get_num_programs())
-    golden_input_output_tensors = convert_golden_input_output_to_torch(
-        input_output_goldens
-    )
+    golden_input_output_tensors = {}
+    if input_output_goldens is not None:
+        golden_input_output_tensors = convert_golden_input_output_to_torch(
+            input_output_goldens
+        )
+    else:
+        disable_golden = True
 
     golden_intermediate_torch_tensors = {}
     if intermediate_goldens is not None:
@@ -705,8 +709,6 @@ def execute_fb(
     if bypass_ops is None:
         bypass_ops = []
     verify_intermediates = enable_intermediate_verification or len(bypass_ops) > 0
-    if input_output_goldens is None:
-        disable_golden = True
 
     callback_runtime_config = CallbackRuntimeConfig(
         device=device,
@@ -757,7 +759,17 @@ def execute_fb(
                         i_dict["desc"]["layout"]["memory_desc"]["data_type"]
                     ),
                 )
-                golden_inputs_torch.append(torch_tensor)
+                if i_dict["desc"]["shard_status"] == "Unsharded":
+                    golden_inputs_torch.append({0: torch_tensor.clone()})
+                else:
+                    golden_inputs_torch.append(
+                        {
+                            i: torch_tensor.clone()
+                            for i in range(
+                                device.get_mesh_shape()[0] * device.get_mesh_shape()[1]
+                            )
+                        }
+                    )
 
         inputs = []
         for i in golden_inputs_torch:

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -620,7 +620,7 @@ def convert_golden_input_output_to_torch(
 
 def execute_fb(
     compiled_bin,
-    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]] = None,
+    input_output_goldens: Dict[int, Dict[str, Dict[int, GoldenMapTensor]]],
     intermediate_goldens: Dict[str, Dict[int, GoldenMapTensor]] = None,
     pcc: float = 0.99,
     atol: float = 1e-08,
@@ -679,14 +679,27 @@ def execute_fb(
     Tuple[Dict[str, Dict], Dict[str, Dict]]
         golden_report, output_tensors
     """
-    fbb = tt_runtime.binary.load_binary_from_capsule(compiled_bin)
+    fbb = None
+    if type(compiled_bin).__name__ == "PyCapsule":
+        fbb = tt_runtime.binary.load_binary_from_capsule(compiled_bin)
+    elif isinstance(compiled_bin, tt_runtime.binary.Binary):
+        fbb = compiled_bin
+    else:
+        raise ValueError(
+            f"Unsupported compiled_bin type: {type(compiled_bin)}, expected PyCapsule or Binary."
+        )
+
     program_indices = range(fbb.get_num_programs())
     golden_input_output_tensors = convert_golden_input_output_to_torch(
         input_output_goldens
     )
-    golden_intermediate_torch_tensors = convert_golden_intermediates_to_torch(
-        intermediate_goldens
-    )
+
+    golden_intermediate_torch_tensors = {}
+    if intermediate_goldens is not None:
+        golden_intermediate_torch_tensors = convert_golden_intermediates_to_torch(
+            intermediate_goldens
+        )
+
     output_tensors = {}
     golden_report = {}
     if bypass_ops is None:


### PR DESCRIPTION
### Ticket
Closes [#7366](https://github.com/tenstorrent/tt-mlir/issues/7366) 

### Problem description
Builder's `execute_fb()` doesn't support loading a pre-compiled flatbuffer

### What's changed
Added ability to pass binary directly into `execute_fb()`
Added builder README example

### Checklist
- [ ] New/Existing tests provide coverage for changes
