### PR TITLE
Replaced optional cluster_axis attribute to required for #7634

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5607,7 +5607,7 @@ def TTIR_MeshPartitionOp: TTIR_NamedOp<"mesh_partition"> {
   }];
   let arguments = (ins AnyRankedTensor:$input,
                        SI32Attr:$dim,
-                       OptionalAttr<UI32Attr>:$cluster_axis);
+                       UI32Attr:$cluster_axis);
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3183,7 +3183,7 @@ def TTNN_MeshPartitionOp: TTNN_Op<"mesh_partition", [TTNN_MemoryConfigOpInterfac
   }];
   let arguments = (ins AnyRankedTensor:$input,
                        SI32Attr:$dim,
-                       OptionalAttr<UI32Attr>:$cluster_axis,
+                       UI32Attr:$cluster_axis,
                        OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
   let results = (outs AnyRankedTensor:$result);
   let hasVerifier = 1;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2901,8 +2901,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::MeshPartitionOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getDim(),
-        rewriter.getUI32IntegerAttr(adaptor.getClusterAxis().value()),
+        adaptor.getInput(), adaptor.getDim(), adaptor.getClusterAxis(),
         /*memory_config=*/nullptr);
 
     return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -4937,10 +4937,10 @@ mlir::OpFoldResult mlir::tt::ttir::RepeatInterleaveOp::fold(FoldAdaptor fold) {
            << dim;
   }
 
-  std::optional<uint32_t> clusterAxis = getClusterAxis();
-  if (clusterAxis.has_value() && clusterAxis.value() > 1) {
-    return emitOpError("Cluster axis must be either None, 0 or 1, got " +
-                       std::to_string(clusterAxis.value()));
+  uint32_t clusterAxis = getClusterAxis();
+  if (clusterAxis > 1) {
+    return emitOpError("Cluster axis must be either 0 or 1, got " +
+                       std::to_string(clusterAxis));
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3684,10 +3684,10 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
            << dim;
   }
 
-  std::optional<uint32_t> clusterAxis = getClusterAxis();
-  if (clusterAxis.has_value() && clusterAxis.value() > 1) {
-    return emitOpError("Cluster axis must be either None, 0 or 1, got " +
-                       std::to_string(clusterAxis.value()));
+  uint32_t clusterAxis = getClusterAxis();
+  if (clusterAxis > 1) {
+    return emitOpError("Cluster axis must be either 0 or 1, got " +
+                       std::to_string(clusterAxis));
   }
 
   return success();


### PR DESCRIPTION
### Ticket
#7634

### Problem description
 As per #7634, ``cluster_axis`` attribute is marked as optional for MeshPartitionOp, yet in practice its always required. This pull request simply replaces optional ``cluster_axis`` with required. As well as modifying any downstream code dependencies. 

### What's changed
Changed ``OptionalAttr<UI32Attr>:$cluster_axis`` to ``UI32Attr:$cluster_axis`` in 
 - ``include/ttmlir/Dialect/TTIR/IR/TTIROps.td (TTIR_MeshPartitionOp)``
 - ``include/ttmlir/Dialect/TTNN/IR/TTNNOps.td (TTNN_MeshPartitionOp)``
 
Removed ``.value()`` calls in ``TTIRTOTTNN.cpp`` and ``TTIROps.cpp``


### Checklist
- [ ] Confirm code compiles
