### PR TITLE
Revert SDPA broadcast batch workaround

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5985,22 +5985,28 @@ def TTIR_ConcatenateHeadsOp: TTIR_NamedOp<"concatenate_heads"> {
 def TTIR_ScaledDotProductAttentionDecodeOp : TTIR_NamedOp<"scaled_dot_product_attention_decode", [AttrSizedOperandSegments]> {
     let summary = "A version of scaled dot product attention specifically for decode.";
     let description = [{
-      A version of scaled dot product attention specifically for decode.
-        The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
+      Flash-Decode SDPA for single-query-token decode. Supports MQA and GQA.
 
-        Args:
-            query (AnyRankedTensor): The query tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            key (AnyRankedTensor): The key tensor [batch x num_kv_heads x seq_len x head_size].
-            value (AnyRankedTensor): The value tensor [batch x num_kv_heads x seq_len x head_size].
-            is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x num_heads x seq_len].
-            cur_pos_tensor (AnyRankedTensor): [batch] Tensor of integers of length batch.
-            attention_sink (AnyRankedTensor, optional): The attention sink [num_heads, 32] (must be a single tile wide).
-            output (AnyRankedTensor): The output DPS operand [1 x batch x num_heads x head_size].
-            scale (float, optional): Defaults to `None`.
+      Shapes use `B` (batch), `Hq`/`Hkv` (query/kv heads), `Sk` (kv seq len),
+      `D` (head size).
 
-        Returns:
-            AnyRankedTensor: The output tensor [1 x batch x num_heads x head_size].
+      Args:
+          query (AnyRankedTensor): `[1 x B x Hq x D]`. Dim 0 must be 1.
+          key (AnyRankedTensor): `[B x Hkv x Sk x D]`.
+          value (AnyRankedTensor): `[B x Hkv x Sk x D]`. Same type as `key`.
+          is_causal (bool, optional): Defaults to `true`. Mutually exclusive
+              with `attention_mask`.
+          attention_mask (AnyRankedTensor, optional): `[1|B x 1 x 1|Hq x Sk]`.
+              Dim 0 broadcasts batch, dim 2 broadcasts heads. Only valid when
+              `is_causal` is `false`.
+          cur_pos_tensor (AnyRankedTensor): 1D `[B]` integer tensor of decode
+              positions.
+          attention_sink (AnyRankedTensor, optional): `[Hq x 32]`, single tile
+              wide.
+          scale (float, optional): Softmax scale. Defaults to `1 / sqrt(D)`.
+
+      Returns:
+          AnyRankedTensor: `[1 x B x Hq x D]` (same type as `query`).
     }];
 
     let arguments = (ins AnyRankedTensor:$query,
@@ -6075,21 +6081,35 @@ def TTIR_PagedFlashMultiLatentAttentionDecodeOp : TTIR_NamedOp<"paged_flash_mult
 def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attention", [AttrSizedOperandSegments]> {
   let summary = "Scaled dot product attention operation.";
   let description = [{
-    Scaled dot product attention.
-    The implementation is FlashAttention-2.
+    FlashAttention-2 SDPA. Supports MHA, MQA, and GQA.
+
+    Lowering to TTNN dispatches on `Sq`: `Sq > 1` lowers to
+    `ttnn.scaled_dot_product_attention` (prefill), while `Sq == 1` lowers to
+    `ttnn.scaled_dot_product_attention_decode` (decode, with the necessary Q
+    and mask permutations applied at the conversion boundary).
+
+    Shapes use `B` (batch), `Hq`/`Hkv` (query/kv heads), `Sq`/`Sk` (query/kv
+    seq len), `D` (head size).
 
     Args:
-        query (AnyRankedTensor): The query tensor.          [batch x num_heads x query_seq_len x head_size]
-        key (AnyRankedTensor): The key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
-        value (AnyRankedTensor): The value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
-        attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
-        output (AnyRankedTensor): The output DPS operand [batch x num_heads x query_seq_len x head_size].
-        is_causal (bool): Whether The attention is causal. Defaults to `true`.
-        scale (float, optional): Defaults to `None`.
-        sliding_window_size (uint, optional): Defaults to `None`. Size of sliding window for attention. If provided && is_causal, only attends to the last `sliding_window_size` tokens. If provided && !is_causal, attends to a window of size `sliding_window_size` centered at the current position.
+        query (AnyRankedTensor): `[B x Hq x Sq x D]`.
+        key (AnyRankedTensor): `[B x Hkv x Sk x D]`.
+        value (AnyRankedTensor): `[B x Hkv x Sk x D]`. Same type as `key`.
+        attention_mask (AnyRankedTensor, optional): `[1|B x 1|Hq x Sq x Sk]`.
+            Dim 0 broadcasts batch, dim 1 broadcasts heads. Only valid when
+            `is_causal` is `false`. Defaults to `None`.
+        is_causal (bool): Defaults to `true`. Requires `Sq == Sk` and no
+            `attention_mask`.
+        scale (float, optional): Softmax scale. Defaults to `1 / sqrt(D)`.
+        sliding_window_size (uint, optional): If `is_causal`, attends to the
+            last N tokens; otherwise attends to a window of size N centered at
+            the current position. Defaults to `None`.
+        attention_sink (AnyRankedTensor, optional): `[1 x Hq x 1 x 1]`, one
+            value per query head broadcast across batch and tile dims.
+            Defaults to `None`.
 
     Returns:
-        AnyRankedTensor: The output tensor [batch x num_heads x seq_len x head_size].
+        AnyRankedTensor: `[B x Hq x Sq x D]` (same type as `query`).
   }];
 
   let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3750,7 +3750,7 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
             input_tensor_k (AnyRankedTensor): The input tensor [batch x num_kv_heads x   seq_len x head_size].
             input_tensor_v (AnyRankedTensor): The input tensor [b x num_kv_heads x   seq_len x head_size].
             is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x query_seq_len x kv_seq_len].
+            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x num_heads x kv_seq_len].
             cur_pos_tensor (AnyRankedTensor): [batch] Tensor of integers of length batch.
             attention_sink (AnyRankedTensor, optional): The attention sink [num_heads, 32] (must be a single tile wide).
             scale (float, optional): Defaults to `None`.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3742,22 +3742,30 @@ def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
 def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attention_decode", [TTNN_MemoryConfigOpInterface, AttrSizedOperandSegments]> {
     let summary = "A version of scaled dot product attention specifically for decode.";
     let description = [{
-      A version of scaled dot product attention specifically for decode.
-        The implementation is Flash-Decode and it currently only supports MQA on decoding single token.
+      Flash-Decode SDPA for single-query-token decode. Supports MQA and GQA.
 
-        Args:
-            input_tensor_q (AnyRankedTensor): The input tensor [1 x batch x num_heads x head_size]. Note that there is no sequence length dimension as this op is intended for processing a single query token.
-            input_tensor_k (AnyRankedTensor): The input tensor [batch x num_kv_heads x   seq_len x head_size].
-            input_tensor_v (AnyRankedTensor): The input tensor [b x num_kv_heads x   seq_len x head_size].
-            is_causal (bool, optional): Whether the attention is causal. Defaults to `true`.
-            attention_mask (AnyRankedTensor, optional): The attention mask [batch x 1 x num_heads x kv_seq_len].
-            cur_pos_tensor (AnyRankedTensor): [batch] Tensor of integers of length batch.
-            attention_sink (AnyRankedTensor, optional): The attention sink [num_heads, 32] (must be a single tile wide).
-            scale (float, optional): Defaults to `None`.
-            memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
+      Shapes use `B` (batch), `Hq`/`Hkv` (query/kv heads), `Sk` (kv seq len),
+      `D` (head size).
 
-        Returns:
-            AnyRankedTensor: The output tensor [1 x b x pnh x dh].
+      Args:
+          query (AnyRankedTensor): `[1 x B x Hq x D]`. Dim 0 must be 1.
+          key (AnyRankedTensor): `[B x Hkv x Sk x D]`.
+          value (AnyRankedTensor): `[B x Hkv x Sk x D]`. Same type as `key`.
+          is_causal (bool, optional): Defaults to `true`. Mutually exclusive
+              with `attention_mask`.
+          attention_mask (AnyRankedTensor, optional): `[1|B x 1 x 1|Hq x Sk]`.
+              Dim 0 broadcasts batch, dim 2 broadcasts heads. Only valid when
+              `is_causal` is `false`.
+          cur_pos_tensor (AnyRankedTensor): 1D `[B]` integer tensor of decode
+              positions.
+          attention_sink (AnyRankedTensor, optional): `[Hq x 32]`, single tile
+              wide.
+          scale (float, optional): Softmax scale. Defaults to `1 / sqrt(D)`.
+          memory_config (MemoryConfigAttr, optional): Memory configuration.
+              Defaults to `None`.
+
+      Returns:
+          AnyRankedTensor: `[1 x B x Hq x D]` (same type as `query`).
     }];
 
     let arguments = (ins AnyRankedTensor:$query,
@@ -3850,22 +3858,32 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
 def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [TTNN_MemoryConfigOpInterface, AttrSizedOperandSegments]> {
     let summary = "Scaled dot product attention operation.";
     let description = [{
-      Scaled dot product attention.
-      The implementation is FlashAttention-2.
+      FlashAttention-2 SDPA. Supports MHA, MQA, and GQA.
+
+      Shapes use `B` (batch), `Hq`/`Hkv` (query/kv heads), `Sq`/`Sk` (query/kv
+      seq len), `D` (head size).
 
       Args:
-          query (AnyRankedTensor): The query tensor.          [batch x num_heads x query_seq_len x head_size]
-          key (AnyRankedTensor): The key tensor.              [batch x num_kv_heads x kv_seq_len x head_size]
-          value (AnyRankedTensor): The value tensor.          [batch x num_kv_heads x kv_seq_len x head_size]
-          attention_mask (AnyRankedTensor, optional): Defaults to `None`. [batch x 1 x query_seq_len x kv_seq_len]. Head broadcasting is implied.
-          is_causal (bool): Whether the attention is causal. Defaults to `true`.
-          scale (float, optional): Defaults to `None`.
-          sliding_window_size (uint, optional): Defaults to `None`. Size of sliding window for attention. If provided && is_causal, only attends to the last `sliding_window_size` tokens. If provided && !is_causal, attends to a window of size `sliding_window_size` centered at the current position.
-          memory_config (MemoryConfigAttr, optional): Memory configuration for the operation. Defaults to `None`.
-
+          query (AnyRankedTensor): `[B x Hq x Sq x D]`.
+          key (AnyRankedTensor): `[B x Hkv x Sk x D]`.
+          value (AnyRankedTensor): `[B x Hkv x Sk x D]`. Same type as `key`.
+          attention_mask (AnyRankedTensor, optional): `[1|B x 1|Hq x Sq x Sk]`.
+              Dim 0 broadcasts batch, dim 1 broadcasts heads. Only valid when
+              `is_causal` is `false`. Defaults to `None`.
+          is_causal (bool): Defaults to `true`. Requires `Sq == Sk` and no
+              `attention_mask`.
+          scale (float, optional): Softmax scale. Defaults to `1 / sqrt(D)`.
+          sliding_window_size (uint, optional): If `is_causal`, attends to the
+              last N tokens; otherwise attends to a window of size N centered at
+              the current position. Defaults to `None`.
+          attention_sink (AnyRankedTensor, optional): `[1 x Hq x 1 x 1]`, one
+              value per query head broadcast across batch and tile dims.
+              Defaults to `None`.
+          memory_config (MemoryConfigAttr, optional): Memory configuration.
+              Defaults to `None`.
 
       Returns:
-          AnyRankedTensor: The output tensor [batch x num_heads x query_seq_len x head_size].
+          AnyRankedTensor: `[B x Hq x Sq x D]` (same type as `query`).
     }];
 
     let arguments = (ins AnyRankedTensor:$query,

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.h
@@ -12,10 +12,15 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// Workaround which broadcasts the attention mask num_heads dimension (dim 2)
-// for ScaledDotProductAttentionDecode when it is 1 (broadcast) to match the
-// query num_heads. tt-metal requires mask[2] == num_heads for decode SDPA and
-// does not support implicit broadcasting on that dimension.
+// Workaround which materializes the heads dim (dim 2) of the decode SDPA
+// attention mask via an explicit repeat when it was emitted as 1.
+//
+// Decode mask layout is [1|B, 1, 1|Hq, Sk]. The kernel:
+//   - natively broadcasts the batch dim (dim 0): mask[0] may be 1 for all B,
+//   - does not broadcast the heads dim (dim 2): mask[2] must equal Hq.
+// Only the heads-dim case needs this rewrite; batch broadcast is handled by
+// the kernel directly.
+//
 // Tracking issue: https://github.com/tenstorrent/tt-metal/issues/39946
 
 class ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -726,10 +726,25 @@ public:
   }
 };
 
-// Special handling for tenstorrent.scaled_dot_product_attention ->
-// ttir.scaled_dot_product_attention
-// Extracts is_causal, scale from composite attributes and sets
-// operandSegmentSizes for AttrSizedOperandSegments
+// Lowers `stablehlo.composite "tenstorrent.scaled_dot_product_attention"` to
+// `ttir.scaled_dot_product_attention`. The composite is emitted by the
+// frontend (tt-xla) wrapper around
+// `torch.nn.functional.scaled_dot_product_attention`.
+//
+// Operand/attribute mapping:
+//   - Operands: [query, key, value] or [query, key, value, attention_mask].
+//     Shapes are passed through unchanged; the TTIR generic verifier enforces
+//     [B, Hq, Sq, D] / [B, Hkv, Sk, D] / [1|B, 1|Hq, Sq, Sk] layouts.
+//   - Attributes: only `is_causal` and `scale` are forwarded from the
+//     composite. Other attributes that PyTorch SDPA may set
+//     (e.g. `sliding_window_size`, `enable_gqa`) are not propagated.
+//
+// Policy decisions baked in below:
+//   1. The 4th operand (`attention_mask`) is forwarded only when
+//      `is_causal == false`, matching the kernel's mutual-exclusivity rule.
+//   2. `attention_sink` is hard-coded to operand-segment size 0; the frontend
+//      cannot supply it yet. Tracked by
+//      https://github.com/tenstorrent/tt-xla/issues/4030.
 class TenstorrentScaledDotProductAttentionConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3477,21 +3477,22 @@ public:
   }
 
 private:
-  // SDPA Query, Key, Value tensors have shape [B, H, S, D] (Batch, NumHeads,
-  // SeqLen, HeadDim).
+  // TTIR generic SDPA layout: Q [B, Hq, Sq, D], K/V [B, Hkv, Sk, D],
+  // mask [1|B, 1|Hq, Sq, Sk]. See ScaledDotProductAttentionOp::verify().
   static constexpr int64_t kNumHeadsDim = 1;
   static constexpr int64_t kSeqLenDim = 2;
 
-  // Permutation to convert query from [B, H, S, D] -> [S, B, H, D] for SDPA
-  // decode op.
+  // Generic->decode dispatch fires only when Sq == 1. Permutes query
+  // [B, Hq, 1, D] -> [1, B, Hq, D] to match the decode op layout.
   static constexpr std::array<int64_t, 4> kToDecodePermutation = {2, 0, 1, 3};
 
-  // Permutation to convert mask from [B, H, S=1, kv_seq] -> [B, 1, H, kv_seq]
-  // for SDPA decode op.
+  // Permutes mask [1|B, 1|Hq, 1, Sk] -> [1|B, 1, 1|Hq, Sk] to match the decode
+  // op mask layout.
   static constexpr std::array<int64_t, 4> kToDecodeMaskPermutation = {0, 2, 1,
                                                                       3};
 
-  // Decode mask layout dim of the heads dimension: [B, 1, H, kv_seq].
+  // Index of the heads dim in the post-permutation decode mask layout
+  // [B, 1, Hq, Sk].
   static constexpr int64_t kDecodeMaskNumHeadsDim = 2;
 
   // Determine if the decode op should be used based on query sequence length.
@@ -3501,8 +3502,10 @@ private:
     return queryType.getDimSize(kSeqLenDim) == 1;
   }
 
-  // Broadcast attention mask's head dimension to match the number of heads.
-  // The decode op requires the mask to have explicit head dimension.
+  // Materialize the heads dim of the decode mask. The decode kernel currently
+  // does not support broadcasting the heads dim of the mask (batch broadcast
+  // is supported).
+  // Tracked by https://github.com/tenstorrent/tt-metal/issues/39946.
   Value broadcastMaskForDecode(Value mask, int64_t numHeads,
                                ConversionPatternRewriter &rewriter,
                                Location loc) const {
@@ -3523,9 +3526,14 @@ private:
     return rewriter.create<ttnn::RepeatOp>(loc, broadcastType, mask, shapeAttr);
   }
 
-  // Lower to SDPA decode op with necessary permutations.
-  // Decode op expects [S, B, H, D] query and [B, 1, H, kv_seq] mask, so we
-  // permute from [B, H, S, D] and [B, H, S=1, kv_seq] respectively.
+  // Lower to SDPA decode op. Operand layout transitions:
+  //   Q:      [B, Hq, 1, D]      -> [1, B, Hq, D]  (permute {2,0,1,3})
+  //   K, V:   [B, Hkv, Sk, D]    -> unchanged (TTIR generic and TTNN decode
+  //                                share this layout)
+  //   mask:   [1|B, 1|Hq, 1, Sk] -> [1|B, 1, 1|Hq, Sk] (permute {0,2,1,3},
+  //                                heads dim materialized when Hq > 1)
+  //   result: [1, B, Hq, D]      -> [B, Hq, 1, D]  (inverse Q permute) to
+  //                                match the original ttir SDPA result type
   LogicalResult lowerToDecodeOp(ttir::ScaledDotProductAttentionOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3486,6 +3486,14 @@ private:
   // decode op.
   static constexpr std::array<int64_t, 4> kToDecodePermutation = {2, 0, 1, 3};
 
+  // Permutation to convert mask from [B, H, S=1, kv_seq] -> [B, 1, H, kv_seq]
+  // for SDPA decode op.
+  static constexpr std::array<int64_t, 4> kToDecodeMaskPermutation = {0, 2, 1,
+                                                                      3};
+
+  // Decode mask layout dim of the heads dimension: [B, 1, H, kv_seq].
+  static constexpr int64_t kDecodeMaskNumHeadsDim = 2;
+
   // Determine if the decode op should be used based on query sequence length.
   // SDPA decode is optimized for autoregressive decoding where seq_len == 1.
   bool shouldUseDecode(ttir::ScaledDotProductAttentionOp op) const {
@@ -3504,7 +3512,7 @@ private:
 
     auto maskType = mlir::cast<RankedTensorType>(mask.getType());
     SmallVector<int64_t> broadcastShape(maskType.getShape());
-    broadcastShape[kSeqLenDim] = numHeads;
+    broadcastShape[kDecodeMaskNumHeadsDim] = numHeads;
 
     auto broadcastType =
         ttnn::utils::RankedTensorTypeFactory::create(maskType, broadcastShape);
@@ -3516,8 +3524,8 @@ private:
   }
 
   // Lower to SDPA decode op with necessary permutations.
-  // Decode op expects [S, B, H, D] query shape, so we permute from [B, H, S,
-  // D].
+  // Decode op expects [S, B, H, D] query and [B, 1, H, kv_seq] mask, so we
+  // permute from [B, H, S, D] and [B, H, S=1, kv_seq] respectively.
   LogicalResult lowerToDecodeOp(ttir::ScaledDotProductAttentionOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
@@ -3529,9 +3537,14 @@ private:
         mlir::cast<TypedValue<mlir::RankedTensorType>>(adaptor.getQuery()),
         llvm::to_vector(kToDecodePermutation), rewriter, op.getLoc());
 
-    // Broadcast mask head dimension if needed.
-    Value attentionMask = broadcastMaskForDecode(
-        adaptor.getAttentionMask(), numHeads, rewriter, op.getLoc());
+    Value attentionMask = adaptor.getAttentionMask();
+    if (attentionMask) {
+      attentionMask = ttir_to_ttnn::utils::generatePermute(
+          mlir::cast<TypedValue<mlir::RankedTensorType>>(attentionMask),
+          llvm::to_vector(kToDecodeMaskPermutation), rewriter, op.getLoc());
+      attentionMask = broadcastMaskForDecode(attentionMask, numHeads, rewriter,
+                                             op.getLoc());
+    }
 
     auto decodeOp = rewriter.create<ttnn::ScaledDotProductAttentionDecodeOp>(
         op.getLoc(), permutedQuery.getType(), permutedQuery, adaptor.getKey(),

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6754,6 +6754,12 @@ mlir::tt::ttir::SplitQueryKeyValueAndSplitHeadsOp::verify() {
 // ScaledDotProductAttentionDecodeOp
 //===----------------------------------------------------------------------===//
 
+// Enforces the decode SDPA layout:
+//   Q:    [1, B, Hq, D]      (dim 0 must be 1)
+//   K, V: [B, Hkv, Sk, D]    (Hq % Hkv == 0)
+//   Mask: [1|B, 1, 1|Hq, Sk] (dim 1 must be 1; dim 0/dim 2 may broadcast)
+//   cur_pos_tensor: 1D int tensor of length B
+// `is_causal` and `attention_mask` are mutually exclusive.
 ::mlir::LogicalResult
 mlir::tt::ttir::ScaledDotProductAttentionDecodeOp::verify() {
 
@@ -7001,6 +7007,12 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 // ScaledDotProductAttentionOp
 //===----------------------------------------------------------------------===//
 
+// Enforces the generic SDPA layout:
+//   Q:    [B, Hq, Sq, D]
+//   K, V: [B, Hkv, Sk, D]    (Hq % Hkv == 0)
+//   Mask: [1|B, 1|Hq, Sq, Sk] (dim 0/dim 1 may broadcast)
+// `is_causal` and `attention_mask` are mutually exclusive; `is_causal` also
+// requires Sq == Sk.
 ::mlir::LogicalResult mlir::tt::ttir::ScaledDotProductAttentionOp::verify() {
 
   RankedTensorType queryType = getQuery().getType();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -6824,13 +6824,14 @@ mlir::tt::ttir::ScaledDotProductAttentionDecodeOp::verify() {
     if (attentionMaskType.getShape().size() != 4) {
       return emitOpError("Attention mask must be a 4D tensor");
     }
-    if (attentionMaskType.getShape()[0] != 1) {
-      return emitOpError("Attention mask dim 0 must be 1");
-    }
-    if (attentionMaskType.getShape()[1] != 1 &&
-        attentionMaskType.getShape()[1] != batchSize) {
+    // Mask layout: [batch_or_1, 1, num_heads_or_1, kv_seq_len].
+    if (attentionMaskType.getShape()[0] != 1 &&
+        attentionMaskType.getShape()[0] != batchSize) {
       return emitOpError("Attention mask batch size must be 1 (broadcast) or "
                          "match query batch size");
+    }
+    if (attentionMaskType.getShape()[1] != 1) {
+      return emitOpError("Attention mask dim 1 must be 1");
     }
     if (attentionMaskType.getShape()[2] != 1 &&
         attentionMaskType.getShape()[2] != nQueryHeads) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -5466,18 +5466,15 @@ mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
     if (attentionMaskType.getShape().size() != 4) {
       return emitOpError("Attention mask must be a 4D tensor");
     }
-    // First 3 dims of the mask must each either be 1 (broadcast) or match the
-    // corresponding query dim. Query layout is [1, batch, nQueryHeads,
-    // headSize].
+    // Mask layout: [batch_or_1, 1, num_heads_or_1, kv_seq_len]. Query layout
+    // is [1, batch, nQueryHeads, headSize].
     if (attentionMaskType.getShape()[0] != 1 &&
-        attentionMaskType.getShape()[0] != queryType.getShape()[0]) {
-      return emitOpError("Attention mask dim 0 must be 1 (broadcast) or "
-                         "match query dim 0");
-    }
-    if (attentionMaskType.getShape()[1] != 1 &&
-        attentionMaskType.getShape()[1] != batchSize) {
+        attentionMaskType.getShape()[0] != batchSize) {
       return emitOpError("Attention mask batch size must be 1 (broadcast) or "
                          "match query batch size");
+    }
+    if (attentionMaskType.getShape()[1] != 1) {
+      return emitOpError("Attention mask dim 1 must be 1");
     }
     if (attentionMaskType.getShape()[2] != 1 &&
         attentionMaskType.getShape()[2] != nQueryHeads) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -5393,6 +5393,12 @@ mlir::LogicalResult RotaryEmbeddingLlamaOp::verify() {
 // ScaledDotProductAttentionDecodeOp
 //===----------------------------------------------------------------------===//
 
+// Enforces the decode SDPA layout:
+//   Q:    [1, B, Hq, D]      (dim 0 must be 1)
+//   K, V: [B, Hkv, Sk, D]    (Hq % Hkv == 0)
+//   Mask: [1|B, 1, 1|Hq, Sk] (dim 1 must be 1; dim 0/dim 2 may broadcast)
+//   cur_pos_tensor: 1D int tensor of length B
+// `is_causal` and `attention_mask` are mutually exclusive.
 ::mlir::LogicalResult
 mlir::tt::ttnn::ScaledDotProductAttentionDecodeOp::verify() {
 
@@ -5644,6 +5650,12 @@ mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 // ScaledDotProductAttentionOp
 //===----------------------------------------------------------------------===//
 
+// Enforces the generic SDPA layout:
+//   Q:    [B, Hq, Sq, D]
+//   K, V: [B, Hkv, Sk, D]    (Hq % Hkv == 0)
+//   Mask: [1|B, 1|Hq, Sq, Sk] (dim 0/dim 1 may broadcast)
+// `is_causal` and `attention_mask` are mutually exclusive; `is_causal` also
+// requires Sq == Sk.
 ::mlir::LogicalResult mlir::tt::ttnn::ScaledDotProductAttentionOp::verify() {
 
   RankedTensorType queryType = getQuery().getType();

--- a/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -27,6 +27,10 @@ static constexpr int64_t kSeqLenDim = 2;
 // decode op.
 static constexpr std::array<int64_t, 4> kToDecodePermutation = {2, 0, 1, 3};
 
+// Permutation to convert mask from [B, H, S=1, kv_seq] -> [B, 1, H, kv_seq]
+// for SDPA decode op.
+static constexpr std::array<int64_t, 4> kToDecodeMaskPermutation = {0, 2, 1, 3};
+
 struct SDPAFusing::SDPAComponents {
   Value query, key, value, mask;
   Value attentionSink;
@@ -707,7 +711,7 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
     if (permutedMask) {
       permutedMask = ttir_to_ttnn::utils::generatePermute(
           mlir::cast<TypedValue<RankedTensorType>>(permutedMask),
-          llvm::to_vector(kToDecodePermutation), rewriter,
+          llvm::to_vector(kToDecodeMaskPermutation), rewriter,
           c.attentionMatmul.getLoc());
     }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
@@ -31,26 +31,21 @@ ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern::matchAndRewrite(
   }
 
   // Mask layout (per ScaledDotProductAttentionDecodeOp::verify):
-  //   [1, batch_or_1, num_heads_or_1, kv_seq_len].
-  int64_t batch = queryType.getShape()[1];
+  //   [batch_or_1, 1, num_heads_or_1, kv_seq_len].
+  // tt-metal handles batch broadcasting natively, so only the heads dimension
+  // still requires this workaround.
+  // See https://github.com/tenstorrent/tt-metal/issues/39910.
   int64_t numHeads = queryType.getShape()[2];
-  int64_t maskBatch = maskType.getShape()[1];
   int64_t maskHeads = maskType.getShape()[2];
 
-  bool needBatchBroadcast = (maskBatch == 1 && batch > 1);
   bool needHeadBroadcast = (maskHeads == 1 && numHeads > 1);
 
-  if (!needBatchBroadcast && !needHeadBroadcast) {
+  if (!needHeadBroadcast) {
     return failure();
   }
 
   SmallVector<int64_t> targetShape(maskType.getShape());
-  if (needBatchBroadcast) {
-    targetShape[1] = batch;
-  }
-  if (needHeadBroadcast) {
-    targetShape[2] = numHeads;
-  }
+  targetShape[2] = numHeads;
 
   auto broadcastType =
       utils::RankedTensorTypeFactory::create(maskType, targetShape);

--- a/test/python/golden/ttir_ops/attention/test_sdpa.py
+++ b/test/python/golden/ttir_ops/attention/test_sdpa.py
@@ -267,10 +267,10 @@ def test_sdpa_mask_broadcast(
 @pytest.mark.parametrize(
     "shapes,mask_shape,scale",
     [
-        # Decode mask: [1, batch, num_heads, kv_seq] - standard
+        # Decode mask: [batch, 1, num_heads, kv_seq] - standard
         pytest.param(
             [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
-            (1, 32, 32, 128),
+            (32, 1, 32, 128),
             0.124999993,
             marks=pytest.mark.xfail(
                 reason="PCC regression, tracked in "
@@ -280,14 +280,14 @@ def test_sdpa_mask_broadcast(
         # Decode mask with GQA: mask num_heads matches query num_heads
         pytest.param(
             [(1, 32, 32, 64), (32, 8, 128, 64), (32, 8, 128, 64), (32,)],
-            (1, 32, 32, 128),
+            (32, 1, 32, 128),
             0.124999993,
             marks=pytest.mark.xfail(
                 reason="PCC regression, tracked in "
                 "https://github.com/tenstorrent/tt-mlir/issues/8112"
             ),
         ),
-        # Decode mask with batch broadcast: mask[1]=1
+        # Decode mask with batch broadcast: mask[0]=1
         (
             [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
             (1, 1, 32, 128),

--- a/test/python/golden/ttir_ops/attention/test_sdpa.py
+++ b/test/python/golden/ttir_ops/attention/test_sdpa.py
@@ -268,24 +268,16 @@ def test_sdpa_mask_broadcast(
     "shapes,mask_shape,scale",
     [
         # Decode mask: [batch, 1, num_heads, kv_seq] - standard
-        pytest.param(
+        (
             [(1, 32, 32, 64), (32, 32, 128, 64), (32, 32, 128, 64), (32,)],
             (32, 1, 32, 128),
             0.124999993,
-            marks=pytest.mark.xfail(
-                reason="PCC regression, tracked in "
-                "https://github.com/tenstorrent/tt-mlir/issues/8112"
-            ),
         ),
         # Decode mask with GQA: mask num_heads matches query num_heads
-        pytest.param(
+        (
             [(1, 32, 32, 64), (32, 8, 128, 64), (32, 8, 128, 64), (32,)],
             (32, 1, 32, 128),
             0.124999993,
-            marks=pytest.mark.xfail(
-                reason="PCC regression, tracked in "
-                "https://github.com/tenstorrent/tt-mlir/issues/8112"
-            ),
         ),
         # Decode mask with batch broadcast: mask[0]=1
         (

--- a/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
+++ b/test/python/golden/ttir_ops/workarounds/decomposition/test_decomposition_workarounds.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import pytest
 import torch
 from collections import OrderedDict
@@ -885,33 +887,19 @@ def test_sdpa_with_mask_no_workaround(
 @pytest.mark.parametrize(
     "shapes",
     [
-        # Decode with mask num_heads=1 (broadcast needed)
+        # Decode with mask num_heads=1 (broadcast needed).
         # Q: [1, batch, num_heads, head_dim], K/V: [batch, kv_heads, kv_seq, head_dim]
-        # Mask: [1, batch, 1, kv_seq] - heads=1 needs broadcast to num_heads
+        # Mask: [batch, 1, 1, kv_seq] - heads=1 needs broadcast to num_heads.
         pytest.param(
             [
                 (1, 32, 32, 64),  # query (decode shape)
                 (32, 32, 128, 64),  # key
                 (32, 32, 128, 64),  # value
                 (32,),  # cur_pos_tensor
-                (1, 32, 1, 128),  # attention mask with heads=1
+                (32, 1, 1, 128),  # attention mask with heads=1
             ],
             marks=pytest.mark.xfail(
                 reason="SDPA decode requires mask[2] == num_heads. Metal issue: https://github.com/tenstorrent/tt-metal/issues/39910"
-            ),
-        ),
-        # Decode with mask batch=1 (broadcast needed)
-        # Mask: [1, 1, num_heads, kv_seq] - batch=1 needs broadcast to query batch
-        pytest.param(
-            [
-                (1, 32, 32, 64),  # query (decode shape)
-                (32, 32, 128, 64),  # key
-                (32, 32, 128, 64),  # value
-                (32,),  # cur_pos_tensor
-                (1, 1, 32, 128),  # attention mask with batch=1
-            ],
-            marks=pytest.mark.xfail(
-                reason="SDPA decode requires mask[1] == query batch. Metal issue: https://github.com/tenstorrent/tt-metal/issues/39910"
             ),
         ),
     ],
@@ -926,8 +914,9 @@ def test_sdpa_decode_mask_broadcast_no_workaround(
     shapes: List[Shape], dtypes: List[torch.dtype], target: str, request, device
 ):
     """
-    Test that SDPA decode with a mask requiring batch or num_heads broadcast
-    fails without the workaround.
+    Test that SDPA decode with a mask requiring num_heads broadcast fails
+    without the workaround. Batch broadcast is handled natively by tt-metal,
+    so only the heads dimension needs the workaround.
     """
     batch = shapes[0][1]
     kv_seq = shapes[1][2]

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_pad_sequence_dim_workaround.mlir
@@ -176,15 +176,16 @@ module @test_sdpa_workaround attributes {} {
 
   // Test 7: Decode workaround SHOULD apply - mask num_heads=1 needs broadcast
   // to match query num_heads. tt-metal requires mask[2] == num_heads for decode.
+  // Mask layout is [batch_or_1, 1, num_heads_or_1, kv_seq_len].
   func.func public @test_sdpa_decode_workaround_broadcast_mask_heads(
     %query: tensor<1x32x32x64xbf16>,
     %key: tensor<32x32x128x64xbf16>,
     %value: tensor<32x32x128x64xbf16>,
-    %mask: tensor<1x32x1x128xbf16>
+    %mask: tensor<32x1x1x128xbf16>
   ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_workaround_broadcast_mask_heads
 
-    // Mask should be broadcast from [1, 32, 1, 128] to [1, 32, 32, 128]
+    // Mask should be broadcast from [32, 1, 1, 128] to [32, 1, 32, 128]
     // CHECK: %[[BROADCAST_MASK:[0-9]+]] = "ttnn.repeat"(%arg3)
     // CHECK-SAME: repeat_dims = #ttnn.shape<1x1x32x1>
 
@@ -195,17 +196,17 @@ module @test_sdpa_workaround attributes {} {
       is_causal = false,
       scale = 0.125 : f32
     }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
-         tensor<32x32x128x64xbf16>, tensor<1x32x1x128xbf16>)
+         tensor<32x32x128x64xbf16>, tensor<32x1x1x128xbf16>)
       -> tensor<1x32x32x64xbf16>
     return %result : tensor<1x32x32x64xbf16>
   }
 
-  // Test 8: Decode workaround should NOT apply - mask already has correct num_heads
+  // Test 8: Decode workaround should NOT apply - mask already has correct num_heads.
   func.func public @test_sdpa_decode_no_workaround_mask_heads_match(
     %query: tensor<1x32x32x64xbf16>,
     %key: tensor<32x32x128x64xbf16>,
     %value: tensor<32x32x128x64xbf16>,
-    %mask: tensor<1x32x32x128xbf16>
+    %mask: tensor<32x1x32x128xbf16>
   ) -> tensor<1x32x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_sdpa_decode_no_workaround_mask_heads_match
 
@@ -218,7 +219,7 @@ module @test_sdpa_workaround attributes {} {
       is_causal = false,
       scale = 0.125 : f32
     }> : (tensor<1x32x32x64xbf16>, tensor<32x32x128x64xbf16>,
-         tensor<32x32x128x64xbf16>, tensor<1x32x32x128xbf16>)
+         tensor<32x32x128x64xbf16>, tensor<32x1x32x128xbf16>)
       -> tensor<1x32x32x64xbf16>
     return %result : tensor<1x32x32x64xbf16>
   }

--- a/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/scaled_dot_product_attention_decode.mlir
@@ -14,9 +14,9 @@ module {
         return %0 : tensor<1x8x12x32xbf16>
     }
 
-    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<1x8x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
+    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<8x1x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
         // CHECK: "ttnn.scaled_dot_product_attention_decode"
-        %0 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<1x8x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
+        %0 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
         return %0 : tensor<1x8x12x32xbf16>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/scaled_dot_product_attention_decode.mlir
@@ -9,9 +9,9 @@ module {
         return %1 : tensor<1x8x12x32xbf16>
     }
 
-    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<1x8x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
+    func.func @qkv_attn_mask_sdpa(%query: tensor<1x8x12x32xbf16>, %key: tensor<8x3x32x32xbf16>, %value: tensor<8x3x32x32xbf16>, %cur_pos: tensor<8xi32>, %attn_mask: tensor<8x1x12x32xbf16>) -> tensor<1x8x12x32xbf16> {
         // CHECK: "ttnn.scaled_dot_product_attention_decode"
-        %1 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<1x8x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
+        %1 = "ttir.scaled_dot_product_attention_decode"(%query, %key, %value, %attn_mask, %cur_pos) <{ operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 0>, is_causal = false, scale = 1.0 : f32 }> : (tensor<1x8x12x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x3x32x32xbf16>, tensor<8x1x12x32xbf16>, tensor<8xi32>) -> tensor<1x8x12x32xbf16>
         return %1 : tensor<1x8x12x32xbf16>
     }
 }

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1765,7 +1765,7 @@ def sdpa_decode_golden(
         Query:  [1, batch, num_heads, head_dim]
         Key:    [batch, num_kv_heads, seq_len, head_dim]
         Value:  [batch, num_kv_heads, seq_len, head_dim]
-        Mask:   [1, batch_or_1, num_heads_or_1, seq_len]
+        Mask:   [batch_or_1, 1, num_heads_or_1, seq_len]
         Output: [1, batch, num_heads, head_dim]
     """
     # Query: [1, B, H, D] -> [B, H, 1, D]
@@ -1788,9 +1788,9 @@ def sdpa_decode_golden(
     qk = torch.matmul(q, k.transpose(-2, -1))
 
     # Add attention mask (before scaling, matching tt-metal)
-    # Mask is in decode layout [1, B, H, S], permute to [B, H, 1, S] to match qk
+    # Mask is in decode layout [B, 1, H, S], permute to [B, H, 1, S] to match qk
     if attention_mask is not None:
-        qk = torch.add(qk, attention_mask.float().permute(1, 2, 0, 3))
+        qk = torch.add(qk, attention_mask.float().permute(0, 2, 1, 3))
 
     # Scale AFTER masking (tt-metal fuses scale into exp)
     if scale is not None:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/8112)

### Problem description
After [fix for metal bug](https://github.com/tenstorrent/tt-metal/pull/42846/changes) has been uplifted, mlir workaround introduced with [this commit](https://github.com/tenstorrent/tt-mlir/commit/8f05ad40f4ad70ac94443b07a6216d96e681c4b4) is no longer needed. 

Before the metal fix, there was no canonical difference between dims 0 and 1 in the attention mask, so it was wrongly assumed that `batch` is dim 1, like in Q and output, while now dim 0 is used as batch. 

When op is going through composite path, it will always use `scaled_dot_product_attention` ttir op, and then switch to `_decode` if needed only in ttir-to-ttnn pass. Here mask should be permuted from `[B, H, L, S]` used in generic `sdpa` op, to `[B, 1, H, S]` used in `sdpa_decode` op.

### What's changed
- Revert changes from batch broadcast workaround, re-enabled failing tests
- Fix mask permutation
- Update docs to match current metal implementation 

### Checklist
- [x] [perf benchmark n150](https://github.com/tenstorrent/tt-xla/actions/runs/24982236259) - [nightly for comparison](https://github.com/tenstorrent/tt-xla/actions/runs/24970760261/job/73131749448)
- [x] [perf benchmark llmbox](https://github.com/tenstorrent/tt-xla/actions/runs/25159724229) - updated
- [x] [perf benchmark galaxy](https://github.com/tenstorrent/tt-xla/actions/runs/25162668144) - updated
