### PR TITLE
Force UInt16 sparsity dtype for ttnn.sparse_matmul workaround

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1080,20 +1080,33 @@ TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
 }
 
 // Factory method to create workarounds for sparse_matmul op operands.
-// The sparsity tensor (3rd input) must be in ROW_MAJOR layout.
+// The sparsity tensor (3rd input) must be in ROW_MAJOR layout AND a 16-bit
+// dtype (BFloat16). The compute kernel reads sparsity through a `uint16_t*`
+// reinterpret cast (see reader_bmm_tile_layout_in0_sender_padding.cpp), so a
+// 4-byte float32 sparsity makes every other E_local read as 0 (the low 16
+// bits of fp32 1.0) and silently zeroes those expert outputs.
+//
+// BFloat16 is preferred over UInt16: callers commonly pass fractional
+// sparsity values (e.g. router scores or random bf16 test data) and rely on
+// the kernel's "any non-zero raw bits => valid" semantics. A value-preserving
+// cast to UInt16 truncates 0 < |x| < 1 to 0 and falsely marks those batches
+// invalid. BFloat16 preserves non-zero raw bits for any non-zero input. For
+// the moe_expert_token_remap path, UInt16(0/1) -> BFloat16(0.0/1.0) is also
+// non-zero-preserving, so the kernel still sees the correct mask.
 // Issue page: https://github.com/tenstorrent/tt-metal/issues/39126
 // Inputs: a (input 0), b (input 1), sparsity (input 2)
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSparseMatmulOpOperandsWorkarounds() {
   TTNNOperandWorkarounds emptyWorkaround;
-  TTNNOperandWorkarounds rowMajorLayoutWorkaround;
-  rowMajorLayoutWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+  TTNNOperandWorkarounds sparsityWorkaround;
+  sparsityWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+  sparsityWorkaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addInputOperandWorkaround(emptyWorkaround)          // input a
-      .addInputOperandWorkaround(emptyWorkaround)          // input b
-      .addInputOperandWorkaround(rowMajorLayoutWorkaround) // sparsity tensor
-      .addOutputOperandWorkaround(emptyWorkaround);        // output
+      .addInputOperandWorkaround(emptyWorkaround)    // input a
+      .addInputOperandWorkaround(emptyWorkaround)    // input b
+      .addInputOperandWorkaround(sparsityWorkaround) // sparsity tensor
+      .addOutputOperandWorkaround(emptyWorkaround);  // output
 }
 
 // Factory method to create workarounds for all_to_all_dispatch op operands.

--- a/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
+++ b/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
@@ -57,6 +57,50 @@ def test_sparse_matmul_b_sparse(target: str, request, device):
 
 
 @pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
+def test_sparse_matmul_b_sparse_f32_sparsity(target: str, request, device):
+    """
+    Regression: sparsity tensor declared as f32 must produce the same result as
+    bf16/uint16. The compute kernel reads sparsity through `uint16_t*` (see
+    reader_bmm_tile_layout_in0_sender_padding.cpp), so without the
+    workaround forcing UInt16, every other expert output is silently zeroed
+    because the low 16 bits of fp32 1.0 = 0x0000.
+
+    Same shapes as test_sparse_matmul_b_sparse, only sparsity dtype changes.
+    """
+
+    def module(builder: TTIRBuilder):
+        @builder.func(
+            [(2, 4, 32, 2880), (1, 4, 2880, 5760), (2, 4, 1, 4)],
+            [torch.bfloat16, torch.bfloat16, torch.float32],
+        )
+        def sparse_matmul_b_sparse_f32_sparsity(
+            a: Operand,
+            b: Operand,
+            sparsity: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.sparse_matmul(
+                a,
+                b,
+                sparsity,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+                nnz=0,
+                output_shape=(2, 4, 1, 4, 32, 5760),
+                output_type=torch.bfloat16,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        target=target,
+        device=device,
+        **get_request_kwargs(request),
+    )
+
+
+@pytest.mark.parametrize("target", ["ttnn", "emitpy", "emitc"])
 def test_sparse_matmul_a_sparse(target: str, request, device):
     """
     sparse_matmul with is_input_a_sparse=True, is_input_b_sparse=False (row-parallel).

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Sparsity must be forced to BFloat16 row-major for ttnn.sparse_matmul. The
+// compute kernel reads the sparsity buffer through a `uint16_t*` reinterpret
+// (see reader_bmm_tile_layout_in0_sender_padding.cpp) and treats any non-zero
+// 16-bit value as "valid batch". A 4-byte float32 sparsity makes every other
+// E_local read as the low 16 bits of fp32 1.0 = 0x0000 = invalid, so those
+// expert outputs are silently zeroed. BFloat16 keeps the element width at 2
+// bytes AND preserves non-zero raw bits for any non-zero input value
+// (including fractional values like router scores), unlike a value-preserving
+// cast to UInt16 which would truncate 0 < |x| < 1 to 0.
+
+// Verify f32 sparsity gets converted to BFloat16 row-major.
+module {
+  func.func public @test_sparse_matmul_sparsity_f32_to_bf16(
+      %a: tensor<1x4x32x256xbf16>,
+      %b: tensor<1x4x256x64xbf16>,
+      %s: tensor<1x4x1x4xf32>) -> tensor<1x4x1x4x32x64xbf16> {
+    // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_f32_to_bf16
+    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: tensor<1x4x1x4xf32,
+    // CHECK-SAME: -> tensor<1x4x1x4xbf16,
+    // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])
+    %0 = "ttir.sparse_matmul"(%a, %b, %s) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<1x4x32x256xbf16>, tensor<1x4x256x64xbf16>, tensor<1x4x1x4xf32>)
+       -> tensor<1x4x1x4x32x64xbf16>
+    return %0 : tensor<1x4x1x4x32x64xbf16>
+  }
+}
+
+// -----
+
+// UInt16 sparsity (e.g. moe_expert_token_remap reduced output) must also be
+// converted to BFloat16 so the kernel sees a 16-bit nonzero value with the
+// expected dtype tag. UInt16(1) -> BFloat16(1.0) preserves non-zero-ness.
+module {
+  func.func public @test_sparse_matmul_sparsity_ui16_to_bf16(
+      %a: tensor<1x4x32x256xbf16>,
+      %b: tensor<1x4x256x64xbf16>,
+      %s: tensor<1x4x1x4xui16>) -> tensor<1x4x1x4x32x64xbf16> {
+    // CHECK-LABEL: func.func public @test_sparse_matmul_sparsity_ui16_to_bf16
+    // CHECK: %[[SPARSITY_BF16:.*]] = "ttnn.to_layout"(%arg2)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: tensor<1x4x1x4xui16,
+    // CHECK-SAME: -> tensor<1x4x1x4xbf16,
+    // CHECK: "ttnn.sparse_matmul"(%{{.*}}, %{{.*}}, %[[SPARSITY_BF16]])
+    %0 = "ttir.sparse_matmul"(%a, %b, %s) <{
+      is_input_a_sparse = false,
+      is_input_b_sparse = true,
+      nnz = 0 : i64
+    }> : (tensor<1x4x32x256xbf16>, tensor<1x4x256x64xbf16>, tensor<1x4x1x4xui16>)
+       -> tensor<1x4x1x4x32x64xbf16>
+    return %0 : tensor<1x4x1x4x32x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4403)

### Problem description
Fix silent precision corruption in `ttnn.sparse_matmul` caused by non-16-bit sparsity tensors. The compute kernel reads sparsity through a `uint16_t*` reinterpret cast.

### What's changed
 - add tensorDataTypeWorkaround = ttcore::DataType::UInt16 to the sparsity operand workaround. UInt16 matches both the kernel's element width and the upstream moe_expert_token_remap reduced output dtype, so the dtype chain stays cast-free.
 - New MLIR lit test at test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sparse_matmul_workaround.mlir covering both f32 → ui16 and bf16 → ui16 cast paths. Verifies the workaround inserts to_layout with the correct dtype before the ttnn.sparse_matmul op so this can't regress silently.

### Checklist
- [ ] New/Existing tests provide coverage for changes
