### PR TITLE
Adding parse/split support for stablehlo not and broadcast_in_dim

### DIFF
--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_broadcast_in_dim.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_broadcast_in_dim.mlir
@@ -1,0 +1,18 @@
+module @jit_broadcast_in_dim attributes {} {
+  func.func public @test_broadcast_1d_to_2d(%arg0: tensor<3xf32>) -> tensor<2x3xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+  func.func public @test_broadcast_scalar(%arg0: tensor<f32>) -> tensor<4x8xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<4x8xf32>
+    return %0 : tensor<4x8xf32>
+  }
+  func.func public @test_broadcast_with_expansion(%arg0: tensor<2x4xf32>) -> tensor<2x3x4xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [0, 2] : (tensor<2x4xf32>) -> tensor<2x3x4xf32>
+    return %0 : tensor<2x3x4xf32>
+  }
+  func.func public @test_broadcast_2d_to_4d(%arg0: tensor<8x16xf32>) -> tensor<4x2x8x16xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [2, 3] : (tensor<8x16xf32>) -> tensor<4x2x8x16xf32>
+    return %0 : tensor<4x2x8x16xf32>
+  }
+}

--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_not.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_not.mlir
@@ -1,0 +1,18 @@
+module @jit_not attributes {} {
+  func.func public @test_logical_not(%arg0: tensor<4xi1>) -> tensor<4xi1> {
+    %0 = stablehlo.not %arg0 : tensor<4xi1>
+    return %0 : tensor<4xi1>
+  }
+  func.func public @test_bitwise_not(%arg0: tensor<4xi32>) -> tensor<4xi32> {
+    %0 = stablehlo.not %arg0 : tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+  func.func public @test_not_2d(%arg0: tensor<2x3xi32>) -> tensor<2x3xi32> {
+    %0 = stablehlo.not %arg0 : tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+  func.func public @test_not_bool_2d(%arg0: tensor<3x4xi1>) -> tensor<3x4xi1> {
+    %0 = stablehlo.not %arg0 : tensor<3x4xi1>
+    return %0 : tensor<3x4xi1>
+  }
+}

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -585,24 +585,6 @@ def module_compare_lt(builder: StableHLOBuilder):
         return builder.compare(in0, in1, "LT", unit_attrs=unit_attrs)
 
 
-def module_broadcast_in_dim(builder: StableHLOBuilder):
-    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
-    def broadcast_in_dim(
-        in0: Operand,
-        builder: StableHLOBuilder,
-        broadcast_dimensions: List[int],
-        output_shape: List[int],
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        builder.set_graph_level_check(True)
-        return builder.broadcast_in_dim(
-            in0,
-            broadcast_dimensions=broadcast_dimensions,
-            output_shape=output_shape,
-            unit_attrs=unit_attrs,
-        )
-
-
 @pytest.mark.parametrize("target", ["ttnn"])
 @pytest.mark.parametrize(
     "test_fn",
@@ -1135,9 +1117,7 @@ def test_logical_binary_ops(
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.bool], ids=["bool"])
 @pytest.mark.parametrize("target", ["ttnn"])
-def test_logical_unary_ops(
-    shape: Shape, dtype: torch.dtype, target: str, request, device
-):
+def test_not(shape: Shape, dtype: torch.dtype, target: str, request, device):
     def module_not_(builder: StableHLOBuilder):
         @builder.func([(128, 128)], [torch.bool])
         def not_(
@@ -1153,7 +1133,7 @@ def test_logical_unary_ops(
         **get_request_kwargs(request),
         target=target,
         device=device,
-        pcc=-1.0,
+        check_pcc=False,
     )
 
 
@@ -2197,11 +2177,44 @@ def test_convolution_groups_dilation(
     )
 
 
-@pytest.mark.parametrize("shape", [(128,)], ids=shape_str)
+@pytest.mark.parametrize(
+    "shape,broadcast_dimensions,output_shape",
+    [
+        # 1D to 2D broadcasts
+        ((128,), [1], [32, 128]),
+        ((128,), [0], [128, 32]),
+        ((64,), [1], [16, 64]),
+        # 1D to 3D broadcasts
+        ((128,), [2], [4, 8, 128]),
+        ((64,), [0], [64, 16, 32]),
+        ((32,), [1], [8, 32, 16]),
+        # 2D to 3D broadcasts
+        ((32, 64), [1, 2], [8, 32, 64]),
+        ((16, 32), [0, 1], [16, 32, 8]),
+        # 2D to 4D broadcasts
+        ((32, 64), [2, 3], [2, 4, 32, 64]),
+        ((16, 32), [0, 2], [16, 8, 32, 4]),
+        # Scalar to multi-dim (0D to 2D)
+        ((), [], [32, 64]),
+        ((), [], [16, 16]),
+    ],
+    ids=[
+        "1d_128_to_2d_32x128",
+        "1d_128_to_2d_128x32",
+        "1d_64_to_2d_16x64",
+        "1d_128_to_3d_4x8x128",
+        "1d_64_to_3d_64x16x32",
+        "1d_32_to_3d_8x32x16",
+        "2d_32x64_to_3d_8x32x64",
+        "2d_16x32_to_3d_16x32x8",
+        "2d_32x64_to_4d_2x4x32x64",
+        "2d_16x32_to_4d_16x8x32x4",
+        "scalar_to_2d_32x64",
+        "scalar_to_2d_16x16",
+    ],
+)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("target", ["ttnn"])
-@pytest.mark.parametrize("broadcast_dimensions", [[1]])
-@pytest.mark.parametrize("output_shape", [[32, 128]])
 def test_broadcast_ops(
     shape: Shape,
     dtype: torch.dtype,

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -2152,60 +2152,160 @@ class StableHLOBuilder(Builder):
 
         return floor_module, floor_builder
 
+    ############### stablehlo.BroadcastInDimOp ###############
+
+    @tag(stablehlo.BroadcastInDimOp)
     def broadcast_in_dim(
         self,
         in0: Operand,
         broadcast_dimensions: List[int],
         output_shape: List[int],
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
         sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.broadcast_in_dim``.
-        *Tensor broadcast operation.*
-        Broadcasts a tensor to a new shape by replicating its values along specified dimensions.
-        The broadcast_dimensions parameter specifies how dimensions of the input map to
-        dimensions of the output.
-        .. code-block:: mlir
-            // Broadcast a 1D tensor to 2D
-            %result = stablehlo.broadcast_in_dim(%input) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<2x3xf32>
-            // Input tensor:
-            // [1.0, 2.0, 3.0]
-            // Output tensor:
-            // [[1.0, 2.0, 3.0],
-            //  [1.0, 2.0, 3.0]]
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor to broadcast
-        broadcast_dimensions : *List[int]*
-            List of dimension mappings from input to output
-        output_shape : *List[int]*
-            Target shape for the broadcasted tensor
-        unit_attrs : *Optional[List[str]]*, optional
-            Optional list of unit attributes
-        sharding_attr : *Optional[sdy.TensorShardingPerValueAttr]*, optional
-            Optional sharding attribute for distributed execution
-        Returns
-        -------
-        (*OpView*)
-            The broadcasted tensor
-        """
-        output_type = self._get_type(in0).element_type
-        return self._op_proxy(
-            stablehlo.BroadcastInDimOp,
-            [in0],
-            organize_golden_args=self._organize_eltwise_golden,
-            organize_stablehlo_args=lambda inputs, output, _: (output, inputs[0]),
-            output_shape=output_shape,
-            output_type=output_type,
-            golden_kwargs={"size": output_shape},
-            stablehlo_kwargs={
-                "broadcast_dimensions": broadcast_dimensions,
-            },
-            unit_attrs=unit_attrs,
-            sharding_attr=sharding_attr,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.broadcast_in_dim)
+
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        broadcast_dimensions_attr = DenseI64ArrayAttr.get(
+            broadcast_dimensions, context=self._ctx
         )
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input0,
+            broadcast_dimensions_attr,
+            output_shape,
+            mlir_output_type,
+        )
+        result_type = self._create_ranked_tensor_type(
+            golden_output.shape, mlir_output_type
+        )
+
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        op = stablehlo_op(
+            result_type,
+            in0,
+            broadcast_dimensions_attr,
+            loc=loc,
+        )
+        op_result = op.result
+
+        if sharding_attr is not None:
+            op.operation.attributes["sdy.sharding"] = sharding_attr
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.BroadcastInDimOp)
+    def broadcast_in_dim_parser(
+        self,
+        old_op: stablehlo.BroadcastInDimOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(
+            StableHLOBuilder.broadcast_in_dim_parser
+        )
+
+        in0 = global_dict[old_op.operand]
+        broadcast_dimensions_attr = old_op.broadcast_dimensions
+        result_type = old_op.result.type
+        output_shape = list(result_type.shape)
+
+        new_op = stablehlo_op(
+            result_type,
+            in0,
+            broadcast_dimensions_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input0,
+            broadcast_dimensions_attr,
+            output_shape,
+            result_type.element_type,
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(stablehlo.BroadcastInDimOp)
+    def broadcast_in_dim_split(
+        self,
+        old_op: stablehlo.BroadcastInDimOp,
+    ) -> Tuple[Module, StableHLOBuilder]:
+        stablehlo_op = self.get_opview_from_split(
+            StableHLOBuilder.broadcast_in_dim_split
+        )
+
+        old_context = old_op.context
+        old_loc = Location.unknown(old_context)
+
+        with old_context, old_loc:
+            broadcast_in_dim_module = Module.create()
+            broadcast_in_dim_builder = StableHLOBuilder(
+                old_context, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [old_op.operand.type]
+
+            with InsertionPoint(broadcast_in_dim_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="broadcast_in_dim_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    broadcast_dimensions_attr = old_op.broadcast_dimensions
+                    result_type = old_op.result.type
+
+                    new_op = stablehlo_op(
+                        result_type,
+                        in0,
+                        broadcast_dimensions_attr,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    input0 = self._get_golden_tensor(old_op.operand)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    broadcast_in_dim_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+                    broadcast_in_dim_builder._set_golden_tensor(in0, input0)
+                    broadcast_in_dim_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                broadcast_in_dim_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return broadcast_in_dim_module, broadcast_in_dim_builder
 
     ################ stablehlo.LogOp ###############
 
@@ -7710,60 +7810,122 @@ class StableHLOBuilder(Builder):
             sharding_attr=sharding_attr,
         )
 
+    ############### stablehlo.NotOp ###############
+
+    @tag(stablehlo.NotOp)
     def not_(
         self,
         in0: Operand,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
         sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.not``.
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.not_)
 
-        *Elementwise NOT operation.*
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
 
-        Performs elementwise NOT operation on a tensor.
-        For booleans, performs logical NOT.
-        For integers, performs bitwise NOT.
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
 
-        Mathematical definition:
-        - Logical: not(x) = NOT x
-        - Bitwise: not(x) = ~x
-
-        .. code-block:: mlir
-
-            // Logical NOT for booleans
-            %result = stablehlo.not(%input) : tensor<3xi1> -> tensor<3xi1>
-            // Input tensor:
-            // input: [true, false, true]
-            // Output tensor:
-            // [false, true, false]
-
-            // Bitwise NOT for integers
-            %result = stablehlo.not(%input) : tensor<3xi32> -> tensor<3xi32>
-            // Input tensor:
-            // input: [0, 1, 2]  // Binary: 000, 001, 010
-            // Output tensor:
-            // [-1, -2, -3]      // Binary (two's complement): 111...111, 111...110, 111...101
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor (boolean or integer type)
-        unit_attrs : *Optional[List[str]]*
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor containing the elementwise NOT of the input
-        """
-
-        return self._eltwise_proxy(
-            stablehlo.NotOp,
-            [in0],
-            unit_attrs=unit_attrs,
-            sharding_attr=sharding_attr,
+        op = stablehlo_op(
+            in0,
+            loc=loc,
         )
+        op_result = op.result
+
+        if sharding_attr is not None:
+            op.operation.attributes["sdy.sharding"] = sharding_attr
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(input0, mlir_output_type)
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.NotOp)
+    def not_parser(
+        self,
+        old_op: stablehlo.NotOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.not_parser)
+        in0 = global_dict[old_op.operand]
+
+        new_op = stablehlo_op(
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(input0, new_op_result.type.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(stablehlo.NotOp)
+    def not_split(
+        self,
+        old_op: stablehlo.NotOp,
+    ) -> Tuple[Module, StableHLOBuilder]:
+        stablehlo_op = self.get_opview_from_split(StableHLOBuilder.not_split)
+
+        old_context = old_op.context
+        old_loc = Location.unknown(old_context)
+
+        with old_context, old_loc:
+            not_module = Module.create()
+            not_builder = StableHLOBuilder(
+                old_context, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [old_op.operand.type]
+
+            with InsertionPoint(not_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="not_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+
+                    new_op = stablehlo_op(
+                        in0,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    input0 = self._get_golden_tensor(old_op.operand)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    not_builder._set_golden_tensor(new_op_result, old_op_result)
+                    not_builder._set_golden_tensor(in0, input0)
+                    not_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                not_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return not_module, not_builder
 
     # ----- Reduce Operations -----
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3189,29 +3189,17 @@ def stablehlo_xor_golden(
         return torch.bitwise_xor(input_tensor, other_tensor)
 
 
-def stablehlo_not_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
-    """
-    Golden function for StableHLO not operation.
+def stablehlo_not_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
 
-    Supports both logical NOT (for boolean tensors) and bitwise NOT (for integer tensors).
-
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor to invert.
-    **kwargs : dict
-        Keyword arguments (unused for this operation).
-
-    Returns
-    -------
-    GoldenMapTensor
-        Tensor containing the NOT of input_tensor.
-    """
     if input_tensor.dtype == torch.bool:
-        result_bool = torch.logical_not(input_tensor)
-        return result_bool.to(input_tensor.dtype)
+        result = torch.logical_not(input_tensor)
     else:
-        return torch.bitwise_not(input_tensor)
+        result = torch.bitwise_not(input_tensor)
+
+    return result.to(output_dtype)
 
 
 ################ Golden Utilities ###############
@@ -5323,6 +5311,32 @@ def stablehlo_reshape_golden(
     shape = unpack_mlir_attr(shape_attr)
     output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
     return torch.reshape(input_tensor, shape).clone().to(output_dtype)
+
+
+def stablehlo_broadcast_in_dim_golden(
+    input_tensor: GoldenMapTensor,
+    broadcast_dimensions_attr: DenseI64ArrayAttr,
+    output_shape: List[int],
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    broadcast_dimensions = unpack_mlir_attr(broadcast_dimensions_attr)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    # broadcast_dimensions specifies which dimensions of the output correspond to input dimensions
+    # We need to reshape the input to match the output rank first, then broadcast
+    input_shape = list(input_tensor.shape)
+
+    # Create a shape with 1s for all dimensions, then fill in the input dimensions
+    expanded_shape = [1] * len(output_shape)
+    for i, dim_idx in enumerate(broadcast_dimensions):
+        expanded_shape[dim_idx] = input_shape[i]
+
+    # Reshape input to the expanded shape
+    reshaped = input_tensor.reshape(expanded_shape)
+
+    # Now broadcast to the target shape
+    result = torch.broadcast_to(reshaped, output_shape)
+    return result.to(output_dtype)
 
 
 def stablehlo_rsqrt_golden(
@@ -7651,7 +7665,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.MinOp: stablehlo_minimum_golden,
     stablehlo.MulOp: stablehlo_multiply_golden,
     # bitcast conversion operation
-    stablehlo.BroadcastInDimOp: torch.broadcast_to,
+    stablehlo.BroadcastInDimOp: stablehlo_broadcast_in_dim_golden,
     stablehlo.SubtractOp: stablehlo_subtract_golden,
     stablehlo.PowOp: stablehlo_pow_golden,
     stablehlo.ShiftRightLogicalOp: stablehlo_shift_right_logical_golden,


### PR DESCRIPTION
### Ticket
Closes [#7252](https://github.com/tenstorrent/tt-mlir/issues/7252) 
Closes [#7255](https://github.com/tenstorrent/tt-mlir/issues/7255) 

### Problem description
`stablehlo.broadcast_in_dim` and `not` still use op_proxy and have no parse split support 

### What's changed
Refactored both

### Checklist
- [ ] New/Existing tests provide coverage for changes
