### PR TITLE
[d2m] exclude scratch from GenericOp::getOperandAlloc

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -3157,6 +3157,14 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
           ++idx;
         }
       } else if (auto allocOp = mlir::dyn_cast<memref::AllocOp>(&op)) {
+        // Scratch buffers are not operand allocs.
+        bool isScratchBuffer =
+            llvm::any_of(allocOp.getResult().getUsers(), [](Operation *user) {
+              return mlir::isa<d2m::ScratchInitOp>(user);
+            });
+        if (isScratchBuffer) {
+          continue;
+        }
         LocalBufferAssociation assoc =
             analyzeLocalBufferAssociation(allocOp.getResult());
         if (assoc.hasRemoteUse) {

--- a/test/python/golden/d2m/test_eltwise_fusion.py
+++ b/test/python/golden/d2m/test_eltwise_fusion.py
@@ -610,7 +610,7 @@ def test_diamond_unary_op_fanout(
 
             return builder.div(neg_0, neg_1)
 
-    options = [grid]
+    options = [grid, "enable-elementwise-fusion=true"]
 
     compile_and_execute_ttir(
         module,


### PR DESCRIPTION
**`GenericOp::getOperandAlloc:`** skip `memref.alloc` ops consumed by `d2m.scratch_init` so scratch buffers are not mis-matched as operand allocs (and later retyped by D2MAllocate).

Enabled previously-failing fusion test.
