### PR TITLE
Support decomposed all_slice in rms_norm CCL fusion

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
@@ -40,60 +40,6 @@ determineClusterAxis(mlir::DenseIntElementsAttr replicaGroups,
   return success();
 }
 
-// Describes the scatter-back portion that follows custom_call @rms_norm.
-// Two forms are supported:
-//
-//   Composite (sdy.all_slice input was fully replicated):
-//     rms_norm → stablehlo.composite "sdy.all_slice..."
-//
-//   Inlined (input was batch-sharded; emitted by UpdateGlobalToLocalShapes
-//   when input_is_fully_replicated == false):
-//     rms_norm → reshape → all_to_all → slice → reshape
-struct AllSliceMatch {
-  mlir::Type resultType;
-  mlir::Operation *resultOp;
-  SmallVector<mlir::Operation *> intermediateOps;
-};
-
-// Try to match sdy.all_slice in either its composite or inlined form.
-static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
-  // Composite form.
-  if (auto composite = mlir::dyn_cast<mlir::stablehlo::CompositeOp>(op)) {
-    if (composite.getName().starts_with("sdy.all_slice")) {
-      return AllSliceMatch{composite.getResult(0).getType(), composite, {}};
-    }
-    return std::nullopt;
-  }
-
-  // Inlined form: reshape → all_to_all → slice → reshape.
-  // UpdateGlobalToLocalShapes emits this sequence when the all_slice input
-  // is not fully replicated across all devices.
-  auto reshape1 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(op);
-  if (!reshape1 || !reshape1.getResult().hasOneUse()) {
-    return std::nullopt;
-  }
-  auto allToAll = mlir::dyn_cast<mlir::stablehlo::AllToAllOp>(
-      *reshape1.getResult().getUsers().begin());
-  if (!allToAll || !allToAll.getResult(0).hasOneUse()) {
-    return std::nullopt;
-  }
-  auto slice = mlir::dyn_cast<mlir::stablehlo::SliceOp>(
-      *allToAll.getResult(0).getUsers().begin());
-  if (!slice || !slice.getResult().hasOneUse()) {
-    return std::nullopt;
-  }
-  auto reshape2 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(
-      *slice.getResult().getUsers().begin());
-  if (!reshape2) {
-    return std::nullopt;
-  }
-
-  return AllSliceMatch{
-      reshape2.getResult().getType(),
-      reshape2.getOperation(),
-      {reshape1.getOperation(), allToAll.getOperation(), slice.getOperation()}};
-}
-
 // Fuse all_gather + custom_call @tenstorrent.rms_norm + sdy.all_slice into a
 // single custom_call @tenstorrent.distributed_rms_norm that operates on local
 // (per-device) tensors which handles cross-device reduction internally.
@@ -233,8 +179,9 @@ public:
     // Replace the scatter-back result with the distributed custom_call result.
     rewriter.replaceOp(allSliceMatch->resultOp, distributedCall.getResults());
 
-    // For the inlined form, erase the intermediate ops in reverse use-def order
-    // (slice before all_to_all before reshape1) now that they have no users.
+    // For the decomposed form, erase the intermediate ops in reverse use-def
+    // order (slice before all_to_all before reshape1) now that they have no
+    // users.
     for (auto *op : llvm::reverse(allSliceMatch->intermediateOps)) {
       rewriter.eraseOp(op);
     }
@@ -250,6 +197,63 @@ public:
     }
 
     return success();
+  }
+
+private:
+  // Describes the scatter-back portion that follows custom_call @rms_norm.
+  // Two forms are supported:
+  //
+  //   Composite (sdy.all_slice input was fully replicated):
+  //     rms_norm -> stablehlo.composite "sdy.all_slice..."
+  //
+  //   Decomposed (sdy.all_slice input was batch-sharded, decomposed by
+  //   UpdateGlobalToLocalShapes and not restored in
+  //   ShardyToStableHLOAllSliceOpRewritePattern since input_is_fully_replicated
+  //   == false):
+  //     rms_norm -> reshape -> all_to_all -> slice -> reshape
+  struct AllSliceMatch {
+    mlir::Type resultType;
+    mlir::Operation *resultOp;
+    SmallVector<mlir::Operation *> intermediateOps;
+  };
+
+  // Try to match sdy.all_slice in either its composite or inlined form.
+  static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
+    // Composite form.
+    if (auto composite = mlir::dyn_cast<mlir::stablehlo::CompositeOp>(op)) {
+      if (composite.getName().starts_with("sdy.all_slice")) {
+        return AllSliceMatch{composite.getResult(0).getType(), composite, {}};
+      }
+      return std::nullopt;
+    }
+
+    // Inlined form: reshape -> all_to_all -> slice -> reshape.
+    // UpdateGlobalToLocalShapes emits this sequence when the all_slice input
+    // is not fully replicated across all devices.
+    auto reshape1 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(op);
+    if (!reshape1 || !reshape1.getResult().hasOneUse()) {
+      return std::nullopt;
+    }
+    auto allToAll = mlir::dyn_cast<mlir::stablehlo::AllToAllOp>(
+        *reshape1.getResult().getUsers().begin());
+    if (!allToAll || !allToAll.getResult(0).hasOneUse()) {
+      return std::nullopt;
+    }
+    auto slice = mlir::dyn_cast<mlir::stablehlo::SliceOp>(
+        *allToAll.getResult(0).getUsers().begin());
+    if (!slice || !slice.getResult().hasOneUse()) {
+      return std::nullopt;
+    }
+    auto reshape2 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(
+        *slice.getResult().getUsers().begin());
+    if (!reshape2) {
+      return std::nullopt;
+    }
+
+    return AllSliceMatch{reshape2.getResult().getType(),
+                         reshape2.getOperation(),
+                         {reshape1.getOperation(), allToAll.getOperation(),
+                          slice.getOperation()}};
   }
 };
 

--- a/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
@@ -88,8 +88,8 @@ public:
     }
 
     // Check that the custom_call has exactly one user and that it matches
-    // sdy.all_slice in either composite or inlined (reshape+all_to_all+slice+
-    // reshape) form.
+    // sdy.all_slice in either composite or decomposed
+    // (reshape+all_to_all+slice+ reshape) form.
     if (!customCallOp.getResult(0).hasOneUse()) {
       return rewriter.notifyMatchFailure(
           customCallOp, "rms_norm result has multiple uses, cannot fuse");
@@ -217,7 +217,7 @@ private:
     SmallVector<mlir::Operation *> intermediateOps;
   };
 
-  // Try to match sdy.all_slice in either its composite or inlined form.
+  // Try to match sdy.all_slice in either its composite or decomposed form.
   static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
     // Composite form.
     if (auto composite = mlir::dyn_cast<mlir::stablehlo::CompositeOp>(op)) {
@@ -227,7 +227,7 @@ private:
       return std::nullopt;
     }
 
-    // Inlined form: reshape -> all_to_all -> slice -> reshape.
+    // Decomposed form: reshape -> all_to_all -> slice -> reshape.
     // UpdateGlobalToLocalShapes emits this sequence when the all_slice input
     // is not fully replicated across all devices.
     auto reshape1 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(op);

--- a/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
@@ -49,9 +49,6 @@ determineClusterAxis(mlir::DenseIntElementsAttr replicaGroups,
 //   Inlined (input was batch-sharded; emitted by UpdateGlobalToLocalShapes
 //   when input_is_fully_replicated == false):
 //     rms_norm → reshape → all_to_all → slice → reshape
-//
-// resultOp is the op to replace with the distributed custom_call result.
-// intermediateOps are additional ops to erase (in reverse) after replacement.
 struct AllSliceMatch {
   mlir::Type resultType;
   mlir::Operation *resultOp;
@@ -70,7 +67,7 @@ static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
 
   // Inlined form: reshape → all_to_all → slice → reshape.
   // UpdateGlobalToLocalShapes emits this sequence when the all_slice input
-  // is not fully replicated (e.g. batch-sharded rms_norm output on galaxy).
+  // is not fully replicated across all devices.
   auto reshape1 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(op);
   if (!reshape1 || !reshape1.getResult().hasOneUse()) {
     return std::nullopt;
@@ -92,9 +89,9 @@ static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
   }
 
   return AllSliceMatch{
-      reshape2.getResult().getType(), reshape2.getOperation(),
-      {reshape1.getOperation(), allToAll.getOperation(),
-       slice.getOperation()}};
+      reshape2.getResult().getType(),
+      reshape2.getOperation(),
+      {reshape1.getOperation(), allToAll.getOperation(), slice.getOperation()}};
 }
 
 // Fuse all_gather + custom_call @tenstorrent.rms_norm + sdy.all_slice into a
@@ -156,8 +153,9 @@ public:
     auto allSliceMatch = tryMatchAllSlice(soleUser);
     if (!allSliceMatch) {
       return rewriter.notifyMatchFailure(
-          customCallOp, "rms_norm sole user is not an sdy.all_slice composite "
-                        "or reshape -> all_to_all -> slice -> reshape sequence");
+          customCallOp,
+          "rms_norm sole user is not an sdy.all_slice composite "
+          "or reshape -> all_to_all -> slice -> reshape sequence");
     }
 
     // Derive cluster_axis from the input all_gather's replica_groups.
@@ -208,8 +206,8 @@ public:
 
     // Create the distributed custom_call with the local result type.
     auto distributedCall = rewriter.create<mlir::stablehlo::CustomCallOp>(
-        customCallOp.getLoc(),
-        mlir::TypeRange{allSliceMatch->resultType}, localOperands,
+        customCallOp.getLoc(), mlir::TypeRange{allSliceMatch->resultType},
+        localOperands,
         rewriter.getStringAttr(utils::kDistributedRmsNormTargetName),
         /*has_side_effect=*/nullptr,
         /*backend_config=*/nullptr,

--- a/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FuseDistributedCustomCalls.cpp
@@ -40,6 +40,63 @@ determineClusterAxis(mlir::DenseIntElementsAttr replicaGroups,
   return success();
 }
 
+// Describes the scatter-back portion that follows custom_call @rms_norm.
+// Two forms are supported:
+//
+//   Composite (sdy.all_slice input was fully replicated):
+//     rms_norm → stablehlo.composite "sdy.all_slice..."
+//
+//   Inlined (input was batch-sharded; emitted by UpdateGlobalToLocalShapes
+//   when input_is_fully_replicated == false):
+//     rms_norm → reshape → all_to_all → slice → reshape
+//
+// resultOp is the op to replace with the distributed custom_call result.
+// intermediateOps are additional ops to erase (in reverse) after replacement.
+struct AllSliceMatch {
+  mlir::Type resultType;
+  mlir::Operation *resultOp;
+  SmallVector<mlir::Operation *> intermediateOps;
+};
+
+// Try to match sdy.all_slice in either its composite or inlined form.
+static std::optional<AllSliceMatch> tryMatchAllSlice(mlir::Operation *op) {
+  // Composite form.
+  if (auto composite = mlir::dyn_cast<mlir::stablehlo::CompositeOp>(op)) {
+    if (composite.getName().starts_with("sdy.all_slice")) {
+      return AllSliceMatch{composite.getResult(0).getType(), composite, {}};
+    }
+    return std::nullopt;
+  }
+
+  // Inlined form: reshape → all_to_all → slice → reshape.
+  // UpdateGlobalToLocalShapes emits this sequence when the all_slice input
+  // is not fully replicated (e.g. batch-sharded rms_norm output on galaxy).
+  auto reshape1 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(op);
+  if (!reshape1 || !reshape1.getResult().hasOneUse()) {
+    return std::nullopt;
+  }
+  auto allToAll = mlir::dyn_cast<mlir::stablehlo::AllToAllOp>(
+      *reshape1.getResult().getUsers().begin());
+  if (!allToAll || !allToAll.getResult(0).hasOneUse()) {
+    return std::nullopt;
+  }
+  auto slice = mlir::dyn_cast<mlir::stablehlo::SliceOp>(
+      *allToAll.getResult(0).getUsers().begin());
+  if (!slice || !slice.getResult().hasOneUse()) {
+    return std::nullopt;
+  }
+  auto reshape2 = mlir::dyn_cast<mlir::stablehlo::ReshapeOp>(
+      *slice.getResult().getUsers().begin());
+  if (!reshape2) {
+    return std::nullopt;
+  }
+
+  return AllSliceMatch{
+      reshape2.getResult().getType(), reshape2.getOperation(),
+      {reshape1.getOperation(), allToAll.getOperation(),
+       slice.getOperation()}};
+}
+
 // Fuse all_gather + custom_call @tenstorrent.rms_norm + sdy.all_slice into a
 // single custom_call @tenstorrent.distributed_rms_norm that operates on local
 // (per-device) tensors which handles cross-device reduction internally.
@@ -87,20 +144,20 @@ public:
           customCallOp, "rms_norm operand does not come from an all_gather op");
     }
 
-    // Check that the custom_call has exactly one user: an sdy.all_slice
-    // composite that slices the gathered result back to local shape.
+    // Check that the custom_call has exactly one user and that it matches
+    // sdy.all_slice in either composite or inlined (reshape+all_to_all+slice+
+    // reshape) form.
     if (!customCallOp.getResult(0).hasOneUse()) {
       return rewriter.notifyMatchFailure(
           customCallOp, "rms_norm result has multiple uses, cannot fuse");
     }
 
     auto *soleUser = *customCallOp.getResult(0).getUsers().begin();
-    auto allSliceComposite =
-        mlir::dyn_cast<mlir::stablehlo::CompositeOp>(soleUser);
-    if (!allSliceComposite ||
-        !allSliceComposite.getName().starts_with("sdy.all_slice")) {
+    auto allSliceMatch = tryMatchAllSlice(soleUser);
+    if (!allSliceMatch) {
       return rewriter.notifyMatchFailure(
-          customCallOp, "rms_norm sole user is not an sdy.all_slice");
+          customCallOp, "rms_norm sole user is not an sdy.all_slice composite "
+                        "or reshape -> all_to_all -> slice -> reshape sequence");
     }
 
     // Derive cluster_axis from the input all_gather's replica_groups.
@@ -149,12 +206,10 @@ public:
         rewriter.getI32IntegerAttr(static_cast<int32_t>(clusterAxis))));
     auto newCompositeAttrs = rewriter.getDictionaryAttr(newAttrEntries);
 
-    // The result type is the all_slice output type (local shape).
-    auto resultType = allSliceComposite.getResult(0).getType();
-
-    // Create the distributed custom_call.
+    // Create the distributed custom_call with the local result type.
     auto distributedCall = rewriter.create<mlir::stablehlo::CustomCallOp>(
-        customCallOp.getLoc(), mlir::TypeRange{resultType}, localOperands,
+        customCallOp.getLoc(),
+        mlir::TypeRange{allSliceMatch->resultType}, localOperands,
         rewriter.getStringAttr(utils::kDistributedRmsNormTargetName),
         /*has_side_effect=*/nullptr,
         /*backend_config=*/nullptr,
@@ -177,8 +232,14 @@ public:
       }
     }
 
-    // Replace the all_slice result with the distributed custom_call result.
-    rewriter.replaceOp(allSliceComposite, distributedCall.getResults());
+    // Replace the scatter-back result with the distributed custom_call result.
+    rewriter.replaceOp(allSliceMatch->resultOp, distributedCall.getResults());
+
+    // For the inlined form, erase the intermediate ops in reverse use-def order
+    // (slice before all_to_all before reshape1) now that they have no users.
+    for (auto *op : llvm::reverse(allSliceMatch->intermediateOps)) {
+      rewriter.eraseOp(op);
+    }
 
     // Erase the original rms_norm custom_call (now has no users).
     rewriter.eraseOp(customCallOp);

--- a/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/fuse_distributed_custom_calls.mlir
+++ b/test/ttmlir/Dialect/StableHLO/Transforms/StableHLOFusing/fuse_distributed_custom_calls.mlir
@@ -1,0 +1,79 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --fuse-distributed-custom-calls --split-input-file -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Test that all_gather + rms_norm + composite sdy.all_slice fuses into distributed_rms_norm.
+// CHECK-LABEL: func.func @fuse_rms_norm_composite_all_slice
+module {
+  func.func @fuse_rms_norm_composite_all_slice(%arg0: tensor<4x64xf32>,
+                                               %arg1: tensor<64xf32>) -> tensor<4x64xf32> {
+    %gathered = "stablehlo.all_gather"(%arg0) <{
+      all_gather_dim = 0 : i64,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      use_global_device_ids
+    }> : (tensor<4x64xf32>) -> tensor<8x64xf32>
+    %norm = stablehlo.custom_call @tenstorrent.rms_norm(%gathered, %arg1) {
+      tt.composite_attributes = {
+        epsilon = 1.000000e-05 : f32,
+        normalized_shape = dense<64> : tensor<1xi64>
+      },
+      tt.has_custom_sharding
+    } : (tensor<8x64xf32>, tensor<64xf32>) -> tensor<8x64xf32>
+    %result = stablehlo.composite "sdy.all_slice" %norm
+      {decomposition = @all_slice_impl} : (tensor<8x64xf32>) -> tensor<4x64xf32>
+    // CHECK: stablehlo.custom_call @tenstorrent.distributed_rms_norm
+    // CHECK-SAME: cluster_axis = 1 : i32
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK-NOT: stablehlo.custom_call @tenstorrent.rms_norm
+    // CHECK-NOT: stablehlo.composite "sdy.all_slice
+    return %result : tensor<4x64xf32>
+  }
+
+  func.func private @all_slice_impl(%arg0: tensor<8x64xf32>) -> tensor<4x64xf32> {
+    %0 = stablehlo.slice %arg0 [0:4, 0:64] : (tensor<8x64xf32>) -> tensor<4x64xf32>
+    return %0 : tensor<4x64xf32>
+  }
+}
+
+// -----
+
+// Test that all_gather + rms_norm + decomposed sdy.all_slice fuses into distributed_rms_norm.
+// The decomposed form (reshape -> all_to_all -> slice -> reshape) is emitted by
+// UpdateGlobalToLocalShapes and not simplified by ShardyToStableHLOAllSliceOpRewritePattern
+// when the all_slice input is not fully replicated.
+// CHECK-LABEL: func.func @fuse_rms_norm_inlined_all_slice
+module {
+  func.func @fuse_rms_norm_inlined_all_slice(%arg0: tensor<4x64xf32>,
+                                             %arg1: tensor<64xf32>) -> tensor<4x64xf32> {
+    %gathered = "stablehlo.all_gather"(%arg0) <{
+      all_gather_dim = 0 : i64,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      use_global_device_ids
+    }> : (tensor<4x64xf32>) -> tensor<8x64xf32>
+    %norm = stablehlo.custom_call @tenstorrent.rms_norm(%gathered, %arg1) {
+      tt.composite_attributes = {
+        epsilon = 1.000000e-05 : f32,
+        normalized_shape = dense<64> : tensor<1xi64>
+      },
+      tt.has_custom_sharding
+    } : (tensor<8x64xf32>, tensor<64xf32>) -> tensor<8x64xf32>
+    %reshape1 = stablehlo.reshape %norm : (tensor<8x64xf32>) -> tensor<2x4x64xf32>
+    %all_to_all = "stablehlo.all_to_all"(%reshape1) <{
+      channel_handle = #stablehlo.channel_handle<handle = 2, type = 1>,
+      concat_dimension = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      split_count = 2 : i64,
+      split_dimension = 0 : i64
+    }> : (tensor<2x4x64xf32>) -> tensor<1x8x64xf32>
+    %sliced = stablehlo.slice %all_to_all [0:1, 0:4, 0:64] : (tensor<1x8x64xf32>) -> tensor<1x4x64xf32>
+    %reshape2 = stablehlo.reshape %sliced : (tensor<1x4x64xf32>) -> tensor<4x64xf32>
+    // CHECK: stablehlo.custom_call @tenstorrent.distributed_rms_norm
+    // CHECK-SAME: cluster_axis = 1 : i32
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK-NOT: stablehlo.custom_call @tenstorrent.rms_norm
+    // CHECK-NOT: stablehlo.all_to_all
+    return %reshape2 : tensor<4x64xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4399

### Problem description
The kimi-k2 benchmark test is failing in tt-xla with L1 OOM. The issue is that `stablehlo.custom_call @tenstorrent.rms_norm` is not flattened by `FlattenOrConvertCompositePass` since it is registered in `kCompositesWithCustomSharding`, however `FuseDistributedCustomCallsPass` doesn't fuse the following pattern into `distributed_rms_norm` (the custom sharding):
```
%17 = "stablehlo.all_gather"(%14) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<4x8xi64>}> : (tensor<32x16x896xbf16>) -> tensor<32x16x7168xbf16>
%18 = "stablehlo.all_gather"(%16) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<4x8xi64>}> : (tensor<896xbf16>) -> tensor<7168xbf16>
%19 = stablehlo.custom_call @tenstorrent.rms_norm(%17, %18) {tt.composite_attributes = {epsilon = 9.99999974E-6 : f32, normalized_shape = dense<7168> : tensor<1xi64>}, tt.has_custom_sharding} : (tensor<32x16x7168xbf16>, tensor<7168xbf16>) -> tensor<32x16x7168xbf16>
%20 = stablehlo.reshape %19 : (tensor<32x16x7168xbf16>) -> tensor<32x16x8x896xbf16>
%21 = "stablehlo.all_to_all"(%20) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, concat_dimension = 2 : i64, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<4x8xi64>, split_count = 8 : i64, split_dimension = 2 : i64}> : (tensor<32x16x8x896xbf16>) -> tensor<32x16x8x896xbf16>
%22 = stablehlo.slice %21 [0:32, 0:16, 0:1, 0:896] : (tensor<32x16x8x896xbf16>) -> tensor<32x16x1x896xbf16>
%23 = stablehlo.reshape %22 : (tensor<32x16x1x896xbf16>) -> tensor<32x16x896xbf16>
```
This fails to fuse since `FuseRMSNormWithCCLPattern` expects to see `sdy.all_slice` but when the input to rms_norm is sharded the `sdy.all_slice` remains decomposed as reshape -> all_to_all -> slice -> reshape. 

This is what's causing the OOM issue since the benchmark test is passing until [the commit](https://github.com/tenstorrent/tt-mlir/commit/8711a9dc52f1ec5b22dabb20ec71eaac7e46e524) that introduces `FuseDistributedCustomCallsPass`.

### What's changed
Added `AllSliceMatch` to `FuseRMSNormWithCCLPattern` so that `stablehlo.custom_call @tenstorrent.rms_norm` and it's surrounding CCLs fuse into `distributed_rms_norm` when either `sdy.all_slice` or reshape -> all_to_all -> slice -> reshape are present.

Added a tests for `FuseRMSNormWithCCLPattern` for both the case when `sdy.all_slice` is present and when it's decomposed.

### Checklist
- [x] New/Existing tests provide coverage for changes
