### PR TITLE
Weight dtype casting using typecast on host

### DIFF
--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1772,6 +1772,11 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
+  if (inputs[0].getBufferType() == BufferType::SystemMemory) {
+    return issueErrorForGetOpConstraints(
+        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+  }
+
   const auto inputShape = getInput().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
@@ -1790,6 +1795,11 @@ llvm::Expected<size_t>
 TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
+
+  if (inputs[0].getBufferType() == BufferType::SystemMemory) {
+    return issueErrorForGetOpRuntime(
+        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+  }
 
   const auto inputShape = getInput().getType().getShape();
 

--- a/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Utils/WeightDtypeParser.h"
 
@@ -98,18 +99,48 @@ public:
     auto newWeightType =
         ttnn::utils::RankedTensorTypeFactory::create(weightType, dtype);
 
-    // Insert typecast operation to convert weight to target dtype.
-    auto typecastOp = rewriter.create<TypecastOp>(
-        op.getLoc(), newWeightType, weight,
-        ttcore::DataTypeAttr::get(rewriter.getContext(), dtype));
+    // Blockfloat targets (BFP_BFloat4, BFP_BFloat8) go through a host-side
+    // typecast via: from_device → typecast (host) → to_device.
+    // The host typecast dispatches to tt-metal's host packer for BFP
+    // formats. Const-eval results are cached at compile time, so the
+    // host roundtrip is paid once per cached weight per program.
+    //
+    // Other targets (e.g. BFloat16 per-tensor override) keep the existing
+    // single-`typecast` device codepath.
+    mlir::Value newWeight;
+    if (dtype == ttcore::DataType::BFP_BFloat4 ||
+        dtype == ttcore::DataType::BFP_BFloat8) {
+      auto hostInputType = ttnn::utils::RankedTensorTypeFactory::create(
+          mlir::cast<RankedTensorType>(weight.getType()),
+          ttnn::BufferType::SystemMemory);
+      auto fromDevOp =
+          rewriter.create<FromDeviceOp>(op.getLoc(), hostInputType, weight);
 
-    // Update op to use the typecast result. The per-op "ttcore.weight_dtype"
+      auto hostOutputType =
+          ttnn::utils::RankedTensorTypeFactory::create(hostInputType, dtype);
+      auto typecastOp = rewriter.create<TypecastOp>(
+          op.getLoc(), hostOutputType, fromDevOp.getResult(),
+          ttcore::DataTypeAttr::get(rewriter.getContext(), dtype));
+
+      mlir::Value device = ttnn::utils::getOrInsertDevice(rewriter, op);
+      auto toDevOp = rewriter.create<ToDeviceOp>(op.getLoc(), newWeightType,
+                                                 typecastOp.getResult(), device,
+                                                 /*memory_config=*/nullptr);
+      newWeight = toDevOp.getResult();
+    } else {
+      // Single device typecast for non-blockfloat targets.
+      auto typecastOp = rewriter.create<TypecastOp>(
+          op.getLoc(), newWeightType, weight,
+          ttcore::DataTypeAttr::get(rewriter.getContext(), dtype));
+      newWeight = typecastOp.getResult();
+    }
+
+    // Update op to use the new weight. The per-op "ttcore.weight_dtype"
     // attribute is intentionally kept: the greedy rewriter may re-match this
     // op, and without the attribute it would fall back to the global default,
     // defeating per-op overrides (e.g. bf16 overridden by global bfp_bf8).
     // The attribute is discardable and harmless in the final IR.
-    rewriter.modifyOpInPlace(
-        op, [&]() { op.getBMutable().assign(typecastOp.getResult()); });
+    rewriter.modifyOpInPlace(op, [&]() { op.getBMutable().assign(newWeight); });
 
     return mlir::success();
   }

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp4_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp4_weights.mlir
@@ -1,9 +1,10 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf4" %s | FileCheck %s
 
 // Test that the weight dtype conversion pass correctly:
-// 1. Inserts a ttnn.typecast operation before the linear
+// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
+//    the linear for blockfloat targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf4
-// 3. Updates the linear to use the typecast result
+// 3. Updates the linear to use the resulting on-device tensor
 // 4. Keeps the output of linear as bf16 (unchanged)
 // 5. Keeps the activation input (A operand) and bias of linear as bf16 (unchanged)
 
@@ -14,11 +15,16 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_linear_bfp4_weights
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
     // CHECK-SAME: -> tensor<1024x2048x!ttcore.tile<32x32, bfp_bf4>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.linear"(%arg2, %[[TYPECAST]], %arg3)
+    // CHECK: "ttnn.linear"(%arg2, %[[TO_DEV]], %arg3)
     // CHECK-SAME: -> tensor<2048x1024xbf16,
     %0 = "ttnn.linear"(%arg2, %arg1, %arg3) <{transpose_a = false, transpose_b = true}> : (tensor<2048x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1024x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp8_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp8_weights.mlir
@@ -1,9 +1,10 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test that the BFP8 weight conversion pass correctly:
-// 1. Inserts a ttnn.typecast operation before the linear
+// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
+//    the linear for blockfloat targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf8
-// 3. Updates the linear to use the typecast result
+// 3. Updates the linear to use the resulting on-device tensor
 // 4. Keeps the output of linear as bf16 (unchanged)
 // 5. Keeps the activation input (A operand) and bias of linear as bf16 (unchanged)
 
@@ -14,11 +15,16 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_linear_bfp8_weights
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
     // CHECK-SAME: -> tensor<1024x2048x!ttcore.tile<32x32, bfp_bf8>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.linear"(%arg2, %[[TYPECAST]], %arg3)
+    // CHECK: "ttnn.linear"(%arg2, %[[TO_DEV]], %arg3)
     // CHECK-SAME: -> tensor<2048x1024xbf16,
     %0 = "ttnn.linear"(%arg2, %arg1, %arg3) <{transpose_a = false, transpose_b = true}> : (tensor<2048x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1024x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/linear_per_arg_weight_dtype.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/linear_per_arg_weight_dtype.mlir
@@ -1,6 +1,8 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion %s | FileCheck %s
 
 // Test per-op weight dtype override on a linear op without a global target-dtype.
+// For blockfloat targets the conversion is the host-side chain
+// (from_device -> typecast -> to_device).
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -8,11 +10,16 @@ module attributes {} {
   // CHECK-LABEL: func.func @test_linear_per_arg_bfp4
   func.func @test_linear_per_arg_bfp4(%arg0: tensor<2048x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, %arg1: tensor<1024x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
     // CHECK-SAME: -> tensor<1024x2048x!ttcore.tile<32x32, bfp_bf4>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.linear"(%arg0, %[[TYPECAST]], %arg2)
+    // CHECK: "ttnn.linear"(%arg0, %[[TO_DEV]], %arg2)
     // CHECK-SAME: -> tensor<2048x1024xbf16,
     %0 = "ttnn.linear"(%arg0, %arg1, %arg2) <{transpose_a = false, transpose_b = true}> {ttcore.weight_dtype = "bfp_bf4"} : (tensor<2048x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1024x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp4_e2e_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp4_e2e_pipeline.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true enable-const-eval=true experimental-weight-dtype=bfp_bf4" %s | FileCheck %s
+// REQUIRES: opmodel
+
+// End-to-end test: TTIR matmul through the full backend pipeline with BFP4
+// weight conversion, optimizer, and const-eval enabled.
+// Verifies that the host-side typecast chain (from_device -> typecast -> to_device)
+// survives all pipeline passes and the typecast operates on a host tensor.
+
+module {
+  func.func @matmul_bfp4_e2e(
+    %arg0: tensor<64x128xbf16>,
+    %arg1: tensor<128x64xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}
+  ) -> tensor<64x64xbf16> {
+    %0 = "ttir.matmul"(%arg0, %arg1) : (tensor<64x128xbf16>, tensor<128x64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
+  }
+}
+
+// The weight conversion should be hoisted into a const_eval function.
+// CHECK: func.func private @matmul_bfp4_e2e_const_eval_0
+// CHECK-SAME: tt.function_type = "const_eval"
+
+// Inside const_eval: from_device brings tensor to host, typecast on host, to_device sends back.
+// CHECK: "ttnn.from_device"
+// CHECK: "ttnn.typecast"
+// CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
+// CHECK: "ttnn.to_device"
+
+// The forward function uses load_cached and matmul.
+// CHECK: func.func @matmul_bfp4_e2e
+// CHECK: ttcore.load_cached
+// CHECK: "ttnn.matmul"

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp4_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp4_weights.mlir
@@ -1,9 +1,10 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf4" %s | FileCheck %s
 
 // Test that the weight dtype conversion pass correctly:
-// 1. Inserts a ttnn.typecast operation before the matmul
+// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
+//    the matmul for blockfloat targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf4
-// 3. Updates the matmul to use the typecast result
+// 3. Updates the matmul to use the resulting on-device tensor
 // 4. Keeps the output of matmul as bf16 (unchanged)
 // 5. Keeps the activation input (A operand) of matmul as bf16 (unchanged)
 
@@ -14,11 +15,16 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_matmul_bfp4_weights
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf4>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp8_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp8_weights.mlir
@@ -1,9 +1,10 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test that the BFP8 weight conversion pass correctly:
-// 1. Inserts a ttnn.typecast operation before the matmul
+// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
+//    the matmul for blockfloat targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf8
-// 3. Updates the matmul to use the typecast result
+// 3. Updates the matmul to use the resulting on-device tensor
 // 4. Keeps the output of matmul as bf16 (unchanged)
 // 5. Keeps the activation input (A operand) of matmul as bf16 (unchanged)
 
@@ -14,11 +15,16 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_matmul_bfp8_weights
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_mixed_per_arg_and_global.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_mixed_per_arg_and_global.mlir
@@ -1,8 +1,9 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test mixed per-op and global weight dtype. Two matmuls:
-// - First matmul: op has per-op annotation "bfp_bf4" → typecast to bfp4
-// - Second matmul: op has no annotation → falls back to global bfp8
+// - First matmul: op has per-op annotation "bfp_bf4" -> host-side chain to bfp4
+// - Second matmul: op has no annotation -> falls back to global bfp8
+// Both blockfloat targets emit the from_device -> typecast -> to_device chain.
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -14,18 +15,25 @@ module attributes {} {
     %arg2: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}
   ) -> (tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) {
 
-    // First matmul: per-op "bfp_bf4" annotation.
-    // CHECK: %[[TYPECAST1:.*]] = "ttnn.typecast"(%arg1)
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    // CHECK: %[[MM1:.*]] = "ttnn.matmul"(%arg0, %[[TYPECAST1]])
+    // First matmul: per-op "bfp_bf4" annotation -> host-side chain to bfp4.
+    // CHECK: %[[FROM_DEV1:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST1:.*]] = "ttnn.typecast"(%[[FROM_DEV1]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
+    // CHECK: %[[TO_DEV1:.*]] = "ttnn.to_device"(%[[TYPECAST1]], %[[DEV]])
+
+    // CHECK: %[[MM1:.*]] = "ttnn.matmul"(%arg0, %[[TO_DEV1]])
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bfp_bf4"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     // Second matmul: no per-op annotation, falls back to global bfp8.
-    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%arg2)
+    // CHECK: %[[FROM_DEV2:.*]] = "ttnn.from_device"(%arg2)
+    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%[[FROM_DEV2]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
+    // CHECK: %[[TO_DEV2:.*]] = "ttnn.to_device"(%[[TYPECAST2]], %[[DEV]])
 
-    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TYPECAST2]])
+    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TO_DEV2]])
     %1 = "ttnn.matmul"(%arg0, %arg2) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     return %0, %1 : tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bfloat16_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bfloat16_override.mlir
@@ -1,8 +1,8 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test bf16 per-op override with global bfp8 default. Two matmuls:
-// - First matmul: op has per-op annotation "bf16" → no typecast (keep as-is)
-// - Second matmul: op has no annotation → falls back to global bfp8
+// - First matmul: op has per-op annotation "bf16" -> no conversion (keep as-is)
+// - Second matmul: op has no annotation -> falls back to global bfp8
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -14,16 +14,22 @@ module attributes {} {
     %arg2: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}
   ) -> (tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) {
 
-    // First matmul: per-op "bf16" annotation, no typecast should be inserted.
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // First matmul: per-op "bf16" annotation, no conversion should be inserted.
     // CHECK-NOT: "ttnn.typecast"(%arg1)
     // CHECK: %[[MM1:.*]] = "ttnn.matmul"(%arg0, %arg1)
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bf16"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
-    // Second matmul: no per-op annotation, falls back to global bfp8.
-    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%arg2)
+    // Second matmul: no per-op annotation, falls back to global bfp8 via the
+    // host-side chain.
+    // CHECK: %[[FROM_DEV2:.*]] = "ttnn.from_device"(%arg2)
+    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%[[FROM_DEV2]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
+    // CHECK: %[[TO_DEV2:.*]] = "ttnn.to_device"(%[[TYPECAST2]], %[[DEV]])
 
-    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TYPECAST2]])
+    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TO_DEV2]])
     %1 = "ttnn.matmul"(%arg0, %arg2) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     return %0, %1 : tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_overrides_global.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_overrides_global.mlir
@@ -9,12 +9,19 @@ module attributes {} {
   // CHECK-LABEL: func.func @test_per_arg_overrides_global
   func.func @test_per_arg_overrides_global(%arg0: tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, %arg1: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {
 
-    // Per-op says bfp4, global says bfp8. Per-op should win.
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // Per-op says bfp4, global says bfp8. Per-op should win and emit the
+    // host-side chain to bfp4.
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf4>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
+    // CHECK-NOT: supportedDataTypes<bfp_bf8>
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bfp_bf4"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_weight_dtype.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_weight_dtype.mlir
@@ -2,7 +2,8 @@
 
 // Test per-op weight dtype override without a global target-dtype.
 // The "ttcore.weight_dtype" discardable attribute on the matmul op should drive
-// the typecast insertion.
+// the conversion. For blockfloat targets the conversion is the host-side
+// chain (from_device -> typecast -> to_device).
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -10,11 +11,16 @@ module attributes {} {
   // CHECK-LABEL: func.func @test_per_arg_bfp8
   func.func @test_per_arg_bfp8(%arg0: tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, %arg1: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf8>
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>,
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bfp_bf8"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/sparse_matmul_bfp4_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/sparse_matmul_bfp4_weights.mlir
@@ -1,9 +1,10 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf4" %s | FileCheck %s
 
 // Test that the weight dtype conversion pass correctly:
-// 1. Inserts a ttnn.typecast operation before the sparse_matmul
+// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
+//    the sparse_matmul for blockfloat targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf4
-// 3. Updates the sparse_matmul to use the typecast result
+// 3. Updates the sparse_matmul to use the resulting on-device tensor
 // 4. Keeps the output of sparse_matmul as bf16 (unchanged)
 
 #dram = #ttnn.buffer_type<dram>
@@ -13,10 +14,15 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_sparse_matmul_bfp4_weights
 
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
+    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
+    %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    // CHECK: "ttnn.sparse_matmul"(%arg0, %[[TYPECAST]], %arg2)
+    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bfp_bf4>
+    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
+
+    // CHECK: "ttnn.sparse_matmul"(%arg0, %[[TO_DEV]], %arg2)
     %0 = "ttnn.sparse_matmul"(%arg0, %arg1, %arg2) <{is_input_a_sparse = false, is_input_b_sparse = true, nnz = 0 : i64}> : (tensor<2x4x32x2880xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4 + d1, d2, d3), <1x1>, memref<8x1x90x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x2880x5760xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1, d2, d3), <1x1>, memref<32x90x180x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<2x4x1x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4 + d1, d2, d3), <1x1>, memref<8x1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2x4x1x32x32x5760xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5) -> (d0 * 4 + d1, d2 * 32 + d3, d4, d5), <1x1>, memref<8x32x1x180x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     return %0 : tensor<2x4x1x32x32x5760xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5) -> (d0 * 4 + d1, d2 * 32 + d3, d4, d5), <1x1>, memref<8x32x1x180x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>


### PR DESCRIPTION
### Ticket
Closes #8138

### Problem description
Turns out that accuracy issues on GPT OSS 120B were caused by on-device ttnn::typecast kernel producing much higher relative-RMS than tt-metal's host packer on the same bf16 input. Turns out that typecast on host restores accuracy on gpt oss 120B.

### What's changed
For blockfloat targets (bfp_bf4, bfp_bf8), we now use host-side typecast instead of device typecast. 
Instead of typecast on device, we have chain - from_device -> typecast -> to_device. 
This uses ttnn::typecast on a host tensor, which dispatches to tt-metal's host packer for BFP formats.

Also added skip OpModel queries for TypecastOp when the input is in system
memory, matching the existing guard pattern for other host-side ops.

Updated weight dtype casting tests. Added one ttirtottnn pipeline test with optimizer on to test that pattern from_device -> typecast -> to_device is preserved with optimizer on.
    
### Impact

## Galaxy 4×8
| Test | OFF TOP1 / TOP5 | ON TOP1 / TOP5 | Δ TOP1 | Δ TOP5 |
|---|---|---|---|---|
| `test_gpt_oss_120b_tp_galaxy_batch_size_64` | 39.06% / 71.88% | 87.50% / 100.00% | +48.44% | +28.12% |
| `test_gpt_oss_20b_tp_galaxy_batch_size_64` | 79.69% / 96.88% | 82.81% / 98.44% | +3.12% | +1.56% |
| `test_llama_3_1_70b_tp_galaxy` | 90.62% / 98.44% | 92.19% / 100.00% | +1.57% | +1.56% |

## Single-chip — no bfp4 weight overrides

These tests do not declare bfp4 overrides on any matmul, so they don't
exercise the new chain. They were run only as a regression check — to
confirm the change does not introduce drift on the default-dtype paths.

| Test | OFF TOP1 / TOP5 | ON TOP1 / TOP5 | Δ TOP1 | Δ TOP5 |
|---|---|---|---|---|
| `test_llama_3_2_1b` | 84.38% / 98.44% | 82.81% / 98.44% | -1.57% | 0.00% |
| `test_llama_3_2_3b` | 84.38% / 100.00% | 87.50% / 100.00% | +3.12% | 0.00% |
| `test_llama_3_1_8b` | 82.81% / 92.19% | 89.06% / 100.00% | +6.25% | +7.81% |
| `test_mistral_7b` | 100.00% / 100.00% | 98.44% / 100.00% | -1.56% | 0.00% |
| `test_qwen_2_5_0_5b` | 90.62% / 100.00% | 90.62% / 100.00% | 0.00% | 0.00% |
| `test_qwen_2_5_1_5b` | 87.50% / 98.44% | 85.94% / 98.44% | -1.56% | 0.00% |
| `test_qwen_2_5_3b` | 92.19% / 100.00% | 90.62% / 100.00% | -1.57% | 0.00% |
| `test_qwen_2_5_7b` | 81.25% / 90.62% | 79.69% / 90.62% | -1.56% | 0.00% |
| `test_qwen_3_0_6b` | 95.31% / 100.00% | 95.31% / 100.00% | 0.00% | 0.00% |
| `test_qwen_3_1_7b` | 96.88% / 100.00% | 95.31% / 100.00% | -1.57% | 0.00% |
| `test_qwen_3_4b` | 87.50% / 98.44% | 89.06% / 100.00% | +1.56% | +1.56% |
| `test_qwen_3_8b` | 98.44% / 100.00% | 98.44% / 100.00% | 0.00% | 0.00% |

Single-chip deltas are at or below the 64-token decode-noise floor
(±1.6pt corresponds to a single token flip per row) — no regressions.

These results are obtained in tt-xla branch: [dgolubovic/host-bfp-packing-validation](https://github.com/tenstorrent/tt-xla/tree/dgolubovic/host-bfp-packing-validation)

Here is the one consteval function inside gpt oss 120B:
```
      func.func private @main_const_eval_2(%arg0: tensor<128x2880x2880xbf16, #ttnn_layout13> loc(unknown)) -> tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout14> attributes {tt.function_type = "const_eval"} {
        %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 4x8>}> : () -> !ttnn.device loc(#loc)
        %1 = "ttnn.to_device"(%arg0, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<128x2880x2880xbf16, #ttnn_layout13>, !ttnn.device) -> tensor<128x2880x2880xbf16, #ttnn_layout15> loc(#loc)
        %2 = "ttnn.to_layout"(%1) <{layout = #ttnn.layout<tile>}> : (tensor<128x2880x2880xbf16, #ttnn_layout15>) -> tensor<128x2880x2880xbf16, #ttnn_layout16> loc(#loc)
        "ttnn.deallocate"(%1) <{force = false}> : (tensor<128x2880x2880xbf16, #ttnn_layout15>) -> () loc(#loc)
        %3 = "ttnn.mesh_shard"(%2, %0) <{shard_dims = array<i64: 2, 0>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 8, 1, 4>, shard_type = #ttcore.shard_type<identity>}> : (tensor<128x2880x2880xbf16, #ttnn_layout16>, !ttnn.device) -> tensor<16x2880x720xbf16, #ttnn_layout17> loc(#loc)
        %4 = "ttnn.from_device"(%3) : (tensor<16x2880x720xbf16, #ttnn_layout17>) -> tensor<16x2880x720xbf16, #ttnn_layout18> loc(#loc2779)
        "ttnn.deallocate"(%2) <{force = false}> : (tensor<128x2880x2880xbf16, #ttnn_layout16>) -> () loc(#loc2779)
        %5 = "ttnn.typecast"(%4) <{dtype = #ttcore.supportedDataTypes<bfp_bf4>}> : (tensor<16x2880x720xbf16, #ttnn_layout18>) -> tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout19> loc(#loc2779)
        "ttnn.deallocate"(%4) <{force = false}> : (tensor<16x2880x720xbf16, #ttnn_layout18>) -> () loc(#loc2779)
        %6 = "ttnn.to_device"(%5, %0) : (tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout19>, !ttnn.device) -> tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout14> loc(#loc2779)
        "ttnn.deallocate"(%5) <{force = false}> : (tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout19>) -> () loc(#loc2779)
        return %6 : tensor<16x2880x720x!ttcore.tile<32x32, bfp_bf4>, #ttnn_layout14> loc(#loc)
      } loc(#loc)
```