### PR TITLE
[Workarounds] Add TopKOp to enabledOpsForWorkaroundWithOptimizer

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -704,5 +704,8 @@ const std::set<mlir::StringRef>
     TTNNWorkarounds::TTNNWorkarounds::enabledOpsForWorkaroundWithOptimizer = {
         ttnn::WhereOp::getOperationName(), ttnn::FullOp::getOperationName(),
         ttnn::EmbeddingOp::getOperationName(),
-        ttnn::ScatterOp::getOperationName()};
+        ttnn::ScatterOp::getOperationName(),
+        // TopK's operands workaround forces input bf16 + indices ui16/ui32;
+        // without it, opt_level>=1 dtype propagation picks f32. See #8141.
+        ttnn::TopKOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir
@@ -1,0 +1,89 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround="ttnn-is-optimizer-enabled=true" --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Regression test: TopKOp must remain in the workaround whitelist when the
+// optimizer is enabled.
+//
+// The TTNN workarounds pass restricts itself to a small set of ops when
+// `optimizer-enabled=true` (chain-based or greedy optimizer paths at
+// opt_level >= 1). TopKOp was previously absent from that set, so its
+// `createTopKOpOperandsWorkarounds` (TTNNWorkaroundsPass.cpp) was skipped
+// at opt >= 1. Without that workaround firing, the optimizer's own dtype
+// propagation filled in for the topk indices output, producing f32 typecasts
+// instead of integer typecasts for some graph patterns (notably the
+// chunked-topk pre-filter used by tt-xla's vLLM sampler, see
+// integrations/vllm_plugin/vllm_tt/sampler.py::apply_top_k_top_p_fast).
+// Downstream the chunk-offset add then had mismatched (f32, si32) operands
+// with a declared si32 result, producing silently wrong global vocab
+// indices. End-to-end symptom: garbage tokens during non-greedy device
+// sampling on Llama at opt_level=1.
+//
+// These tests assert the same behavior as `topk_workaround.mlir` (input
+// bf16/bfp_bf8 -> ui16/ui32 indices via metal kernel -> to_layout back to
+// the originally-requested si32) but with the optimizer-enabled path
+// engaged. Without TopKOp in `enabledOpsForWorkaroundWithOptimizer`, the
+// to_layout to si32 below would be absent and these tests would fail.
+
+module {
+  func.func public @test_topk_workaround_with_optimizer_ui16(%arg0: tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
+    // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_ui16
+    // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
+    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: tensor<2x3x32x128xbf16,
+    // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
+    // CHECK-SAME: tensor<2x3x32x5xui16,
+    %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<2x3x32x5xui16,
+    // CHECK-SAME: -> tensor<2x3x32x5xsi32,
+    return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>
+  }
+}
+
+// -----
+module {
+  func.func public @test_topk_workaround_with_optimizer_ui32(%arg0: tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>) {
+    // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_ui32
+    // CHECK: %{{.*}}, %[[INDICES:.*]] = "ttnn.topk"
+    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: tensor<2x3x32x128000xbf16,
+    // CHECK-SAME: -> (tensor<2x3x32x5xbf16,
+    // CHECK-SAME: tensor<2x3x32x5xui32,
+    %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128000xbf16>) -> (tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>)
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<2x3x32x5xui32,
+    // CHECK-SAME: -> tensor<2x3x32x5xsi32,
+    return %values, %indices : tensor<2x3x32x5xbf16>, tensor<2x3x32x5xsi32>
+  }
+}
+
+// -----
+// Bonus case: f32 input must also be converted to bf16 by the workaround,
+// matching `topk_f32_input_workaround.mlir` but with optimizer-enabled.
+
+module {
+  func.func public @test_topk_workaround_with_optimizer_f32_input(%arg0: tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>) {
+    // CHECK-LABEL: func.func public @test_topk_workaround_with_optimizer_f32_input
+    // CHECK: %[[INPUT_BF16:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<2x3x32x128xf32
+    // CHECK-SAME: -> tensor<2x3x32x128xbf16
+    // CHECK: %[[VALUES:.*]], %[[INDICES:.*]] = "ttnn.topk"(%[[INPUT_BF16]])
+    // CHECK-SAME: <{dim = -1 : i32, k = 5 : i32, largest = true, sorted = false}>
+    // CHECK-SAME: tensor<2x3x32x128xbf16
+    // CHECK-SAME: -> (tensor<2x3x32x5xbf16
+    // CHECK-SAME: tensor<2x3x32x5xui16
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[INDICES]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<2x3x32x5xui16
+    // CHECK-SAME: -> tensor<2x3x32x5xsi32
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[VALUES]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+    // CHECK-SAME: tensor<2x3x32x5xbf16
+    // CHECK-SAME: -> tensor<2x3x32x5xf32
+    %values, %indices = "ttir.topk"(%arg0) { k = 5 : i32 } : (tensor<2x3x32x128xf32>) -> (tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>)
+    return %values, %indices : tensor<2x3x32x5xf32>, tensor<2x3x32x5xsi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/topk/topk_ttnn_fusing_pass.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/topk/topk_ttnn_fusing_pass.mlir
@@ -19,10 +19,10 @@
 #layout_3x2_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_3x5_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 #layout_3x2_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
-#layout_2x3x8_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 3 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#layout_2x3x4_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 3 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-#layout_2x3x8_si32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 3 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
-#layout_2x3x4_si32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 3 + d1, d2), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#layout_2x3x8_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<2x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_2x3x4_f32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<2x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_2x3x8_si32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<2x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
+#layout_2x3x4_si32 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<2x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 #layout_2x8_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_2x8_si32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 #layout_4x6_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>


### PR DESCRIPTION
### Ticket

[tt-mlir #8141](https://github.com/tenstorrent/tt-mlir/issues/8141)

### Problem description

- `TTNNWorkarounds` restricts itself to a small whitelist of ops when `optimizer-enabled=true`. `TopKOp` was missing, so `createTopKOpOperandsWorkarounds` (which forces input bf16 + output indices ui16/ui32 + the `to_layout` round-trip back to the originally-requested integer dtype) was skipped at `opt_level >= 1`. Without it, the optimizer's own dtype propagation could pick f32 for the topk indices output in some graph patterns, producing downstream `ttnn.add` ops with mismatched `(f32, si32)` operands and silently wrong integer values.

- Found via tt-xla's chunked-topk vLLM sampler (4 sequential topk calls → per-chunk offset add → concat → gather). At `opt_level=1`, 3 of 4 chunks got `f32` indices typecasts instead of `si32`, producing garbage tokens during non-greedy device sampling on Llama.

### What's changed

- Add `ttnn::TopKOp::getOperationName()` to `enabledOpsForWorkaroundWithOptimizer` in `lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp`. The existing `createTopKOpOperandsWorkarounds` then applies at `opt >= 1` the same way it does at `opt = 0`.

- Also adds `test/ttmlir/Dialect/TTNN/Transforms/Workarounds/topk_workaround_with_optimizer.mlir` — mirrors the existing `topk_workaround.mlir` and `topk_f32_input_workaround.mlir` but invokes the workaround pass with `ttnn-is-optimizer-enabled=true`. Three sub-cases: vocab ≤ 65535 (`ui16` indices), vocab > 65535 (`ui32` indices), and f32 input requiring bf16 conversion. All three fail without this commit (raw types from `ttir.topk` pass through `ttnn.topk` unchanged) and pass with it.

- Updates `test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/topk/topk_ttnn_fusing_pass.mlir` 3D layouts from the artificial `(d0 * 3 + d1, d2)` 1x1-tile encoding to the realistic `(d0 * 32 + d1, d2)` 2x1-tile encoding that `--ttnn-layout` actually produces for `tensor<2x3x{8,4}x{f32,si32}>`. The fusion validator runs the topk workaround on the candidate fused op; with the artificial encoding, `TTNNLayoutAttr::withElementType` recreates the output layout from defaults, mismatches the function-declared return type, and the verifier rejects the fusion. CHECK lines for the 3D case are unchanged.

### Checklist

- [x] New/Existing tests provide coverage for changes
- [x] End-to-end impact on tt-xla's vLLM sampler at `opt_level=1`: garbage tokens become coherent text, and Llama-3.1-8B b=2 nongreedy-device throughput rises from 4.83 tok/s (broken pre-PR baseline) to 12.49 tok/s (2.59×). Llama-3.2-1B b=2 nongreedy-device: 5.81 → 21.41 tok/s (3.69×). Greedy paths and CPU sampling paths are unaffected (no regression).

