### PR TITLE
d2m: fuse sibling scratch loops in InsertScratch

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1213,6 +1213,7 @@ def D2M_UnpackStallOnPackOp : D2M_GenericRegionOp<"unpack_stall_on_pack"> {
     read by the next, and the usual tile_regs_acquire semwait is not present
     (single-tile shard path).
   }];
+  let hasCanonicalizer = 1;
   let assemblyFormat = [{ attr-dict }];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -51,6 +51,7 @@ def TTKernel_UnpackStallOnPackOp
     is visible. Used between consecutive linalg.generics sharing an
     intermediate L1 buffer in the single-tile shard path.
   }];
+  let hasCanonicalizer = 1;
   let assemblyFormat = [{ attr-dict }];
 }
 

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
@@ -11,6 +11,7 @@ namespace experimental {
 // committed to L1. Call this before unpacking data that was just packed
 // by the previous linalg.generic to guarantee L1 read-after-write ordering.
 ALWI void unpack_stall_on_pack() {
+  PACK(t6_semaphore_init(semaphore::PACK_DONE, 0, 1));
   PACK(t6_semaphore_post<>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_get<>(semaphore::PACK_DONE));

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -2285,6 +2285,19 @@ void WaitOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,
   });
 }
 
+void UnpackStallOnPackOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  patterns.add(+[](UnpackStallOnPackOp op,
+                   mlir::PatternRewriter &rewriter) -> mlir::LogicalResult {
+    if (!mlir::isa_and_nonnull<UnpackStallOnPackOp>(op->getPrevNode())) {
+      return mlir::failure();
+    }
+
+    rewriter.eraseOp(op);
+    return mlir::success();
+  });
+}
+
 mlir::LogicalResult YieldOp::verify() {
   auto generic = getOperation()->getParentOfType<GenericOp>();
   if (!generic || !generic.hasPureTensorSemantics()) {

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -403,7 +403,8 @@ getScratchAccessMapAndOperands(ScratchLoopInfo &info, MLIRContext *ctx) {
 static SmallVector<affine::AffineForOp>
 getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
                               ScratchLoopInfo &consumer) {
-  // Find the shared outer loops the consumer needs to line up with producer scratch.
+  // Find the shared outer loops the consumer needs to line up with producer
+  // scratch.
   size_t consumerRank = 1 + consumer.allLoops.size();
   if (producer.scratchShape.size() <= consumerRank) {
     return {};
@@ -454,7 +455,8 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
     SmallVector<Value> operands;
     unsigned dimIdx = 0;
 
-    // Build the straightforward consumer index including any shared prefix loops.
+    // Build the straightforward consumer index including any shared prefix
+    // loops.
     auto addLoop = [&](affine::AffineForOp loop) {
       operands.push_back(loop.getInductionVar());
       AffineExpr dim = getAffineDimExpr(dimIdx++, ctx);
@@ -953,7 +955,8 @@ fuseScratchLoopSiblings(GenericOp genericOp,
 
     size_t bestBegin = scratchSpaceLoops.size();
     size_t bestEnd = 0;
-    // Pick the widest producer->consumer span so one fusion covers the whole chain.
+    // Pick the widest producer->consumer span so one fusion covers the whole
+    // chain.
     for (auto &intermediate : intermediates) {
       size_t producerIdx =
           static_cast<size_t>(intermediate.producer - loopShells.data());

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -92,8 +92,7 @@ static int64_t estimateScratchDemand(ArrayRef<IntermediateAllocInfo> infos) {
     if (!info.producer) {
       continue;
     }
-    if (llvm::is_contained(info.producer->scratchShape,
-                           ShapedType::kDynamic)) {
+    if (llvm::is_contained(info.producer->scratchShape, ShapedType::kDynamic)) {
       return ShapedType::kDynamic;
     }
     demand += ttmlir::utils::volume<int64_t>(info.producer->scratchShape);
@@ -878,10 +877,12 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
 
 static bool containsUnsafeFusedConsumer(ArrayRef<affine::AffineForOp> loops) {
   return llvm::any_of(loops, [](affine::AffineForOp loop) {
-    return loop.walk([](Operation *op) {
-      return isa<TileDivOp, TileWhereOp>(op) ? WalkResult::interrupt()
-                                             : WalkResult::advance();
-    }).wasInterrupted();
+    return loop
+        .walk([](Operation *op) {
+          return isa<TileDivOp, TileWhereOp>(op) ? WalkResult::interrupt()
+                                                 : WalkResult::advance();
+        })
+        .wasInterrupted();
   });
 }
 

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -13,6 +13,8 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/PatternMatch.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MINSERTSPILLANDSCRATCH
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
@@ -121,6 +123,19 @@ static bool computeScratchShape(ScratchLoopInfo &info) {
   return true;
 }
 
+/// Gather all unprocessed scratch_space_loop ops in a generic.
+static SmallVector<affine::AffineForOp>
+collectScratchSpaceLoops(GenericOp genericOp) {
+  SmallVector<affine::AffineForOp> scratchSpaceLoops;
+  genericOp.walk([&](affine::AffineForOp forOp) {
+    if (forOp->hasAttr("d2m.scratch_space_loop") &&
+        !forOp->hasAttr("d2m.scratch_inserted")) {
+      scratchSpaceLoops.push_back(forOp);
+    }
+  });
+  return scratchSpaceLoops;
+}
+
 /// Check whether an allocation is a compiler-local intermediate of this
 /// d2m.generic.
 /// Inputs/outputs of the generic already have externally visible storage and
@@ -184,6 +199,172 @@ static void collectLoadsInLoop(Value memref, ScratchLoopInfo &loopInfo,
   });
 }
 
+/// Check whether two affine loops have identical static iteration spaces.
+static bool haveMatchingConstantBounds(affine::AffineForOp lhs,
+                                       affine::AffineForOp rhs) {
+  if (!lhs.hasConstantBounds() || !rhs.hasConstantBounds()) {
+    return false;
+  }
+  return lhs.getConstantLowerBound() == rhs.getConstantLowerBound() &&
+         lhs.getConstantUpperBound() == rhs.getConstantUpperBound() &&
+         lhs.getStepAsInt() == rhs.getStepAsInt();
+}
+
+/// Return the single top-level affine child in a loop body, if one exists.
+static affine::AffineForOp
+getSingleTopLevelAffineChild(affine::AffineForOp loop) {
+  affine::AffineForOp child = nullptr;
+  for (Operation &op : *loop.getBody()) {
+    if (isa<affine::AffineYieldOp>(op)) {
+      continue;
+    }
+    auto innerFor = dyn_cast<affine::AffineForOp>(op);
+    if (!innerFor || child) {
+      return nullptr;
+    }
+    child = innerFor;
+  }
+  return child;
+}
+
+/// Return true if an op uses any value from the provided set.
+static bool usesAnyValue(Operation *op, ArrayRef<Value> values) {
+  return llvm::any_of(op->getOperands(), [&](Value operand) {
+    return llvm::is_contained(values, operand);
+  });
+}
+
+static UnpackStallOnPackOp
+getUnpackStallImmediatelyBefore(Operation *consumerLoop) {
+  Operation *previous = consumerLoop->getPrevNode();
+  if (!previous) {
+    return nullptr;
+  }
+
+  return dyn_cast<UnpackStallOnPackOp>(previous);
+}
+
+static void ensureUnpackStallBeforeConsumer(
+    ScratchLoopInfo &producer, ScratchLoopInfo &consumer, IRRewriter &rewriter,
+    llvm::SmallPtrSetImpl<Operation *> &guardedConsumers) {
+  if (consumer.scratchLoop == producer.scratchLoop) {
+    return;
+  }
+
+  Operation *producerLoop = producer.scratchLoop.getOperation();
+  Operation *consumerLoop = consumer.scratchLoop.getOperation();
+  if (producerLoop->getBlock() != consumerLoop->getBlock() ||
+      !producerLoop->isBeforeInBlock(consumerLoop)) {
+    return;
+  }
+
+  if (!guardedConsumers.insert(consumerLoop).second) {
+    return;
+  }
+
+  if (auto previousStall = getUnpackStallImmediatelyBefore(consumerLoop)) {
+    rewriter.eraseOp(previousStall);
+  }
+
+  rewriter.setInsertionPoint(consumerLoop);
+  rewriter.create<UnpackStallOnPackOp>(consumerLoop->getLoc());
+}
+
+/// Fuse a dependence-related group of sibling scratch loops under one shared
+/// affine prefix.
+static bool manuallyFuseScratchLoopGroup(ArrayRef<affine::AffineForOp> loops,
+                                         IRRewriter &rewriter) {
+  if (loops.size() < 2) {
+    return false;
+  }
+
+  Block *parentBlock = loops.front()->getBlock();
+  SmallVector<Value> oldIvs;
+  oldIvs.reserve(loops.size());
+  for (auto loop : loops) {
+    if (loop->getBlock() != parentBlock ||
+        !haveMatchingConstantBounds(loops.front(), loop)) {
+      return false;
+    }
+
+    affine::AffineForOp inner = getSingleTopLevelAffineChild(loop);
+    // Hoist exactly one common affine prefix. The inner loop becomes the new
+    // scratch boundary and must still contain a nested linalg root.
+    if (!inner || inner->hasAttr("d2m.linalg_root")) {
+      return false;
+    }
+    oldIvs.push_back(loop.getInductionVar());
+  }
+
+  for (size_t i = 1; i < loops.size(); ++i) {
+    if (!loops[i - 1]->isBeforeInBlock(loops[i])) {
+      return false;
+    }
+  }
+
+  SmallVector<SmallVector<Operation *>> setupOpsBeforeLoop(loops.size());
+  SmallVector<Operation *> staleStalls;
+  for (size_t i = 1; i < loops.size(); ++i) {
+    for (auto it = std::next(loops[i - 1]->getIterator());
+         it != loops[i]->getIterator(); ++it) {
+      Operation *op = &*it;
+      if (isa<UnpackStallOnPackOp>(op)) {
+        staleStalls.push_back(op);
+        continue;
+      }
+
+      if (usesAnyValue(op, oldIvs)) {
+        return false;
+      }
+      setupOpsBeforeLoop[i].push_back(op);
+    }
+  }
+
+  rewriter.setInsertionPoint(loops.front());
+  affine::AffineForOp firstLoop = loops.front();
+  auto sharedLoop = rewriter.create<affine::AffineForOp>(
+      firstLoop.getLoc(), firstLoop.getConstantLowerBound(),
+      firstLoop.getConstantUpperBound(), firstLoop.getStepAsInt());
+
+  for (auto loop : loops) {
+    loop.getInductionVar().replaceAllUsesWith(sharedLoop.getInductionVar());
+  }
+
+  Operation *sharedYield = sharedLoop.getBody()->getTerminator();
+  for (auto &ops : setupOpsBeforeLoop) {
+    for (Operation *op : ops) {
+      op->moveBefore(sharedLoop);
+    }
+  }
+
+  for (auto indexedLoop : llvm::enumerate(loops)) {
+    affine::AffineForOp loop = indexedLoop.value();
+    auto &ops = loop.getBody()->getOperations();
+    sharedLoop.getBody()->getOperations().splice(
+        sharedYield->getIterator(), ops, ops.begin(), std::prev(ops.end()));
+  }
+
+  for (Operation *stallOp : staleStalls) {
+    rewriter.eraseOp(stallOp);
+  }
+
+  for (Operation &op : *sharedLoop.getBody()) {
+    auto innerFor = dyn_cast<affine::AffineForOp>(&op);
+    if (!innerFor) {
+      continue;
+    }
+    innerFor->setAttr("d2m.scratch_space_loop",
+                      UnitAttr::get(rewriter.getContext()));
+    innerFor->removeAttr("d2m.scratch_inserted");
+  }
+
+  for (auto loop : loops) {
+    rewriter.eraseOp(loop);
+  }
+
+  return true;
+}
+
 /// Build an affine map and operands for accessing the scratch buffer.
 /// For loops with step > 1, the IV is normalized to give contiguous indices.
 /// E.g., affine.for %i = 0 to 8 step 2 gives IV values 0,2,4,6 which are
@@ -219,6 +400,29 @@ getScratchAccessMapAndOperands(ScratchLoopInfo &info, MLIRContext *ctx) {
   return {AffineMap::get(dimIdx, 0, exprs, ctx), operands};
 }
 
+static SmallVector<affine::AffineForOp>
+getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
+                              ScratchLoopInfo &consumer) {
+  // Find the shared outer loops the consumer needs to line up with producer scratch.
+  size_t consumerRank = 1 + consumer.allLoops.size();
+  if (producer.scratchShape.size() <= consumerRank) {
+    return {};
+  }
+
+  size_t missingRank = producer.scratchShape.size() - consumerRank;
+  SmallVector<affine::AffineForOp> prefixes;
+  Operation *parent = consumer.scratchLoop->getParentOp();
+  while (parent && prefixes.size() < missingRank) {
+    if (auto parentLoop = dyn_cast<affine::AffineForOp>(parent)) {
+      prefixes.push_back(parentLoop);
+    }
+    parent = parent->getParentOp();
+  }
+
+  std::reverse(prefixes.begin(), prefixes.end());
+  return prefixes;
+}
+
 /// Build an access map for a consumer loading from a scratch buffer that was
 /// shaped by a producer with a potentially different inner loop step.
 ///
@@ -246,7 +450,34 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
                             consumer.allLoops.front().getStepAsInt();
 
   if (!needsCrossStep) {
-    return getScratchAccessMapAndOperands(consumer, ctx);
+    SmallVector<AffineExpr> exprs;
+    SmallVector<Value> operands;
+    unsigned dimIdx = 0;
+
+    // Build the straightforward consumer index including any shared prefix loops.
+    auto addLoop = [&](affine::AffineForOp loop) {
+      operands.push_back(loop.getInductionVar());
+      AffineExpr dim = getAffineDimExpr(dimIdx++, ctx);
+      int64_t lb = loop.getConstantLowerBound();
+      int64_t step = loop.getStepAsInt();
+      if (lb != 0) {
+        dim = dim - lb;
+      }
+      if (step != 1) {
+        dim = dim.floorDiv(step);
+      }
+      exprs.push_back(dim);
+    };
+
+    for (auto prefixLoop : getMissingConsumerPrefixLoops(producer, consumer)) {
+      addLoop(prefixLoop);
+    }
+    addLoop(consumer.scratchLoop);
+    for (auto loop : consumer.allLoops) {
+      addLoop(loop);
+    }
+
+    return {AffineMap::get(dimIdx, 0, exprs, ctx), operands};
   }
 
   // Cross-step case: consumer batches tile columns in different sizes than the
@@ -278,6 +509,10 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
     }
     return dim;
   };
+
+  for (auto prefixLoop : getMissingConsumerPrefixLoops(producer, consumer)) {
+    exprs.push_back(addLoop(prefixLoop));
+  }
 
   // Dimension 0: scratchLoop (normalized pass-through, same step for both).
   exprs.push_back(addLoop(consumer.scratchLoop));
@@ -353,7 +588,6 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   }
 
   struct ChainInfo {
-    affine::AffineForOp scratchLoop;
     // The enclosing scf.for chain, ordered from outermost to innermost.
     SmallVector<scf::ForOp> chain;
   };
@@ -361,7 +595,6 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   SmallVector<ChainInfo> chains;
   for (auto sl : scratchLoops) {
     ChainInfo ci;
-    ci.scratchLoop = sl;
     Operation *parent = sl->getParentOp();
     while (auto scfFor = dyn_cast<scf::ForOp>(parent)) {
       ci.chain.push_back(scfFor);
@@ -596,6 +829,170 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   return true;
 }
 
+static SmallVector<IntermediateAllocInfo>
+findIntermediates(GenericOp genericOp,
+                  SmallVectorImpl<ScratchLoopInfo> &scratchLoops) {
+  SmallVector<IntermediateAllocInfo> intermediates;
+  if (scratchLoops.size() < 2) {
+    return intermediates;
+  }
+
+  genericOp.walk([&](memref::AllocOp allocOp) {
+    if (!isIntermediateAlloc(allocOp, genericOp)) {
+      return;
+    }
+    IntermediateAllocInfo allocInfo;
+    allocInfo.allocOp = allocOp;
+    allocInfo.producer = nullptr;
+    allocInfo.lastConsumerIndex = 0;
+
+    Value allocResult = allocOp.getResult();
+    SmallVector<SmallVector<affine::AffineStoreOp>> storesByLoop(
+        scratchLoops.size());
+
+    // Find which loop nests write to and read from this allocation.
+    // Keep per-loop stores in a side table so we can later answer: "which
+    // loop is the earliest writer whose value is consumed by a later loop?"
+    for (auto indexedLoop : llvm::enumerate(scratchLoops)) {
+      size_t loopIdx = indexedLoop.index();
+      auto &loopInfo = indexedLoop.value();
+      SmallVector<affine::AffineStoreOp> stores;
+      collectStoresInLoop(allocResult, loopInfo, stores);
+      if (!stores.empty()) {
+        storesByLoop[loopIdx] = std::move(stores);
+      }
+
+      SmallVector<affine::AffineLoadOp> loads;
+      collectLoadsInLoop(allocResult, loopInfo, loads);
+      if (!loads.empty()) {
+        allocInfo.consumers.push_back(
+            ConsumerLoopLoads{&loopInfo, std::move(loads)});
+      }
+    }
+
+    // Only include if we found a producer and at least one consumer in a
+    // *subsequent* scratch_space_loop (i.e., consumer index > producer
+    // index). A consumer that appears before or at the same loop as the
+    // producer does not require cross-loop scratch spilling.
+    //
+    // Example:
+    //   loop 0: alloc = sin(...)
+    //   loop 1: tmp = load alloc; alloc = add(tmp, ...)
+    //
+    // loop 1 both reads and writes the same alloc, but loop 0 is still the
+    // true producer of the value that must survive into loop 1. If we chose
+    // loop 1 as the producer just because it is a later writer, we would lose
+    // the real producer->consumer dependency and either spill the wrong thing
+    // or fail to spill at all.
+    bool hasSubsequentExternalConsumer = false;
+    for (auto indexedStores : llvm::enumerate(storesByLoop)) {
+      size_t loopIdx = indexedStores.index();
+      auto &stores = indexedStores.value();
+      if (stores.empty()) {
+        continue;
+      }
+
+      // Pick the earliest writer with a later read so in-place consumer
+      // updates do not replace the true producer for this intermediate.
+      size_t firstLaterWriterIdx = scratchLoops.size();
+      for (size_t laterIdx = loopIdx + 1; laterIdx < storesByLoop.size();
+           ++laterIdx) {
+        if (!storesByLoop[laterIdx].empty()) {
+          firstLaterWriterIdx = laterIdx;
+          break;
+        }
+      }
+
+      bool hasLaterConsumer =
+          llvm::any_of(allocInfo.consumers, [&](const ConsumerLoopLoads &c) {
+            size_t consIdx = static_cast<size_t>(c.loop - scratchLoops.data());
+            return consIdx > loopIdx && consIdx <= firstLaterWriterIdx;
+          });
+      if (!hasLaterConsumer) {
+        continue;
+      }
+
+      allocInfo.producer = &scratchLoops[loopIdx];
+      allocInfo.lastConsumerIndex = firstLaterWriterIdx;
+      allocInfo.stores = std::move(stores);
+      hasSubsequentExternalConsumer = true;
+      break;
+    }
+    if (hasSubsequentExternalConsumer) {
+      intermediates.push_back(allocInfo);
+    }
+  });
+
+  return intermediates;
+}
+
+/// Repeatedly fuse dependence-related sibling scratch loops.
+static bool
+fuseScratchLoopSiblings(GenericOp genericOp,
+                        SmallVector<affine::AffineForOp> &scratchSpaceLoops,
+                        IRRewriter &rewriter) {
+  bool changed = false;
+  bool madeProgress = true;
+
+  while (madeProgress) {
+    madeProgress = false;
+
+    SmallVector<ScratchLoopInfo> loopShells;
+    loopShells.reserve(scratchSpaceLoops.size());
+    for (auto scratchLoop : scratchSpaceLoops) {
+      ScratchLoopInfo info;
+      info.scratchLoop = scratchLoop;
+      loopShells.push_back(info);
+    }
+
+    SmallVector<IntermediateAllocInfo> intermediates =
+        findIntermediates(genericOp, loopShells);
+    if (intermediates.empty()) {
+      break;
+    }
+
+    size_t bestBegin = scratchSpaceLoops.size();
+    size_t bestEnd = 0;
+    // Pick the widest producer->consumer span so one fusion covers the whole chain.
+    for (auto &intermediate : intermediates) {
+      size_t producerIdx =
+          static_cast<size_t>(intermediate.producer - loopShells.data());
+      for (auto &consumer : intermediate.consumers) {
+        if (consumer.loop == intermediate.producer) {
+          continue;
+        }
+        size_t consumerIdx =
+            static_cast<size_t>(consumer.loop - loopShells.data());
+        if (consumerIdx <= producerIdx ||
+            consumerIdx > intermediate.lastConsumerIndex) {
+          continue;
+        }
+        if (bestBegin == scratchSpaceLoops.size() ||
+            consumerIdx - producerIdx > bestEnd - bestBegin) {
+          bestBegin = producerIdx;
+          bestEnd = consumerIdx;
+        }
+      }
+    }
+
+    if (bestBegin == scratchSpaceLoops.size()) {
+      break;
+    }
+
+    SmallVector<affine::AffineForOp> loopsToFuse;
+    for (size_t i = bestBegin; i <= bestEnd; ++i) {
+      loopsToFuse.push_back(scratchSpaceLoops[i]);
+    }
+
+    if (manuallyFuseScratchLoopGroup(loopsToFuse, rewriter)) {
+      scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
+      changed = madeProgress = true;
+    }
+  }
+
+  return changed;
+}
+
 /// Main pass implementation
 class D2MInsertSpillAndScratch
     : public impl::D2MInsertSpillAndScratchBase<D2MInsertSpillAndScratch> {
@@ -617,24 +1014,19 @@ private:
   LogicalResult processGenericOp(GenericOp genericOp) {
     IRRewriter rewriter(&getContext());
 
-    // Step 0: Find all scratch_space_loops first (before any modifications).
+    // Find all scratch_space_loops first (before any modifications).
     //
     // Gather the candidate loops up front because later rewriting may erase or
     // re-parent surrounding structure. Skip loops already marked as processed
     // so the pass is idempotent if it is run more than once.
-    SmallVector<affine::AffineForOp> scratchSpaceLoops;
-    genericOp.walk([&](affine::AffineForOp forOp) {
-      if (forOp->hasAttr("d2m.scratch_space_loop") &&
-          !forOp->hasAttr("d2m.scratch_inserted")) {
-        scratchSpaceLoops.push_back(forOp);
-      }
-    });
+    SmallVector<affine::AffineForOp> scratchSpaceLoops =
+        collectScratchSpaceLoops(genericOp);
 
     if (scratchSpaceLoops.empty()) {
       return success();
     }
 
-    // Step 0.5: Fuse outer scf.for loops across scratch_space_loop nests.
+    // Fuse outer scf.for loops across scratch_space_loop nests.
     // This ensures producer/consumer computations share the outer iteration
     // space, allowing the scratch buffer to be reused per outer iteration
     // rather than needing full-shard capacity.
@@ -642,7 +1034,12 @@ private:
       return success();
     }
 
-    // Step 1: Collect structural information for each scratch_space_loop.
+    // Regather, fuse sibling loops and gather again.
+    scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
+    fuseScratchLoopSiblings(genericOp, scratchSpaceLoops, rewriter);
+    scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
+
+    // Collect structural information for each scratch_space_loop.
     //
     // Only keep loops where we can identify a linalg_root and where every
     // relevant loop bound/step is static enough to build a concrete scratch
@@ -666,97 +1063,13 @@ private:
       return success();
     }
 
-    // Step 3: Find intermediate allocations that connect loop nests.
+    // Find intermediate allocations that connect loop nests.
     //
     // Looking for the pattern:
     //   scratch_space_loop P writes alloc A
     //   scratch_space_loop C (later in program order) reads alloc A
-    SmallVector<IntermediateAllocInfo> intermediates;
-
-    genericOp.walk([&](memref::AllocOp allocOp) {
-      if (!isIntermediateAlloc(allocOp, genericOp)) {
-        return;
-      }
-      IntermediateAllocInfo allocInfo;
-      allocInfo.allocOp = allocOp;
-      allocInfo.producer = nullptr;
-      allocInfo.lastConsumerIndex = 0;
-
-      Value allocResult = allocOp.getResult();
-      SmallVector<SmallVector<affine::AffineStoreOp>> storesByLoop(
-          scratchLoops.size());
-
-      // Find which loop nests write to and read from this allocation.
-      // Keep per-loop stores in a side table so we can later answer: "which
-      // loop is the earliest writer whose value is consumed by a later loop?"
-      for (auto indexedLoop : llvm::enumerate(scratchLoops)) {
-        size_t loopIdx = indexedLoop.index();
-        auto &loopInfo = indexedLoop.value();
-        SmallVector<affine::AffineStoreOp> stores;
-        collectStoresInLoop(allocResult, loopInfo, stores);
-        if (!stores.empty()) {
-          storesByLoop[loopIdx] = std::move(stores);
-        }
-
-        SmallVector<affine::AffineLoadOp> loads;
-        collectLoadsInLoop(allocResult, loopInfo, loads);
-        if (!loads.empty()) {
-          allocInfo.consumers.push_back({&loopInfo, std::move(loads)});
-        }
-      }
-
-      // Only include if we found a producer and at least one consumer in a
-      // *subsequent* scratch_space_loop (i.e., consumer index > producer
-      // index). A consumer that appears before or at the same loop as the
-      // producer does not require cross-loop scratch spilling.
-      // Example:
-      //   loop 0: alloc = sin(...)
-      //   loop 1: tmp = load alloc; alloc = add(tmp, ...)
-      //
-      // loop 1 both reads and writes the same alloc, but loop 0 is still the
-      // true producer of the value that must survive into loop 1. If we chose
-      // loop 1 as the producer just because it is a later writer, we would
-      // lose the real producer->consumer dependency and either spill the wrong
-      // thing or fail to spill at all.
-      bool hasSubsequentExternalConsumer = false;
-      for (auto indexedStores : llvm::enumerate(storesByLoop)) {
-        size_t loopIdx = indexedStores.index();
-        auto &stores = indexedStores.value();
-        if (stores.empty()) {
-          continue;
-        }
-
-        // Pick the earliest writer with a later read so in-place consumer
-        // updates do not replace the true producer for this intermediate.
-        size_t firstLaterWriterIdx = scratchLoops.size();
-        for (size_t laterIdx = loopIdx + 1; laterIdx < storesByLoop.size();
-             ++laterIdx) {
-          if (!storesByLoop[laterIdx].empty()) {
-            firstLaterWriterIdx = laterIdx;
-            break;
-          }
-        }
-
-        bool hasLaterConsumer =
-            llvm::any_of(allocInfo.consumers, [&](const ConsumerLoopLoads &c) {
-              size_t consIdx =
-                  static_cast<size_t>(c.loop - scratchLoops.data());
-              return consIdx > loopIdx && consIdx <= firstLaterWriterIdx;
-            });
-        if (!hasLaterConsumer) {
-          continue;
-        }
-
-        allocInfo.producer = &scratchLoops[loopIdx];
-        allocInfo.lastConsumerIndex = firstLaterWriterIdx;
-        allocInfo.stores = std::move(stores);
-        hasSubsequentExternalConsumer = true;
-        break;
-      }
-      if (hasSubsequentExternalConsumer) {
-        intermediates.push_back(allocInfo);
-      }
-    });
+    SmallVector<IntermediateAllocInfo> intermediates =
+        findIntermediates(genericOp, scratchLoops);
 
     if (intermediates.empty()) {
       // Mark loops as processed even if no intermediates found.
@@ -767,11 +1080,12 @@ private:
       return success();
     }
 
-    // Step 4: Replace intermediate allocations with scratch buffers.
+    // Replace intermediate allocations with scratch buffers.
     auto l1Attr = ttcore::MemorySpaceAttr::get(&getContext(),
                                                ttcore::MemorySpace::DeviceL1);
 
     int64_t slotIndex = 0;
+    llvm::SmallPtrSet<Operation *, 8> guardedScratchConsumers;
     for (auto &allocInfo : intermediates) {
       ScratchLoopInfo &producer = *allocInfo.producer;
 
@@ -795,7 +1109,7 @@ private:
           loc, scratchMemRefType, slotIndex++);
       Value scratchBuf = scratchOp.getResult();
 
-      // Step 5: Update stores in the producer loop.
+      // Update stores in the producer loop.
       // Use an affine map to normalize loop IVs (handling step > 1).
       auto [producerMap, producerOperands] =
           getScratchAccessMapAndOperands(producer, &getContext());
@@ -811,7 +1125,7 @@ private:
         rewriter.eraseOp(storeOp);
       }
 
-      // Step 6: Update loads in all consumer loops.
+      // Update loads in all consumer loops.
       for (auto &consumerEntry : allocInfo.consumers) {
         if (consumerEntry.loop == allocInfo.producer) {
           continue;
@@ -823,6 +1137,9 @@ private:
         }
 
         ScratchLoopInfo &consumer = *consumerEntry.loop;
+        ensureUnpackStallBeforeConsumer(producer, consumer, rewriter,
+                                        guardedScratchConsumers);
+
         // Use producer-aware map so that consumers with a different linalgRoot
         // step size correctly address the scratch buffer (which is laid out
         // according to the producer's step).
@@ -839,7 +1156,7 @@ private:
         }
       }
 
-      // Step 7: Clean up dead pieces of the original local-allocation path.
+      // Clean up dead pieces of the original local-allocation path.
       SmallVector<memref::SubViewOp> subviews;
       for (Operation *user : allocInfo.allocOp.getResult().getUsers()) {
         if (auto subview = dyn_cast<memref::SubViewOp>(user)) {

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -13,7 +13,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/PatternMatch.h"
-
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 #include <optional>
@@ -68,20 +68,32 @@ struct IntermediateAllocInfo {
   SmallVector<affine::AffineStoreOp> stores; // Stores to this alloc
 };
 
-// Compute total static scratch buffer capacity required by a GenericOp.
-static std::optional<int64_t> getScratchCapacity(GenericOp genericOp) {
+// Compute the static capacity of the single scratch buffer owned by a
+// GenericOp.
+//
+// LowerScratchAllocate lays out d2m.scratch_allocate slots sequentially into
+// this buffer, so total slot demand must fit within this capacity.
+static FailureOr<std::optional<int64_t>>
+getScratchCapacity(GenericOp genericOp) {
   std::optional<int64_t> capacity;
-  genericOp.walk([&](ScratchInitOp scratchInit) {
+  WalkResult result = genericOp.walk([&](ScratchInitOp scratchInit) {
+    if (capacity) {
+      return WalkResult::interrupt();
+    }
+
     auto memrefType =
-        mlir::dyn_cast<MemRefType>(scratchInit.getScratch().getType());
-    if (!memrefType) {
-      return;
-    }
+        mlir::cast<MemRefType>(scratchInit.getScratch().getType());
     ArrayRef<int64_t> shape = memrefType.getShape();
-    if (!llvm::is_contained(shape, ShapedType::kDynamic)) {
-      capacity = ttmlir::utils::volume<int64_t>(shape);
+    if (llvm::is_contained(shape, ShapedType::kDynamic)) {
+      return WalkResult::interrupt();
     }
+
+    capacity = ttmlir::utils::volume<int64_t>(shape);
+    return WalkResult::advance();
   });
+  if (result.wasInterrupted()) {
+    return failure();
+  }
   return capacity;
 }
 
@@ -269,6 +281,17 @@ static bool usesAnyValue(Operation *op, ArrayRef<Value> values) {
   });
 }
 
+static bool hasNoMemoryEffects(Operation *op) {
+  auto effectOp = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectOp) {
+    return false;
+  }
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  effectOp.getEffects(effects);
+  return effects.empty();
+}
+
 static UnpackStallOnPackOp
 getUnpackStallImmediatelyBefore(Operation *consumerLoop) {
   Operation *previous = consumerLoop->getPrevNode();
@@ -348,7 +371,7 @@ static bool manuallyFuseScratchLoopGroup(ArrayRef<affine::AffineForOp> loops,
         continue;
       }
 
-      if (usesAnyValue(op, oldIvs)) {
+      if (usesAnyValue(op, oldIvs) || !hasNoMemoryEffects(op)) {
         return false;
       }
       setupOpsBeforeLoop[i].push_back(op);
@@ -435,14 +458,14 @@ getScratchAccessMapAndOperands(ScratchLoopInfo &info, MLIRContext *ctx) {
   return {AffineMap::get(dimIdx, 0, exprs, ctx), operands};
 }
 
-static SmallVector<affine::AffineForOp>
+static FailureOr<SmallVector<affine::AffineForOp>>
 getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
                               ScratchLoopInfo &consumer) {
   // Find the shared outer loops the consumer needs to line up with producer
   // scratch.
   size_t consumerRank = 1 + consumer.allLoops.size();
   if (producer.scratchShape.size() <= consumerRank) {
-    return {};
+    return SmallVector<affine::AffineForOp>{};
   }
 
   size_t missingRank = producer.scratchShape.size() - consumerRank;
@@ -450,9 +473,15 @@ getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
   Operation *parent = consumer.scratchLoop->getParentOp();
   while (parent && prefixes.size() < missingRank) {
     if (auto parentLoop = dyn_cast<affine::AffineForOp>(parent)) {
+      if (!parentLoop.hasConstantBounds()) {
+        return failure();
+      }
       prefixes.push_back(parentLoop);
     }
     parent = parent->getParentOp();
+  }
+  if (prefixes.size() != missingRank) {
+    return failure();
   }
 
   std::reverse(prefixes.begin(), prefixes.end());
@@ -473,11 +502,15 @@ getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
 /// Consumer allLoops[0] step=6 must access as:
 ///   [arg10, (arg11+arg13)/4, arg12, (arg11+arg13)%4]
 /// instead of the wrong: [arg10, arg11/6, arg12, arg13].
-static std::pair<AffineMap, SmallVector<Value>>
+static FailureOr<std::pair<AffineMap, SmallVector<Value>>>
 getConsumerScratchAccessMap(ScratchLoopInfo &producer,
                             ScratchLoopInfo &consumer, MLIRContext *ctx) {
-  SmallVector<affine::AffineForOp> prefixLoops =
+  FailureOr<SmallVector<affine::AffineForOp>> prefixLoopsOr =
       getMissingConsumerPrefixLoops(producer, consumer);
+  if (failed(prefixLoopsOr)) {
+    return failure();
+  }
+  SmallVector<affine::AffineForOp> &prefixLoops = *prefixLoopsOr;
 
   // Cross-step handling is needed when the first inner loop (column-batching
   // loop, allLoops[0]) has a different step between producer and consumer.
@@ -523,7 +556,7 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
       addLoop(loop);
     }
 
-    return {AffineMap::get(dimIdx, 0, exprs, ctx), operands};
+    return std::make_pair(AffineMap::get(dimIdx, 0, exprs, ctx), operands);
   }
 
   // Cross-step case: consumer batches tile columns in different sizes than the
@@ -602,7 +635,7 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
   }
   exprs.push_back(absCol % prodColStep);
 
-  return {AffineMap::get(dimIdx, 0, exprs, ctx), operands};
+  return std::make_pair(AffineMap::get(dimIdx, 0, exprs, ctx), operands);
 }
 
 /// Fuse outer scf.for loops that enclose scratch_space_loop nests.
@@ -876,6 +909,9 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
 }
 
 static bool containsUnsafeFusedConsumer(ArrayRef<affine::AffineForOp> loops) {
+  // TODO (anuragsingh): Investigate the TileDivOp/TileWhereOp DST allocation
+  // failures and remove this guard once sibling fusion is safe for these ops.
+  // Issue: https://github.com/tenstorrent/tt-mlir/issues/8198
   return llvm::any_of(loops, [](affine::AffineForOp loop) {
     return loop
         .walk([](Operation *op) {
@@ -1100,7 +1136,13 @@ private:
     // demand cannot fit in the available scratch buffer.
     scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
     bool needsSiblingFusionForCapacity = true;
-    if (std::optional<int64_t> capacity = getScratchCapacity(genericOp)) {
+    FailureOr<std::optional<int64_t>> capacityOr =
+        getScratchCapacity(genericOp);
+    if (failed(capacityOr)) {
+      return genericOp.emitOpError()
+             << "expected at most one statically-shaped scratch_init";
+    }
+    if (std::optional<int64_t> capacity = *capacityOr) {
       SmallVector<ScratchLoopInfo> preSiblingFusionScratchLoops;
       for (auto scratchLoop : scratchSpaceLoops) {
         ScratchLoopInfo info;
@@ -1230,8 +1272,13 @@ private:
         // Use producer-aware map so that consumers with a different linalgRoot
         // step size correctly address the scratch buffer (which is laid out
         // according to the producer's step).
-        auto [consumerMap, consumerOperands] =
+        FailureOr<std::pair<AffineMap, SmallVector<Value>>> consumerMapOr =
             getConsumerScratchAccessMap(producer, consumer, &getContext());
+        if (failed(consumerMapOr)) {
+          return genericOp.emitOpError()
+                 << "cannot build static scratch access map for consumer";
+        }
+        auto &[consumerMap, consumerOperands] = *consumerMapOr;
 
         for (auto loadOp : consumerEntry.loads) {
           rewriter.setInsertionPoint(loadOp);

--- a/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertSpillAndScratch.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -14,6 +15,8 @@
 #include "mlir/IR/PatternMatch.h"
 
 #include "llvm/ADT/SmallPtrSet.h"
+
+#include <optional>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MINSERTSPILLANDSCRATCH
@@ -64,6 +67,39 @@ struct IntermediateAllocInfo {
       consumers; // all consumer loop nests that read from it
   SmallVector<affine::AffineStoreOp> stores; // Stores to this alloc
 };
+
+// Compute total static scratch buffer capacity required by a GenericOp.
+static std::optional<int64_t> getScratchCapacity(GenericOp genericOp) {
+  std::optional<int64_t> capacity;
+  genericOp.walk([&](ScratchInitOp scratchInit) {
+    auto memrefType =
+        mlir::dyn_cast<MemRefType>(scratchInit.getScratch().getType());
+    if (!memrefType) {
+      return;
+    }
+    ArrayRef<int64_t> shape = memrefType.getShape();
+    if (!llvm::is_contained(shape, ShapedType::kDynamic)) {
+      capacity = ttmlir::utils::volume<int64_t>(shape);
+    }
+  });
+  return capacity;
+}
+
+// Estimate total scratch memory demand from intermediate allocations.
+static int64_t estimateScratchDemand(ArrayRef<IntermediateAllocInfo> infos) {
+  int64_t demand = 0;
+  for (auto &info : infos) {
+    if (!info.producer) {
+      continue;
+    }
+    if (llvm::is_contained(info.producer->scratchShape,
+                           ShapedType::kDynamic)) {
+      return ShapedType::kDynamic;
+    }
+    demand += ttmlir::utils::volume<int64_t>(info.producer->scratchShape);
+  }
+  return demand;
+}
 
 /// Find the innermost affine.for loop with d2m.linalg_root attribute.
 ///
@@ -262,7 +298,7 @@ static void ensureUnpackStallBeforeConsumer(
     return;
   }
 
-  if (auto previousStall = getUnpackStallImmediatelyBefore(consumerLoop)) {
+  while (auto previousStall = getUnpackStallImmediatelyBefore(consumerLoop)) {
     rewriter.eraseOp(previousStall);
   }
 
@@ -441,11 +477,17 @@ getMissingConsumerPrefixLoops(ScratchLoopInfo &producer,
 static std::pair<AffineMap, SmallVector<Value>>
 getConsumerScratchAccessMap(ScratchLoopInfo &producer,
                             ScratchLoopInfo &consumer, MLIRContext *ctx) {
+  SmallVector<affine::AffineForOp> prefixLoops =
+      getMissingConsumerPrefixLoops(producer, consumer);
+
   // Cross-step handling is needed when the first inner loop (column-batching
   // loop, allLoops[0]) has a different step between producer and consumer.
   // The scratchLoop itself typically has step=1 for both, so we must compare
   // allLoops[0] steps rather than scratchLoop steps.
-  bool needsCrossStep = consumer.allLoops.size() >= 2 &&
+  size_t targetRank = producer.scratchShape.size();
+  size_t consumerRank = 1 + consumer.allLoops.size();
+  bool needsCrossStep = prefixLoops.empty() && targetRank == consumerRank &&
+                        consumer.allLoops.size() >= 2 &&
                         !producer.allLoops.empty() &&
                         producer.allLoops.front().getStepAsInt() !=
                             consumer.allLoops.front().getStepAsInt();
@@ -458,6 +500,9 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
     // Build the straightforward consumer index including any shared prefix
     // loops.
     auto addLoop = [&](affine::AffineForOp loop) {
+      if (exprs.size() == targetRank) {
+        return;
+      }
       operands.push_back(loop.getInductionVar());
       AffineExpr dim = getAffineDimExpr(dimIdx++, ctx);
       int64_t lb = loop.getConstantLowerBound();
@@ -471,7 +516,7 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
       exprs.push_back(dim);
     };
 
-    for (auto prefixLoop : getMissingConsumerPrefixLoops(producer, consumer)) {
+    for (auto prefixLoop : prefixLoops) {
       addLoop(prefixLoop);
     }
     addLoop(consumer.scratchLoop);
@@ -512,7 +557,7 @@ getConsumerScratchAccessMap(ScratchLoopInfo &producer,
     return dim;
   };
 
-  for (auto prefixLoop : getMissingConsumerPrefixLoops(producer, consumer)) {
+  for (auto prefixLoop : prefixLoops) {
     exprs.push_back(addLoop(prefixLoop));
   }
 
@@ -831,6 +876,15 @@ static bool fuseOuterScfLoops(SmallVector<affine::AffineForOp> &scratchLoops,
   return true;
 }
 
+static bool containsUnsafeFusedConsumer(ArrayRef<affine::AffineForOp> loops) {
+  return llvm::any_of(loops, [](affine::AffineForOp loop) {
+    return loop.walk([](Operation *op) {
+      return isa<TileDivOp, TileWhereOp>(op) ? WalkResult::interrupt()
+                                             : WalkResult::advance();
+    }).wasInterrupted();
+  });
+}
+
 static SmallVector<IntermediateAllocInfo>
 findIntermediates(GenericOp genericOp,
                   SmallVectorImpl<ScratchLoopInfo> &scratchLoops) {
@@ -987,6 +1041,10 @@ fuseScratchLoopSiblings(GenericOp genericOp,
       loopsToFuse.push_back(scratchSpaceLoops[i]);
     }
 
+    if (containsUnsafeFusedConsumer(loopsToFuse)) {
+      break;
+    }
+
     if (manuallyFuseScratchLoopGroup(loopsToFuse, rewriter)) {
       scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
       changed = madeProgress = true;
@@ -1037,10 +1095,35 @@ private:
       return success();
     }
 
-    // Regather, fuse sibling loops and gather again.
+    // Regather, then only fuse sibling scratch loops when the unfused scratch
+    // demand cannot fit in the available scratch buffer.
     scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
-    fuseScratchLoopSiblings(genericOp, scratchSpaceLoops, rewriter);
-    scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
+    bool needsSiblingFusionForCapacity = true;
+    if (std::optional<int64_t> capacity = getScratchCapacity(genericOp)) {
+      SmallVector<ScratchLoopInfo> preSiblingFusionScratchLoops;
+      for (auto scratchLoop : scratchSpaceLoops) {
+        ScratchLoopInfo info;
+        info.scratchLoop = scratchLoop;
+        info.linalgRoot = findLinalgRootLoop(scratchLoop);
+        if (!info.linalgRoot) {
+          continue;
+        }
+        collectAllInnerLoops(scratchLoop, info.allLoops);
+        if (computeScratchShape(info)) {
+          preSiblingFusionScratchLoops.push_back(info);
+        }
+      }
+
+      int64_t demand = estimateScratchDemand(
+          findIntermediates(genericOp, preSiblingFusionScratchLoops));
+      needsSiblingFusionForCapacity =
+          demand == ShapedType::kDynamic || demand > *capacity;
+    }
+
+    if (needsSiblingFusionForCapacity) {
+      fuseScratchLoopSiblings(genericOp, scratchSpaceLoops, rewriter);
+      scratchSpaceLoops = collectScratchSpaceLoops(genericOp);
+    }
 
     // Collect structural information for each scratch_space_loop.
     //

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
@@ -15,16 +16,6 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-
-// Calculate total number of elements in a statically-shaped memref.
-static int64_t getNumElements(MemRefType memrefType) {
-  int64_t numElements = 1;
-  for (int64_t dim : memrefType.getShape()) {
-    assert(dim != ShapedType::kDynamic && "scratch memrefs must be static");
-    numElements *= dim;
-  }
-  return numElements;
-}
 
 // Information about a single scratch allocation.
 struct ScratchAllocationInfo {
@@ -81,8 +72,11 @@ private:
     SmallVector<ScratchAllocationInfo> allocations;
     region.walk([&](ScratchAllocateOp allocOp) {
       auto memrefType = mlir::cast<MemRefType>(allocOp.getResult().getType());
+      assert(!llvm::is_contained(memrefType.getShape(), ShapedType::kDynamic) &&
+             "scratch memrefs must be static");
       allocations.push_back({allocOp, static_cast<int64_t>(allocOp.getSlot()),
-                             getNumElements(memrefType),
+                             ttmlir::utils::volume<int64_t>(
+                                 memrefType.getShape()),
                              /*elementOffset=*/0});
     });
 
@@ -105,7 +99,11 @@ private:
     }
 
     // Verify allocations fit in the scratch buffer.
-    int64_t scratchCapacity = getNumElements(scratchMemRefType);
+    assert(!llvm::is_contained(scratchMemRefType.getShape(),
+                               ShapedType::kDynamic) &&
+           "scratch memrefs must be static");
+    int64_t scratchCapacity =
+        ttmlir::utils::volume<int64_t>(scratchMemRefType.getShape());
     if (currentOffset > scratchCapacity) {
       return genericOp.emitOpError()
              << "total scratch allocations (" << currentOffset

--- a/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerScratchAllocate.cpp
@@ -74,10 +74,10 @@ private:
       auto memrefType = mlir::cast<MemRefType>(allocOp.getResult().getType());
       assert(!llvm::is_contained(memrefType.getShape(), ShapedType::kDynamic) &&
              "scratch memrefs must be static");
-      allocations.push_back({allocOp, static_cast<int64_t>(allocOp.getSlot()),
-                             ttmlir::utils::volume<int64_t>(
-                                 memrefType.getShape()),
-                             /*elementOffset=*/0});
+      allocations.push_back(
+          {allocOp, static_cast<int64_t>(allocOp.getSlot()),
+           ttmlir::utils::volume<int64_t>(memrefType.getShape()),
+           /*elementOffset=*/0});
     });
 
     if (allocations.empty()) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -538,4 +538,17 @@ void NocAsyncWriteBarrierOp::getCanonicalizationPatterns(
   });
 }
 
+void UnpackStallOnPackOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  patterns.add(+[](UnpackStallOnPackOp op,
+                   mlir::PatternRewriter &rewriter) -> mlir::LogicalResult {
+    if (!mlir::isa_and_nonnull<UnpackStallOnPackOp>(op->getPrevNode())) {
+      return mlir::failure();
+    }
+
+    rewriter.eraseOp(op);
+    return mlir::success();
+  });
+}
+
 } // namespace mlir::tt::ttkernel

--- a/test/python/golden/d2m/test_binary_tree.py
+++ b/test/python/golden/d2m/test_binary_tree.py
@@ -49,15 +49,6 @@ def test_binary_tree(
             right = builder.add(in2, in3)
             return builder.add(left, right)
 
-    if (
-        shape == (2048, 2048)
-        and dtype == torch.bfloat16
-        and get_board_id(system_desc) == "p150"
-    ):
-        pytest.skip("See issue https://github.com/tenstorrent/tt-mlir/issues/8120")
-    if shape == (2048, 2048) and dtype == torch.float32:
-        pytest.skip("See issue https://github.com/tenstorrent/tt-mlir/issues/8120")
-
     compile_and_execute_ttir(
         module,
         **get_request_kwargs(request),

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -558,3 +558,86 @@ func.func @outer_scf_loops_get_fused(
   }
   return
 }
+
+// ---------------------------------------------------------------------------
+// Test: dependence-related sibling scratch_space_loop nests with a matching
+//       affine prefix are fused under one shared prefix before spill insertion.
+//       Scratch shapes must omit that shared row dimension, and inter-loop
+//       unpack_stall_on_pack ordering must be preserved inside the fused loop.
+// ---------------------------------------------------------------------------
+
+// CHECK-LABEL: func.func @dependent_sibling_scratch_loops_get_fused
+// CHECK-DAG:   %[[SCRATCH_A:.*]] = d2m.scratch_allocate {slot = 0 : i64} : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-DAG:   %[[SCRATCH_B:.*]] = d2m.scratch_allocate {slot = 1 : i64} : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK-NOT:   memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+// CHECK:       affine.for {{.*}} = 0 to 2
+// CHECK:       "d2m.tile_exp"
+// CHECK:       affine.store {{.*}}, %[[SCRATCH_A]]
+// CHECK:       "d2m.tile_sin"
+// CHECK:       affine.store {{.*}}, %[[SCRATCH_B]]
+// CHECK:       d2m.unpack_stall_on_pack
+// CHECK:       affine.load %[[SCRATCH_A]]
+// CHECK:       affine.load %[[SCRATCH_B]]
+// CHECK:       "d2m.tile_add"
+// CHECK:       } {d2m.scratch_inserted, d2m.scratch_space_loop}
+func.func @dependent_sibling_scratch_loops_get_fused(
+    %in0  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %in1  : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+    %out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>,
+               indexing_maps = [], iterator_types = [],
+               threads = [#d2m.thread<unified>]}
+      ins(%in0, %in1 :
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>,
+          memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>)
+      outs(%out0 : memref<1x1x2x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>) {
+  ^unified0:
+    %cb0_raw = d2m.get_cb(0) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb1_raw = d2m.get_cb(1) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb2_raw = d2m.get_cb(2) : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+    %cb0 = d2m.wait %cb0_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb1 = d2m.wait %cb1_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %cb2 = d2m.reserve %cb2_raw
+        : !d2m.cb<memref<2x1x!ttcore.tile<32x32, bf16>, #l1>>
+        -> memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp_a = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    %tmp_b = memref.alloc() {alignment = 64 : i64}
+        : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        affine.for %k = 0 to 1 {
+          %v = affine.load %cb0[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          %r = "d2m.tile_exp"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+          affine.store %r, %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        } {d2m.linalg_root}
+      }
+    } {d2m.scratch_space_loop}
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        affine.for %k = 0 to 1 {
+          %v = affine.load %cb1[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          %r = "d2m.tile_sin"(%v) : (!ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+          affine.store %r, %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        } {d2m.linalg_root}
+      }
+    } {d2m.scratch_space_loop}
+    d2m.unpack_stall_on_pack
+    affine.for %i = 0 to 2 {
+      affine.for %j = 0 to 1 {
+        affine.for %k = 0 to 1 {
+          %va = affine.load %tmp_a[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          %vb = affine.load %tmp_b[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+          %r = "d2m.tile_add"(%va, %vb)
+              : (!ttcore.tile<32x32, bf16>, !ttcore.tile<32x32, bf16>) -> !ttcore.tile<32x32, bf16>
+          affine.store %r, %cb2[%i, %j] : memref<2x1x!ttcore.tile<32x32, bf16>, #l1>
+        } {d2m.linalg_root}
+      }
+    } {d2m.scratch_space_loop}
+  }
+  return
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_spill_and_scratch.mlir
@@ -576,6 +576,7 @@ func.func @outer_scf_loops_get_fused(
 // CHECK:       "d2m.tile_sin"
 // CHECK:       affine.store {{.*}}, %[[SCRATCH_B]]
 // CHECK:       d2m.unpack_stall_on_pack
+// CHECK-NOT:   d2m.unpack_stall_on_pack
 // CHECK:       affine.load %[[SCRATCH_A]]
 // CHECK:       affine.load %[[SCRATCH_B]]
 // CHECK:       "d2m.tile_add"

--- a/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
+++ b/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
@@ -24,9 +24,9 @@ func.func @test_consecutive_write_barriers() {
 // CHECK-LABEL: func.func @test_consecutive_unpack_stall_on_pack
 func.func @test_consecutive_unpack_stall_on_pack() {
   // CHECK: ttkernel.experimental::unpack_stall_on_pack
-  ttkernel.experimental::unpack_stall_on_pack
+  "ttkernel.experimental::unpack_stall_on_pack"() : () -> ()
   // CHECK-NOT: ttkernel.experimental::unpack_stall_on_pack
-  ttkernel.experimental::unpack_stall_on_pack
+  "ttkernel.experimental::unpack_stall_on_pack"() : () -> ()
   // CHECK: return
   return
 }

--- a/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
+++ b/test/ttmlir/Dialect/TTKernel/canonicalize_barriers.mlir
@@ -21,6 +21,16 @@ func.func @test_consecutive_write_barriers() {
   return
 }
 
+// CHECK-LABEL: func.func @test_consecutive_unpack_stall_on_pack
+func.func @test_consecutive_unpack_stall_on_pack() {
+  // CHECK: ttkernel.experimental::unpack_stall_on_pack
+  ttkernel.experimental::unpack_stall_on_pack
+  // CHECK-NOT: ttkernel.experimental::unpack_stall_on_pack
+  ttkernel.experimental::unpack_stall_on_pack
+  // CHECK: return
+  return
+}
+
 // CHECK-LABEL: func.func @test_read_then_write_barrier
 func.func @test_read_then_write_barrier() {
   // CHECK: ttkernel.noc_async_read_barrier


### PR DESCRIPTION
### Ticket
Solves #8120 

### Problem description
Encountered a 10x13 Blackhole regression when running fused D2M binary-tree pytests.

The original scratch spill path could produce scratch allocations that were too large for the available scratch buffer. The fix fused sibling scratch loops so producer and consumer work shared the same outer iteration space which exposed two additional issues:
- stale unpack_stall_on_pack ops could be carried over from the old unfused loop layout
- consumer scratch loads could miss prefix loop dimensions after fusion, producing rank-mismatched affine loads.

On simulator, the fused shape also exposed that experimental::unpack_stall_on_pack() was using PACK_DONE without initializing it first, causing a semaphore runtime error. 

### What's changed
- Fuse sibling scratch loops that are part of the same producer-to-consumer chain. 

```
Before:
scf.for { scratch_space_loop_1 { producer } }
scf.for { scratch_space_loop_2 { consumer } }

After:
scf.for {
    scratch_space_loop_1 { producer }
    scratch_space_loop_2 { consumer }
}
```
- Initialize PACK_DONE before posting in unpack_stall_on_pack. This is probably not the right ownership model and should be revisited. Issue here: #8144 
- With these new changes the pass is getting a bit large and should be split up into two separate passes. Issue here: #8145 
- New lit test added. bf16 p150 pytest restored.  