### PR TITLE
Add prepare conv3d weights op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1772,6 +1772,20 @@ def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias", [TTNN_ComputeKerne
     let hasVerifier = 1;
 }
 
+def TTNN_PrepareConv3dWeightsOp : TTNN_Op<"prepare_conv3d_weights"> {
+    let summary = "Prepares conv3d weights so that they can be consumed by the conv3d op.";
+
+    let arguments = (ins AnyRankedTensor:$weight_tensor,
+                         I32Attr:$groups,
+                         I32Attr:$c_in_block,
+                         I32Attr:$alignment,
+                         TTNN_Device:$device);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_PrepareConvTranspose2dWeightsOp : TTNN_Op<"prepare_conv_transpose2d_weights", [TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Prepares conv_transpose2d weights so that they can be consumed by the conv_transpose2d op.";
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1783,6 +1783,13 @@ def TTNN_PrepareConv3dWeightsOp : TTNN_Op<"prepare_conv3d_weights"> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createPrepareConv3dWeightsOpOperandsWorkarounds();
+      }
+    }];
+
     let hasVerifier = 1;
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -372,6 +372,11 @@ public:
   // Issue page: https://github.com/tenstorrent/tt-metal/issues/39126
   static TTNNOperandsWorkarounds createSparseMatmulOpOperandsWorkarounds();
 
+  // Create workarounds for prepare_conv3d_weights op operands.
+  // Weight tensor must be in system memory and ROW_MAJOR layout.
+  static TTNNOperandsWorkarounds
+  createPrepareConv3dWeightsOpOperandsWorkarounds();
+
   // Create workarounds for all_to_all_dispatch op operands.
   // Expert indices and mapping require uint16 dtype and ROW_MAJOR layout.
   // Issue page: https://github.com/tenstorrent/tt-metal/issues/39127

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -65,6 +65,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/embedding_backward/embedding_backward.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d.hpp"
+#include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/dropout/dropout.hpp"
 #include "ttnn/operations/experimental/paged_cache/paged_cache.hpp"
 #include "ttnn/operations/experimental/topk_router_gpt/topk_router_gpt.hpp"

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -93,6 +93,15 @@ table PrepareConv2dBiasOp {
   conv2d_slice_config: tt.target.ttnn.Conv2dSliceConfig;
 }
 
+table PrepareConv3dWeightsOp {
+  weight_tensor: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  groups: uint32;
+  c_in_block: uint32;
+  alignment: uint32;
+  device: tt.target.DeviceRef;
+}
+
 table PrepareConvTranspose2dWeightsOp {
   weight_tensor: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -109,6 +109,7 @@ union OpType {
   Pool2dOp,
   PrepareConv2dBiasOp,
   PrepareConv2dWeightsOp,
+  PrepareConv3dWeightsOp,
   PrepareConvTranspose2dBiasOp,
   PrepareConvTranspose2dWeightsOp,
   RandOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1996,14 +1996,29 @@ public:
     auto outputDtypeAttr =
         rewriter.getAttr<ttcore::DataTypeAttr>(outputLayoutAttr.getDataType());
 
-    // Preserve TT-Metal's default conv3d behavior when no config is attached to
-    // the lowered TTNN op. Weight preparation must use C_in_block = 0 as well,
-    // otherwise the weights are pre-blocked differently from runtime defaults.
-    // Current tt-metal default conv3d config sets C_in_block = TILE_WIDTH.
     constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
-    Value reshapedWeight = reshapeWeightForConv3d(adaptor.getWeight(), weightTy,
-                                                  rewriter, op.getLoc(),
-                                                  /*cInBlock=*/TILE_WIDTH);
+    constexpr int64_t ALIGNMENT = TILE_WIDTH;
+
+    auto weightShape = weightTy.getShape();
+    int64_t outChannels = weightShape[0];
+    int64_t inChannelsPerGroup = weightShape[1];
+    int64_t kernelDepth = weightShape[2];
+    int64_t kernelHeight = weightShape[3];
+    int64_t kernelWidth = weightShape[4];
+    int64_t cInAligned =
+        llvm::divideCeil(inChannelsPerGroup, ALIGNMENT) * ALIGNMENT;
+    int64_t numCInBlocks = cInAligned / TILE_WIDTH;
+    llvm::SmallVector<int64_t> preparedWeightShape = {
+        numCInBlocks * kernelDepth * kernelHeight * kernelWidth * TILE_WIDTH,
+        outChannels};
+    auto preparedWeightType = ttnn::utils::RankedTensorTypeFactory::create(
+        weightTy, preparedWeightShape);
+    Value reshapedWeight = rewriter.create<ttnn::PrepareConv3dWeightsOp>(
+        ttmlir::utils::appendLocationSuffix(op.getLoc(),
+                                            "_prepare_conv3d_weight"),
+        preparedWeightType, adaptor.getWeight(), groupsAttr,
+        rewriter.getI32IntegerAttr(TILE_WIDTH),
+        rewriter.getI32IntegerAttr(ALIGNMENT), device);
 
     // Reshape bias tensor: (1, 1, 1, 1, O) → (1, O)
     Value reshapedBias = adaptor.getBias();
@@ -2068,81 +2083,6 @@ private:
 
     return llvm::createStringError("Unexpected attribute type for '%s'",
                                    attrName.data());
-  }
-
-  // Transforms: (O, C/G, K_D, K_H, K_W) →
-  //   (num_C_in_blocks * K_D * K_H * K_W * C_in_block, O)
-  // When cInBlock == 0, uses full padded C (no blocking).
-  Value reshapeWeightForConv3d(Value weight, RankedTensorType weightTy,
-                               PatternRewriter &rewriter, Location loc,
-                               uint32_t cInBlock = 0) const {
-    constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
-
-    llvm::ArrayRef<int64_t> weightShape = weightTy.getShape();
-    int64_t outChannels = weightShape[0];
-    int64_t inChannPerGroup = weightShape[1];
-    int64_t kernelDepth = weightShape[2];
-    int64_t kernelHeight = weightShape[3];
-    int64_t kernelWidth = weightShape[4];
-
-    // Step 1: Permute (O, C/G, K_D, K_H, K_W) → (K_D, K_H, K_W, C/G, O)
-    Value result = ttir_to_ttnn::utils::generatePermute(
-        mlir::cast<TypedValue<RankedTensorType>>(weight), {2, 3, 4, 1, 0},
-        rewriter, loc);
-
-    // Step 2: Pad C/G to tile width alignment
-    int64_t cInAligned =
-        llvm::divideCeil(inChannPerGroup, TILE_WIDTH) * TILE_WIDTH;
-    if (cInAligned != inChannPerGroup) {
-      int32_t cinPadAmount = static_cast<int32_t>(cInAligned - inChannPerGroup);
-      llvm::SmallVector<int32_t> padding = {0, 0, 0, 0, 0, 0, 0, cinPadAmount,
-                                            0, 0};
-      result = ttir_to_ttnn::utils::generatePad(
-          mlir::cast<TypedValue<RankedTensorType>>(result), padding, rewriter,
-          ttmlir::utils::appendLocationSuffix(loc, "_pad_cin"));
-    }
-
-    // Step 3: Block C_in and reorder so num_C_in_blocks is outermost
-    // cInBlock == 0 means use full cInAligned (no blocking).
-    if (cInBlock == 0) {
-      cInBlock = cInAligned;
-    }
-    int64_t numCInBlocks = cInAligned / cInBlock;
-
-    if (numCInBlocks > 1) {
-      // Reshape 5D→6D: (K_D, K_H, K_W, C_aligned, O)
-      //              → (K_D, K_H, K_W, num_blocks, C_in_block, O)
-      llvm::SmallVector<int64_t> blockedShape = {kernelDepth, kernelHeight,
-                                                 kernelWidth, numCInBlocks,
-                                                 cInBlock,    outChannels};
-      llvm::SmallVector<int32_t> blockedShapeI32(blockedShape.begin(),
-                                                 blockedShape.end());
-      auto curTy = mlir::cast<RankedTensorType>(result.getType());
-      auto blockedTy =
-          ttnn::utils::RankedTensorTypeFactory::create(curTy, blockedShape);
-      result = rewriter.create<ttnn::ReshapeOp>(
-          loc, blockedTy, result, rewriter.getI32ArrayAttr(blockedShapeI32));
-
-      // Permute 6D: (K_D, K_H, K_W, num_blocks, C_in_block, O)
-      //           → (num_blocks, K_D, K_H, K_W, C_in_block, O)
-      result = ttir_to_ttnn::utils::generatePermute(
-          mlir::cast<TypedValue<RankedTensorType>>(result), {3, 0, 1, 2, 4, 5},
-          rewriter, ttmlir::utils::appendLocationSuffix(loc, "_block_permute"));
-    }
-
-    // Step 4: Flatten to 2D
-    int64_t flattenedDim =
-        numCInBlocks * kernelDepth * kernelHeight * kernelWidth * cInBlock;
-    llvm::SmallVector<int64_t> finalShape = {flattenedDim, outChannels};
-    llvm::SmallVector<int32_t> finalShapeI32(finalShape.begin(),
-                                             finalShape.end());
-
-    auto resultTy = mlir::cast<RankedTensorType>(result.getType());
-    RankedTensorType outputType =
-        ttnn::utils::RankedTensorTypeFactory::create(resultTy, finalShape);
-
-    return rewriter.create<ttnn::ReshapeOp>(
-        loc, outputType, result, rewriter.getI32ArrayAttr(finalShapeI32));
   }
 
   // Transforms bias tensor to 2D: (1, 1, 1, 1, O) → (1, O)

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2013,12 +2013,13 @@ public:
         outChannels};
     auto oldWeightLayout =
         mlir::cast<ttnn::TTNNLayoutAttr>(weightTy.getEncoding());
-    auto preparedWeightLayout = ttnn::TTNNLayoutAttr::get(
-        rewriter.getContext(), preparedWeightShape,
-        oldWeightLayout.getScalarElementType(), ttnn::BufferType::DRAM,
-        oldWeightLayout.getGrid(),
-        ttnn::TensorMemoryLayoutAttr::get(
-            rewriter.getContext(), ttnn::TensorMemoryLayout::Interleaved));
+    auto preparedWeightLayout =
+        ttnn::TTNNLayoutAttr::Builder(rewriter.getContext(),
+                                      preparedWeightShape,
+                                      oldWeightLayout.getScalarElementType())
+            .setBufferType(ttnn::BufferType::DRAM)
+            .setMemoryLayout(ttnn::TensorMemoryLayout::Interleaved)
+            .build();
     auto preparedWeightType = mlir::RankedTensorType::get(
         preparedWeightShape, oldWeightLayout.getScalarElementType(),
         preparedWeightLayout);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2011,8 +2011,17 @@ public:
     llvm::SmallVector<int64_t> preparedWeightShape = {
         numCInBlocks * kernelDepth * kernelHeight * kernelWidth * TILE_WIDTH,
         outChannels};
-    auto preparedWeightType = ttnn::utils::RankedTensorTypeFactory::create(
-        weightTy, preparedWeightShape);
+    auto oldWeightLayout =
+        mlir::cast<ttnn::TTNNLayoutAttr>(weightTy.getEncoding());
+    auto preparedWeightLayout = ttnn::TTNNLayoutAttr::get(
+        rewriter.getContext(), preparedWeightShape,
+        oldWeightLayout.getScalarElementType(), ttnn::BufferType::DRAM,
+        oldWeightLayout.getGrid(),
+        ttnn::TensorMemoryLayoutAttr::get(
+            rewriter.getContext(), ttnn::TensorMemoryLayout::Interleaved));
+    auto preparedWeightType = mlir::RankedTensorType::get(
+        preparedWeightShape, oldWeightLayout.getScalarElementType(),
+        preparedWeightLayout);
     Value reshapedWeight = rewriter.create<ttnn::PrepareConv3dWeightsOp>(
         ttmlir::utils::appendLocationSuffix(op.getLoc(),
                                             "_prepare_conv3d_weight"),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1431,6 +1431,49 @@ public:
 };
 } // namespace
 
+// PrepareConv3dWeights op conversion pattern
+//
+namespace {
+class PrepareConv3dWeightsOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::PrepareConv3dWeightsOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.prepare_conv3d_weights";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::operations::experimental::conv3d::prepare_conv3d_weights";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::PrepareConv3dWeightsOp>::
+      TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::PrepareConv3dWeightsOp srcOp,
+                  mlir::tt::ttnn::PrepareConv3dWeightsOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::PrepareConv3dWeightsOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getWeightTensor()),
+        emitter.emit(srcOp.getGroups()),
+        emitter.emit(srcOp.getCInBlock()),
+        emitter.emit(srcOp.getAlignment()),
+        emitter.emit(srcOp.getDevice()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // PrepareConvTranspose2dWeights op conversion pattern
 //
 namespace {
@@ -5383,6 +5426,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<PrepareConv2dWeightsOpConversionPattern>(typeConverter, ctx);
   patterns.add<PrepareConv2dBiasOpConversionPattern>(typeConverter, ctx);
+  patterns.add<PrepareConv3dWeightsOpConversionPattern>(typeConverter, ctx);
   patterns.add<PrepareConvTranspose2dWeightsOpConversionPattern>(typeConverter,
                                                                  ctx);
   patterns.add<PrepareConvTranspose2dBiasOpConversionPattern>(typeConverter,

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -1828,6 +1828,49 @@ public:
 };
 } // namespace
 
+// PrepareConv3dWeights op conversion pattern
+//
+namespace {
+class PrepareConv3dWeightsOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::PrepareConv3dWeightsOp> {
+
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.prepare_conv3d_weights";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn.experimental.prepare_conv3d_weights";
+  }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::PrepareConv3dWeightsOp>::
+      TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::PrepareConv3dWeightsOp srcOp,
+                  mlir::tt::ttnn::PrepareConv3dWeightsOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::PrepareConv3dWeightsOp>
+        emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getWeightTensor(), "weight_tensor"),
+        emitter.emit(srcOp.getGroups(), "groups"),
+        emitter.emit(srcOp.getCInBlock(), "C_in_block"),
+        emitter.emit(srcOp.getAlignment(), "alignment"),
+        emitter.emit(srcOp.getDevice(), "device"),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // PrepareConvTranspose2dWeights op conversion pattern
 //
 namespace {
@@ -5131,6 +5174,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<Conv2dOpConversionPattern, ConvTranspose2dOpConversionPattern,
                PrepareConv2dWeightsOpConversionPattern,
                PrepareConv2dBiasOpConversionPattern,
+               PrepareConv3dWeightsOpConversionPattern,
                PrepareConvTranspose2dWeightsOpConversionPattern,
                PrepareConvTranspose2dBiasOpConversionPattern,
                Conv3dOpConversionPattern>(typeConverter, ctx);

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -387,6 +387,81 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// PrepareConv3dWeightsOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::PrepareConv3dWeightsOp::verify() {
+  mlir::RankedTensorType weightType = getWeightTensor().getType();
+  mlir::RankedTensorType resultType = getResult().getType();
+
+  if (weightType.getRank() != 5) {
+    return emitOpError("Weight must be a 5D tensor");
+  }
+
+  if (resultType.getRank() != 2) {
+    return emitOpError("Result must be a 2D tensor");
+  }
+
+  if (getGroups() <= 0) {
+    return emitOpError("Groups must be positive");
+  }
+
+  if (getCInBlock() < 0) {
+    return emitOpError("C_in_block must be non-negative");
+  }
+
+  if (getAlignment() <= 0) {
+    return emitOpError("Alignment must be positive");
+  }
+
+  if (llvm::any_of(weightType.getShape(), ShapedType::isDynamic) ||
+      llvm::any_of(resultType.getShape(), ShapedType::isDynamic)) {
+    return success();
+  }
+
+  constexpr unsigned int WEIGHT_OUT_CHANNEL_DIM = 0;
+  constexpr unsigned int WEIGHT_IN_CHANNEL_DIM = 1;
+  constexpr unsigned int WEIGHT_KERNEL_DEPTH_DIM = 2;
+  constexpr unsigned int WEIGHT_KERNEL_HEIGHT_DIM = 3;
+  constexpr unsigned int WEIGHT_KERNEL_WIDTH_DIM = 4;
+
+  int64_t outChannels = weightType.getShape()[WEIGHT_OUT_CHANNEL_DIM];
+  int64_t inChannels =
+      weightType.getShape()[WEIGHT_IN_CHANNEL_DIM] * getGroups();
+  int64_t alignment = getAlignment();
+  int64_t cInAligned = llvm::divideCeil(inChannels, alignment) * alignment;
+  int64_t cInBlock = getCInBlock() == 0 ? cInAligned : getCInBlock();
+
+  if (cInAligned % cInBlock != 0) {
+    return emitOpError() << "C_in_block (" << cInBlock
+                         << ") must divide aligned input channels ("
+                         << cInAligned << ")";
+  }
+
+  int64_t numCInBlocks = cInAligned / cInBlock;
+  int64_t flattenedDim =
+      numCInBlocks * weightType.getShape()[WEIGHT_KERNEL_DEPTH_DIM] *
+      weightType.getShape()[WEIGHT_KERNEL_HEIGHT_DIM] *
+      weightType.getShape()[WEIGHT_KERNEL_WIDTH_DIM] * cInBlock;
+
+  if (resultType.getShape()[0] != flattenedDim) {
+    return emitOpError()
+           << "Expected result first dimension (" << resultType.getShape()[0]
+           << ") to match prepared conv3d weight flattened dimension ("
+           << flattenedDim << ")";
+  }
+
+  if (resultType.getShape()[1] != outChannels) {
+    return emitOpError() << "Expected result second dimension ("
+                         << resultType.getShape()[1]
+                         << ") to match output channels (" << outChannels
+                         << ")";
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PrepareConvTranspose2dWeightsOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -362,6 +362,19 @@ TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
       .addOutputOperandWorkaround(hostRowMajorWorkaround);
 }
 
+TTNNOperandsWorkarounds TTNNOperandsWorkaroundsFactory::
+    createPrepareConv3dWeightsOpOperandsWorkarounds() {
+  TTNNOperandWorkarounds hostRowMajorWorkaround;
+  hostRowMajorWorkaround.tensorBufferTypeWorkaround = BufferType::SystemMemory;
+  hostRowMajorWorkaround.tensorMemoryLayoutWorkaround =
+      TensorMemoryLayoutAttr();
+  hostRowMajorWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(hostRowMajorWorkaround)
+      .addOutputOperandWorkaround(TTNNOperandWorkarounds());
+}
+
 // Factory method to create a set of workarounds for where op operands.
 // tt-metal uses predicate type for where op operation. If the predicate data
 // type does not match with inputs/output data type; tt-metal can generate

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -3556,6 +3556,25 @@ PrepareConv2dBiasOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// PrepareConv3dWeightsOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv3dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+PrepareConv3dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // PrepareConvTranspose2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -748,5 +748,6 @@ const std::set<mlir::StringRef>
         ttnn::ScatterOp::getOperationName(),
         // TopK's operands workaround forces input bf16 + indices ui16/ui32;
         // without it, opt_level>=1 dtype propagation picks f32. See #8141.
-        ttnn::TopKOp::getOperationName()};
+        ttnn::TopKOp::getOperationName(),
+        ttnn::PrepareConv3dWeightsOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -749,5 +749,7 @@ const std::set<mlir::StringRef>
         // TopK's operands workaround forces input bf16 + indices ui16/ui32;
         // without it, opt_level>=1 dtype propagation picks f32. See #8141.
         ttnn::TopKOp::getOperationName(),
+        // PrepareConv3dWeightsOp is needed for conv3d and it requires ROW_MAJOR
+        // layout. See #8411.
         ttnn::PrepareConv3dWeightsOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -752,6 +752,21 @@ createOp(FlatbufferObjectCache &cache, PrepareConv2dBiasOp op) {
       computeConfig.value_or(0), sliceConfig.value_or(0));
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::PrepareConv3dWeightsOp>
+createOp(FlatbufferObjectCache &cache, PrepareConv3dWeightsOp op) {
+  auto weightTensor = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getWeightTensor()));
+  auto output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+
+                                  /*local_shape*/ std::nullopt);
+  auto device = getOperandThroughDPSOps(op.getDevice());
+
+  return ::tt::target::ttnn::CreatePrepareConv3dWeightsOp(
+      *cache.fbb, weightTensor, output, op.getGroups(), op.getCInBlock(),
+      op.getAlignment(), cache.at<::tt::target::DeviceRef>(device));
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::PrepareConvTranspose2dWeightsOp>
 createOp(FlatbufferObjectCache &cache, PrepareConvTranspose2dWeightsOp op) {
   auto weightTensor = cache.at<::tt::target::ttnn::TensorRef>(
@@ -4356,6 +4371,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto prepareConv2dBiasOp = dyn_cast<PrepareConv2dBiasOp>(op);
       prepareConv2dBiasOp) {
     return createOperation(cache, createOp(cache, prepareConv2dBiasOp),
+                           debugString, locInfo);
+  }
+  if (auto prepareConv3dWeightsOp = dyn_cast<PrepareConv3dWeightsOp>(op);
+      prepareConv3dWeightsOp) {
+    return createOperation(cache, createOp(cache, prepareConv3dWeightsOp),
                            debugString, locInfo);
   }
   if (auto prepareConvTranspose2dWeightsOp =

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -39,6 +39,7 @@
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/operations/experimental/ccl/moe/selective_reduce_combine/selective_reduce_combine.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d.hpp"
+#include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/paged_cache/paged_cache.hpp"
 #include "ttnn/operations/experimental/topk_router_gpt/topk_router_gpt.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv2d_weights.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv2d_bias.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv3d_weights.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv_transpose2d_weights.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv_transpose2d_bias.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv3d.cpp

--- a/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/conv/prepare_conv3d_weights.h"
+
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+namespace tt::runtime::ttnn::operations::conv {
+void run(const ::tt::target::ttnn::PrepareConv3dWeightsOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &weightTensor =
+      tensorPool.getTTNNTensorAndValidate(op->weight_tensor());
+
+  ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
+  ::ttnn::Tensor out =
+      ::ttnn::operations::experimental::conv3d::prepare_conv3d_weights(
+          weightTensor, op->groups(), op->c_in_block(), op->alignment(),
+          &targetDevice);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+} // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.h
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv3d_weights.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CONV_PREPARE_CONV3D_WEIGHTS_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CONV_PREPARE_CONV3D_WEIGHTS_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::conv {
+void run(const ::tt::target::ttnn::PrepareConv3dWeightsOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::conv
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -31,6 +31,7 @@
 #include "operations/conv/conv_transpose2d.h"
 #include "operations/conv/prepare_conv2d_bias.h"
 #include "operations/conv/prepare_conv2d_weights.h"
+#include "operations/conv/prepare_conv3d_weights.h"
 #include "operations/conv/prepare_conv_transpose2d_bias.h"
 #include "operations/conv/prepare_conv_transpose2d_weights.h"
 #include "operations/cpu/cpu.h"
@@ -482,6 +483,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::PrepareConv2dBiasOp: {
     return operations::conv::run(op->type_as_PrepareConv2dBiasOp(),
+                                 getContext());
+  }
+  case ::tt::target::ttnn::OpType::PrepareConv3dWeightsOp: {
+    return operations::conv::run(op->type_as_PrepareConv3dWeightsOp(),
                                  getContext());
   }
   case ::tt::target::ttnn::OpType::PrepareConvTranspose2dWeightsOp: {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1243,6 +1243,10 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     tensorRefs = {opContext.type_as_PrepareConv2dBiasOp()->out()};
     break;
   }
+  case ::tt::target::ttnn::OpType::PrepareConv3dWeightsOp: {
+    tensorRef = opContext.type_as_PrepareConv3dWeightsOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::PrepareConvTranspose2dWeightsOp: {
     tensorRefs = {opContext.type_as_PrepareConvTranspose2dWeightsOp()->out()};
     break;
@@ -1755,6 +1759,10 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   }
   case ::tt::target::ttnn::OpType::PrepareConv2dBiasOp: {
     tensorRefs = {opContext.type_as_PrepareConv2dBiasOp()->bias_tensor()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::PrepareConv3dWeightsOp: {
+    tensorRefs = {opContext.type_as_PrepareConv3dWeightsOp()->weight_tensor()};
     break;
   }
   case ::tt::target::ttnn::OpType::PrepareConvTranspose2dWeightsOp: {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1244,7 +1244,7 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     break;
   }
   case ::tt::target::ttnn::OpType::PrepareConv3dWeightsOp: {
-    tensorRef = opContext.type_as_PrepareConv3dWeightsOp()->out();
+    tensorRefs = {opContext.type_as_PrepareConv3dWeightsOp()->out()};
     break;
   }
   case ::tt::target::ttnn::OpType::PrepareConvTranspose2dWeightsOp: {

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv3d_typecast_workaround.mlir
@@ -5,10 +5,8 @@
 module {
   func.func public @test_conv3d_f32_to_bf16(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK: "ttnn.to_layout"{{.*}}dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK: "ttnn.to_layout"{{.*}}dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{
@@ -22,12 +20,9 @@ module {
 
   func.func public @test_conv3d_f32_to_bf16_with_bias(%arg0: tensor<1x8x28x28x4xf32>, %arg1: tensor<16x4x3x3x3xf32>, %arg2: tensor<1x1x1x1x16xf32>) -> tensor<1x6x26x26x16xf32> {
     // CHECK-LABEL: func.func public @test_conv3d_f32_to_bf16_with_bias
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
-    // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK: "ttnn.to_layout"{{.*}}dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK: "ttnn.to_layout"{{.*}}dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK: "ttnn.to_layout"{{.*}}dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1, %arg2)
             <{

--- a/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_positive.mlir
@@ -3,7 +3,7 @@
 module {
   // Test simple 3D convolution
   func.func @conv3d_simple(%arg0: tensor<1x8x28x28x4xbf16>, %arg1: tensor<16x4x3x3x3xbf16>) -> tensor<1x6x26x26x16xbf16> {
-    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{
@@ -17,7 +17,7 @@ module {
 
   // Test 3D convolution with stride
   func.func @conv3d_with_stride(%arg0: tensor<1x8x28x28x16xbf16>, %arg1: tensor<32x16x3x3x3xbf16>) -> tensor<1x4x14x14x32xbf16> {
-    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{
@@ -31,7 +31,7 @@ module {
 
   // Test 3D convolution with bias
   func.func @conv3d_with_bias(%arg0: tensor<1x8x28x28x4xbf16>, %arg1: tensor<16x4x3x3x3xbf16>, %arg2: tensor<1x1x1x1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
-    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1, %arg2)
             <{
@@ -45,7 +45,7 @@ module {
 
   // Test 3D convolution with different padding mode
   func.func @conv3d_padding_replicate(%arg0: tensor<1x8x28x28x4xbf16>, %arg1: tensor<16x4x3x3x3xbf16>) -> tensor<1x8x28x28x16xbf16> {
-    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK: "ttnn.conv3d"
     // CHECK-SAME: padding_mode = "replicate"
     %0 = "ttir.conv3d"(%arg0, %arg1)
@@ -60,7 +60,7 @@ module {
 
   // Test 3D convolution with larger kernel
   func.func @conv3d_large_kernel(%arg0: tensor<1x16x32x32x8xbf16>, %arg1: tensor<32x8x5x5x5xbf16>) -> tensor<1x12x28x28x32xbf16> {
-    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.prepare_conv3d_weights"
     // CHECK: "ttnn.conv3d"
     %0 = "ttir.conv3d"(%arg0, %arg1)
             <{

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -33,6 +33,7 @@
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/operations/embedding_backward/embedding_backward.hpp"
 #include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
+#include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp"

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -33,6 +33,7 @@
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/operations/embedding_backward/embedding_backward.hpp"
 #include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
+#include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp"

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -37,6 +37,7 @@
 #include "operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.hpp"
 #include "operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
 #include "operations/experimental/conv3d/conv3d.hpp"
+#include "operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "operations/experimental/dropout/dropout.hpp"
 #include "operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp"
 #include "operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp"


### PR DESCRIPTION
### Problem description
PrepareConv3dWeights helper was introduced in TT-metal but was not used in compiler.

### What's changed
Added ttnn prepareConv3dWeights op and removed manual preparation of weights. Added explicit requirement that this op works on systemMemory RM tensor because ttnn helper expects that. 

### Checklist
- [x] New/Existing tests provide coverage for changes
