### PR TITLE
[hot fix] Fix mlir main due to stale merge (`distributed_rms_norm` tests) and ('Force UInt16 sparsity dtype for ttnn.sparse_matmul workaround')

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -32,7 +32,6 @@
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
     { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
     { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
-    { "runs-on": "llmbox", "image": "speedy", "script": "ttrt.sh", "args": ["run", "Dialect/TTNN/trace/scenarios/llmbox", "--enable-program-cache", "--loops", "3"] },
     { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },

--- a/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
+++ b/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
@@ -86,7 +86,6 @@ def test_sparse_matmul_b_sparse_f32_sparsity(target: str, request, device):
                 is_input_a_sparse=False,
                 is_input_b_sparse=True,
                 nnz=0,
-                output_shape=(2, 4, 1, 4, 32, 5760),
                 output_type=torch.bfloat16,
                 unit_attrs=unit_attrs,
             )

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -405,6 +405,8 @@ def test_distributed_rms_norm(
         (1, 1, 32, 512),
         (1, 1, 32, 4096),
         (1, 1, 32, 8192),
+        (32, 128),
+        (1, 32, 128),
     ]:
         pytest.skip(
             f"Hangs on n300 with has_weight=True and shape={shape} after metal uplift "


### PR DESCRIPTION
- Due to a stale merge of https://github.com/tenstorrent/tt-mlir/pull/8099 after https://github.com/tenstorrent/tt-mlir/pull/8116 was merged, mlir main broke.
- See some [failed jobs](https://github.com/tenstorrent/tt-mlir/actions/runs/25028120598/job/73305533609).
- This PR skips the problematic tests. 
- [This issue](https://github.com/tenstorrent/tt-mlir/issues/8129) tracks re-enabling these tests once we consume [metal's fix](https://github.com/tenstorrent/tt-metal/pull/43230)
- The [current uplift](https://github.com/tenstorrent/tt-mlir/pull/8147) will consume metal fix.