### PR TITLE
Adding parse/split support for stablehlo reduce and not

### DIFF
--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_not.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_not.mlir
@@ -1,0 +1,21 @@
+module @jit_not attributes {} {
+  func.func public @test_logical_not(%arg0: tensor<4xi1>) -> tensor<4xi1> {
+    %0 = stablehlo.not %arg0 : tensor<4xi1>
+    return %0 : tensor<4xi1>
+  }
+
+  func.func public @test_bitwise_not(%arg0: tensor<4xi32>) -> tensor<4xi32> {
+    %0 = stablehlo.not %arg0 : tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+
+  func.func public @test_not_2d(%arg0: tensor<2x3xi32>) -> tensor<2x3xi32> {
+    %0 = stablehlo.not %arg0 : tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+
+  func.func public @test_not_bool_2d(%arg0: tensor<3x4xi1>) -> tensor<3x4xi1> {
+    %0 = stablehlo.not %arg0 : tensor<3x4xi1>
+    return %0 : tensor<3x4xi1>
+  }
+}

--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_reduce.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_reduce.mlir
@@ -1,4 +1,3 @@
-
 module {
   func.func @forward_sum(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<3xf32> {
     %0 = "stablehlo.reduce"(%arg0, %arg1) ({

--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_reduce.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_reduce.mlir
@@ -1,0 +1,27 @@
+
+module {
+  func.func @forward_sum(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<3xf32> {
+    %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+      %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) {dimensions = array<i64: 0>} : (tensor<2x3xf32>, tensor<f32>) -> tensor<3xf32>
+    return %0 : tensor<3xf32>
+  }
+  func.func @forward_max(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<2xf32> {
+    %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+      %1 = stablehlo.maximum %arg2, %arg3 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) {dimensions = array<i64: 1>} : (tensor<2x3xf32>, tensor<f32>) -> tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+  func.func @forward_min(%arg0: tensor<4x5xf32>, %arg1: tensor<f32>) -> tensor<5xf32> {
+    %0 = "stablehlo.reduce"(%arg0, %arg1) ({
+    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+      %1 = stablehlo.minimum %arg2, %arg3 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) {dimensions = array<i64: 0>} : (tensor<4x5xf32>, tensor<f32>) -> tensor<5xf32>
+    return %0 : tensor<5xf32>
+  }
+}

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -1098,9 +1098,7 @@ def test_logical_binary_ops(
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.bool], ids=["bool"])
 @pytest.mark.parametrize("target", ["ttnn"])
-def test_logical_unary_ops(
-    shape: Shape, dtype: torch.dtype, target: str, request, device
-):
+def test_not(shape: Shape, dtype: torch.dtype, target: str, request, device):
     def module_not_(builder: StableHLOBuilder):
         @builder.func([(128, 128)], [torch.bool])
         def not_(
@@ -1277,102 +1275,25 @@ def test_bitwise_unary_ops(
     )
 
 
-# ----- Reduce Operations -----
-
-
-def reduce_sum(
-    in0: Operand,
-    builder: StableHLOBuilder,
-    dimensions: List[int],
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.reduce_sum(in0, dimensions, unit_attrs=unit_attrs)
-
-
-def reduce_max(
-    in0: Operand,
-    builder: StableHLOBuilder,
-    dimensions: List[int],
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.reduce_max(in0, dimensions, unit_attrs=unit_attrs)
-
-
-def reduce_min(
-    in0: Operand,
-    builder: StableHLOBuilder,
-    dimensions: List[int],
-    unit_attrs: Optional[List[str]] = None,
-):
-    return builder.reduce_min(in0, dimensions, unit_attrs=unit_attrs)
-
-
 @pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 @pytest.mark.parametrize("target", ["ttnn"])
 @pytest.mark.parametrize("dimensions", [[0], [1]])
-def test_reduce_sum(
+@pytest.mark.parametrize("body", ["add", "max", "min"])
+def test_reduce(
     shape: Shape,
     dtype: torch.dtype,
     dimensions: List[int],
+    body: str,
     target: str,
     request,
     device,
 ):
     def module(builder: StableHLOBuilder):
         @builder.func([shape], [dtype])
-        def reduce_sum_wrapper(in0: Operand, builder: StableHLOBuilder):
-            return reduce_sum(in0, builder, dimensions)
-
-    compile_and_execute_shlo(
-        module,
-        **get_request_kwargs(request),
-        target=target,
-        device=device,
-    )
-
-
-@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
-@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
-@pytest.mark.parametrize("target", ["ttnn"])
-@pytest.mark.parametrize("dimensions", [[0], [1]])
-def test_reduce_max(
-    shape: Shape,
-    dtype: torch.dtype,
-    dimensions: List[int],
-    target: str,
-    request,
-    device,
-):
-    def module(builder: StableHLOBuilder):
-        @builder.func([shape], [dtype])
-        def reduce_max_wrapper(in0: Operand, builder: StableHLOBuilder):
-            return reduce_max(in0, builder, dimensions)
-
-    compile_and_execute_shlo(
-        module,
-        **get_request_kwargs(request),
-        target=target,
-        device=device,
-    )
-
-
-@pytest.mark.parametrize("shape", [(128, 128)], ids=shape_str)
-@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
-@pytest.mark.parametrize("target", ["ttnn"])
-@pytest.mark.parametrize("dimensions", [[0], [1]])
-def test_reduce_min(
-    shape: Shape,
-    dtype: torch.dtype,
-    dimensions: List[int],
-    target: str,
-    request,
-    device,
-):
-    def module(builder: StableHLOBuilder):
-        @builder.func([shape], [dtype])
-        def reduce_min_wrapper(in0: Operand, builder: StableHLOBuilder):
-            return reduce_min(in0, builder, dimensions)
+        def reduce_wrapper(in0: Operand, builder: StableHLOBuilder):
+            builder.set_graph_level_check(True)
+            return builder.reduce(in0, 0.0, dimensions, body=body)
 
     compile_and_execute_shlo(
         module,

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -7593,8 +7593,6 @@ class StableHLOBuilder(Builder):
 
         return not_module, not_builder
 
-    # ----- Reduce Operations -----
-
     ############### stablehlo.ReduceOp ###############
 
     @tag(stablehlo.ReduceOp)
@@ -7814,197 +7812,46 @@ class StableHLOBuilder(Builder):
             ]
 
             with InsertionPoint(reduce_module.body):
-                func_type = FunctionType.get(
-                    inputs=op_input_types,
-                    results=[old_op.results[0].type],
-                )
-                func_op = func.FuncOp(
-                    name="main",
-                    type=func_type,
-                    visibility="public",
-                    ip=reduce_module.body,
-                )
-                entry_block = func_op.add_entry_block()
+                ordered_inputs = []
+                ordered_outputs = []
 
-                with InsertionPoint(entry_block):
+                @func.func(*op_input_types, name="main")
+                def decorated_func(*inputs):
+                    input_tensor = inputs[0]
+                    init_value = inputs[1]
+
+                    # Copy golden tensors BEFORE calling reduce
+                    input0_golden = self._get_golden_tensor(old_op.inputs[0])
+                    init_golden = self._get_golden_tensor(old_op.init_values[0])
+                    result_golden = self._get_golden_tensor(old_op.results[0])
+
+                    reduce_builder._set_golden_tensor(input_tensor, input0_golden)
+                    reduce_builder._set_golden_tensor(init_value, init_golden)
+                    reduce_builder._annotate_presharded_arg(input_tensor)
+                    reduce_builder._annotate_presharded_arg(init_value)
+
                     result = reduce_builder.reduce(
-                        entry_block.arguments[0],
-                        entry_block.arguments[1],
+                        input_tensor,
+                        init_value,
                         list(old_op.dimensions),
                         body=body,
                     )
-                    func.ReturnOp([result])
+
+                    # Override the golden tensor for the result with the original one
+                    reduce_builder._set_golden_tensor(result, result_golden)
+
+                    ordered_inputs.extend([input_tensor, init_value])
+                    ordered_outputs.append(result)
+
+                    return result
+
+                new_func_op = decorated_func.func_op
+                reduce_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
 
         return reduce_module, reduce_builder
-
-    def reduce_sum(
-        self,
-        in0: Operand,
-        dimensions: List[int],
-        keep_dims: bool = False,
-        unit_attrs: Optional[List[str]] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.reduce`` with sum reduction.
-
-        *Sum reduction operation.*
-
-        Reduces the input tensor by summing elements along the specified dimensions.
-
-        Mathematical definition: For each output element, sum all input elements
-        along the specified reduction dimensions.
-
-        .. code-block:: mlir
-
-            // Sum along dimension 0
-            %result = stablehlo.reduce(%input init: %init) applies stablehlo.add across dimensions = [0] :
-                (tensor<2x3xf32>, tensor<f32>) -> tensor<3xf32>
-            // Input tensor:
-            // [[1.0, 2.0, 3.0],
-            //  [4.0, 5.0, 6.0]]
-            // Output tensor:
-            // [5.0, 7.0, 9.0]
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor to reduce
-        dimensions : List[int]
-            Dimensions along which to reduce (0-indexed)
-        keep_dims : bool, optional
-            Whether to keep the reduced dimensions with size 1. Default is False.
-        unit_attrs : Optional[List[str]]
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor with reduced dimensions
-        """
-        input_type = RankedTensorType(in0.type)
-        element_type = input_type.element_type
-        zero_attr = self._get_zero_attr(element_type)
-
-        # Extract scalar value from zero_attr
-        if IntegerType.isinstance(element_type):
-            init_value = 0
-        else:
-            init_value = 0.0
-
-        result = self.reduce(
-            in0, init_value, dimensions, body="add", unit_attrs=unit_attrs
-        )
-
-        return result
-
-    def reduce_max(
-        self,
-        in0: Operand,
-        dimensions: List[int],
-        keep_dims: bool = False,
-        unit_attrs: Optional[List[str]] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.reduce`` with max reduction.
-
-        *Max reduction operation.*
-
-        Reduces the input tensor by taking the maximum element along the specified dimensions.
-
-        Mathematical definition: For each output element, find the maximum of all input
-        elements along the specified reduction dimensions.
-
-        .. code-block:: mlir
-
-            // Max along dimension 0
-            %result = stablehlo.reduce(%input init: %init) applies stablehlo.maximum across dimensions = [0] :
-                (tensor<2x3xf32>, tensor<f32>) -> tensor<3xf32>
-            // Input tensor:
-            // [[1.0, 5.0, 3.0],
-            //  [4.0, 2.0, 6.0]]
-            // Output tensor:
-            // [4.0, 5.0, 6.0]
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor to reduce
-        dimensions : List[int]
-            Dimensions along which to reduce (0-indexed)
-        keep_dims : bool, optional
-            Whether to keep the reduced dimensions with size 1. Default is False.
-        unit_attrs : Optional[List[str]]
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor with reduced dimensions
-        """
-        input_type = RankedTensorType(in0.type)
-        element_type = input_type.element_type
-
-        # Get negative infinity as init value
-        if IntegerType.isinstance(element_type):
-            # For integers, use minimum value
-            init_value = float("-inf")
-        else:
-            init_value = float("-inf")
-
-        result = self.reduce(
-            in0, init_value, dimensions, body="max", unit_attrs=unit_attrs
-        )
-
-        return result
-
-    def reduce_min(
-        self,
-        in0: Operand,
-        dimensions: List[int],
-        keep_dims: bool = False,
-        unit_attrs: Optional[List[str]] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.reduce`` with min reduction.
-
-        *Min reduction operation.*
-
-        Reduces the input tensor by taking the minimum element along the specified dimensions.
-
-        Mathematical definition: For each output element, find the minimum of all input
-        elements along the specified reduction dimensions.
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor to reduce
-        dimensions : List[int]
-            Dimensions along which to reduce (0-indexed)
-        keep_dims : bool, optional
-            Whether to keep the reduced dimensions with size 1. Default is False.
-        unit_attrs : Optional[List[str]]
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor with reduced dimensions
-        """
-        input_type = RankedTensorType(in0.type)
-        element_type = input_type.element_type
-
-        # Get positive infinity as init value
-        if IntegerType.isinstance(element_type):
-            # For integers, use maximum value
-            init_value = float("inf")
-        else:
-            init_value = float("inf")
-
-        result = self.reduce(
-            in0, init_value, dimensions, body="min", unit_attrs=unit_attrs
-        )
-
-        return result
 
     def pool_2d(
         self,

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -7595,75 +7595,247 @@ class StableHLOBuilder(Builder):
 
     # ----- Reduce Operations -----
 
-    def _reduce_op_proxy(
+    ############### stablehlo.ReduceOp ###############
+
+    @tag(stablehlo.ReduceOp)
+    def reduce(
         self,
         in0: Operand,
+        init_value: Union[Operand, float, int],
         dimensions: List[int],
-        init_attr: Attribute,
-        reduce_op_creator: Callable,
-        loc: Optional[Location] = None,
-    ) -> OpView:
-        """
-        Helper method to create a StableHLO reduce operation.
+        body: str = "add",
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.reduce)
 
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor to reduce
-        dimensions : List[int]
-            Dimensions along which to reduce
-        init_attr : Attribute
-            Initial value attribute
-        reduce_op_creator : Callable
-            Function that creates the reduce operation in the body
-        loc : Optional[Location]
-            Location for the operation
+        input_type = RankedTensorType(in0.type)
+        element_type = input_type.element_type
 
-        Returns
-        -------
-        OpView
-            The reduce operation result
-        """
-        with self._ctx, self._loc:
+        input_shape = list(input_type.shape)
+        dimensions_set = set(dimensions)
+        output_shape = [
+            input_shape[i] for i in range(len(input_shape)) if i not in dimensions_set
+        ]
+
+        if output_type is None:
+            mlir_output_type = element_type
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+
+        output_ranked_type = RankedTensorType.get(output_shape, mlir_output_type)
+
+        # Handle init_value
+        if isinstance(init_value, (int, float)):
+            if isinstance(init_value, float):
+                init_attr = DenseElementsAttr.get_splat(
+                    RankedTensorType.get([], element_type),
+                    FloatAttr.get(element_type, init_value),
+                )
+            else:
+                init_attr = DenseElementsAttr.get_splat(
+                    RankedTensorType.get([], element_type),
+                    IntegerAttr.get(element_type, init_value),
+                )
             if loc is None:
-                id = self._get_next_global_id()
-                loc = self._get_loc_of_extra_file_callee(id=id)
+                const_loc = self._get_location()
+            else:
+                const_loc = Location.name(loc)
+            init_value_op = stablehlo.ConstantOp(init_attr, loc=const_loc).result
 
-            input_type = RankedTensorType(in0.type)
-            element_type = input_type.element_type
+            # Set golden for init constant
+            init_golden_function = get_golden_function(stablehlo.ConstantOp)
+            mesh_shape_attr = DenseI32ArrayAttr.get(self._mesh_shape)
+            init_golden = init_golden_function(init_attr, mesh_shape_attr)
+            self._set_golden_tensor(init_value_op, init_golden)
+        else:
+            init_value_op = init_value
 
-            input_shape = list(input_type.shape)
-            dimensions_set = set(dimensions)
-            output_shape = [
-                input_shape[i]
-                for i in range(len(input_shape))
-                if i not in dimensions_set
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
+
+        # Create the reduce operation
+        reduce_op = stablehlo_op(
+            [output_ranked_type],
+            inputs=[in0],
+            init_values=[init_value_op],
+            dimensions=dimensions,
+            loc=loc,
+        )
+
+        # Create the reduction body
+        reduction_type = RankedTensorType.get([], element_type)
+        block = Block.create_at_start(
+            reduce_op.regions[0], [reduction_type, reduction_type]
+        )
+
+        with InsertionPoint(block):
+            if body == "add":
+                reduction_result = stablehlo.AddOp(
+                    block.arguments[0], block.arguments[1], loc=loc
+                ).result
+            elif body == "max":
+                reduction_result = stablehlo.MaxOp(
+                    block.arguments[0], block.arguments[1], loc=loc
+                ).result
+            elif body == "min":
+                reduction_result = stablehlo.MinOp(
+                    block.arguments[0], block.arguments[1], loc=loc
+                ).result
+            else:
+                raise ValueError(
+                    f"Unsupported reduction body: {body}. "
+                    "Supported options: 'add', 'max', 'min'"
+                )
+            stablehlo.ReturnOp([reduction_result], loc=loc)
+
+        op_result = reduce_op.result
+
+        if sharding_attr is not None:
+            reduce_op.operation.attributes["sdy.sharding"] = sharding_attr
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                reduce_op.operation.attributes[attr_name] = UnitAttr.get()
+
+        # Compute golden output
+        input_golden = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input_golden, dimensions, body, mlir_output_type
+        )
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.ReduceOp)
+    def reduce_parser(
+        self,
+        old_op: stablehlo.ReduceOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.reduce_parser)
+
+        in0 = global_dict[old_op.inputs[0]]
+        init_value = global_dict[old_op.init_values[0]]
+
+        # Determine the body type from the old operation's region
+        body = "add"
+        for op in old_op.body.blocks[0].operations:
+            if isinstance(op, stablehlo.AddOp):
+                body = "add"
+                break
+            elif isinstance(op, stablehlo.MaxOp):
+                body = "max"
+                break
+            elif isinstance(op, stablehlo.MinOp):
+                body = "min"
+                break
+
+        new_op = stablehlo_op(
+            [old_op.results[0].type],
+            inputs=[in0],
+            init_values=[init_value],
+            dimensions=old_op.dimensions,
+            loc=old_op.location,
+        )
+
+        # Recreate the reduction body
+        element_type = RankedTensorType(old_op.inputs[0].type).element_type
+        reduction_type = RankedTensorType.get([], element_type)
+        block = Block.create_at_start(
+            new_op.regions[0], [reduction_type, reduction_type]
+        )
+
+        with InsertionPoint(block):
+            if body == "add":
+                reduction_result = stablehlo.AddOp(
+                    block.arguments[0], block.arguments[1], loc=old_op.location
+                ).result
+            elif body == "max":
+                reduction_result = stablehlo.MaxOp(
+                    block.arguments[0], block.arguments[1], loc=old_op.location
+                ).result
+            elif body == "min":
+                reduction_result = stablehlo.MinOp(
+                    block.arguments[0], block.arguments[1], loc=old_op.location
+                ).result
+            stablehlo.ReturnOp([reduction_result], loc=old_op.location)
+
+        new_op_result = new_op.results[0]
+
+        # Compute golden output
+        input_golden = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input_golden, new_op.dimensions, body, new_op_result.type.element_type
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.results[0]] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(stablehlo.ReduceOp)
+    def reduce_split(
+        self,
+        old_op: stablehlo.ReduceOp,
+    ) -> Tuple[Module, StableHLOBuilder]:
+        stablehlo_op = self.get_opview_from_split(StableHLOBuilder.reduce_split)
+
+        old_context = old_op.context
+        old_loc = Location.unknown(old_context)
+
+        # Determine the body type from the old operation's region
+        body = "add"
+        for op in old_op.body.blocks[0].operations:
+            if isinstance(op, stablehlo.AddOp):
+                body = "add"
+                break
+            elif isinstance(op, stablehlo.MaxOp):
+                body = "max"
+                break
+            elif isinstance(op, stablehlo.MinOp):
+                body = "min"
+                break
+
+        with old_context, old_loc:
+            reduce_module = Module.create()
+            reduce_builder = StableHLOBuilder(
+                old_context, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [
+                old_op.inputs[0].type,
+                old_op.init_values[0].type,
             ]
 
-            output_type = RankedTensorType.get(output_shape, element_type)
-
-            init_value = stablehlo.ConstantOp(init_attr, loc=loc).result
-
-            reduce_op = stablehlo.ReduceOp(
-                [output_type],
-                inputs=[in0],
-                init_values=[init_value],
-                dimensions=dimensions,
-                loc=loc,
-            )
-
-            reduction_type = RankedTensorType.get([], element_type)
-            block = Block.create_at_start(
-                reduce_op.regions[0], [reduction_type, reduction_type]
-            )
-
-            with InsertionPoint(block):
-                reduce_result = reduce_op_creator(
-                    block.arguments[0], block.arguments[1], loc
+            with InsertionPoint(reduce_module.body):
+                func_type = FunctionType.get(
+                    inputs=op_input_types,
+                    results=[old_op.results[0].type],
                 )
-                stablehlo.ReturnOp([reduce_result], loc=loc)
+                func_op = func.FuncOp(
+                    name="main",
+                    type=func_type,
+                    visibility="public",
+                    ip=reduce_module.body,
+                )
+                entry_block = func_op.add_entry_block()
 
-            return reduce_op.result
+                with InsertionPoint(entry_block):
+                    result = reduce_builder.reduce(
+                        entry_block.arguments[0],
+                        entry_block.arguments[1],
+                        list(old_op.dimensions),
+                        body=body,
+                    )
+                    func.ReturnOp([result])
+
+        return reduce_module, reduce_builder
 
     def reduce_sum(
         self,
@@ -7713,14 +7885,15 @@ class StableHLOBuilder(Builder):
         element_type = input_type.element_type
         zero_attr = self._get_zero_attr(element_type)
 
-        def add_creator(arg0, arg1, loc):
-            return stablehlo.AddOp(arg0, arg1, loc=loc).result
+        # Extract scalar value from zero_attr
+        if IntegerType.isinstance(element_type):
+            init_value = 0
+        else:
+            init_value = 0.0
 
-        result = self._reduce_op_proxy(in0, dimensions, zero_attr, add_creator)
-
-        input_golden = self._get_golden_tensor(in0)
-        output_golden = torch.sum(input_golden, dim=dimensions, keepdim=keep_dims)
-        self._set_golden_tensor(result, output_golden)
+        result = self.reduce(
+            in0, init_value, dimensions, body="add", unit_attrs=unit_attrs
+        )
 
         return result
 
@@ -7770,19 +7943,17 @@ class StableHLOBuilder(Builder):
         """
         input_type = RankedTensorType(in0.type)
         element_type = input_type.element_type
-        neg_inf_attr = self._get_neg_inf_attr(element_type)
 
-        def max_creator(arg0, arg1, loc):
-            return stablehlo.MaxOp(arg0, arg1, loc=loc).result
-
-        result = self._reduce_op_proxy(in0, dimensions, neg_inf_attr, max_creator)
-
-        input_golden = self._get_golden_tensor(in0)
-        if dimensions:
-            output_golden = torch.amax(input_golden, dim=dimensions, keepdim=keep_dims)
+        # Get negative infinity as init value
+        if IntegerType.isinstance(element_type):
+            # For integers, use minimum value
+            init_value = float("-inf")
         else:
-            output_golden = torch.amax(input_golden, keepdim=keep_dims)
-        self._set_golden_tensor(result, output_golden)
+            init_value = float("-inf")
+
+        result = self.reduce(
+            in0, init_value, dimensions, body="max", unit_attrs=unit_attrs
+        )
 
         return result
 
@@ -7821,19 +7992,17 @@ class StableHLOBuilder(Builder):
         """
         input_type = RankedTensorType(in0.type)
         element_type = input_type.element_type
-        pos_inf_attr = self._get_pos_inf_attr(element_type)
 
-        def min_creator(arg0, arg1, loc):
-            return stablehlo.MinOp(arg0, arg1, loc=loc).result
-
-        result = self._reduce_op_proxy(in0, dimensions, pos_inf_attr, min_creator)
-
-        input_golden = self._get_golden_tensor(in0)
-        if dimensions:
-            output_golden = torch.amin(input_golden, dim=dimensions, keepdim=keep_dims)
+        # Get positive infinity as init value
+        if IntegerType.isinstance(element_type):
+            # For integers, use maximum value
+            init_value = float("inf")
         else:
-            output_golden = torch.amin(input_golden, keepdim=keep_dims)
-        self._set_golden_tensor(result, output_golden)
+            init_value = float("inf")
+
+        result = self.reduce(
+            in0, init_value, dimensions, body="min", unit_attrs=unit_attrs
+        )
 
         return result
 

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -7698,7 +7698,7 @@ class StableHLOBuilder(Builder):
 
         if unit_attrs is not None:
             for attr_name in unit_attrs:
-                reduce_op.operation.attributes[attr_name] = UnitAttr.get()
+                reduce_op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
         # Compute golden output
         input_golden = self._get_golden_tensor(in0)

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -7476,60 +7476,122 @@ class StableHLOBuilder(Builder):
             sharding_attr=sharding_attr,
         )
 
+    ############### stablehlo.NotOp ###############
+
+    @tag(stablehlo.NotOp)
     def not_(
         self,
         in0: Operand,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
         sharding_attr: Optional[sdy.TensorShardingPerValueAttr] = None,
-    ) -> OpView:
-        """
-        Creates ``stablehlo.not``.
+    ) -> OpResult:
+        stablehlo_op = self.get_opview_from_method(StableHLOBuilder.not_)
 
-        *Elementwise NOT operation.*
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
 
-        Performs elementwise NOT operation on a tensor.
-        For booleans, performs logical NOT.
-        For integers, performs bitwise NOT.
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
 
-        Mathematical definition:
-        - Logical: not(x) = NOT x
-        - Bitwise: not(x) = ~x
-
-        .. code-block:: mlir
-
-            // Logical NOT for booleans
-            %result = stablehlo.not(%input) : tensor<3xi1> -> tensor<3xi1>
-            // Input tensor:
-            // input: [true, false, true]
-            // Output tensor:
-            // [false, true, false]
-
-            // Bitwise NOT for integers
-            %result = stablehlo.not(%input) : tensor<3xi32> -> tensor<3xi32>
-            // Input tensor:
-            // input: [0, 1, 2]  // Binary: 000, 001, 010
-            // Output tensor:
-            // [-1, -2, -3]      // Binary (two's complement): 111...111, 111...110, 111...101
-
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor (boolean or integer type)
-        unit_attrs : *Optional[List[str]]*
-            Optional list of unit attributes
-
-        Returns
-        -------
-        (*OpView*)
-            A tensor containing the elementwise NOT of the input
-        """
-
-        return self._eltwise_proxy(
-            stablehlo.NotOp,
-            [in0],
-            unit_attrs=unit_attrs,
-            sharding_attr=sharding_attr,
+        op = stablehlo_op(
+            in0,
+            loc=loc,
         )
+        op_result = op.result
+
+        if sharding_attr is not None:
+            op.operation.attributes["sdy.sharding"] = sharding_attr
+
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(input0, mlir_output_type)
+        self._set_golden_tensor(op_result, golden_output)
+
+        return op_result
+
+    @parse(stablehlo.NotOp)
+    def not_parser(
+        self,
+        old_op: stablehlo.NotOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(StableHLOBuilder.not_parser)
+        in0 = global_dict[old_op.operand]
+
+        new_op = stablehlo_op(
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(input0, new_op_result.type.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(stablehlo.NotOp)
+    def not_split(
+        self,
+        old_op: stablehlo.NotOp,
+    ) -> Tuple[Module, StableHLOBuilder]:
+        stablehlo_op = self.get_opview_from_split(StableHLOBuilder.not_split)
+
+        old_context = old_op.context
+        old_loc = Location.unknown(old_context)
+
+        with old_context, old_loc:
+            not_module = Module.create()
+            not_builder = StableHLOBuilder(
+                old_context, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [old_op.operand.type]
+
+            with InsertionPoint(not_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="not_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+
+                    new_op = stablehlo_op(
+                        in0,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    input0 = self._get_golden_tensor(old_op.operand)
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    not_builder._set_golden_tensor(new_op_result, old_op_result)
+                    not_builder._set_golden_tensor(in0, input0)
+                    not_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                not_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return not_module, not_builder
 
     # ----- Reduce Operations -----
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3212,29 +3212,17 @@ def stablehlo_xor_golden(
         return torch.bitwise_xor(input_tensor, other_tensor)
 
 
-def stablehlo_not_golden(input_tensor: GoldenMapTensor, **kwargs) -> GoldenMapTensor:
-    """
-    Golden function for StableHLO not operation.
+def stablehlo_not_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
 
-    Supports both logical NOT (for boolean tensors) and bitwise NOT (for integer tensors).
-
-    Parameters
-    ----------
-    input_tensor : GoldenMapTensor
-        Input tensor to invert.
-    **kwargs : dict
-        Keyword arguments (unused for this operation).
-
-    Returns
-    -------
-    GoldenMapTensor
-        Tensor containing the NOT of input_tensor.
-    """
     if input_tensor.dtype == torch.bool:
-        result_bool = torch.logical_not(input_tensor)
-        return result_bool.to(input_tensor.dtype)
+        result = torch.logical_not(input_tensor)
     else:
-        return torch.bitwise_not(input_tensor)
+        result = torch.bitwise_not(input_tensor)
+
+    return result.to(output_dtype)
 
 
 ################ Golden Utilities ###############

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -5723,6 +5723,40 @@ def stablehlo_pad_golden(
     ).to(output_dtype)
 
 
+def stablehlo_reduce_golden(
+    input_tensor: GoldenMapTensor,
+    dimensions: DenseI64ArrayAttr,
+    body: str,
+    output_type_mlir: Type,
+) -> GoldenMapTensor:
+    dims = unpack_mlir_attr(dimensions)
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+
+    # Convert to list if single integer
+    if isinstance(dims, int):
+        dims = [dims]
+    elif isinstance(dims, np.ndarray):
+        dims = dims.tolist()
+
+    # Perform the appropriate reduction
+    if body == "add":
+        result = torch.sum(input_tensor, dim=dims if dims else None, keepdim=False)
+    elif body == "max":
+        if dims:
+            result = torch.amax(input_tensor, dim=dims, keepdim=False)
+        else:
+            result = torch.amax(input_tensor, keepdim=False)
+    elif body == "min":
+        if dims:
+            result = torch.amin(input_tensor, dim=dims, keepdim=False)
+        else:
+            result = torch.amin(input_tensor, keepdim=False)
+    else:
+        raise ValueError(f"Unsupported reduction body: {body}")
+
+    return result.to(output_dtype)
+
+
 def stablehlo_reduce_window_golden(
     input_tensor: GoldenMapTensor,
     init_value: GoldenMapTensor,
@@ -7528,6 +7562,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     # CCL (Collective Communication Library) operations
     stablehlo.AllGatherOp: stablehlo_all_gather_golden,
     stablehlo.AllReduceOp: stablehlo_all_reduce_golden,
+    stablehlo.ReduceOp: stablehlo_reduce_golden,
     stablehlo.ReduceScatterOp: stablehlo_reduce_scatter_golden,
     stablehlo.ReduceWindowOp: stablehlo_reduce_window_golden,
     stablehlo.CollectivePermuteOp: stablehlo_collective_permute_golden,


### PR DESCRIPTION
### Ticket
Closes [#7254](https://github.com/tenstorrent/tt-mlir/issues/7254)
Closes [#7255](https://github.com/tenstorrent/tt-mlir/issues/7255)  

### Problem description
`stablehlo.not` and `stablehlo.reduce` still use op_proxy and have no parse split support

### What's changed
Refactored both

### Checklist
- [ ] New/Existing tests provide coverage for changes
