### PR TITLE
Fix sparse_matmul test passing removed output_shape kwarg

### DIFF
--- a/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
+++ b/test/python/golden/ttir_ops/matmul/test_sparse_matmul.py
@@ -86,7 +86,6 @@ def test_sparse_matmul_b_sparse_f32_sparsity(target: str, request, device):
                 is_input_a_sparse=False,
                 is_input_b_sparse=True,
                 nnz=0,
-                output_shape=(2, 4, 1, 4, 32, 5760),
                 output_type=torch.bfloat16,
                 unit_attrs=unit_attrs,
             )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`test_sparse_matmul_b_sparse_f32_sparsity` (added in #8130) calls `builder.sparse_matmul(..., output_shape=(2, 4, 1, 4, 32, 5760), ...)`, but `TTIRBuilder.sparse_matmul` no longer accepts `output_shape` — it was removed in #8005 (Miscellaneous Builder Cleanup) along with the sibling test updates.

The signature mismatch slipped into main because #8130 was authored against a pre-#8005 builder, the test file was newly added (no merge conflict surface), and only the workaround pass + lit test were exercised in that PR's CI scope.

### What's changed
Remove params from the test.

### Checklist
- [ ] New/Existing tests provide coverage for changes
