### PR TITLE
D2M: normalize d2m.spatial after grid selection

### DIFF
--- a/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
+++ b/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,6 @@ class GenericOp;
 // Bring each d2m.spatial op to canonical form: hoist non-d2m.generic ops out of
 // its regions, rebuild yields, refresh ins/outs from nested generics, and when
 // result arity matches outs, update spatial result types from output values.
-// Idempotent for already-normal IR. Violates invariants only via TT_assertv.
 void normalizeSpatialOpsInModule(ModuleOp module);
 
 // If genericOp lies inside a d2m.spatial, apply the same normalization to that

--- a/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
+++ b/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_UTILS_SPATIALOPNORMALIZEUTIL_H
+#define TTMLIR_DIALECT_D2M_UTILS_SPATIALOPNORMALIZEUTIL_H
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::tt::d2m {
+
+class GenericOp;
+
+// Bring each d2m.spatial op to canonical form: hoist non-d2m.generic ops out of
+// its regions, rebuild yields, refresh ins/outs from nested generics, and when
+// result arity matches outs, update spatial result types from output values.
+// Idempotent for already-normal IR. Violates invariants only via TT_assertv.
+void normalizeSpatialOpsInModule(ModuleOp module);
+
+// If genericOp lies inside a d2m.spatial, apply the same normalization to that
+// enclosing spatial only; otherwise no-op. Use after rewrites to a generic so
+// other spatials (not yet updated) are left untouched.
+void normalizeSpatialOpContainingGeneric(GenericOp genericOp);
+
+} // namespace mlir::tt::d2m
+
+#endif

--- a/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
+++ b/include/ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h
@@ -6,10 +6,9 @@
 #define TTMLIR_DIALECT_D2M_UTILS_SPATIALOPNORMALIZEUTIL_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 
 namespace mlir::tt::d2m {
-
-class GenericOp;
 
 // Bring each d2m.spatial op to canonical form: hoist non-d2m.generic ops out of
 // its regions, rebuild yields, refresh ins/outs from nested generics, and when

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
@@ -589,10 +590,11 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
 
 // Recreate the d2m.generic with updated operands.
 // After updating ToLayout and ViewLayout ops, the generic's operands have
-// new types with the selected grids. The generic grid is still anchored by the
-// output operand's chosen grid, but we must re-materialize the generic attrs
-// from the selected operand grids after those rewrites so the rebuilt op stays
-// consistent with the new operand types and the derived block factors.
+// new types with the selected grids. The generic grid is still anchored by
+// the output operand's chosen grid, but we must re-materialize the generic
+// attrs from the selected operand grids after those rewrites so the rebuilt
+// op stays consistent with the new operand types and the derived block
+// factors.
 //
 // Returns the generic to use for further work: on success this is the new op
 // (the input handle is erased); on failure or empty grids the original op.
@@ -631,10 +633,10 @@ recreateGenericOp(d2m::GenericOp genericOp,
 static void applyGridDecisions(d2m::GenericOp genericOp,
                                const GenericGridAnalysisResult &result,
                                bool ttnnMode) {
-  // effectiveTargetGrid is the generic's target grid (full device grid, or the
-  // range scoped by an enclosing d2m.spatial region), used for virtual grid
-  // physical mapping. Per-operand target grids (info.targetGrid) are used
-  // for alignment computation.
+  // effectiveTargetGrid is the generic's target grid (full device grid, or
+  // the range scoped by an enclosing d2m.spatial region), used for virtual
+  // grid physical mapping. Per-operand target grids (info.targetGrid) are
+  // used for alignment computation.
   ArrayRef<int64_t> effectiveTargetGrid = result.effectiveTargetGrid;
   OpBuilder builder(genericOp->getContext());
 
@@ -725,11 +727,11 @@ public:
 
   D2MGridSelectionPass(const D2MGridSelectionOptions &options) : Base() {
     this->overrideDeviceShape = llvm::to_vector(options.overrideDeviceShape);
-    // Setting TTNN mode to true ensures we do not implicitly pad or wrap-around
-    // when sharding. Any grid decisions in this mode are representable
-    // using a TTNNLayoutAttr and can be created with a single ttnn.empty()
-    // call. This can be removed only when we implement support for creating
-    // padded tensors in D2MToTTNN pass.
+    // Setting TTNN mode to true ensures we do not implicitly pad or
+    // wrap-around when sharding. Any grid decisions in this mode are
+    // representable using a TTNNLayoutAttr and can be created with a single
+    // ttnn.empty() call. This can be removed only when we implement support
+    // for creating padded tensors in D2MToTTNN pass.
     this->ttnnMode = options.ttnnMode;
   }
 

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
+#include "ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -17,7 +18,9 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -590,11 +593,14 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
 // output operand's chosen grid, but we must re-materialize the generic attrs
 // from the selected operand grids after those rewrites so the rebuilt op stays
 // consistent with the new operand types and the derived block factors.
-static void
+//
+// Returns the generic to use for further work: on success this is the new op
+// (the input handle is erased); on failure or empty grids the original op.
+static d2m::GenericOp
 recreateGenericOp(d2m::GenericOp genericOp,
                   ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids) {
   if (optimalOperandGrids.empty()) {
-    return;
+    return genericOp;
   }
 
   OpBuilder builder(genericOp);
@@ -609,11 +615,13 @@ recreateGenericOp(d2m::GenericOp genericOp,
   if (failed(ret)) {
     genericOp.emitOpError()
         << "failed to recreate generic op with withParallelization";
-    return;
+    return genericOp;
   }
 
-  genericOp->replaceAllUsesWith(ret->genericOp);
+  d2m::GenericOp newGeneric = ret->genericOp;
+  genericOp->replaceAllUsesWith(newGeneric);
   genericOp.erase();
+  return newGeneric;
 }
 
 // ----------------------------------------------------------------------------
@@ -695,58 +703,9 @@ static void applyGridDecisions(d2m::GenericOp genericOp,
     }
   }
 
-  recreateGenericOp(genericOp, result.normalizedOperandGrids);
-}
-
-// Resolve to a value that dominates the spatial op by following view_layout
-// chains defined inside the spatial's regions (region-border value).
-static Value resolveToRegionBorderValue(Value operand,
-                                        d2m::SpatialOp spatialOp) {
-  auto inSpatialRegion = [&](Value val) {
-    Operation *def = val.getDefiningOp();
-    if (!def) {
-      return false;
-    }
-    Region *parent = def->getBlock()->getParent();
-    return llvm::any_of(spatialOp->getRegions(),
-                        [parent](Region &r) { return &r == parent; });
-  };
-  Value current = operand;
-  while (inSpatialRegion(current)) {
-    if (auto viewOp = current.getDefiningOp<d2m::ViewLayoutOp>()) {
-      current = viewOp.getInput();
-    } else {
-      break;
-    }
-  }
-  return current;
-}
-
-// Rebuild d2m.spatial's ins and outs from the operands actually used by
-// d2m.generic ops in each region, and set result types from the collected outs.
-static void reconstructSpatialOperands(d2m::SpatialOp spatialOp) {
-  llvm::SmallVector<mlir::Value> inputs;
-  llvm::SmallVector<mlir::Value> outputs;
-  for (Region &region : spatialOp->getRegions()) {
-    if (region.empty()) {
-      continue;
-    }
-    for (d2m::GenericOp genericOp : region.front().getOps<d2m::GenericOp>()) {
-      for (mlir::Value input : genericOp.getInputs()) {
-        inputs.push_back(resolveToRegionBorderValue(input, spatialOp));
-      }
-      for (mlir::Value output : genericOp.getOutputs()) {
-        outputs.push_back(resolveToRegionBorderValue(output, spatialOp));
-      }
-    }
-  }
-  spatialOp.getInputsMutable().assign(inputs);
-  spatialOp.getOutputsMutable().assign(outputs);
-  if (spatialOp->getNumResults() == outputs.size()) {
-    for (auto [result, outVal] : llvm::zip(spatialOp->getResults(), outputs)) {
-      result.setType(outVal.getType());
-    }
-  }
+  d2m::GenericOp newGenericOp =
+      recreateGenericOp(genericOp, result.normalizedOperandGrids);
+  normalizeSpatialOpContainingGeneric(newGenericOp);
 }
 
 // ----------------------------------------------------------------------------
@@ -793,12 +752,6 @@ public:
       }
       applyGridDecisions(genericOp, *result, this->ttnnMode);
     }
-
-    // Phase 3: Rebuild each SpatialOp's ins/outs from the operands actually
-    // used by generics in its regions.
-    module.walk([&](d2m::SpatialOp spatialOp) {
-      reconstructSpatialOperands(spatialOp);
-    });
   }
 
 private:

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
@@ -596,9 +597,11 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
 // op stays consistent with the new operand types and the derived block
 // factors.
 //
-// Returns the generic to use for further work: on success this is the new op
-// (the input handle is erased); on failure or empty grids the original op.
-static d2m::GenericOp
+// Returns the generic to use for further work. Success is either:
+//  - no-op (empty grids): returns original op
+//  - recreated op: returns new op and erases original op
+// Failure is returned when generic recreation fails.
+static FailureOr<d2m::GenericOp>
 recreateGenericOp(d2m::GenericOp genericOp,
                   ArrayRef<llvm::SmallVector<int64_t>> optimalOperandGrids) {
   if (optimalOperandGrids.empty()) {
@@ -615,9 +618,7 @@ recreateGenericOp(d2m::GenericOp genericOp,
   auto ret = genericOp.withParallelization(builder, grid, blockFactors,
                                            /*generateReturnView=*/false);
   if (failed(ret)) {
-    genericOp.emitOpError()
-        << "failed to recreate generic op with withParallelization";
-    return genericOp;
+    return failure();
   }
 
   d2m::GenericOp newGeneric = ret->genericOp;
@@ -630,9 +631,9 @@ recreateGenericOp(d2m::GenericOp genericOp,
 // Apply all grid decisions from a GenericGridAnalysisResult to a GenericOp.
 // ----------------------------------------------------------------------------
 
-static void applyGridDecisions(d2m::GenericOp genericOp,
-                               const GenericGridAnalysisResult &result,
-                               bool ttnnMode) {
+static LogicalResult applyGridDecisions(d2m::GenericOp genericOp,
+                                        const GenericGridAnalysisResult &result,
+                                        bool ttnnMode) {
   // effectiveTargetGrid is the generic's target grid (full device grid, or
   // the range scoped by an enclosing d2m.spatial region), used for virtual
   // grid physical mapping. Per-operand target grids (info.targetGrid) are
@@ -705,9 +706,15 @@ static void applyGridDecisions(d2m::GenericOp genericOp,
     }
   }
 
-  d2m::GenericOp newGenericOp =
+  FailureOr<d2m::GenericOp> newGenericOp =
       recreateGenericOp(genericOp, result.normalizedOperandGrids);
-  normalizeSpatialOpContainingGeneric(newGenericOp);
+  if (failed(newGenericOp)) {
+    genericOp.emitOpError() << "grid selection failed to recreate generic op";
+    return failure();
+  }
+
+  normalizeSpatialOpContainingGeneric(*newGenericOp);
+  return success();
 }
 
 // ----------------------------------------------------------------------------
@@ -752,7 +759,10 @@ public:
       if (!result) {
         continue;
       }
-      applyGridDecisions(genericOp, *result, this->ttnnMode);
+      if (failed(applyGridDecisions(genericOp, *result, this->ttnnMode))) {
+        signalPassFailure();
+        return;
+      }
     }
   }
 

--- a/lib/Dialect/D2M/Utils/CMakeLists.txt
+++ b/lib/Dialect/D2M/Utils/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_library(MLIRD2MUtils
   DMAUtils.cpp
   DstRegisterAnalysis.cpp
   GridSelectionUtils.cpp
+  SpatialOpNormalizeUtil.cpp
   Utils.cpp
   AffineMapAnalysis.cpp
   VirtualGrid.cpp

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h"
+
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::d2m {
+namespace detail {
+
+// Operand used by a nested generic, traced through view_layout chains that stay
+// inside the spatial op until a value defined outside the spatial regions.
+static Value resolveToRegionBorderValue(Value operand,
+                                        d2m::SpatialOp spatialOp) {
+  auto inSpatialRegion = [&](Value val) {
+    Operation *def = val.getDefiningOp();
+    if (!def) {
+      return false;
+    }
+    Region *parent = def->getBlock()->getParent();
+    return llvm::any_of(
+        spatialOp->getRegions(),
+        [parent](Region &spatialRegion) { return &spatialRegion == parent; });
+  };
+  Value current = operand;
+  while (inSpatialRegion(current)) {
+    if (auto viewOp = current.getDefiningOp<d2m::ViewLayoutOp>()) {
+      current = viewOp.getInput();
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+// Hoist every op except d2m.generic out of each spatial region: prefix ops
+// move before the spatial (forward moveBefore order), suffix ops (after generic
+// until an optional d2m.spatial_yield or block end) move after the spatial
+// with generic-result uses rewired to spatial results. Any existing
+// d2m.spatial_yield ops in the region are erased, then a fresh yield of the
+// generic's results is created at the end of the region block.
+static void hoistNonGenericOpsAroundSpatial(d2m::SpatialOp spatialOp) {
+  mlir::OpBuilder builder(spatialOp.getContext());
+  Operation *suffixInsertTail = spatialOp.getOperation();
+  unsigned cumulativeGenericResults = 0;
+
+  for (Region &spatialRegion : spatialOp->getRegions()) {
+    TT_assertv(!spatialRegion.empty(),
+               "each spatial region must not be empty.");
+    Block &regionBlock = spatialRegion.front();
+    auto genericOps = llvm::to_vector(regionBlock.getOps<d2m::GenericOp>());
+    TT_assertv(genericOps.size() == 1u,
+               "each spatial region must contain exactly one d2m.generic op.");
+    d2m::GenericOp genericOp = genericOps.front();
+
+    llvm::SmallVector<Operation *> beforeOps;
+    llvm::SmallVector<Operation *> afterOps;
+    bool seenGeneric = false;
+    for (Operation &regionBodyOp : regionBlock) {
+      if (&regionBodyOp == genericOp.getOperation()) {
+        seenGeneric = true;
+        continue;
+      }
+      if (!seenGeneric) {
+        beforeOps.push_back(&regionBodyOp);
+      } else {
+        if (mlir::isa<d2m::SpatialYieldOp>(&regionBodyOp)) {
+          break;
+        }
+        afterOps.push_back(&regionBodyOp);
+      }
+    }
+
+    for (d2m::SpatialYieldOp yieldOp :
+         llvm::to_vector(regionBlock.getOps<d2m::SpatialYieldOp>())) {
+      yieldOp.erase();
+    }
+
+    for (Operation *prefixOp : beforeOps) {
+      prefixOp->moveBefore(spatialOp);
+    }
+
+    if (!afterOps.empty()) {
+      const unsigned resultBase = cumulativeGenericResults;
+      const unsigned numGenResults = genericOp->getNumResults();
+      const unsigned numSpatialResults = spatialOp->getNumResults();
+      TT_assertv(((numGenResults == 0u) ||
+                  (resultBase + numGenResults <= numSpatialResults)),
+                 "spatial op result count must cover generic results for "
+                 "suffix hoist remapping");
+
+      for (unsigned resultIndex = 0; resultIndex < numGenResults;
+           ++resultIndex) {
+        Value genericResult = genericOp.getResult(resultIndex);
+        Value spatialResult = spatialOp.getResult(resultBase + resultIndex);
+        genericResult.replaceUsesWithIf(spatialResult, [&](OpOperand &operand) {
+          return llvm::is_contained(afterOps, operand.getOwner());
+        });
+      }
+
+      for (Operation *suffixOp : afterOps) {
+        for (Value operand : suffixOp->getOperands()) {
+          TT_assertv(!llvm::is_contained(genericOp.getResults(), operand),
+                     "suffix op operand should use spatial op results after "
+                     "remapping");
+        }
+      }
+
+      for (Operation *suffixOp : afterOps) {
+        suffixOp->moveAfter(suffixInsertTail);
+        suffixInsertTail = suffixOp;
+      }
+    }
+
+    cumulativeGenericResults += genericOp->getNumResults();
+
+    builder.setInsertionPointToEnd(&regionBlock);
+    builder.create<d2m::SpatialYieldOp>(genericOp.getLoc(),
+                                        genericOp.getResults());
+  }
+}
+
+// Reassign d2m.spatial ins/outs from generics' operands; when result count
+// matches outs, update each spatial result's type from the corresponding out
+// value (extensible for fuller result-type policy later).
+static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
+  llvm::SmallVector<Value> inputs;
+  llvm::SmallVector<Value> outputs;
+  for (Region &region : spatialOp->getRegions()) {
+    if (region.empty()) {
+      continue;
+    }
+    for (d2m::GenericOp genericOp : region.front().getOps<d2m::GenericOp>()) {
+      for (Value input : genericOp.getInputs()) {
+        inputs.push_back(resolveToRegionBorderValue(input, spatialOp));
+      }
+      for (Value output : genericOp.getOutputs()) {
+        outputs.push_back(resolveToRegionBorderValue(output, spatialOp));
+      }
+    }
+  }
+  spatialOp.getInputsMutable().assign(inputs);
+  spatialOp.getOutputsMutable().assign(outputs);
+  if (spatialOp->getNumResults() == outputs.size()) {
+    for (auto [result, outVal] : llvm::zip(spatialOp->getResults(), outputs)) {
+      result.setType(outVal.getType());
+    }
+  }
+}
+
+void normalizeSingleSpatialOp(d2m::SpatialOp spatialOp) {
+  hoistNonGenericOpsAroundSpatial(spatialOp);
+  rebuildSpatialOpInsOutsAndResultTypes(spatialOp);
+}
+
+} // namespace detail
+
+void normalizeSpatialOpsInModule(ModuleOp module) {
+  SmallVector<d2m::SpatialOp> spatials;
+  module.walk([&](d2m::SpatialOp spatialOp) { spatials.push_back(spatialOp); });
+
+  for (d2m::SpatialOp spatialOp : spatials) {
+    detail::normalizeSingleSpatialOp(spatialOp);
+  }
+}
+
+void normalizeSpatialOpContainingGeneric(GenericOp genericOp) {
+  for (Region *r = genericOp->getParentRegion(); r;) {
+    Operation *parent = r->getParentOp();
+    if (!parent) {
+      break;
+    }
+    if (auto spatial = mlir::dyn_cast<d2m::SpatialOp>(parent)) {
+      detail::normalizeSingleSpatialOp(spatial);
+      return;
+    }
+    r = parent->getParentRegion();
+  }
+}
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir::tt::d2m {
@@ -129,7 +130,8 @@ static void hoistNonGenericOpsAroundSpatial(d2m::SpatialOp spatialOp) {
 
 // Reassign d2m.spatial ins/outs from generics' operands; when result count
 // matches outs, update each spatial result's type from the corresponding out
-// value (extensible for fuller result-type policy later).
+// value only when that out is a ranked tensor (spatial results are tensors;
+// outs may be memref).
 static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
   llvm::SmallVector<Value> inputs;
   llvm::SmallVector<Value> outputs;
@@ -150,7 +152,9 @@ static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
   spatialOp.getOutputsMutable().assign(outputs);
   if (spatialOp->getNumResults() == outputs.size()) {
     for (auto [result, outVal] : llvm::zip(spatialOp->getResults(), outputs)) {
-      result.setType(outVal.getType());
+      if (mlir::isa<RankedTensorType>(outVal.getType())) {
+        result.setType(outVal.getType());
+      }
     }
   }
 }

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -25,31 +25,6 @@ static d2m::GenericOp getSingleGenericOpFromSpatialRegion(Region &region) {
   return genericOps.front();
 }
 
-// Operand used by a nested generic, traced through view_layout chains that stay
-// inside the spatial op until a value defined outside the spatial regions.
-static Value resolveToRegionBorderValue(Value operand,
-                                        d2m::SpatialOp spatialOp) {
-  auto inSpatialRegion = [&](Value val) {
-    Operation *def = val.getDefiningOp();
-    if (!def) {
-      return false;
-    }
-    Region *parent = def->getBlock()->getParent();
-    return llvm::any_of(
-        spatialOp->getRegions(),
-        [parent](Region &spatialRegion) { return &spatialRegion == parent; });
-  };
-  Value current = operand;
-  while (inSpatialRegion(current)) {
-    if (auto viewOp = current.getDefiningOp<d2m::ViewLayoutOp>()) {
-      current = viewOp.getInput();
-    } else {
-      break;
-    }
-  }
-  return current;
-}
-
 // Hoist every op except d2m.generic out of each spatial region: prefix ops
 // move before the spatial (forward moveBefore order), suffix ops (after generic
 // until an optional d2m.spatial_yield or block end) move after the spatial
@@ -144,13 +119,12 @@ static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
   for (Region &region : spatialOp->getRegions()) {
     d2m::GenericOp genericOp = getSingleGenericOpFromSpatialRegion(region);
     for (Value input : genericOp.getInputs()) {
-      Value borderInput = resolveToRegionBorderValue(input, spatialOp);
-      if (seenInputs.insert(borderInput).second) {
-        inputs.push_back(borderInput);
+      if (seenInputs.insert(input).second) {
+        inputs.push_back(input);
       }
     }
     for (Value output : genericOp.getOutputs()) {
-      outputs.push_back(resolveToRegionBorderValue(output, spatialOp));
+      outputs.push_back(output);
     }
   }
   spatialOp.getInputsMutable().assign(inputs);

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -10,7 +10,7 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir::tt::d2m {
@@ -139,11 +139,15 @@ static void hoistNonGenericOpsAroundSpatial(d2m::SpatialOp spatialOp) {
 // outs may be memref).
 static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
   llvm::SmallVector<Value> inputs;
+  llvm::SmallDenseSet<Value, 16> seenInputs;
   llvm::SmallVector<Value> outputs;
   for (Region &region : spatialOp->getRegions()) {
     d2m::GenericOp genericOp = getSingleGenericOpFromSpatialRegion(region);
     for (Value input : genericOp.getInputs()) {
-      inputs.push_back(resolveToRegionBorderValue(input, spatialOp));
+      Value borderInput = resolveToRegionBorderValue(input, spatialOp);
+      if (seenInputs.insert(borderInput).second) {
+        inputs.push_back(borderInput);
+      }
     }
     for (Value output : genericOp.getOutputs()) {
       outputs.push_back(resolveToRegionBorderValue(output, spatialOp));

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -16,6 +16,15 @@
 namespace mlir::tt::d2m {
 namespace detail {
 
+static d2m::GenericOp getSingleGenericOpFromSpatialRegion(Region &region) {
+  TT_assertv(!region.empty(), "each spatial region must not be empty.");
+  Block &regionBlock = region.front();
+  auto genericOps = llvm::to_vector(regionBlock.getOps<d2m::GenericOp>());
+  TT_assertv(genericOps.size() == 1u,
+             "each spatial region must contain exactly one d2m.generic op.");
+  return genericOps.front();
+}
+
 // Operand used by a nested generic, traced through view_layout chains that stay
 // inside the spatial op until a value defined outside the spatial regions.
 static Value resolveToRegionBorderValue(Value operand,
@@ -53,13 +62,9 @@ static void hoistNonGenericOpsAroundSpatial(d2m::SpatialOp spatialOp) {
   unsigned cumulativeGenericResults = 0;
 
   for (Region &spatialRegion : spatialOp->getRegions()) {
-    TT_assertv(!spatialRegion.empty(),
-               "each spatial region must not be empty.");
+    d2m::GenericOp genericOp =
+        getSingleGenericOpFromSpatialRegion(spatialRegion);
     Block &regionBlock = spatialRegion.front();
-    auto genericOps = llvm::to_vector(regionBlock.getOps<d2m::GenericOp>());
-    TT_assertv(genericOps.size() == 1u,
-               "each spatial region must contain exactly one d2m.generic op.");
-    d2m::GenericOp genericOp = genericOps.front();
 
     llvm::SmallVector<Operation *> beforeOps;
     llvm::SmallVector<Operation *> afterOps;
@@ -136,16 +141,12 @@ static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
   llvm::SmallVector<Value> inputs;
   llvm::SmallVector<Value> outputs;
   for (Region &region : spatialOp->getRegions()) {
-    if (region.empty()) {
-      continue;
+    d2m::GenericOp genericOp = getSingleGenericOpFromSpatialRegion(region);
+    for (Value input : genericOp.getInputs()) {
+      inputs.push_back(resolveToRegionBorderValue(input, spatialOp));
     }
-    for (d2m::GenericOp genericOp : region.front().getOps<d2m::GenericOp>()) {
-      for (Value input : genericOp.getInputs()) {
-        inputs.push_back(resolveToRegionBorderValue(input, spatialOp));
-      }
-      for (Value output : genericOp.getOutputs()) {
-        outputs.push_back(resolveToRegionBorderValue(output, spatialOp));
-      }
+    for (Value output : genericOp.getOutputs()) {
+      outputs.push_back(resolveToRegionBorderValue(output, spatialOp));
     }
   }
   spatialOp.getInputsMutable().assign(inputs);

--- a/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
+++ b/lib/Dialect/D2M/Utils/SpatialOpNormalizeUtil.cpp
@@ -10,7 +10,7 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir::tt::d2m {
@@ -113,21 +113,18 @@ static void hoistNonGenericOpsAroundSpatial(d2m::SpatialOp spatialOp) {
 // value only when that out is a ranked tensor (spatial results are tensors;
 // outs may be memref).
 static void rebuildSpatialOpInsOutsAndResultTypes(d2m::SpatialOp spatialOp) {
-  llvm::SmallVector<Value> inputs;
-  llvm::SmallDenseSet<Value, 16> seenInputs;
+  llvm::SetVector<Value> inputs;
   llvm::SmallVector<Value> outputs;
   for (Region &region : spatialOp->getRegions()) {
     d2m::GenericOp genericOp = getSingleGenericOpFromSpatialRegion(region);
     for (Value input : genericOp.getInputs()) {
-      if (seenInputs.insert(input).second) {
-        inputs.push_back(input);
-      }
+      inputs.insert(input);
     }
     for (Value output : genericOp.getOutputs()) {
       outputs.push_back(output);
     }
   }
-  spatialOp.getInputsMutable().assign(inputs);
+  spatialOp.getInputsMutable().assign(inputs.getArrayRef());
   spatialOp.getOutputsMutable().assign(outputs);
   if (spatialOp->getNumResults() == outputs.size()) {
     for (auto [result, outVal] : llvm::zip(spatialOp->getResults(), outputs)) {


### PR DESCRIPTION
### Ticket
closes #8148

### Problem description
GridSelection can replace a nested d2m.generic with a new op and grids, but the surrounding d2m.spatial was not always updated in step. Its ins/outs, yields, and what stayed inside each region could then disagree with the generic’s actual operands and region-border buffers.

### What's changed
Add SpatialOpNormalizeUtil and run it on the enclosing d2m.spatial right after each successful recreateGenericOp: hoist non-generic ops, rebuild yields, reassign ins/outs from the new generic (resolving view_layout to the same border values), and align result types where applicable.

### Checklist
- [ ] New/Existing tests provide coverage for changes
