### PR TITLE
[ttkernel] add optional full_fp32 argument to reduce_uninit

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -617,8 +617,14 @@ def TTKernel_ReduceUninitOp : TTKernel_InitOp<"reduce_uninit"> {
        same dimension, this call can be omitted. If this function is not called, the packer will continue to use the edge masks set
        by the latest reduce_init call, which may lead to incorrect packing behavior in subsequent operations.
 
+       The `full_fp32` attribute emits reduce_uninit<true>, which performs the extra cleanup required after some
+       full-fp32 reduce sequences. Without the attribute, lowering emits reduce_uninit(), matching tt-metal's
+       default false behavior.
+
        This function is not in line with our programming mode. To be removed by end of 2025. tt-metal#22904.
     }];
+
+    let arguments = (ins UnitAttr:$full_fp32);
 
     let assemblyFormat = [{
       `(` `)` attr-dict `:` functional-type(operands, results)

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -294,6 +294,15 @@ public:
       template_args.push_back(emitc::OpaqueAttr::get(
           op.getContext(), op.getFullFp32() ? "true" : "false"));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp, ttkernel::ReduceUninitOp>) {
+      // The default `reduce_uninit()` signature already resolves to <false>,
+      // so emit a template arg only when full_fp32 is set.
+      if (!op.getFullFp32()) {
+        return ArrayAttr::get(op.getContext(), {});
+      }
+      SmallVector<Attribute, 1> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(op.getContext(), "true"));
+      return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::SFPUReduceInitOp>) {
       // sfpu_reduce_init<PoolType, DataFormat>()
       SmallVector<Attribute, 2> template_args;

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -298,7 +298,7 @@ public:
       // The default `reduce_uninit()` signature already resolves to <false>,
       // so emit a template arg only when full_fp32 is set.
       if (!op.getFullFp32()) {
-        return ArrayAttr::get(op.getContext(), {});
+        return ArrayAttr();
       }
       SmallVector<Attribute, 1> template_args;
       template_args.push_back(emitc::OpaqueAttr::get(op.getContext(), "true"));

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -524,6 +524,13 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @reduce_uninit_full_fp32
+    func.func @reduce_uninit_full_fp32() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.call_opaque "reduce_uninit"() {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.reduce_uninit"() <{full_fp32}> : () -> ()
+      return
+    }
+
     // CHECK-LABEL: func @reduce_init_avg
     func.func @reduce_init_avg() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -531,6 +531,14 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @reduce_uninit_default
+    func.func @reduce_uninit_default() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.call_opaque "reduce_uninit"()
+      // CHECK-NOT: template_args
+      "ttkernel.reduce_uninit"() : () -> ()
+      return
+    }
+
     // CHECK-LABEL: func @reduce_init_avg
     func.func @reduce_init_avg() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles


### PR DESCRIPTION
Previously the reduce_uninit ttkernel op did not have any arguments, unlike the llk API which has a template argument:
```template <bool enforce_fp32_accumulation = false>
ALWI void reduce_uninit() {
    if constexpr (enforce_fp32_accumulation) {
        MATH((tensix_sync()));
        MATH((reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0)));
    }
    PACK((llk_pack_reduce_mask_clear()));
}
```

This patch adds an argument to the reduce_uninit to enable setting that argument in emitc code for reduce_uninit() above.

Used in tt-lang https://github.com/tenstorrent/tt-lang/pull/534
