### PR TITLE
[Builder] Add tag/parse/split support for stablehlo.broadcast_in_dim

### DIFF
--- a/test/python/golden/mlir_snippets/stablehlo/stablehlo_broadcast_in_dim.mlir
+++ b/test/python/golden/mlir_snippets/stablehlo/stablehlo_broadcast_in_dim.mlir
@@ -1,0 +1,6 @@
+module @jit_broadcast_in_dim attributes {} {
+  func.func public @test_broadcast_in_dim(%arg0: tensor<3x1x5xf32>) -> tensor<3x4x1x5x6xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [0, 2, 3] : (tensor<3x1x5xf32>) -> tensor<3x4x1x5x6xf32>
+    return %0 : tensor<3x4x1x5x6xf32>
+  }
+}

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -585,24 +585,6 @@ def module_compare_lt(builder: StableHLOBuilder):
         return builder.compare(in0, in1, "LT", unit_attrs=unit_attrs)
 
 
-def module_broadcast_in_dim(builder: StableHLOBuilder):
-    @builder.func([(128, 128), (128, 128)], [torch.float32, torch.float32])
-    def broadcast_in_dim(
-        in0: Operand,
-        builder: StableHLOBuilder,
-        broadcast_dimensions: List[int],
-        output_shape: List[int],
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        builder.set_graph_level_check(True)
-        return builder.broadcast_in_dim(
-            in0,
-            broadcast_dimensions=broadcast_dimensions,
-            output_shape=output_shape,
-            unit_attrs=unit_attrs,
-        )
-
-
 @pytest.mark.parametrize("target", ["ttnn"])
 @pytest.mark.parametrize(
     "test_fn",

--- a/tools/builder/stablehlo/stablehlo_builder.py
+++ b/tools/builder/stablehlo/stablehlo_builder.py
@@ -2152,6 +2152,7 @@ class StableHLOBuilder(Builder):
 
         return floor_module, floor_builder
 
+    @tag(stablehlo.BroadcastInDimOp)
     def broadcast_in_dim(
         self,
         in0: Operand,
@@ -2199,13 +2200,110 @@ class StableHLOBuilder(Builder):
             organize_stablehlo_args=lambda inputs, output, _: (output, inputs[0]),
             output_shape=output_shape,
             output_type=output_type,
-            golden_kwargs={"size": output_shape},
+            golden_kwargs={
+                "broadcast_dimensions": broadcast_dimensions,
+                "output_shape": output_shape,
+            },
             stablehlo_kwargs={
                 "broadcast_dimensions": broadcast_dimensions,
             },
             unit_attrs=unit_attrs,
             sharding_attr=sharding_attr,
         )
+
+    @parse(stablehlo.BroadcastInDimOp)
+    def broadcast_in_dim_parser(
+        self,
+        old_op: stablehlo.BroadcastInDimOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        stablehlo_op = self.get_opview_from_parser(
+            StableHLOBuilder.broadcast_in_dim_parser
+        )
+        in0 = global_dict[old_op.operand]
+        broadcast_dimensions_attr = old_op.broadcast_dimensions
+
+        new_op = stablehlo_op(
+            old_op.result.type,
+            in0,
+            broadcast_dimensions_attr,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(stablehlo_op)
+        golden_output = op_golden_function(
+            input0,
+            broadcast_dimensions=list(broadcast_dimensions_attr),
+            output_shape=list(new_op_result.type.shape),
+        )
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(stablehlo.BroadcastInDimOp)
+    def broadcast_in_dim_split(
+        self,
+        old_op: stablehlo.BroadcastInDimOp,
+    ) -> Tuple[Module, StableHLOBuilder]:
+        stablehlo_op = self.get_opview_from_split(
+            StableHLOBuilder.broadcast_in_dim_split
+        )
+
+        old_context = old_op.context
+        old_loc = Location.unknown(old_context)
+        with old_context, old_loc:
+            broadcast_in_dim_module = Module.create()
+            broadcast_in_dim_builder = StableHLOBuilder(
+                old_context,
+                old_loc,
+                mesh_name=self._mesh_name,
+                mesh_dict=self._mesh_dict,
+            )
+            op_input_types = [
+                old_op.operand.type,
+            ]
+
+            with InsertionPoint(broadcast_in_dim_module.body):
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="broadcast_in_dim_module")
+                def decorated_func(*inputs):
+                    operand = inputs[0]
+                    result_type = old_op.result.type
+                    broadcast_dimensions_attr = old_op.broadcast_dimensions
+
+                    new_op = stablehlo_op(
+                        result_type,
+                        operand,
+                        broadcast_dimensions_attr,
+                        loc=old_op.location,
+                    )
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    broadcast_in_dim_builder._set_golden_tensor(
+                        new_op_result, old_op_result
+                    )
+                    input0 = self._get_golden_tensor(old_op.operand)
+                    broadcast_in_dim_builder._set_golden_tensor(operand, input0)
+                    broadcast_in_dim_builder._annotate_presharded_arg(operand)
+                    ordered_inputs.append(operand)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                broadcast_in_dim_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return broadcast_in_dim_module, broadcast_in_dim_builder
 
     ################ stablehlo.LogOp ###############
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -5325,6 +5325,24 @@ def stablehlo_reshape_golden(
     return torch.reshape(input_tensor, shape).clone().to(output_dtype)
 
 
+def stablehlo_broadcast_in_dim_golden(
+    input_tensor: GoldenMapTensor,
+    broadcast_dimensions: Union[DenseI64ArrayAttr, List[int], Tuple[int, ...]],
+    output_shape: Union[ArrayAttr, List[int], Tuple[int, ...]],
+) -> GoldenMapTensor:
+    broadcast_dimensions = [
+        int(dim) for dim in unpack_mlir_attr(broadcast_dimensions)
+    ]
+    output_shape = [int(dim) for dim in unpack_mlir_attr(output_shape)]
+
+    intermediate_shape = [1] * len(output_shape)
+    for src_dim, dst_dim in enumerate(broadcast_dimensions):
+        intermediate_shape[dst_dim] = input_tensor.shape[src_dim]
+
+    reshaped = torch.reshape(input_tensor, intermediate_shape)
+    return torch.broadcast_to(reshaped, output_shape).clone()
+
+
 def stablehlo_rsqrt_golden(
     input_tensor: GoldenMapTensor, output_type_mlir: Type
 ) -> GoldenMapTensor:
@@ -7650,8 +7668,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     stablehlo.MaxOp: stablehlo_maximum_golden,
     stablehlo.MinOp: stablehlo_minimum_golden,
     stablehlo.MulOp: stablehlo_multiply_golden,
-    # bitcast conversion operation
-    stablehlo.BroadcastInDimOp: torch.broadcast_to,
+    stablehlo.BroadcastInDimOp: stablehlo_broadcast_in_dim_golden,
     stablehlo.SubtractOp: stablehlo_subtract_golden,
     stablehlo.PowOp: stablehlo_pow_golden,
     stablehlo.ShiftRightLogicalOp: stablehlo_shift_right_logical_golden,


### PR DESCRIPTION
## Summary

Adds full `@tag` / `@parse` / `@split` support for `stablehlo.broadcast_in_dim`.

Closes #7252.

### What was added

- `tools/builder/stablehlo/stablehlo_builder.py`
  - Added `@tag(stablehlo.BroadcastInDimOp)` for `broadcast_in_dim`
  - Added `broadcast_in_dim_parser` (`@parse`)
  - Added `broadcast_in_dim_split` (`@split`)
  - Parser normalizes attrs via:
    - `broadcast_dimensions=list(...)`
    - `output_shape=list(...)`

- `tools/golden/mapping.py`
  - Added `stablehlo_broadcast_in_dim_golden` (`reshape` -> `broadcast_to`)
  - Registered `stablehlo.BroadcastInDimOp` in `GOLDEN_MAPPINGS`

- `test/python/golden/mlir_snippets/stablehlo/stablehlo_broadcast_in_dim.mlir`
  - Added parse/split fixture

- `test/python/golden/test_stablehlo_ops.py`
  - Removed unused `module_broadcast_in_dim` helper

### Validation

- `python3 -m py_compile` passed for modified Python files.
- `pytest` was not run in this environment.
