### PR TITLE
Add MLIRLinalgSynchronizableOpInterfaceImpl to TTMLIRTargets export set

### DIFF
--- a/cmake/modules/TTMLIRInstall.cmake
+++ b/cmake/modules/TTMLIRInstall.cmake
@@ -50,6 +50,7 @@ set(ttmlir_export_targets
   MLIRD2MAnalysis
   MLIRD2MTransforms
   MLIRD2MUtils
+  MLIRLinalgSynchronizableOpInterfaceImpl
 
   # Conversions
   TTMLIRTosaToTTIR


### PR DESCRIPTION
## Problem

PR #8106 (i.e [d2m] Introduce SynchronizableOpInterface) added the new library `MLIRLinalgSynchronizableOpInterfaceImpl` and linked it into `TTMLIRCompilerStatic` via `TTMLIR_LIBS`. However, the library was not added to the explicit export target list in `cmake/modules/TTMLIRInstall.cmake`.

`TTMLIRCompilerStatic` is installed into the `TTMLIRTargets` CMake export set. CMake requires all linked dependencies of an exported target to also be in an export set, so the generate step aborted with:

```
CMake Error in cmake/modules/CMakeLists.txt:
  install(EXPORT "TTMLIRTargets") includes target "TTMLIRCompilerStatic"
  which requires target "MLIRLinalgSynchronizableOpInterfaceImpl" that is
  not in any export set.
```

This was caught during the tt-forge-onnx tt-mlir uplift PR ([tenstorrent/tt-forge-onnx#3289](https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25100101437)), where  build jobs failed at the tt-mlir CMake configure step.

## Fix

Add `MLIRLinalgSynchronizableOpInterfaceImpl` to `ttmlir_export_targets` in `cmake/modules/TTMLIRInstall.cmake`
