### PR TITLE
[TTIR] Replace MoE bridge ops with ttir.composite

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6254,7 +6254,7 @@ def TTIR_SparseMatmulOp : TTIR_NamedOp<"sparse_matmul"> {
 def TTIR_CompositeOp : TTIR_Op<"composite"> {
     let summary = "Opaque composite op that lowers 1:1 to a matching TTNN op.";
     let description = [{
-      Carries a symbolic `name` and a dictionary of `composite_attributes`. Used
+      Carries a symbolic `name` and a dictionary of `op_attributes`. Used
       as a bridge for `stablehlo.composite` / `stablehlo.custom_call` operations
       that map 1:1 to a TTNN op (no transformation is performed at the TTIR
       level). The TTIR->TTNN conversion dispatches on `name` and constructs the
@@ -6273,12 +6273,8 @@ def TTIR_CompositeOp : TTIR_Op<"composite"> {
 
     let arguments = (ins StrAttr:$name,
                          Variadic<AnyRankedTensor>:$inputs,
-                         DictionaryAttr:$composite_attributes);
+                         DictionaryAttr:$op_attributes);
     let results = (outs Variadic<AnyRankedTensor>:$results);
-
-    let assemblyFormat = [{
-      $name `(` $inputs `)` attr-dict `:` functional-type($inputs, $results)
-    }];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6251,158 +6251,34 @@ def TTIR_SparseMatmulOp : TTIR_NamedOp<"sparse_matmul"> {
     let hasVerifier = 1;
 }
 
-def TTIR_AllToAllDispatchOp : TTIR_NamedOp<"all_to_all_dispatch", [TTIR_CCL]> {
-    let summary = "Dispatch tokens to expert devices for MoE computation.";
+def TTIR_CompositeOp : TTIR_Op<"composite"> {
+    let summary = "Opaque composite op that lowers 1:1 to a matching TTNN op.";
     let description = [{
-      Routes tokens to devices holding their selected experts via all-to-all
-      communication. Used before sparse_matmul in the MoE dispatch/combine flow.
+      Carries a symbolic `name` and a dictionary of `composite_attributes`. Used
+      as a bridge for `stablehlo.composite` / `stablehlo.custom_call` operations
+      that map 1:1 to a TTNN op (no transformation is performed at the TTIR
+      level). The TTIR->TTNN conversion dispatches on `name` and constructs the
+      corresponding TTNN op.
 
-      Input shapes:
-      - input_tensor: [B, S, 1, H]
-      - expert_indices: [B, S, 1, K]
-      - expert_mapping: [1, 1, E, D]
+      Supported names:
+        - "tt.all_to_all_dispatch"
+        - "tt.all_to_all_dispatch_metadata"
+        - "tt.all_to_all_combine"
+        - "tt.selective_reduce_combine"
+        - "tt.moe_expert_token_remap"
 
-      Output shapes:
-      - dispatched: [1, B*D, S, H]
-      - metadata: [1, B*D, S, K]
+      Shape and attribute constraints for each supported name are enforced in
+      the op verifier.
     }];
 
-    let arguments = (ins AnyRankedTensor:$input_tensor,
-                         AnyRankedTensor:$expert_indices,
-                         AnyRankedTensor:$expert_mapping,
-                         I64Attr:$num_devices,
-                         I64Attr:$cluster_axis);
+    let arguments = (ins StrAttr:$name,
+                         Variadic<AnyRankedTensor>:$inputs,
+                         DictionaryAttr:$composite_attributes);
+    let results = (outs Variadic<AnyRankedTensor>:$results);
 
-    let results = (outs AnyRankedTensor:$dispatched, AnyRankedTensor:$metadata);
-
-    let hasVerifier = 1;
-}
-
-def TTIR_AllToAllDispatchMetadataOp : TTIR_NamedOp<"all_to_all_dispatch_metadata", [TTIR_CCL]> {
-    let summary = "Dispatch tokens with metadata to expert devices for MoE computation.";
-    let description = [{
-      Routes tokens along with expert scores to devices holding their selected
-      experts via all-to-all communication within a ring (cluster_axis).
-      Returns dispatched tokens (sparse — only routed token slots are filled),
-      all-gathered expert indices, and all-gathered expert scores.
-
-      Dimensions:
-        M = tokens per ring device
-        K = selected experts per token
-        D = total devices
-        E = total experts
-
-      Input shapes (per device, after mesh sharding):
-      - input_tensor: [1, 1, M, H]
-      - expert_indices: [1, 1, M, K]
-      - expert_scores: [1, 1, M, K]
-      - expert_mapping: [1, 1, D, E]
-        Each entry [d, e] is the device ID that owns expert e.
-
-      Output shapes (3D, per device, num_devices * M = tokens_global):
-      - dispatched: [1, tokens_global, H]
-      - indices: [1, tokens_global, K] (all-gathered across ring)
-      - scores: [1, tokens_global, K] (all-gathered across ring)
+    let assemblyFormat = [{
+      $name `(` $inputs `)` attr-dict `:` functional-type($inputs, $results)
     }];
-
-    let arguments = (ins AnyRankedTensor:$input_tensor,
-                         AnyRankedTensor:$expert_indices,
-                         AnyRankedTensor:$expert_scores,
-                         AnyRankedTensor:$expert_mapping,
-                         I64Attr:$num_devices,
-                         I64Attr:$cluster_axis);
-
-    let results = (outs AnyRankedTensor:$dispatched,
-                       AnyRankedTensor:$indices,
-                       AnyRankedTensor:$scores);
-
-    let hasVerifier = 1;
-}
-
-def TTIR_AllToAllCombineOp : TTIR_NamedOp<"all_to_all_combine", [TTIR_CCL]> {
-    let summary = "Combine expert outputs back to original token positions.";
-    let description = [{
-      Inverse of dispatch: gathers expert computation results from expert devices
-      and restores tokens to their original device and order.
-
-      Input shapes:
-      - input_tensor: [E_local, B*D, S, H]
-      - expert_metadata: [1, B*D, S, K]
-      - expert_mapping: [1, 1, E, D]
-
-      Output shape:
-      - result: [K, B, S, H]
-    }];
-
-    let arguments = (ins AnyRankedTensor:$input_tensor,
-                         AnyRankedTensor:$expert_metadata,
-                         AnyRankedTensor:$expert_mapping,
-                         I64Attr:$num_devices,
-                         I64Attr:$cluster_axis,
-                         I64Attr:$num_experts_per_tok,
-                         DefaultValuedAttr<I64Attr, "2">:$output_shard_dim);
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let hasVerifier = 1;
-}
-
-def TTIR_SelectiveReduceCombineOp : TTIR_NamedOp<"selective_reduce_combine",
-    [TTIR_CCL]> {
-    let summary = "Reduce and combine phase of the MoE pipeline.";
-    let description = [{
-      Takes dense blocks of expert-computed tokens from the MoE compute kernel,
-      sparsifies them, and sends tokens back to their originating devices via
-      fabric.
-
-      Input shapes:
-      - dense_input_tensor: dense expert output
-      - dense_activations_tensor: activation metadata
-      - dense_token_maps_tensor: token routing maps
-      - dense_token_counts_tensor: token counts per expert
-
-      Output shape:
-      - result: combined expert contributions
-    }];
-
-    let arguments = (ins AnyRankedTensor:$dense_input_tensor,
-                         AnyRankedTensor:$dense_activations_tensor,
-                         AnyRankedTensor:$dense_token_maps_tensor,
-                         AnyRankedTensor:$dense_token_counts_tensor,
-                         UI32Attr:$hidden_size,
-                         UI32Attr:$batch_size,
-                         UI32Attr:$seq_size,
-                         UI32Attr:$select_experts_k,
-                         UI32Attr:$experts);
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let hasVerifier = 1;
-}
-
-def TTIR_MoeExpertTokenRemapOp : TTIR_NamedOp<"moe_expert_token_remap"> {
-    let summary = "Remap global expert routing to local device experts with sparsity.";
-    let description = [{
-      Converts global expert routing scores to local per-device expert mapping
-      and creates a sparsity pattern for efficient sparse_matmul. Used after
-      all_to_all_dispatch in the MoE dispatch/compute/combine flow.
-
-      Input shapes:
-      - topk_tensor: [D, B, S, E] (bf16 routing scores)
-      - expert_mapping: [1, 1, E, D] (uint16 one-hot mapping)
-      - expert_metadata: [D, B, S, K] (uint16 expert indices)
-
-      Output shapes:
-      - mapping: [1, B, S, E_local] (bf16 local routing weights)
-      - reduced: [1, 1, ceil(B*S/reduction_size), E_local] (uint16 sparsity)
-    }];
-
-    let arguments = (ins AnyRankedTensor:$topk_tensor,
-                         AnyRankedTensor:$expert_mapping,
-                         AnyRankedTensor:$expert_metadata,
-                         I64Attr:$reduction_size);
-
-    let results = (outs AnyRankedTensor:$mapping, AnyRankedTensor:$reduced);
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6251,7 +6251,7 @@ def TTIR_SparseMatmulOp : TTIR_NamedOp<"sparse_matmul"> {
     let hasVerifier = 1;
 }
 
-def TTIR_CompositeOp : TTIR_Op<"composite"> {
+def TTIR_CompositeOp : TTIR_NamedOp<"composite"> {
     let summary = "Opaque composite op that lowers 1:1 to a matching TTNN op.";
     let description = [{
       Carries a symbolic `name` and a dictionary of `op_attributes`. Used

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -8484,10 +8484,88 @@ public:
     return success();
   }
 };
-// This pattern recognizes and converts stablehlo.custom_call
-// @tt.all_to_all_dispatch to ttir.all_to_all_dispatch.
-// Dispatch returns a tuple (dispatched, metadata), which stablehlo represents
-// as a tuple type with get_tuple_element users.
+// Helper: parse a string-typed integer from an mhlo.frontend_attributes dict.
+// Returns the parsed value on success, or std::nullopt (with a notify failure)
+// on missing/malformed entries.
+static std::optional<int64_t>
+parseFrontendIntAttr(mlir::stablehlo::CustomCallOp srcOp,
+                     mlir::DictionaryAttr frontendAttributes,
+                     llvm::StringRef key, int64_t defaultValue,
+                     ConversionPatternRewriter &rewriter) {
+  auto stringAttr = frontendAttributes.getAs<mlir::StringAttr>(key);
+  if (!stringAttr) {
+    return defaultValue;
+  }
+  int64_t parsed = 0;
+  if (stringAttr.getValue().getAsInteger(10, parsed)) {
+    (void)rewriter.notifyMatchFailure(
+        srcOp, (key + " must be a valid integer.").str());
+    return std::nullopt;
+  }
+  return parsed;
+}
+
+// Shared helper: build a ttir.composite op from a custom_call with a
+// possibly-tuple, possibly-unpacked result. Routes get_tuple_element users or
+// replaces multi-result custom_calls directly.
+static LogicalResult replaceCustomCallWithComposite(
+    mlir::stablehlo::CustomCallOp srcOp, llvm::StringRef compositeName,
+    mlir::ValueRange operands, mlir::DictionaryAttr compositeAttrs,
+    size_t expectedResults, const TypeConverter *typeConverter,
+    ConversionPatternRewriter &rewriter) {
+  auto nameAttr = rewriter.getStringAttr(compositeName);
+  SmallVector<mlir::Type> resultTypes;
+
+  auto resultType = srcOp.getResult(0).getType();
+  if (auto tupleType = mlir::dyn_cast<mlir::TupleType>(resultType)) {
+    if (tupleType.size() != expectedResults) {
+      return rewriter.notifyMatchFailure(
+          srcOp, (compositeName + " must return a " +
+                  std::to_string(expectedResults) + "-element tuple.")
+                     .str());
+    }
+    for (size_t i = 0; i < expectedResults; ++i) {
+      resultTypes.push_back(typeConverter->convertType(tupleType.getType(i)));
+    }
+
+    auto newOp = rewriter.create<ttir::CompositeOp>(
+        srcOp.getLoc(), resultTypes, nameAttr, operands, compositeAttrs);
+
+    for (auto &use : llvm::make_early_inc_range(srcOp.getResult(0).getUses())) {
+      if (auto getTupleOp =
+              dyn_cast<mlir::stablehlo::GetTupleElementOp>(use.getOwner())) {
+        int64_t index = getTupleOp.getIndex();
+        if (index < 0 || static_cast<size_t>(index) >= expectedResults) {
+          return rewriter.notifyMatchFailure(srcOp,
+                                             "Unexpected tuple element index.");
+        }
+        rewriter.replaceOp(getTupleOp, newOp.getResult(index));
+      }
+    }
+    rewriter.eraseOp(srcOp);
+    return success();
+  }
+
+  if (srcOp.getNumResults() != expectedResults) {
+    return rewriter.notifyMatchFailure(srcOp, (compositeName + " must return " +
+                                               std::to_string(expectedResults) +
+                                               " results.")
+                                                  .str());
+  }
+
+  for (size_t i = 0; i < expectedResults; ++i) {
+    resultTypes.push_back(
+        typeConverter->convertType(srcOp.getResult(i).getType()));
+  }
+
+  auto newOp = rewriter.create<ttir::CompositeOp>(
+      srcOp.getLoc(), resultTypes, nameAttr, operands, compositeAttrs);
+  rewriter.replaceOp(srcOp, newOp.getResults());
+  return success();
+}
+
+// Converts stablehlo.custom_call @tt.all_to_all_dispatch to
+// ttir.composite "tt.all_to_all_dispatch".
 class StableHLOToTTIRAllToAllDispatchOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
   using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
@@ -8510,104 +8588,35 @@ public:
           srcOp, "all_to_all_dispatch op must have mhlo.frontend_attributes.");
     }
 
-    // Parse num_devices attribute
-    auto numDevicesStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("num_devices");
-    int64_t numDevices = 1;
-    if (numDevicesStringAttr) {
-      if (numDevicesStringAttr.getValue().getAsInteger(10, numDevices)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "num_devices must be a valid integer.");
-      }
+    auto numDevices = parseFrontendIntAttr(srcOp, frontendAttributes,
+                                           "num_devices", 1, rewriter);
+    auto clusterAxis = parseFrontendIntAttr(srcOp, frontendAttributes,
+                                            "cluster_axis", 0, rewriter);
+    if (!numDevices || !clusterAxis) {
+      return failure();
     }
 
-    // Parse cluster_axis attribute
-    auto clusterAxisStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("cluster_axis");
-    int64_t clusterAxis = 0;
-    if (clusterAxisStringAttr) {
-      if (clusterAxisStringAttr.getValue().getAsInteger(10, clusterAxis)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "cluster_axis must be a valid integer.");
-      }
-    }
-
-    // Get operands: input_tensor, expert_indices, expert_mapping
     if (adaptor.getOperands().size() != 3) {
       return rewriter.notifyMatchFailure(
           srcOp, "all_to_all_dispatch expects exactly 3 operands.");
     }
 
-    Value inputTensor = adaptor.getOperands()[0];
-    Value expertIndices = adaptor.getOperands()[1];
-    Value expertMapping = adaptor.getOperands()[2];
+    SmallVector<NamedAttribute> compositeAttrs = {
+        rewriter.getNamedAttr("num_devices",
+                              rewriter.getI64IntegerAttr(*numDevices)),
+        rewriter.getNamedAttr("cluster_axis",
+                              rewriter.getI64IntegerAttr(*clusterAxis))};
 
-    IntegerAttr numDevicesAttr = rewriter.getI64IntegerAttr(numDevices);
-    IntegerAttr clusterAxisAttr = rewriter.getI64IntegerAttr(clusterAxis);
-
-    // Handle multi-output: dispatch returns 2 results.
-    // Depending on the torch_xla version, the custom_call may produce:
-    //   (a) 2 separate results: %r:2 = custom_call -> (tensor, tensor)
-    //   (b) A tuple result extracted via get_tuple_element
-    auto resultType = srcOp.getResult(0).getType();
-    if (auto tupleType = mlir::dyn_cast<mlir::TupleType>(resultType)) {
-      // Tuple result: get individual element types
-      if (tupleType.size() != 2) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "all_to_all_dispatch must return a 2-element tuple.");
-      }
-
-      RankedTensorType dispatchedType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(tupleType.getType(0)));
-      RankedTensorType metadataType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(tupleType.getType(1)));
-
-      auto newOp = rewriter.create<ttir::AllToAllDispatchOp>(
-          srcOp.getLoc(), dispatchedType, metadataType, inputTensor,
-          expertIndices, expertMapping, numDevicesAttr, clusterAxisAttr);
-
-      // Replace get_tuple_element users with the new op's results
-      for (auto &use :
-           llvm::make_early_inc_range(srcOp.getResult(0).getUses())) {
-        if (auto getTupleOp =
-                dyn_cast<mlir::stablehlo::GetTupleElementOp>(use.getOwner())) {
-          int64_t index = getTupleOp.getIndex();
-          if (index == 0) {
-            rewriter.replaceOp(getTupleOp, newOp.getDispatched());
-          } else if (index == 1) {
-            rewriter.replaceOp(getTupleOp, newOp.getMetadata());
-          } else {
-            return rewriter.notifyMatchFailure(
-                srcOp, "Unexpected tuple element index.");
-          }
-        }
-      }
-      rewriter.eraseOp(srcOp);
-      return success();
-    }
-
-    // Non-tuple: 2 separate results (%r:2 = custom_call -> (tensor, tensor))
-    if (srcOp.getNumResults() == 2) {
-      RankedTensorType dispatchedType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(srcOp.getResult(0).getType()));
-      RankedTensorType metadataType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(srcOp.getResult(1).getType()));
-
-      auto newOp = rewriter.create<ttir::AllToAllDispatchOp>(
-          srcOp.getLoc(), dispatchedType, metadataType, inputTensor,
-          expertIndices, expertMapping, numDevicesAttr, clusterAxisAttr);
-
-      rewriter.replaceOp(srcOp, {newOp.getDispatched(), newOp.getMetadata()});
-      return success();
-    }
-
-    return rewriter.notifyMatchFailure(
-        srcOp, "all_to_all_dispatch must return 2 results.");
+    return replaceCustomCallWithComposite(
+        srcOp, "tt.all_to_all_dispatch", adaptor.getOperands(),
+        rewriter.getDictionaryAttr(compositeAttrs), /*expectedResults=*/2,
+        getTypeConverter(), rewriter);
   }
 };
 
-// This pattern recognizes and converts stablehlo.custom_call
-// @tt.all_to_all_combine to ttir.all_to_all_combine.
+// Converts stablehlo.custom_call @tt.all_to_all_combine to
+// ttir.composite "tt.all_to_all_combine" (plus an all_reduce for compound
+// sharding over the non-cluster axis).
 class StableHLOToTTIRAllToAllCombineOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
   using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
@@ -8630,53 +8639,19 @@ public:
           srcOp, "all_to_all_combine op must have mhlo.frontend_attributes.");
     }
 
-    // Parse num_devices attribute
-    auto numDevicesStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("num_devices");
-    int64_t numDevices = 1;
-    if (numDevicesStringAttr) {
-      if (numDevicesStringAttr.getValue().getAsInteger(10, numDevices)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "num_devices must be a valid integer.");
-      }
+    auto numDevices = parseFrontendIntAttr(srcOp, frontendAttributes,
+                                           "num_devices", 1, rewriter);
+    auto clusterAxis = parseFrontendIntAttr(srcOp, frontendAttributes,
+                                            "cluster_axis", 0, rewriter);
+    auto numExpertsPerTok = parseFrontendIntAttr(
+        srcOp, frontendAttributes, "num_experts_per_tok", 2, rewriter);
+    // Default output_shard_dim = 2 for [E, 1, tokens, H] layout.
+    auto outputShardDim = parseFrontendIntAttr(srcOp, frontendAttributes,
+                                               "output_shard_dim", 2, rewriter);
+    if (!numDevices || !clusterAxis || !numExpertsPerTok || !outputShardDim) {
+      return failure();
     }
 
-    // Parse cluster_axis attribute
-    auto clusterAxisStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("cluster_axis");
-    int64_t clusterAxis = 0;
-    if (clusterAxisStringAttr) {
-      if (clusterAxisStringAttr.getValue().getAsInteger(10, clusterAxis)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "cluster_axis must be a valid integer.");
-      }
-    }
-
-    // Parse num_experts_per_tok attribute
-    auto numExpertsPerTokStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("num_experts_per_tok");
-    int64_t numExpertsPerTok = 2;
-    if (numExpertsPerTokStringAttr) {
-      if (numExpertsPerTokStringAttr.getValue().getAsInteger(
-              10, numExpertsPerTok)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "num_experts_per_tok must be a valid integer.");
-      }
-    }
-
-    // Parse output_shard_dim attribute (default=2 for [E, 1, tokens, H] layout)
-    auto outputShardDimStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("output_shard_dim");
-    int64_t outputShardDim = 2;
-    if (outputShardDimStringAttr) {
-      if (outputShardDimStringAttr.getValue().getAsInteger(10,
-                                                           outputShardDim)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "output_shard_dim must be a valid integer.");
-      }
-    }
-
-    // Get operands: input_tensor, expert_metadata, expert_mapping
     if (adaptor.getOperands().size() != 3) {
       return rewriter.notifyMatchFailure(
           srcOp, "all_to_all_combine expects exactly 3 operands.");
@@ -8689,14 +8664,23 @@ public:
     RankedTensorType outputType = cast<RankedTensorType>(
         getTypeConverter()->convertType(srcOp.getResult(0).getType()));
 
-    auto combineOp = rewriter.create<ttir::AllToAllCombineOp>(
-        srcOp.getLoc(), outputType, inputTensor, expertMetadata, expertMapping,
-        rewriter.getI64IntegerAttr(numDevices),
-        rewriter.getI64IntegerAttr(clusterAxis),
-        rewriter.getI64IntegerAttr(numExpertsPerTok),
-        rewriter.getI64IntegerAttr(outputShardDim));
+    SmallVector<NamedAttribute> compositeAttrs = {
+        rewriter.getNamedAttr("num_devices",
+                              rewriter.getI64IntegerAttr(*numDevices)),
+        rewriter.getNamedAttr("cluster_axis",
+                              rewriter.getI64IntegerAttr(*clusterAxis)),
+        rewriter.getNamedAttr("num_experts_per_tok",
+                              rewriter.getI64IntegerAttr(*numExpertsPerTok)),
+        rewriter.getNamedAttr("output_shard_dim",
+                              rewriter.getI64IntegerAttr(*outputShardDim))};
 
-    Value result = combineOp.getResult();
+    auto combineOp = rewriter.create<ttir::CompositeOp>(
+        srcOp.getLoc(), TypeRange{outputType},
+        rewriter.getStringAttr("tt.all_to_all_combine"),
+        ValueRange{inputTensor, expertMetadata, expertMapping},
+        rewriter.getDictionaryAttr(compositeAttrs));
+
+    Value result = combineOp.getResult(0);
 
     // For 2D mesh with compound-sharded experts, the combine only handles
     // communication along the dispatch axis (cluster_axis). If the non-cluster
@@ -8708,9 +8692,9 @@ public:
     auto mappingType = cast<RankedTensorType>(expertMapping.getType());
     int64_t totalDevices = mappingType.getShape()[3];
     int64_t nonClusterSize =
-        totalDevices / std::max(numDevices, static_cast<int64_t>(1));
-    if (nonClusterSize > 1 && numDevices > 1) {
-      uint32_t reduceAxis = (clusterAxis == 0) ? 1 : 0;
+        totalDevices / std::max(*numDevices, static_cast<int64_t>(1));
+    if (nonClusterSize > 1 && *numDevices > 1) {
+      uint32_t reduceAxis = (*clusterAxis == 0) ? 1 : 0;
       auto allReduceOp = rewriter.create<ttir::AllReduceOp>(
           srcOp.getLoc(), outputType, result, ttcore::ReduceType::Sum,
           reduceAxis);
@@ -8718,14 +8702,12 @@ public:
     }
 
     rewriter.replaceOp(srcOp, result);
-
     return success();
   }
 };
 
-// This pattern recognizes and converts stablehlo.custom_call
-// @tt.moe_expert_token_remap to ttir.moe_expert_token_remap.
-// Returns a tuple (mapping, reduced), same pattern as all_to_all_dispatch.
+// Converts stablehlo.custom_call @tt.moe_expert_token_remap to
+// ttir.composite "tt.moe_expert_token_remap".
 class StableHLOToTTIRMoeExpertTokenRemapOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
   using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
@@ -8749,15 +8731,11 @@ public:
           "moe_expert_token_remap op must have mhlo.frontend_attributes.");
     }
 
-    // Parse reduction_size attribute
-    auto reductionSizeStringAttr =
-        frontendAttributes.getAs<mlir::StringAttr>("reduction_size");
-    int64_t reductionSize = 16;
-    if (reductionSizeStringAttr) {
-      if (reductionSizeStringAttr.getValue().getAsInteger(10, reductionSize)) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "reduction_size must be a valid integer.");
-      }
+    auto reductionSize =
+        parseFrontendIntAttr(srcOp, frontendAttributes, "reduction_size",
+                             /*defaultValue=*/16, rewriter);
+    if (!reductionSize) {
+      return failure();
     }
 
     if (adaptor.getOperands().size() != 3) {
@@ -8765,65 +8743,13 @@ public:
           srcOp, "moe_expert_token_remap expects exactly 3 operands.");
     }
 
-    Value topkTensor = adaptor.getOperands()[0];
-    Value expertMapping = adaptor.getOperands()[1];
-    Value expertMetadata = adaptor.getOperands()[2];
+    SmallVector<NamedAttribute> compositeAttrs = {rewriter.getNamedAttr(
+        "reduction_size", rewriter.getI64IntegerAttr(*reductionSize))};
 
-    IntegerAttr reductionSizeAttr = rewriter.getI64IntegerAttr(reductionSize);
-
-    // Handle multi-output: returns 2 results (mapping, reduced).
-    auto resultType = srcOp.getResult(0).getType();
-    if (auto tupleType = mlir::dyn_cast<mlir::TupleType>(resultType)) {
-      if (tupleType.size() != 2) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "moe_expert_token_remap must return a 2-element tuple.");
-      }
-
-      RankedTensorType mappingType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(tupleType.getType(0)));
-      RankedTensorType reducedType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(tupleType.getType(1)));
-
-      auto newOp = rewriter.create<ttir::MoeExpertTokenRemapOp>(
-          srcOp.getLoc(), mappingType, reducedType, topkTensor, expertMapping,
-          expertMetadata, reductionSizeAttr);
-
-      for (auto &use :
-           llvm::make_early_inc_range(srcOp.getResult(0).getUses())) {
-        if (auto getTupleOp =
-                dyn_cast<mlir::stablehlo::GetTupleElementOp>(use.getOwner())) {
-          int64_t index = getTupleOp.getIndex();
-          if (index == 0) {
-            rewriter.replaceOp(getTupleOp, newOp.getMapping());
-          } else if (index == 1) {
-            rewriter.replaceOp(getTupleOp, newOp.getReduced());
-          } else {
-            return rewriter.notifyMatchFailure(
-                srcOp, "Unexpected tuple element index.");
-          }
-        }
-      }
-      rewriter.eraseOp(srcOp);
-      return success();
-    }
-
-    // Non-tuple: 2 separate results
-    if (srcOp.getNumResults() == 2) {
-      RankedTensorType mappingType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(srcOp.getResult(0).getType()));
-      RankedTensorType reducedType = cast<RankedTensorType>(
-          getTypeConverter()->convertType(srcOp.getResult(1).getType()));
-
-      auto newOp = rewriter.create<ttir::MoeExpertTokenRemapOp>(
-          srcOp.getLoc(), mappingType, reducedType, topkTensor, expertMapping,
-          expertMetadata, reductionSizeAttr);
-
-      rewriter.replaceOp(srcOp, {newOp.getMapping(), newOp.getReduced()});
-      return success();
-    }
-
-    return rewriter.notifyMatchFailure(
-        srcOp, "moe_expert_token_remap must return 2 results.");
+    return replaceCustomCallWithComposite(
+        srcOp, "tt.moe_expert_token_remap", adaptor.getOperands(),
+        rewriter.getDictionaryAttr(compositeAttrs), /*expectedResults=*/2,
+        getTypeConverter(), rewriter);
   }
 };
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1753,7 +1753,7 @@ public:
 namespace {
 // Dispatches ttir.composite -> matching TTNN op based on the `name` attribute.
 // Each branch pulls the same attributes the old per-op pattern used out of the
-// composite_attributes dictionary and builds the TTNN op directly.
+// op_attributes dictionary and builds the TTNN op directly.
 class CompositeOpConversionPattern
     : public OpConversionPattern<ttir::CompositeOp> {
 public:
@@ -1763,7 +1763,7 @@ public:
   matchAndRewrite(ttir::CompositeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     llvm::StringRef name = op.getName();
-    mlir::DictionaryAttr attrs = op.getCompositeAttributes();
+    mlir::DictionaryAttr attrs = op.getOpAttributes();
     auto inputs = adaptor.getInputs();
 
     auto convertedType = [&](mlir::Type t) -> RankedTensorType {
@@ -1823,7 +1823,7 @@ public:
       auto getUI32 = [&](llvm::StringRef key) -> mlir::IntegerAttr {
         auto a = attrs.getAs<mlir::IntegerAttr>(key);
         return a ? rewriter.getUI32IntegerAttr(
-                       static_cast<uint32_t>(a.getInt()))
+                       static_cast<uint32_t>(a.getValue().getZExtValue()))
                  : mlir::IntegerAttr();
       };
       rewriter.replaceOpWithNewOp<ttnn::SelectiveReduceCombineOp>(

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1751,140 +1751,99 @@ public:
 } // namespace
 
 namespace {
-class AllToAllDispatchOpConversionPattern
-    : public OpConversionPattern<ttir::AllToAllDispatchOp> {
+// Dispatches ttir.composite -> matching TTNN op based on the `name` attribute.
+// Each branch pulls the same attributes the old per-op pattern used out of the
+// composite_attributes dictionary and builds the TTNN op directly.
+class CompositeOpConversionPattern
+    : public OpConversionPattern<ttir::CompositeOp> {
 public:
-  using OpConversionPattern<ttir::AllToAllDispatchOp>::OpConversionPattern;
+  using OpConversionPattern<ttir::CompositeOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ttir::AllToAllDispatchOp op, OpAdaptor adaptor,
+  matchAndRewrite(ttir::CompositeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto dispatchedType = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getDispatched().getType()));
-    auto metadataType = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getMetadata().getType()));
+    llvm::StringRef name = op.getName();
+    mlir::DictionaryAttr attrs = op.getCompositeAttributes();
+    auto inputs = adaptor.getInputs();
 
-    rewriter.replaceOpWithNewOp<ttnn::AllToAllDispatchOp>(
-        op, dispatchedType, metadataType, adaptor.getInputTensor(),
-        adaptor.getExpertIndices(), adaptor.getExpertMapping(),
-        op.getNumDevicesAttr(), op.getClusterAxisAttr(),
-        /*memory_config=*/nullptr);
-    return success();
-  }
-};
-} // namespace
+    auto convertedType = [&](mlir::Type t) -> RankedTensorType {
+      return cast<RankedTensorType>(this->getTypeConverter()->convertType(t));
+    };
+    auto getI64 = [&](llvm::StringRef key) -> mlir::IntegerAttr {
+      return attrs.getAs<mlir::IntegerAttr>(key);
+    };
 
-namespace {
-class AllToAllDispatchMetadataOpConversionPattern
-    : public OpConversionPattern<ttir::AllToAllDispatchMetadataOp> {
-public:
-  using OpConversionPattern<
-      ttir::AllToAllDispatchMetadataOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttir::AllToAllDispatchMetadataOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    // TTIR outputs are 3D [1, tokens_global, C], matching the metal kernel.
-    // No output reshape needed.
-    auto dispatched3D = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getDispatched().getType()));
-    auto indices3D = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getIndices().getType()));
-    auto scores3D = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getScores().getType()));
-
-    // Reshape expert_mapping from 4D [1, 1, D, E] to 2D [D, E].
-    Value expertMapping = adaptor.getExpertMapping();
-    auto mappingType = cast<RankedTensorType>(expertMapping.getType());
-    if (mappingType.getRank() == 4) {
-      int64_t D = mappingType.getShape()[2];
-      int64_t E = mappingType.getShape()[3];
-      SmallVector<int64_t> newShape = {D, E};
-      auto reshapedType =
-          ttnn::utils::RankedTensorTypeFactory::create(mappingType, newShape);
-      auto shapeAttr = rewriter.getI32ArrayAttr(
-          {static_cast<int32_t>(D), static_cast<int32_t>(E)});
-      expertMapping = rewriter.create<ttnn::ReshapeOp>(
-          op.getLoc(), reshapedType, expertMapping, shapeAttr,
+    if (name == "tt.all_to_all_dispatch") {
+      rewriter.replaceOpWithNewOp<ttnn::AllToAllDispatchOp>(
+          op, convertedType(op.getResult(0).getType()),
+          convertedType(op.getResult(1).getType()), inputs[0], inputs[1],
+          inputs[2], getI64("num_devices"), getI64("cluster_axis"),
           /*memory_config=*/nullptr);
+      return success();
     }
 
-    rewriter.replaceOpWithNewOp<ttnn::AllToAllDispatchMetadataOp>(
-        op, dispatched3D, indices3D, scores3D, adaptor.getInputTensor(),
-        adaptor.getExpertIndices(), adaptor.getExpertScores(), expertMapping,
-        op.getNumDevicesAttr(), op.getClusterAxisAttr(),
-        /*memory_config=*/nullptr,
-        /*drain_core=*/nullptr);
-    return success();
-  }
-};
-} // namespace
+    if (name == "tt.all_to_all_dispatch_metadata") {
+      // Reshape expert_mapping from 4D [1, 1, D, E] to 2D [D, E].
+      Value expertMapping = inputs[3];
+      auto mappingType = cast<RankedTensorType>(expertMapping.getType());
+      if (mappingType.getRank() == 4) {
+        int64_t D = mappingType.getShape()[2];
+        int64_t E = mappingType.getShape()[3];
+        SmallVector<int64_t> newShape = {D, E};
+        auto reshapedType =
+            ttnn::utils::RankedTensorTypeFactory::create(mappingType, newShape);
+        auto shapeAttr = rewriter.getI32ArrayAttr(
+            {static_cast<int32_t>(D), static_cast<int32_t>(E)});
+        expertMapping = rewriter.create<ttnn::ReshapeOp>(
+            op.getLoc(), reshapedType, expertMapping, shapeAttr,
+            /*memory_config=*/nullptr);
+      }
 
-namespace {
-class AllToAllCombineOpConversionPattern
-    : public OpConversionPattern<ttir::AllToAllCombineOp> {
-public:
-  using OpConversionPattern<ttir::AllToAllCombineOp>::OpConversionPattern;
+      rewriter.replaceOpWithNewOp<ttnn::AllToAllDispatchMetadataOp>(
+          op, convertedType(op.getResult(0).getType()),
+          convertedType(op.getResult(1).getType()),
+          convertedType(op.getResult(2).getType()), inputs[0], inputs[1],
+          inputs[2], expertMapping, getI64("num_devices"),
+          getI64("cluster_axis"),
+          /*memory_config=*/nullptr,
+          /*drain_core=*/nullptr);
+      return success();
+    }
 
-  LogicalResult
-  matchAndRewrite(ttir::AllToAllCombineOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto outputType = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getResult().getType()));
+    if (name == "tt.all_to_all_combine") {
+      rewriter.replaceOpWithNewOp<ttnn::AllToAllCombineOp>(
+          op, convertedType(op.getResult(0).getType()), inputs[0], inputs[1],
+          inputs[2], getI64("num_devices"), getI64("cluster_axis"),
+          getI64("num_experts_per_tok"), getI64("output_shard_dim"),
+          /*memory_config=*/nullptr);
+      return success();
+    }
 
-    // Pass through output_shard_dim from TTIR (set by frontend).
-    rewriter.replaceOpWithNewOp<ttnn::AllToAllCombineOp>(
-        op, outputType, adaptor.getInputTensor(), adaptor.getExpertMetadata(),
-        adaptor.getExpertMapping(), op.getNumDevicesAttr(),
-        op.getClusterAxisAttr(), op.getNumExpertsPerTokAttr(),
-        op.getOutputShardDimAttr(),
-        /*memory_config=*/nullptr);
-    return success();
-  }
-};
-} // namespace
+    if (name == "tt.selective_reduce_combine") {
+      auto getUI32 = [&](llvm::StringRef key) -> mlir::IntegerAttr {
+        auto a = attrs.getAs<mlir::IntegerAttr>(key);
+        return a ? rewriter.getUI32IntegerAttr(
+                       static_cast<uint32_t>(a.getInt()))
+                 : mlir::IntegerAttr();
+      };
+      rewriter.replaceOpWithNewOp<ttnn::SelectiveReduceCombineOp>(
+          op, convertedType(op.getResult(0).getType()), inputs[0], inputs[1],
+          inputs[2], inputs[3], getUI32("hidden_size"), getUI32("batch_size"),
+          getUI32("seq_size"), getUI32("select_experts_k"), getUI32("experts"));
+      return success();
+    }
 
-namespace {
-class SelectiveReduceCombineOpConversionPattern
-    : public OpConversionPattern<ttir::SelectiveReduceCombineOp> {
-public:
-  using OpConversionPattern<
-      ttir::SelectiveReduceCombineOp>::OpConversionPattern;
+    if (name == "tt.moe_expert_token_remap") {
+      rewriter.replaceOpWithNewOp<ttnn::MoeExpertTokenRemapOp>(
+          op, convertedType(op.getResult(0).getType()),
+          convertedType(op.getResult(1).getType()), inputs[0], inputs[1],
+          inputs[2], getI64("reduction_size"),
+          /*memory_config=*/nullptr);
+      return success();
+    }
 
-  LogicalResult
-  matchAndRewrite(ttir::SelectiveReduceCombineOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<ttnn::SelectiveReduceCombineOp>(
-        op, this->getTypeConverter()->convertType(op.getResult().getType()),
-        adaptor.getDenseInputTensor(), adaptor.getDenseActivationsTensor(),
-        adaptor.getDenseTokenMapsTensor(), adaptor.getDenseTokenCountsTensor(),
-        op.getHiddenSizeAttr(), op.getBatchSizeAttr(), op.getSeqSizeAttr(),
-        op.getSelectExpertsKAttr(), op.getExpertsAttr());
-    return success();
-  }
-};
-} // namespace
-
-namespace {
-class MoeExpertTokenRemapOpConversionPattern
-    : public OpConversionPattern<ttir::MoeExpertTokenRemapOp> {
-public:
-  using OpConversionPattern<ttir::MoeExpertTokenRemapOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttir::MoeExpertTokenRemapOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto mappingType = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getMapping().getType()));
-    auto reducedType = cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getReduced().getType()));
-
-    rewriter.replaceOpWithNewOp<ttnn::MoeExpertTokenRemapOp>(
-        op, mappingType, reducedType, adaptor.getTopkTensor(),
-        adaptor.getExpertMapping(), adaptor.getExpertMetadata(),
-        op.getReductionSizeAttr(),
-        /*memory_config=*/nullptr);
-    return success();
+    return rewriter.notifyMatchFailure(op, "unsupported ttir.composite name: " +
+                                               name);
   }
 };
 } // namespace
@@ -3850,11 +3809,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            GroupNormOpConversionPattern,
            MatmulOpConversionPattern,
            SparseMatmulOpConversionPattern,
-           AllToAllDispatchOpConversionPattern,
-           AllToAllDispatchMetadataOpConversionPattern,
-           AllToAllCombineOpConversionPattern,
-           SelectiveReduceCombineOpConversionPattern,
-           MoeExpertTokenRemapOpConversionPattern,
+           CompositeOpConversionPattern,
            Conv2dOpConversionPattern,
            Conv3dOpConversionPattern,
            ConvTranspose2dOpConversionPattern,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7142,10 +7142,9 @@ static ::mlir::LogicalResult requireIntAttr(::mlir::Operation *op,
                                             bool mustBePositive) {
   auto attr = attrs.getAs<::mlir::IntegerAttr>(key);
   if (!attr) {
-    return op->emitOpError()
-           << "composite_attributes missing integer '" << key << "'";
+    return op->emitOpError() << "op_attributes missing integer '" << key << "'";
   }
-  int64_t out = attr.getInt();
+  int64_t out = attr.getValue().getSExtValue();
   if (mustBePositive && out <= 0) {
     return op->emitOpError() << "'" << key << "' must be positive";
   }
@@ -7156,9 +7155,9 @@ static ::mlir::LogicalResult verifyClusterAxis(::mlir::Operation *op,
                                                ::mlir::DictionaryAttr attrs) {
   auto attr = attrs.getAs<::mlir::IntegerAttr>("cluster_axis");
   if (!attr) {
-    return op->emitOpError("composite_attributes missing 'cluster_axis'");
+    return op->emitOpError("op_attributes missing 'cluster_axis'");
   }
-  int64_t v = attr.getInt();
+  int64_t v = attr.getValue().getSExtValue();
   if (v < 0 || v > 1) {
     return op->emitOpError("'cluster_axis' must be 0 or 1");
   }
@@ -7169,7 +7168,7 @@ static ::mlir::LogicalResult verifyClusterAxis(::mlir::Operation *op,
 
 ::mlir::LogicalResult mlir::tt::ttir::CompositeOp::verify() {
   llvm::StringRef name = getName();
-  ::mlir::DictionaryAttr attrs = getCompositeAttributes();
+  ::mlir::DictionaryAttr attrs = getOpAttributes();
   auto inputs = getInputs();
   auto results = getResults();
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7127,200 +7127,199 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// AllToAllDispatchOp
+// CompositeOp
 //===----------------------------------------------------------------------===//
 
-::mlir::LogicalResult mlir::tt::ttir::AllToAllDispatchOp::verify() {
-  ::mlir::RankedTensorType inputType = getInputTensor().getType();
-  ::mlir::RankedTensorType indicesType = getExpertIndices().getType();
-  ::mlir::RankedTensorType mappingType = getExpertMapping().getType();
-  ::mlir::RankedTensorType dispatchedType = getDispatched().getType();
-  ::mlir::RankedTensorType metadataType = getMetadata().getType();
+namespace {
 
-  // All tensors must be 4D
-  if (inputType.getRank() != 4) {
-    return emitOpError("input_tensor must be a 4D tensor [B, S, 1, H]");
-  }
-  if (indicesType.getRank() != 4) {
-    return emitOpError("expert_indices must be a 4D tensor [B, S, 1, K]");
-  }
-  if (mappingType.getRank() != 4) {
-    return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
-  }
-  if (dispatchedType.getRank() != 4) {
-    return emitOpError("dispatched output must be a 4D tensor [1, B*D, S, H]");
-  }
-  if (metadataType.getRank() != 4) {
-    return emitOpError("metadata output must be a 4D tensor [1, B*D, S, K]");
-  }
-
-  // Verify num_devices > 0
-  if (getNumDevices() <= 0) {
-    return emitOpError("num_devices must be positive");
-  }
-
-  // Verify cluster_axis is 0 or 1.
-  int64_t clusterAxis = static_cast<int64_t>(getClusterAxis());
-  if (clusterAxis < 0 || clusterAxis > 1) {
-    return emitOpError("cluster_axis must be 0 or 1");
-  }
-
-  return success();
+static int64_t rankOf(::mlir::Value v) {
+  return ::mlir::cast<::mlir::RankedTensorType>(v.getType()).getRank();
 }
 
-//===----------------------------------------------------------------------===//
-// AllToAllDispatchMetadataOp
-//===----------------------------------------------------------------------===//
-
-::mlir::LogicalResult mlir::tt::ttir::AllToAllDispatchMetadataOp::verify() {
-  ::mlir::RankedTensorType inputType = getInputTensor().getType();
-  ::mlir::RankedTensorType indicesType = getExpertIndices().getType();
-  ::mlir::RankedTensorType scoresType = getExpertScores().getType();
-  ::mlir::RankedTensorType mappingType = getExpertMapping().getType();
-  ::mlir::RankedTensorType dispatchedType = getDispatched().getType();
-  ::mlir::RankedTensorType indicesOutType = getIndices().getType();
-  ::mlir::RankedTensorType scoresOutType = getScores().getType();
-
-  // Inputs must be 4D
-  if (inputType.getRank() != 4) {
-    return emitOpError("input_tensor must be a 4D tensor [1, 1, M, H]");
+static ::mlir::LogicalResult requireIntAttr(::mlir::Operation *op,
+                                            ::mlir::DictionaryAttr attrs,
+                                            llvm::StringRef key,
+                                            bool mustBePositive) {
+  auto attr = attrs.getAs<::mlir::IntegerAttr>(key);
+  if (!attr) {
+    return op->emitOpError()
+           << "composite_attributes missing integer '" << key << "'";
   }
-  if (indicesType.getRank() != 4) {
-    return emitOpError("expert_indices must be a 4D tensor [1, 1, M, K]");
+  int64_t out = attr.getInt();
+  if (mustBePositive && out <= 0) {
+    return op->emitOpError() << "'" << key << "' must be positive";
   }
-  if (scoresType.getRank() != 4) {
-    return emitOpError("expert_scores must be a 4D tensor [1, 1, M, K]");
-  }
-  if (mappingType.getRank() != 4) {
-    return emitOpError("expert_mapping must be a 4D tensor [1, 1, D, E]");
-  }
-  // Outputs are 3D matching the metal kernel output shapes
-  if (dispatchedType.getRank() != 3) {
-    return emitOpError(
-        "dispatched output must be a 3D tensor [1, tokens_global, H]");
-  }
-  if (indicesOutType.getRank() != 3) {
-    return emitOpError(
-        "indices output must be a 3D tensor [1, tokens_global, K]");
-  }
-  if (scoresOutType.getRank() != 3) {
-    return emitOpError(
-        "scores output must be a 3D tensor [1, tokens_global, K]");
-  }
-
-  // Verify num_devices > 0
-  if (getNumDevices() <= 0) {
-    return emitOpError("num_devices must be positive");
-  }
-
-  // Verify cluster_axis is 0 or 1.
-  int64_t clusterAxis = static_cast<int64_t>(getClusterAxis());
-  if (clusterAxis < 0 || clusterAxis > 1) {
-    return emitOpError("cluster_axis must be 0 or 1");
-  }
-
-  return success();
+  return ::mlir::success();
 }
 
-//===----------------------------------------------------------------------===//
-// AllToAllCombineOp
-//===----------------------------------------------------------------------===//
-
-::mlir::LogicalResult mlir::tt::ttir::AllToAllCombineOp::verify() {
-  ::mlir::RankedTensorType inputType = getInputTensor().getType();
-  ::mlir::RankedTensorType metadataType = getExpertMetadata().getType();
-  ::mlir::RankedTensorType mappingType = getExpertMapping().getType();
-  ::mlir::RankedTensorType resultType = getResult().getType();
-
-  // All tensors must be 4D
-  if (inputType.getRank() != 4) {
-    return emitOpError("input_tensor must be a 4D tensor [E_local, B*D, S, H]");
+static ::mlir::LogicalResult verifyClusterAxis(::mlir::Operation *op,
+                                               ::mlir::DictionaryAttr attrs) {
+  auto attr = attrs.getAs<::mlir::IntegerAttr>("cluster_axis");
+  if (!attr) {
+    return op->emitOpError("composite_attributes missing 'cluster_axis'");
   }
-  if (metadataType.getRank() != 4) {
-    return emitOpError("expert_metadata must be a 4D tensor [1, B*D, S, K]");
+  int64_t v = attr.getInt();
+  if (v < 0 || v > 1) {
+    return op->emitOpError("'cluster_axis' must be 0 or 1");
   }
-  if (mappingType.getRank() != 4) {
-    return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
-  }
-  if (resultType.getRank() != 4) {
-    return emitOpError("result must be a 4D tensor [K, B, S, H]");
-  }
-
-  // Verify num_devices > 0
-  if (getNumDevices() <= 0) {
-    return emitOpError("num_devices must be positive");
-  }
-
-  // Verify cluster_axis is 0 or 1.
-  int64_t clusterAxis = static_cast<int64_t>(getClusterAxis());
-  if (clusterAxis < 0 || clusterAxis > 1) {
-    return emitOpError("cluster_axis must be 0 or 1");
-  }
-
-  // Verify num_experts_per_tok > 0
-  if (getNumExpertsPerTok() <= 0) {
-    return emitOpError("num_experts_per_tok must be positive");
-  }
-
-  return success();
+  return ::mlir::success();
 }
 
-//===----------------------------------------------------------------------===//
-// SelectiveReduceCombineOp
-//===----------------------------------------------------------------------===//
+} // namespace
 
-::mlir::LogicalResult mlir::tt::ttir::SelectiveReduceCombineOp::verify() {
-  // Verify select_experts_k > 0
-  if (getSelectExpertsK() == 0) {
-    return emitOpError("select_experts_k must be positive");
+::mlir::LogicalResult mlir::tt::ttir::CompositeOp::verify() {
+  llvm::StringRef name = getName();
+  ::mlir::DictionaryAttr attrs = getCompositeAttributes();
+  auto inputs = getInputs();
+  auto results = getResults();
+
+  if (name == "tt.all_to_all_dispatch") {
+    if (inputs.size() != 3) {
+      return emitOpError("tt.all_to_all_dispatch expects 3 inputs "
+                         "(input_tensor, expert_indices, expert_mapping)");
+    }
+    if (results.size() != 2) {
+      return emitOpError(
+          "tt.all_to_all_dispatch produces 2 results (dispatched, metadata)");
+    }
+    if (rankOf(inputs[0]) != 4) {
+      return emitOpError("input_tensor must be a 4D tensor [B, S, 1, H]");
+    }
+    if (rankOf(inputs[1]) != 4) {
+      return emitOpError("expert_indices must be a 4D tensor [B, S, 1, K]");
+    }
+    if (rankOf(inputs[2]) != 4) {
+      return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
+    }
+    if (rankOf(results[0]) != 4) {
+      return emitOpError(
+          "dispatched output must be a 4D tensor [1, B*D, S, H]");
+    }
+    if (rankOf(results[1]) != 4) {
+      return emitOpError("metadata output must be a 4D tensor [1, B*D, S, K]");
+    }
+    if (failed(requireIntAttr(getOperation(), attrs, "num_devices",
+                              /*mustBePositive=*/true))) {
+      return failure();
+    }
+    return verifyClusterAxis(getOperation(), attrs);
   }
 
-  // Verify experts > 0
-  if (getExperts() == 0) {
-    return emitOpError("experts must be positive");
+  if (name == "tt.all_to_all_dispatch_metadata") {
+    if (inputs.size() != 4) {
+      return emitOpError("tt.all_to_all_dispatch_metadata expects 4 inputs");
+    }
+    if (results.size() != 3) {
+      return emitOpError("tt.all_to_all_dispatch_metadata produces 3 results");
+    }
+    if (rankOf(inputs[0]) != 4) {
+      return emitOpError("input_tensor must be a 4D tensor [1, 1, M, H]");
+    }
+    if (rankOf(inputs[1]) != 4) {
+      return emitOpError("expert_indices must be a 4D tensor [1, 1, M, K]");
+    }
+    if (rankOf(inputs[2]) != 4) {
+      return emitOpError("expert_scores must be a 4D tensor [1, 1, M, K]");
+    }
+    if (rankOf(inputs[3]) != 4) {
+      return emitOpError("expert_mapping must be a 4D tensor [1, 1, D, E]");
+    }
+    if (rankOf(results[0]) != 3) {
+      return emitOpError(
+          "dispatched output must be a 3D tensor [1, tokens_global, H]");
+    }
+    if (rankOf(results[1]) != 3) {
+      return emitOpError(
+          "indices output must be a 3D tensor [1, tokens_global, K]");
+    }
+    if (rankOf(results[2]) != 3) {
+      return emitOpError(
+          "scores output must be a 3D tensor [1, tokens_global, K]");
+    }
+    if (failed(requireIntAttr(getOperation(), attrs, "num_devices",
+                              /*mustBePositive=*/true))) {
+      return failure();
+    }
+    return verifyClusterAxis(getOperation(), attrs);
   }
 
-  // Verify hidden_size > 0
-  if (getHiddenSize() == 0) {
-    return emitOpError("hidden_size must be positive");
+  if (name == "tt.all_to_all_combine") {
+    if (inputs.size() != 3) {
+      return emitOpError("tt.all_to_all_combine expects 3 inputs");
+    }
+    if (results.size() != 1) {
+      return emitOpError("tt.all_to_all_combine produces 1 result");
+    }
+    if (rankOf(inputs[0]) != 4) {
+      return emitOpError(
+          "input_tensor must be a 4D tensor [E_local, B*D, S, H]");
+    }
+    if (rankOf(inputs[1]) != 4) {
+      return emitOpError("expert_metadata must be a 4D tensor [1, B*D, S, K]");
+    }
+    if (rankOf(inputs[2]) != 4) {
+      return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
+    }
+    if (rankOf(results[0]) != 4) {
+      return emitOpError("result must be a 4D tensor [K, B, S, H]");
+    }
+    if (failed(requireIntAttr(getOperation(), attrs, "num_devices",
+                              /*mustBePositive=*/true))) {
+      return failure();
+    }
+    if (failed(verifyClusterAxis(getOperation(), attrs))) {
+      return failure();
+    }
+    return requireIntAttr(getOperation(), attrs, "num_experts_per_tok",
+                          /*mustBePositive=*/true);
   }
 
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// MoeExpertTokenRemapOp
-//===----------------------------------------------------------------------===//
-
-::mlir::LogicalResult mlir::tt::ttir::MoeExpertTokenRemapOp::verify() {
-  ::mlir::RankedTensorType topkType = getTopkTensor().getType();
-  ::mlir::RankedTensorType mappingInputType = getExpertMapping().getType();
-  ::mlir::RankedTensorType metadataType = getExpertMetadata().getType();
-  ::mlir::RankedTensorType mappingOutputType = getMapping().getType();
-  ::mlir::RankedTensorType reducedType = getReduced().getType();
-
-  if (topkType.getRank() != 4) {
-    return emitOpError("topk_tensor must be a 4D tensor [D, B, S, E]");
-  }
-  if (mappingInputType.getRank() != 4) {
-    return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
-  }
-  if (metadataType.getRank() != 4) {
-    return emitOpError("expert_metadata must be a 4D tensor [D, B, S, K]");
-  }
-  if (mappingOutputType.getRank() != 4) {
-    return emitOpError("mapping output must be a 4D tensor [1, B, S, E_local]");
-  }
-  if (reducedType.getRank() != 4) {
-    return emitOpError(
-        "reduced output must be a 4D tensor [1, 1, ceil(B*S/R), E_local]");
+  if (name == "tt.selective_reduce_combine") {
+    if (inputs.size() != 4) {
+      return emitOpError("tt.selective_reduce_combine expects 4 inputs");
+    }
+    if (results.size() != 1) {
+      return emitOpError("tt.selective_reduce_combine produces 1 result");
+    }
+    for (llvm::StringRef key : {"hidden_size", "batch_size", "seq_size",
+                                "select_experts_k", "experts"}) {
+      if (failed(requireIntAttr(getOperation(), attrs, key,
+                                /*mustBePositive=*/true))) {
+        return failure();
+      }
+    }
+    return success();
   }
 
-  if (getReductionSize() <= 0) {
-    return emitOpError("reduction_size must be positive");
+  if (name == "tt.moe_expert_token_remap") {
+    if (inputs.size() != 3) {
+      return emitOpError("tt.moe_expert_token_remap expects 3 inputs");
+    }
+    if (results.size() != 2) {
+      return emitOpError("tt.moe_expert_token_remap produces 2 results");
+    }
+    if (rankOf(inputs[0]) != 4) {
+      return emitOpError("topk_tensor must be a 4D tensor [D, B, S, E]");
+    }
+    if (rankOf(inputs[1]) != 4) {
+      return emitOpError("expert_mapping must be a 4D tensor [1, 1, E, D]");
+    }
+    if (rankOf(inputs[2]) != 4) {
+      return emitOpError("expert_metadata must be a 4D tensor [D, B, S, K]");
+    }
+    if (rankOf(results[0]) != 4) {
+      return emitOpError(
+          "mapping output must be a 4D tensor [1, B, S, E_local]");
+    }
+    if (rankOf(results[1]) != 4) {
+      return emitOpError(
+          "reduced output must be a 4D tensor [1, 1, ceil(B*S/R), E_local]");
+    }
+    return requireIntAttr(getOperation(), attrs, "reduction_size",
+                          /*mustBePositive=*/true);
   }
 
-  return success();
+  return emitOpError() << "unsupported composite name: '" << name << "'";
 }
 
 } // namespace mlir::tt::ttir

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/sparse_moe_ops.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/sparse_moe_ops.mlir
@@ -85,11 +85,13 @@ module @sparse_moe_ops attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repli
   }
 }
 
-// CHECK: "ttir.all_to_all_dispatch"
+// CHECK: "ttir.composite"
+// CHECK-SAME: name = "tt.all_to_all_dispatch"
 // CHECK-SAME: cluster_axis = 0
 // CHECK-SAME: num_devices = 2
 
-// CHECK: "ttir.moe_expert_token_remap"
+// CHECK: "ttir.composite"
+// CHECK-SAME: name = "tt.moe_expert_token_remap"
 // CHECK-SAME: reduction_size = 32
 
 // CHECK: "ttir.sparse_matmul"
@@ -100,7 +102,8 @@ module @sparse_moe_ops attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repli
 // CHECK-SAME: is_input_a_sparse = true
 // CHECK-SAME: is_input_b_sparse = false
 
-// CHECK: "ttir.all_to_all_combine"
+// CHECK: "ttir.composite"
+// CHECK-SAME: name = "tt.all_to_all_combine"
 // CHECK-SAME: cluster_axis = 0
 // CHECK-SAME: num_devices = 2
 // CHECK-SAME: num_experts_per_tok = 4

--- a/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
@@ -6,14 +6,14 @@
 // Sparse MoE ops TTIR to TTNN lowering test.
 // Shapes extracted from a real GPT-OSS model dump with 2x4 mesh (post-sharding local shapes).
 
-// Verify lowering of ttir.all_to_all_dispatch to ttnn.all_to_all_dispatch
+// Verify lowering of ttir.composite "tt.all_to_all_dispatch" to ttnn.all_to_all_dispatch
 module attributes {} {
   func.func @all_to_all_dispatch(
     %activations: tensor<1x1x128x2880xbf16>,
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.all_to_all_dispatch"(%activations, %indices, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -24,7 +24,7 @@ module attributes {} {
 
 // -----
 
-// Verify lowering of ttir.all_to_all_dispatch_metadata to ttnn.all_to_all_dispatch_metadata
+// Verify lowering of ttir.composite "tt.all_to_all_dispatch_metadata" to ttnn.all_to_all_dispatch_metadata
 module attributes {} {
   func.func @all_to_all_dispatch_metadata(
     %activations: tensor<1x1x128x2880xbf16>,
@@ -32,7 +32,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.all_to_all_dispatch_metadata"(%activations, %indices, %scores, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -44,14 +44,14 @@ module attributes {} {
 
 // -----
 
-// Verify lowering of ttir.moe_expert_token_remap to ttnn.moe_expert_token_remap
+// Verify lowering of ttir.composite "tt.moe_expert_token_remap" to ttnn.moe_expert_token_remap
 module attributes {} {
   func.func @moe_expert_token_remap(
     %topk_weights: tensor<1x2x128x32xbf16>,
     %expert_mapping: tensor<1x1x32x8xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.moe_expert_token_remap"(%topk_weights, %expert_mapping, %metadata) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -97,14 +97,14 @@ module attributes {} {
 
 // -----
 
-// Verify lowering of ttir.all_to_all_combine to ttnn.all_to_all_combine
+// Verify lowering of ttir.composite "tt.all_to_all_combine" to ttnn.all_to_all_combine
 module attributes {} {
   func.func @all_to_all_combine(
     %input: tensor<4x2x128x2880xbf16>,
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.all_to_all_combine"(%input, %metadata, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 1 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 1 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }
@@ -124,7 +124,7 @@ module attributes {} {
     %metadata: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> tensor<4x1x64x2880xbf16> {
-    %result = "ttir.all_to_all_combine"(%input, %metadata, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 2 : i64}> : (tensor<4x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x64x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 2 : i64}}> : (tensor<4x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x64x2880xbf16>
     return %result : tensor<4x1x64x2880xbf16>
   }
 }

--- a/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/sparse_moe_ops.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -32,7 +32,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -51,7 +51,7 @@ module attributes {} {
     %expert_mapping: tensor<1x1x32x8xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", op_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -104,7 +104,7 @@ module attributes {} {
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 1 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 1 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }
@@ -124,7 +124,7 @@ module attributes {} {
     %metadata: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x32x8xi64>
   ) -> tensor<4x1x64x2880xbf16> {
-    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 2 : i64}}> : (tensor<4x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x64x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64, output_shard_dim = 2 : i64}}> : (tensor<4x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x64x2880xbf16>
     return %result : tensor<4x1x64x2880xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_combine/all_to_all_combine_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_combine/all_to_all_combine_negative.mlir
@@ -7,7 +7,7 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @combine_input_rank(%input: tensor<128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
@@ -18,7 +18,7 @@ module attributes {} {
 // num_devices must be positive
 module attributes {} {
   func.func @combine_num_devices(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
@@ -29,7 +29,7 @@ module attributes {} {
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @combine_cluster_axis(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 3 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 3 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
@@ -40,7 +40,7 @@ module attributes {} {
 // num_experts_per_tok must be positive
 module attributes {} {
   func.func @combine_num_experts(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 0 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 0 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_combine/all_to_all_combine_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_combine/all_to_all_combine_negative.mlir
@@ -7,41 +7,41 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @combine_input_rank(%input: tensor<128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.all_to_all_combine"(%input, %meta, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}> : (tensor<128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_combine' op input_tensor must be a 4D tensor
+// CHECK: error: 'ttir.composite' op input_tensor must be a 4D tensor
 
 // -----
 
 // num_devices must be positive
 module attributes {} {
   func.func @combine_num_devices(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.all_to_all_combine"(%input, %meta, %mapping) <{cluster_axis = 0 : i64, num_devices = 0 : i64, num_experts_per_tok = 4 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_combine' op num_devices must be positive
+// CHECK: error: 'ttir.composite' op 'num_devices' must be positive
 
 // -----
 
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @combine_cluster_axis(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.all_to_all_combine"(%input, %meta, %mapping) <{cluster_axis = 3 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 3 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_combine' op cluster_axis must be 0 or 1
+// CHECK: error: 'ttir.composite' op 'cluster_axis' must be 0 or 1
 
 // -----
 
 // num_experts_per_tok must be positive
 module attributes {} {
   func.func @combine_num_experts(%input: tensor<4x2x128x2880xbf16>, %meta: tensor<1x2x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16> {
-    %0 = "ttir.all_to_all_combine"(%input, %meta, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 0 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
+    %0 = "ttir.composite"(%input, %meta, %mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 0 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x32x8xi64>) -> tensor<4x1x128x2880xbf16>
     return %0 : tensor<4x1x128x2880xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_combine' op num_experts_per_tok must be positive
+// CHECK: error: 'ttir.composite' op 'num_experts_per_tok' must be positive

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
@@ -7,7 +7,7 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @dispatch_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -18,7 +18,7 @@ module attributes {} {
 // expert_indices must be 4D
 module attributes {} {
   func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -29,7 +29,7 @@ module attributes {} {
 // num_devices must be positive
 module attributes {} {
   func.func @dispatch_num_devices(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -40,7 +40,7 @@ module attributes {} {
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @dispatch_cluster_axis(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch/all_to_all_dispatch_negative.mlir
@@ -7,41 +7,41 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @dispatch_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
-    return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op input_tensor must be a 4D tensor
+// CHECK: error: 'ttir.composite' op input_tensor must be a 4D tensor
 
 // -----
 
 // expert_indices must be 4D
 module attributes {} {
   func.func @dispatch_indices_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
-    return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op expert_indices must be a 4D tensor
+// CHECK: error: 'ttir.composite' op expert_indices must be a 4D tensor
 
 // -----
 
 // num_devices must be positive
 module attributes {} {
   func.func @dispatch_num_devices(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 0 : i64, num_devices = 0 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
-    return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op num_devices must be positive
+// CHECK: error: 'ttir.composite' op 'num_devices' must be positive
 
 // -----
 
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @dispatch_cluster_axis(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %0, %1 = "ttir.all_to_all_dispatch"(%input, %indices, %mapping) <{cluster_axis = 5 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
-    return %0, %1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
+    %0:2 = "ttir.composite"(%input, %indices, %mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x32x8xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    return %0#0, %0#1 : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch' op cluster_axis must be 0 or 1
+// CHECK: error: 'ttir.composite' op 'cluster_axis' must be 0 or 1

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_negative.mlir
@@ -7,7 +7,7 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @dispatch_metadata_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -18,7 +18,7 @@ module attributes {} {
 // expert_scores must be 4D
 module attributes {} {
   func.func @dispatch_metadata_scores_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -29,7 +29,7 @@ module attributes {} {
 // num_devices must be positive
 module attributes {} {
   func.func @dispatch_metadata_num_devices(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -40,7 +40,7 @@ module attributes {} {
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @dispatch_metadata_cluster_axis(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_negative.mlir
@@ -7,41 +7,41 @@
 // input_tensor must be 4D
 module attributes {} {
   func.func @dispatch_metadata_input_rank(%input: tensor<128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0, %1, %2 = "ttir.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
-    return %0, %1, %2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch_metadata' op input_tensor must be a 4D tensor
+// CHECK: error: 'ttir.composite' op input_tensor must be a 4D tensor
 
 // -----
 
 // expert_scores must be 4D
 module attributes {} {
   func.func @dispatch_metadata_scores_rank(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0, %1, %2 = "ttir.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
-    return %0, %1, %2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch_metadata' op expert_scores must be a 4D tensor
+// CHECK: error: 'ttir.composite' op expert_scores must be a 4D tensor
 
 // -----
 
 // num_devices must be positive
 module attributes {} {
   func.func @dispatch_metadata_num_devices(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0, %1, %2 = "ttir.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping) <{cluster_axis = 0 : i64, num_devices = 0 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
-    return %0, %1, %2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 0 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch_metadata' op num_devices must be positive
+// CHECK: error: 'ttir.composite' op 'num_devices' must be positive
 
 // -----
 
 // cluster_axis must be 0 or 1
 module attributes {} {
   func.func @dispatch_metadata_cluster_axis(%input: tensor<1x1x128x2880xbf16>, %indices: tensor<1x1x128x4xi64>, %scores: tensor<1x1x128x4xbf16>, %mapping: tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %0, %1, %2 = "ttir.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping) <{cluster_axis = 5 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
-    return %0, %1, %2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
+    %0:3 = "ttir.composite"(%input, %indices, %scores, %mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 5 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x32x8xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
-// CHECK: error: 'ttir.all_to_all_dispatch_metadata' op cluster_axis must be 0 or 1
+// CHECK: error: 'ttir.composite' op 'cluster_axis' must be 0 or 1

--- a/test/ttmlir/Dialect/TTIR/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
@@ -7,19 +7,19 @@
 // expert_mapping must be 4D
 module attributes {} {
   func.func @remap_mapping_rank(%topk: tensor<1x2x128x32xbf16>, %mapping: tensor<32x8xi64>, %meta: tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %0, %1 = "ttir.moe_expert_token_remap"(%topk, %mapping, %meta) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16>, tensor<32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
-    return %0, %1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
+    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    return %0#0, %0#1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
-// CHECK: error: 'ttir.moe_expert_token_remap' op expert_mapping must be a 4D tensor
+// CHECK: error: 'ttir.composite' op expert_mapping must be a 4D tensor
 
 // -----
 
 // expert_metadata must be 4D
 module attributes {} {
   func.func @remap_metadata_rank(%topk: tensor<1x2x128x32xbf16>, %mapping: tensor<1x1x32x8xi64>, %meta: tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %0, %1 = "ttir.moe_expert_token_remap"(%topk, %mapping, %meta) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
-    return %0, %1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
+    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    return %0#0, %0#1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
-// CHECK: error: 'ttir.moe_expert_token_remap' op expert_metadata must be a 4D tensor
+// CHECK: error: 'ttir.composite' op expert_metadata must be a 4D tensor

--- a/test/ttmlir/Dialect/TTIR/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/moe_expert_token_remap/moe_expert_token_remap_negative.mlir
@@ -7,7 +7,7 @@
 // expert_mapping must be 4D
 module attributes {} {
   func.func @remap_mapping_rank(%topk: tensor<1x2x128x32xbf16>, %mapping: tensor<32x8xi64>, %meta: tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", op_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<32x8xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %0#0, %0#1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -18,7 +18,7 @@ module attributes {} {
 // expert_metadata must be 4D
 module attributes {} {
   func.func @remap_metadata_rank(%topk: tensor<1x2x128x32xbf16>, %mapping: tensor<1x1x32x8xi64>, %meta: tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %0:2 = "ttir.composite"(%topk, %mapping, %meta) <{name = "tt.moe_expert_token_remap", op_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x32x8xi64>, tensor<128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %0#0, %0#1 : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/selective_reduce_combine/simple_selective_reduce_combine.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/selective_reduce_combine/simple_selective_reduce_combine.mlir
@@ -8,7 +8,7 @@
 module attributes {} {
   // CHECK-LABEL: selective_reduce_combine_gpt_oss
   func.func @selective_reduce_combine_gpt_oss(%arg0: tensor<16x128x1x2880xbf16>, %arg1: tensor<16x128x1x2880xbf16>, %arg2: tensor<1x128x1x4xi64>, %arg3: tensor<1x128x1x1xi64>) -> tensor<16x128x1x2880xbf16> {
-    %0 = "ttir.selective_reduce_combine"(%arg0, %arg1, %arg2, %arg3) <{hidden_size = 2880 : ui32, batch_size = 128 : ui32, seq_size = 1 : ui32, select_experts_k = 4 : ui32, experts = 32 : ui32}> : (tensor<16x128x1x2880xbf16>, tensor<16x128x1x2880xbf16>, tensor<1x128x1x4xi64>, tensor<1x128x1x1xi64>) -> tensor<16x128x1x2880xbf16>
+    %0 = "ttir.composite"(%arg0, %arg1, %arg2, %arg3) <{name = "tt.selective_reduce_combine", op_attributes = {hidden_size = 2880 : ui32, batch_size = 128 : ui32, seq_size = 1 : ui32, select_experts_k = 4 : ui32, experts = 32 : ui32}}> : (tensor<16x128x1x2880xbf16>, tensor<16x128x1x2880xbf16>, tensor<1x128x1x4xi64>, tensor<1x128x1x1xi64>) -> tensor<16x128x1x2880xbf16>
     // CHECK: "ttnn.selective_reduce_combine"
     return %0 : tensor<16x128x1x2880xbf16>
   }

--- a/test/ttmlir/EmitC/TTNN/sparse_moe.mlir
+++ b/test/ttmlir/EmitC/TTNN/sparse_moe.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.all_to_all_dispatch"(%activations, %indices, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -28,7 +28,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.all_to_all_dispatch_metadata"(%activations, %indices, %scores, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -42,7 +42,7 @@ module attributes {} {
     %expert_mapping: tensor<1x1x8x32xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.moe_expert_token_remap"(%topk_weights, %expert_mapping, %metadata) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -70,7 +70,7 @@ module attributes {} {
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.all_to_all_combine"(%input, %metadata, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/sparse_moe.mlir
+++ b/test/ttmlir/EmitC/TTNN/sparse_moe.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -28,7 +28,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -42,7 +42,7 @@ module attributes {} {
     %expert_mapping: tensor<1x1x8x32xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", op_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -70,7 +70,7 @@ module attributes {} {
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }

--- a/test/ttmlir/EmitPy/sparse_moe.mlir
+++ b/test/ttmlir/EmitPy/sparse_moe.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -28,7 +28,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -42,7 +42,7 @@ module attributes {} {
     %expert_mapping: tensor<1x1x8x32xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", op_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -84,7 +84,7 @@ module attributes {} {
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", op_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }

--- a/test/ttmlir/EmitPy/sparse_moe.mlir
+++ b/test/ttmlir/EmitPy/sparse_moe.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %indices: tensor<1x1x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>) {
-    %dispatched, %metadata = "ttir.all_to_all_dispatch"(%activations, %indices, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
+    %dispatched, %metadata = "ttir.composite"(%activations, %indices, %expert_mapping) <{name = "tt.all_to_all_dispatch", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x8x32xi64>) -> (tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>)
     return %dispatched, %metadata : tensor<1x2x128x2880xbf16>, tensor<1x2x128x4xi64>
   }
 }
@@ -28,7 +28,7 @@ module attributes {} {
     %scores: tensor<1x1x128x4xbf16>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>) {
-    %dispatched, %idx_out, %scores_out = "ttir.all_to_all_dispatch_metadata"(%activations, %indices, %scores, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
+    %dispatched, %idx_out, %scores_out = "ttir.composite"(%activations, %indices, %scores, %expert_mapping) <{name = "tt.all_to_all_dispatch_metadata", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64}}> : (tensor<1x1x128x2880xbf16>, tensor<1x1x128x4xi64>, tensor<1x1x128x4xbf16>, tensor<1x1x8x32xi64>) -> (tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>)
     return %dispatched, %idx_out, %scores_out : tensor<1x256x2880xbf16>, tensor<1x256x4xi64>, tensor<1x256x4xbf16>
   }
 }
@@ -42,7 +42,7 @@ module attributes {} {
     %expert_mapping: tensor<1x1x8x32xi64>,
     %metadata: tensor<1x2x128x4xi64>
   ) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>) {
-    %mapping, %reduced = "ttir.moe_expert_token_remap"(%topk_weights, %expert_mapping, %metadata) <{reduction_size = 32 : i64}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
+    %mapping, %reduced = "ttir.composite"(%topk_weights, %expert_mapping, %metadata) <{name = "tt.moe_expert_token_remap", composite_attributes = {reduction_size = 32 : i64}}> : (tensor<1x2x128x32xbf16>, tensor<1x1x8x32xi64>, tensor<1x2x128x4xi64>) -> (tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>)
     return %mapping, %reduced : tensor<1x2x128x4xbf16>, tensor<1x1x8x4xbf16>
   }
 }
@@ -84,7 +84,7 @@ module attributes {} {
     %metadata: tensor<1x2x128x4xi64>,
     %expert_mapping: tensor<1x1x8x32xi64>
   ) -> tensor<4x1x128x2880xbf16> {
-    %result = "ttir.all_to_all_combine"(%input, %metadata, %expert_mapping) <{cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
+    %result = "ttir.composite"(%input, %metadata, %expert_mapping) <{name = "tt.all_to_all_combine", composite_attributes = {cluster_axis = 0 : i64, num_devices = 2 : i64, num_experts_per_tok = 4 : i64}}> : (tensor<4x2x128x2880xbf16>, tensor<1x2x128x4xi64>, tensor<1x1x8x32xi64>) -> tensor<4x1x128x2880xbf16>
     return %result : tensor<4x1x128x2880xbf16>
   }
 }

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -15569,7 +15569,7 @@ class TTIRBuilder(Builder):
 
     ############### ttir.composite (MoE bridge ops) ###############
     # These helpers emit ttir.composite with a specific `name` and
-    # composite_attributes. Each name maps 1:1 to a TTNN op during the
+    # op_attributes. Each name maps 1:1 to a TTNN op during the
     # TTIR->TTNN conversion; no TTIR-level transformation is performed.
 
     def _emit_composite(
@@ -16332,7 +16332,7 @@ class TTIRBuilder(Builder):
             result_types,
             old_op.name,
             new_inputs,
-            old_op.composite_attributes,
+            old_op.op_attributes,
             loc=old_op.location,
         )
 
@@ -16342,7 +16342,7 @@ class TTIRBuilder(Builder):
         if isinstance(name, str) and name.startswith('"') and name.endswith('"'):
             name = name[1:-1]
 
-        attr_dict = old_op.composite_attributes
+        attr_dict = old_op.op_attributes
 
         def _attr_int(key: str, default: int = 0) -> int:
             a = attr_dict.get(key) if attr_dict is not None else None
@@ -16433,7 +16433,7 @@ class TTIRBuilder(Builder):
                         result_types,
                         old_op.name,
                         list(inputs),
-                        old_op.composite_attributes,
+                        old_op.op_attributes,
                         loc=old_op.location,
                     )
 

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -20,6 +20,13 @@ from builder.base.builder_utils import *
 from builder.base.builder_enums import *
 
 from golden import *
+from golden.mapping import (
+    mlir_type_to_torch_dtype,
+    ttir_all_to_all_dispatch_golden,
+    ttir_all_to_all_dispatch_metadata_golden,
+    ttir_all_to_all_combine_golden,
+    ttir_moe_expert_token_remap_golden,
+)
 
 
 class TTIRBuilder(Builder):
@@ -15568,9 +15575,9 @@ class TTIRBuilder(Builder):
         return sparse_matmul_module, sparse_matmul_builder
 
     ############### ttir.composite (MoE bridge ops) ###############
-    # These helpers emit ttir.composite with a specific `name` and
-    # op_attributes. Each name maps 1:1 to a TTNN op during the
-    # TTIR->TTNN conversion; no TTIR-level transformation is performed.
+    # These helpers emit ttir.CompositeOp with a specific `name` and
+    # op_attributes dictionary.  Each name maps 1:1 to a TTNN op during
+    # the TTIR->TTNN conversion; no TTIR-level transformation is performed.
 
     def _emit_composite(
         self,
@@ -15579,8 +15586,10 @@ class TTIRBuilder(Builder):
         result_types: List,
         attrs: Dict[str, "Attribute"],
         unit_attrs: Optional[List[str]] = None,
+        loc: Optional[Location] = None,
     ):
-        loc = self._get_location()
+        if loc is None:
+            loc = self._get_location()
         dict_attr = DictAttr.get(attrs, context=self._ctx)
         op = ttir.CompositeOp(
             result_types,
@@ -15608,8 +15617,6 @@ class TTIRBuilder(Builder):
         loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> Tuple[OpResult, OpResult]:
-        ttir_op = self.get_opview_from_method(TTIRBuilder.all_to_all_dispatch)
-
         assert (
             dispatched_shape is not None
         ), "dispatched_shape must be provided for all_to_all_dispatch"
@@ -15623,27 +15630,29 @@ class TTIRBuilder(Builder):
             metadata_type is not None
         ), "metadata_type must be provided for all_to_all_dispatch"
 
+        mlir_dispatched_type = self._get_type_from_torch_dtype(dispatched_type)
+        mlir_metadata_type = self._get_type_from_torch_dtype(metadata_type)
+
         dispatched_result = self._create_ranked_tensor_type(
-            dispatched_shape, self._get_type_from_torch_dtype(dispatched_type)
+            dispatched_shape, mlir_dispatched_type
         )
         metadata_result = self._create_ranked_tensor_type(
-            metadata_shape, self._get_type_from_torch_dtype(metadata_type)
+            metadata_shape, mlir_metadata_type
         )
+
         i64 = IntegerType.get_signless(64)
+        num_devices_attr = IntegerAttr.get(i64, num_devices)
+        cluster_axis_attr = IntegerAttr.get(i64, cluster_axis)
 
-        num_devices_attr = IntegerAttr.get(IntegerType.get_signless(64), num_devices)
-        cluster_axis_attr = IntegerAttr.get(IntegerType.get_signless(64), cluster_axis)
-
-        if loc is None:
-            loc = self._get_location()
+        if loc is not None:
+            op_loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
         else:
-            loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
+            op_loc = None
 
         in0 = self._get_golden_tensor(input_tensor)
         in1 = self._get_golden_tensor(expert_indices)
         in2 = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        golden_dispatched, golden_metadata = op_golden_function(
+        golden_dispatched, golden_metadata = ttir_all_to_all_dispatch_golden(
             in0,
             in1,
             in2,
@@ -15653,150 +15662,24 @@ class TTIRBuilder(Builder):
             mlir_metadata_type,
         )
 
-        op = ttir_op(
-            dispatched_result,
-            metadata_result,
-            input_tensor,
-            expert_indices,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            loc=loc,
+        op = self._emit_composite(
+            "tt.all_to_all_dispatch",
+            [input_tensor, expert_indices, expert_mapping],
+            [dispatched_result, metadata_result],
+            {
+                "num_devices": num_devices_attr,
+                "cluster_axis": cluster_axis_attr,
+            },
+            unit_attrs=unit_attrs,
+            loc=op_loc,
         )
         dispatched, metadata = op.results[0], op.results[1]
 
-        self._set_golden_tensor(op.dispatched, golden_dispatched)
-        self._set_golden_tensor(op.metadata, golden_metadata)
+        self._set_golden_tensor(dispatched, golden_dispatched)
+        self._set_golden_tensor(metadata, golden_metadata)
 
-        return op.dispatched, op.metadata
+        return dispatched, metadata
 
-    @parse(ttir.AllToAllDispatchOp)
-    def all_to_all_dispatch_parser(
-        self,
-        old_op: ttir.AllToAllDispatchOp,
-        global_dict: Dict[Operand, Operand],
-    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
-        ttir_op = self.get_opview_from_parser(TTIRBuilder.all_to_all_dispatch_parser)
-
-        input_tensor = global_dict[old_op.input_tensor]
-        expert_indices = global_dict[old_op.expert_indices]
-        expert_mapping = global_dict[old_op.expert_mapping]
-        dispatched_type = old_op.dispatched.type
-        metadata_type = old_op.metadata.type
-        num_devices_attr = old_op.num_devices
-        cluster_axis_attr = old_op.cluster_axis
-
-        new_op = ttir_op(
-            dispatched_type,
-            metadata_type,
-            input_tensor,
-            expert_indices,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            loc=old_op.location,
-        )
-        new_op_dispatched = new_op.dispatched
-        new_op_metadata = new_op.metadata
-
-        input0 = self._get_golden_tensor(input_tensor)
-        input1 = self._get_golden_tensor(expert_indices)
-        input2 = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        golden_dispatched, golden_metadata = op_golden_function(
-            input0,
-            input1,
-            input2,
-            num_devices_attr,
-            cluster_axis_attr,
-            dispatched_type.element_type,
-            metadata_type.element_type,
-        )
-        self._set_golden_tensor(new_op_dispatched, golden_dispatched)
-        self._set_golden_tensor(new_op_metadata, golden_metadata)
-
-        op_map_dictionary = {
-            old_op.dispatched: new_op_dispatched,
-            old_op.metadata: new_op_metadata,
-        }
-        return new_op, op_map_dictionary
-
-    @split(ttir.AllToAllDispatchOp)
-    def all_to_all_dispatch_split(
-        self,
-        old_op: ttir.AllToAllDispatchOp,
-    ) -> Tuple[Module, TTIRBuilder]:
-        ttir_op = self.get_opview_from_split(TTIRBuilder.all_to_all_dispatch_split)
-
-        old_ctx = old_op.context
-        old_loc = Location.unknown(old_ctx)
-        with old_ctx, old_loc:
-            dispatch_module = Module.create()
-            dispatch_builder = TTIRBuilder(
-                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
-            )
-            op_input_types = [
-                old_op.input_tensor.type,
-                old_op.expert_indices.type,
-                old_op.expert_mapping.type,
-            ]
-
-            with InsertionPoint(dispatch_module.body):
-                ordered_inputs = []
-                ordered_outputs = []
-
-                @func.func(*op_input_types, name="all_to_all_dispatch_module")
-                def decorated_func(*inputs):
-                    input_tensor = inputs[0]
-                    expert_indices = inputs[1]
-                    expert_mapping = inputs[2]
-                    dispatched_type = old_op.dispatched.type
-                    metadata_type = old_op.metadata.type
-
-                    new_op = ttir_op(
-                        dispatched_type,
-                        metadata_type,
-                        input_tensor,
-                        expert_indices,
-                        expert_mapping,
-                        old_op.num_devices,
-                        old_op.cluster_axis,
-                        loc=old_op.location,
-                    )
-                    new_op_dispatched = new_op.dispatched
-                    new_op_metadata = new_op.metadata
-
-                    input0 = self._get_golden_tensor(old_op.input_tensor)
-                    input1 = self._get_golden_tensor(old_op.expert_indices)
-                    input2 = self._get_golden_tensor(old_op.expert_mapping)
-                    old_dispatched = self._get_golden_tensor(old_op.dispatched)
-                    old_metadata = self._get_golden_tensor(old_op.metadata)
-
-                    dispatch_builder._set_golden_tensor(
-                        new_op_dispatched, old_dispatched
-                    )
-                    dispatch_builder._set_golden_tensor(new_op_metadata, old_metadata)
-                    dispatch_builder._set_golden_tensor(input_tensor, input0)
-                    dispatch_builder._set_golden_tensor(expert_indices, input1)
-                    dispatch_builder._set_golden_tensor(expert_mapping, input2)
-                    ordered_inputs.extend(
-                        [input_tensor, expert_indices, expert_mapping]
-                    )
-                    ordered_outputs.extend([new_op_dispatched, new_op_metadata])
-
-                    return new_op
-
-                new_func_op = decorated_func.func_op
-                dispatch_builder._func_ops_generated[new_func_op] = [
-                    ordered_inputs,
-                    ordered_outputs,
-                ]
-
-        return dispatch_module, dispatch_builder
-
-    ############### ttir.AllToAllDispatchMetadataOp ###############
-
-    @tag(ttir.AllToAllDispatchMetadataOp)
     def all_to_all_dispatch_metadata(
         self,
         input_tensor: Operand,
@@ -15814,8 +15697,6 @@ class TTIRBuilder(Builder):
         loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> Tuple[OpResult, OpResult, OpResult]:
-        ttir_op = self.get_opview_from_method(TTIRBuilder.all_to_all_dispatch_metadata)
-
         assert (
             dispatched_shape is not None
         ), "dispatched_shape must be provided for all_to_all_dispatch_metadata"
@@ -15835,28 +15716,36 @@ class TTIRBuilder(Builder):
             scores_type is not None
         ), "scores_type must be provided for all_to_all_dispatch_metadata"
 
+        mlir_dispatched_type = self._get_type_from_torch_dtype(dispatched_type)
+        mlir_indices_type = self._get_type_from_torch_dtype(indices_type)
+        mlir_scores_type = self._get_type_from_torch_dtype(scores_type)
+
         dispatched_result = self._create_ranked_tensor_type(
-            dispatched_shape, self._get_type_from_torch_dtype(dispatched_type)
+            dispatched_shape, mlir_dispatched_type
         )
         indices_result = self._create_ranked_tensor_type(
-            indices_shape, self._get_type_from_torch_dtype(indices_type)
+            indices_shape, mlir_indices_type
         )
         scores_result = self._create_ranked_tensor_type(scores_shape, mlir_scores_type)
 
-        num_devices_attr = IntegerAttr.get(IntegerType.get_signless(64), num_devices)
-        cluster_axis_attr = IntegerAttr.get(IntegerType.get_signless(64), cluster_axis)
+        i64 = IntegerType.get_signless(64)
+        num_devices_attr = IntegerAttr.get(i64, num_devices)
+        cluster_axis_attr = IntegerAttr.get(i64, cluster_axis)
 
-        if loc is None:
-            loc = self._get_location()
+        if loc is not None:
+            op_loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
         else:
-            loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
+            op_loc = None
 
         in0 = self._get_golden_tensor(input_tensor)
         in1 = self._get_golden_tensor(expert_indices)
         in2 = self._get_golden_tensor(expert_scores)
         in3 = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
+        (
+            golden_dispatched,
+            golden_indices,
+            golden_scores,
+        ) = ttir_all_to_all_dispatch_metadata_golden(
             in0,
             in1,
             in2,
@@ -15868,199 +15757,29 @@ class TTIRBuilder(Builder):
             mlir_scores_type,
         )
 
-        op = ttir_op(
-            dispatched_result,
-            indices_result,
-            scores_result,
-            input_tensor,
-            expert_indices,
-            expert_scores,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            loc=loc,
-        )
-        i64 = IntegerType.get_signless(64)
-
         op = self._emit_composite(
             "tt.all_to_all_dispatch_metadata",
             [input_tensor, expert_indices, expert_scores, expert_mapping],
             [dispatched_result, indices_result, scores_result],
             {
-                "num_devices": IntegerAttr.get(i64, num_devices),
-                "cluster_axis": IntegerAttr.get(i64, cluster_axis),
+                "num_devices": num_devices_attr,
+                "cluster_axis": cluster_axis_attr,
             },
             unit_attrs=unit_attrs,
+            loc=op_loc,
         )
-        dispatched, indices, scores = op.results[0], op.results[1], op.results[2]
-
-        self._set_golden_tensor(op.dispatched, golden_dispatched)
-        self._set_golden_tensor(op.indices, golden_indices)
-        self._set_golden_tensor(op.scores, golden_scores)
-
-        return op.dispatched, op.indices, op.scores
-
-    @parse(ttir.AllToAllDispatchMetadataOp)
-    def all_to_all_dispatch_metadata_parser(
-        self,
-        old_op: ttir.AllToAllDispatchMetadataOp,
-        global_dict: Dict[Operand, Operand],
-    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
-        ttir_op = self.get_opview_from_parser(
-            TTIRBuilder.all_to_all_dispatch_metadata_parser
+        dispatched, indices, scores = (
+            op.results[0],
+            op.results[1],
+            op.results[2],
         )
 
-        input_tensor = global_dict[old_op.input_tensor]
-        expert_indices = global_dict[old_op.expert_indices]
-        expert_scores = global_dict[old_op.expert_scores]
-        expert_mapping = global_dict[old_op.expert_mapping]
-        dispatched_type = old_op.dispatched.type
-        indices_type = old_op.indices.type
-        scores_type = old_op.scores.type
-        num_devices_attr = old_op.num_devices
-        cluster_axis_attr = old_op.cluster_axis
+        self._set_golden_tensor(dispatched, golden_dispatched)
+        self._set_golden_tensor(indices, golden_indices)
+        self._set_golden_tensor(scores, golden_scores)
 
-        new_op = ttir_op(
-            dispatched_type,
-            indices_type,
-            scores_type,
-            input_tensor,
-            expert_indices,
-            expert_scores,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            loc=old_op.location,
-        )
-        new_op_dispatched = new_op.dispatched
-        new_op_indices = new_op.indices
-        new_op_scores = new_op.scores
+        return dispatched, indices, scores
 
-        input0 = self._get_golden_tensor(input_tensor)
-        input1 = self._get_golden_tensor(expert_indices)
-        input2 = self._get_golden_tensor(expert_scores)
-        input3 = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
-            input0,
-            input1,
-            input2,
-            input3,
-            num_devices_attr,
-            cluster_axis_attr,
-            dispatched_type.element_type,
-            indices_type.element_type,
-            scores_type.element_type,
-        )
-        self._set_golden_tensor(new_op_dispatched, golden_dispatched)
-        self._set_golden_tensor(new_op_indices, golden_indices)
-        self._set_golden_tensor(new_op_scores, golden_scores)
-
-        op_map_dictionary = {
-            old_op.dispatched: new_op_dispatched,
-            old_op.indices: new_op_indices,
-            old_op.scores: new_op_scores,
-        }
-        return new_op, op_map_dictionary
-
-    @split(ttir.AllToAllDispatchMetadataOp)
-    def all_to_all_dispatch_metadata_split(
-        self,
-        old_op: ttir.AllToAllDispatchMetadataOp,
-    ) -> Tuple[Module, TTIRBuilder]:
-        ttir_op = self.get_opview_from_split(
-            TTIRBuilder.all_to_all_dispatch_metadata_split
-        )
-
-        old_ctx = old_op.context
-        old_loc = Location.unknown(old_ctx)
-        with old_ctx, old_loc:
-            dispatch_module = Module.create()
-            dispatch_builder = TTIRBuilder(
-                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
-            )
-            op_input_types = [
-                old_op.input_tensor.type,
-                old_op.expert_indices.type,
-                old_op.expert_scores.type,
-                old_op.expert_mapping.type,
-            ]
-
-            with InsertionPoint(dispatch_module.body):
-                ordered_inputs = []
-                ordered_outputs = []
-
-                @func.func(
-                    *op_input_types,
-                    name="all_to_all_dispatch_metadata_module",
-                )
-                def decorated_func(*inputs):
-                    input_tensor = inputs[0]
-                    expert_indices = inputs[1]
-                    expert_scores = inputs[2]
-                    expert_mapping = inputs[3]
-                    dispatched_type = old_op.dispatched.type
-                    indices_type = old_op.indices.type
-                    scores_type = old_op.scores.type
-
-                    new_op = ttir_op(
-                        dispatched_type,
-                        indices_type,
-                        scores_type,
-                        input_tensor,
-                        expert_indices,
-                        expert_scores,
-                        expert_mapping,
-                        old_op.num_devices,
-                        old_op.cluster_axis,
-                        loc=old_op.location,
-                    )
-                    new_op_dispatched = new_op.dispatched
-                    new_op_indices = new_op.indices
-                    new_op_scores = new_op.scores
-
-                    input0 = self._get_golden_tensor(old_op.input_tensor)
-                    input1 = self._get_golden_tensor(old_op.expert_indices)
-                    input2 = self._get_golden_tensor(old_op.expert_scores)
-                    input3 = self._get_golden_tensor(old_op.expert_mapping)
-                    old_dispatched = self._get_golden_tensor(old_op.dispatched)
-                    old_indices = self._get_golden_tensor(old_op.indices)
-                    old_scores = self._get_golden_tensor(old_op.scores)
-
-                    dispatch_builder._set_golden_tensor(
-                        new_op_dispatched, old_dispatched
-                    )
-                    dispatch_builder._set_golden_tensor(new_op_indices, old_indices)
-                    dispatch_builder._set_golden_tensor(new_op_scores, old_scores)
-                    dispatch_builder._set_golden_tensor(input_tensor, input0)
-                    dispatch_builder._set_golden_tensor(expert_indices, input1)
-                    dispatch_builder._set_golden_tensor(expert_scores, input2)
-                    dispatch_builder._set_golden_tensor(expert_mapping, input3)
-                    ordered_inputs.extend(
-                        [
-                            input_tensor,
-                            expert_indices,
-                            expert_scores,
-                            expert_mapping,
-                        ]
-                    )
-                    ordered_outputs.extend(
-                        [new_op_dispatched, new_op_indices, new_op_scores]
-                    )
-
-                    return new_op
-
-                new_func_op = decorated_func.func_op
-                dispatch_builder._func_ops_generated[new_func_op] = [
-                    ordered_inputs,
-                    ordered_outputs,
-                ]
-
-        return dispatch_module, dispatch_builder
-
-    ############### ttir.AllToAllCombineOp ###############
-
-    @tag(ttir.AllToAllCombineOp)
     def all_to_all_combine(
         self,
         input_tensor: Operand,
@@ -16075,8 +15794,6 @@ class TTIRBuilder(Builder):
         loc: Optional[str] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpResult:
-        ttir_op = self.get_opview_from_method(TTIRBuilder.all_to_all_combine)
-
         assert (
             output_shape is not None
         ), "output_shape must be provided for all_to_all_combine"
@@ -16084,180 +15801,52 @@ class TTIRBuilder(Builder):
             output_type is not None
         ), "output_type must be provided for all_to_all_combine"
 
-        result_type = self._create_ranked_tensor_type(
-            output_shape, self._get_type_from_torch_dtype(output_type)
-        )
+        mlir_output_type = self._get_type_from_torch_dtype(output_type)
+        result_type = self._create_ranked_tensor_type(output_shape, mlir_output_type)
+
         i64 = IntegerType.get_signless(64)
+        num_devices_attr = IntegerAttr.get(i64, num_devices)
+        cluster_axis_attr = IntegerAttr.get(i64, cluster_axis)
+        num_experts_per_tok_attr = IntegerAttr.get(i64, num_experts_per_tok)
+        output_shard_dim_attr = IntegerAttr.get(i64, output_shard_dim)
 
-        op = self._emit_composite(
-            "tt.all_to_all_combine",
-            [input_tensor, expert_metadata, expert_mapping],
-            [result_type],
-            {
-                "num_devices": IntegerAttr.get(i64, num_devices),
-                "cluster_axis": IntegerAttr.get(i64, cluster_axis),
-                "num_experts_per_tok": IntegerAttr.get(i64, num_experts_per_tok),
-                "output_shard_dim": IntegerAttr.get(i64, output_shard_dim),
-            },
-            unit_attrs=unit_attrs,
-        )
-
-        if loc is None:
-            loc = self._get_location()
+        if loc is not None:
+            op_loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
         else:
-            loc = Location.unknown(self._ctx) if loc == "" else Location.name(loc)
+            op_loc = None
 
         in0 = self._get_golden_tensor(input_tensor)
-        metadata = self._get_golden_tensor(expert_metadata)
-        mapping = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        golden = op_golden_function(
+        md = self._get_golden_tensor(expert_metadata)
+        mp = self._get_golden_tensor(expert_mapping)
+        golden = ttir_all_to_all_combine_golden(
             in0,
-            metadata,
-            mapping,
+            md,
+            mp,
             num_devices_attr,
             cluster_axis_attr,
             num_experts_per_tok_attr,
             mlir_output_type,
         )
 
-        op = ttir_op(
-            result,
-            input_tensor,
-            expert_metadata,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            num_experts_per_tok_attr,
-            output_shard_dim=output_shard_dim_attr,
-            loc=loc,
+        op = self._emit_composite(
+            "tt.all_to_all_combine",
+            [input_tensor, expert_metadata, expert_mapping],
+            [result_type],
+            {
+                "num_devices": num_devices_attr,
+                "cluster_axis": cluster_axis_attr,
+                "num_experts_per_tok": num_experts_per_tok_attr,
+                "output_shard_dim": output_shard_dim_attr,
+            },
+            unit_attrs=unit_attrs,
+            loc=op_loc,
         )
-        op_result = op.result
-
-        if unit_attrs is not None:
-            for attr_name in unit_attrs:
-                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+        op_result = op.results[0]
 
         self._set_golden_tensor(op_result, golden)
 
         return op_result
 
-    @parse(ttir.AllToAllCombineOp)
-    def all_to_all_combine_parser(
-        self,
-        old_op: ttir.AllToAllCombineOp,
-        global_dict: Dict[Operand, Operand],
-    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
-        ttir_op = self.get_opview_from_parser(TTIRBuilder.all_to_all_combine_parser)
-
-        input_tensor = global_dict[old_op.input_tensor]
-        expert_metadata = global_dict[old_op.expert_metadata]
-        expert_mapping = global_dict[old_op.expert_mapping]
-        result = old_op.result.type
-        num_devices_attr = old_op.num_devices
-        cluster_axis_attr = old_op.cluster_axis
-        num_experts_per_tok_attr = old_op.num_experts_per_tok
-
-        new_op = ttir_op(
-            result,
-            input_tensor,
-            expert_metadata,
-            expert_mapping,
-            num_devices_attr,
-            cluster_axis_attr,
-            num_experts_per_tok_attr,
-            loc=old_op.location,
-        )
-        new_op_result = new_op.result
-
-        input0 = self._get_golden_tensor(input_tensor)
-        metadata0 = self._get_golden_tensor(expert_metadata)
-        mapping0 = self._get_golden_tensor(expert_mapping)
-        op_golden_function = get_golden_function(ttir_op)
-        golden = op_golden_function(
-            input0,
-            metadata0,
-            mapping0,
-            num_devices_attr,
-            cluster_axis_attr,
-            num_experts_per_tok_attr,
-            result.element_type,
-        )
-        self._set_golden_tensor(new_op_result, golden)
-
-        op_map_dictionary = {old_op.result: new_op_result}
-        return new_op, op_map_dictionary
-
-    @split(ttir.AllToAllCombineOp)
-    def all_to_all_combine_split(
-        self,
-        old_op: ttir.AllToAllCombineOp,
-    ) -> Tuple[Module, TTIRBuilder]:
-        ttir_op = self.get_opview_from_split(TTIRBuilder.all_to_all_combine_split)
-
-        old_ctx = old_op.context
-        old_loc = Location.unknown(old_ctx)
-        with old_ctx, old_loc:
-            combine_module = Module.create()
-            combine_builder = TTIRBuilder(
-                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
-            )
-            op_input_types = [
-                old_op.input_tensor.type,
-                old_op.expert_metadata.type,
-                old_op.expert_mapping.type,
-            ]
-
-            with InsertionPoint(combine_module.body):
-                ordered_inputs = []
-                ordered_outputs = []
-
-                @func.func(*op_input_types, name="all_to_all_combine_module")
-                def decorated_func(*inputs):
-                    input_tensor = inputs[0]
-                    expert_metadata = inputs[1]
-                    expert_mapping = inputs[2]
-                    result = old_op.result.type
-
-                    new_op = ttir_op(
-                        result,
-                        input_tensor,
-                        expert_metadata,
-                        expert_mapping,
-                        old_op.num_devices,
-                        old_op.cluster_axis,
-                        old_op.num_experts_per_tok,
-                        loc=old_op.location,
-                    )
-                    new_op_result = new_op.result
-
-                    input0 = self._get_golden_tensor(old_op.input_tensor)
-                    input1 = self._get_golden_tensor(old_op.expert_metadata)
-                    input2 = self._get_golden_tensor(old_op.expert_mapping)
-                    old_result = self._get_golden_tensor(old_op.result)
-
-                    combine_builder._set_golden_tensor(new_op_result, old_result)
-                    combine_builder._set_golden_tensor(input_tensor, input0)
-                    combine_builder._set_golden_tensor(expert_metadata, input1)
-                    combine_builder._set_golden_tensor(expert_mapping, input2)
-                    ordered_inputs.extend(
-                        [input_tensor, expert_metadata, expert_mapping]
-                    )
-                    ordered_outputs.append(new_op_result)
-
-                    return new_op
-
-                new_func_op = decorated_func.func_op
-                combine_builder._func_ops_generated[new_func_op] = [
-                    ordered_inputs,
-                    ordered_outputs,
-                ]
-
-        return combine_module, combine_builder
-
-    ############### ttir.MoeExpertTokenRemapOp ###############
-
-    @tag(ttir.MoeExpertTokenRemapOp)
     def moe_expert_token_remap(
         self,
         topk_tensor: Operand,
@@ -16283,25 +15872,29 @@ class TTIRBuilder(Builder):
             reduced_type is not None
         ), "reduced_type must be provided for moe_expert_token_remap"
 
+        mlir_mapping_type = self._get_type_from_torch_dtype(mapping_type)
+        mlir_reduced_type = self._get_type_from_torch_dtype(reduced_type)
+
         mapping_result = self._create_ranked_tensor_type(
-            mapping_shape, self._get_type_from_torch_dtype(mapping_type)
+            mapping_shape, mlir_mapping_type
         )
         reduced_result = self._create_ranked_tensor_type(
-            reduced_shape, self._get_type_from_torch_dtype(reduced_type)
+            reduced_shape, mlir_reduced_type
         )
+
+        i64 = IntegerType.get_signless(64)
+        reduction_size_attr = IntegerAttr.get(i64, reduction_size)
 
         op = self._emit_composite(
             "tt.moe_expert_token_remap",
             [topk_tensor, expert_mapping, expert_metadata],
             [mapping_result, reduced_result],
             {
-                "reduction_size": IntegerAttr.get(
-                    IntegerType.get_signless(64), reduction_size
-                ),
+                "reduction_size": reduction_size_attr,
             },
             unit_attrs=unit_attrs,
         )
-        mapping, reduced = op.results[0], op.results[1]
+        mapping_out, reduced_out = op.results[0], op.results[1]
 
         golden_mapping = GoldenMapTensor(
             {0: torch.zeros(mapping_shape, dtype=mapping_type)},
@@ -16311,143 +15904,193 @@ class TTIRBuilder(Builder):
             {0: torch.zeros(reduced_shape, dtype=reduced_type)},
             mesh_shape=self._mesh_shape,
         )
-        self._set_golden_tensor(mapping, golden_mapping)
-        self._set_golden_tensor(reduced, golden_reduced)
-        return mapping, reduced
+        self._set_golden_tensor(mapping_out, golden_mapping)
+        self._set_golden_tensor(reduced_out, golden_reduced)
 
-    # Generic round-trip parser/splitter for ttir.composite. Dispatches on the
-    # composite `name` to recompute goldens for the supported MoE bridge ops.
+        return mapping_out, reduced_out
+
+    def selective_reduce_combine(
+        self,
+        input_tensor_0: Operand,
+        input_tensor_1: Operand,
+        expert_indices: Operand,
+        expert_metadata: Operand,
+        hidden_size: int,
+        batch_size: int,
+        seq_size: int,
+        select_experts_k: int,
+        experts: int,
+        output_shape: Optional[Shape] = None,
+        output_type: Optional[torch.dtype] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        assert (
+            output_shape is not None
+        ), "output_shape must be provided for selective_reduce_combine"
+        assert (
+            output_type is not None
+        ), "output_type must be provided for selective_reduce_combine"
+
+        mlir_output_type = self._get_type_from_torch_dtype(output_type)
+        result_type = self._create_ranked_tensor_type(output_shape, mlir_output_type)
+
+        ui32 = IntegerType.get_unsigned(32)
+        attrs = {
+            "hidden_size": IntegerAttr.get(ui32, hidden_size),
+            "batch_size": IntegerAttr.get(ui32, batch_size),
+            "seq_size": IntegerAttr.get(ui32, seq_size),
+            "select_experts_k": IntegerAttr.get(ui32, select_experts_k),
+            "experts": IntegerAttr.get(ui32, experts),
+        }
+
+        op = self._emit_composite(
+            "tt.selective_reduce_combine",
+            [input_tensor_0, input_tensor_1, expert_indices, expert_metadata],
+            [result_type],
+            attrs,
+            unit_attrs=unit_attrs,
+        )
+        op_result = op.results[0]
+
+        golden = GoldenMapTensor(
+            {0: torch.zeros(output_shape, dtype=output_type)},
+            mesh_shape=self._mesh_shape,
+        )
+        self._set_golden_tensor(op_result, golden)
+
+        return op_result
+
+    # --- ttir.CompositeOp parse / split dispatchers ---
+
+    def _rebuild_composite(
+        self,
+        old_op: ttir.CompositeOp,
+        new_inputs: List[Operand],
+        loc: Optional[Location] = None,
+    ) -> ttir.CompositeOp:
+        result_types = [r.type for r in old_op.results]
+        name = str(old_op.name)
+        dict_attr = old_op.op_attributes
+        attrs = {named.name: named.attr for named in dict_attr}
+        if loc is None:
+            loc = old_op.location
+        return self._emit_composite(name, new_inputs, result_types, attrs, loc=loc)
+
+    def _compute_composite_goldens(
+        self,
+        name: str,
+        new_inputs: List[Operand],
+        attr_dict: DictAttr,
+        result_types: List,
+    ):
+        input_goldens = [self._get_golden_tensor(inp) for inp in new_inputs]
+        elem_types = [rt.element_type for rt in result_types]
+
+        if name == "tt.all_to_all_dispatch":
+            return ttir_all_to_all_dispatch_golden(
+                *input_goldens,
+                attr_dict["num_devices"],
+                attr_dict["cluster_axis"],
+                *elem_types,
+            )
+        if name == "tt.all_to_all_dispatch_metadata":
+            return ttir_all_to_all_dispatch_metadata_golden(
+                *input_goldens,
+                attr_dict["num_devices"],
+                attr_dict["cluster_axis"],
+                *elem_types,
+            )
+        if name == "tt.all_to_all_combine":
+            return ttir_all_to_all_combine_golden(
+                *input_goldens,
+                attr_dict["num_devices"],
+                attr_dict["cluster_axis"],
+                attr_dict["num_experts_per_tok"],
+                *elem_types,
+            )
+        if name == "tt.moe_expert_token_remap":
+            return ttir_moe_expert_token_remap_golden(
+                *input_goldens,
+                reduction_size=unpack_mlir_attr(attr_dict["reduction_size"]),
+            )
+        return None
+
     @parse(ttir.CompositeOp)
     def composite_parser(
         self,
-        old_op: "ttir.CompositeOp",
+        old_op: ttir.CompositeOp,
         global_dict: Dict[Operand, Operand],
     ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
-        ttir_op = self.get_opview_from_parser(TTIRBuilder.composite_parser)
+        new_inputs = [global_dict[inp] for inp in old_op.inputs]
+        new_op = self._rebuild_composite(old_op, new_inputs)
 
-        new_inputs = [global_dict[v] for v in old_op.inputs]
-        result_types = [r.type for r in old_op.results]
-
-        new_op = ttir_op(
-            result_types,
-            old_op.name,
-            new_inputs,
-            old_op.op_attributes,
-            loc=old_op.location,
-        )
-
-        # Re-derive goldens by composite name where possible. Unknown names get
-        # zero-filled goldens that preserve the result types.
         name = str(old_op.name)
-        if isinstance(name, str) and name.startswith('"') and name.endswith('"'):
-            name = name[1:-1]
-
-        attr_dict = old_op.op_attributes
-
-        def _attr_int(key: str, default: int = 0) -> int:
-            a = attr_dict.get(key) if attr_dict is not None else None
-            return int(unpack_mlir_attr(a)) if a is not None else default
-
-        if name == "tt.all_to_all_dispatch":
-            in0 = self._get_golden_tensor(new_inputs[0])
-            in1 = self._get_golden_tensor(new_inputs[1])
-            gd, gm = self._build_all_to_all_dispatch_golden(
-                in0, in1, _attr_int("num_devices", 1)
-            )
-            self._set_golden_tensor(new_op.results[0], gd)
-            self._set_golden_tensor(new_op.results[1], gm)
-        elif name == "tt.all_to_all_dispatch_metadata":
-            in0 = self._get_golden_tensor(new_inputs[0])
-            in1 = self._get_golden_tensor(new_inputs[1])
-            in2 = self._get_golden_tensor(new_inputs[2])
-            in3 = self._get_golden_tensor(new_inputs[3])
-            gd, gi, gs = self._build_all_to_all_dispatch_metadata_golden(
-                in0,
-                in1,
-                in2,
-                in3,
-                _attr_int("num_devices", 1),
-                _attr_int("cluster_axis", 0),
-            )
-            self._set_golden_tensor(new_op.results[0], gd)
-            self._set_golden_tensor(new_op.results[1], gi)
-            self._set_golden_tensor(new_op.results[2], gs)
-        elif name == "tt.all_to_all_combine":
-            in0 = self._get_golden_tensor(new_inputs[0])
-            in1 = self._get_golden_tensor(new_inputs[1])
-            in2 = self._get_golden_tensor(new_inputs[2])
-            output_shape = tuple(int(dim) for dim in result_types[0].shape)
-            golden = self._build_all_to_all_combine_golden(
-                in0, in1, in2, output_shape, _attr_int("cluster_axis", 0)
-            )
-            self._set_golden_tensor(new_op.results[0], golden)
-        elif name == "tt.moe_expert_token_remap":
-            for i, t in enumerate(result_types):
-                shape = tuple(int(dim) for dim in t.shape)
-                dtype = mlir_type_to_torch_dtype(t.element_type)
+        result_types = [r.type for r in new_op.results]
+        golden_results = self._compute_composite_goldens(
+            name, new_inputs, old_op.op_attributes, result_types
+        )
+        if golden_results is not None:
+            if not isinstance(golden_results, tuple):
+                golden_results = (golden_results,)
+            for new_r, g in zip(new_op.results, golden_results):
+                self._set_golden_tensor(new_r, g)
+        else:
+            for new_r in new_op.results:
+                shape = tuple(int(d) for d in new_r.type.shape)
+                dtype = mlir_type_to_torch_dtype(new_r.type.element_type)
                 self._set_golden_tensor(
-                    new_op.results[i],
+                    new_r,
                     GoldenMapTensor(
                         {0: torch.zeros(shape, dtype=dtype)},
                         mesh_shape=self._mesh_shape,
                     ),
                 )
-        # Unknown composite names fall through with no golden registered.
 
-        op_map_dictionary = {
-            old_op.results[i]: new_op.results[i] for i in range(len(result_types))
-        }
+        op_map_dictionary = {}
+        for old_r, new_r in zip(old_op.results, new_op.results):
+            op_map_dictionary[old_r] = new_r
+
         return new_op, op_map_dictionary
 
     @split(ttir.CompositeOp)
     def composite_split(
         self,
-        old_op: "ttir.CompositeOp",
+        old_op: ttir.CompositeOp,
     ) -> Tuple[Module, TTIRBuilder]:
-        ttir_op = self.get_opview_from_split(TTIRBuilder.composite_split)
-
         old_ctx = old_op.context
         old_loc = Location.unknown(old_ctx)
+        composite_name = str(old_op.name)
+
         with old_ctx, old_loc:
-            token_remap_module = Module.create()
-            token_remap_builder = TTIRBuilder(
+            split_module = Module.create()
+            split_builder = TTIRBuilder(
                 old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
             )
-            op_input_types = [v.type for v in old_op.inputs]
-            result_types = [r.type for r in old_op.results]
-
-            # Synthesize a function name from the composite name so split
-            # modules are stable per-op.
-            raw_name = str(old_op.name)
-            if raw_name.startswith('"') and raw_name.endswith('"'):
-                raw_name = raw_name[1:-1]
-            module_name = raw_name.replace(".", "_") + "_module"
+            op_input_types = [inp.type for inp in old_op.inputs]
 
             with InsertionPoint(split_module.body):
                 ordered_inputs = []
                 ordered_outputs = []
 
-                @func.func(*op_input_types, name=module_name)
+                @func.func(
+                    *op_input_types,
+                    name=f"{composite_name.replace('.', '_')}_module",
+                )
                 def decorated_func(*inputs):
-                    new_op = ttir_op(
-                        result_types,
-                        old_op.name,
-                        list(inputs),
-                        old_op.op_attributes,
-                        loc=old_op.location,
+                    new_op = split_builder._rebuild_composite(
+                        old_op, list(inputs), loc=old_op.location
                     )
 
-                    for old_in, new_in in zip(old_op.inputs, inputs):
-                        split_builder._set_golden_tensor(
-                            new_in, self._get_golden_tensor(old_in)
-                        )
-                    for old_res, new_res in zip(old_op.results, new_op.results):
-                        split_builder._set_golden_tensor(
-                            new_res, self._get_golden_tensor(old_res)
-                        )
+                    for inp, old_inp in zip(inputs, old_op.inputs):
+                        inp_golden = self._get_golden_tensor(old_inp)
+                        split_builder._set_golden_tensor(inp, inp_golden)
+                    ordered_inputs.extend(inputs)
 
-                    ordered_inputs.extend(list(inputs))
-                    ordered_outputs.extend(list(new_op.results))
+                    for new_r, old_r in zip(new_op.results, old_op.results):
+                        old_golden = self._get_golden_tensor(old_r)
+                        split_builder._set_golden_tensor(new_r, old_golden)
+                        ordered_outputs.append(new_r)
+
                     return new_op
 
                 new_func_op = decorated_func.func_op

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -15567,9 +15567,33 @@ class TTIRBuilder(Builder):
 
         return sparse_matmul_module, sparse_matmul_builder
 
-    ############### ttir.AllToAllDispatchOp ###############
+    ############### ttir.composite (MoE bridge ops) ###############
+    # These helpers emit ttir.composite with a specific `name` and
+    # composite_attributes. Each name maps 1:1 to a TTNN op during the
+    # TTIR->TTNN conversion; no TTIR-level transformation is performed.
 
-    @tag(ttir.AllToAllDispatchOp)
+    def _emit_composite(
+        self,
+        name: str,
+        input_values: List[Operand],
+        result_types: List,
+        attrs: Dict[str, "Attribute"],
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        loc = self._get_location()
+        dict_attr = DictAttr.get(attrs, context=self._ctx)
+        op = ttir.CompositeOp(
+            result_types,
+            name,
+            input_values,
+            dict_attr,
+            loc=loc,
+        )
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+        return op
+
     def all_to_all_dispatch(
         self,
         input_tensor: Operand,
@@ -15599,15 +15623,13 @@ class TTIRBuilder(Builder):
             metadata_type is not None
         ), "metadata_type must be provided for all_to_all_dispatch"
 
-        mlir_dispatched_type = self._get_type_from_torch_dtype(dispatched_type)
-        mlir_metadata_type = self._get_type_from_torch_dtype(metadata_type)
-
         dispatched_result = self._create_ranked_tensor_type(
-            dispatched_shape, mlir_dispatched_type
+            dispatched_shape, self._get_type_from_torch_dtype(dispatched_type)
         )
         metadata_result = self._create_ranked_tensor_type(
-            metadata_shape, mlir_metadata_type
+            metadata_shape, self._get_type_from_torch_dtype(metadata_type)
         )
+        i64 = IntegerType.get_signless(64)
 
         num_devices_attr = IntegerAttr.get(IntegerType.get_signless(64), num_devices)
         cluster_axis_attr = IntegerAttr.get(IntegerType.get_signless(64), cluster_axis)
@@ -15641,10 +15663,7 @@ class TTIRBuilder(Builder):
             cluster_axis_attr,
             loc=loc,
         )
-
-        if unit_attrs is not None:
-            for attr_name in unit_attrs:
-                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+        dispatched, metadata = op.results[0], op.results[1]
 
         self._set_golden_tensor(op.dispatched, golden_dispatched)
         self._set_golden_tensor(op.metadata, golden_metadata)
@@ -15816,15 +15835,11 @@ class TTIRBuilder(Builder):
             scores_type is not None
         ), "scores_type must be provided for all_to_all_dispatch_metadata"
 
-        mlir_dispatched_type = self._get_type_from_torch_dtype(dispatched_type)
-        mlir_indices_type = self._get_type_from_torch_dtype(indices_type)
-        mlir_scores_type = self._get_type_from_torch_dtype(scores_type)
-
         dispatched_result = self._create_ranked_tensor_type(
-            dispatched_shape, mlir_dispatched_type
+            dispatched_shape, self._get_type_from_torch_dtype(dispatched_type)
         )
         indices_result = self._create_ranked_tensor_type(
-            indices_shape, mlir_indices_type
+            indices_shape, self._get_type_from_torch_dtype(indices_type)
         )
         scores_result = self._create_ranked_tensor_type(scores_shape, mlir_scores_type)
 
@@ -15865,10 +15880,19 @@ class TTIRBuilder(Builder):
             cluster_axis_attr,
             loc=loc,
         )
+        i64 = IntegerType.get_signless(64)
 
-        if unit_attrs is not None:
-            for attr_name in unit_attrs:
-                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+        op = self._emit_composite(
+            "tt.all_to_all_dispatch_metadata",
+            [input_tensor, expert_indices, expert_scores, expert_mapping],
+            [dispatched_result, indices_result, scores_result],
+            {
+                "num_devices": IntegerAttr.get(i64, num_devices),
+                "cluster_axis": IntegerAttr.get(i64, cluster_axis),
+            },
+            unit_attrs=unit_attrs,
+        )
+        dispatched, indices, scores = op.results[0], op.results[1], op.results[2]
 
         self._set_golden_tensor(op.dispatched, golden_dispatched)
         self._set_golden_tensor(op.indices, golden_indices)
@@ -16060,16 +16084,22 @@ class TTIRBuilder(Builder):
             output_type is not None
         ), "output_type must be provided for all_to_all_combine"
 
-        mlir_output_type = self._get_type_from_torch_dtype(output_type)
-        result = self._create_ranked_tensor_type(output_shape, mlir_output_type)
-
-        num_devices_attr = IntegerAttr.get(IntegerType.get_signless(64), num_devices)
-        cluster_axis_attr = IntegerAttr.get(IntegerType.get_signless(64), cluster_axis)
-        num_experts_per_tok_attr = IntegerAttr.get(
-            IntegerType.get_signless(64), num_experts_per_tok
+        result_type = self._create_ranked_tensor_type(
+            output_shape, self._get_type_from_torch_dtype(output_type)
         )
-        output_shard_dim_attr = IntegerAttr.get(
-            IntegerType.get_signless(64), output_shard_dim
+        i64 = IntegerType.get_signless(64)
+
+        op = self._emit_composite(
+            "tt.all_to_all_combine",
+            [input_tensor, expert_metadata, expert_mapping],
+            [result_type],
+            {
+                "num_devices": IntegerAttr.get(i64, num_devices),
+                "cluster_axis": IntegerAttr.get(i64, cluster_axis),
+                "num_experts_per_tok": IntegerAttr.get(i64, num_experts_per_tok),
+                "output_shard_dim": IntegerAttr.get(i64, output_shard_dim),
+            },
+            unit_attrs=unit_attrs,
         )
 
         if loc is None:
@@ -16253,35 +16283,25 @@ class TTIRBuilder(Builder):
             reduced_type is not None
         ), "reduced_type must be provided for moe_expert_token_remap"
 
-        mlir_mapping_type = self._get_type_from_torch_dtype(mapping_type)
-        mlir_reduced_type = self._get_type_from_torch_dtype(reduced_type)
-
         mapping_result = self._create_ranked_tensor_type(
-            mapping_shape, mlir_mapping_type
+            mapping_shape, self._get_type_from_torch_dtype(mapping_type)
         )
         reduced_result = self._create_ranked_tensor_type(
-            reduced_shape, mlir_reduced_type
+            reduced_shape, self._get_type_from_torch_dtype(reduced_type)
         )
 
-        reduction_size_attr = IntegerAttr.get(
-            IntegerType.get_signless(64), reduction_size
+        op = self._emit_composite(
+            "tt.moe_expert_token_remap",
+            [topk_tensor, expert_mapping, expert_metadata],
+            [mapping_result, reduced_result],
+            {
+                "reduction_size": IntegerAttr.get(
+                    IntegerType.get_signless(64), reduction_size
+                ),
+            },
+            unit_attrs=unit_attrs,
         )
-
-        loc = self._get_location()
-
-        op = ttir.MoeExpertTokenRemapOp(
-            mapping_result,
-            reduced_result,
-            topk_tensor,
-            expert_mapping,
-            expert_metadata,
-            reduction_size_attr,
-            loc=loc,
-        )
-
-        if unit_attrs is not None:
-            for attr_name in unit_attrs:
-                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
+        mapping, reduced = op.results[0], op.results[1]
 
         golden_mapping = GoldenMapTensor(
             {0: torch.zeros(mapping_shape, dtype=mapping_type)},
@@ -16291,65 +16311,100 @@ class TTIRBuilder(Builder):
             {0: torch.zeros(reduced_shape, dtype=reduced_type)},
             mesh_shape=self._mesh_shape,
         )
-        self._set_golden_tensor(op.mapping, golden_mapping)
-        self._set_golden_tensor(op.reduced, golden_reduced)
+        self._set_golden_tensor(mapping, golden_mapping)
+        self._set_golden_tensor(reduced, golden_reduced)
+        return mapping, reduced
 
-        return op.mapping, op.reduced
-
-    @parse(ttir.MoeExpertTokenRemapOp)
-    def moe_expert_token_remap_parser(
+    # Generic round-trip parser/splitter for ttir.composite. Dispatches on the
+    # composite `name` to recompute goldens for the supported MoE bridge ops.
+    @parse(ttir.CompositeOp)
+    def composite_parser(
         self,
-        old_op: ttir.MoeExpertTokenRemapOp,
+        old_op: "ttir.CompositeOp",
         global_dict: Dict[Operand, Operand],
     ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
-        ttir_op = self.get_opview_from_parser(TTIRBuilder.moe_expert_token_remap_parser)
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.composite_parser)
 
-        topk_tensor = global_dict[old_op.topk_tensor]
-        expert_mapping = global_dict[old_op.expert_mapping]
-        expert_metadata = global_dict[old_op.expert_metadata]
-        mapping_type = old_op.mapping.type
-        reduced_type = old_op.reduced.type
-        reduction_size_attr = old_op.reduction_size
+        new_inputs = [global_dict[v] for v in old_op.inputs]
+        result_types = [r.type for r in old_op.results]
 
         new_op = ttir_op(
-            mapping_type,
-            reduced_type,
-            topk_tensor,
-            expert_mapping,
-            expert_metadata,
-            reduction_size_attr,
+            result_types,
+            old_op.name,
+            new_inputs,
+            old_op.composite_attributes,
             loc=old_op.location,
         )
-        new_op_mapping = new_op.mapping
-        new_op_reduced = new_op.reduced
 
-        mapping_shape = tuple(int(dim) for dim in mapping_type.shape)
-        reduced_shape = tuple(int(dim) for dim in reduced_type.shape)
-        mapping_dtype = mlir_type_to_torch_dtype(mapping_type.element_type)
-        reduced_dtype = mlir_type_to_torch_dtype(reduced_type.element_type)
-        golden_mapping = GoldenMapTensor(
-            {0: torch.zeros(mapping_shape, dtype=mapping_dtype)},
-            mesh_shape=self._mesh_shape,
-        )
-        golden_reduced = GoldenMapTensor(
-            {0: torch.zeros(reduced_shape, dtype=reduced_dtype)},
-            mesh_shape=self._mesh_shape,
-        )
-        self._set_golden_tensor(new_op_mapping, golden_mapping)
-        self._set_golden_tensor(new_op_reduced, golden_reduced)
+        # Re-derive goldens by composite name where possible. Unknown names get
+        # zero-filled goldens that preserve the result types.
+        name = str(old_op.name)
+        if isinstance(name, str) and name.startswith('"') and name.endswith('"'):
+            name = name[1:-1]
+
+        attr_dict = old_op.composite_attributes
+
+        def _attr_int(key: str, default: int = 0) -> int:
+            a = attr_dict.get(key) if attr_dict is not None else None
+            return int(unpack_mlir_attr(a)) if a is not None else default
+
+        if name == "tt.all_to_all_dispatch":
+            in0 = self._get_golden_tensor(new_inputs[0])
+            in1 = self._get_golden_tensor(new_inputs[1])
+            gd, gm = self._build_all_to_all_dispatch_golden(
+                in0, in1, _attr_int("num_devices", 1)
+            )
+            self._set_golden_tensor(new_op.results[0], gd)
+            self._set_golden_tensor(new_op.results[1], gm)
+        elif name == "tt.all_to_all_dispatch_metadata":
+            in0 = self._get_golden_tensor(new_inputs[0])
+            in1 = self._get_golden_tensor(new_inputs[1])
+            in2 = self._get_golden_tensor(new_inputs[2])
+            in3 = self._get_golden_tensor(new_inputs[3])
+            gd, gi, gs = self._build_all_to_all_dispatch_metadata_golden(
+                in0,
+                in1,
+                in2,
+                in3,
+                _attr_int("num_devices", 1),
+                _attr_int("cluster_axis", 0),
+            )
+            self._set_golden_tensor(new_op.results[0], gd)
+            self._set_golden_tensor(new_op.results[1], gi)
+            self._set_golden_tensor(new_op.results[2], gs)
+        elif name == "tt.all_to_all_combine":
+            in0 = self._get_golden_tensor(new_inputs[0])
+            in1 = self._get_golden_tensor(new_inputs[1])
+            in2 = self._get_golden_tensor(new_inputs[2])
+            output_shape = tuple(int(dim) for dim in result_types[0].shape)
+            golden = self._build_all_to_all_combine_golden(
+                in0, in1, in2, output_shape, _attr_int("cluster_axis", 0)
+            )
+            self._set_golden_tensor(new_op.results[0], golden)
+        elif name == "tt.moe_expert_token_remap":
+            for i, t in enumerate(result_types):
+                shape = tuple(int(dim) for dim in t.shape)
+                dtype = mlir_type_to_torch_dtype(t.element_type)
+                self._set_golden_tensor(
+                    new_op.results[i],
+                    GoldenMapTensor(
+                        {0: torch.zeros(shape, dtype=dtype)},
+                        mesh_shape=self._mesh_shape,
+                    ),
+                )
+        # Unknown composite names fall through with no golden registered.
 
         op_map_dictionary = {
-            old_op.mapping: new_op_mapping,
-            old_op.reduced: new_op_reduced,
+            old_op.results[i]: new_op.results[i] for i in range(len(result_types))
         }
         return new_op, op_map_dictionary
 
-    @split(ttir.MoeExpertTokenRemapOp)
-    def moe_expert_token_remap_split(
+    @split(ttir.CompositeOp)
+    def composite_split(
         self,
-        old_op: ttir.MoeExpertTokenRemapOp,
+        old_op: "ttir.CompositeOp",
     ) -> Tuple[Module, TTIRBuilder]:
-        ttir_op = self.get_opview_from_split(TTIRBuilder.moe_expert_token_remap_split)
+        ttir_op = self.get_opview_from_split(TTIRBuilder.composite_split)
 
         old_ctx = old_op.context
         old_loc = Location.unknown(old_ctx)
@@ -16358,61 +16413,50 @@ class TTIRBuilder(Builder):
             token_remap_builder = TTIRBuilder(
                 old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
             )
-            op_input_types = [
-                old_op.topk_tensor.type,
-                old_op.expert_mapping.type,
-                old_op.expert_metadata.type,
-            ]
+            op_input_types = [v.type for v in old_op.inputs]
+            result_types = [r.type for r in old_op.results]
 
-            with InsertionPoint(token_remap_module.body):
+            # Synthesize a function name from the composite name so split
+            # modules are stable per-op.
+            raw_name = str(old_op.name)
+            if raw_name.startswith('"') and raw_name.endswith('"'):
+                raw_name = raw_name[1:-1]
+            module_name = raw_name.replace(".", "_") + "_module"
+
+            with InsertionPoint(split_module.body):
                 ordered_inputs = []
                 ordered_outputs = []
 
-                @func.func(*op_input_types, name="moe_expert_token_remap_module")
+                @func.func(*op_input_types, name=module_name)
                 def decorated_func(*inputs):
-                    topk_tensor = inputs[0]
-                    expert_mapping = inputs[1]
-                    expert_metadata = inputs[2]
-                    mapping_type = old_op.mapping.type
-                    reduced_type = old_op.reduced.type
-
                     new_op = ttir_op(
-                        mapping_type,
-                        reduced_type,
-                        topk_tensor,
-                        expert_mapping,
-                        expert_metadata,
-                        old_op.reduction_size,
+                        result_types,
+                        old_op.name,
+                        list(inputs),
+                        old_op.composite_attributes,
                         loc=old_op.location,
                     )
-                    new_op_mapping = new_op.mapping
-                    new_op_reduced = new_op.reduced
 
-                    input0 = self._get_golden_tensor(old_op.topk_tensor)
-                    input1 = self._get_golden_tensor(old_op.expert_mapping)
-                    input2 = self._get_golden_tensor(old_op.expert_metadata)
-                    old_mapping = self._get_golden_tensor(old_op.mapping)
-                    old_reduced = self._get_golden_tensor(old_op.reduced)
+                    for old_in, new_in in zip(old_op.inputs, inputs):
+                        split_builder._set_golden_tensor(
+                            new_in, self._get_golden_tensor(old_in)
+                        )
+                    for old_res, new_res in zip(old_op.results, new_op.results):
+                        split_builder._set_golden_tensor(
+                            new_res, self._get_golden_tensor(old_res)
+                        )
 
-                    token_remap_builder._set_golden_tensor(new_op_mapping, old_mapping)
-                    token_remap_builder._set_golden_tensor(new_op_reduced, old_reduced)
-                    token_remap_builder._set_golden_tensor(topk_tensor, input0)
-                    token_remap_builder._set_golden_tensor(expert_mapping, input1)
-                    token_remap_builder._set_golden_tensor(expert_metadata, input2)
-                    ordered_inputs.extend(
-                        [topk_tensor, expert_mapping, expert_metadata]
-                    )
-                    ordered_outputs.extend([new_op_mapping, new_op_reduced])
-
+                    ordered_inputs.extend(list(inputs))
+                    ordered_outputs.extend(list(new_op.results))
                     return new_op
 
                 new_func_op = decorated_func.func_op
-                token_remap_builder._func_ops_generated[new_func_op] = [
+                split_builder._func_ops_generated[new_func_op] = [
                     ordered_inputs,
                     ordered_outputs,
                 ]
 
-        return token_remap_module, token_remap_builder
+        return split_module, split_builder
 
     def upsample2d(
         self,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -7595,10 +7595,6 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.CollectiveBroadcastOp: ttir_collective_broadcast_golden,
     # Sparse MoE operations
     ttir.SparseMatmulOp: ttir_sparse_matmul_golden,
-    ttir.AllToAllDispatchOp: ttir_all_to_all_dispatch_golden,
-    ttir.AllToAllDispatchMetadataOp: ttir_all_to_all_dispatch_metadata_golden,
-    ttir.AllToAllCombineOp: ttir_all_to_all_combine_golden,
-    ttir.MoeExpertTokenRemapOp: ttir_moe_expert_token_remap_golden,
     # Operations with parameter transformations
     ttir.LeakyReluOp: leaky_relu_golden,
     # Attention operations


### PR DESCRIPTION
The 5 MoE ops (all_to_all_dispatch, all_to_all_dispatch_metadata,
all_to_all_combine, selective_reduce_combine, moe_expert_token_remap)
had no TTIR-level semantics — they were 1:1 passthroughs between
stablehlo.custom_call and the matching TTNN op. Letting
stablehlo.composite
flow through TTIR is not ideal because it would couple the TTIR dialect
to
stablehlo permanently and force every downstream pass/target to
whitelist it.
A self-contained ttir.composite op keeps TTIR independent and gives us a
single bridge construct.

Changes:
- Add ttir.composite (StrAttr name, variadic operands/results,
  DictionaryAttr composite_attributes) with a name-dispatched verifier
that
  preserves the checks of the deleted ops.
- Delete the 5 named TTIR ops and their verifiers.
- StableHLOToTTIR: rewrite custom_call patterns to emit ttir.composite.
- TTIRToTTNN: replace 5 per-op patterns with a single name-dispatching
  CompositeOpConversionPattern.
- Python builder: keep user-facing helpers (now emitting ttir.composite)
  and add generic @parse / @split dispatchers on ttir.CompositeOp.
- Drop the 4 deleted op-class entries from the golden mapping.
- Update lit tests (4 negative + 2 sparse_moe) to ttir.composite syntax.