### PR TITLE
Added gather index int32 support

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3598,10 +3598,10 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
   const ::mlir::RankedTensorType resultType = getResult().getType();
 
   if (!indexType.getElementType().isUnsignedInteger(16) &&
-      !indexType.getElementType().isUnsignedInteger(32)) {
-    return emitOpError() << "Index tensor must have an unsigned integer "
-                         << "type of ui16 or ui32, got "
-                         << indexType.getElementType();
+      !indexType.getElementType().isUnsignedInteger(32) &&
+      !indexType.getElementType().isSignedInteger(32)) {
+    return emitOpError() << "Index tensor must have type ui16, ui32, or si32, "
+                         << "got " << indexType.getElementType();
   }
 
   const int64_t inputRank = inputType.getRank();

--- a/runtime/lib/ttnn/operations/data_movement/gather.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/gather.cpp
@@ -21,8 +21,14 @@ void run(const ::tt::target::ttnn::GatherOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           op->memory_config());
 
+  // Indices must be non negative, otherwise this will break
+  ::ttnn::Tensor newIndex = index;
+  if (index.dtype() == ::tt::tt_metal::DataType::INT32) {
+    newIndex = ::ttnn::typecast(index, ::tt::tt_metal::DataType::UINT32);
+  }
+
   ::ttnn::Tensor out =
-      ::ttnn::gather(input, dim, index, /*sparse_grad=*/false,
+      ::ttnn::gather(input, dim, newIndex, /*sparse_grad=*/false,
                      outputMemoryConfig, std::nullopt, std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/operations/data_movement/gather.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/gather.cpp
@@ -9,6 +9,16 @@
 
 namespace tt::runtime::ttnn::operations::data_movement {
 
+namespace {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+bool allNonNegative(const ::ttnn::Tensor &index) {
+  std::vector<int32_t> values = index.to_vector<int32_t>();
+  return std::all_of(values.begin(), values.end(),
+                     [](int32_t v) { return v >= 0; });
+}
+#endif
+} // namespace
+
 void run(const ::tt::target::ttnn::GatherOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input =
@@ -21,10 +31,11 @@ void run(const ::tt::target::ttnn::GatherOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           op->memory_config());
 
-  // Indices must be non negative, otherwise this will break
   ::ttnn::Tensor newIndex = index;
-  if (index.dtype() == ::tt::tt_metal::DataType::INT32) {
-    newIndex = ::ttnn::typecast(index, ::tt::tt_metal::DataType::UINT32);
+  if (index.dtype() == ::ttnn::DataType::INT32) {
+    DEBUG_ASSERT(allNonNegative(index),
+                 "ttnn::gather INT32 index must be non-negative");
+    newIndex = ::ttnn::typecast(index, ::ttnn::DataType::UINT32);
   }
 
   ::ttnn::Tensor out =

--- a/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/gather/gather_tests_negative.mlir
@@ -1,11 +1,33 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for ttnn gather operation
 
-// Verify that index tensor must be unsigned integer type.
+// Verify that signless i32 is rejected (only ui16, ui32, and si32 are accepted).
 module {
-  func.func @gather_signed_index(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xi32>) -> tensor<2x3xf32> {
-    // CHECK: error: 'ttnn.gather' op Index tensor must have an unsigned integer type of ui16 or ui32, got 'i32'
+  func.func @gather_signless_index(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xi32>) -> tensor<2x3xf32> {
+    // CHECK: error: 'ttnn.gather' op Index tensor must have type ui16, ui32, or si32, got 'i32'
     %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xi32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+}
+
+// -----
+
+// Verify that si64 indices are rejected (si32 is allowed, but other signed widths are not).
+module {
+  func.func @gather_si64_index(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xsi64>) -> tensor<2x3xf32> {
+    // CHECK: error: 'ttnn.gather' op Index tensor must have type ui16, ui32, or si32, got 'si64'
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xsi64>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+}
+
+// -----
+
+// Verify that si16 indices are rejected (only si32 among signed widths is allowed).
+module {
+  func.func @gather_si16_index(%arg0: tensor<5x3xf32>, %arg1: tensor<2x3xsi16>) -> tensor<2x3xf32> {
+    // CHECK: error: 'ttnn.gather' op Index tensor must have type ui16, ui32, or si32, got 'si16'
+    %0 = "ttnn.gather"(%arg0, %arg1) <{dim = 0 : i32}> : (tensor<5x3xf32>, tensor<2x3xsi16>) -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/gather/gather.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/gather/gather.mlir
@@ -1,0 +1,83 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+// Tests for ttir.gather_dim lowering to ttnn.gather with si32 indices.
+// The runtime (gather.cpp) typecasts INT32 -> UINT32 before calling ::ttnn::gather.
+// All indices here are non-negative; the runtime assumes that contract.
+
+// Basic gather along dim 0 with si32 indices.
+func.func @gather_dim0_si32(%input: tensor<3x4xbf16>, %idx: tensor<2x4xi32>) -> tensor<2x4xbf16> {
+  // CHECK-LABEL: func.func @gather_dim0_si32
+  // CHECK: "ttnn.gather"({{.*}}) <{dim = 0 : i32}>
+  // CHECK-SAME: (tensor<3x4xbf16, {{.*}}>, tensor<2x4xsi32, {{.*}}>) -> tensor<2x4xbf16, {{.*}}>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  return %0 : tensor<2x4xbf16>
+}
+
+// Gather along dim 1 with si32 indices.
+func.func @gather_dim1_si32(%input: tensor<3x4xf32>, %idx: tensor<3x2xi32>) -> tensor<3x2xf32> {
+  // CHECK-LABEL: func.func @gather_dim1_si32
+  // CHECK: "ttnn.gather"({{.*}}) <{dim = 1 : i32}>
+  // CHECK-SAME: tensor<3x2xsi32, {{.*}}>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 1 : i32}> : (tensor<3x4xf32>, tensor<3x2xi32>) -> tensor<3x2xf32>
+  return %0 : tensor<3x2xf32>
+}
+
+// Higher-rank gather with si32 indices.
+func.func @gather_4d_si32(%input: tensor<2x3x4x5xbf16>, %idx: tensor<2x3x2x5xi32>) -> tensor<2x3x2x5xbf16> {
+  // CHECK-LABEL: func.func @gather_4d_si32
+  // CHECK: "ttnn.gather"({{.*}}) <{dim = 2 : i32}>
+  // CHECK-SAME: tensor<2x3x2x5xsi32, {{.*}}>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 2 : i32}> : (tensor<2x3x4x5xbf16>, tensor<2x3x2x5xi32>) -> tensor<2x3x2x5xbf16>
+  return %0 : tensor<2x3x2x5xbf16>
+}
+
+// Constant si32 indices: input [10..33], expected output rows {0,1} = [[10,21,32,13],[20,31,12,23]].
+// Const-evaluated, so the gather op lands in a hoisted `_const_eval_0` function.
+func.func @gather_const_si32() -> tensor<2x4xbf16> {
+  // CHECK-LABEL: func.func private @gather_const_si32_const_eval_0
+  // CHECK: "ttnn.gather"
+  // CHECK-SAME: tensor<2x4xsi32, {{.*}}>
+  // CHECK-LABEL: func.func @gather_const_si32(
+  %input = "ttir.constant"() <{value = dense<[
+    [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01],
+    [2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01],
+    [3.000000e+01, 3.100000e+01, 3.200000e+01, 3.300000e+01]
+  ]> : tensor<3x4xbf16>}> : () -> tensor<3x4xbf16>
+  %idx = "ttir.constant"() <{value = dense<[
+    [0, 1, 2, 0],
+    [1, 2, 0, 1]
+  ]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  return %0 : tensor<2x4xbf16>
+}
+
+// Constant si32 indices at the upper bound of the gather dim (size-1).
+// Verifies max valid index does not trip the typecast wrap.
+func.func @gather_const_si32_max_idx() -> tensor<2x4xbf16> {
+  // CHECK-LABEL: func.func private @gather_const_si32_max_idx_const_eval_0
+  // CHECK: "ttnn.gather"
+  // CHECK-SAME: tensor<2x4xsi32, {{.*}}>
+  // CHECK-LABEL: func.func @gather_const_si32_max_idx(
+  %input = "ttir.constant"() <{value = dense<[
+    [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01],
+    [2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01],
+    [3.000000e+01, 3.100000e+01, 3.200000e+01, 3.300000e+01]
+  ]> : tensor<3x4xbf16>}> : () -> tensor<3x4xbf16>
+  %idx = "ttir.constant"() <{value = dense<[
+    [2, 2, 2, 2],
+    [2, 2, 2, 2]
+  ]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  return %0 : tensor<2x4xbf16>
+}
+
+// Sanity: ui32 indices should still work (no typecast inserted at runtime).
+func.func @gather_dim0_ui32(%input: tensor<3x4xbf16>, %idx: tensor<2x4xui32>) -> tensor<2x4xbf16> {
+  // CHECK-LABEL: func.func @gather_dim0_ui32
+  // CHECK: "ttnn.gather"({{.*}}) <{dim = 0 : i32}>
+  // CHECK-SAME: tensor<2x4xui32, {{.*}}>
+  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xui32>) -> tensor<2x4xbf16>
+  return %0 : tensor<2x4xbf16>
+}

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/gather/gather.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/gather/gather.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
 
-// Tests for ttir.gather_dim lowering to ttnn.gather with si32 indices.
+// Tests for ttir.gather lowering to ttnn.gather with si32 indices.
 // The runtime (gather.cpp) typecasts INT32 -> UINT32 before calling ::ttnn::gather.
 // All indices here are non-negative; the runtime assumes that contract.
 
@@ -11,7 +11,7 @@ func.func @gather_dim0_si32(%input: tensor<3x4xbf16>, %idx: tensor<2x4xi32>) -> 
   // CHECK-LABEL: func.func @gather_dim0_si32
   // CHECK: "ttnn.gather"({{.*}}) <{dim = 0 : i32}>
   // CHECK-SAME: (tensor<3x4xbf16, {{.*}}>, tensor<2x4xsi32, {{.*}}>) -> tensor<2x4xbf16, {{.*}}>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
   return %0 : tensor<2x4xbf16>
 }
 
@@ -20,7 +20,7 @@ func.func @gather_dim1_si32(%input: tensor<3x4xf32>, %idx: tensor<3x2xi32>) -> t
   // CHECK-LABEL: func.func @gather_dim1_si32
   // CHECK: "ttnn.gather"({{.*}}) <{dim = 1 : i32}>
   // CHECK-SAME: tensor<3x2xsi32, {{.*}}>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 1 : i32}> : (tensor<3x4xf32>, tensor<3x2xi32>) -> tensor<3x2xf32>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 1 : i32}> : (tensor<3x4xf32>, tensor<3x2xi32>) -> tensor<3x2xf32>
   return %0 : tensor<3x2xf32>
 }
 
@@ -29,7 +29,7 @@ func.func @gather_4d_si32(%input: tensor<2x3x4x5xbf16>, %idx: tensor<2x3x2x5xi32
   // CHECK-LABEL: func.func @gather_4d_si32
   // CHECK: "ttnn.gather"({{.*}}) <{dim = 2 : i32}>
   // CHECK-SAME: tensor<2x3x2x5xsi32, {{.*}}>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 2 : i32}> : (tensor<2x3x4x5xbf16>, tensor<2x3x2x5xi32>) -> tensor<2x3x2x5xbf16>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 2 : i32}> : (tensor<2x3x4x5xbf16>, tensor<2x3x2x5xi32>) -> tensor<2x3x2x5xbf16>
   return %0 : tensor<2x3x2x5xbf16>
 }
 
@@ -49,7 +49,7 @@ func.func @gather_const_si32() -> tensor<2x4xbf16> {
     [0, 1, 2, 0],
     [1, 2, 0, 1]
   ]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
   return %0 : tensor<2x4xbf16>
 }
 
@@ -69,7 +69,7 @@ func.func @gather_const_si32_max_idx() -> tensor<2x4xbf16> {
     [2, 2, 2, 2],
     [2, 2, 2, 2]
   ]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xi32>) -> tensor<2x4xbf16>
   return %0 : tensor<2x4xbf16>
 }
 
@@ -78,6 +78,6 @@ func.func @gather_dim0_ui32(%input: tensor<3x4xbf16>, %idx: tensor<2x4xui32>) ->
   // CHECK-LABEL: func.func @gather_dim0_ui32
   // CHECK: "ttnn.gather"({{.*}}) <{dim = 0 : i32}>
   // CHECK-SAME: tensor<2x4xui32, {{.*}}>
-  %0 = "ttir.gather_dim"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xui32>) -> tensor<2x4xbf16>
+  %0 = "ttir.gather"(%input, %idx) <{dim = 0 : i32}> : (tensor<3x4xbf16>, tensor<2x4xui32>) -> tensor<2x4xbf16>
   return %0 : tensor<2x4xbf16>
 }


### PR DESCRIPTION
### Ticket
Related to #7664 

### Problem description
The current gather implementation didn't account for index tensor having INT32 dtype, so we can just convert them to UINT32, afaik we are not supporting negative indexes on gather op so this typecasting should be valid.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] New/Existing tests provide coverage for changes
