### PR TITLE
Re-enable d2m all gather test

### DIFF
--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1866,9 +1866,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     if (useAlwaysStreamPolicy()) {
       return true;
     }
-    if (genericOp.isDMAOnlyForm()) {
-      return false;
-    }
 
     // Non-trivial views need a stream to represent the implied data movement.
     if (isNonTrivialView(operandCtx)) {

--- a/test/python/golden/d2m/test_allgather.py
+++ b/test/python/golden/d2m/test_allgather.py
@@ -78,13 +78,6 @@ def test_all_gather(
         pytest.skip("all_gather_dim is out of range")
     if mesh_shape[cluster_axis] == 1:
         pytest.skip("all_gather across 1 device is meaningless")
-    if fabric_config == tt_runtime.runtime.FabricConfig.FABRIC_1D_RING and tuple(
-        mesh_shape
-    ) == (1, 8):
-        pytest.skip(
-            "Temporarily disabled: hangs on civ2 llmbox-stable runners "
-            "(stale eth-core fabric state)."
-        )
 
     rank_in = len(test_shape)
     rank_mesh = len(mesh_shape)


### PR DESCRIPTION
### Problem description
In https://github.com/tenstorrent/tt-mlir/pull/7738, there was a change to skip stream insertion for DMA-only generics but the DMA-only generic for the all gather op does in fact require a CB since we are not aliasing either the remote_load or the remote_store (since the remote_load is required to fetch the data from the input, and the remote_store is a write over fabric).

### What's changed
Revert the change.

### Checklist
- [x] New/Existing tests provide coverage for changes
