### PR TITLE
D2M: object-oriented CB API migration

### DIFF
--- a/docs/src/builder/ttir-builder.md
+++ b/docs/src/builder/ttir-builder.md
@@ -64,13 +64,10 @@ An MLIR module containing an MLIR op graph defined by `fn` and the `TTIRBuilder`
 ```mlir
 module {
   func.func @model(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>, %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
-    %2 = ttir.empty() : tensor<32x32xf32>
-    %3 = "ttir.multiply"(%arg1, %1, %2) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
-    %4 = ttir.empty() : tensor<32x32xf32>
-    %5 = "ttir.multiply"(%3, %arg2, %4) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
-    return %5 : tensor<32x32xf32>
+    %0 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.multiply"(%arg1, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %2 = "ttir.multiply"(%1, %arg2) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %2 : tensor<32x32xf32>
   }
 }
 ```
@@ -162,270 +159,327 @@ An MLIR module lowered into TTMetal
 
 ```mlir
 #l1 = #ttcore.memory_space<l1>
-#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_helper_cores = {dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 103712, erisc_l1_unreserved_base = 98304, dram_unreserved_base = 32, dram_unreserved_end = 1073119552, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_physical_size_tiles = 16, num_cbs = 64, num_compute_threads = 1, num_datamovement_threads = 2, dram_grid = 1x12, dram_bank_to_logical_worker_noc0 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (7, 7), (1, 4), (3, 6), (6, 4), (2, 4), (4, 4), (5, 4)], dram_bank_to_logical_worker_noc1 = [(7, 3), (0, 0), (4, 0), (5, 0), (0, 4), (7, 7), (1, 4), (3, 6), (6, 4), (2, 4), (4, 4), (5, 4)]}], [0], [1 : i32], [ 0x0x0x0]>
 module {
   ttcore.device_module {
     builtin.module attributes {ttcore.system_desc = #system_desc} {
-      ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
-      func.func @model(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) -> memref<32x32xf32> {
-        %0 = "ttmetal.create_buffer"() <{address = 9216 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        %1 = "ttmetal.create_buffer"() <{address = 1024 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>
-        "ttmetal.enqueue_write_buffer"(%arg0, %1) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        "ttmetal.enqueue_program"(%1, %0, %1, %0) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>, #ttmetal.compute_config<@compute_kernel1, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%1) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        %2 = "ttmetal.create_buffer"() <{address = 1024 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        %3 = "ttmetal.create_buffer"() <{address = 5120 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>
-        "ttmetal.enqueue_write_buffer"(%arg1, %3) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        "ttmetal.enqueue_program"(%3, %2, %3, %2) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel2, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>, #ttmetal.compute_config<@compute_kernel3, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%3) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        %4 = "ttmetal.create_buffer"() <{address = 13312 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        "ttmetal.enqueue_program"(%0, %2, %4, %0, %2, %4) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel4, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc0>, #ttmetal.noc_config<@datamovement_kernel5, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc1>, #ttmetal.compute_config<@compute_kernel6, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%0) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%2) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        %5 = "ttmetal.create_buffer"() <{address = 1024 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        %6 = "ttmetal.create_buffer"() <{address = 5120 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>
-        "ttmetal.enqueue_write_buffer"(%arg1, %6) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        "ttmetal.enqueue_program"(%6, %5, %6, %5) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel7, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>, #ttmetal.compute_config<@compute_kernel8, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%6) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        %7 = "ttmetal.create_buffer"() <{address = 17408 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        "ttmetal.enqueue_program"(%5, %4, %7, %5, %4, %7) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel9, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc0>, #ttmetal.noc_config<@datamovement_kernel10, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc1>, #ttmetal.compute_config<@compute_kernel11, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%5) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%4) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        %8 = "ttmetal.create_buffer"() <{address = 9216 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        %9 = "ttmetal.create_buffer"() <{address = 1024 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>
-        "ttmetal.enqueue_write_buffer"(%arg2, %9) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        "ttmetal.enqueue_program"(%9, %8, %9, %8) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel12, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>, #ttmetal.compute_config<@compute_kernel13, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%9) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        %10 = "ttmetal.create_buffer"() <{address = 5120 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>
-        "ttmetal.enqueue_program"(%7, %8, %10, %7, %8, %10) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel14, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc0>, #ttmetal.noc_config<@datamovement_kernel15, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, noc1>, #ttmetal.compute_config<@compute_kernel16, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>, <cb_port[2]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%8) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%7) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
+      ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+      func.func @model(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) -> memref<32x32xf32> attributes {tt.function_type = "forward_device"} {
+        %0 = "ttmetal.create_buffer"() <{address = 107808 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        %1 = "ttmetal.create_buffer"() <{address = 103712 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+        "ttmetal.enqueue_write_buffer"(%arg0, %1) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        "ttmetal.enqueue_program"(%1, %0, %1, %0) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel1, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%1) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        %2 = "ttmetal.create_buffer"() <{address = 103712 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        %3 = "ttmetal.create_buffer"() <{address = 111904 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+        "ttmetal.enqueue_write_buffer"(%arg1, %3) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        "ttmetal.enqueue_program"(%3, %2, %3, %2) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel2, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel3, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%3) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        %4 = "ttmetal.create_buffer"() <{address = 116000 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        "ttmetal.enqueue_program"(%0, %2, %4, %0, %2, %4) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel4, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel5, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%0) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%2) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        %5 = "ttmetal.create_buffer"() <{address = 111904 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        %6 = "ttmetal.create_buffer"() <{address = 103712 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+        "ttmetal.enqueue_write_buffer"(%arg1, %6) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        "ttmetal.enqueue_program"(%6, %5, %6, %5) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel6, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel7, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%6) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        %7 = "ttmetal.create_buffer"() <{address = 107808 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        "ttmetal.enqueue_program"(%5, %4, %7, %5, %4, %7) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel8, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel9, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%5) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%4) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        %8 = "ttmetal.create_buffer"() <{address = 111904 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        %9 = "ttmetal.create_buffer"() <{address = 103712 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+        "ttmetal.enqueue_write_buffer"(%arg2, %9) : (memref<32x32xf32>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        "ttmetal.enqueue_program"(%9, %8, %9, %8) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel10, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel11, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%9) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        %10 = "ttmetal.create_buffer"() <{address = 103712 : i64}> : () -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+        "ttmetal.enqueue_program"(%7, %8, %10, %7, %8, %10) <{cb_ports = array<i64: 0, 1, 2>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel12, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel13, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[2]>, <cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 3, 3>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%7) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%8) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
         %alloc = memref.alloc() : memref<32x32xf32>
-        %11 = "ttmetal.create_buffer"() <{address = 1024 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>
-        "ttmetal.enqueue_program"(%10, %11, %10, %11) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel17, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, noc0>, #ttmetal.compute_config<@compute_kernel18, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <cb_port[1]>]>, hifi4, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
-        "ttmetal.deallocate_buffer"(%10) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096>, #l1>) -> ()
-        "ttmetal.enqueue_read_buffer"(%11, %alloc) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>, memref<32x32xf32>) -> ()
+        %11 = "ttmetal.create_buffer"() <{address = 107808 : i64}> : () -> memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>
+        "ttmetal.enqueue_program"(%10, %11, %10, %11) <{cb_ports = array<i64: 0, 1>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel14, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, noc0>, #ttmetal.compute_config<@compute_kernel15, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[1]>, <cb_port[0]>]>, hifi4, true, false, false, [default]>], operandSegmentSizes = array<i32: 2, 2>}> : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%10) : (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) -> ()
+        "ttmetal.enqueue_read_buffer"(%11, %alloc) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>, memref<32x32xf32>) -> ()
         "ttmetal.finish"() : () -> ()
-        "ttmetal.deallocate_buffer"(%11) : (memref<1x1x32x32xf32, #ttcore.shard<128x4>, #l1>) -> ()
+        "ttmetal.deallocate_buffer"(%11) : (memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #l1>) -> ()
         return %alloc : memref<32x32xf32>
       }
-      func.func private @datamovement_kernel0() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @compute_kernel1() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "tilize_init"(%1, %0, %2) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "experimental::tilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @compute_kernel1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> i32 {
+          %3 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %3 : i32
+        }
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        %2 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %2 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.call_opaque "compute_kernel_hw_startup"(%2, %1) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "tilize_init"(%2, %0, %1) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "experimental::tilize_block"(%2, %1, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
         return
       }
-      func.func private @datamovement_kernel2() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel2() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @compute_kernel3() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "tilize_init"(%1, %0, %2) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "experimental::tilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @compute_kernel3() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> i32 {
+          %3 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %3 : i32
+        }
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        %2 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %2 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.call_opaque "compute_kernel_hw_startup"(%2, %1) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "tilize_init"(%2, %0, %1) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "experimental::tilize_block"(%2, %1, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
         return
       }
-      func.func private @datamovement_kernel4() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel4() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @datamovement_kernel5() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        return
-      }
-      func.func private @compute_kernel6() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
-        %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+      func.func private @compute_kernel5() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %1 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %2 = emitc.expression  : () -> i32 {
+          %6 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %6 : i32
+        }
+        %3 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %3 : !emitc.opaque<"::tt::CB">
+        %4 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %4 : !emitc.opaque<"::tt::CB">
+        %5 = emitc.literal "get_compile_time_arg_val(2)" {ttkernel.cb_ctarg_idx = 2 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_2({});" args %5 : !emitc.opaque<"::tt::CB">
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.verbatim "cb_ctarg_2.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %2 : i32
         emitc.call_opaque "tile_regs_acquire"() : () -> ()
-        %2 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %3 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        %4 = emitc.literal "get_compile_time_arg_val(2)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "binary_op_init_common"(%2, %3, %4) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "add_tiles_init"(%2, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "add_tiles"(%2, %3, %0, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%5) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%5, %1, %1) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%4) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%4, %1, %0) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "add_binary_tile_init"() : () -> ()
+        emitc.call_opaque "add_binary_tile"(%1, %0, %1) : (!emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_commit"() : () -> ()
         emitc.call_opaque "tile_regs_wait"() : () -> ()
-        emitc.call_opaque "pack_tile"(%0, %4, %0) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
+        emitc.call_opaque "pack_tile"(%1, %3, %1) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_release"() : () -> ()
-        emitc.call_opaque "cb_push_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %2 : i32
         return
       }
-      func.func private @datamovement_kernel7() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel6() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @compute_kernel8() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "tilize_init"(%1, %0, %2) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "experimental::tilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @compute_kernel7() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> i32 {
+          %3 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %3 : i32
+        }
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        %2 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %2 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.call_opaque "compute_kernel_hw_startup"(%2, %1) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "tilize_init"(%2, %0, %1) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "experimental::tilize_block"(%2, %1, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
         return
       }
-      func.func private @datamovement_kernel9() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel8() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @datamovement_kernel10() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        return
-      }
-      func.func private @compute_kernel11() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
-        %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+      func.func private @compute_kernel9() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %1 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %2 = emitc.expression  : () -> i32 {
+          %6 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %6 : i32
+        }
+        %3 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %3 : !emitc.opaque<"::tt::CB">
+        %4 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %4 : !emitc.opaque<"::tt::CB">
+        %5 = emitc.literal "get_compile_time_arg_val(2)" {ttkernel.cb_ctarg_idx = 2 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_2({});" args %5 : !emitc.opaque<"::tt::CB">
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.verbatim "cb_ctarg_2.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %2 : i32
         emitc.call_opaque "tile_regs_acquire"() : () -> ()
-        %2 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %3 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        %4 = emitc.literal "get_compile_time_arg_val(2)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "binary_op_init_common"(%2, %3, %4) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "mul_tiles_init"(%2, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "mul_tiles"(%2, %3, %0, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%5) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%5, %1, %1) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%4) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%4, %1, %0) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "mul_binary_tile_init"() : () -> ()
+        emitc.call_opaque "mul_binary_tile"(%1, %0, %1) : (!emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_commit"() : () -> ()
         emitc.call_opaque "tile_regs_wait"() : () -> ()
-        emitc.call_opaque "pack_tile"(%0, %4, %0) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
+        emitc.call_opaque "pack_tile"(%1, %3, %1) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_release"() : () -> ()
-        emitc.call_opaque "cb_push_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %2 : i32
         return
       }
-      func.func private @datamovement_kernel12() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel10() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @compute_kernel13() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "tilize_init"(%1, %0, %2) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "experimental::tilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @compute_kernel11() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> i32 {
+          %3 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %3 : i32
+        }
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        %2 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %2 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.call_opaque "compute_kernel_hw_startup"(%2, %1) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "tilize_init"(%2, %0, %1) : (!emitc.opaque<"::tt::CB">, i32, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "experimental::tilize_block"(%2, %1, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
         return
       }
-      func.func private @datamovement_kernel14() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel12() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @datamovement_kernel15() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        return
-      }
-      func.func private @compute_kernel16() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
-        %1 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+      func.func private @compute_kernel13() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 2>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %1 = emitc.expression  : () -> !emitc.size_t {
+          %6 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
+          yield %6 : !emitc.size_t
+        }
+        %2 = emitc.expression  : () -> i32 {
+          %6 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %6 : i32
+        }
+        %3 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %3 : !emitc.opaque<"::tt::CB">
+        %4 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %4 : !emitc.opaque<"::tt::CB">
+        %5 = emitc.literal "get_compile_time_arg_val(2)" {ttkernel.cb_ctarg_idx = 2 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_2({});" args %5 : !emitc.opaque<"::tt::CB">
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "init_sfpu"(%5, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.verbatim "cb_ctarg_2.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %2 : i32
         emitc.call_opaque "tile_regs_acquire"() : () -> ()
-        %2 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %3 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        %4 = emitc.literal "get_compile_time_arg_val(2)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "binary_op_init_common"(%2, %3, %4) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "mul_tiles_init"(%2, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "mul_tiles"(%2, %3, %0, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%5) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%5, %1, %1) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "copy_tile_init"(%4) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "copy_tile"(%4, %1, %0) : (!emitc.opaque<"::tt::CB">, !emitc.size_t, !emitc.size_t) -> ()
+        emitc.call_opaque "mul_binary_tile_init"() : () -> ()
+        emitc.call_opaque "mul_binary_tile"(%1, %0, %1) : (!emitc.size_t, !emitc.size_t, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_commit"() : () -> ()
         emitc.call_opaque "tile_regs_wait"() : () -> ()
-        emitc.call_opaque "pack_tile"(%0, %4, %0) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
+        emitc.call_opaque "pack_tile"(%1, %3, %1) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
         emitc.call_opaque "tile_regs_release"() : () -> ()
-        emitc.call_opaque "cb_push_back"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%3, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%4, %1) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_2.pop_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %2 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %2 : i32
         return
       }
-      func.func private @datamovement_kernel17() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @datamovement_kernel14() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
         return
       }
-      func.func private @compute_kernel18() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
-        %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "untilize_init"(%1) : (!emitc.opaque<"::tt::CB">) -> ()
-        emitc.call_opaque "experimental::untilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+      func.func private @compute_kernel15() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+        %0 = emitc.expression  : () -> i32 {
+          %3 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
+          yield %3 : i32
+        }
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        %2 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %2 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.call_opaque "compute_kernel_hw_startup"(%2, %1) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "pack_untilize_init"(%2, %1) {template_args = [#emitc.opaque<"1">, #emitc.opaque<"1">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "experimental::pack_untilize_block"(%2, %1, %0, %0) {template_args = [#emitc.opaque<"1">, #emitc.opaque<"1">]} : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
+        emitc.call_opaque "pack_untilize_uninit"(%1) : (!emitc.opaque<"::tt::CB">) -> ()
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
         return
       }
     }

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -32,12 +32,6 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         // The TTKernelToEmitC pass inserts this as a LiteralOp, so the TTKernelToCpp pass won't hit this entry.
         {"get_compile_time_arg_val",                       {"api/compile_time_args.h", "api/compile_time_args.h"}},
 
-        // CB.
-        {"cb_pop_front",                                   {"api/compute/cb_api.h", "api/dataflow/dataflow_api.h"}},
-        {"cb_push_back",                                   {"api/compute/cb_api.h", "api/dataflow/dataflow_api.h"}},
-        {"cb_reserve_back",                                {"api/compute/cb_api.h", "api/dataflow/dataflow_api.h"}},
-        {"cb_wait_front",                                  {"api/compute/cb_api.h", "api/dataflow/dataflow_api.h"}},
-
         // NoC.
         // The "get_interleaved_addr_gen_fast" op materializes as "InterleavedAddrGenFast<true>".
         {"get_dataformat",                                 {"", "api/dataflow/dataflow_api.h"}},

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -28,7 +28,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <cctype>
 #include <string>
 
 using namespace mlir;
@@ -108,43 +107,38 @@ datatypeToDataformatEnumValueOpaqueAttr(Builder &builder,
   return builder.getType<emitc::OpaqueAttr>(expression.c_str());
 }
 
-static std::string sanitizeIdentifier(llvm::StringRef identifier) {
-  std::string sanitized;
-  sanitized.reserve(identifier.size());
-  for (char ch : identifier) {
-    sanitized.push_back(std::isalnum(static_cast<unsigned char>(ch)) ? ch
-                                                                     : '_');
-  }
-  if (sanitized.empty() ||
-      std::isdigit(static_cast<unsigned char>(sanitized.front()))) {
-    sanitized.insert(sanitized.begin(), '_');
-  }
-  return sanitized;
-}
-
-static std::string getValueIdentifier(Value value, llvm::StringRef prefix) {
-  std::string ssaName;
-  llvm::raw_string_ostream os(ssaName);
-  mlir::OpPrintingFlags flags;
-  value.printAsOperand(os, flags);
-  os.flush();
-
-  llvm::StringRef baseName = ssaName;
-  if (baseName.starts_with("%")) {
-    baseName = baseName.drop_front();
-  }
-
-  return (prefix + sanitizeIdentifier(baseName)).str();
-}
-
 static std::string getCBName(Value cb) {
-  if (auto *defOp = cb.getDefiningOp()) {
-    if (auto idxAttr =
-            defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_ctarg_index")) {
-      return "cb_ctarg_" + std::to_string(idxAttr.getInt());
-    }
+  Operation *defOp = cb.getDefiningOp();
+
+  if (auto idxAttr =
+          defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_ctarg_idx")) {
+    return "cb_ctarg_" + std::to_string(idxAttr.getInt());
   }
-  return getValueIdentifier(cb, "cb_ssa_");
+
+  auto idxAttr = defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_arg_idx");
+  assert(idxAttr && "CB value must have a stable lowering name");
+  return "cb_arg_" + std::to_string(idxAttr.getInt());
+}
+
+// Assign deterministic names to non-compile-time CB arguments before dialect
+// conversion. Runtime and common runtime arguments use their own common index
+// space, derived from the function-local source-order to be stable &
+// non-conflicting.
+static void assignRuntimeCBArgIndices(func::FuncOp funcOp) {
+  int32_t nextCBArgIndex = 0;
+  funcOp.walk([&](Operation *op) {
+    if (!isa<ttkernel::GetArgValOp, ttkernel::GetCommonArgValOp>(op)) {
+      return;
+    }
+
+    if (!isa<ttkernel::CBType>(op->getResult(0).getType())) {
+      return;
+    }
+
+    op->setAttr("ttkernel.cb_arg_idx",
+                IntegerAttr::get(IntegerType::get(op->getContext(), 32),
+                                 nextCBArgIndex++));
+  });
 }
 
 static bool isCBDeclaration(emitc::VerbatimOp verbatim,
@@ -705,17 +699,25 @@ public:
           (Twine("get_compile_time_arg_val(") + Twine(op.getArgIndex()) + ")")
               .str());
       if (mlir::isa<ttkernel::CBType>(op.getResult().getType())) {
-        literal->setAttr("ttkernel.cb_ctarg_index",
+        literal->setAttr("ttkernel.cb_ctarg_idx",
                          rewriter.getI32IntegerAttr(op.getArgIndex()));
       }
       return literal.getResult();
     }
 
-    return rewriter
-        .create<emitc::CallOpaqueOp>(op.getLoc(), resultType, getOpName(op),
-                                     nullptr, getTemplateArgs(rewriter, op),
-                                     adaptor.getOperands())
-        .getResult(0);
+    auto call = rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), resultType, getOpName(op), nullptr,
+        getTemplateArgs(rewriter, op), adaptor.getOperands());
+
+    // Relay the preassigned CB runtime arg index.
+    if (mlir::isa<ttkernel::CBType>(op.getResult().getType())) {
+      auto idxAttr =
+          op->template getAttrOfType<IntegerAttr>("ttkernel.cb_arg_idx");
+      assert(idxAttr && "CB runtime arg must have a stable lowering name");
+      call->setAttr("ttkernel.cb_arg_idx", idxAttr);
+    }
+
+    return call.getResult(0);
   }
 
   LogicalResult
@@ -1512,6 +1514,8 @@ public:
     if (!funcOp->hasAttr(ttkernel::ThreadTypeAttr::name)) {
       return success();
     }
+
+    assignRuntimeCBArgIndices(funcOp);
 
     ConversionTarget target(*funcOp.getContext());
     target.addLegalDialect<emitc::EmitCDialect>();

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -17,7 +17,6 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/PassManager.h"
@@ -108,16 +107,23 @@ datatypeToDataformatEnumValueOpaqueAttr(Builder &builder,
 }
 
 static std::string getCBName(Value cb) {
-  Operation *defOp = cb.getDefiningOp();
+  std::string prefix = "";
+  IntegerAttr cbIdxAttr = nullptr;
 
-  if (auto idxAttr =
-          defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_ctarg_idx")) {
-    return "cb_ctarg_" + std::to_string(idxAttr.getInt());
+  if (auto *defOp = cb.getDefiningOp()) {
+    if (auto attr =
+            defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_ctarg_idx")) {
+      prefix = "cb_ctarg_";
+      cbIdxAttr = attr;
+    } else if (auto attr =
+                   defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_arg_idx")) {
+      prefix = "cb_arg_";
+      cbIdxAttr = attr;
+    }
   }
 
-  auto idxAttr = defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_arg_idx");
-  assert(idxAttr && "CB value must have a stable lowering name");
-  return "cb_arg_" + std::to_string(idxAttr.getInt());
+  TT_assertv(cbIdxAttr, "CB value must have a stable lowering name");
+  return prefix + std::to_string(cbIdxAttr.getInt());
 }
 
 // Assign deterministic names to non-compile-time CB arguments before dialect
@@ -147,28 +153,38 @@ static bool isCBDeclaration(emitc::VerbatimOp verbatim,
   return verbatim.getValue().starts_with(prefix);
 }
 
-// Check whether a CB declaration for `cbName` exists & dominates `useOp`, so we
-// can reuse it instead of emitting a duplicate. Dominance (rather than
-// block-local scanning) is needed because the declaration may live in an outer
-// block (e.g. entry block) while the use is inside a loop body.
+// Check whether a CB declaration for `cbName` exists & dominates `useOp`, to
+// avoid duplication.
+//
+// To handle declarations that live in outer enclosing blocks, walk upward
+// through the lexical parent chain and scan ops that appear before the current
+// use at each nesting level. Since the IR is all-SCF at this stage, this
+// strategy is equivalent but faster than full-funcOp level dominance analysis.
 static bool hasDominatingCBDeclaration(Operation *useOp,
                                        llvm::StringRef cbName) {
-  auto funcOp = useOp->getParentOfType<func::FuncOp>();
-  if (!funcOp) {
-    return false;
+  Operation *currentOp = useOp;
+  Block *currentBlock = currentOp->getBlock();
+
+  while (currentBlock) {
+    for (Operation &op : *currentBlock) {
+      if (&op == currentOp) {
+        break;
+      }
+      if (auto verbatimOp = mlir::dyn_cast<emitc::VerbatimOp>(op);
+          verbatimOp && isCBDeclaration(verbatimOp, cbName)) {
+        return true;
+      }
+    }
+
+    if (Operation *parentOp = currentBlock->getParentOp()) {
+      currentOp = parentOp;
+      currentBlock = parentOp->getBlock();
+    } else {
+      break;
+    }
   }
 
-  DominanceInfo domInfo(funcOp);
-  bool found = false;
-  funcOp.walk([&](emitc::VerbatimOp verbatim) {
-    if (isCBDeclaration(verbatim, cbName) &&
-        domInfo.dominates(verbatim.getOperation(), useOp)) {
-      found = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return found;
+  return false;
 }
 
 // Lazily emit a CB declaration only when a CB method is actually invoked

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -767,18 +767,11 @@ public:
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto operands = adaptor.getOperands();
-    assert(!operands.empty());
+    TT_assert(operands.size() == 2u);
 
     std::string callStr =
         ensureCBDeclaration(operands.front(), op.getOperation(), rewriter) +
-        "." + methodName + "(";
-    for (size_t i = 1; i < operands.size(); ++i) {
-      if (i > 1) {
-        callStr += ", ";
-      }
-      callStr += "{}";
-    }
-    callStr += ");";
+        "." + methodName + "({});";
 
     rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr,
                                        operands.drop_front());
@@ -1558,7 +1551,6 @@ public:
     populateMemRefToEmitCTypeConversion(typeConverter);
     populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
 
-    // clang-format off
     patterns.add<
         TTKernelBitcastOpRewriter,
         TTKernelToEmitCArgValRewriter<ttkernel::GetCompileArgValOp>,
@@ -1576,7 +1568,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreIncOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SemaphoreWaitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreIncMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::UnpackStallOnPackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsAcquireOp>,
@@ -1598,7 +1591,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalUntilizeBlockOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::PackUntilizeInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::PackUntilizeUninitOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalPackUntilizeBlockOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::ExperimentalPackUntilizeBlockOp>,
 
         // Datamovement
         TTKernelToEmitCOpaqueRewriter<ttkernel::CopyTileInitOp>,
@@ -1791,24 +1785,31 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadTileOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketSetStateOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketWithStateOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketWithStateWithTridOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncReadOnePacketSetStateOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncReadOnePacketWithStateOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncReadOnePacketWithStateWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadSetTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteSetTridOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOnePacketWithTridOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncWriteOnePacketWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ResetNocTridBarrierCounterOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocMulticastAddrOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalGetNocMulticastAddrOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastOnePacketOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::ExperimentalGetNocMulticastAddrOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncWriteMulticastOnePacketOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalXToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalYToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetMyDeviceIdOp>,
@@ -1816,40 +1817,62 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricMulticastWriteOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricSemIncOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricMulticastSemIncOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::CreateFabricConnectionManagerOp>,
+        TTKernelToEmitCOpaqueRewriter<
+            ttkernel::CreateFabricConnectionManagerOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SetupFabricConnectionsOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::CloseFabricConnectionsOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetTileSizeOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrFromBankIDOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetDataFormatOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TensorAccessorOp>>(
-                typeConverter, funcOp.getContext());
+        typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPushBackOp>>(typeConverter, funcOp.getContext(), "push_back");
-    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPopFrontOp>>(typeConverter, funcOp.getContext(), "pop_front");
-    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBReserveBackOp>>(typeConverter, funcOp.getContext(), "reserve_back");
-    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBWaitFrontOp>>(typeConverter, funcOp.getContext(), "wait_front");
-    patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetWritePtrOp>>(typeConverter, funcOp.getContext(), "get_write_ptr");
-    patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetReadPtrOp>>(typeConverter, funcOp.getContext(), "get_read_ptr");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPushBackOp>>(
+        typeConverter, funcOp.getContext(), "push_back");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPopFrontOp>>(
+        typeConverter, funcOp.getContext(), "pop_front");
+    patterns
+        .add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBReserveBackOp>>(
+            typeConverter, funcOp.getContext(), "reserve_back");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBWaitFrontOp>>(
+        typeConverter, funcOp.getContext(), "wait_front");
+    patterns
+        .add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetWritePtrOp>>(
+            typeConverter, funcOp.getContext(), "get_write_ptr");
+    patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetReadPtrOp>>(
+        typeConverter, funcOp.getContext(), "get_read_ptr");
 
-    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(typeConverter, funcOp.getContext(), "get_noc_addr");
-    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncAtomicBarrierOp>>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
+        typeConverter, funcOp.getContext(), "get_noc_addr");
+    patterns
+        .add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncAtomicBarrierOp>>(
+            typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter,
+                                               funcOp.getContext());
 
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyXOp>>(typeConverter, funcOp.getContext(), "my_x[noc_index]");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyYOp>>(typeConverter, funcOp.getContext(), "my_y[noc_index]");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalXOp>>(typeConverter, funcOp.getContext(), "get_absolute_logical_x()");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalYOp>>(typeConverter, funcOp.getContext(), "get_absolute_logical_y()");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyXOp>>(
+        typeConverter, funcOp.getContext(), "my_x[noc_index]");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyYOp>>(
+        typeConverter, funcOp.getContext(), "my_y[noc_index]");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalXOp>>(
+        typeConverter, funcOp.getContext(), "get_absolute_logical_x()");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalYOp>>(
+        typeConverter, funcOp.getContext(), "get_absolute_logical_y()");
 
-    patterns.add<TTKernelStoreToL1OpToEmitCOpRewriter>(typeConverter, funcOp.getContext());
-    patterns.add<TTKernelLoadFromL1OpToEmitCOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelStoreToL1OpToEmitCOpRewriter>(typeConverter,
+                                                       funcOp.getContext());
+    patterns.add<TTKernelLoadFromL1OpToEmitCOpRewriter>(typeConverter,
+                                                        funcOp.getContext());
 
-    patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(
+        typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter,
+                                                       funcOp.getContext());
 
-    patterns.add<TTKernelCreateFabricConnectionManagerOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelCreateFabricConnectionManagerOpRewriter>(
+        typeConverter, funcOp.getContext());
 
     patterns.add<
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorGetNocAddrOp>,
@@ -1859,14 +1882,13 @@ public:
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalAddrOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalPageOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalShardOp>,
-        TTKernelClassMethodRewriter<ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(
-                typeConverter, funcOp.getContext());
+        TTKernelClassMethodRewriter<
+            ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
+                                                           funcOp.getContext());
 
-    patterns.add<ArithFloorDivRewriter,
-                 ArithBitcastRewriter,
-                 ArithMaxUIRewriter,
-                 ArithMinUIRewriter>(typeConverter, funcOp.getContext());
-    // clang-format on
+    patterns.add<ArithFloorDivRewriter, ArithBitcastRewriter,
+                 ArithMaxUIRewriter, ArithMinUIRewriter>(typeConverter,
+                                                         funcOp.getContext());
 
     return applyFullConversion(funcOp, target, std::move(patterns));
   }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/PassManager.h"
@@ -27,6 +28,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cctype>
 #include <string>
 
 using namespace mlir;
@@ -104,6 +106,99 @@ datatypeToDataformatEnumValueOpaqueAttr(Builder &builder,
   expression += datatypeToDataformatStr(dtype);
   expression += ")";
   return builder.getType<emitc::OpaqueAttr>(expression.c_str());
+}
+
+static std::string sanitizeIdentifier(llvm::StringRef identifier) {
+  std::string sanitized;
+  sanitized.reserve(identifier.size());
+  for (char ch : identifier) {
+    sanitized.push_back(std::isalnum(static_cast<unsigned char>(ch)) ? ch
+                                                                     : '_');
+  }
+  if (sanitized.empty() ||
+      std::isdigit(static_cast<unsigned char>(sanitized.front()))) {
+    sanitized.insert(sanitized.begin(), '_');
+  }
+  return sanitized;
+}
+
+static std::string getValueIdentifier(Value value, llvm::StringRef prefix) {
+  std::string ssaName;
+  llvm::raw_string_ostream os(ssaName);
+  mlir::OpPrintingFlags flags;
+  value.printAsOperand(os, flags);
+  os.flush();
+
+  llvm::StringRef baseName = ssaName;
+  if (baseName.starts_with("%")) {
+    baseName = baseName.drop_front();
+  }
+
+  return (prefix + sanitizeIdentifier(baseName)).str();
+}
+
+static std::string getCBName(Value cb) {
+  if (auto *defOp = cb.getDefiningOp()) {
+    if (auto idxAttr =
+            defOp->getAttrOfType<IntegerAttr>("ttkernel.cb_ctarg_index")) {
+      return "cb_ctarg_" + std::to_string(idxAttr.getInt());
+    }
+  }
+  return getValueIdentifier(cb, "cb_ssa_");
+}
+
+static bool isCBDeclaration(emitc::VerbatimOp verbatim,
+                            llvm::StringRef cbName) {
+  std::string prefix = "experimental::CircularBuffer " + cbName.str() + "(";
+  return verbatim.getValue().starts_with(prefix);
+}
+
+// Check whether a CB declaration for `cbName` exists & dominates `useOp`, so we
+// can reuse it instead of emitting a duplicate. Dominance (rather than
+// block-local scanning) is needed because the declaration may live in an outer
+// block (e.g. entry block) while the use is inside a loop body.
+static bool hasDominatingCBDeclaration(Operation *useOp,
+                                       llvm::StringRef cbName) {
+  auto funcOp = useOp->getParentOfType<func::FuncOp>();
+  if (!funcOp) {
+    return false;
+  }
+
+  DominanceInfo domInfo(funcOp);
+  bool found = false;
+  funcOp.walk([&](emitc::VerbatimOp verbatim) {
+    if (isCBDeclaration(verbatim, cbName) &&
+        domInfo.dominates(verbatim.getOperation(), useOp)) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+// Lazily emit a CB declaration only when a CB method is actually invoked
+// (compute API only uses CB IDs).
+static std::string ensureCBDeclaration(Value cb, Operation *useOp,
+                                       ConversionPatternRewriter &rewriter) {
+  std::string cbName = getCBName(cb);
+  if (hasDominatingCBDeclaration(useOp, cbName)) {
+    return cbName;
+  }
+
+  // Place the declaration right after the value's definition so it dominates
+  // every use site, including those in nested regions (e.g. loop bodies). For
+  // block arguments (no defining op), use the block start.
+  OpBuilder::InsertionGuard guard(rewriter);
+  if (Operation *defOp = cb.getDefiningOp()) {
+    rewriter.setInsertionPointAfter(defOp);
+  } else {
+    rewriter.setInsertionPointToStart(cb.getParentBlock());
+  }
+
+  std::string cbDecl = "experimental::CircularBuffer " + cbName + "({});";
+  rewriter.create<emitc::VerbatimOp>(useOp->getLoc(), cbDecl, ValueRange{cb});
+  return cbName;
 }
 
 // Type converter used for TTKernel/TTMetal conversions:
@@ -369,14 +464,6 @@ public:
       template_args.push_back(emitc::OpaqueAttr::get(
           op.getContext(), getBroadcastType(op.getBcastType())));
       return ArrayAttr::get(op.getContext(), template_args);
-    } else if constexpr (std::is_same_v<SourceOp, ttkernel::GetArgValOp> ||
-                         std::is_same_v<SourceOp,
-                                        ttkernel::GetCommonArgValOp>) {
-      SmallVector<Attribute, 1> template_args;
-
-      template_args.push_back(
-          emitc::OpaqueAttr::get(op.getContext(), "uint32_t"));
-      return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp,
                                         ttkernel::GetNocAddrFromBankIDOp>) {
       SmallVector<Attribute, 1> template_args;
@@ -585,20 +672,136 @@ public:
 } // namespace
 
 namespace {
-class TTKernelToEmitCGetCompileArgValRewriter
-    : public OpConversionPattern<ttkernel::GetCompileArgValOp> {
+template <typename SourceOp>
+class TTKernelToEmitCArgValRewriter : public OpConversionPattern<SourceOp> {
 public:
-  using OpConversionPattern<ttkernel::GetCompileArgValOp>::OpConversionPattern;
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  StringRef getOpName(SourceOp op) const {
+    auto name = op.getOperation()->getName().getStringRef();
+    if (name.starts_with("ttkernel.")) {
+      return name.drop_front(9);
+    }
+    return name;
+  }
+
+  ArrayAttr getTemplateArgs(Builder &builder, SourceOp op) const {
+    if constexpr (std::is_same_v<SourceOp, ttkernel::GetArgValOp> ||
+                  std::is_same_v<SourceOp, ttkernel::GetCommonArgValOp>) {
+      SmallVector<Attribute, 1> templateArgs;
+      templateArgs.push_back(
+          emitc::OpaqueAttr::get(builder.getContext(), "uint32_t"));
+      return ArrayAttr::get(op.getContext(), templateArgs);
+    }
+    return ArrayAttr();
+  }
+
+  Value createRawValue(SourceOp op, typename SourceOp::Adaptor adaptor,
+                       Type resultType,
+                       ConversionPatternRewriter &rewriter) const {
+    if constexpr (std::is_same_v<SourceOp, ttkernel::GetCompileArgValOp>) {
+      auto literal = rewriter.create<emitc::LiteralOp>(
+          op.getLoc(), resultType,
+          (Twine("get_compile_time_arg_val(") + Twine(op.getArgIndex()) + ")")
+              .str());
+      if (mlir::isa<ttkernel::CBType>(op.getResult().getType())) {
+        literal->setAttr("ttkernel.cb_ctarg_index",
+                         rewriter.getI32IntegerAttr(op.getArgIndex()));
+      }
+      return literal.getResult();
+    }
+
+    return rewriter
+        .create<emitc::CallOpaqueOp>(op.getLoc(), resultType, getOpName(op),
+                                     nullptr, getTemplateArgs(rewriter, op),
+                                     adaptor.getOperands())
+        .getResult(0);
+  }
 
   LogicalResult
-  matchAndRewrite(ttkernel::GetCompileArgValOp op, OpAdaptor adaptor,
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<emitc::LiteralOp>(
-        op, getTypeConverter()->convertType(op.getResult().getType()),
-        (Twine("get_compile_time_arg_val(") + Twine(op.getArgIndex()) + ")")
-            .str());
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "Failed to convert result type");
+    }
+
+    Value rawValue = createRawValue(op, adaptor, resultType, rewriter);
+    rewriter.replaceOp(op, rawValue);
     return success();
   }
+};
+} // namespace
+
+namespace {
+template <typename SourceOp>
+class TTKernelToEmitCCBVoidMethodRewriter
+    : public OpConversionPattern<SourceOp> {
+public:
+  TTKernelToEmitCCBVoidMethodRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx,
+      std::string methodName)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx),
+        methodName(std::move(methodName)) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto operands = adaptor.getOperands();
+    assert(!operands.empty());
+
+    std::string callStr =
+        ensureCBDeclaration(operands.front(), op.getOperation(), rewriter) +
+        "." + methodName + "(";
+    for (size_t i = 1; i < operands.size(); ++i) {
+      if (i > 1) {
+        callStr += ", ";
+      }
+      callStr += "{}";
+    }
+    callStr += ");";
+
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(), callStr,
+                                       operands.drop_front());
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  std::string methodName;
+};
+} // namespace
+
+namespace {
+template <typename SourceOp>
+class TTKernelToEmitCCBResultMethodRewriter
+    : public OpConversionPattern<SourceOp> {
+public:
+  TTKernelToEmitCCBResultMethodRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx,
+      std::string methodName)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx),
+        methodName(std::move(methodName)) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "Failed to convert result type");
+    }
+
+    std::string cbName =
+        ensureCBDeclaration(adaptor.getCb(), op.getOperation(), rewriter);
+    rewriter.replaceOpWithNewOp<emitc::LiteralOp>(
+        op, resultType, cbName + "." + methodName + "()");
+    return success();
+  }
+
+private:
+  std::string methodName;
 };
 } // namespace
 
@@ -1335,15 +1538,17 @@ public:
     populateMemRefToEmitCTypeConversion(typeConverter);
     populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
 
+    // clang-format off
     patterns.add<
-        TTKernelBitcastOpRewriter, TTKernelToEmitCGetCompileArgValRewriter,
+        TTKernelBitcastOpRewriter,
+        TTKernelToEmitCArgValRewriter<ttkernel::GetCompileArgValOp>,
+        TTKernelToEmitCArgValRewriter<ttkernel::GetArgValOp>,
+        TTKernelToEmitCArgValRewriter<ttkernel::GetCommonArgValOp>,
         TTKernelToEmitCDPrintRewriter,
         TTKernelToEmitCGetDeviceIdFromLogicalMeshPositionOpRewriter,
         TTKernelToEmitCGetMyLogicalMeshPositionOpRewriter,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosBaseOp>,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosSizeOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::GetArgValOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::GetCommonArgValOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::CastToL1PtrOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetSemaphoreOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetOp>,
@@ -1351,18 +1556,13 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreIncOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SemaphoreWaitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreIncMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::UnpackStallOnPackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsAcquireOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsCommitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsWaitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsReleaseOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::CBPushBackOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::CBPopFrontOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::CBReserveBackOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::CBWaitFrontOp>,
 
         // Compute kernel hardware startup
         TTKernelToEmitCOpaqueRewriter<ttkernel::ComputeKernelHWStartupOp>,
@@ -1378,8 +1578,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalUntilizeBlockOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::PackUntilizeInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::PackUntilizeUninitOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::ExperimentalPackUntilizeBlockOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalPackUntilizeBlockOp>,
 
         // Datamovement
         TTKernelToEmitCOpaqueRewriter<ttkernel::CopyTileInitOp>,
@@ -1572,31 +1771,24 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadTileOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketSetStateOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketWithStateOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncReadOnePacketWithStateWithTridOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketSetStateOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketWithStateOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOnePacketWithStateWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadSetTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteTileOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteSetTridOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncWriteOnePacketWithTridOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOnePacketWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierWithTridOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ResetNocTridBarrierCounterOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocMulticastAddrOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::ExperimentalGetNocMulticastAddrOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncWriteMulticastOnePacketOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::ExperimentalGetNocMulticastAddrOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastOnePacketOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastLoopbackSrcOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalXToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::ConvertLogicalYToTranslatedOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetMyDeviceIdOp>,
@@ -1604,50 +1796,40 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricMulticastWriteOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricSemIncOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::FabricMulticastSemIncOp>,
-        TTKernelToEmitCOpaqueRewriter<
-            ttkernel::CreateFabricConnectionManagerOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::CreateFabricConnectionManagerOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SetupFabricConnectionsOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::CloseFabricConnectionsOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::GetReadPtrOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetTileSizeOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrFromBankIDOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetDataFormatOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TensorAccessorOp>>(
-        typeConverter, funcOp.getContext());
+                typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
-        typeConverter, funcOp.getContext(), "get_noc_addr");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPushBackOp>>(typeConverter, funcOp.getContext(), "push_back");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBPopFrontOp>>(typeConverter, funcOp.getContext(), "pop_front");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBReserveBackOp>>(typeConverter, funcOp.getContext(), "reserve_back");
+    patterns.add<TTKernelToEmitCCBVoidMethodRewriter<ttkernel::CBWaitFrontOp>>(typeConverter, funcOp.getContext(), "wait_front");
+    patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetWritePtrOp>>(typeConverter, funcOp.getContext(), "get_write_ptr");
+    patterns.add<TTKernelToEmitCCBResultMethodRewriter<ttkernel::GetReadPtrOp>>(typeConverter, funcOp.getContext(), "get_read_ptr");
 
-    patterns
-        .add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncAtomicBarrierOp>>(
-            typeConverter, funcOp.getContext());
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(typeConverter, funcOp.getContext(), "get_noc_addr");
+    patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncAtomicBarrierOp>>(typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter,
-                                               funcOp.getContext());
+    patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyXOp>>(
-        typeConverter, funcOp.getContext(), "my_x[noc_index]");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyYOp>>(
-        typeConverter, funcOp.getContext(), "my_y[noc_index]");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalXOp>>(
-        typeConverter, funcOp.getContext(), "get_absolute_logical_x()");
-    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalYOp>>(
-        typeConverter, funcOp.getContext(), "get_absolute_logical_y()");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyXOp>>(typeConverter, funcOp.getContext(), "my_x[noc_index]");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyYOp>>(typeConverter, funcOp.getContext(), "my_y[noc_index]");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalXOp>>(typeConverter, funcOp.getContext(), "get_absolute_logical_x()");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyLogicalYOp>>(typeConverter, funcOp.getContext(), "get_absolute_logical_y()");
 
-    patterns.add<TTKernelStoreToL1OpToEmitCOpRewriter>(typeConverter,
-                                                       funcOp.getContext());
-    patterns.add<TTKernelLoadFromL1OpToEmitCOpRewriter>(typeConverter,
-                                                        funcOp.getContext());
+    patterns.add<TTKernelStoreToL1OpToEmitCOpRewriter>(typeConverter, funcOp.getContext());
+    patterns.add<TTKernelLoadFromL1OpToEmitCOpRewriter>(typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(
-        typeConverter, funcOp.getContext());
+    patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter,
-                                                       funcOp.getContext());
+    patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelCreateFabricConnectionManagerOpRewriter>(
-        typeConverter, funcOp.getContext());
+    patterns.add<TTKernelCreateFabricConnectionManagerOpRewriter>(typeConverter, funcOp.getContext());
 
     patterns.add<
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorGetNocAddrOp>,
@@ -1657,13 +1839,14 @@ public:
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalAddrOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalPageOp>,
         TTKernelClassMethodRewriter<ttkernel::TensorAccessorIsLocalShardOp>,
-        TTKernelClassMethodRewriter<
-            ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
-                                                           funcOp.getContext());
+        TTKernelClassMethodRewriter<ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(
+                typeConverter, funcOp.getContext());
 
-    patterns.add<ArithFloorDivRewriter, ArithBitcastRewriter,
-                 ArithMaxUIRewriter, ArithMinUIRewriter>(typeConverter,
-                                                         funcOp.getContext());
+    patterns.add<ArithFloorDivRewriter,
+                 ArithBitcastRewriter,
+                 ArithMaxUIRewriter,
+                 ArithMinUIRewriter>(typeConverter, funcOp.getContext());
+    // clang-format on
 
     return applyFullConversion(funcOp, target, std::move(patterns));
   }

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -176,6 +176,10 @@ public:
     region->walk([&](emitc::VerbatimOp verbatimOp) {
       llvm::StringRef value = verbatimOp.getValue();
 
+      if (value.starts_with("experimental::CircularBuffer")) {
+        headers.insert("experimental/circular_buffer.h");
+      }
+
       // Some callees are embedded in VerbatimOps.
       for (const auto &[callee, reqs] : headerMap) {
         if (value.starts_with(callee)) {

--- a/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast.mlir
@@ -77,9 +77,11 @@ module attributes {} {
 
     // Get CB write pointers
     %cb0 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-    %src_ptr = emitc.call_opaque "get_write_ptr"(%cb0) : (!emitc.opaque<"::tt::CB">) -> i32
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %cb0 : !emitc.opaque<"::tt::CB">
+    %src_ptr = emitc.literal "cb_ctarg_0.get_write_ptr()" : i32
     %cb1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-    %dst_ptr = emitc.call_opaque "get_write_ptr"(%cb1) : (!emitc.opaque<"::tt::CB">) -> i32
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %cb1 : !emitc.opaque<"::tt::CB">
+    %dst_ptr = emitc.literal "cb_ctarg_1.get_write_ptr()" : i32
 
     // Get NOC address
     %noc_addr = emitc.call_opaque "get_noc_addr"(%translated_x, %translated_y, %dst_ptr) : (!emitc.size_t, !emitc.size_t, i32) -> i64

--- a/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_generic_op_unicast_sem_inc.mlir
@@ -80,9 +80,11 @@ module attributes {} {
 
     // Get CB write pointers
     %cb0 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-    %src_ptr = emitc.call_opaque "get_write_ptr"(%cb0) : (!emitc.opaque<"::tt::CB">) -> i32
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %cb0 : !emitc.opaque<"::tt::CB">
+    %src_ptr = emitc.literal "cb_ctarg_0.get_write_ptr()" : i32
     %cb1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-    %dst_ptr = emitc.call_opaque "get_write_ptr"(%cb1) : (!emitc.opaque<"::tt::CB">) -> i32
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %cb1 : !emitc.opaque<"::tt::CB">
+    %dst_ptr = emitc.literal "cb_ctarg_1.get_write_ptr()" : i32
 
     // Get noc address
     %global_semaphore_arg_idx = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -22,6 +22,7 @@ module {
     %icb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
     // CHECK: %[[OCB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
     %ocb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb2_tiles
+    // CHECK-NOT: experimental::CircularBuffer
     // CHECK: emitc.call_opaque "compute_kernel_hw_startup"(%[[INCB]], %[[OCB]])
     "ttkernel.compute_kernel_hw_startup"(%icb, %ocb) : (!cb0_tiles, !cb2_tiles) -> ()
     return
@@ -35,6 +36,7 @@ module {
     %icb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
     // CHECK: %[[OCB:.*]] = emitc.literal "get_compile_time_arg_val(2)"
     %ocb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
+    // CHECK-NOT: experimental::CircularBuffer
     // CHECK: emitc.call_opaque "compute_kernel_hw_startup"(%[[INCB0]], %[[INCB1]], %[[OCB]])
     "ttkernel.compute_kernel_hw_startup"(%icb0, %icb1, %ocb) : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
     return
@@ -1517,10 +1519,11 @@ module {
     // CHECK-LABEL: func @cb_push_back
     func.func @cb_push_back() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[PUSH_CB:cb_ctarg_0]]({});"
       %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "cb_push_back"(%[[CB]], %[[NUM_PAGES]])
+      // CHECK: emitc.verbatim "[[PUSH_CB]].push_back({});"
       "ttkernel.cb_push_back"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
       return
     }
@@ -1528,10 +1531,11 @@ module {
     // CHECK-LABEL: func @cb_pop_front
     func.func @cb_pop_front() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[POP_CB:cb_ctarg_0]]({});"
       %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "cb_pop_front"(%[[CB]], %[[NUM_PAGES]])
+      // CHECK: emitc.verbatim "[[POP_CB]].pop_front({});"
       "ttkernel.cb_pop_front"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
       return
     }
@@ -1539,10 +1543,11 @@ module {
     // CHECK-LABEL: func @cb_reserve_back
     func.func @cb_reserve_back() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[RESERVE_CB:cb_ctarg_0]]({});"
       %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "cb_reserve_back"(%[[CB]], %[[NUM_PAGES]])
+      // CHECK: emitc.verbatim "[[RESERVE_CB]].reserve_back({});"
       "ttkernel.cb_reserve_back"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
       return
     }
@@ -1550,11 +1555,76 @@ module {
     // CHECK-LABEL: func @cb_wait_front
     func.func @cb_wait_front() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[WAIT_CB:cb_ctarg_0]]({});"
       %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
-      // CHECK: emitc.call_opaque "cb_wait_front"(%[[CB]], %[[NUM_PAGES]])
+      // CHECK: emitc.verbatim "[[WAIT_CB]].wait_front({});"
       "ttkernel.cb_wait_front"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @get_write_ptr
+    func.func @get_write_ptr() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[WRITE_CB:cb_ctarg_0]]({});"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[PTR:.*]] = emitc.literal "[[WRITE_CB]].get_write_ptr()"
+      %ptr = "ttkernel.get_write_ptr"(%cb) : (!cb0_tiles) -> i32
+      return
+    }
+
+    // CHECK-LABEL: func @get_read_ptr
+    func.func @get_read_ptr() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[READ_CB:cb_ctarg_0]]({});"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[PTR:.*]] = emitc.literal "[[READ_CB]].get_read_ptr()"
+      %ptr = "ttkernel.get_read_ptr"(%cb) : (!cb0_tiles) -> i32
+      return
+    }
+
+    // CHECK-LABEL: func @cb_object_dedup
+    func.func @cb_object_dedup() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[DEDUP_CB:cb_ctarg_0]]({});"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %num_pages = arith.constant 1 : i32
+      // CHECK: emitc.verbatim "[[DEDUP_CB]].reserve_back({});"
+      "ttkernel.cb_reserve_back"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
+      // CHECK-NOT: emitc.verbatim "experimental::CircularBuffer
+      // CHECK: emitc.verbatim "[[DEDUP_CB]].push_back({});"
+      "ttkernel.cb_push_back"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @cb_object_dedup_same_port
+    func.func @cb_object_dedup_same_port() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.verbatim "experimental::CircularBuffer [[DEDUP_PORT_CB:cb_ctarg_0]]({});"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %cb_again = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %num_pages = arith.constant 1 : i32
+      // CHECK: emitc.verbatim "[[DEDUP_PORT_CB]].reserve_back({});"
+      "ttkernel.cb_reserve_back"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
+      // CHECK-NOT: emitc.verbatim "experimental::CircularBuffer
+      // CHECK: emitc.verbatim "[[DEDUP_PORT_CB]].push_back({});"
+      "ttkernel.cb_push_back"(%cb_again, %num_pages) : (!cb0_tiles, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @cb_object_cross_block
+    func.func @cb_object_cross_block() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK-NEXT: emitc.verbatim "experimental::CircularBuffer [[LOOP_CB:cb_ctarg_0]]({});"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      %lb = arith.constant 0 : index
+      %ub = arith.constant 2 : index
+      %step = arith.constant 1 : index
+      %num_pages = arith.constant 1 : i32
+      // CHECK: emitc.for
+      scf.for %i = %lb to %ub step %step {
+        // CHECK: verbatim "[[LOOP_CB]].wait_front({});"
+        "ttkernel.cb_wait_front"(%cb, %num_pages) : (!cb0_tiles, i32) -> ()
+      }
       return
     }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1584,6 +1584,28 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @cb_runtime_arg_names
+    func.func @cb_runtime_arg_names() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %idx = arith.constant 0 : index
+      %num_pages = arith.constant 1 : i32
+      // CHECK: %[[CTARG_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      // CHECK-NEXT: emitc.verbatim "experimental::CircularBuffer [[CB_CTARG0:cb_ctarg_0]]({});"
+      %cb_ctarg = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb2_tiles
+      // CHECK: %[[ARG_CB0:.*]] = emitc.call_opaque "get_arg_val"
+      // CHECK-NEXT: emitc.verbatim "experimental::CircularBuffer [[CB_ARG0:cb_arg_0]]({});"
+      %cb0 = "ttkernel.get_arg_val"(%idx) : (index) -> !cb0_tiles
+      // CHECK: %[[ARG_CB1:.*]] = emitc.call_opaque "get_common_arg_val"
+      // CHECK-NEXT: emitc.verbatim "experimental::CircularBuffer [[CB_ARG1:cb_arg_1]]({});"
+      %cb1 = "ttkernel.get_common_arg_val"(%idx) : (index) -> !cb1_tiles
+      // CHECK: emitc.verbatim "[[CB_CTARG0]].wait_front({});"
+      "ttkernel.cb_wait_front"(%cb_ctarg, %num_pages) : (!cb2_tiles, i32) -> ()
+      // CHECK: emitc.verbatim "[[CB_ARG0]].reserve_back({});"
+      "ttkernel.cb_reserve_back"(%cb0, %num_pages) : (!cb0_tiles, i32) -> ()
+      // CHECK: emitc.verbatim "[[CB_ARG1]].push_back({});"
+      "ttkernel.cb_push_back"(%cb1, %num_pages) : (!cb1_tiles, i32) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @cb_object_dedup
     func.func @cb_object_dedup() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.verbatim "experimental::CircularBuffer [[DEDUP_CB:cb_ctarg_0]]({});"

--- a/test/ttmlir/Dialect/TTNN/nd_layout_encoding.mlir
+++ b/test/ttmlir/Dialect/TTNN/nd_layout_encoding.mlir
@@ -18,9 +18,10 @@ module {
             %2 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
             yield %2 : i32
         }
-        %1 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_reserve_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_push_back"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+        %1 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %1 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
         return
     }
     func.func private @datamovement_kernel1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
@@ -28,9 +29,10 @@ module {
             %2 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
             yield %2 : i32
         }
-        %1 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
-        emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "cb_pop_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+        %1 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %1 : !emitc.opaque<"::tt::CB">
+        emitc.verbatim "cb_ctarg_1.wait_front({});" args %0 : i32
+        emitc.verbatim "cb_ctarg_1.pop_front({});" args %0 : i32
         return
     }
     func.func private @compute_kernel2() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {

--- a/test/ttmlir/Silicon/TTNN/n150/generic_op/generic_op.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/generic_op/generic_op.mlir
@@ -117,29 +117,32 @@ module {
 
     %zero = "emitc.constant"() <{value = 0 : i32}> : () -> i32
     %2 = emitc.call_opaque "get_common_arg_val"(%zero) {template_args = [#emitc.opaque<"uint32_t">]} : (i32) -> i32
-    %3 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
+    %3 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %3 : !emitc.opaque<"::tt::CB">
     %4 = emitc.literal "my_x[noc_index]" : !emitc.size_t
     %5 = emitc.literal "my_y[noc_index]" : !emitc.size_t
 
     // Move single tile from address in L1 to CB
-    emitc.call_opaque "cb_reserve_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_0.reserve_back({});" args %0 : i32
     %6 = emitc.call_opaque "get_write_ptr"(%3) : (!emitc.opaque<"::tt::CB">) -> i32
     %7 = emitc.call_opaque "get_noc_addr"(%4, %5, %2) : (!emitc.size_t, !emitc.size_t, i32) -> i64
     emitc.call_opaque "noc_async_read"(%7, %6, %1) : (i64, i32, i32) -> ()
     emitc.call_opaque "noc_async_read_barrier"() : () -> ()
-    emitc.call_opaque "cb_push_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_0.push_back({});" args %0 : i32
     return
   }
   func.func private @compute_kernel() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     %0 = "emitc.constant"() <{value = 1 : i32}> : () -> i32
     %1 = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
 
-    %2 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
-    %3 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
+    %2 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %2 : !emitc.opaque<"::tt::CB">
+    %3 = emitc.literal "get_compile_time_arg_val(1)" {ttkernel.cb_ctarg_idx = 1 : i32} : !emitc.opaque<"::tt::CB">
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_1({});" args %3 : !emitc.opaque<"::tt::CB">
 
     // Move single tile from CB to register
-    emitc.call_opaque "cb_reserve_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-    emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_1.reserve_back({});" args %0 : i32
+    emitc.verbatim "cb_ctarg_0.wait_front({});" args %0 : i32
     emitc.call_opaque "init_sfpu"(%2, %3) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
     emitc.call_opaque "tile_regs_acquire"() : () -> ()
     emitc.call_opaque "copy_tile_init"(%2) : (!emitc.opaque<"::tt::CB">) -> ()
@@ -154,8 +157,8 @@ module {
     emitc.call_opaque "tile_regs_wait"() : () -> ()
     emitc.call_opaque "pack_tile"(%1, %3, %1) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
     emitc.call_opaque "tile_regs_release"() : () -> ()
-    emitc.call_opaque "cb_push_back"(%3, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-    emitc.call_opaque "cb_pop_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_1.push_back({});" args %0 : i32
+    emitc.verbatim "cb_ctarg_0.pop_front({});" args %0 : i32
     return
   }
   // Test named arguments by passing page size as a constant
@@ -165,17 +168,18 @@ module {
 
     %zero = "emitc.constant"() <{value = 0 : i32}> : () -> i32
     %2 = emitc.call_opaque "get_arg_val"(%zero) {template_args = [#emitc.opaque<"uint32_t">]} : (i32) -> i32
-    %3 = emitc.literal "get_compile_time_arg_val(0)" : !emitc.opaque<"::tt::CB">
+    %3 = emitc.literal "get_compile_time_arg_val(0)" {ttkernel.cb_ctarg_idx = 0 : i32} : !emitc.opaque<"::tt::CB">
+    emitc.verbatim "experimental::CircularBuffer cb_ctarg_0({});" args %3 : !emitc.opaque<"::tt::CB">
     %4 = emitc.literal "my_x[noc_index]" : !emitc.size_t
     %5 = emitc.literal "my_y[noc_index]" : !emitc.size_t
 
     // Move single tile from CB to address in L1
-    emitc.call_opaque "cb_wait_front"(%3, %one) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_0.wait_front({});" args %one : i32
     %6 = emitc.call_opaque "get_read_ptr"(%3) : (!emitc.opaque<"::tt::CB">) -> i32
     %7 = emitc.call_opaque "get_noc_addr"(%4, %5, %2) : (!emitc.size_t, !emitc.size_t, i32) -> i64
     emitc.call_opaque "noc_async_write"(%6, %7, %1) : (i32, i64, i32) -> ()
     emitc.call_opaque "noc_async_write_barrier"() : () -> ()
-    emitc.call_opaque "cb_pop_front"(%3, %one) : (!emitc.opaque<"::tt::CB">, i32) -> ()
+    emitc.verbatim "cb_ctarg_0.pop_front({});" args %one : i32
     return
   }
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
@@ -4,25 +4,28 @@
 
 #l1_ = #ttcore.memory_space<l1>
 
+// CHECK: #include "experimental/circular_buffer.h"
 // CHECK: void kernel_main()
 func.func @ttkernel_compute() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     // CHECK: int32_t v1 = 4
     %c4_i32 = arith.constant 4 : i32
     %arg1 = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
     %arg2 = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8192, f32>
+    // CHECK: experimental::CircularBuffer [[CB0:cb_ctarg_0]](get_compile_time_arg_val(0));
+    // CHECK: experimental::CircularBuffer [[CB1:cb_ctarg_1]](get_compile_time_arg_val(1));
     // CHECK: untilize_init(get_compile_time_arg_val(0))
     ttkernel.untilize_init(%arg1) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>) -> ()
     // CHECK: untilize_block(get_compile_time_arg_val(0), v1, get_compile_time_arg_val(1))
     ttkernel.untilize_block(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32, !ttkernel.cb<8192, f32>) -> ()
-    // CHECK: cb_pop_front(get_compile_time_arg_val(0), v1)
+    // CHECK: [[CB0]].pop_front(v1)
     ttkernel.cb_pop_front(%arg1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
-    // CHECK: cb_push_back(get_compile_time_arg_val(1), v1)
+    // CHECK: [[CB1]].push_back(v1)
     ttkernel.cb_push_back(%arg2, %c4_i32) : (!ttkernel.cb<8192, f32>, i32) -> ()
     // CHECK: untilize_block(get_compile_time_arg_val(0), v1, get_compile_time_arg_val(1))
     ttkernel.untilize_block(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32, !ttkernel.cb<8192, f32>) -> ()
-    // CHECK: cb_pop_front(get_compile_time_arg_val(0), v1)
+    // CHECK: [[CB0]].pop_front(v1)
     ttkernel.cb_pop_front(%arg1, %c4_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
-    // CHECK: cb_push_back(get_compile_time_arg_val(1), v1)
+    // CHECK: [[CB1]].push_back(v1)
     ttkernel.cb_push_back(%arg2, %c4_i32) : (!ttkernel.cb<8192, f32>, i32) -> ()
     // CHECK: return
     func.return

--- a/test/ttmlir/Translate/TTKernel/ttkernel_compute_cb_ids_only.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_compute_cb_ids_only.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc -o %t %s
+// RUN: ttmlir-translate --ttkernel-to-cpp -o %t.cpp %t
+// RUN: FileCheck %s --input-file=%t.cpp
+
+// CHECK-NOT: #include "experimental/circular_buffer.h"
+// CHECK: void kernel_main()
+func.func @ttkernel_compute_cb_ids_only() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+  %icb = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+  %ocb = ttkernel.get_compile_time_arg_val(1) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+  // CHECK: compute_kernel_hw_startup(get_compile_time_arg_val(0), get_compile_time_arg_val(1))
+  "ttkernel.compute_kernel_hw_startup"(%icb, %ocb) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, !ttkernel.cb<8, !ttcore.tile<32x32, f32>>) -> ()
+  func.return
+}

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -3,6 +3,33 @@
 // RUN: FileCheck %s --input-file=%t.cpp
 
 // CHECK: #include "api/dataflow/dataflow_api.h"
+// CHECK: #include "experimental/circular_buffer.h"
+// CHECK: void kernel_main
+func.func @ttkernel_noc_cb() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+    // CHECK: int32_t [[C0:.*]] = 32
+    %c32_i32 = arith.constant 32 : i32
+    // CHECK: size_t [[A0:.*]] = 0
+    %c0_idx = arith.constant 0 : index
+    // CHECK: int32_t [[A1:.*]] = 262144;
+    %c262144_i32 = arith.constant 262144 : i32
+    %cb = ttkernel.get_compile_time_arg_val(0) : () -> !ttkernel.cb<8, !ttcore.tile<32x32, f32>>
+    // CHECK: experimental::CircularBuffer [[CB:cb_ctarg_0]](get_compile_time_arg_val(0));
+    %c1_i32 = arith.constant 1 : i32
+    // CHECK: [[CB]].reserve_back
+    "ttkernel.cb_reserve_back"(%cb, %c1_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
+    // CHECK: int64_t [[NOCADDR0:.*]] = get_noc_addr([[A0]], [[A0]], [[A1]])
+    %3 = ttkernel.get_noc_addr(%c0_idx, %c0_idx, %c262144_i32) : (index, index, i32) -> !ttkernel.noc_addr
+    // CHECK: noc_async_read([[NOCADDR0]], [[CB]].get_write_ptr(), [[C0]])
+    %wptr = "ttkernel.get_write_ptr"(%cb) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>) -> i32
+    ttkernel.noc_async_read(%3, %wptr, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
+    // CHECK: noc_async_read_barrier
+    ttkernel.noc_async_read_barrier() : () -> ()
+    // CHECK: [[CB]].push_back
+    "ttkernel.cb_push_back"(%cb, %c1_i32) : (!ttkernel.cb<8, !ttcore.tile<32x32, f32>>, i32) -> ()
+    // CHECK: return
+    func.return
+}
+
 // CHECK: void kernel_main
 func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     // CHECK: int32_t [[B0:.*]] = 262432


### PR DESCRIPTION
### Problem description
We need to migrate to the OO-style device API to prepare for Quasar bringup.

This PR migrates the D2M backend from the free-function CB API to the new OO-style CB API.

```cpp
#include "api/compute/cb_api.h" // Old compute core header.
#include "api/dataflow/dataflow_api.h" // Old data movement core header.

#include "experimental/circular_buffer.h" // New unified header.

// Explicit CB object creation.
constexpr int32_t cb_id = get_compile_time_arg_val(0);
experimental::CircularBuffer cb(cb_id);

// CB method call mappings.
cb_reserve_back(cb, n) -> cb.reserve_back(n)
cb_wait_front(cb, n) -> cb.wait_front(n)
cb_push_back(cb, n) -> cb.push_back(n)
cb_pop_front(cb, n) -> cb.pop_front(n)
get_write_ptr(cb) -> cb.get_write_ptr()
get_read_ptr(cb) -> cb.get_read_ptr()

// Compute API still uses numerical IDs.
add_tiles_init(cb_id, cb_id);
add_tiles(cb_id, cb_id, 0, 0, 0);
```

### What's changed
- The migration is implemented in the `TTKernelToEmitC` & `TTKernelToCpp` passes.
  - The `TTKernel` dialect still uses the old CB API names, since it still captures the right semantics.
- Naming the CB identifiers:
  - A consistent & precise name is needed since the same CB port can appear as multiple SSA values in the IR.
  - Ideally the name of the CB should be `cb_n` where n is the CB port/ID, so the kernel is easy to understand.
  - In most cases, the CB ID is passed as a kernel compile-time argument.
    - The CB port from the D2M dialect is discarded when `D2MToTTKernel` lowers `d2m.get_cb(port)` to `ttkernel.get_compile_time_arg_val(ctArgIndex)`.
    - The CB port actually used by the runtime is assigned in the `D2mToTTMetal` pass, sequentially.
    - Additionally, the spatial op can remap CBs and so we must be careful to not produce misleading names.
    - Name these CBs as `cb_ctarg_{arg_index}` so at least it matches its index in the kernel's compile-time arguments.
  - It's also possible to create CBs from (common) runtime arguments, for them we use `cb_arg_{i}` where `i` is assigned sequentially as we walk the `funcOp`.
- Lowering kernel arguments:
  - Replaced `TTKernelToEmitCGetCompileArgValRewriter` with a more general `TTKernelToEmitCArgValRewriter` that handles all three types of kernel args.
  - For CB args, it attaches an internal attribute to indicate the index of the argument, preparing for naming the CB objects later.
- Lowering to OO CB API calls:
  - Lazily create the `experimental::CircularBuffer cb_xxx_n(...)` declaration once per block.
    - The compute API only uses CB IDs so there's no need to create a CB object if there's no CB method invocation.
    - Perform dominance analysis so same-port repeated SSA values and loop/cross-block uses reuse a single dominating `experimental::CircularBuffer` declaration.
  - `TTKernelToEmitCCBVoidMethodRewriter` handles void-return API calls like `ttkernel.cb_push_back -> cb_obj.push_back(...)`.
    - Use the `emitc::VerbatimOp` because these are statement-like method calls and is the most direct way to preserve the exact OO spelling we want.
  - `TTKernelToEmitCCBResultMethodRewriter` handles API calls that return values like `ttkernel.get_write_ptr -> cb_obj.get_write_ptr()`.
    - These are emitted as `emitc::LiteralOp` because the result participates in later expressions and needs to behave like a value.
- The `ttkernle::CBType -> !emitc.opaque<"::tt::CB">` lowering is untouched for now to simplify things (DFB migration will require integer type).
- CB header inclusion now scans `emitc::VerbatimOp` values and includes the experimental header when it sees `experimental::CircularBuffer`.
  - The old `cb_api.h` is removed except from the experimental tilize/untilize kernels.
- Delete the `GetArgValOp/GetCommonArgValOp` branches from `TTKernelToEmitCOpaqueRewriter::getTemplateArgs`.
- Various lit test updates & additions.

### Checklist
- [x] New/Existing tests provide coverage for changes
