### PR TITLE
Move conv3d permutation to channel last to decomposition

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1410,10 +1410,11 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// Conv2d/ConvTranspose2d Channel Layout Decomposition
+// Conv2d/Conv3d/ConvTranspose2d Channel Layout Decomposition
 //===----------------------------------------------------------------------===//
-// These patterns add permutes to convert from non-NHWC layouts to NHWC format
-// when the dimension indices indicate a non-NHWC layout.
+// These patterns add permutes to convert from non-channel-last layouts to
+// channel-last format when the dimension indices indicate a non-channel-last
+// layout.
 
 namespace {
 template <typename ConvOpType>
@@ -1492,6 +1493,74 @@ struct ConvChannelLastDecompositionPattern
     // Permute output from NHWC back to original layout.
     auto outputPermute = rewriter.create<ttir::PermuteOp>(
         op.getLoc(), outputType, newConv.getResult(), fromNhwc);
+
+    rewriter.replaceOp(op, outputPermute.getResult());
+    return success();
+  }
+};
+
+struct Conv3dChannelLastDecompositionPattern
+    : public OpConversionPattern<ttir::Conv3dOp> {
+  using OpConversionPattern<ttir::Conv3dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv3dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Only process ops that are not already in NDHWC format.
+    if (op.isNDHWC()) {
+      return failure();
+    }
+
+    auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    int64_t batchDim = op.getBatchDim();
+    int64_t depthDim = op.getDepthDim();
+    int64_t heightDim = op.getHeightDim();
+    int64_t widthDim = op.getWidthDim();
+    int64_t channelDim = op.getChannelDim();
+
+    llvm::SmallVector<int64_t, 5> toNdhwc{batchDim, depthDim, heightDim,
+                                          widthDim, channelDim};
+
+    // Compute inverse permutation from NDHWC back to original layout.
+    llvm::SmallVector<int64_t> fromNdhwc =
+        ttmlir::utils::inversePermutation(toNdhwc);
+    auto permutedInputShape =
+        ttmlir::utils::applyPermutation(inputType.getShape(), toNdhwc);
+    auto permutedInputType =
+        RankedTensorType::get(permutedInputShape, inputType.getElementType(),
+                              inputType.getEncoding());
+    auto permutedInput = rewriter.create<ttir::PermuteOp>(
+        op.getLoc(), permutedInputType, adaptor.getInput(), toNdhwc);
+
+    // Compute output shape in NDHWC format.
+    auto permutedOutputShape =
+        ttmlir::utils::applyPermutation(outputType.getShape(), toNdhwc);
+    auto permutedOutputType =
+        RankedTensorType::get(permutedOutputShape, outputType.getElementType(),
+                              outputType.getEncoding());
+
+    // Permute bias from current layout to NDHWC if present.
+    Value permutedBias = adaptor.getBias();
+    if (permutedBias) {
+      auto biasType = mlir::cast<RankedTensorType>(permutedBias.getType());
+      auto permutedBiasShape =
+          ttmlir::utils::applyPermutation(biasType.getShape(), toNdhwc);
+      auto permutedBiasType = RankedTensorType::get(
+          permutedBiasShape, biasType.getElementType(), biasType.getEncoding());
+      permutedBias = rewriter.create<ttir::PermuteOp>(
+          op.getLoc(), permutedBiasType, adaptor.getBias(), toNdhwc);
+    }
+
+    auto newConv = rewriter.create<ttir::Conv3dOp>(
+        op.getLoc(), permutedOutputType, permutedInput, adaptor.getWeight(),
+        permutedBias, adaptor.getStride(), adaptor.getPadding(), op.getGroups(),
+        op.getPaddingModeAttr());
+
+    // Permute output from NDHWC back to original layout.
+    auto outputPermute = rewriter.create<ttir::PermuteOp>(
+        op.getLoc(), outputType, newConv.getResult(), fromNdhwc);
 
     rewriter.replaceOp(op, outputPermute.getResult());
     return success();
@@ -1951,6 +2020,7 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
       typeConverter, ctx);
   patterns.add<ConvChannelLastDecompositionPattern<ttir::ConvTranspose2dOp>>(
       typeConverter, ctx);
+  patterns.add<Conv3dChannelLastDecompositionPattern>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -76,10 +76,12 @@ struct TTIRToTTIRDecompositionPass
       target.addIllegalOp<ttir::DequantizeOp>();
       target.addIllegalOp<ttir::ReverseOp>();
 
-      // Conv2d and ConvTranspose2d are legal only if already in NHWC format.
-      // Non-NHWC ops will be decomposed with permutes to NHWC.
+      // Conv ops are legal only if already in channel-last format.
+      // Non-channel-last ops will be decomposed with permutes.
       target.addDynamicallyLegalOp<ttir::Conv2dOp>(
           [](ttir::Conv2dOp op) { return op.isNHWC(); });
+      target.addDynamicallyLegalOp<ttir::Conv3dOp>(
+          [](ttir::Conv3dOp op) { return op.isNDHWC(); });
       target.addDynamicallyLegalOp<ttir::ConvTranspose2dOp>(
           [](ttir::ConvTranspose2dOp op) { return op.isNHWC(); });
       break;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2076,16 +2076,7 @@ public:
           outChannelsAttr.getInt(), rewriter, op.getLoc());
     }
 
-    llvm::SmallVector<int64_t, 5> toNdhwcPermutation = {
-        batchDim, depthDim, heightDim, widthDim, channelDim};
-    bool needsPermute = !op.isNDHWC();
     Value input = adaptor.getInput();
-    if (needsPermute) {
-      input = ttir_to_ttnn::utils::generatePermute(
-          mlir::cast<TypedValue<RankedTensorType>>(input), toNdhwcPermutation,
-          rewriter,
-          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_to_ndhwc"));
-    }
 
     int64_t inChannels = inputShape[channelDim];
     if (inChannels % TILE_WIDTH != 0) {
@@ -2102,12 +2093,6 @@ public:
 
     RankedTensorType outputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
-    if (needsPermute) {
-      auto permutedOutputShape = ttmlir::utils::applyPermutation(
-          outputType.getShape(), toNdhwcPermutation);
-      outputType = ttnn::utils::RankedTensorTypeFactory::create(
-          outputType, permutedOutputShape);
-    }
 
     auto convOp = rewriter.create<ttnn::Conv3dOp>(
         op.getLoc(), outputType, input, reshapedWeight, reshapedBias, device,
@@ -2115,17 +2100,6 @@ public:
         inputHeightAttr, inputWidthAttr, kernelSizeAttr, *strideAttr,
         *paddingAttr, paddingModeAttr, groupsAttr, outputDtypeAttr, nullptr,
         nullptr);
-
-    if (needsPermute) {
-      auto fromNdhwcPermutation =
-          ttmlir::utils::inversePermutation(toNdhwcPermutation);
-      Value permutedOutput = ttir_to_ttnn::utils::generatePermute(
-          mlir::cast<TypedValue<RankedTensorType>>(convOp.getResult()),
-          fromNdhwcPermutation, rewriter,
-          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_from_ndhwc"));
-      rewriter.replaceOp(op, permutedOutput);
-      return success();
-    }
 
     rewriter.replaceOp(op, convOp.getResult());
 


### PR DESCRIPTION
### Problem description
Conv3d requires channel last in metal and permutation to this layout is currently added during conversion from TTIR to TTNN. This is problematic because EIO pass can never fold those permutes.

### What's changed
Moved adding permutations to TTIRtoTTIRdecomposition pass.

### Checklist
- [x] New/Existing tests provide coverage for changes
