### PR TITLE
Invoke XLA tooling tests on tt-metal uplift

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -91,7 +91,8 @@ jobs:
         projects: [
           { name: "tenstorrent/tt-forge-onnx", workflow-name: "on-pr.yml" },
           { name: "tenstorrent/tt-xla", workflow-name: "manual-test.yml" },
-          { name: "tenstorrent/tt-xla", workflow-name: "manual-benchmark.yml" }
+          { name: "tenstorrent/tt-xla", workflow-name: "manual-benchmark.yml" },
+          { name: "tenstorrent/tt-xla", workflow-name: "manual-test-tools.yml" }
         ]
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
TT-XLA depends on ttnn and tracy, which come from tt-metal. To catch basic regressions earlier (on tt-metal uplift instead of tt-mlir uplift), invoke the small test suite in TT-XLA that validates these dependencies.