### PR TITLE
Builder fixes

### DIFF
--- a/test/python/golden/mlir_snippets/ttir/ttir_gelu.mlir
+++ b/test/python/golden/mlir_snippets/ttir/ttir_gelu.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @gelu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %1 = "ttir.gelu"(%arg0) : (tensor<128x128xf32>) -> tensor<128x128xf32>
+    return %1 : tensor<128x128xf32>
+  }
+}

--- a/test/python/golden/ttir_ops/kv_cache/test_kv_cache.py
+++ b/test/python/golden/ttir_ops/kv_cache/test_kv_cache.py
@@ -14,7 +14,12 @@ pytestmark = pytest.mark.frontend("ttir")
 
 
 @pytest.mark.parametrize(
-    "shapes", [[(1, 32, 64, 512), (1, 32, 1, 512), (1,)]], ids=shapes_list_str
+    "shapes",
+    [
+        pytest.param([(1, 32, 64, 512), (1, 32, 1, 512), (1,)], id="single_user"),
+        # Multi-user decoder pattern: num_input_users == num_users > 1.
+        pytest.param([(8, 4, 16, 32), (1, 4, 8, 32), (1,)], id="multi_user"),
+    ],
 )
 @pytest.mark.parametrize("dtypes", [[torch.float32, torch.float32, torch.int32]])
 @pytest.mark.parametrize("target", ["ttnn", "emitpy"])

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -11583,7 +11583,7 @@ class TTIRBuilder(Builder):
         with old_ctx, old_loc:
             gelu_module = Module.create()
             gelu_builder = TTIRBuilder(
-                old_ctx, old_loc, self._mesh_shape, self._mesh_dict
+                old_ctx, old_loc, mesh_name=self._mesh_name, mesh_dict=self._mesh_dict
             )
             op_input_types = [old_op.input.type]
 

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -11511,40 +11511,112 @@ class TTIRBuilder(Builder):
         """
         return self._op_proxy(ttir.ErfcOp, [in0], unit_attrs)
 
-    def gelu(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
-        """
-        Creates ``ttir.gelu``.
+    @tag(ttir.GeluOp)
+    def gelu(
+        self,
+        in0: Operand,
+        output_type: Optional[torch.dtype] = None,
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+    ) -> OpResult:
+        ttir_op = self.get_opview_from_method(TTIRBuilder.gelu)
+        input0 = self._get_golden_tensor(in0)
+        if output_type is None:
+            mlir_output_type = self.get_type(in0)
+        else:
+            mlir_output_type = self._get_type_from_torch_dtype(output_type)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, mlir_output_type)
+        result = self._create_ranked_tensor_type(golden_output.shape, mlir_output_type)
 
-        *Elementwise GELU operation.*
+        if loc is None:
+            loc = self._get_location()
+        else:
+            loc = Location.name(loc)
 
-        Computes the GELU (Gaussian Error Linear Unit) of each element in the input tensor.
-        GELU is a smooth, non-monotonic activation function that approximates the cumulative
-        distribution function of a standard normal distribution.
+        op = ttir_op(result, in0, loc=loc)
+        op_result = op.result
 
-        Mathematical definition: gelu(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                op.operation.attributes[attr_name] = UnitAttr.get(self._ctx)
 
-        .. code-block:: mlir
+        self._set_golden_tensor(op_result, golden_output)
 
-            // Compute GELU of all elements
-            %result = ttir.gelu(%input, %output) : tensor<4xf32>, tensor<4xf32> -> tensor<4xf32>
-            // Input tensor:
-            // [1.0, -0.5, 2.0, -2.0]
-            // Output tensor:
-            // [0.841, -0.154, 1.954, -0.046]
+        return op_result
 
-        Parameters
-        ----------
-        in0 : Operand
-            Input tensor
-        unit_attrs : *Optional[List[str]]*, optional
-            Optional list of unit attributes
+    @parse(ttir.GeluOp)
+    def gelu_parser(
+        self,
+        old_op: ttir.GeluOp,
+        global_dict: Dict[Operand, Operand],
+    ) -> Tuple[Operation, Dict[OpResult, OpResult]]:
+        ttir_op = self.get_opview_from_parser(TTIRBuilder.gelu_parser)
+        in0 = global_dict[old_op.input]
+        result = old_op.result.type
 
-        Returns
-        -------
-        (*OpView*)
-            A tensor containing the GELU values of each element in the input tensor
-        """
-        return self._op_proxy(ttir.GeluOp, [in0], unit_attrs)
+        new_op = ttir_op(
+            result,
+            in0,
+            loc=old_op.location,
+        )
+        new_op_result = new_op.result
+
+        input0 = self._get_golden_tensor(in0)
+        op_golden_function = get_golden_function(ttir_op)
+        golden_output = op_golden_function(input0, result.element_type)
+        self._set_golden_tensor(new_op_result, golden_output)
+
+        op_map_dictionary = {}
+        op_map_dictionary[old_op.result] = new_op_result
+        return new_op, op_map_dictionary
+
+    @split(ttir.GeluOp)
+    def gelu_split(
+        self,
+        old_op: ttir.GeluOp,
+    ) -> Tuple[Module, TTIRBuilder]:
+        ttir_op = self.get_opview_from_split(TTIRBuilder.gelu_split)
+
+        old_ctx = old_op.context
+        old_loc = Location.unknown(old_ctx)
+        with old_ctx, old_loc:
+            gelu_module = Module.create()
+            gelu_builder = TTIRBuilder(
+                old_ctx, old_loc, self._mesh_shape, self._mesh_dict
+            )
+            op_input_types = [old_op.input.type]
+
+            with InsertionPoint(gelu_module.body):
+
+                ordered_inputs = []
+                ordered_outputs = []
+
+                @func.func(*op_input_types, name="gelu_module")
+                def decorated_func(*inputs):
+                    in0 = inputs[0]
+                    result = old_op.result.type
+
+                    new_op = ttir_op(result, in0, loc=old_op.location)
+                    new_op_result = new_op.result
+
+                    old_op_result = self._get_golden_tensor(old_op.result)
+                    gelu_builder._set_golden_tensor(new_op_result, old_op_result)
+                    input0 = self._get_golden_tensor(old_op.input)
+                    gelu_builder._set_golden_tensor(in0, input0)
+                    gelu_builder._annotate_presharded_arg(in0)
+                    ordered_inputs.append(in0)
+                    ordered_outputs.append(new_op_result)
+
+                    return new_op
+
+                new_func_op = decorated_func.func_op
+                gelu_builder._func_ops_generated[new_func_op] = [
+                    ordered_inputs,
+                    ordered_outputs,
+                ]
+
+        return gelu_module, gelu_builder
 
     def gelu_backward(
         self,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6709,12 +6709,16 @@ def ttnn_layer_norm_golden(
     epsilon = unpack_mlir_attr(epsilon)
     output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
     input_float = input.float()
+    # Upcast weight/bias to match input's float32 dtype. torch.layer_norm
+    # rejects mixed fp32 input + bf16 params on CPU.
+    weight_float = weight.float() if weight is not None else None
+    bias_float = bias.float() if bias is not None else None
 
     return torch.nn.functional.layer_norm(
         input_float,
         normalized_shape=normalized_shape,
-        weight=weight,
-        bias=bias,
+        weight=weight_float,
+        bias=bias_float,
         eps=epsilon,
     ).to(output_dtype)
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3387,6 +3387,14 @@ def ttir_gelu_backward_golden(grad, input, approximate="none"):
     return torch.ops.aten.gelu_backward(grad, input, approximate=approximate)
 
 
+
+def ttir_gelu_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    output_dtype = mlir_type_to_torch_dtype(output_type_mlir)
+    return torch.nn.functional.gelu(input_tensor).to(output_dtype)
+
+
 def ttir_cos_golden(
     input_tensor: GoldenMapTensor, output_type_mlir: Type
 ) -> GoldenMapTensor:
@@ -7542,7 +7550,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.ErfOp: ttir_erf_golden,
     ttir.ErfcOp: torch.erfc,
     ttir.FloorOp: ttir_floor_golden,
-    ttir.GeluOp: torch.nn.functional.gelu,
+    ttir.GeluOp: ttir_gelu_golden,
     ttir.GeluBackwardOp: ttir_gelu_backward_golden,
     ttir.IsFiniteOp: ttir_isfinite_golden,
     ttir.MishOp: torch.nn.functional.mish,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2683,10 +2683,9 @@ def update_cache_golden(
     indices = indices_tensor.shard_at(0).to(torch.long)
     update_idx = int(indices.flatten()[0].item())
 
-    batch_offset_val = 0
-    if batch_offset is not None:
-        unpacked = unpack_mlir_attr(batch_offset)
-        batch_offset_val = int(unpacked) if unpacked is not None else 0
+    batch_offset_val = (
+        int(unpack_mlir_attr(batch_offset)) if batch_offset is not None else 0
+    )
 
     for device_id, shard in result.shard_map.items():
         update_data = update_tensor.shard_at(device_id)
@@ -3402,7 +3401,6 @@ def ttir_gelu_backward_golden(grad, input, approximate="none"):
     # implicit broadcasting (ONEDNN limitation). Broadcast inputs explicitly.
     grad, input = torch.broadcast_tensors(grad, input)
     return torch.ops.aten.gelu_backward(grad, input, approximate=approximate)
-
 
 
 def ttir_gelu_golden(

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -2650,6 +2650,14 @@ def update_cache_golden(
     """
     Custom golden function for update_cache operation.
 
+    Matches TTNN ``update_cache`` semantics:
+      cache shape: [num_users, num_heads, max_seq_len, head_dim]
+      input shape: [1, num_heads, num_input_users, head_dim]
+      update_index: scalar position in the cache sequence dimension
+    The update writes:
+      cache[batch_offset + b, h, update_index, d] = input[0, h, b, d]
+    for ``b`` in ``[0, num_input_users)``.
+
     Parameters
     ----------
     cache_tensor : GoldenMapTensor
@@ -2657,9 +2665,9 @@ def update_cache_golden(
     update_tensor : GoldenMapTensor
         Tensor containing update data
     indices_tensor : GoldenMapTensor
-        Tensor containing update indices
+        Tensor containing the (scalar) update index
     batch_offset : IntegerAttr, optional
-        Batch offset attribute (ignored in golden computation)
+        Offset along the cache batch dimension where the input batch starts
     output_type_mlir : Type, optional
         MLIR output type (ignored in golden computation)
     **kwargs : dict
@@ -2672,15 +2680,24 @@ def update_cache_golden(
     """
     result = cache_tensor.clone()
 
-    # indices_tensor contains the position(s) in the sequence dimension
-    # where update_tensor values should be written
     indices = indices_tensor.shard_at(0).to(torch.long)
-    seq_len = update_tensor.shape[2]
+    update_idx = int(indices.flatten()[0].item())
+
+    batch_offset_val = 0
+    if batch_offset is not None:
+        unpacked = unpack_mlir_attr(batch_offset)
+        batch_offset_val = int(unpacked) if unpacked is not None else 0
+
     for device_id, shard in result.shard_map.items():
         update_data = update_tensor.shard_at(device_id)
-        for i in range(seq_len):
-            idx = indices[i].item()
-            shard[:, :, idx, :] = update_data[:, :, i, :]
+        num_input_users = update_data.shape[2]
+        # update_data[0, h, b, d] -> shard[batch_offset + b, h, update_idx, d]
+        shard[
+            batch_offset_val : batch_offset_val + num_input_users,
+            :,
+            update_idx,
+            :,
+        ] = update_data[0].permute(1, 0, 2)
     return result
 
 


### PR DESCRIPTION
### Ticket

### Problem description
There were three TTIR builder bugs found while using it for testing PCC:
- TTIR builder `gelu` uses `_op_proxy` form
-  `ttnn_layer_norm_golden` upcasts `input` to fp32 but passed `weight`/`bias` through unchanged. On CPU, `torch.nn.functional.layer_norm` rejects mixed fp32 input + bf16 params. 
- `update_cache_golden` doesn't match TTNN `update_cache` semantics

### What's changed
1. Rewrite `gelu` builder to use the `@tag` / `@parse` / `@split` decorator triplet, replacing the old `_op_proxy` form. Brings `gelu` in line with `cos`, `sin`, `sqrt`, etc.

2. In `ttnn_layer_norm_golden` also `.float()` `weight` and `bias` (when present).

3. Fix `update_cache_golden` to match TTNN `update_cache` semantics:

Previous golden:
- Treated `update_index` as a per-slot vector and looped over `update.shape[2]`, indexing out of range whenever `num_input_users > 1`.
- Ignored the `batch_offset` attribute.
- Broadcast the input row across all users in the cache (`shard[:, :, idx, :] = update_data[:, :, i, :]`).

Now:
- Reads a single scalar `update_index`.
- Honors `batch_offset`.
- Writes `cache[batch_offset + b, h, update_idx, d] = input[0, h, b, d]` for `b in [0, num_input_users)`.

### Checklist
- [x] New/Existing tests provide coverage for changes
