### PR TITLE
[Runtime][TTNN] Reuse global semaphores in capture run through the global semaphore pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ env/build/
 
 # Generated Artifacts
 generated/*
+test/python/golden/generated/*

--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1977,11 +1977,6 @@ inline constexpr const char *kCreateVectorFunctionName = "util_create_vec";
 inline constexpr const char *kGetScalarFromTensorFunctionName =
     "::ttnn::getScalarFromTensor";
 
-// Name for the function that creates a GlobalSemaphore from a tensor's shard
-// spec.
-inline constexpr const char *kCreateGlobalSemaphoreFunctionName =
-    "::ttnn::createGlobalSemaphore";
-
 template <typename TTNNOp>
 class EmitCTTNNEmitter {
 public:

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNDeviceOperandInterface.h"
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNWorkaroundInterface.h"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2361,6 +2361,7 @@ def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
                          Optional<AnyRankedTensor>:$weight,
                          Optional<AnyRankedTensor>:$residual,
                          Optional<AnyRankedTensor>:$stats,
+                         Optional<TTNN_GlobalSemaphore>:$semaphore,
                          TTNN_Device:$device,
                          UI32Attr:$cluster_axis,
                          DefaultValuedAttr<F32Attr, "1e-12">:$epsilon,
@@ -3334,7 +3335,8 @@ def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace", [OpModelExempt]> 
   let hasVerifier = 1;
 }
 
-def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace", [OpModelExempt]> {
+def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace",
+    [AttrSizedOperandSegments, OpModelExempt]> {
   let summary = "Capture or execute trace.";
   let description = [{
     Captures or executes the trace. Will have read/write memory effects on the cached trace data.
@@ -3346,6 +3348,7 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
       - `capture_callee` FlatSymbolRefAttr: The symbol of the capture trace function.
       - `execute_callee` FlatSymbolRefAttr: The symbol of the execute trace function.
       - `inputs` Variadic<AnyRankedTensor>: The input tensors to the trace function.
+      - `semaphore_inputs` Variadic<TTNN_GlobalSemaphore>: Global semaphores forwarded into the capture/execute programs.
     Outputs:
       - `results` Variadic<AnyRankedTensor>: The output tensors from the trace function.
   }];
@@ -3353,7 +3356,8 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
   let arguments = (ins TTNN_Device:$device,
                        FlatSymbolRefAttr:$capture_callee,
                        FlatSymbolRefAttr:$execute_callee,
-                       Variadic<AnyRankedTensor>:$inputs);
+                       Variadic<AnyRankedTensor>:$inputs,
+                       Variadic<TTNN_GlobalSemaphore>:$semaphore_inputs);
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
 
@@ -3972,7 +3976,7 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
   let hasVerifier = 1;
 }
 
-def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [OpModelExempt]> {
+def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [TTCore_CreationOpTrait, TTCore_NonCacheableTrait, OpModelExempt]> {
     let summary = "Create global semaphore op.";
     let description = [{
       Creates a global semaphore with the specified core range and initial value.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2375,7 +2375,6 @@ def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
     let results = (outs AnyRankedTensor:$result);
 
     let extraClassDeclaration = [{
-      // DistributedOpInterface implementations.
       bool hasUnboundBuffers();
       void allocateBuffers(::mlir::RewriterBase &rewriter);
       bool hasUnboundSemaphores();

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -7,6 +7,7 @@
 
 include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td"
 include "ttmlir/Dialect/TTNN/Interfaces/TTNNDeviceOperandInterface.td"
+include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.td"
 include "ttmlir/Dialect/TTNN/Interfaces/TTNNTensorSpecInterface.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
@@ -2311,7 +2312,7 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_Compute
 }
 
 def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
-    [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
+    [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface, TTNN_DistributedOpInterface, OpModelExempt]> {
     let summary = "Distributed RMS normalization with all-gather op.";
     let description = [{
       Fused distributed RMS normalization operation across mesh devices.
@@ -2372,6 +2373,14 @@ def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
                          OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // DistributedOpInterface implementations.
+      bool hasUnboundBuffers();
+      void allocateBuffers(::mlir::RewriterBase &rewriter);
+      bool hasUnboundSemaphores();
+      void allocateSemaphores(::mlir::RewriterBase &rewriter);
+    }];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -112,6 +112,12 @@ def TTNN_CoreRangeSetAttr: TTNN_Attr<"CoreRangeSet", "core_range_set"> {
   let parameters = (ins OptionalArrayRefParameter<"CoreRangeAttr">:$core_ranges);
   let assemblyFormat = "`<` (`[` qualified($core_ranges)^ `]`)? `>`";
 
+  let extraClassDeclaration = [{
+    // Returns the smallest CoreRange that contains every core in this set.
+    // Returns std::nullopt for an empty set.
+    std::optional<CoreRangeAttr> getBoundingBox() const;
+  }];
+
   let genVerifyDecl = 1;
 }
 

--- a/include/ttmlir/Dialect/TTNN/Interfaces/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_mlir_interface(TTNNDistributedOpInterface)
 add_mlir_interface(TTNNDeviceOperandInterface)
 add_mlir_interface(TTNNOpModelInterface)
 add_mlir_interface(TTNNWorkaroundInterface)

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_H
+#define TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_H
+
+#include "mlir/IR/PatternMatch.h"
+
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h.inc"
+
+#endif // TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_H

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.td
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_TD
+#define TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_TD
+
+include "mlir/IR/OpBase.td"
+
+// Interface for TTNN distributed (multi-device) ops that take explicit
+// scratch-buffer and/or global-semaphore operands at the MLIR level.
+//
+// This is intentionally separate from plain CCL ops (`all_gather`,
+// `reduce_scatter`, `all_reduce`) whose semaphores and scratch buffers
+// are fully managed inside tt-metal at runtime and never appear in the
+// IR. Distributed ops in this interface's sense are composite ops that
+// combine compute with cross-device synchronization and need their
+// resources materialized in MLIR so the compiler can reason about
+// L1 usage, trace-hoist boundaries, and resource lifetimes.
+//
+// Buffer and semaphore allocation are split into two interface methods
+// because they are run in two distinct passes at different points in the
+// pipeline:
+//   - Buffers must be allocated before the optimizer so it can account
+//     for their L1 footprint when budgeting shard sizes / per-op CB
+//     allocations.
+//   - Semaphores must be allocated after the optimizer because their
+//     core range is derived from the finalized input shard spec.
+//
+// Both operations create their resources in the function prelude (right
+// after the `ttnn.get_device` op) so that `TTNNTraceHoistTransform` can
+// hoist the trace body cleanly: prelude allocations become device-resident
+// block args, and there are no host-side allocations interleaved with
+// hoistable device ops.
+def TTNN_DistributedOpInterface : OpInterface<"DistributedOpInterface"> {
+  let cppNamespace = "::mlir::tt::ttnn";
+  let description = [{
+    Interface implemented by distributed ops that take explicit
+    scratch-buffer and/or global-semaphore operands. Each `allocate*`
+    method is responsible for materializing the corresponding prelude
+    allocation op (e.g. `ttnn.empty`, `ttnn.create_global_semaphore`)
+    and binding it to the matching operand. Implementations must be
+    idempotent: calling them when all operands are already bound is a
+    no-op.
+  }];
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op has any unbound buffer operands that
+        require allocation.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"hasUnboundBuffers",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Materialize prelude EmptyOps for any unbound buffer operands and
+        bind them. No-op if all buffer operands are already set.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"allocateBuffers",
+      /*args=*/(ins "::mlir::RewriterBase &":$rewriter)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op has any unbound semaphore operands that
+        require allocation.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"hasUnboundSemaphores",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Materialize prelude CreateGlobalSemaphoreOps for any unbound
+        semaphore operands and bind them. No-op if all semaphore
+        operands are already set.
+      }],
+      /*retTy=*/"void",
+      /*methodName=*/"allocateSemaphores",
+      /*args=*/(ins "::mlir::RewriterBase &":$rewriter)
+    >,
+  ];
+}
+
+#endif // TTMLIR_DIALECT_TTNN_INTERFACES_TTNNDISTRIBUTEDOPINTERFACE_TD

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -709,6 +709,38 @@ def TTNNConfigureCCLOps : Pass<"ttnn-configure-ccl-ops", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTNNAllocateDistributedOpBuffers
+    : Pass<"ttnn-allocate-distributed-op-buffers", "::mlir::ModuleOp"> {
+  let summary = "Allocate explicit scratch buffers for distributed ops.";
+  let description = [{
+    This pass walks ops implementing `DistributedOpInterface` and asks each
+    of them to materialize any unbound scratch / persistent buffer operands
+    by inserting `ttnn.empty` ops in the function prelude (right after
+    `ttnn.get_device`).
+
+    Runs before the optimizer so that downstream L1 budgeting analyses can
+    account for these allocations. This is the buffer counterpart to
+    `TTNNAllocateDistributedOpSemaphores`, which runs later because
+    semaphore core ranges depend on the finalized shard spec.
+  }];
+}
+
+def TTNNAllocateDistributedOpSemaphores
+    : Pass<"ttnn-allocate-distributed-op-semaphores", "::mlir::ModuleOp"> {
+  let summary = "Allocate explicit global semaphores for distributed ops.";
+  let description = [{
+    This pass walks ops implementing `DistributedOpInterface` and asks each
+    of them to materialize any unbound global-semaphore operands by
+    inserting `ttnn.create_global_semaphore` ops in the function prelude
+    (right after `ttnn.get_device`).
+
+    Runs after the optimizer so that semaphore core ranges are derived from
+    the finalized input shard spec. This is the semaphore counterpart to
+    `TTNNAllocateDistributedOpBuffers`, which must run before the optimizer
+    so that buffers contribute to L1 budgeting.
+  }];
+}
+
 def TTNNMemoryManagement : Pass<"ttnn-memory-management", "::mlir::ModuleOp"> {
   let summary = "Memory usage optimization pass.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -713,15 +713,10 @@ def TTNNAllocateDistributedOpBuffers
     : Pass<"ttnn-allocate-distributed-op-buffers", "::mlir::ModuleOp"> {
   let summary = "Allocate explicit scratch buffers for distributed ops.";
   let description = [{
-    This pass walks ops implementing `DistributedOpInterface` and asks each
-    of them to materialize any unbound scratch / persistent buffer operands
-    by inserting `ttnn.empty` ops in the function prelude (right after
-    `ttnn.get_device`).
-
-    Runs before the optimizer so that downstream L1 budgeting analyses can
-    account for these allocations. This is the buffer counterpart to
-    `TTNNAllocateDistributedOpSemaphores`, which runs later because
-    semaphore core ranges depend on the finalized shard spec.
+    Walks every op implementing `DistributedOpInterface` and invokes
+    `allocateBuffers` on it. See `DistributedOpInterface` for the rationale
+    behind splitting buffer and semaphore allocation into separate passes
+    and for the prelude placement contract.
   }];
 }
 
@@ -729,15 +724,10 @@ def TTNNAllocateDistributedOpSemaphores
     : Pass<"ttnn-allocate-distributed-op-semaphores", "::mlir::ModuleOp"> {
   let summary = "Allocate explicit global semaphores for distributed ops.";
   let description = [{
-    This pass walks ops implementing `DistributedOpInterface` and asks each
-    of them to materialize any unbound global-semaphore operands by
-    inserting `ttnn.create_global_semaphore` ops in the function prelude
-    (right after `ttnn.get_device`).
-
-    Runs after the optimizer so that semaphore core ranges are derived from
-    the finalized input shard spec. This is the semaphore counterpart to
-    `TTNNAllocateDistributedOpBuffers`, which must run before the optimizer
-    so that buffers contribute to L1 budgeting.
+    Walks every op implementing `DistributedOpInterface` and invokes
+    `allocateSemaphores` on it. See `DistributedOpInterface` for the
+    rationale behind splitting buffer and semaphore allocation into
+    separate passes and for the prelude placement contract.
   }];
 }
 

--- a/include/ttmlir/Target/TTNN/operations/mlir_native.fbs
+++ b/include/ttmlir/Target/TTNN/operations/mlir_native.fbs
@@ -7,4 +7,5 @@ table FuncCallOp {
   program_id: uint32;
   inputs: [tt.target.ttnn.TensorRef];
   outputs: [tt.target.ttnn.TensorRef];
+  semaphore_inputs: [tt.target.ttnn.GlobalSemaphoreRef];
 }

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -69,6 +69,7 @@ table DistributedRMSNormOp {
   stats: tt.target.ttnn.TensorRef;
   program_config: tt.target.ttnn.LayerNormShardedMultiCoreProgramConfig;
   out: tt.target.ttnn.TensorRef;
+  semaphore: tt.target.ttnn.GlobalSemaphoreRef;
 }
 
 table RMSNormPreAllGatherOp {

--- a/include/ttmlir/Target/TTNN/operations/trace.fbs
+++ b/include/ttmlir/Target/TTNN/operations/trace.fbs
@@ -28,4 +28,5 @@ table CaptureOrExecuteTraceOp {
   execute_program_id: uint32;
   inputs: [tt.target.ttnn.TensorRef];
   outputs: [tt.target.ttnn.TensorRef];
+  semaphore_inputs: [tt.target.ttnn.GlobalSemaphoreRef];
 }

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -168,4 +168,5 @@ table Program {
   // Flag to indicate if this program is intended to be called or only for internal use (e.g. hoisted const-eval func).
   private: bool;
   mesh_shape: Dim2d;
+  semaphore_inputs: [GlobalSemaphoreRef];
 }

--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -76,8 +76,8 @@ funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry, FnT fn,
 
   for (auto &input : entry.getBody().getArguments()) {
     if (mlir::isa<mlir::tt::ttnn::GlobalSemaphoreType>(input.getType())) {
-      program.semaphoreInputs.push_back(cache.getOrCreate(
-          input, [](FlatbufferObjectCache &c, mlir::Value) {
+      program.semaphoreInputs.push_back(
+          cache.getOrCreate(input, [](FlatbufferObjectCache &c, mlir::Value) {
             return ::tt::target::ttnn::CreateGlobalSemaphoreRef(
                 *c.fbb, c.nextGlobalId());
           }));

--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -9,6 +9,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "flatbuffers/flatbuffers.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
@@ -22,6 +23,8 @@ struct Program {
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> inputs;
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> outputs;
   std::vector<::flatbuffers::Offset<OpT>> ops;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+      semaphoreInputs;
 };
 
 inline std::string getOpDebugString(mlir::Operation *op,
@@ -72,6 +75,15 @@ funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry, FnT fn,
   program.name = entry.getSymName().data();
 
   for (auto &input : entry.getBody().getArguments()) {
+    if (mlir::isa<mlir::tt::ttnn::GlobalSemaphoreType>(input.getType())) {
+      program.semaphoreInputs.push_back(cache.getOrCreate(
+          input, [](FlatbufferObjectCache &c, mlir::Value) {
+            return ::tt::target::ttnn::CreateGlobalSemaphoreRef(
+                *c.fbb, c.nextGlobalId());
+          }));
+      continue;
+    }
+
     // Get argument encoding to determine sharding status.
     mlir::DictionaryAttr argAttrDict =
         entry.getArgAttrDict(input.getArgNumber());

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1282,7 +1282,8 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::DistributedRMSNormOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getWeight(), adaptor.getResidual(),
-        /*stats=*/nullptr, device,
+        /*stats=*/nullptr,
+        /*semaphore=*/nullptr, device,
         static_cast<uint32_t>(adaptor.getClusterAxis()), adaptor.getEpsilon(),
         /*sub_device_id=*/nullptr,
         /*num_links=*/nullptr,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3628,16 +3628,9 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::DistributedRMSNormOp>
         emitter(srcOp, adaptor, rewriter);
 
-    mlir::Value globalSemaphore =
-        rewriter
-            .create<emitc::CallOpaqueOp>(
-                srcOp.getLoc(),
-                emitc::OpaqueType::get(rewriter.getContext(),
-                                       "::ttnn::GlobalSemaphore"),
-                ttnn_to_emitc::kCreateGlobalSemaphoreFunctionName,
-                /*args=*/nullptr,
-                /*template_args=*/nullptr, adaptor.getInput())
-            .getResult(0);
+    if (!srcOp.getSemaphore()) {
+      return rewriter.notifyMatchFailure(srcOp, "missing semaphore operand");
+    }
 
     // Emit SSA operands in ODS order to maintain correct index mapping, then
     // arrange the returned attributes in the C++ API call order.
@@ -3647,8 +3640,7 @@ public:
     auto statsIndexAttr = emitter.emit(srcOp.getStats());
     auto deviceIndexAttr =
         emitter.emit<::ttnn::distributed::MeshDevice>(srcOp.getDevice());
-    auto semaphoreIndexAttr =
-        emitter.emit(globalSemaphore, srcOp->getNumOperands());
+    auto semaphoreIndexAttr = emitter.emit(srcOp.getSemaphore());
 
     llvm::SmallVector<mlir::Attribute> args{
         inputIndexAttr,

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3859,19 +3859,16 @@ public:
     ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::DistributedRMSNormOp>
         emitter(srcOp, adaptor, rewriter);
 
-    auto opaqueType =
-        emitpy::OpaqueType::get(rewriter.getContext(), "ttnn.Tensor");
-
-    auto globalSemaphoreOp = rewriter.create<emitpy::CallOpaqueOp>(
-        srcOp.getLoc(), opaqueType, "utils.create_global_semaphore",
-        llvm::SmallVector<mlir::Value>{adaptor.getInput()});
+    if (!srcOp.getSemaphore()) {
+      return rewriter.notifyMatchFailure(srcOp, "missing semaphore operand");
+    }
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getProgramConfig()),
         emitter.emit(srcOp.getClusterAxis()),
         emitter.emit(srcOp.getDevice()),
-        emitter.emit(globalSemaphoreOp.getResult(0), "", 2),
+        emitter.emit(srcOp.getSemaphore()),
         emitter.emit(srcOp.getStats(), "stats"),
         emitter.emitSubDeviceId(srcOp.getSubDeviceId(), "subdevice_id"),
         emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),

--- a/lib/Dialect/TTNN/IR/CMakeLists.txt
+++ b/lib/Dialect/TTNN/IR/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRTTNNDialect
         DEPENDS
         MLIRTTNNOpsIncGen
         MLIRTTCoreOpsIncGen
+        MLIRTTNNDistributedOpInterfaceIncGen
         MLIRTTNNOpModelInterfaceIncGen
         MLIRTTNNTensorSpecInterfaceIncGen
         MLIRTTNNWorkaroundInterfaceIncGen

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -14,7 +14,6 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsInterfaces.cpp.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
-#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Utils/VerificationUtils.h"
@@ -3152,33 +3151,26 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
   ttcore::DataType statsDataType =
       fp32DestAccEn ? ttcore::DataType::Float32 : ttcore::DataType::BFloat16;
 
-  auto physicalGrid =
-      ttcore::getCurrentScopeSystemDesc(*this).getChipDescs()[0].getGrid();
-  auto [virtToPhysicalMap, physicalToVirtMap] =
-      optimizer_utils::createSingleDeviceVirtualToPhysicalAffineMaps(
-          rewriter.getContext(), TensorMemoryLayout::WidthSharded,
-          physicalGrid);
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(*this);
 
   // One tile (32x32) per device, width-sharded on core (0,0) in L1. The fused
   // kernel writes partial RMS statistics here and exchanges them across
   // devices via the all-gather.
-  SmallVector<int64_t> statsGridShape = {1, 1};
-  auto statsGrid = ttcore::GridAttr::get(rewriter.getContext(), statsGridShape,
-                                         virtToPhysicalMap, physicalToVirtMap);
-  auto statsMemLayoutAttr = TensorMemoryLayoutAttr::get(
-      rewriter.getContext(), TensorMemoryLayout::WidthSharded);
-
   SmallVector<int64_t> statsShape = {1, 1, 32, 32};
+  SmallVector<int64_t> statsGridShape = {1, 1};
   TTNNLayoutAttr statsLayout =
-      TTNNLayoutAttr::get(rewriter.getContext(), statsShape,
-                          ttcore::TileType::get(statsElementType),
-                          BufferType::L1, statsGrid, statsMemLayoutAttr);
+      TTNNLayoutAttr::Builder(rewriter.getContext(), statsShape,
+                              ttcore::TileType::get(statsElementType))
+          .setBufferType(BufferType::L1)
+          .setMemoryLayout(TensorMemoryLayout::WidthSharded)
+          .setGridShape(statsGridShape)
+          .buildWithCanonicalCorePlacement(deviceAttr);
 
   auto statsShapeAttr = ShapeAttr::get(rewriter.getContext(), statsShape);
   auto statsDtypeAttr =
       ttcore::DataTypeAttr::get(rewriter.getContext(), statsDataType);
   auto statsLayoutAttr = LayoutAttr::get(rewriter.getContext(), Layout::Tile);
-  auto statsMemConfig = MemoryConfigAttr::get(statsLayout, statsGrid);
+  auto statsMemConfig = MemoryConfigAttr::get(statsLayout);
 
   RankedTensorType statsResultType =
       RankedTensorType::get(statsShape, statsElementType, statsLayout);

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3126,7 +3126,7 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
 }
 
 bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundBuffers() {
-  return getStats() == nullptr;
+  return !getStats();
 }
 
 void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
@@ -3135,10 +3135,9 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
     return;
   }
 
-  // The fused kernel CB data format must match the compute_config's
-  // fp32_dest_acc_en (Float32 when set, BFloat16 otherwise). The compute
-  // config is expected to be set by the workaround pattern (or an earlier
-  // pass like TTNNSetComputeKernelConfig); fall back to fp32 if missing.
+  // The fused kernel CB data format must match compute_config.fp32_dest_acc_en
+  // (Float32 when set, BFloat16 otherwise). compute_config is set upstream by
+  // the workaround pattern or TTNNSetComputeKernelConfig; default to fp32.
   bool fp32DestAccEn = true;
   if (auto computeConfig = getComputeConfigAttr()) {
     if (auto fp32Attr = computeConfig.getFp32DestAccEn()) {
@@ -3156,11 +3155,12 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
       ttcore::getCurrentScopeSystemDesc(*this).getChipDescs()[0].getGrid();
   auto [virtToPhysicalMap, physicalToVirtMap] =
       optimizer_utils::createSingleDeviceVirtualToPhysicalAffineMaps(
-          rewriter.getContext(), TensorMemoryLayout::WidthSharded, physicalGrid);
+          rewriter.getContext(), TensorMemoryLayout::WidthSharded,
+          physicalGrid);
 
-  // One tile (32x32) per device, width-sharded on core (0,0) in L1. The
-  // fused kernel writes partial RMS statistics here and exchanges them
-  // across devices via the all-gather.
+  // One tile (32x32) per device, width-sharded on core (0,0) in L1. The fused
+  // kernel writes partial RMS statistics here and exchanges them across
+  // devices via the all-gather.
   SmallVector<int64_t> statsGridShape = {1, 1};
   auto statsGrid = ttcore::GridAttr::get(rewriter.getContext(), statsGridShape,
                                          virtToPhysicalMap, physicalToVirtMap);
@@ -3168,9 +3168,10 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
       rewriter.getContext(), TensorMemoryLayout::WidthSharded);
 
   SmallVector<int64_t> statsShape = {1, 1, 32, 32};
-  TTNNLayoutAttr statsLayout = TTNNLayoutAttr::get(
-      rewriter.getContext(), statsShape, ttcore::TileType::get(statsElementType),
-      BufferType::L1, statsGrid, statsMemLayoutAttr);
+  TTNNLayoutAttr statsLayout =
+      TTNNLayoutAttr::get(rewriter.getContext(), statsShape,
+                          ttcore::TileType::get(statsElementType),
+                          BufferType::L1, statsGrid, statsMemLayoutAttr);
 
   auto statsShapeAttr = ShapeAttr::get(rewriter.getContext(), statsShape);
   auto statsDtypeAttr =
@@ -3183,38 +3184,9 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
 
   auto device = utils::getOrInsertDevice(rewriter, *this);
 
-  // Scratch buffer for the fused kernel's all-gather stats.
-  //
-  // Placement: inserted right after GetDeviceOp so it sits in the block
-  //   prelude. Leaving it inline would trip TTNNTraceHoistTransform with
-  //   "Non-hoistable op in the middle of hoistable ops". EmptyOp is a
-  //   host-side allocation and cannot appear inside the trace body: device
-  //   buffer allocations during trace capture are forbidden by tt-metal
-  //   (allocator warns "Allocating device buffers is unsafe due to the
-  //   existence of an active trace"; dispatch-side writes TT_FATAL).
-  //
-  // Runtime behavior under capture_or_execute_trace:
-  //   - First @main call: this EmptyOp result is passed into the trace
-  //     function as an `argument_type<constant>` operand and retained by
-  //     TraceData; the trace records its L1 address.
-  //   - Subsequent @main calls: a fresh EmptyOp result is allocated and gets
-  //     a new TTNNTensorWrapper version (versions are a monotonically
-  //     incrementing global counter). Because the version differs from the
-  //     retained slot's, capture_or_execute_trace performs a
-  //     device->host->device copy into the retained slot before each replay.
-  //     This copy is wasted work on every iteration.
-  //
-  // Why it is correct today: rms_allgather's writer kernel
-  //   (rms_writer.cpp) writes its partial-stats buffer before reading it,
-  //   so whatever the version-mismatch copy left in the slot is overwritten.
-  //
-  // Failure mode if violated: a future consumer of this slot that depends
-  //   on its initial state will be silently corrupted, since the
-  //   version-mismatch path copies uninitialized contents in.
-  //
-  // Proper fix (out of scope here): a dedicated
-  //   `argument_type<persistent_buffer>` that bypasses the version-
-  //   reconciliation path in capture_or_execute_trace.cpp.
+  // Inserted right after GetDeviceOp so the EmptyOp sits in the block prelude.
+  // TTNNTraceHoistTransform requires a contiguous block of hoistable ops, and
+  // EmptyOp (a host-side allocation) is forbidden inside the trace body.
   ttnn::EmptyOp statsEmptyOp;
   {
     OpBuilder::InsertionGuard guard(rewriter);
@@ -3224,13 +3196,12 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
         statsLayoutAttr, statsMemConfig);
   }
 
-  rewriter.modifyOpInPlace(*this, [&]() {
-    getStatsMutable().assign(statsEmptyOp.getResult());
-  });
+  rewriter.modifyOpInPlace(
+      *this, [&]() { getStatsMutable().assign(statsEmptyOp.getResult()); });
 }
 
 bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundSemaphores() {
-  return getSemaphore() == nullptr;
+  return !getSemaphore();
 }
 
 void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
@@ -3239,11 +3210,10 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
     return;
   }
 
-  // The fused kernel's global semaphore lives on the bounding box of the
-  // input's actual shard cores, so the semaphore is guaranteed to live on
-  // cores that exist on the device. We read the shard spec from the op's
-  // memory_config attribute, which is populated by the workaround pattern
-  // and may be further refined by the optimizer before this pass runs.
+  // Derive the semaphore core range from the input's shard spec so it lives on
+  // cores that actually exist on the device. memory_config is populated by the
+  // workaround pattern and may be further refined by the optimizer before this
+  // runs.
   MemoryConfigAttr memoryConfig = getMemoryConfigAttr();
   assert(memoryConfig &&
          "DistributedRMSNormOp must have a memory_config before semaphore "
@@ -3259,32 +3229,10 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
 
   auto device = utils::getOrInsertDevice(rewriter, *this);
 
-  // Global semaphore for the fused kernel's all-gather.
-  //
-  // Placement: same prelude position as the buffer allocation, for the
-  //   same reasons. CreateGlobalSemaphoreOp is a host-side allocation and
-  //   TTNNTraceHoistTransform requires a contiguous block of hoistable ops.
-  //
-  // Cross-replay reset is the kernel's responsibility: rms_writer.cpp resets
-  //   `out_ready_sem_bank_addr_ptr` to 0 via on-device `noc_semaphore_set`.
-  //   That on-device write is recorded into the trace and runs every replay.
-  //
-  // Why we cannot insert `ttnn.reset_global_semaphore` instead:
-  //   - In the trace body: forbidden. Its runtime impl calls
-  //     `EnqueueWriteMeshBuffer` (host-mediated, blocking), which TT_FATALs
-  //     during capture (fd_mesh_command_queue.cpp: "Writes are not supported
-  //     during trace capture").
-  //   - In the prelude: would only run on the first @main call (during
-  //     capture), not between replays. Does not solve cross-replay state
-  //     leakage.
-  //   - In the postlude (after capture_or_execute_trace): would force a
-  //     blocking host sync on every call, defeating the purpose of trace.
-  //
-  // Failure mode if violated: if a future CCL kernel reused through this
-  //   rewrite does NOT reset its global semaphore, trace replays from the
-  //   second iteration onwards will see the leftover value from the previous
-  //   replay. Waits-for-N pass immediately, before any cores have done their
-  //   work, producing silent wrong outputs.
+  // Same prelude placement as the scratch buffer above, for the same
+  // trace-hoisting reasons. Cross-replay semaphore reset is handled on-device
+  // by the kernel (rms_writer.cpp), so ttnn.reset_global_semaphore is
+  // intentionally not inserted here.
   ttnn::CreateGlobalSemaphoreOp semaphoreOp;
   {
     OpBuilder::InsertionGuard guard(rewriter);
@@ -3294,9 +3242,8 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
         /*initial_value=*/rewriter.getUI32IntegerAttr(0), *semaphoreCoreRange);
   }
 
-  rewriter.modifyOpInPlace(*this, [&]() {
-    getSemaphoreMutable().assign(semaphoreOp.getResult());
-  });
+  rewriter.modifyOpInPlace(
+      *this, [&]() { getSemaphoreMutable().assign(semaphoreOp.getResult()); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -4844,14 +4791,14 @@ void CaptureOrExecuteTraceOp::getEffects(
   }
 
   for (BlockArgument arg : traceFuncOp.getArguments()) {
-    if (::mlir::isa<ttnn::GlobalSemaphoreType>(arg.getType())) {
-      continue;
-    }
-    if (!::mlir::isa<RankedTensorType>(arg.getType())) {
+    auto tensorType = ::mlir::dyn_cast<RankedTensorType>(arg.getType());
+    if (!tensorType) {
+      if (::mlir::isa<ttnn::GlobalSemaphoreType>(arg.getType())) {
+        continue;
+      }
       return emitOpError() << "All input arguments of trace function must be "
                            << "ranked tensors or global semaphores";
     }
-    auto tensorType = ::mlir::cast<RankedTensorType>(arg.getType());
     if (!utils::isTensorOnDevice(tensorType)) {
       return emitOpError()
              << "All input arguments of trace function must be on device."

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsInterfaces.cpp.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Utils/VerificationUtils.h"
@@ -3122,6 +3123,180 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
   }
 
   return success();
+}
+
+bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundBuffers() {
+  return getStats() == nullptr;
+}
+
+void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
+    ::mlir::RewriterBase &rewriter) {
+  if (!hasUnboundBuffers()) {
+    return;
+  }
+
+  // The fused kernel CB data format must match the compute_config's
+  // fp32_dest_acc_en (Float32 when set, BFloat16 otherwise). The compute
+  // config is expected to be set by the workaround pattern (or an earlier
+  // pass like TTNNSetComputeKernelConfig); fall back to fp32 if missing.
+  bool fp32DestAccEn = true;
+  if (auto computeConfig = getComputeConfigAttr()) {
+    if (auto fp32Attr = computeConfig.getFp32DestAccEn()) {
+      fp32DestAccEn = fp32Attr.getValue();
+    }
+  }
+  Type statsElementType =
+      fp32DestAccEn
+          ? static_cast<Type>(Float32Type::get(rewriter.getContext()))
+          : static_cast<Type>(BFloat16Type::get(rewriter.getContext()));
+  ttcore::DataType statsDataType =
+      fp32DestAccEn ? ttcore::DataType::Float32 : ttcore::DataType::BFloat16;
+
+  auto physicalGrid =
+      ttcore::getCurrentScopeSystemDesc(*this).getChipDescs()[0].getGrid();
+  auto [virtToPhysicalMap, physicalToVirtMap] =
+      optimizer_utils::createSingleDeviceVirtualToPhysicalAffineMaps(
+          rewriter.getContext(), TensorMemoryLayout::WidthSharded, physicalGrid);
+
+  // One tile (32x32) per device, width-sharded on core (0,0) in L1. The
+  // fused kernel writes partial RMS statistics here and exchanges them
+  // across devices via the all-gather.
+  SmallVector<int64_t> statsGridShape = {1, 1};
+  auto statsGrid = ttcore::GridAttr::get(rewriter.getContext(), statsGridShape,
+                                         virtToPhysicalMap, physicalToVirtMap);
+  auto statsMemLayoutAttr = TensorMemoryLayoutAttr::get(
+      rewriter.getContext(), TensorMemoryLayout::WidthSharded);
+
+  SmallVector<int64_t> statsShape = {1, 1, 32, 32};
+  TTNNLayoutAttr statsLayout = TTNNLayoutAttr::get(
+      rewriter.getContext(), statsShape, ttcore::TileType::get(statsElementType),
+      BufferType::L1, statsGrid, statsMemLayoutAttr);
+
+  auto statsShapeAttr = ShapeAttr::get(rewriter.getContext(), statsShape);
+  auto statsDtypeAttr =
+      ttcore::DataTypeAttr::get(rewriter.getContext(), statsDataType);
+  auto statsLayoutAttr = LayoutAttr::get(rewriter.getContext(), Layout::Tile);
+  auto statsMemConfig = MemoryConfigAttr::get(statsLayout, statsGrid);
+
+  RankedTensorType statsResultType =
+      RankedTensorType::get(statsShape, statsElementType, statsLayout);
+
+  auto device = utils::getOrInsertDevice(rewriter, *this);
+
+  // Scratch buffer for the fused kernel's all-gather stats.
+  //
+  // Placement: inserted right after GetDeviceOp so it sits in the block
+  //   prelude. Leaving it inline would trip TTNNTraceHoistTransform with
+  //   "Non-hoistable op in the middle of hoistable ops". EmptyOp is a
+  //   host-side allocation and cannot appear inside the trace body: device
+  //   buffer allocations during trace capture are forbidden by tt-metal
+  //   (allocator warns "Allocating device buffers is unsafe due to the
+  //   existence of an active trace"; dispatch-side writes TT_FATAL).
+  //
+  // Runtime behavior under capture_or_execute_trace:
+  //   - First @main call: this EmptyOp result is passed into the trace
+  //     function as an `argument_type<constant>` operand and retained by
+  //     TraceData; the trace records its L1 address.
+  //   - Subsequent @main calls: a fresh EmptyOp result is allocated and gets
+  //     a new TTNNTensorWrapper version (versions are a monotonically
+  //     incrementing global counter). Because the version differs from the
+  //     retained slot's, capture_or_execute_trace performs a
+  //     device->host->device copy into the retained slot before each replay.
+  //     This copy is wasted work on every iteration.
+  //
+  // Why it is correct today: rms_allgather's writer kernel
+  //   (rms_writer.cpp) writes its partial-stats buffer before reading it,
+  //   so whatever the version-mismatch copy left in the slot is overwritten.
+  //
+  // Failure mode if violated: a future consumer of this slot that depends
+  //   on its initial state will be silently corrupted, since the
+  //   version-mismatch path copies uninitialized contents in.
+  //
+  // Proper fix (out of scope here): a dedicated
+  //   `argument_type<persistent_buffer>` that bypasses the version-
+  //   reconciliation path in capture_or_execute_trace.cpp.
+  ttnn::EmptyOp statsEmptyOp;
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfter(device);
+    statsEmptyOp = rewriter.create<ttnn::EmptyOp>(
+        getLoc(), statsResultType, device, statsShapeAttr, statsDtypeAttr,
+        statsLayoutAttr, statsMemConfig);
+  }
+
+  rewriter.modifyOpInPlace(*this, [&]() {
+    getStatsMutable().assign(statsEmptyOp.getResult());
+  });
+}
+
+bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundSemaphores() {
+  return getSemaphore() == nullptr;
+}
+
+void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
+    ::mlir::RewriterBase &rewriter) {
+  if (!hasUnboundSemaphores()) {
+    return;
+  }
+
+  // The fused kernel's global semaphore lives on the bounding box of the
+  // input's actual shard cores, so the semaphore is guaranteed to live on
+  // cores that exist on the device. We read the shard spec from the op's
+  // memory_config attribute, which is populated by the workaround pattern
+  // and may be further refined by the optimizer before this pass runs.
+  MemoryConfigAttr memoryConfig = getMemoryConfigAttr();
+  assert(memoryConfig &&
+         "DistributedRMSNormOp must have a memory_config before semaphore "
+         "allocation; expected the workaround pattern to set it.");
+  std::optional<ShardSpecAttr> inputShardSpec = memoryConfig.getShardSpec();
+  assert(inputShardSpec.has_value() &&
+         "DistributedRMSNormOp memory_config must have a shard spec for "
+         "semaphore core range derivation.");
+  std::optional<CoreRangeAttr> semaphoreCoreRange =
+      inputShardSpec->getCoreRangeSet().getBoundingBox();
+  assert(semaphoreCoreRange.has_value() &&
+         "shard spec must have at least one core range");
+
+  auto device = utils::getOrInsertDevice(rewriter, *this);
+
+  // Global semaphore for the fused kernel's all-gather.
+  //
+  // Placement: same prelude position as the buffer allocation, for the
+  //   same reasons. CreateGlobalSemaphoreOp is a host-side allocation and
+  //   TTNNTraceHoistTransform requires a contiguous block of hoistable ops.
+  //
+  // Cross-replay reset is the kernel's responsibility: rms_writer.cpp resets
+  //   `out_ready_sem_bank_addr_ptr` to 0 via on-device `noc_semaphore_set`.
+  //   That on-device write is recorded into the trace and runs every replay.
+  //
+  // Why we cannot insert `ttnn.reset_global_semaphore` instead:
+  //   - In the trace body: forbidden. Its runtime impl calls
+  //     `EnqueueWriteMeshBuffer` (host-mediated, blocking), which TT_FATALs
+  //     during capture (fd_mesh_command_queue.cpp: "Writes are not supported
+  //     during trace capture").
+  //   - In the prelude: would only run on the first @main call (during
+  //     capture), not between replays. Does not solve cross-replay state
+  //     leakage.
+  //   - In the postlude (after capture_or_execute_trace): would force a
+  //     blocking host sync on every call, defeating the purpose of trace.
+  //
+  // Failure mode if violated: if a future CCL kernel reused through this
+  //   rewrite does NOT reset its global semaphore, trace replays from the
+  //   second iteration onwards will see the leftover value from the previous
+  //   replay. Waits-for-N pass immediately, before any cores have done their
+  //   work, producing silent wrong outputs.
+  ttnn::CreateGlobalSemaphoreOp semaphoreOp;
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfter(device);
+    semaphoreOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
+        getLoc(), GlobalSemaphoreType::get(rewriter.getContext()),
+        /*initial_value=*/rewriter.getUI32IntegerAttr(0), *semaphoreCoreRange);
+  }
+
+  rewriter.modifyOpInPlace(*this, [&]() {
+    getSemaphoreMutable().assign(semaphoreOp.getResult());
+  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3129,6 +3129,7 @@ bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundBuffers() {
   return !getStats();
 }
 
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
     ::mlir::RewriterBase &rewriter) {
   if (!hasUnboundBuffers()) {
@@ -3199,11 +3200,13 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
   rewriter.modifyOpInPlace(
       *this, [&]() { getStatsMutable().assign(statsEmptyOp.getResult()); });
 }
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
 
 bool mlir::tt::ttnn::DistributedRMSNormOp::hasUnboundSemaphores() {
   return !getSemaphore();
 }
 
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
     ::mlir::RewriterBase &rewriter) {
   if (!hasUnboundSemaphores()) {
@@ -3245,6 +3248,7 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
   rewriter.modifyOpInPlace(
       *this, [&]() { getSemaphoreMutable().assign(semaphoreOp.getResult()); });
 }
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
 
 //===----------------------------------------------------------------------===//
 // RMSNormPreAllGatherOp

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4596,12 +4596,15 @@ void CaptureOrExecuteTraceOp::getEffects(
   }
 
   // Verify that the input arguments to this op match the capture_callee
-  // function's arguments
+  // function's arguments.
   auto captureInputTypes = captureFuncOp.getFunctionType().getInputs();
   auto opInputs = this->getInputs();
+  auto opSemaphoreInputs = this->getSemaphoreInputs();
+  size_t expectedCaptureInputs = opInputs.size() + opSemaphoreInputs.size();
 
-  if (captureInputTypes.size() != opInputs.size()) {
-    return emitOpError() << "Number of input arguments (" << opInputs.size()
+  if (captureInputTypes.size() != expectedCaptureInputs) {
+    return emitOpError() << "Number of input arguments ("
+                         << expectedCaptureInputs
                          << ") does not match capture function '"
                          << captureCalleeAttr.getValue() << "' input count ("
                          << captureInputTypes.size() << ")";
@@ -4613,6 +4616,17 @@ void CaptureOrExecuteTraceOp::getEffects(
                            << "expected " << captureInputTypes[i]
                            << " from capture function, but got "
                            << opInputs[i].getType();
+    }
+  }
+
+  for (size_t i = 0; i < opSemaphoreInputs.size(); ++i) {
+    size_t captureIdx = opInputs.size() + i;
+    if (opSemaphoreInputs[i].getType() != captureInputTypes[captureIdx]) {
+      return emitOpError() << "Semaphore input argument " << i
+                           << " type mismatch: "
+                           << "expected " << captureInputTypes[captureIdx]
+                           << " from capture function, but got "
+                           << opSemaphoreInputs[i].getType();
     }
   }
 
@@ -4654,9 +4668,12 @@ void CaptureOrExecuteTraceOp::getEffects(
   }
 
   for (BlockArgument arg : traceFuncOp.getArguments()) {
+    if (::mlir::isa<ttnn::GlobalSemaphoreType>(arg.getType())) {
+      continue;
+    }
     if (!::mlir::isa<RankedTensorType>(arg.getType())) {
       return emitOpError() << "All input arguments of trace function must be "
-                           << "ranked tensors";
+                           << "ranked tensors or global semaphores";
     }
     auto tensorType = ::mlir::cast<RankedTensorType>(arg.getType());
     if (!utils::isTensorOnDevice(tensorType)) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4603,11 +4603,12 @@ void CaptureOrExecuteTraceOp::getEffects(
   size_t expectedCaptureInputs = opInputs.size() + opSemaphoreInputs.size();
 
   if (captureInputTypes.size() != expectedCaptureInputs) {
-    return emitOpError() << "Number of input arguments ("
-                         << expectedCaptureInputs
-                         << ") does not match capture function '"
-                         << captureCalleeAttr.getValue() << "' input count ("
-                         << captureInputTypes.size() << ")";
+    return emitOpError()
+           << "Number of input arguments (inputs + semaphore_inputs = "
+           << opInputs.size() << " + " << opSemaphoreInputs.size() << " = "
+           << expectedCaptureInputs << ") does not match capture function '"
+           << captureCalleeAttr.getValue() << "' input count ("
+           << captureInputTypes.size() << ")";
   }
 
   for (size_t i = 0; i < opInputs.size(); ++i) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3151,26 +3151,27 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
   ttcore::DataType statsDataType =
       fp32DestAccEn ? ttcore::DataType::Float32 : ttcore::DataType::BFloat16;
 
-  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(*this);
-
   // One tile (32x32) per device, width-sharded on core (0,0) in L1. The fused
-  // kernel writes partial RMS statistics here and exchanges them across
-  // devices via the all-gather.
+  // kernel hard-requires core (0,0), so spell the placement out explicitly
+  // rather than relying on canonical placement.
+  MLIRContext *ctx = rewriter.getContext();
   SmallVector<int64_t> statsShape = {1, 1, 32, 32};
   SmallVector<int64_t> statsGridShape = {1, 1};
+  CoreRangeSetAttr statsCoreRangeSet = CoreRangeSetAttr::get(
+      ctx, CoreRangeAttr::get(ctx, CoreCoordAttr::get(ctx, 0, 0),
+                              CoreCoordAttr::get(ctx, 0, 0)));
   TTNNLayoutAttr statsLayout =
-      TTNNLayoutAttr::Builder(rewriter.getContext(), statsShape,
+      TTNNLayoutAttr::Builder(ctx, statsShape,
                               ttcore::TileType::get(statsElementType))
           .setBufferType(BufferType::L1)
           .setMemoryLayout(TensorMemoryLayout::WidthSharded)
           .setGridShape(statsGridShape)
-          .buildWithCanonicalCorePlacement(deviceAttr);
+          .setCoreRangeSet(statsCoreRangeSet)
+          .build();
 
-  auto statsShapeAttr = ShapeAttr::get(rewriter.getContext(), statsShape);
-  auto statsDtypeAttr =
-      ttcore::DataTypeAttr::get(rewriter.getContext(), statsDataType);
-  auto statsLayoutAttr = LayoutAttr::get(rewriter.getContext(), Layout::Tile);
-  auto statsMemConfig = MemoryConfigAttr::get(statsLayout);
+  auto statsShapeAttr = ShapeAttr::get(ctx, statsShape);
+  auto statsDtypeAttr = ttcore::DataTypeAttr::get(ctx, statsDataType);
+  auto statsLayoutAttr = LayoutAttr::get(ctx, Layout::Tile);
 
   RankedTensorType statsResultType =
       RankedTensorType::get(statsShape, statsElementType, statsLayout);
@@ -3186,7 +3187,7 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateBuffers(
     rewriter.setInsertionPointAfter(device);
     statsEmptyOp = rewriter.create<ttnn::EmptyOp>(
         getLoc(), statsResultType, device, statsShapeAttr, statsDtypeAttr,
-        statsLayoutAttr, statsMemConfig);
+        statsLayoutAttr);
   }
 
   rewriter.modifyOpInPlace(

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -613,6 +613,31 @@ bool CoreRangeAttr::intersects(CoreRangeAttr other) const {
   return ::llvm::success();
 }
 
+std::optional<CoreRangeAttr> CoreRangeSetAttr::getBoundingBox() const {
+  llvm::ArrayRef<CoreRangeAttr> coreRanges = getCoreRanges();
+  if (coreRanges.empty()) {
+    return std::nullopt;
+  }
+
+  CoreCoordAttr firstStart = coreRanges.front().getStartCoord();
+  CoreCoordAttr firstEnd = coreRanges.front().getEndCoord();
+  uint64_t minStartX = firstStart.getX();
+  uint64_t minStartY = firstStart.getY();
+  uint64_t maxEndX = firstEnd.getX();
+  uint64_t maxEndY = firstEnd.getY();
+  for (CoreRangeAttr range : coreRanges.drop_front()) {
+    minStartX = std::min(minStartX, range.getStartCoord().getX());
+    minStartY = std::min(minStartY, range.getStartCoord().getY());
+    maxEndX = std::max(maxEndX, range.getEndCoord().getX());
+    maxEndY = std::max(maxEndY, range.getEndCoord().getY());
+  }
+
+  MLIRContext *context = getContext();
+  return CoreRangeAttr::get(context,
+                            CoreCoordAttr::get(context, minStartX, minStartY),
+                            CoreCoordAttr::get(context, maxEndX, maxEndY));
+}
+
 ::llvm::LogicalResult CoreRangeSetAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     llvm::ArrayRef<mlir::tt::ttnn::CoreRangeAttr> coreRanges) {

--- a/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRTTNNInterfaces
+  TTNNDistributedOpInterface.cpp
   TTNNDeviceOperandInterface.cpp
   TTNNOpModelInterface.cpp
   TTNNTensorSpecInterface.cpp
@@ -10,6 +11,7 @@ add_mlir_library(MLIRTTNNInterfaces
   ${PROJECT_SOURCE_DIR}/include/ttmlir
 
   DEPENDS
+  MLIRTTNNDistributedOpInterfaceIncGen
   MLIRTTNNDeviceOperandInterfaceIncGen
   MLIRTTNNOpModelInterfaceIncGen
   MLIRTTNNTensorSpecInterfaceIncGen

--- a/lib/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h"
+
+namespace mlir::tt::ttnn {
+#define GET_OP_CLASSES
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.cpp.inc"
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -441,11 +441,8 @@ void createTTIRToTTNNCommonPipeline(
 
     // Bind distributed-op semaphores after the optimizer (core range derives
     // from the finalized input shard spec) and before trace hoisting (SSA
-    // values must be visible at the trace boundary). The CSE that follows
-    // folds identical create_global_semaphore ops across multiple distributed
-    // ops; on-device kernel reset makes sharing safe.
+    // values must be visible at the trace boundary).
     devicePm.addPass(createTTNNAllocateDistributedOpSemaphores());
-    devicePm.addPass(mlir::createCSEPass());
 
     // Trace hoisting must run before layout decomposition because it adjusts
     // layouts of function arguments (e.g. moving inputs to system_memory). It

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -242,6 +242,13 @@ void createTTNNPipelineWorkaroundPass(
   workaroundOptions.optimizationLevel = options.optimizationLevel;
 
   pm.addPass(createTTNNWorkarounds(workaroundOptions));
+
+  // Bind scratch / persistent buffers for distributed ops (e.g. the stats
+  // EmptyOp for distributed_rms_norm) right after the workaround that creates
+  // them in the IR, so the canonicalize + CSE below can deduplicate identical
+  // EmptyOps across multiple distributed ops with matching shape/dtype/layout.
+  pm.addPass(createTTNNAllocateDistributedOpBuffers());
+
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
 }
@@ -432,6 +439,13 @@ void createTTIRToTTNNCommonPipeline(
         devicePm.addPass(mlir::createCanonicalizerPass());
       }
     }
+
+    // Allocate global semaphores for distributed ops (e.g.
+    // distributed_rms_norm) after the optimizer so the semaphore core range
+    // is derived from the finalized input shard spec. Must run before trace
+    // hoisting so the semaphore SSA values are visible at the trace
+    // boundary and get treated as pass-through handles.
+    devicePm.addPass(createTTNNAllocateDistributedOpSemaphores());
 
     // Trace hoisting must run before layout decomposition because it adjusts
     // layouts of function arguments (e.g. moving inputs to system_memory). It

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -447,6 +447,12 @@ void createTTIRToTTNNCommonPipeline(
     // boundary and get treated as pass-through handles.
     devicePm.addPass(createTTNNAllocateDistributedOpSemaphores());
 
+    // CSE folds identical create_global_semaphore ops produced by the
+    // allocator across multiple distributed ops with matching core range
+    // and initial value (kernel design guarantees on-device reset, so
+    // sharing is safe).
+    devicePm.addPass(mlir::createCSEPass());
+
     // Trace hoisting must run before layout decomposition because it adjusts
     // layouts of function arguments (e.g. moving inputs to system_memory). It
     // is much easier to work at the layout abstraction level than on individual

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -243,10 +243,9 @@ void createTTNNPipelineWorkaroundPass(
 
   pm.addPass(createTTNNWorkarounds(workaroundOptions));
 
-  // Bind scratch / persistent buffers for distributed ops (e.g. the stats
-  // EmptyOp for distributed_rms_norm) right after the workaround that creates
-  // them in the IR, so the canonicalize + CSE below can deduplicate identical
-  // EmptyOps across multiple distributed ops with matching shape/dtype/layout.
+  // Bind distributed-op scratch buffers before the optimizer so they
+  // contribute to L1 budgeting; the canonicalize + CSE below dedupe matching
+  // EmptyOps across multiple distributed ops.
   pm.addPass(createTTNNAllocateDistributedOpBuffers());
 
   pm.addPass(mlir::createCanonicalizerPass());
@@ -440,17 +439,12 @@ void createTTIRToTTNNCommonPipeline(
       }
     }
 
-    // Allocate global semaphores for distributed ops (e.g.
-    // distributed_rms_norm) after the optimizer so the semaphore core range
-    // is derived from the finalized input shard spec. Must run before trace
-    // hoisting so the semaphore SSA values are visible at the trace
-    // boundary and get treated as pass-through handles.
+    // Bind distributed-op semaphores after the optimizer (core range derives
+    // from the finalized input shard spec) and before trace hoisting (SSA
+    // values must be visible at the trace boundary). The CSE that follows
+    // folds identical create_global_semaphore ops across multiple distributed
+    // ops; on-device kernel reset makes sharing safe.
     devicePm.addPass(createTTNNAllocateDistributedOpSemaphores());
-
-    // CSE folds identical create_global_semaphore ops produced by the
-    // allocator across multiple distributed ops with matching core range
-    // and initial value (kernel design guarantees on-device reset, so
-    // sharing is safe).
     devicePm.addPass(mlir::createCSEPass());
 
     // Trace hoisting must run before layout decomposition because it adjusts

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -16,6 +16,8 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         OptimizerPasses/RowMajorLayoutPropagation.cpp
         OptimizerPasses/TTNNPrepareConv2dWeightsAndBias.cpp
         TTNNAdjustDeallocs.cpp
+        TTNNAllocateDistributedOpBuffers.cpp
+        TTNNAllocateDistributedOpSemaphores.cpp
         TTNNCollaspeD2M.cpp
         TTNNCollectPerfMetrics.cpp
         TTNNCreateD2MSubgraphs.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -118,8 +118,8 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
       auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
           loc, resultType, op.getInput(), reshapedWeight, op.getResidual(),
           op.getStats(), op.getSemaphore(), op.getDevice(), op.getClusterAxis(),
-          op.getEpsilon(), op.getSubDeviceIdAttr(), op.getMemoryConfigAttr(),
-          op.getNumLinksAttr(), op.getTopologyAttr(), op.getComputeConfigAttr(),
+          op.getEpsilon(), op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
+          op.getTopologyAttr(), op.getComputeConfigAttr(),
           op.getProgramConfigAttr());
       rewriter.replaceOp(op, newOp.getResult());
       return success();
@@ -151,8 +151,8 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
         loc, canonicalResultType, reshapedInput, reshapedWeight,
         reshapedResidual, op.getStats(), op.getSemaphore(), op.getDevice(),
         op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
-        op.getNumLinksAttr(), op.getTopologyAttr(),
-        op.getComputeConfigAttr(), op.getProgramConfigAttr());
+        op.getNumLinksAttr(), op.getTopologyAttr(), op.getComputeConfigAttr(),
+        op.getProgramConfigAttr());
 
     mlir::Value reshapedResult =
         ttir_to_ttnn::utils::generateReshape(

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -46,6 +46,46 @@ bool isAlreadyCanonicalShape(ArrayRef<int64_t> shape) {
   return shape.size() == 4 && shape[0] == 1 && shape[1] == 1;
 }
 
+mlir::Value reshapeTo(PatternRewriter &rewriter, Location loc, mlir::Value v,
+                      ArrayRef<int64_t> targetShape) {
+  auto srcType = mlir::cast<RankedTensorType>(v.getType());
+  RankedTensorType targetType =
+      utils::RankedTensorTypeFactory::create(srcType, targetShape);
+  SmallVector<int32_t> targetShapeI32(targetShape.begin(), targetShape.end());
+  return rewriter
+      .create<ttnn::ReshapeOp>(loc, targetType, v,
+                               rewriter.getI32ArrayAttr(targetShapeI32))
+      .getResult();
+}
+
+// The fused_rms_minimal kernel requires the weight (gamma) tensor to be
+// 2D with width equal to tile_width (32). If the weight is still 1D (N,),
+// reshape it to (N/32, 32). The Tile -> RowMajor layout conversion is
+// handled separately by the layout/sharding workaround pattern.
+//
+// Returns the (possibly new) weight value, or the original value if no
+// reshape is needed.
+constexpr int64_t kTileWidth = 32;
+
+mlir::Value maybeReshapeWeightToTileWidth(PatternRewriter &rewriter,
+                                          Location loc, mlir::Value weight) {
+  if (!weight) {
+    return weight;
+  }
+  auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+  if (weightType.getRank() != 1) {
+    return weight;
+  }
+  int64_t totalElements = weightType.getShape()[0];
+  if (totalElements % kTileWidth != 0) {
+    // Cannot reshape to (N/32, 32) cleanly; leave as-is and let downstream
+    // verification surface the error.
+    return weight;
+  }
+  SmallVector<int64_t> reshapedShape = {totalElements / kTileWidth, kTileWidth};
+  return reshapeTo(rewriter, loc, weight, reshapedShape);
+}
+
 } // namespace
 
 LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
@@ -58,14 +98,35 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   ArrayRef<int64_t> inputShape = inputType.getShape();
 
   if (isEligibleForFusedKernel(op)) {
+    Location loc = op.getLoc();
+
+    // The fused kernel requires the weight in (N/32, 32) form. Reshape
+    // here, alongside the input reshape, so that all kernel-shape prep
+    // happens in one place. The Tile -> RowMajor layout conversion stays
+    // in the workaround pattern (it is a layout change, not a shape one).
+    mlir::Value reshapedWeight =
+        maybeReshapeWeightToTileWidth(rewriter, loc, op.getWeight());
+
     if (isAlreadyCanonicalShape(inputShape)) {
-      // Already (1,1,32,M) - the fused kernel handles this directly.
-      return failure();
+      if (reshapedWeight == op.getWeight()) {
+        // Already (1,1,32,M) and weight already in tile-width form — the
+        // fused kernel handles this directly.
+        return failure();
+      }
+      // Input is canonical but weight needed reshaping: rebuild the op
+      // with the new weight and forward all other operands/attrs through.
+      auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
+          loc, resultType, op.getInput(), reshapedWeight, op.getResidual(),
+          op.getStats(), op.getSemaphore(), op.getDevice(),
+          op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
+          op.getMemoryConfigAttr(), op.getNumLinksAttr(), op.getTopologyAttr(),
+          op.getComputeConfigAttr(), op.getProgramConfigAttr());
+      rewriter.replaceOp(op, newOp.getResult());
+      return success();
     }
 
     // Reshape to canonical (1,1,32,M), forward to the fused kernel, then
     // reshape the result back to the original shape.
-    Location loc = op.getLoc();
     SmallVector<int64_t> canonicalShape = {1, 1, 32, inputShape.back()};
 
     mlir::Value reshapedInput =
@@ -87,7 +148,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
         utils::RankedTensorTypeFactory::create(resultType, canonicalShape);
 
     auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
-        loc, canonicalResultType, reshapedInput, op.getWeight(),
+        loc, canonicalResultType, reshapedInput, reshapedWeight,
         reshapedResidual, op.getStats(), op.getSemaphore(), op.getDevice(),
         op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
         op.getNumLinksAttr(), op.getTopologyAttr(),

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -6,6 +6,8 @@
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
@@ -65,8 +67,6 @@ mlir::Value reshapeTo(PatternRewriter &rewriter, Location loc, mlir::Value v,
 //
 // Returns the (possibly new) weight value, or the original value if no
 // reshape is needed.
-constexpr int64_t kTileWidth = 32;
-
 mlir::Value maybeReshapeWeightToTileWidth(PatternRewriter &rewriter,
                                           Location loc, mlir::Value weight) {
   if (!weight) {
@@ -77,12 +77,12 @@ mlir::Value maybeReshapeWeightToTileWidth(PatternRewriter &rewriter,
     return weight;
   }
   int64_t totalElements = weightType.getShape()[0];
-  if (totalElements % kTileWidth != 0) {
+  if (totalElements % TILE_WIDTH != 0) {
     // Cannot reshape to (N/32, 32) cleanly; leave as-is and let downstream
     // verification surface the error.
     return weight;
   }
-  SmallVector<int64_t> reshapedShape = {totalElements / kTileWidth, kTileWidth};
+  SmallVector<int64_t> reshapedShape = {totalElements / TILE_WIDTH, TILE_WIDTH};
   return reshapeTo(rewriter, loc, weight, reshapedShape);
 }
 
@@ -117,10 +117,10 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
       // with the new weight and forward all other operands/attrs through.
       auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
           loc, resultType, op.getInput(), reshapedWeight, op.getResidual(),
-          op.getStats(), op.getSemaphore(), op.getDevice(),
-          op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
-          op.getMemoryConfigAttr(), op.getNumLinksAttr(), op.getTopologyAttr(),
-          op.getComputeConfigAttr(), op.getProgramConfigAttr());
+          op.getStats(), op.getSemaphore(), op.getDevice(), op.getClusterAxis(),
+          op.getEpsilon(), op.getSubDeviceIdAttr(), op.getMemoryConfigAttr(),
+          op.getNumLinksAttr(), op.getTopologyAttr(), op.getComputeConfigAttr(),
+          op.getProgramConfigAttr());
       rewriter.replaceOp(op, newOp.getResult());
       return success();
     }

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -88,10 +88,10 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
     auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
         loc, canonicalResultType, reshapedInput, op.getWeight(),
-        reshapedResidual, op.getStats(), op.getDevice(), op.getClusterAxis(),
-        op.getEpsilon(), op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
-        op.getTopologyAttr(), op.getComputeConfigAttr(),
-        op.getProgramConfigAttr());
+        reshapedResidual, op.getStats(), op.getSemaphore(), op.getDevice(),
+        op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
+        op.getNumLinksAttr(), op.getTopologyAttr(),
+        op.getComputeConfigAttr(), op.getProgramConfigAttr());
 
     mlir::Value reshapedResult =
         ttir_to_ttnn::utils::generateReshape(

--- a/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn {
+
+#define GEN_PASS_DEF_TTNNALLOCATEDISTRIBUTEDOPBUFFERS
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+// Allocates explicit scratch / persistent buffers for distributed ops that
+// implement DistributedOpInterface. Runs before the optimizer so the
+// allocated EmptyOps are visible to L1 budgeting analyses.
+//
+// The interface implementation owns the allocation logic (shape, dtype,
+// layout, prelude placement). This pass only walks the IR and dispatches.
+class TTNNAllocateDistributedOpBuffers
+    : public impl::TTNNAllocateDistributedOpBuffersBase<
+          TTNNAllocateDistributedOpBuffers> {
+public:
+  using impl::TTNNAllocateDistributedOpBuffersBase<
+      TTNNAllocateDistributedOpBuffers>::TTNNAllocateDistributedOpBuffersBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    moduleOp.walk([&](DistributedOpInterface op) {
+      if (op.hasUnboundBuffers()) {
+        op.allocateBuffers(rewriter);
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
@@ -15,12 +15,8 @@ namespace mlir::tt::ttnn {
 
 namespace {
 
-// Allocates explicit scratch / persistent buffers for distributed ops that
-// implement DistributedOpInterface. Runs before the optimizer so the
-// allocated EmptyOps are visible to L1 budgeting analyses.
-//
-// The interface implementation owns the allocation logic (shape, dtype,
-// layout, prelude placement). This pass only walks the IR and dispatches.
+// Walks every DistributedOpInterface op and invokes allocateBuffers. The
+// interface implementation owns the allocation logic and is idempotent.
 class TTNNAllocateDistributedOpBuffers
     : public impl::TTNNAllocateDistributedOpBuffersBase<
           TTNNAllocateDistributedOpBuffers> {
@@ -32,11 +28,8 @@ public:
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
 
-    moduleOp.walk([&](DistributedOpInterface op) {
-      if (op.hasUnboundBuffers()) {
-        op.allocateBuffers(rewriter);
-      }
-    });
+    moduleOp.walk(
+        [&](DistributedOpInterface op) { op.allocateBuffers(rewriter); });
   }
 };
 

--- a/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpSemaphores.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpSemaphores.cpp
@@ -15,13 +15,8 @@ namespace mlir::tt::ttnn {
 
 namespace {
 
-// Allocates explicit global semaphores for distributed ops that implement
-// DistributedOpInterface. Runs after the optimizer so semaphore core ranges
-// are derived from the finalized input shard spec.
-//
-// The interface implementation owns the allocation logic (core range,
-// initial value, prelude placement). This pass only walks the IR and
-// dispatches.
+// Walks every DistributedOpInterface op and invokes allocateSemaphores. The
+// interface implementation owns the allocation logic and is idempotent.
 class TTNNAllocateDistributedOpSemaphores
     : public impl::TTNNAllocateDistributedOpSemaphoresBase<
           TTNNAllocateDistributedOpSemaphores> {
@@ -34,11 +29,8 @@ public:
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
 
-    moduleOp.walk([&](DistributedOpInterface op) {
-      if (op.hasUnboundSemaphores()) {
-        op.allocateSemaphores(rewriter);
-      }
-    });
+    moduleOp.walk(
+        [&](DistributedOpInterface op) { op.allocateSemaphores(rewriter); });
   }
 };
 

--- a/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpSemaphores.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpSemaphores.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn {
+
+#define GEN_PASS_DEF_TTNNALLOCATEDISTRIBUTEDOPSEMAPHORES
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+// Allocates explicit global semaphores for distributed ops that implement
+// DistributedOpInterface. Runs after the optimizer so semaphore core ranges
+// are derived from the finalized input shard spec.
+//
+// The interface implementation owns the allocation logic (core range,
+// initial value, prelude placement). This pass only walks the IR and
+// dispatches.
+class TTNNAllocateDistributedOpSemaphores
+    : public impl::TTNNAllocateDistributedOpSemaphoresBase<
+          TTNNAllocateDistributedOpSemaphores> {
+public:
+  using impl::TTNNAllocateDistributedOpSemaphoresBase<
+      TTNNAllocateDistributedOpSemaphores>::
+      TTNNAllocateDistributedOpSemaphoresBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    moduleOp.walk([&](DistributedOpInterface op) {
+      if (op.hasUnboundSemaphores()) {
+        op.allocateSemaphores(rewriter);
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -22,6 +22,21 @@ namespace mlir::tt::ttnn {
 
 using TraceSmallString = llvm::SmallString<64>;
 
+namespace {
+// GlobalSemaphore values are pass-through handles into the trace wrapper:
+// they are part of the trace function signature so device kernels can use
+// them, but they have no host-side representation, no persistent device
+// slot, and no host-to-device transfer. Their position in the wrapper
+// signature is fixed at the end (after all tensor inputs) so the runtime
+// program signature matches.
+inline bool isSemaphoreType(mlir::Type type) {
+  return ::mlir::isa<ttnn::GlobalSemaphoreType>(type);
+}
+inline bool isSemaphoreValue(mlir::Value value) {
+  return isSemaphoreType(value.getType());
+}
+} // namespace
+
 class TTNNTraceHoistTransform
     : public impl::TTNNTraceHoistTransformBase<TTNNTraceHoistTransform> {
 public:
@@ -143,8 +158,8 @@ private:
     // Collect inputs: operands that come from outside the operation set
     for (Operation *op : opsToHoist) {
       for (auto operand : op->getOperands()) {
-        if (!::mlir::isa<RankedTensorType, ttnn::GlobalSemaphoreType>(
-                operand.getType())) {
+        if (!::mlir::isa<RankedTensorType>(operand.getType()) &&
+            !isSemaphoreValue(operand)) {
           continue;
         }
         Operation *definingOp = operand.getDefiningOp();
@@ -159,8 +174,8 @@ private:
     llvm::sort(inputs.begin(), inputs.end(), [](mlir::Value a, mlir::Value b) {
       // Tensors before semaphores; capture/execute op operand groups and the
       // runtime program signature follow this layout.
-      bool aIsSemaphore = ::mlir::isa<ttnn::GlobalSemaphoreType>(a.getType());
-      bool bIsSemaphore = ::mlir::isa<ttnn::GlobalSemaphoreType>(b.getType());
+      bool aIsSemaphore = isSemaphoreValue(a);
+      bool bIsSemaphore = isSemaphoreValue(b);
       if (aIsSemaphore != bIsSemaphore) {
         return !aIsSemaphore;
       }
@@ -373,9 +388,7 @@ private:
     for (size_t i = 0; i < traceFunc.getNumArguments(); i++) {
       mlir::Value traceFuncArg = traceFunc.getArgument(i);
 
-      // Semaphores are pass-through handles, not tensors. They go through the
-      // wrapper signature but have no persistent slot.
-      if (::mlir::isa<ttnn::GlobalSemaphoreType>(traceFuncArg.getType())) {
+      if (isSemaphoreValue(traceFuncArg)) {
         inputTypes.push_back(traceFuncArg.getType());
         continue;
       }
@@ -477,7 +490,7 @@ private:
     for (size_t i = 0; i < runAndCaptureTraceFunc.getNumArguments(); i++) {
       mlir::Value funcArg = runAndCaptureTraceFunc.getArgument(i);
 
-      if (::mlir::isa<ttnn::GlobalSemaphoreType>(funcArg.getType())) {
+      if (isSemaphoreValue(funcArg)) {
         traceCallArgs.push_back(funcArg);
         continue;
       }
@@ -810,15 +823,15 @@ private:
 
     auto device = utils::getOrInsertDevice(rewriter, firstOp);
 
-    // Convert inputs to match capture function signature.
-    llvm::SmallVector<mlir::Value> captureOrExecuteTraceOpTensorInputs;
-    llvm::SmallVector<mlir::Value> captureOrExecuteTraceOpSemaphoreInputs;
+    // Split inputs into the two operand groups expected by the op.
+    llvm::SmallVector<mlir::Value> tensorInputs;
+    llvm::SmallVector<mlir::Value> semaphoreInputs;
 
     for (size_t i = 0; i < inputs.size(); i++) {
       mlir::Value input = inputs[i];
 
-      if (::mlir::isa<ttnn::GlobalSemaphoreType>(input.getType())) {
-        captureOrExecuteTraceOpSemaphoreInputs.push_back(input);
+      if (isSemaphoreValue(input)) {
+        semaphoreInputs.push_back(input);
         continue;
       }
 
@@ -844,7 +857,7 @@ private:
               "Device-resident input must be on device, but found on "
               "system memory");
         }
-        captureOrExecuteTraceOpTensorInputs.push_back(input);
+        tensorInputs.push_back(input);
       }
       // For inputs, convert them to system memory/row major if needed
       else if (layout.getBufferType() != ttnn::BufferType::SystemMemory) {
@@ -857,17 +870,16 @@ private:
             funcOp.getLoc(), systemMemoryTileType, input,
             /*layout=*/LayoutAttr::get(context, layout.getLayout()),
             /*dtype=*/ttcore::DataTypeAttr::get(context, layout.getDataType()));
-        captureOrExecuteTraceOpTensorInputs.push_back(toLayoutOp.getResult());
+        tensorInputs.push_back(toLayoutOp.getResult());
       } else {
         // Already on system memory
-        captureOrExecuteTraceOpTensorInputs.push_back(input);
+        tensorInputs.push_back(input);
       }
     }
 
     auto traceOp = builder.create<ttnn::CaptureOrExecuteTraceOp>(
         funcOp.getLoc(), outputTypes, device, captureTraceSymbolAttr,
-        executeTraceSymbolAttr, captureOrExecuteTraceOpTensorInputs,
-        captureOrExecuteTraceOpSemaphoreInputs);
+        executeTraceSymbolAttr, tensorInputs, semaphoreInputs);
 
     // Replace uses of original outputs with the output of the trace op function
     for (size_t i = 0; i < outputs.size(); i++) {

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -491,7 +491,8 @@ private:
       // Regular inputs need device memory allocation for host-to-device
       // transfer. Create empty tensors on device that will serve as persistent
       // slots for trace input data during capture and replay.
-      mlir::Type traceInputSlotType = traceInputSlotTypes[traceInputSlots.size()];
+      mlir::Type traceInputSlotType =
+          traceInputSlotTypes[traceInputSlots.size()];
 
       RankedTensorType deviceTensorType =
           mlir::cast<RankedTensorType>(traceInputSlotType);
@@ -822,8 +823,8 @@ private:
       }
 
       if (!mlir::isa<RankedTensorType>(input.getType())) {
-        captureOrExecuteTraceOpTensorInputs.push_back(input);
-        continue;
+        return funcOp.emitError(
+            "Trace input must be a ranked tensor or global semaphore");
       }
 
       // Check if this value should remain on device during trace capture.

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -129,7 +129,8 @@ private:
     return false;
   }
 
-  // Collect all inputs and outputs outside the operation set to hoist
+  // Collect all inputs and outputs outside the operation set to hoist.
+  // Tensor inputs come first, followed by semaphore inputs.
   void collectFunctionBoundary(llvm::ArrayRef<Operation *> opsToHoist,
                                llvm::SmallVector<mlir::Value> &inputs,
                                llvm::SmallVector<mlir::Value> &outputs) {
@@ -142,7 +143,8 @@ private:
     // Collect inputs: operands that come from outside the operation set
     for (Operation *op : opsToHoist) {
       for (auto operand : op->getOperands()) {
-        if (!::mlir::isa<RankedTensorType>(operand.getType())) {
+        if (!::mlir::isa<RankedTensorType, ttnn::GlobalSemaphoreType>(
+                operand.getType())) {
           continue;
         }
         Operation *definingOp = operand.getDefiningOp();
@@ -155,6 +157,13 @@ private:
     }
 
     llvm::sort(inputs.begin(), inputs.end(), [](mlir::Value a, mlir::Value b) {
+      // Tensors before semaphores; capture/execute op operand groups and the
+      // runtime program signature follow this layout.
+      bool aIsSemaphore = ::mlir::isa<ttnn::GlobalSemaphoreType>(a.getType());
+      bool bIsSemaphore = ::mlir::isa<ttnn::GlobalSemaphoreType>(b.getType());
+      if (aIsSemaphore != bIsSemaphore) {
+        return !aIsSemaphore;
+      }
       // prioritize block arguments
       // this is ok now since we check that the funcOp has only 1 block
       // should be updated if we support multiple blocks in the future
@@ -356,12 +365,20 @@ private:
     // - Regular inputs from host memory that need to be transferred to device
     // - Constants/parameters that are already on device (persisted)
     // - KV cache tensors that are device-native and updated in-place
+    // - Global semaphores: pass-through, no slot, no host staging
     // For each argument, we determine the appropriate input type and slot
     // allocation strategy.
     llvm::SmallVector<mlir::Type> inputTypes;
     llvm::SmallVector<mlir::Type> traceInputSlotTypes;
     for (size_t i = 0; i < traceFunc.getNumArguments(); i++) {
       mlir::Value traceFuncArg = traceFunc.getArgument(i);
+
+      // Semaphores are pass-through handles, not tensors. They go through the
+      // wrapper signature but have no persistent slot.
+      if (::mlir::isa<ttnn::GlobalSemaphoreType>(traceFuncArg.getType())) {
+        inputTypes.push_back(traceFuncArg.getType());
+        continue;
+      }
 
       RankedTensorType originalRankedTensorType =
           mlir::cast<RankedTensorType>(traceFuncArg.getType());
@@ -408,8 +425,8 @@ private:
     // execution.
     outputTypes.push_back(utils::getTraceIdType(context));
 
-    // Trace input slots for all inputs (including constants/parameters and KV
-    // cache) that are persisted on device.
+    // Trace input slots for all tensor inputs (including constants/parameters
+    // and KV cache) that are persisted on device.
     for (mlir::Type traceInputSlotType : traceInputSlotTypes) {
       outputTypes.push_back(traceInputSlotType);
     }
@@ -447,20 +464,34 @@ private:
     auto deviceOp =
         utils::getOrInsertDevice(rewriter, runAndCaptureTraceFuncEntryBlock);
 
-    // Create or reuse trace input slots on device.
-    // - Device-resident args (constants/parameters/KV cache): use directly
-    // - Regular inputs: allocate new empty tensors on device for data transfer
+    // Create or reuse trace input slots on device, and build the operand list
+    // for the inner func.call to the trace function.
+    // - Device-resident tensor args (constants/parameters/KV cache): use
+    //   directly as slots.
+    // - Regular tensor inputs: allocate new empty tensors on device for data
+    //   transfer; these become persistent slots.
+    // - Semaphores: pass-through into the inner call only, not slots.
     llvm::SmallVector<mlir::Value> traceInputSlots;
+    llvm::SmallVector<mlir::Value> traceCallArgs;
+    llvm::SmallVector<std::pair<mlir::Value, mlir::Value>> hostToSlotTransfers;
     for (size_t i = 0; i < runAndCaptureTraceFunc.getNumArguments(); i++) {
+      mlir::Value funcArg = runAndCaptureTraceFunc.getArgument(i);
+
+      if (::mlir::isa<ttnn::GlobalSemaphoreType>(funcArg.getType())) {
+        traceCallArgs.push_back(funcArg);
+        continue;
+      }
+
       if (shouldKeepArgOnDevice(traceFunc, i)) {
-        traceInputSlots.push_back(runAndCaptureTraceFunc.getArgument(i));
+        traceInputSlots.push_back(funcArg);
+        traceCallArgs.push_back(funcArg);
         continue;
       }
 
       // Regular inputs need device memory allocation for host-to-device
       // transfer. Create empty tensors on device that will serve as persistent
       // slots for trace input data during capture and replay.
-      mlir::Type traceInputSlotType = traceInputSlotTypes[i];
+      mlir::Type traceInputSlotType = traceInputSlotTypes[traceInputSlots.size()];
 
       RankedTensorType deviceTensorType =
           mlir::cast<RankedTensorType>(traceInputSlotType);
@@ -474,28 +505,21 @@ private:
           ttnn::LayoutAttr::get(context, ttnnLayoutAttr.getLayout()));
 
       traceInputSlots.push_back(emptyOp.getResult());
+      traceCallArgs.push_back(emptyOp.getResult());
+      hostToSlotTransfers.push_back({funcArg, emptyOp.getResult()});
     }
 
     // Transfer host inputs to their corresponding device slots.
-    // Device-resident arguments are skipped as they're already in place.
-    for (size_t i = 0; i < traceInputSlots.size(); i++) {
-      if (shouldKeepArgOnDevice(traceFunc, i)) {
-        continue;
-      }
-
-      // Copy the input argument from host to the allocated device slot for this
-      // input.
-      mlir::Value input = runAndCaptureTraceFunc.getArgument(i);
-
+    for (auto [hostInput, deviceSlot] : hostToSlotTransfers) {
       builder.create<ttnn::WriteTensorOp>(runAndCaptureTraceFunc.getLoc(),
-                                          input, traceInputSlots[i],
+                                          hostInput, deviceSlot,
                                           /*blocking=*/false, /*cq_id=*/0);
     }
 
     // Execute the trace function once without capture to compile programs and
     // populate program cache.
     builder.create<func::CallOp>(runAndCaptureTraceFunc.getLoc(), traceFunc,
-                                 traceInputSlots);
+                                 traceCallArgs);
 
     // Start capturing the trace.
     auto beginTraceCaptureOp = builder.create<ttnn::BeginTraceCaptureOp>(
@@ -505,7 +529,7 @@ private:
 
     // Execute the trace on device and capture it.
     auto captureTraceCall = builder.create<func::CallOp>(
-        runAndCaptureTraceFunc.getLoc(), traceFunc, traceInputSlots);
+        runAndCaptureTraceFunc.getLoc(), traceFunc, traceCallArgs);
 
     // Complete the trace capture.
     builder.create<ttnn::EndTraceCaptureOp>(runAndCaptureTraceFunc.getLoc(),
@@ -522,7 +546,7 @@ private:
 
     // Return the trace ID for correlation with execution.
     returnValues.push_back(beginTraceCaptureOp.getTraceId());
-    // Return the trace input slots for all inputs (including
+    // Return the trace input slots for all tensor inputs (including
     // constants/parameters and KV cache) that are persisted on device.
     for (mlir::Value inputSlot : traceInputSlots) {
       returnValues.push_back(inputSlot);
@@ -785,13 +809,20 @@ private:
 
     auto device = utils::getOrInsertDevice(rewriter, firstOp);
 
-    // Convert inputs to match capture function signature
-    llvm::SmallVector<mlir::Value> captureOrExecuteTraceOpInputs;
+    // Convert inputs to match capture function signature.
+    llvm::SmallVector<mlir::Value> captureOrExecuteTraceOpTensorInputs;
+    llvm::SmallVector<mlir::Value> captureOrExecuteTraceOpSemaphoreInputs;
 
     for (size_t i = 0; i < inputs.size(); i++) {
       mlir::Value input = inputs[i];
+
+      if (::mlir::isa<ttnn::GlobalSemaphoreType>(input.getType())) {
+        captureOrExecuteTraceOpSemaphoreInputs.push_back(input);
+        continue;
+      }
+
       if (!mlir::isa<RankedTensorType>(input.getType())) {
-        captureOrExecuteTraceOpInputs.push_back(input);
+        captureOrExecuteTraceOpTensorInputs.push_back(input);
         continue;
       }
 
@@ -812,7 +843,7 @@ private:
               "Device-resident input must be on device, but found on "
               "system memory");
         }
-        captureOrExecuteTraceOpInputs.push_back(input);
+        captureOrExecuteTraceOpTensorInputs.push_back(input);
       }
       // For inputs, convert them to system memory/row major if needed
       else if (layout.getBufferType() != ttnn::BufferType::SystemMemory) {
@@ -825,16 +856,17 @@ private:
             funcOp.getLoc(), systemMemoryTileType, input,
             /*layout=*/LayoutAttr::get(context, layout.getLayout()),
             /*dtype=*/ttcore::DataTypeAttr::get(context, layout.getDataType()));
-        captureOrExecuteTraceOpInputs.push_back(toLayoutOp.getResult());
+        captureOrExecuteTraceOpTensorInputs.push_back(toLayoutOp.getResult());
       } else {
         // Already on system memory
-        captureOrExecuteTraceOpInputs.push_back(input);
+        captureOrExecuteTraceOpTensorInputs.push_back(input);
       }
     }
 
     auto traceOp = builder.create<ttnn::CaptureOrExecuteTraceOp>(
         funcOp.getLoc(), outputTypes, device, captureTraceSymbolAttr,
-        executeTraceSymbolAttr, captureOrExecuteTraceOpInputs);
+        executeTraceSymbolAttr, captureOrExecuteTraceOpTensorInputs,
+        captureOrExecuteTraceOpSemaphoreInputs);
 
     // Replace uses of original outputs with the output of the trace op function
     for (size_t i = 0; i < outputs.size(); i++) {

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -193,6 +193,7 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   // shard cores. The semaphore-allocation pass independently derives the
   // semaphore core range from the same shard spec at a later pipeline
   // stage (post-optimizer); see DistributedRMSNormOp::allocateSemaphores.
+  auto inputMemoryConfig = ttnn::MemoryConfigAttr::get(desiredInputLayout);
   std::optional<ttnn::ShardSpecAttr> inputShardSpec =
       inputMemoryConfig.getShardSpec();
   assert(inputShardSpec.has_value() &&
@@ -222,8 +223,8 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
       op.getLoc(), shardedOutputType, inputToLayoutOp.getResult(), weight,
       residual, /*stats=*/nullptr, /*semaphore=*/nullptr, op.getDevice(),
       static_cast<uint32_t>(op.getClusterAxis()), op.getEpsilon(),
-      op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
-      op.getTopologyAttr(), computeConfigAttr, programConfigAttr);
+      op.getSubDeviceIdAttr(), op.getNumLinksAttr(), op.getTopologyAttr(),
+      computeConfigAttr, programConfigAttr);
 
   // If the original output had a different layout (e.g. interleaved DRAM),
   // insert a to_memory_config to convert back.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -11,6 +11,8 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 
+#include <optional>
+
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 // Prepares DistributedRMSNormOp for the tt-metal fused_rms_minimal kernel.
@@ -247,20 +249,34 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   auto scalarShardShape = desiredInputLayout.getScalarShardShape();
   int64_t blockH = scalarShardShape[0] / tileWidth;
   int64_t blockW = scalarShardShape[1] / tileWidth;
-  int64_t gridW = std::min(numCores, physicalGrid[0]);
-  int64_t gridH = (numCores + physicalGrid[0] - 1) / physicalGrid[0];
+
+  // Derive both the kernel's compute grid and the global-semaphore range
+  // from the bounding box of the input's shard cores
+  std::optional<ttnn::ShardSpecAttr> inputShardSpec =
+      inputMemoryConfig.getShardSpec();
+  assert(inputShardSpec.has_value() &&
+         "width-sharded input must have a shard spec");
+  std::optional<ttnn::CoreRangeAttr> semaphoreCoreRange =
+      inputShardSpec->getCoreRangeSet().getBoundingBox();
+  assert(semaphoreCoreRange.has_value() &&
+         "width-sharded input shard spec must have at least one core range");
+  ttnn::CoreCoordAttr boxStart = semaphoreCoreRange->getStartCoord();
+  ttnn::CoreCoordAttr boxEnd = semaphoreCoreRange->getEndCoord();
+
+  // Same as tt-metal GridParams: gs = bbox.end - bbox.start + 1 (inclusive
+  // bounding box of the input shard cores).
+  uint64_t gridW = boxEnd.getX() - boxStart.getX() + 1;
+  uint64_t gridH = boxEnd.getY() - boxStart.getY() + 1;
   auto programConfigAttr =
       ttnn::LayerNormShardedMultiCoreProgramConfigAttr::get(
           rewriter.getContext(),
           ttnn::CoreCoordAttr::get(rewriter.getContext(), gridW, gridH),
           /*subblock_w=*/1, blockH, blockW, /*inplace=*/false);
 
-  // Global semaphore for the fused kernel's all-gather. The core range
-  // mirrors the input's shard grid.
-  auto semaphoreCoreRangeAttr = ttnn::CoreRangeAttr::get(
-      rewriter.getContext(),
-      ttnn::CoreCoordAttr::get(rewriter.getContext(), 0, 0),
-      ttnn::CoreCoordAttr::get(rewriter.getContext(), gridW - 1, gridH - 1));
+  // Global semaphore for the fused kernel's all-gather. The core range is
+  // the bounding box of the input's actual shard cores so the semaphore is
+  // guaranteed to live on cores that exist on the device.
+  ttnn::CoreRangeAttr semaphoreCoreRangeAttr = *semaphoreCoreRange;
   ttnn::CreateGlobalSemaphoreOp semaphoreOp;
   {
     OpBuilder::InsertionGuard guard(rewriter);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -6,7 +6,6 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
-#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/IR/BuiltinTypes.h"
@@ -15,23 +14,28 @@
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
-// Prepares DistributedRMSNormOp for the tt-metal fused_rms_minimal kernel.
+// Prepares DistributedRMSNormOp for the tt-metal fused_rms_minimal kernel
+// at the layout / sharding level. This pattern only handles operand layout
+// changes; it does not allocate scratch buffers or global semaphores. Those
+// are handled by the dedicated TTNNAllocateDistributedOpBuffers and
+// TTNNAllocateDistributedOpSemaphores passes (see DistributedOpInterface).
+// Weight 1D->2D ReshapeOps are emitted in
+// DistributedRMSNormDecompositionRewritePattern alongside the input reshape.
 //
-// The workaround addresses the following requirements:
+// What this pattern enforces:
 //
 //  1. Input and residual tensors must be width-sharded in L1 with a ROW_MAJOR
 //     shard spec (so the program factory can read the shard grid/shape).
-//  2. The weight tensor must be in ROW_MAJOR layout with width equal to
-//     tile_width (32). We reshape from 1D (N,) to 2D (N/32, 32) and convert.
+//  2. The weight tensor (assumed already 2D after decomposition) must be in
+//     ROW_MAJOR layout. We insert a ToLayoutOp if it is currently tiled.
 //  3. The output memory config must match the input shard spec
 //     (skip_write_back = true). The fused kernel only all-gathers stats,
 //     not data, so output shape == input shape.
 //  4. A compute_config must be set. If absent, a default HiFi4 config with
-//     fp32_dest_acc_en=true is created.
-//  5. A stats scratch tensor (1x1x32x32, width-sharded on core (0,0), L1) is
-//     created as an EmptyOp. Its dtype (Float32 or BFloat16) is derived from
-//     fp32_dest_acc_en in the compute_config.
-//  6. A LayerNormShardedMultiCoreProgramConfig is computed from the input's
+//     fp32_dest_acc_en=true is created. Downstream passes (in particular
+//     TTNNAllocateDistributedOpBuffers) read fp32_dest_acc_en to derive
+//     the stats scratch dtype.
+//  5. A LayerNormShardedMultiCoreProgramConfig is computed from the input's
 //     shard spec (grid size, block_h, block_w) and attached as an attribute.
 //
 // If the original output layout differs from the sharded config (e.g.
@@ -107,8 +111,9 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
           rewriter.getContext(),
           ttcore::elementTypeToDataType(inputElementType)));
 
-  // The runtime requires the weight tensor in ROW_MAJOR layout with
-  // width = tile_width (32). Reshape from 1D (N,) to 2D (N/32, 32) first.
+  // The fused kernel requires the weight in ROW_MAJOR layout. The 1D->2D
+  // shape reshape is handled by the decomposition pattern; here we only
+  // convert from Tile to RowMajor if needed.
   mlir::Value weight = op.getWeight();
   if (weight) {
     RankedTensorType weightType =
@@ -122,25 +127,6 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
       weightElementType = weightTileType.getElementType();
     }
 
-    // Reshape weight to 2D: (N,) -> (N/32, 32) so width matches tile width.
-    int64_t totalElements = 1;
-    for (int64_t dim : weightType.getShape()) {
-      totalElements *= dim;
-    }
-    SmallVector<int64_t> reshapedShape = {totalElements / tileWidth, tileWidth};
-    SmallVector<int32_t> reshapedShapeI32(reshapedShape.begin(),
-                                          reshapedShape.end());
-    RankedTensorType reshapedWeightType =
-        ttnn::utils::RankedTensorTypeFactory::create(weightType, reshapedShape);
-    auto reshapeOp = rewriter.create<ttnn::ReshapeOp>(
-        op.getLoc(), reshapedWeightType, weight,
-        rewriter.getI32ArrayAttr(reshapedShapeI32));
-    weight = reshapeOp.getResult();
-
-    // Convert to ROW_MAJOR layout.
-    weightType = mlir::cast<RankedTensorType>(weight.getType());
-    weightLayout =
-        mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(weightType.getEncoding());
     if (weightLayout && weightLayout.isTiled()) {
       ttnn::TTNNLayoutAttr rowMajorLayout =
           ttnn::TTNNLayoutAttr::Builder(weightLayout, weightType.getShape())
@@ -176,7 +162,9 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
     }
   }
 
-  // Ensure compute_config is set (needed for stats dtype and by the kernel).
+  // Ensure compute_config is set. The buffer-allocation pass derives the
+  // stats scratch dtype from compute_config.fp32_dest_acc_en, so the
+  // attribute must be populated before that pass runs.
   auto computeConfigAttr = op.getComputeConfigAttr();
   if (!computeConfigAttr) {
     computeConfigAttr = DeviceComputeKernelConfigAttr::get(
@@ -186,55 +174,6 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
         /*fp32DestAccEn=*/BoolAttr::get(rewriter.getContext(), true),
         /*packerL1Acc=*/BoolAttr::get(rewriter.getContext(), true),
         /*dstFullSyncEn=*/nullptr);
-  }
-
-  // Derive stats tensor dtype from fp32_dest_acc_en in compute_config.
-  // The CB data format must match: Float32 when fp32_dest_acc_en, else
-  // BFloat16.
-  bool fp32DestAccEn = true;
-  if (auto fp32Attr = computeConfigAttr.getFp32DestAccEn()) {
-    fp32DestAccEn = fp32Attr.getValue();
-  }
-  auto statsElementType =
-      fp32DestAccEn
-          ? static_cast<Type>(Float32Type::get(rewriter.getContext()))
-          : static_cast<Type>(BFloat16Type::get(rewriter.getContext()));
-  auto statsDataType =
-      fp32DestAccEn ? ttcore::DataType::Float32 : ttcore::DataType::BFloat16;
-
-  // Create stats scratch tensor: one tile (32x32) per device, width-sharded
-  // on core (0,0) in L1. The fused kernel writes partial RMS statistics here
-  // and exchanges them across devices via the allgather.
-  SmallVector<int64_t> statsGridShape = {1, 1};
-  SmallVector<int64_t> statsShape = {1, 1, 32, 32};
-  ttnn::TTNNLayoutAttr statsLayout =
-      ttnn::TTNNLayoutAttr::Builder(rewriter.getContext(), statsShape,
-                                    ttcore::TileType::get(statsElementType))
-          .setBufferType(ttnn::BufferType::L1)
-          .setMemoryLayout(ttnn::TensorMemoryLayout::WidthSharded)
-          .setGridShape(statsGridShape)
-          .buildWithCanonicalCorePlacement(deviceAttr);
-
-  auto statsShapeAttr = ttnn::ShapeAttr::get(rewriter.getContext(), statsShape);
-  auto statsDtypeAttr =
-      ttcore::DataTypeAttr::get(rewriter.getContext(), statsDataType);
-  auto statsLayoutAttr =
-      ttnn::LayoutAttr::get(rewriter.getContext(), ttnn::Layout::Tile);
-  RankedTensorType statsResultType =
-      RankedTensorType::get(statsShape, statsElementType, statsLayout);
-
-  auto device = ttnn::utils::getOrInsertDevice(rewriter, op);
-
-  // Insert the scratch EmptyOp right after GetDeviceOp so it sits with the
-  // block-prelude ops; leaving it inline would trip TTNNTraceHoistTransform
-  // ("Non-hoistable op in the middle of hoistable ops").
-  ttnn::EmptyOp statsEmptyOp;
-  {
-    OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointAfter(device);
-    statsEmptyOp = rewriter.create<ttnn::EmptyOp>(
-        op.getLoc(), statsResultType, device, statsShapeAttr, statsDtypeAttr,
-        statsLayoutAttr);
   }
 
   // The fused kernel output shape == input shape (only stats are all-gathered,
@@ -250,18 +189,20 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
   int64_t blockH = scalarShardShape[0] / tileWidth;
   int64_t blockW = scalarShardShape[1] / tileWidth;
 
-  // Derive both the kernel's compute grid and the global-semaphore range
-  // from the bounding box of the input's shard cores
+  // Derive the kernel's compute grid from the bounding box of the input's
+  // shard cores. The semaphore-allocation pass independently derives the
+  // semaphore core range from the same shard spec at a later pipeline
+  // stage (post-optimizer); see DistributedRMSNormOp::allocateSemaphores.
   std::optional<ttnn::ShardSpecAttr> inputShardSpec =
       inputMemoryConfig.getShardSpec();
   assert(inputShardSpec.has_value() &&
          "width-sharded input must have a shard spec");
-  std::optional<ttnn::CoreRangeAttr> semaphoreCoreRange =
+  std::optional<ttnn::CoreRangeAttr> inputBoundingBox =
       inputShardSpec->getCoreRangeSet().getBoundingBox();
-  assert(semaphoreCoreRange.has_value() &&
+  assert(inputBoundingBox.has_value() &&
          "width-sharded input shard spec must have at least one core range");
-  ttnn::CoreCoordAttr boxStart = semaphoreCoreRange->getStartCoord();
-  ttnn::CoreCoordAttr boxEnd = semaphoreCoreRange->getEndCoord();
+  ttnn::CoreCoordAttr boxStart = inputBoundingBox->getStartCoord();
+  ttnn::CoreCoordAttr boxEnd = inputBoundingBox->getEndCoord();
 
   // Same as tt-metal GridParams: gs = bbox.end - bbox.start + 1 (inclusive
   // bounding box of the input shard cores).
@@ -273,27 +214,16 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
           ttnn::CoreCoordAttr::get(rewriter.getContext(), gridW, gridH),
           /*subblock_w=*/1, blockH, blockW, /*inplace=*/false);
 
-  // Global semaphore for the fused kernel's all-gather. The core range is
-  // the bounding box of the input's actual shard cores so the semaphore is
-  // guaranteed to live on cores that exist on the device.
-  ttnn::CoreRangeAttr semaphoreCoreRangeAttr = *semaphoreCoreRange;
-  ttnn::CreateGlobalSemaphoreOp semaphoreOp;
-  {
-    OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPointAfter(statsEmptyOp);
-    semaphoreOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
-        op.getLoc(), ttnn::GlobalSemaphoreType::get(rewriter.getContext()),
-        /*initial_value=*/rewriter.getUI32IntegerAttr(0),
-        semaphoreCoreRangeAttr);
-  }
-
+  // Rebuild the op with the converted operands and updated attributes.
+  // The stats and semaphore operands stay null here; they are populated by
+  // the TTNNAllocateDistributedOpBuffers / TTNNAllocateDistributedOpSemaphores
+  // passes (see DistributedOpInterface implementation in TTNNOps.cpp).
   auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
       op.getLoc(), shardedOutputType, inputToLayoutOp.getResult(), weight,
-      residual, statsEmptyOp.getResult(), semaphoreOp.getResult(),
-      op.getDevice(), static_cast<uint32_t>(op.getClusterAxis()),
-      op.getEpsilon(), op.getSubDeviceIdAttr(),
-      op.getNumLinksAttr(), op.getTopologyAttr(), computeConfigAttr,
-      programConfigAttr);
+      residual, /*stats=*/nullptr, /*semaphore=*/nullptr, op.getDevice(),
+      static_cast<uint32_t>(op.getClusterAxis()), op.getEpsilon(),
+      op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
+      op.getTopologyAttr(), computeConfigAttr, programConfigAttr);
 
   // If the original output had a different layout (e.g. interleaved DRAM),
   // insert a to_memory_config to convert back.

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.cpp
@@ -255,12 +255,29 @@ LogicalResult DistributedRMSNormWidthShardInputRewritePattern::matchAndRewrite(
           ttnn::CoreCoordAttr::get(rewriter.getContext(), gridW, gridH),
           /*subblock_w=*/1, blockH, blockW, /*inplace=*/false);
 
+  // Global semaphore for the fused kernel's all-gather. The core range
+  // mirrors the input's shard grid.
+  auto semaphoreCoreRangeAttr = ttnn::CoreRangeAttr::get(
+      rewriter.getContext(),
+      ttnn::CoreCoordAttr::get(rewriter.getContext(), 0, 0),
+      ttnn::CoreCoordAttr::get(rewriter.getContext(), gridW - 1, gridH - 1));
+  ttnn::CreateGlobalSemaphoreOp semaphoreOp;
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfter(statsEmptyOp);
+    semaphoreOp = rewriter.create<ttnn::CreateGlobalSemaphoreOp>(
+        op.getLoc(), ttnn::GlobalSemaphoreType::get(rewriter.getContext()),
+        /*initial_value=*/rewriter.getUI32IntegerAttr(0),
+        semaphoreCoreRangeAttr);
+  }
+
   auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
       op.getLoc(), shardedOutputType, inputToLayoutOp.getResult(), weight,
-      residual, statsEmptyOp.getResult(), op.getDevice(),
-      static_cast<uint32_t>(op.getClusterAxis()), op.getEpsilon(),
-      op.getSubDeviceIdAttr(), op.getNumLinksAttr(), op.getTopologyAttr(),
-      computeConfigAttr, programConfigAttr);
+      residual, statsEmptyOp.getResult(), semaphoreOp.getResult(),
+      op.getDevice(), static_cast<uint32_t>(op.getClusterAxis()),
+      op.getEpsilon(), op.getSubDeviceIdAttr(),
+      op.getNumLinksAttr(), op.getTopologyAttr(), computeConfigAttr,
+      programConfigAttr);
 
   // If the original output had a different layout (e.g. interleaved DRAM),
   // insert a to_memory_config to convert back.

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1518,8 +1518,8 @@ createOp(FlatbufferObjectCache &cache, DistributedRMSNormOp op) {
 
   ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef> semaphore = 0;
   if (op.getSemaphore()) {
-    semaphore = cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
-        op.getSemaphore());
+    semaphore =
+        cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(op.getSemaphore());
   }
 
   return ::tt::target::ttnn::CreateDistributedRMSNormOp(
@@ -3064,9 +3064,8 @@ createOp(FlatbufferObjectCache &cache, CaptureOrExecuteTraceOp op,
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
       semaphoreInputs;
   for (auto semaphore : op.getSemaphoreInputs()) {
-    semaphoreInputs.push_back(
-        cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
-            getOperandThroughDPSOps(semaphore)));
+    semaphoreInputs.push_back(cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
+        getOperandThroughDPSOps(semaphore)));
   }
 
   auto captureIt = programIndexMap.find(op.getCaptureCallee().str());

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -606,7 +606,15 @@ createOp(FlatbufferObjectCache &cache, func::CallOp op,
   uint32_t programIndex = it->second;
 
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> inputs;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+      semaphoreInputs;
   for (const auto input : op.getOperands()) {
+    if (::mlir::isa<::mlir::tt::ttnn::GlobalSemaphoreType>(input.getType())) {
+      semaphoreInputs.push_back(
+          cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
+              getOperandThroughDPSOps(input)));
+      continue;
+    }
     inputs.push_back(cache.at<::tt::target::ttnn::TensorRef>(
         getOperandThroughDPSOps(input)));
   }
@@ -619,8 +627,8 @@ createOp(FlatbufferObjectCache &cache, func::CallOp op,
                                     /*local_shape*/ std::nullopt));
   }
 
-  return ::tt::target::ttnn::CreateFuncCallOpDirect(*cache.fbb, programIndex,
-                                                    &inputs, &outputs);
+  return ::tt::target::ttnn::CreateFuncCallOpDirect(
+      *cache.fbb, programIndex, &inputs, &outputs, &semaphoreInputs);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::CumSumOp>
@@ -1508,10 +1516,17 @@ createOp(FlatbufferObjectCache &cache, DistributedRMSNormOp op) {
     programConfig = toFlatbuffer(cache, op.getProgramConfig().value());
   }
 
+  ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef> semaphore = 0;
+  if (op.getSemaphore()) {
+    semaphore = cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
+        op.getSemaphore());
+  }
+
   return ::tt::target::ttnn::CreateDistributedRMSNormOp(
       *cache.fbb, input, weight, residual, op.getClusterAxis(),
       op.getEpsilon().convertToFloat(), subDeviceId, memoryConfig, numLinks,
-      topology, computeConfig.value_or(0), stats, programConfig, output);
+      topology, computeConfig.value_or(0), stats, programConfig, output,
+      semaphore);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::RMSNormPreAllGatherOp>
@@ -3046,6 +3061,14 @@ createOp(FlatbufferObjectCache &cache, CaptureOrExecuteTraceOp op,
                                     /*local_shape*/ std::nullopt));
   }
 
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+      semaphoreInputs;
+  for (auto semaphore : op.getSemaphoreInputs()) {
+    semaphoreInputs.push_back(
+        cache.at<::tt::target::ttnn::GlobalSemaphoreRef>(
+            getOperandThroughDPSOps(semaphore)));
+  }
+
   auto captureIt = programIndexMap.find(op.getCaptureCallee().str());
   assert(captureIt != programIndexMap.end() &&
          "Program name not found in program index map!");
@@ -3058,7 +3081,7 @@ createOp(FlatbufferObjectCache &cache, CaptureOrExecuteTraceOp op,
 
   return ::tt::target::ttnn::CreateCaptureOrExecuteTraceOpDirect(
       *cache.fbb, cache.at<::tt::target::DeviceRef>(device), captureProgramIdx,
-      executeProgramIdx, &inputs, &outputs);
+      executeProgramIdx, &inputs, &outputs, &semaphoreInputs);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ConcatenateHeadsOp>
@@ -4847,7 +4870,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
 
     programs.push_back(::tt::target::ttnn::CreateProgramDirect(
         fbb, program.name, &program.inputs, &program.outputs, &program.ops,
-        &dylibs, debugInfo, func.isPrivate(), &meshShape));
+        &dylibs, debugInfo, func.isPrivate(), &meshShape,
+        &program.semaphoreInputs));
   }
 
   auto binary = ::tt::target::ttnn::CreateTTNNBinaryDirect(

--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -62,6 +62,12 @@ createLayerNormShardedMultiCoreProgramConfig(
 allocateTensorOnDevice(const ::tt::target::ttnn::TensorRef *tensorRef,
                        ::ttnn::MeshDevice &meshDevice);
 
+std::vector<::ttnn::GlobalSemaphore> collectSemaphoreInputs(
+    const ::flatbuffers::Vector<
+        ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+        *semaphoreInputs,
+    ProgramContext &context);
+
 template <std::integral T>
 inline ::ttnn::Shape toTTNNShape(const flatbuffers::Vector<T> &vec) {
   std::vector<uint32_t> rawShape;

--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -62,7 +62,7 @@ createLayerNormShardedMultiCoreProgramConfig(
 allocateTensorOnDevice(const ::tt::target::ttnn::TensorRef *tensorRef,
                        ::ttnn::MeshDevice &meshDevice);
 
-std::vector<::ttnn::GlobalSemaphore> collectSemaphoreInputs(
+std::vector<::tt::runtime::GlobalSemaphore> collectSemaphoreInputs(
     const ::flatbuffers::Vector<
         ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
         *semaphoreInputs,

--- a/runtime/include/tt/runtime/detail/ttnn/program_executor.h
+++ b/runtime/include/tt/runtime/detail/ttnn/program_executor.h
@@ -19,15 +19,12 @@ class ProgramContext; // Forward declaration
  */
 class ProgramExecutor {
 public:
-  // `parentContext` (optional) links this executor's ProgramContext to the
-  // caller's context so child programs can share state (e.g. implicit
-  // GlobalSemaphores) across nested invocations.
-  ProgramExecutor(::tt::runtime::Device deviceHandle,
-                  ::tt::runtime::Binary &executableHandle,
-                  const size_t programIndex,
-                  std::vector<::tt::runtime::Tensor> &programInputs,
-                  bool constEvalProgram = false,
-                  ProgramContext *parentContext = nullptr);
+  ProgramExecutor(
+      ::tt::runtime::Device deviceHandle,
+      ::tt::runtime::Binary &executableHandle, const size_t programIndex,
+      std::vector<::tt::runtime::Tensor> &programInputs,
+      bool constEvalProgram = false,
+      const std::vector<::ttnn::GlobalSemaphore> &programSemaphoreInputs = {});
 
   /**
    * Executes pre/post operation callbacks if registered

--- a/runtime/include/tt/runtime/detail/ttnn/program_executor.h
+++ b/runtime/include/tt/runtime/detail/ttnn/program_executor.h
@@ -19,12 +19,13 @@ class ProgramContext; // Forward declaration
  */
 class ProgramExecutor {
 public:
-  ProgramExecutor(
-      ::tt::runtime::Device deviceHandle,
-      ::tt::runtime::Binary &executableHandle, const size_t programIndex,
-      std::vector<::tt::runtime::Tensor> &programInputs,
-      bool constEvalProgram = false,
-      const std::vector<::ttnn::GlobalSemaphore> &programSemaphoreInputs = {});
+  ProgramExecutor(::tt::runtime::Device deviceHandle,
+                  ::tt::runtime::Binary &executableHandle,
+                  const size_t programIndex,
+                  std::vector<::tt::runtime::Tensor> &programInputs,
+                  bool constEvalProgram = false,
+                  const std::vector<::tt::runtime::GlobalSemaphore>
+                      &programSemaphoreInputs = {});
 
   /**
    * Executes pre/post operation callbacks if registered

--- a/runtime/include/tt/runtime/detail/ttnn/types/types.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/types.h
@@ -248,15 +248,14 @@ public:
                  GlobalSemaphoreMap &&liveGlobalSemaphores,
                  common::DylibManager &&programDylibManager,
                  ::tt::runtime::Device deviceHandle,
-                 const Binary &executableHandle, size_t programIndex = 0,
-                 ProgramContext *parentContext = nullptr)
+                 const Binary &executableHandle, size_t programIndex = 0)
       : tensorPool(ProgramTensorPool(programInputIds, programOutputIds,
                                      std::move(liveTensors))),
         globalSemaphorePool(
             ProgramGlobalSemaphorePool(std::move(liveGlobalSemaphores))),
         dylibManager(std::move(programDylibManager)),
         deviceHandle(deviceHandle), executableHandle(executableHandle),
-        programIndex(programIndex), parentContext(parentContext) {
+        programIndex(programIndex) {
     LOG_ASSERT(deviceHandle.handle, "DeviceHandle cannot be null");
   }
 
@@ -307,23 +306,6 @@ public:
     return globalSemaphorePool;
   }
 
-  // Returns a cached GlobalSemaphore for `opKey`, creating it on first use.
-  // Lookups forward to the root context so a semaphore created during warmup
-  // is reused during trace capture (create_global_semaphore writes L1 and
-  // cannot run inside capture).
-  ::ttnn::GlobalSemaphore getOrCreateImplicitGlobalSemaphore(
-      uintptr_t opKey,
-      const std::function<::ttnn::GlobalSemaphore()> &factory) {
-    if (parentContext) {
-      return parentContext->getOrCreateImplicitGlobalSemaphore(opKey, factory);
-    }
-    auto it = implicitOpSemaphores.find(opKey);
-    if (it == implicitOpSemaphores.end()) {
-      it = implicitOpSemaphores.emplace(opKey, factory()).first;
-    }
-    return it->second;
-  }
-
   Binary &getExecutableHandle() { return executableHandle; }
 
   //
@@ -336,9 +318,6 @@ private:
 
   ProgramGlobalSemaphorePool globalSemaphorePool;
 
-  // Op-implicit GlobalSemaphores keyed by flatbuffer op pointer; root only.
-  std::unordered_map<uintptr_t, ::ttnn::GlobalSemaphore> implicitOpSemaphores;
-
   common::DylibManager dylibManager;
 
   ::tt::runtime::Device deviceHandle;
@@ -348,10 +327,6 @@ private:
 
   // The index of the program within the binary
   const size_t programIndex;
-
-  // Caller's context (e.g. FuncCallOp), used to forward state shared across
-  // nested invocations. Non-owning.
-  ProgramContext *parentContext = nullptr;
 };
 
 } // namespace tt::runtime::ttnn

--- a/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
+++ b/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
@@ -18,11 +18,19 @@ void run(const ::tt::target::ttnn::FuncCallOp *op, ProgramContext &context) {
         context.getTensorPool().getRuntimeTensorAndValidate(input));
   }
 
-  // Forward the caller's context so state that must persist across nested
-  // invocations (e.g. implicit GlobalSemaphores) is shared with the parent.
+  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs;
+  if (op->semaphore_inputs()) {
+    semaphoreInputs.reserve(op->semaphore_inputs()->size());
+    for (const auto *semaphoreRef : *op->semaphore_inputs()) {
+      semaphoreInputs.push_back(
+          context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+              semaphoreRef));
+    }
+  }
+
   ProgramExecutor executor(context.getDeviceHandle(),
                            context.getExecutableHandle(), programIndex, inputs,
-                           /*constEvalProgram=*/false, &context);
+                           /*constEvalProgram=*/false, semaphoreInputs);
 
   executor.execute();
   std::vector<::tt::runtime::Tensor> outputs = executor.gatherOutputTensors();

--- a/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
+++ b/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
@@ -4,6 +4,7 @@
 
 #include "operations/mlir_native/func_call.h"
 #include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/program_executor.h"
 #include "tt/runtime/detail/ttnn/types/types.h"
 
@@ -18,15 +19,8 @@ void run(const ::tt::target::ttnn::FuncCallOp *op, ProgramContext &context) {
         context.getTensorPool().getRuntimeTensorAndValidate(input));
   }
 
-  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs;
-  if (op->semaphore_inputs()) {
-    semaphoreInputs.reserve(op->semaphore_inputs()->size());
-    for (const auto *semaphoreRef : *op->semaphore_inputs()) {
-      semaphoreInputs.push_back(
-          context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
-              semaphoreRef));
-    }
-  }
+  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs =
+      utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
 
   ProgramExecutor executor(context.getDeviceHandle(),
                            context.getExecutableHandle(), programIndex, inputs,

--- a/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
+++ b/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
@@ -19,7 +19,7 @@ void run(const ::tt::target::ttnn::FuncCallOp *op, ProgramContext &context) {
         context.getTensorPool().getRuntimeTensorAndValidate(input));
   }
 
-  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs =
+  std::vector<::tt::runtime::GlobalSemaphore> semaphoreInputs =
       utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
 
   ProgramExecutor executor(context.getDeviceHandle(),

--- a/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
@@ -65,16 +65,11 @@ void run(const ::tt::target::ttnn::DistributedRMSNormOp *op,
         op->program_config());
   }
 
-  auto shardSpec = input.shard_spec();
-  LOG_ASSERT(shardSpec.has_value(),
-             "Input tensor must have shard spec for distributed_rms_norm");
-  // create_global_semaphore writes L1 and cannot run inside trace capture;
-  // cache and reuse the one created during warmup.
-  auto semaphore = context.getOrCreateImplicitGlobalSemaphore(
-      reinterpret_cast<uintptr_t>(op), [&]() {
-        return ::ttnn::global_semaphore::create_global_semaphore(
-            &meshDevice, shardSpec->grid, 0);
-      });
+  LOG_ASSERT(op->semaphore() != nullptr,
+             "DistributedRMSNormOp expects an explicit global semaphore");
+  ::ttnn::GlobalSemaphore semaphore =
+      context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+          op->semaphore());
 
   ::ttnn::Tensor &statsTensor =
       tensorPool.getTTNNTensorAndValidate(op->stats());

--- a/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/distributed_rms_norm.cpp
@@ -65,7 +65,7 @@ void run(const ::tt::target::ttnn::DistributedRMSNormOp *op,
         op->program_config());
   }
 
-  LOG_ASSERT(op->semaphore() != nullptr,
+  LOG_ASSERT(op->semaphore(),
              "DistributedRMSNormOp expects an explicit global semaphore");
   ::ttnn::GlobalSemaphore semaphore =
       context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -44,6 +44,22 @@ static void copyTensorFromDeviceToDevice(const ::ttnn::Tensor &srcTensor,
   ::tt::tt_metal::copy_to_device(hostSrcTensor, dstTensor);
 }
 
+static std::vector<::ttnn::GlobalSemaphore>
+collectSemaphoreInputs(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+                       ProgramContext &context) {
+  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs;
+  if (!op->semaphore_inputs()) {
+    return semaphoreInputs;
+  }
+  semaphoreInputs.reserve(op->semaphore_inputs()->size());
+  for (const auto *semaphoreRef : *op->semaphore_inputs()) {
+    semaphoreInputs.push_back(
+        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+            semaphoreRef));
+  }
+  return semaphoreInputs;
+}
+
 static void runTraceProgramAndCaptureTrace(
     const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
     ProgramContext &context, ::tt::runtime::ttnn::TraceCache &traceCache) {
@@ -58,9 +74,12 @@ static void runTraceProgramAndCaptureTrace(
     inputTensors.push_back(inputTensor);
   }
 
+  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs =
+      collectSemaphoreInputs(op, context);
+
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
                            op->capture_program_id(), inputTensors,
-                           /*constEvalProgram=*/false);
+                           /*constEvalProgram=*/false, semaphoreInputs);
   executor.execute();
   std::vector<::tt::runtime::Tensor> outputTensors =
       executor.gatherOutputTensors();
@@ -184,9 +203,13 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
   std::vector<::tt::runtime::Tensor> inputTensors = {
       ::tt::runtime::ttnn::utils::createRuntimeTensorFromTTNN(traceIdTensor)};
 
+  // The execute trace program only invokes ttnn.execute_trace(traceId); the
+  // semaphores were baked into the captured trace at capture time and are not
+  // arguments of the execute program. Passing them here would mismatch
+  // program->semaphore_inputs() (which is empty for the execute program).
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
                            op->execute_program_id(), inputTensors,
-                           /*constEvalProgram=*/false);
+                           /*constEvalProgram=*/false, /*programSemaphoreInputs=*/{});
   executor.execute();
 
   for (size_t i = 0; i < op->outputs()->size(); i++) {

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -44,22 +44,6 @@ static void copyTensorFromDeviceToDevice(const ::ttnn::Tensor &srcTensor,
   ::tt::tt_metal::copy_to_device(hostSrcTensor, dstTensor);
 }
 
-static std::vector<::ttnn::GlobalSemaphore>
-collectSemaphoreInputs(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
-                       ProgramContext &context) {
-  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs;
-  if (!op->semaphore_inputs()) {
-    return semaphoreInputs;
-  }
-  semaphoreInputs.reserve(op->semaphore_inputs()->size());
-  for (const auto *semaphoreRef : *op->semaphore_inputs()) {
-    semaphoreInputs.push_back(
-        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
-            semaphoreRef));
-  }
-  return semaphoreInputs;
-}
-
 static void runTraceProgramAndCaptureTrace(
     const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
     ProgramContext &context, ::tt::runtime::ttnn::TraceCache &traceCache) {
@@ -75,7 +59,7 @@ static void runTraceProgramAndCaptureTrace(
   }
 
   std::vector<::ttnn::GlobalSemaphore> semaphoreInputs =
-      collectSemaphoreInputs(op, context);
+      utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
 
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
                            op->capture_program_id(), inputTensors,
@@ -209,7 +193,8 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
   // program->semaphore_inputs() (which is empty for the execute program).
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
                            op->execute_program_id(), inputTensors,
-                           /*constEvalProgram=*/false, /*programSemaphoreInputs=*/{});
+                           /*constEvalProgram=*/false,
+                           /*programSemaphoreInputs=*/{});
   executor.execute();
 
   for (size_t i = 0; i < op->outputs()->size(); i++) {

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -58,7 +58,7 @@ static void runTraceProgramAndCaptureTrace(
     inputTensors.push_back(inputTensor);
   }
 
-  std::vector<::ttnn::GlobalSemaphore> semaphoreInputs =
+  std::vector<::tt::runtime::GlobalSemaphore> semaphoreInputs =
       utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
 
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -15,6 +15,24 @@ void eventSync(::ttnn::MeshDevice *meshDevice, const ::ttnn::QueueId &recordCq,
   ::ttnn::events::wait_for_mesh_event(waitCq, event);
 }
 
+std::vector<::ttnn::GlobalSemaphore> collectSemaphoreInputs(
+    const ::flatbuffers::Vector<
+        ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
+        *semaphoreInputs,
+    ProgramContext &context) {
+  std::vector<::ttnn::GlobalSemaphore> result;
+  if (!semaphoreInputs) {
+    return result;
+  }
+  result.reserve(semaphoreInputs->size());
+  for (const auto *semaphoreRef : *semaphoreInputs) {
+    result.push_back(
+        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+            semaphoreRef));
+  }
+  return result;
+}
+
 bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
   const ::tt::target::Dim2d *tileShape =
       tensorRef->desc()->layout()->memory_desc()->tile_shape();

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -15,19 +15,19 @@ void eventSync(::ttnn::MeshDevice *meshDevice, const ::ttnn::QueueId &recordCq,
   ::ttnn::events::wait_for_mesh_event(waitCq, event);
 }
 
-std::vector<::ttnn::GlobalSemaphore> collectSemaphoreInputs(
+std::vector<::tt::runtime::GlobalSemaphore> collectSemaphoreInputs(
     const ::flatbuffers::Vector<
         ::flatbuffers::Offset<::tt::target::ttnn::GlobalSemaphoreRef>>
         *semaphoreInputs,
     ProgramContext &context) {
-  std::vector<::ttnn::GlobalSemaphore> result;
+  std::vector<::tt::runtime::GlobalSemaphore> result;
   if (!semaphoreInputs) {
     return result;
   }
   result.reserve(semaphoreInputs->size());
   for (const auto *semaphoreRef : *semaphoreInputs) {
     result.push_back(
-        context.getGlobalSemaphorePool().getTTNNGlobalSemaphoreAndValidate(
+        context.getGlobalSemaphorePool().getRuntimeGlobalSemaphoreAndValidate(
             semaphoreRef));
   }
   return result;

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -132,7 +132,7 @@ ProgramExecutor::ProgramExecutor(
     ::tt::runtime::Device deviceHandle, ::tt::runtime::Binary &executableHandle,
     const size_t programIndex,
     std::vector<::tt::runtime::Tensor> &programInputs, bool constEvalProgram,
-    ProgramContext *parentContext)
+    const std::vector<::ttnn::GlobalSemaphore> &programSemaphoreInputs)
     : program(utils::getProgram(executableHandle, programIndex)),
       executableHandle(executableHandle), constEvalProgram(constEvalProgram) {
   LOG_ASSERT(program, "Program must be provided for execution");
@@ -155,10 +155,32 @@ ProgramExecutor::ProgramExecutor(
     programOutputIds.push_back(output->global_id());
   }
 
+  GlobalSemaphoreMap liveGlobalSemaphores;
+  size_t expectedSemaphoreInputs =
+      program->semaphore_inputs() ? program->semaphore_inputs()->size() : 0;
+  LOG_ASSERT(programSemaphoreInputs.size() == expectedSemaphoreInputs,
+             "Program semaphore input size mismatch: ",
+             expectedSemaphoreInputs,
+             " != ", programSemaphoreInputs.size());
+  if (program->semaphore_inputs()) {
+    size_t i = 0;
+    for (const ::tt::target::ttnn::GlobalSemaphoreRef *semaphoreRef :
+         *program->semaphore_inputs()) {
+      auto semaphorePtr = std::make_shared<::ttnn::GlobalSemaphore>(
+          programSemaphoreInputs[i++]);
+      auto [iter, inserted] = liveGlobalSemaphores.try_emplace(
+          semaphoreRef->global_id(),
+          ::tt::runtime::GlobalSemaphore(
+              std::static_pointer_cast<void>(semaphorePtr),
+              DeviceRuntime::TTNN));
+      LOG_ASSERT(inserted, "Duplicate input semaphore");
+    }
+  }
+
   context = std::make_unique<ProgramContext>(
       programInputIds, programOutputIds, std::move(liveTensors),
-      GlobalSemaphoreMap(), common::DylibManager(program->dylibs()),
-      std::move(deviceHandle), executableHandle, programIndex, parentContext);
+      std::move(liveGlobalSemaphores), common::DylibManager(program->dylibs()),
+      std::move(deviceHandle), executableHandle, programIndex);
 }
 
 void ProgramExecutor::runOpCallback(

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -159,8 +159,7 @@ ProgramExecutor::ProgramExecutor(
   size_t expectedSemaphoreInputs =
       program->semaphore_inputs() ? program->semaphore_inputs()->size() : 0;
   LOG_ASSERT(programSemaphoreInputs.size() == expectedSemaphoreInputs,
-             "Program semaphore input size mismatch: ",
-             expectedSemaphoreInputs,
+             "Program semaphore input size mismatch: ", expectedSemaphoreInputs,
              " != ", programSemaphoreInputs.size());
   if (program->semaphore_inputs()) {
     size_t i = 0;

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -132,7 +132,7 @@ ProgramExecutor::ProgramExecutor(
     ::tt::runtime::Device deviceHandle, ::tt::runtime::Binary &executableHandle,
     const size_t programIndex,
     std::vector<::tt::runtime::Tensor> &programInputs, bool constEvalProgram,
-    const std::vector<::ttnn::GlobalSemaphore> &programSemaphoreInputs)
+    const std::vector<::tt::runtime::GlobalSemaphore> &programSemaphoreInputs)
     : program(utils::getProgram(executableHandle, programIndex)),
       executableHandle(executableHandle), constEvalProgram(constEvalProgram) {
   LOG_ASSERT(program, "Program must be provided for execution");
@@ -165,13 +165,8 @@ ProgramExecutor::ProgramExecutor(
     size_t i = 0;
     for (const ::tt::target::ttnn::GlobalSemaphoreRef *semaphoreRef :
          *program->semaphore_inputs()) {
-      auto semaphorePtr = std::make_shared<::ttnn::GlobalSemaphore>(
-          programSemaphoreInputs[i++]);
       auto [iter, inserted] = liveGlobalSemaphores.try_emplace(
-          semaphoreRef->global_id(),
-          ::tt::runtime::GlobalSemaphore(
-              std::static_pointer_cast<void>(semaphorePtr),
-              DeviceRuntime::TTNN));
+          semaphoreRef->global_id(), programSemaphoreInputs[i++]);
       LOG_ASSERT(inserted, "Duplicate input semaphore");
     }
   }

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -362,9 +362,6 @@ def test_hoisted_layer_norm(
         (1, 1, 128, 128),
         (1, 1, 32, 68),
         (1, 1, 37, 72),
-        # Shapes below exercise the relaxed fused-kernel eligibility check and
-        # the canonical-shape reshape in the decomposition pass: dim -2 == 32
-        # and dim -1 % 32 == 0 with all leading dims equal to 1, but rank != 4.
         (32, 128),
         (1, 32, 128),
     ],
@@ -396,20 +393,22 @@ def test_distributed_rms_norm(
     2. RMS normalization
     3. All-gather collective communication
     """
-    # Skip combinations that hang on n300 after metal uplift to commit 7fb82fd0
-    # (Reduce compute and dataflow helpers, tt-metal#41637).
-    # Hangs occur when has_weight=True with shape (1, 1, 32, X) where X is a
-    # power-of-2 last dimension. Tracked in tt-mlir#8129 / tt-metal#43173.
-    if has_weight and shape in [
-        (1, 1, 32, 128),
-        (1, 1, 32, 512),
-        (1, 1, 32, 4096),
-        (1, 1, 32, 8192),
-    ]:
+    if (
+        target in ("emitpy", "emitc")
+        and has_weight
+        and shape
+        in [
+            (1, 1, 32, 128),
+            (1, 1, 32, 512),
+            (1, 1, 32, 4096),
+            (1, 1, 32, 8192),
+            (32, 128),
+            (1, 32, 128),
+        ]
+    ):
         pytest.skip(
-            f"Hangs on n300 with has_weight=True and shape={shape} after metal uplift "
-            "(Reduce compute and dataflow helpers, tt-metal#41637). "
-            "Tracked in tt-mlir#8129 / tt-metal#43173."
+            "EmitPy/EmitC: missing ttnn.create_global_semaphore conversion. "
+            "Issue: https://github.com/tenstorrent/tt-mlir/issues/8464"
         )
 
     # Determine input shapes

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -28,7 +28,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK: "ttnn.multiply"
     // CHECK-NOT: "ttnn.distributed_rms_norm"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
     return %1 : tensor<1x1x64x128xbf16, #ttnn_layout>
   }
 
@@ -40,7 +40,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK: "ttnn.distributed_rms_norm"
     // CHECK-NOT: "ttnn.rsqrt"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_supported>
   }
 
@@ -64,7 +64,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK-SAME: shape = [1 : i32, 32 : i32, 128 : i32]
     // CHECK-SAME: -> tensor<1x32x128
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<1x32x128xbf16, #ttnn_layout_supported_rank3>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x32x128xbf16, #ttnn_layout_supported_rank3>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x32x128xbf16, #ttnn_layout_supported_rank3>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x32x128xbf16, #ttnn_layout_supported_rank3>
     return %1 : tensor<1x32x128xbf16, #ttnn_layout_supported_rank3>
   }
 
@@ -79,7 +79,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.distributed_rms_norm"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>
     return %1 : tensor<1x2x32x128xbf16, #ttnn_layout_unsupported_leading>
   }
 
@@ -95,7 +95,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.distributed_rms_norm"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %arg2, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, tensor<1x1x64x128xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %arg2, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, tensor<1x1x64x128xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
     return %1 : tensor<1x1x64x128xbf16, #ttnn_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -36,8 +36,13 @@ module @test_distributed_rms_norm_decomposition attributes {} {
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_supported>,
       %arg1: tensor<128xbf16, #ttnn_layout_weight>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
     // CHECK-LABEL: func.func public @test_no_decompose_supported_shape
-    // The (1,1,32,M) shape must NOT be decomposed — op survives for the fused kernel.
+    // The (1,1,32,M) shape stays on the fused op, but the 1D weight (N,)
+    // must still be reshaped to 2D (N/32, 32) so the fused kernel can run.
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [4 : i32, 32 : i32]
+    // CHECK-SAME: -> tensor<4x32
     // CHECK: "ttnn.distributed_rms_norm"
+    // CHECK-SAME: tensor<1x1x32x128
     // CHECK-NOT: "ttnn.rsqrt"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
@@ -49,8 +54,13 @@ module @test_distributed_rms_norm_decomposition attributes {} {
       %arg1: tensor<128xbf16, #ttnn_layout_weight>) -> tensor<1x32x128xbf16, #ttnn_layout_supported_rank3> {
     // CHECK-LABEL: func.func public @test_reshape_rank3_to_canonical_shape
     // Rank-3 (1, 32, M) is eligible for the fused kernel but not yet canonical.
-    // The decomposition pass wraps it: reshape to (1,1,32,M), forward to the
-    // fused op, then reshape the result back to (1,32,M).
+    // The decomposition pass wraps it: reshape weight to 2D, reshape input to
+    // (1,1,32,M), forward to the fused op, then reshape the result back to
+    // (1,32,M).
+    // Weight is reshaped from 1D (128) to 2D (4, 32).
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [4 : i32, 32 : i32]
+    // CHECK-SAME: -> tensor<4x32
     // Input is reshaped to (1, 1, 32, 128).
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -3,20 +3,35 @@
 
 #dram = #ttnn.buffer_type<dram>
 #ttnn_layout_supported = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#ttnn_layout_weight = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+// Weight in 2D form (4, 32) as produced by ttnn-decomposition prior to this pass.
+#ttnn_layout_weight_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
-// Test: (1,1,32,M) shape must NOT be decomposed by workarounds — the fused kernel handles it.
+// The workaround pattern only converts layout / sharding. It must:
+//   - Width-shard the input.
+//   - Convert the weight from Tile to RowMajor.
+//   - Leave stats / semaphore unbound (allocated by dedicated passes later).
 module @test_distributed_rms_norm_workaround attributes {} {
-  func.func public @test_no_decompose_supported_shape(
+  func.func public @test_workaround_layout_only(
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_supported>,
-      %arg1: tensor<128xbf16, #ttnn_layout_weight>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
-    // CHECK-LABEL: func.func public @test_no_decompose_supported_shape
-    // The (1,1,32,M) shape must survive as distributed_rms_norm.
+      %arg1: tensor<4x32xbf16, #ttnn_layout_weight_2d>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
+    // CHECK-LABEL: func.func public @test_workaround_layout_only
+    // Input is converted to a width-sharded L1 layout.
+    // CHECK: "ttnn.to_layout"
+    // CHECK-SAME: <l1>
+    // CHECK-SAME: <width_sharded>
+    // Weight is converted from Tile to RowMajor.
+    // CHECK: "ttnn.to_layout"
+    // CHECK-SAME: row_major
+    // The fused op survives.
     // CHECK: "ttnn.distributed_rms_norm"
+    // The workaround pass does not allocate stats or semaphores; both
+    // operand segments stay zero.
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>
+    // CHECK-NOT: "ttnn.empty"
+    // CHECK-NOT: "ttnn.create_global_semaphore"
     // CHECK-NOT: "ttnn.rsqrt"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<4x32xbf16, #ttnn_layout_weight_2d>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_supported>
   }
-
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -3,29 +3,19 @@
 
 #dram = #ttnn.buffer_type<dram>
 #ttnn_layout_supported = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-// Weight in 2D form (4, 32) as produced by ttnn-decomposition prior to this pass.
 #ttnn_layout_weight_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
-// The workaround pattern only converts layout / sharding. It must:
-//   - Width-shard the input.
-//   - Convert the weight from Tile to RowMajor.
-//   - Leave stats / semaphore unbound (allocated by dedicated passes later).
 module @test_distributed_rms_norm_workaround attributes {} {
   func.func public @test_workaround_layout_only(
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_supported>,
       %arg1: tensor<4x32xbf16, #ttnn_layout_weight_2d>) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported> {
+    // CHECK: #[[INPUT_WS_LAYOUT:.+]] = #ttnn.ttnn_layout{{.*}}#l1{{.*}}<width_sharded>
     // CHECK-LABEL: func.func public @test_workaround_layout_only
-    // Input is converted to a width-sharded L1 layout.
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: #l1
-    // CHECK-SAME: <width_sharded>
-    // Weight is converted from Tile to RowMajor.
+    // CHECK-SAME: tensor<{{.*}}, #[[INPUT_WS_LAYOUT]]>
     // CHECK: "ttnn.to_layout"
     // CHECK-SAME: row_major
-    // The fused op survives.
     // CHECK: "ttnn.distributed_rms_norm"
-    // The workaround pass does not allocate stats or semaphores; both
-    // operand segments stay zero.
     // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>
     // CHECK-NOT: "ttnn.empty"
     // CHECK-NOT: "ttnn.create_global_semaphore"
@@ -34,5 +24,4 @@ module @test_distributed_rms_norm_workaround attributes {} {
     %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<4x32xbf16, #ttnn_layout_weight_2d>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_supported>
   }
-
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -15,7 +15,7 @@ module @test_distributed_rms_norm_workaround attributes {} {
     // CHECK: "ttnn.distributed_rms_norm"
     // CHECK-NOT: "ttnn.rsqrt"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<128xbf16, #ttnn_layout_weight>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_supported>
   }
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/distributed_rms_norm_decomposition_workaround.mlir
@@ -17,7 +17,7 @@ module @test_distributed_rms_norm_workaround attributes {} {
     // CHECK-LABEL: func.func public @test_workaround_layout_only
     // Input is converted to a width-sharded L1 layout.
     // CHECK: "ttnn.to_layout"
-    // CHECK-SAME: <l1>
+    // CHECK-SAME: #l1
     // CHECK-SAME: <width_sharded>
     // Weight is converted from Tile to RowMajor.
     // CHECK: "ttnn.to_layout"
@@ -34,4 +34,5 @@ module @test_distributed_rms_norm_workaround attributes {} {
     %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>}> : (tensor<1x1x32x128xbf16, #ttnn_layout_supported>, tensor<4x32xbf16, #ttnn_layout_weight_2d>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_supported>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_supported>
   }
+
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
@@ -1,0 +1,38 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-allocate-distributed-op-buffers -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#l1 = #ttnn.buffer_type<l1>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
+
+// The pass walks DistributedOpInterface ops with unbound buffer operands and
+// inserts a ttnn.empty in the function prelude (right after ttnn.get_device)
+// for each missing buffer. The op's operand_segment_sizes is updated to
+// reflect the newly-bound stats operand.
+module @test_allocate_buffers attributes {} {
+  func.func public @test_allocates_stats_buffer(
+      %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>,
+      %arg1: tensor<4x32xbf16, #ttnn_layout_weight_rm>) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws> {
+    // CHECK-LABEL: func.func public @test_allocates_stats_buffer
+    // The stats EmptyOp must sit in the prelude, between get_device and the
+    // norm op, so trace hoisting keeps a contiguous block of non-hoistable
+    // ops at the start of the function.
+    // CHECK: %[[DEV:.+]] = "ttnn.get_device"
+    // CHECK: %[[STATS:.+]] = "ttnn.empty"
+    // CHECK-SAME: <width_sharded>
+    // The op must consume the new stats buffer; segment sizes update to
+    // 1,1,0,1,0,1 (input, weight, residual, stats, semaphore, device).
+    // CHECK: "ttnn.distributed_rms_norm"
+    // CHECK-SAME: %[[STATS]]
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 1, 0, 1>
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{
+      cluster_axis = 1 : ui32,
+      epsilon = 1.000000e-05 : f32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>,
+      compute_config = #ttnn.compute_kernel_config<math_fidelity = HiFi4, math_approx_mode = false, fp32_dest_acc_en = true, packer_l1_acc = true>
+    }> : (tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>, tensor<4x32xbf16, #ttnn_layout_weight_rm>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
+    return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
@@ -3,7 +3,7 @@
 
 #l1 = #ttnn.buffer_type<l1>
 #system_memory = #ttnn.buffer_type<system_memory>
-#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
 // The pass walks DistributedOpInterface ops with unbound buffer operands and
@@ -31,7 +31,7 @@ module @test_allocate_buffers attributes {} {
       cluster_axis = 1 : ui32,
       epsilon = 1.000000e-05 : f32,
       operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>,
-      compute_config = #ttnn.compute_kernel_config<math_fidelity = HiFi4, math_approx_mode = false, fp32_dest_acc_en = true, packer_l1_acc = true>
+      compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, math_approx_mode = false, fp32_dest_acc_en = true, packer_l1_acc = true>
     }> : (tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>, tensor<4x32xbf16, #ttnn_layout_weight_rm>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
@@ -6,23 +6,15 @@
 #ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
-// The pass walks DistributedOpInterface ops with unbound buffer operands and
-// inserts a ttnn.empty in the function prelude (right after ttnn.get_device)
-// for each missing buffer. The op's operand_segment_sizes is updated to
-// reflect the newly-bound stats operand.
 module @test_allocate_buffers attributes {} {
   func.func public @test_allocates_stats_buffer(
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>,
       %arg1: tensor<4x32xbf16, #ttnn_layout_weight_rm>) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws> {
+    // CHECK: #[[STATS_LAYOUT:.+]] = #ttnn.ttnn_layout{{.*}}tile<32x32, f32>{{.*}}<width_sharded>
     // CHECK-LABEL: func.func public @test_allocates_stats_buffer
-    // The stats EmptyOp must sit in the prelude, between get_device and the
-    // norm op, so trace hoisting keeps a contiguous block of non-hoistable
-    // ops at the start of the function.
     // CHECK: %[[DEV:.+]] = "ttnn.get_device"
     // CHECK: %[[STATS:.+]] = "ttnn.empty"
-    // CHECK-SAME: <width_sharded>
-    // The op must consume the new stats buffer; segment sizes update to
-    // 1,1,0,1,0,1 (input, weight, residual, stats, semaphore, device).
+    // CHECK-SAME: tensor<1x1x32x32xf32, #[[STATS_LAYOUT]]>
     // CHECK: "ttnn.distributed_rms_norm"
     // CHECK-SAME: %[[STATS]]
     // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 1, 0, 1>

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_buffers.mlir
@@ -3,7 +3,7 @@
 
 #l1 = #ttnn.buffer_type<l1>
 #system_memory = #ttnn.buffer_type<system_memory>
-#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
 // The pass walks DistributedOpInterface ops with unbound buffer operands and

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
@@ -3,7 +3,7 @@
 
 #l1 = #ttnn.buffer_type<l1>
 #system_memory = #ttnn.buffer_type<system_memory>
-#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
 // The pass walks DistributedOpInterface ops with unbound semaphore operands

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-allocate-distributed-op-semaphores -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+#l1 = #ttnn.buffer_type<l1>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
+
+// The pass walks DistributedOpInterface ops with unbound semaphore operands
+// and inserts a ttnn.create_global_semaphore in the function prelude for
+// each missing semaphore. The op must already have a memory_config attribute
+// (the workaround pattern populates this), since the semaphore core range
+// is derived from the input shard spec.
+module @test_allocate_semaphores attributes {} {
+  func.func public @test_allocates_global_semaphore(
+      %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>,
+      %arg1: tensor<4x32xbf16, #ttnn_layout_weight_rm>) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws> {
+    // CHECK-LABEL: func.func public @test_allocates_global_semaphore
+    // The semaphore must sit in the prelude alongside any other distributed-op
+    // resources so trace hoisting can keep them all in one contiguous block.
+    // CHECK: %[[DEV:.+]] = "ttnn.get_device"
+    // CHECK: %[[SEM:.+]] = "ttnn.create_global_semaphore"
+    // The op must consume the new semaphore; segment sizes update to
+    // 1,1,0,0,1,1 (input, weight, residual, stats, semaphore, device).
+    // CHECK: "ttnn.distributed_rms_norm"
+    // CHECK-SAME: %[[SEM]]
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 1, 1>
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %0) <{
+      cluster_axis = 1 : ui32,
+      epsilon = 1.000000e-05 : f32,
+      operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>,
+      memory_config = #ttnn.memory_config<#l1, <width_sharded>, <shard_spec<grid = #ttnn.core_range_set<[<#ttnn.core_range<<0, 0>, <3, 0>>]>>, <32x32>, <row_major>, <physical>>>>
+    }> : (tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>, tensor<4x32xbf16, #ttnn_layout_weight_rm>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
+    return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
@@ -3,7 +3,7 @@
 
 #l1 = #ttnn.buffer_type<l1>
 #system_memory = #ttnn.buffer_type<system_memory>
-#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
+#ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1, d2) -> (d1, d2)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
 // The pass walks DistributedOpInterface ops with unbound semaphore operands
@@ -30,7 +30,7 @@ module @test_allocate_semaphores attributes {} {
       cluster_axis = 1 : ui32,
       epsilon = 1.000000e-05 : f32,
       operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 1>,
-      memory_config = #ttnn.memory_config<#l1, <width_sharded>, <shard_spec<grid = #ttnn.core_range_set<[<#ttnn.core_range<<0, 0>, <3, 0>>]>>, <32x32>, <row_major>, <physical>>>>
+      memory_config = #ttnn.memory_config<#l1, <width_sharded>, #ttnn.shard_spec<#ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>, <32x32>, <row_major>>>
     }> : (tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>, tensor<4x32xbf16, #ttnn_layout_weight_rm>, !ttnn.device) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
     return %1 : tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/distributed_rms_norm_allocate_semaphores.mlir
@@ -6,22 +6,13 @@
 #ttnn_layout_input_ws = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x4>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <width_sharded>, core_ranges = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (3,0)>]>>
 #ttnn_layout_weight_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x32xbf16, #system_memory>>
 
-// The pass walks DistributedOpInterface ops with unbound semaphore operands
-// and inserts a ttnn.create_global_semaphore in the function prelude for
-// each missing semaphore. The op must already have a memory_config attribute
-// (the workaround pattern populates this), since the semaphore core range
-// is derived from the input shard spec.
 module @test_allocate_semaphores attributes {} {
   func.func public @test_allocates_global_semaphore(
       %arg0: tensor<1x1x32x128xbf16, #ttnn_layout_input_ws>,
       %arg1: tensor<4x32xbf16, #ttnn_layout_weight_rm>) -> tensor<1x1x32x128xbf16, #ttnn_layout_input_ws> {
     // CHECK-LABEL: func.func public @test_allocates_global_semaphore
-    // The semaphore must sit in the prelude alongside any other distributed-op
-    // resources so trace hoisting can keep them all in one contiguous block.
     // CHECK: %[[DEV:.+]] = "ttnn.get_device"
     // CHECK: %[[SEM:.+]] = "ttnn.create_global_semaphore"
-    // The op must consume the new semaphore; segment sizes update to
-    // 1,1,0,0,1,1 (input, weight, residual, stats, semaphore, device).
     // CHECK: "ttnn.distributed_rms_norm"
     // CHECK-SAME: %[[SEM]]
     // CHECK-SAME: operandSegmentSizes = array<i32: 1, 1, 0, 0, 1, 1>

--- a/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
@@ -19,7 +19,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 }
 func.func @test_capture_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @nonexistent_capture, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @nonexistent_capture, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -31,7 +31,7 @@ func.func @test_capture_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>, 
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
 // --- Test 2: Input argument count mismatch with capture function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Number of input arguments (2) does not match capture function 'capture_fn' input count (1)
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Number of input arguments (inputs + semaphore_inputs = 2 + 0 = 2) does not match capture function 'capture_fn' input count (1)
 func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   return %arg0 : tensor<32x32xbf16, #layout>
 }
@@ -50,7 +50,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 }
 func.func @test_input_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -83,7 +83,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 func.func @test_input_type_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   // Op passes bf16 but capture_fn expects f32 for arg1.
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -107,7 +107,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 }
 func.func @test_no_trace_function(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -140,7 +140,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 func.func @test_output_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   // trace_fn returns 1 result, but op declares 2 outputs.
-  %1, %2 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> (tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>)
+  %1, %2 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> (tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>)
   return %1, %2 : tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>
 }
 
@@ -173,7 +173,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 func.func @test_output_type_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xf32, #layout_f32> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   // trace_fn returns bf16 but op declares f32 output.
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xf32, #layout_f32>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xf32, #layout_f32>
   return %1 : tensor<32x32xf32, #layout_f32>
 }
 
@@ -204,7 +204,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 }
 func.func @test_trace_arg_not_on_device(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -238,7 +238,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
 }
 func.func @test_device_config_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -267,7 +267,7 @@ func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tenso
 }
 func.func @test_execute_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @nonexistent_execute}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @nonexistent_execute, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -299,7 +299,7 @@ func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>, %arg1: tensor
 }
 func.func @test_execute_wrong_arg_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -331,6 +331,6 @@ func.func private @execute_fn(%arg0: tensor<32x32xbf16, #layout>) {
 }
 func.func @test_execute_wrong_arg_type(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
@@ -24,7 +24,7 @@ module {
     // As ttnn.zeros and ttnn.ones are not const-eval'd, they will be recreated on each iteration of execution, hence they should be treated as regular inputs. We need to move them to host, and create a device trace input slot for them.
     // CHECK: %[[ZEROS_ON_HOST:.+]] = "ttnn.from_device"
     // CHECK: %[[ONES_ON_HOST:.+]] = "ttnn.from_device"
-    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %[[ZEROS_ON_HOST]], %[[ONES_ON_HOST]]) <{capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops}>
+    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %[[ZEROS_ON_HOST]], %[[ONES_ON_HOST]]) <{capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK: return %[[TRACE_RESULT]]
     %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
     %1 = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
@@ -26,7 +26,7 @@ module {
   func.func @matmul_with_multiply(%arg0: tensor<64x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg1: tensor<32x64xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<64x64xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
     // CHECK: %[[LOAD_CACHED_RESULT:.+]] = ttcore.load_cached(@matmul_with_multiply_const_eval_0, [%arg0, %arg1])
-    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg2, %[[LOAD_CACHED_RESULT]]) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply}>
+    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg2, %[[LOAD_CACHED_RESULT]]) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK-NOT: "ttnn.multiply"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
@@ -19,7 +19,7 @@ module {
   // CHECK-LABEL: func.func @matmul_with_multiply(
   func.func @matmul_with_multiply(%arg0: tensor<64x32xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1, %arg2) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply}>
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1, %arg2) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 3, 0>}>
     // CHECK-NOT: "ttnn.multiply"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
@@ -20,7 +20,7 @@ module {
   // CHECK-LABEL: func.func @single_add(
   func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x32xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1) <{capture_callee = @run_and_capture_trace_0_single_add, execute_callee = @execute_trace_0_single_add}>
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1) <{capture_callee = @run_and_capture_trace_0_single_add, execute_callee = @execute_trace_0_single_add, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK-NOT: "ttnn.add"
     // CHECK: return %[[TRACE_RESULT]]
     %1 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/8205)

### Problem description
Ops that use global semaphores (like `distributed_rms_norm`) didn’t work with trace because the capture run created new semaphores instead of reusing the ones from warmup. 

This [commit](https://github.com/tenstorrent/tt-mlir/commit/5b85073695682d062a0ac7fe5888bfb5b410853d) fixed this as a quick unblock by giving each child `ProgramContext` a `parentContext` pointer and making the runtime op create the semaphore on warmup and cache it on the parent where capture run could later find it.

Cleaner way is to create them with `ttnn.create_global_semaphore` op, propagate to subprogram calls and trace the same way as input tensors, and resolve at runtime through existing global semaphore pool.

### What's changed

- `distributed_rms_norm` now takes an explicit `ttnn.global_semaphore` operand at the MLIR level, so the runtime dependency is visible in IR instead of being implicit. The workaround that lowers the op leaves the operand as `nullptr`; materialization is delegated to a dedicated allocation pass that runs after optimizer.

- The `DistributedRMSNormWidthShardInputRewritePattern` workaround is now strictly a layout/sharding workaround — it leaves `stats` (buffer) and `semaphore` operands as `nullptr` on the rebuilt op and delegates their materialization to the allocation passes.

- New `TTNN_DistributedOpInterface` for composite multi-device ops that need explicit scratch buffers and/or global semaphores in IR. The interface exposes `hasUnboundBuffers` / `allocateBuffers` and `hasUnboundSemaphores` / `allocateSemaphores`; implementations are idempotent and create their resources in the function prelude (right after `ttnn.get_device`) so trace hoisting stays clean. Currently only used for `DistributedRMSNormOp`, but will be used for future ccls, like `all_gather_async` and `reduce_scatter_async`

- Two dedicated passes drive allocation through the interface:
  - `TTNNAllocateDistributedOpBuffers` runs **before** the optimizer, so scratch buffers contribute to L1 budgeting (currently they are ignored, but that will be fixed separately). A canonicalize + CSE pair runs immediately after it to dedupe identical `EmptyOp`s across distributed ops. This way buffer of every dimension is allocated once and reused for all the ops that need it. This is ok for distributed rms norm as it doesn't care for the content of the buffer before use, when we come into ops that do this will be handled differently.
  - `TTNNAllocateDistributedOpSemaphores` runs **after** the optimizer (semaphore core range is derived from the finalized input shard spec) and **before** trace hoisting (semaphore SSA values must be visible at the trace boundary). Semaphores are not CSE'd because it was breaking resnet test, and it would not be contributing much as semaphores are small anyway and it would rely on op correctly resetting before and after usage.

- `ttnn.create_global_semaphore` is marked as a creation op (`TTCoreCreationOpTrait` + `NonCacheableTrait`), so the trace-hoist pass keeps it outside the trace region.

- Global semaphores flow through `func.call` and `ttnn.capture_or_execute_trace` the same way input tensors do, distinguished by their `GlobalSemaphoreType`:
  - For `func.call`, semaphores ride as ordinary SSA operands; the flatbuffer serializer partitions them into a separate `semaphore_inputs: [GlobalSemaphoreRef]` field on `FuncCallOp` (mirroring how tensor operands become `inputs: [TensorRef]`).
  - `ttnn.capture_or_execute_trace` gets an explicit `semaphore_inputs` variadic operand.
  - The trace-hoist pass scans inputs by SSA type and forwards semaphores into the trace function (as block args of `GlobalSemaphoreType`) and through the wrapping `func.call` / `CaptureOrExecuteTraceOp`.
  - At the program (function) level, function arguments of `GlobalSemaphoreType` are surfaced as `program.semaphore_inputs` in the flatbuffer.

- At runtime, semaphores are serialized as `GlobalSemaphoreRefs` and resolved through the existing per-`ProgramContext` global semaphore pool, the same way input tensors already use the tensor pool. When entering a subprogram or trace, the parent seeds the child's pool from the inputs it received, so capture and replay reuse the same semaphore objects.

### Checklist
- [ ] New/Existing tests provide coverage for changes
- [ ] [perf benchmark for llama](https://github.com/tenstorrent/tt-xla/actions/runs/25312821286)
