### PR TITLE
Fix rare build race between MLIRTTNNInterfaces and TTCore tablegen

### DIFF
--- a/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Interfaces/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_library(MLIRTTNNInterfaces
   MLIRTTNNWorkaroundInterfaceIncGen
   MLIRTTNNKernelInterfaceIncGen
   TTNNOpsInterfacesIncGen
+  MLIRTTCoreOpsIncGen
 
   LINK_LIBS
   PUBLIC


### PR DESCRIPTION
## Summary
- Add `MLIRTTCoreOpsIncGen` to `DEPENDS` in `lib/Dialect/TTNN/Interfaces/CMakeLists.txt` to fix a build race condition

The `MLIRTTNNInterfaces` library sources include headers that transitively depend on `TTCoreOpsTypes.h.inc` (generated by tablegen). Without an explicit `DEPENDS` on `MLIRTTCoreOpsIncGen`, parallel builds can start compiling these sources before the `.h.inc` file is generated, causing build failures with:

```
fatal error: 'ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h.inc' file not found
```

The existing `LINK_LIBS PRIVATE MLIRTTCoreDialect` only establishes link-time dependencies, not compile-time build-order dependencies for tablegen targets.


🤖 Generated with [Claude Code](https://claude.com/claude-code)