### PR TITLE
D2M builder: allow explicit outputs and VGM-capable d2m.empty

### DIFF
--- a/tools/builder/d2m/d2m_builder.py
+++ b/tools/builder/d2m/d2m_builder.py
@@ -112,6 +112,39 @@ class D2MBuilder(Builder):
         """Get D2M-specific empty operation."""
         return d2m.EmptyOp(tensor_type).result
 
+    def empty(
+        self,
+        output_type: RankedTensorType,
+        virtual_grid_inverse_mapping: Optional[Union[AffineMap, AffineMapAttr]] = None,
+        virtual_grid_forward_mapping: Optional[Union[AffineMap, AffineMapAttr]] = None,
+    ) -> OpView:
+        """Create a D2M empty op with optional virtual-grid mappings."""
+        vgm_inv_attr = (
+            virtual_grid_inverse_mapping
+            if isinstance(virtual_grid_inverse_mapping, AffineMapAttr)
+            else (
+                AffineMapAttr.get(virtual_grid_inverse_mapping)
+                if virtual_grid_inverse_mapping is not None
+                else None
+            )
+        )
+        vgm_fwd_attr = (
+            virtual_grid_forward_mapping
+            if isinstance(virtual_grid_forward_mapping, AffineMapAttr)
+            else (
+                AffineMapAttr.get(virtual_grid_forward_mapping)
+                if virtual_grid_forward_mapping is not None
+                else None
+            )
+        )
+
+        with self._ctx, self._loc:
+            return d2m.EmptyOp(
+                output_type,
+                virtualGridInverseMapping=vgm_inv_attr,
+                virtualGridForwardMapping=vgm_fwd_attr,
+            ).result
+
     # ----- D2M Layout Operations -----
 
     def to_layout(

--- a/tools/builder/d2m/d2m_builder.py
+++ b/tools/builder/d2m/d2m_builder.py
@@ -117,7 +117,8 @@ class D2MBuilder(Builder):
     def to_layout(
         self,
         input: Operand,
-        output_type: Type,
+        output: Optional[Operand] = None,
+        output_type: Optional[Type] = None,
         unit_attrs: Optional[List[str]] = None,
         loc: Optional[Union[str, Location]] = None,
     ) -> OpView:
@@ -126,25 +127,46 @@ class D2MBuilder(Builder):
 
         Args:
             input: Input operand
-            output_type: Desired output type with layout
+            output: Optional destination operand to use directly.
+            output_type: Optional destination type. Must provide exactly one of
+                `output` or `output_type`.
             unit_attrs: Optional unit attributes
             loc: Optional location string
 
         Returns:
             OpView of the D2M to_layout operation
         """
+        # Backward compatibility for legacy positional calls:
+        # to_layout(input, output_type, ...)
+        if output_type is None and output is not None and isinstance(output, Type):
+            output_type = output
+            output = None
+
+        if (output is None) == (output_type is None):
+            raise ValueError(
+                "to_layout requires exactly one of `output` or `output_type`."
+            )
+
+        if output is not None:
+            resolved_output = output
+            resolved_output_type = self._get_type(output)
+            output_create_fn = lambda _shape, _type: resolved_output
+        else:
+            resolved_output_type = output_type
+            output_create_fn = self._create_empty_from_tensor_type
 
         def organize_to_layout_args(inputs, output, output_shape):
             # D2M ToLayoutOp expects: (results_, input, output)
-            return ([output_type], inputs[0], output)
+            return ([resolved_output_type], inputs[0], output)
 
         return self._op_proxy(
             d2m.ToLayoutOp,
             [input],
             unit_attrs=unit_attrs,
             organize_d2m_args=organize_to_layout_args,
-            output_type=output_type,
-            output_shape=output_type.shape,
+            output_type=resolved_output_type,
+            output_shape=resolved_output_type.shape,
+            output_create_fn=output_create_fn,
             loc=loc,
         )
 

--- a/tools/builder/d2m/d2m_builder.py
+++ b/tools/builder/d2m/d2m_builder.py
@@ -102,8 +102,6 @@ class D2MBuilder(Builder):
     def _resolve_output_spec(
         self, output: Optional[Operand], output_type: Optional[Type]
     ) -> Tuple[Type, Callable]:
-        # Backward compatibility for legacy positional calls:
-        # <op>(input, output_type, ...)
         if output_type is None and output is not None and isinstance(output, Type):
             output_type = output
             output = None
@@ -254,8 +252,8 @@ class D2MBuilder(Builder):
         """
         Create a D2M tilize operation (specialized to_layout with tiled output).
 
-        This is a convenience wrapper over to_layout and accepts the same
-        destination specification (`output` xor `output_type`).
+        This is a convenience method that creates a to_layout operation
+        with a tiled layout output type.
         """
         return self.to_layout(
             input,
@@ -274,8 +272,8 @@ class D2MBuilder(Builder):
         """
         Create a D2M untilize operation (specialized to_layout with row-major output).
 
-        This is a convenience wrapper over to_layout and accepts the same
-        destination specification (`output` xor `output_type`).
+        This is a convenience method that creates a to_layout operation
+        with a row-major (untiled) layout output type.
         """
         return self.to_layout(
             input,

--- a/tools/builder/d2m/d2m_builder.py
+++ b/tools/builder/d2m/d2m_builder.py
@@ -99,6 +99,26 @@ class D2MBuilder(Builder):
 
             return op.result
 
+    def _resolve_output_spec(
+        self, output: Optional[Operand], output_type: Optional[Type]
+    ) -> Tuple[Type, Callable]:
+        # Backward compatibility for legacy positional calls:
+        # <op>(input, output_type, ...)
+        if output_type is None and output is not None and isinstance(output, Type):
+            output_type = output
+            output = None
+
+        if (output is None) == (output_type is None):
+            raise ValueError("requires exactly one of `output` or `output_type`.")
+
+        if output is not None:
+            resolved_output = output
+            resolved_output_type = self._get_type(output)
+            output_create_fn = lambda _shape, _type: resolved_output
+            return resolved_output_type, output_create_fn
+
+        return output_type, self._create_empty_from_tensor_type
+
     def create_tensor_encoding(
         self, shape: Shape, element_type: Union[torch.dtype, TypeInfo]
     ) -> ttnn.ir.TTNNLayoutAttr:
@@ -169,24 +189,9 @@ class D2MBuilder(Builder):
         Returns:
             OpView of the D2M to_layout operation
         """
-        # Backward compatibility for legacy positional calls:
-        # to_layout(input, output_type, ...)
-        if output_type is None and output is not None and isinstance(output, Type):
-            output_type = output
-            output = None
-
-        if (output is None) == (output_type is None):
-            raise ValueError(
-                "to_layout requires exactly one of `output` or `output_type`."
-            )
-
-        if output is not None:
-            resolved_output = output
-            resolved_output_type = self._get_type(output)
-            output_create_fn = lambda _shape, _type: resolved_output
-        else:
-            resolved_output_type = output_type
-            output_create_fn = self._create_empty_from_tensor_type
+        resolved_output_type, output_create_fn = self._resolve_output_spec(
+            output=output, output_type=output_type
+        )
 
         def organize_to_layout_args(inputs, output, output_shape):
             # D2M ToLayoutOp expects: (results_, input, output)
@@ -242,50 +247,40 @@ class D2MBuilder(Builder):
     def tilize(
         self,
         input: Operand,
-        output_type: Type,
+        output: Optional[Operand] = None,
+        output_type: Optional[Type] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         """
         Create a D2M tilize operation (specialized to_layout with tiled output).
 
-        This is a convenience method that creates a to_layout operation
-        with a tiled layout output type.
+        This is a convenience wrapper over to_layout and accepts the same
+        destination specification (`output` xor `output_type`).
         """
-        return self._op_proxy(
-            d2m.ToLayoutOp,
-            [input],
+        return self.to_layout(
+            input,
+            output=output,
             output_type=output_type,
-            output_create_fn=self._create_empty_from_tensor_type,
-            organize_d2m_args=lambda i, o, _: (
-                [self._get_type(o)],
-                i[0],
-                o,
-            ),
             unit_attrs=unit_attrs,
         )
 
     def untilize(
         self,
         input: Operand,
-        output_type: Type,
+        output: Optional[Operand] = None,
+        output_type: Optional[Type] = None,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         """
         Create a D2M untilize operation (specialized to_layout with row-major output).
 
-        This is a convenience method that creates a to_layout operation
-        with a row-major (untiled) layout output type.
+        This is a convenience wrapper over to_layout and accepts the same
+        destination specification (`output` xor `output_type`).
         """
-        return self._op_proxy(
-            d2m.ToLayoutOp,
-            [input],
+        return self.to_layout(
+            input,
+            output=output,
             output_type=output_type,
-            output_create_fn=self._create_empty_from_tensor_type,
-            organize_d2m_args=lambda i, o, _: (
-                [self._get_type(o)],
-                i[0],
-                o,
-            ),
             unit_attrs=unit_attrs,
         )
 


### PR DESCRIPTION
### Ticket
closes #8195

### Problem description
The D2M builder’s `to_layout` API was type-driven, so output tensors were created internally and could not carry `virtualGridInverseMapping` / `virtualGridForwardMapping` when needed. This made it hard to express valid d2m.empty forms for virtual-grid-aware cases, even though the dialect supports them. 

### What's changed
Added a public D2MBuilder.empty(...) API that can set optional virtual-grid mapping attributes. Updated to_layout API (and wrappers using it) to accept either output or output_type (exactly one), and centralized that resolution logic in one private helper. tilize and untilize now delegate through the unified to_layout path.

### Checklist
- [ ] New/Existing tests provide coverage for changes
