### PR TITLE
[d2m] argmax

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1649,6 +1649,74 @@ def D2M_IndexedRowCopyOp : D2M_GenericRegionDatamovementOp<"indexed_row_copy",
     let hasVerifier = 1;
 }
 
+def D2M_ArgMaxInterleavedOp : D2M_GenericRegionDatamovementOp<"argmax_interleaved",
+  [ DeclareOpInterfaceMethods<MemoryEffectsOpInterface> ]> {
+    let summary = "D2M interleaved argmax op";
+    let description = [{
+      Data-movement primitive for computing argmax over the last logical
+      dimension of a row-major tensor. The op reads source elements from L1,
+      scans each row on the data-movement core, and writes 32-bit indices to
+      the output buffer.
+
+      The op is memref-only. Tensor-level semantic ops should bufferize to this
+      op after choosing a scratch circular buffer.
+    }];
+
+    let arguments = (ins
+      DeviceL1MemRef:$input,
+      DeviceL1MemRef:$output,
+      DeviceL1MemRef:$scratch,
+      I64Attr:$numRows,
+      I64Attr:$rowWidth,
+      DenseI64ArrayAttr:$rowShape
+    );
+
+    let assemblyFormat = [{
+      $input `,` $output `scratch` $scratch
+      `<` $numRows `,` $rowWidth `>`
+      attr-dict `:` type($input) `,` type($output) `,` type($scratch)
+    }];
+
+    let hasVerifier = 1;
+}
+
+def D2M_ArgMaxOp : D2M_GenericRegionDatamovementOp<"argmax",
+  [ DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [
+      "bufferizesToMemoryRead",
+      "bufferizesToMemoryWrite",
+      "bufferize",
+      "getAliasingValues",
+      "getBufferType",
+      "hasTensorSemantics"
+    ]>
+  ]> {
+    let summary = "D2M argmax op";
+    let description = [{
+      Tensor-level data-movement argmax over the last logical dimension. During
+      bufferization, this op allocates a scratch circular buffer and lowers to
+      `d2m.argmax_interleaved`, which owns the backend dataflow implementation.
+    }];
+
+    let arguments = (ins
+      AnyRankedTensor:$input,
+      AnyRankedTensor:$output,
+      I64Attr:$numRows,
+      I64Attr:$rowWidth,
+      DenseI64ArrayAttr:$rowShape
+    );
+    let results = (outs AnyRankedTensor:$result);
+
+    let assemblyFormat = [{
+      $input `,` $output
+      `<` $numRows `,` $rowWidth `>`
+      attr-dict `:` type($input) `,` type($output)
+      `->` type($result)
+    }];
+
+    let hasVerifier = 1;
+}
+
 def D2M_EmbeddingOp : D2M_GenericRegionDatamovementOp<"embedding",
   [ DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   , DeclareOpInterfaceMethods<BufferizableOpInterface, [

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -45,6 +45,13 @@ Type getRegionLargestDstElemType(Region &region);
 // Returns nullptr if no DST-using ops are found.
 Type getRegionLargestDstElemTypeOrNull(Region &region);
 
+// Returns true for the 32-bit integer type used by D2M scalar data-movement
+// helpers.
+bool isI32ElementType(Type type);
+
+// Element types currently supported by the D2M argmax data-movement lowering.
+bool isSupportedArgMaxInputElementType(Type type);
+
 // Computes dim constraints implied by the indexing maps and shapes. If
 // successful, returns a vector of dim constraints for each dimension; a '0'
 // indicates that the dimension is not constrained. If the shapes imply

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3675,14 +3675,15 @@ def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val",
 //===----------------------------------------------------------------------===//
 
 def TTKernel_BitcastOp : TTKernel_Op<"bitcast", [Pure]> {
-    let summary = "Reinterpret a ui32 compile-time arg value as a scalar type.";
+    let summary = "Reinterpret a 32-bit integer value as a scalar type.";
     let description = [{
-      Reinterprets the bits of a ui32 compile-time arg as the given type.
-      Used to recover typed scalar kernel arguments after reading them from
-      the compile-time arg slot (which always stores ui32).
+      Reinterprets the bits of an i32 or ui32 value as the given type. Used to
+      recover typed scalar kernel arguments after reading them from the
+      compile-time arg slot (which always stores ui32), or to preserve the bit
+      pattern of a signed 32-bit value.
     }];
 
-    let arguments = (ins UI32:$input);
+    let arguments = (ins AnyTypeOf<[I32, UI32]>:$input);
 
     let results = (outs AnyType:$result);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2585,52 +2585,44 @@ public:
 } // namespace
 
 namespace {
-static bool isI32ElementType(Type type) {
-  auto intType = mlir::dyn_cast<IntegerType>(type);
-  return intType && intType.getWidth() == 32;
+static Value compareArgMaxCandidates(OpBuilder &rewriter, Location loc,
+                                     Value candidate, Value currentMax) {
+  Type candidateType = candidate.getType();
+  if (mlir::isa<FloatType>(candidateType)) {
+    // Ordered greater-than keeps the existing maximum if either operand is NaN.
+    return rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT,
+                                          candidate, currentMax);
+  }
+  if (d2m::utils::isI32ElementType(candidateType)) {
+    return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
+                                          candidate, currentMax);
+  }
+  llvm_unreachable("Unsupported argmax candidate type");
 }
 
-static Value loadArgMaxElement(OpBuilder &rewriter, Location loc,
-                               Value scratchCb, Value inputBase,
-                               AffineMap inputMemoryMap, MemRefType inputType,
-                               Value row, Value column,
-                               ttcore::ChipDescAttr chipDesc) {
-  Type elementType = inputType.getElementType();
+static Value loadArgMaxElementFromPacket(OpBuilder &rewriter, Location loc,
+                                         Value l1Ptr, Type elementType,
+                                         Value packetLane) {
   bool isBF16 = mlir::isa<BFloat16Type>(elementType);
   bool isF32 = mlir::isa<Float32Type>(elementType);
-  bool isI32 = isI32ElementType(elementType);
+  bool isI32 = d2m::utils::isI32ElementType(elementType);
   assert((isBF16 || isF32 || isI32) &&
          "argmax supports f32, bf16, and i32 inputs only");
 
-  Value packetColumn;
   Value wordLane;
   Value halfLane = index(rewriter, loc, 0);
   if (isBF16) {
-    Value eight = index(rewriter, loc, 8);
     Value two = index(rewriter, loc, 2);
-    Value packetIndex = rewriter.create<arith::DivSIOp>(loc, column, eight);
-    packetColumn = rewriter.create<arith::MulIOp>(loc, packetIndex, eight);
-    Value packetOffset =
-        rewriter.create<arith::SubIOp>(loc, column, packetColumn);
-    wordLane = rewriter.create<arith::DivSIOp>(loc, packetOffset, two);
+    wordLane = rewriter.create<arith::DivSIOp>(loc, packetLane, two);
     Value wordBase = rewriter.create<arith::MulIOp>(loc, wordLane, two);
-    halfLane = rewriter.create<arith::SubIOp>(loc, packetOffset, wordBase);
+    halfLane = rewriter.create<arith::SubIOp>(loc, packetLane, wordBase);
   } else {
-    Value four = index(rewriter, loc, 4);
-    Value packetIndex = rewriter.create<arith::DivSIOp>(loc, column, four);
-    packetColumn = rewriter.create<arith::MulIOp>(loc, packetIndex, four);
-    wordLane = rewriter.create<arith::SubIOp>(loc, column, packetColumn);
+    wordLane = packetLane;
   }
 
-  SmallVector<Value> inputLogicalIndices =
-      getCollapsed2DElementIndices(rewriter, loc, inputType, row, packetColumn);
-  Value inputNocAddr = buildMappedL1NocAddr(
-      rewriter, loc, inputBase, inputMemoryMap, inputLogicalIndices, chipDesc);
   Value wordLaneI32 =
       rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), wordLane);
-  Value word = loadI32FromL1PacketThroughScratch(
-      rewriter, loc, scratchCb, inputNocAddr, wordLaneI32,
-      i32(rewriter, loc, 16), i32(rewriter, loc, 1));
+  Value word = rewriter.create<ttkernel::LoadFromL1Op>(loc, l1Ptr, wordLaneI32);
 
   if (isF32) {
     return rewriter.create<ttkernel::BitcastOp>(loc, rewriter.getF32Type(),
@@ -2640,6 +2632,9 @@ static Value loadArgMaxElement(OpBuilder &rewriter, Location loc,
     return word;
   }
 
+  // TTKernel exposes each 16B packet as four little-endian i32 words. BF16
+  // values are packed two per word, with the low halfword holding the even
+  // lane.
   Value lowBits =
       rewriter.create<arith::AndIOp>(loc, word, i32(rewriter, loc, 0xffff));
   Value highBits =
@@ -2653,18 +2648,82 @@ static Value loadArgMaxElement(OpBuilder &rewriter, Location loc,
   return rewriter.create<arith::ExtFOp>(loc, rewriter.getF32Type(), bf16Value);
 }
 
-static Value compareArgMaxCandidates(OpBuilder &rewriter, Location loc,
-                                     Value candidate, Value currentMax) {
-  Type candidateType = candidate.getType();
-  if (mlir::isa<FloatType>(candidateType)) {
-    return rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT,
-                                          candidate, currentMax);
-  }
-  if (isI32ElementType(candidateType)) {
-    return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
-                                          candidate, currentMax);
-  }
-  llvm_unreachable("Unsupported argmax candidate type");
+static Value loadArgMaxElement(OpBuilder &rewriter, Location loc,
+                               Value scratchCb, Value inputBase,
+                               AffineMap inputMemoryMap, MemRefType inputType,
+                               Value row, Value column,
+                               ttcore::ChipDescAttr chipDesc) {
+  Type elementType = inputType.getElementType();
+  Value elementsPerPacket =
+      index(rewriter, loc, mlir::isa<BFloat16Type>(elementType) ? 8 : 4);
+  Value packetIndex =
+      rewriter.create<arith::DivSIOp>(loc, column, elementsPerPacket);
+  Value packetColumn =
+      rewriter.create<arith::MulIOp>(loc, packetIndex, elementsPerPacket);
+  Value packetLane = rewriter.create<arith::SubIOp>(loc, column, packetColumn);
+
+  SmallVector<Value> inputLogicalIndices =
+      getCollapsed2DElementIndices(rewriter, loc, inputType, row, packetColumn);
+  Value inputNocAddr = buildMappedL1NocAddr(
+      rewriter, loc, inputBase, inputMemoryMap, inputLogicalIndices, chipDesc);
+  Value onePage = i32(rewriter, loc, 1);
+  rewriter.create<ttkernel::CBReserveBackOp>(loc, scratchCb, onePage);
+  Value writePtr = rewriter.create<ttkernel::GetWritePtrOp>(loc, scratchCb);
+  rewriter.create<ttkernel::NocAsyncReadOp>(loc, inputNocAddr, writePtr,
+                                            i32(rewriter, loc, 16));
+  rewriter.create<ttkernel::NocAsyncReadBarrierOp>(loc);
+  rewriter.create<ttkernel::CBPushBackOp>(loc, scratchCb, onePage);
+  rewriter.create<ttkernel::CBWaitFrontOp>(loc, scratchCb, onePage);
+  Value readPtr = rewriter.create<ttkernel::GetReadPtrOp>(loc, scratchCb);
+  Value l1Ptr = rewriter.create<ttkernel::CastToL1PtrOp>(loc, readPtr);
+  Value element = loadArgMaxElementFromPacket(rewriter, loc, l1Ptr, elementType,
+                                              packetLane);
+  rewriter.create<ttkernel::CBPopFrontOp>(loc, scratchCb, onePage);
+  return element;
+}
+
+static scf::ForOp
+scanArgMaxPacket(OpBuilder &rewriter, Location loc, Value scratchCb,
+                 Value inputBase, AffineMap inputMemoryMap,
+                 MemRefType inputType, Value inputRow, Value packetColumn,
+                 Value startLane, Value endLane, Value currentMax,
+                 Value currentIndex, ttcore::ChipDescAttr chipDesc) {
+  SmallVector<Value> inputLogicalIndices = getCollapsed2DElementIndices(
+      rewriter, loc, inputType, inputRow, packetColumn);
+  Value inputNocAddr = buildMappedL1NocAddr(
+      rewriter, loc, inputBase, inputMemoryMap, inputLogicalIndices, chipDesc);
+  Value onePage = i32(rewriter, loc, 1);
+  rewriter.create<ttkernel::CBReserveBackOp>(loc, scratchCb, onePage);
+  Value writePtr = rewriter.create<ttkernel::GetWritePtrOp>(loc, scratchCb);
+  rewriter.create<ttkernel::NocAsyncReadOp>(loc, inputNocAddr, writePtr,
+                                            i32(rewriter, loc, 16));
+  rewriter.create<ttkernel::NocAsyncReadBarrierOp>(loc);
+  rewriter.create<ttkernel::CBPushBackOp>(loc, scratchCb, onePage);
+  rewriter.create<ttkernel::CBWaitFrontOp>(loc, scratchCb, onePage);
+  Value readPtr = rewriter.create<ttkernel::GetReadPtrOp>(loc, scratchCb);
+  Value l1Ptr = rewriter.create<ttkernel::CastToL1PtrOp>(loc, readPtr);
+
+  auto laneLoop = rewriter.create<scf::ForOp>(
+      loc, startLane, endLane, index(rewriter, loc, 1),
+      ValueRange{currentMax, currentIndex},
+      [&](OpBuilder &builder, Location bodyLoc, Value lane,
+          ValueRange iterArgs) {
+        Value candidate = loadArgMaxElementFromPacket(
+            builder, bodyLoc, l1Ptr, inputType.getElementType(), lane);
+        Value isGreater =
+            compareArgMaxCandidates(builder, bodyLoc, candidate, iterArgs[0]);
+        Value column =
+            builder.create<arith::AddIOp>(bodyLoc, packetColumn, lane);
+        Value columnIndex = builder.create<arith::IndexCastOp>(
+            bodyLoc, builder.getI32Type(), column);
+        Value nextMax = builder.create<arith::SelectOp>(bodyLoc, isGreater,
+                                                        candidate, iterArgs[0]);
+        Value nextIndex = builder.create<arith::SelectOp>(
+            bodyLoc, isGreater, columnIndex, iterArgs[1]);
+        builder.create<scf::YieldOp>(bodyLoc, ValueRange{nextMax, nextIndex});
+      });
+  rewriter.create<ttkernel::CBPopFrontOp>(loc, scratchCb, onePage);
+  return laneLoop;
 }
 
 static void storeArgMaxIndex(OpBuilder &rewriter, Location loc, Value scratchCb,
@@ -2745,7 +2804,7 @@ public:
         loc, myX, index(rewriter, loc, outputShardShape[1]));
     Value tentativeEndColumn = rewriter.create<arith::AddIOp>(
         loc, startColumn, index(rewriter, loc, outputShardShape[1]));
-    Value outputWidth = index(rewriter, loc, 1);
+    Value outputWidth = index(rewriter, loc, outputShardShape[1]);
     Value columnEndsBeforeTensorEnd = rewriter.create<arith::CmpIOp>(
         loc, arith::CmpIPredicate::slt, tentativeEndColumn, outputWidth);
     Value endColumn = rewriter.create<arith::SelectOp>(
@@ -2775,32 +2834,43 @@ public:
                               inputRow, index(rewriter, loc, 0), chipDesc);
         Value initialIndex = i32(rewriter, loc, 0);
 
-        auto scanLoop = rewriter.create<scf::ForOp>(
-            loc, index(rewriter, loc, 1),
-            index(rewriter, loc, op.getRowWidth()), oneIndex,
-            ValueRange{initialMax, initialIndex},
-            [&](OpBuilder &builder, Location bodyLoc, Value column,
-                ValueRange iterArgs) {
-              Value currentMax = iterArgs[0];
-              Value currentIndex = iterArgs[1];
-              Value candidate = loadArgMaxElement(
-                  builder, bodyLoc, adaptor.getScratch(), adaptor.getInput(),
-                  inputMemoryMap, inputType, inputRow, column, chipDesc);
-              Value isGreater = compareArgMaxCandidates(builder, bodyLoc,
-                                                        candidate, currentMax);
-              Value columnIndex = builder.create<arith::IndexCastOp>(
-                  bodyLoc, builder.getI32Type(), column);
-              Value nextMax = builder.create<arith::SelectOp>(
-                  bodyLoc, isGreater, candidate, currentMax);
-              Value nextIndex = builder.create<arith::SelectOp>(
-                  bodyLoc, isGreater, columnIndex, currentIndex);
-              builder.create<scf::YieldOp>(bodyLoc,
-                                           ValueRange{nextMax, nextIndex});
-            });
+        Value elementsPerPacket =
+            index(rewriter, loc,
+                  mlir::isa<BFloat16Type>(inputType.getElementType()) ? 8 : 4);
+        auto packetLoop = rewriter.create<scf::ForOp>(
+            loc, index(rewriter, loc, 0),
+            index(rewriter, loc, op.getRowWidth()), elementsPerPacket,
+            ValueRange{initialMax, initialIndex});
+        {
+          OpBuilder::InsertionGuard packetGuard(rewriter);
+          rewriter.setInsertionPointToStart(packetLoop.getBody());
+          Value packetColumn = packetLoop.getInductionVar();
+          Value packetEnd = rewriter.create<arith::AddIOp>(loc, packetColumn,
+                                                           elementsPerPacket);
+          Value rowWidth = index(rewriter, loc, op.getRowWidth());
+          Value packetEndsBeforeRowEnd = rewriter.create<arith::CmpIOp>(
+              loc, arith::CmpIPredicate::slt, packetEnd, rowWidth);
+          Value endColumn = rewriter.create<arith::SelectOp>(
+              loc, packetEndsBeforeRowEnd, packetEnd, rowWidth);
+          Value endLane =
+              rewriter.create<arith::SubIOp>(loc, endColumn, packetColumn);
+          Value isFirstPacket = rewriter.create<arith::CmpIOp>(
+              loc, arith::CmpIPredicate::eq, packetColumn,
+              index(rewriter, loc, 0));
+          Value startLane = rewriter.create<arith::SelectOp>(
+              loc, isFirstPacket, index(rewriter, loc, 1),
+              index(rewriter, loc, 0));
+          auto laneLoop = scanArgMaxPacket(
+              rewriter, loc, adaptor.getScratch(), adaptor.getInput(),
+              inputMemoryMap, inputType, inputRow, packetColumn, startLane,
+              endLane, packetLoop.getRegionIterArgs()[0],
+              packetLoop.getRegionIterArgs()[1], chipDesc);
+          rewriter.create<scf::YieldOp>(loc, laneLoop.getResults());
+        }
 
         storeArgMaxIndex(rewriter, loc, adaptor.getScratch(),
                          adaptor.getOutput(), outputMemoryMap, outputType,
-                         outputRow, outputColumn, scanLoop.getResults()[1],
+                         outputRow, outputColumn, packetLoop.getResults()[1],
                          chipDesc);
       }
     }

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2585,6 +2585,233 @@ public:
 } // namespace
 
 namespace {
+static bool isI32ElementType(Type type) {
+  auto intType = mlir::dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == 32;
+}
+
+static Value loadArgMaxElement(OpBuilder &rewriter, Location loc,
+                               Value scratchCb, Value inputBase,
+                               AffineMap inputMemoryMap, MemRefType inputType,
+                               Value row, Value column,
+                               ttcore::ChipDescAttr chipDesc) {
+  Type elementType = inputType.getElementType();
+  bool isBF16 = mlir::isa<BFloat16Type>(elementType);
+  bool isF32 = mlir::isa<Float32Type>(elementType);
+  bool isI32 = isI32ElementType(elementType);
+  assert((isBF16 || isF32 || isI32) &&
+         "argmax supports f32, bf16, and i32 inputs only");
+
+  Value packetColumn;
+  Value wordLane;
+  Value halfLane = index(rewriter, loc, 0);
+  if (isBF16) {
+    Value eight = index(rewriter, loc, 8);
+    Value two = index(rewriter, loc, 2);
+    Value packetIndex = rewriter.create<arith::DivSIOp>(loc, column, eight);
+    packetColumn = rewriter.create<arith::MulIOp>(loc, packetIndex, eight);
+    Value packetOffset =
+        rewriter.create<arith::SubIOp>(loc, column, packetColumn);
+    wordLane = rewriter.create<arith::DivSIOp>(loc, packetOffset, two);
+    Value wordBase = rewriter.create<arith::MulIOp>(loc, wordLane, two);
+    halfLane = rewriter.create<arith::SubIOp>(loc, packetOffset, wordBase);
+  } else {
+    Value four = index(rewriter, loc, 4);
+    Value packetIndex = rewriter.create<arith::DivSIOp>(loc, column, four);
+    packetColumn = rewriter.create<arith::MulIOp>(loc, packetIndex, four);
+    wordLane = rewriter.create<arith::SubIOp>(loc, column, packetColumn);
+  }
+
+  SmallVector<Value> inputLogicalIndices =
+      getCollapsed2DElementIndices(rewriter, loc, inputType, row, packetColumn);
+  Value inputNocAddr = buildMappedL1NocAddr(
+      rewriter, loc, inputBase, inputMemoryMap, inputLogicalIndices, chipDesc);
+  Value wordLaneI32 =
+      rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), wordLane);
+  Value word = loadI32FromL1PacketThroughScratch(
+      rewriter, loc, scratchCb, inputNocAddr, wordLaneI32,
+      i32(rewriter, loc, 16), i32(rewriter, loc, 1));
+
+  if (isF32) {
+    return rewriter.create<ttkernel::BitcastOp>(loc, rewriter.getF32Type(),
+                                                word);
+  }
+  if (isI32) {
+    return word;
+  }
+
+  Value lowBits =
+      rewriter.create<arith::AndIOp>(loc, word, i32(rewriter, loc, 0xffff));
+  Value highBits =
+      rewriter.create<arith::ShRUIOp>(loc, word, i32(rewriter, loc, 16));
+  Value isHighLane = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ne, halfLane, index(rewriter, loc, 0));
+  Value bf16Bits =
+      rewriter.create<arith::SelectOp>(loc, isHighLane, highBits, lowBits);
+  Value bf16Value = rewriter.create<ttkernel::BitcastOp>(
+      loc, rewriter.getBF16Type(), bf16Bits);
+  return rewriter.create<arith::ExtFOp>(loc, rewriter.getF32Type(), bf16Value);
+}
+
+static Value compareArgMaxCandidates(OpBuilder &rewriter, Location loc,
+                                     Value candidate, Value currentMax) {
+  Type candidateType = candidate.getType();
+  if (mlir::isa<FloatType>(candidateType)) {
+    return rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT,
+                                          candidate, currentMax);
+  }
+  if (isI32ElementType(candidateType)) {
+    return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
+                                          candidate, currentMax);
+  }
+  llvm_unreachable("Unsupported argmax candidate type");
+}
+
+static void storeArgMaxIndex(OpBuilder &rewriter, Location loc, Value scratchCb,
+                             Value outputBase, AffineMap outputMemoryMap,
+                             MemRefType outputType, Value row, Value column,
+                             Value indexValue, ttcore::ChipDescAttr chipDesc) {
+  SmallVector<Value> outputLogicalIndices =
+      getCollapsed2DElementIndices(rewriter, loc, outputType, row, column);
+  Value outputNocAddr =
+      buildMappedL1NocAddr(rewriter, loc, outputBase, outputMemoryMap,
+                           outputLogicalIndices, chipDesc);
+
+  Value onePage = i32(rewriter, loc, 1);
+  rewriter.create<ttkernel::CBReserveBackOp>(loc, scratchCb, onePage);
+  Value writePtr = rewriter.create<ttkernel::GetWritePtrOp>(loc, scratchCb);
+  Value l1Ptr = rewriter.create<ttkernel::CastToL1PtrOp>(loc, writePtr);
+  rewriter.create<ttkernel::StoreToL1Op>(loc, indexValue, l1Ptr,
+                                         i32(rewriter, loc, 0));
+  rewriter.create<ttkernel::NocAsyncWriteOp>(loc, writePtr, outputNocAddr,
+                                             i32(rewriter, loc, 4));
+  rewriter.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
+  rewriter.create<ttkernel::CBPushBackOp>(loc, scratchCb, onePage);
+  rewriter.create<ttkernel::CBWaitFrontOp>(loc, scratchCb, onePage);
+  rewriter.create<ttkernel::CBPopFrontOp>(loc, scratchCb, onePage);
+}
+
+class D2MArgMaxInterleavedRewriter
+    : public OpConversionPattern<d2m::ArgMaxInterleavedOp> {
+public:
+  using OpConversionPattern<d2m::ArgMaxInterleavedOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::ArgMaxInterleavedOp op,
+                  d2m::ArgMaxInterleavedOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto inputType = mlir::cast<MemRefType>(op.getInput().getType());
+    auto outputType = mlir::cast<MemRefType>(op.getOutput().getType());
+
+    if (ttcore::getMemorySpace(inputType) != ttcore::MemorySpace::DeviceL1 ||
+        ttcore::getMemorySpace(outputType) != ttcore::MemorySpace::DeviceL1) {
+      return rewriter.notifyMatchFailure(
+          op, "argmax currently supports L1 input and output");
+    }
+    if (!hasCollapsed2DShard(inputType) || !hasCollapsed2DShard(outputType)) {
+      return rewriter.notifyMatchFailure(
+          op, "argmax currently requires collapsed 2D sharded memrefs");
+    }
+
+    Location loc = op.getLoc();
+    auto chipDesc = ttcore::getOpChipDescAttr(op);
+    ttcore::DeviceAttr device = ttcore::lookupDevice(op);
+    ArrayRef<int64_t> outputShardShape = ttcore::getShardShape(op.getOutput());
+    if (outputShardShape.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "argmax currently requires a 2D output shard");
+    }
+
+    AffineMap inputMemoryMap =
+        d2m::utils::getMemoryMap(device, op.getInput(), true);
+    AffineMap outputMemoryMap =
+        d2m::utils::getMemoryMap(device, op.getOutput(), true);
+    ArrayRef<int64_t> rowShape = op.getRowShape();
+
+    Value oneIndex = index(rewriter, loc, 1);
+    Value myY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
+    Value myX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+    Value startRow = rewriter.create<arith::MulIOp>(
+        loc, myY, index(rewriter, loc, outputShardShape[0]));
+    Value tentativeEndRow = rewriter.create<arith::AddIOp>(
+        loc, startRow, index(rewriter, loc, outputShardShape[0]));
+    Value numRows = index(rewriter, loc, op.getNumRows());
+    Value rowEndsBeforeTensorEnd = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::slt, tentativeEndRow, numRows);
+    Value endRow = rewriter.create<arith::SelectOp>(loc, rowEndsBeforeTensorEnd,
+                                                    tentativeEndRow, numRows);
+
+    Value startColumn = rewriter.create<arith::MulIOp>(
+        loc, myX, index(rewriter, loc, outputShardShape[1]));
+    Value tentativeEndColumn = rewriter.create<arith::AddIOp>(
+        loc, startColumn, index(rewriter, loc, outputShardShape[1]));
+    Value outputWidth = index(rewriter, loc, 1);
+    Value columnEndsBeforeTensorEnd = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::slt, tentativeEndColumn, outputWidth);
+    Value endColumn = rewriter.create<arith::SelectOp>(
+        loc, columnEndsBeforeTensorEnd, tentativeEndColumn, outputWidth);
+
+    auto columnLoop =
+        rewriter.create<scf::ForOp>(loc, startColumn, endColumn, oneIndex);
+    {
+      OpBuilder::InsertionGuard columnGuard(rewriter);
+      rewriter.setInsertionPointToStart(columnLoop.getBody());
+      Value outputColumn = columnLoop.getInductionVar();
+      auto rowLoop =
+          rewriter.create<scf::ForOp>(loc, startRow, endRow, oneIndex);
+      {
+        OpBuilder::InsertionGuard rowGuard(rewriter);
+        rewriter.setInsertionPointToStart(rowLoop.getBody());
+        Value logicalRow = rowLoop.getInductionVar();
+        Value inputRow =
+            getCollapsedOutputRow(rewriter, loc, rowShape, logicalRow,
+                                  getCollapsed2DPhysicalRows(inputType));
+        Value outputRow =
+            getCollapsedOutputRow(rewriter, loc, rowShape, logicalRow,
+                                  getCollapsed2DPhysicalRows(outputType));
+        Value initialMax =
+            loadArgMaxElement(rewriter, loc, adaptor.getScratch(),
+                              adaptor.getInput(), inputMemoryMap, inputType,
+                              inputRow, index(rewriter, loc, 0), chipDesc);
+        Value initialIndex = i32(rewriter, loc, 0);
+
+        auto scanLoop = rewriter.create<scf::ForOp>(
+            loc, index(rewriter, loc, 1),
+            index(rewriter, loc, op.getRowWidth()), oneIndex,
+            ValueRange{initialMax, initialIndex},
+            [&](OpBuilder &builder, Location bodyLoc, Value column,
+                ValueRange iterArgs) {
+              Value currentMax = iterArgs[0];
+              Value currentIndex = iterArgs[1];
+              Value candidate = loadArgMaxElement(
+                  builder, bodyLoc, adaptor.getScratch(), adaptor.getInput(),
+                  inputMemoryMap, inputType, inputRow, column, chipDesc);
+              Value isGreater = compareArgMaxCandidates(builder, bodyLoc,
+                                                        candidate, currentMax);
+              Value columnIndex = builder.create<arith::IndexCastOp>(
+                  bodyLoc, builder.getI32Type(), column);
+              Value nextMax = builder.create<arith::SelectOp>(
+                  bodyLoc, isGreater, candidate, currentMax);
+              Value nextIndex = builder.create<arith::SelectOp>(
+                  bodyLoc, isGreater, columnIndex, currentIndex);
+              builder.create<scf::YieldOp>(bodyLoc,
+                                           ValueRange{nextMax, nextIndex});
+            });
+
+        storeArgMaxIndex(rewriter, loc, adaptor.getScratch(),
+                         adaptor.getOutput(), outputMemoryMap, outputType,
+                         outputRow, outputColumn, scanLoop.getResults()[1],
+                         chipDesc);
+      }
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class D2MCoreIndexRewriter : public OpConversionPattern<d2m::CoreIndexOp> {
 public:
   using OpConversionPattern<d2m::CoreIndexOp>::OpConversionPattern;
@@ -3248,6 +3475,7 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MMeshPositionRewriter,
                ttkernel::D2MNullTxRewriter,
                ttkernel::D2MIndexedRowCopyRewriter,
+               ttkernel::D2MArgMaxInterleavedRewriter,
                ttkernel::MemRefCollapseRewriter,
                ttkernel::D2MSemaphoreUpdateRewriter<d2m::SemaphoreSetOp>,
                ttkernel::D2MSemaphoreUpdateRewriter<d2m::SemaphoreIncOp>,

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -1979,6 +1979,149 @@ public:
 
 // ----------------------------------------------------------------------------
 //
+// D2MArgMaxRewriter: lowers TTIR argmax to a D2M data-movement op, mirroring
+// TTNN's reader/dataflow argmax implementation. The current backend primitive
+// supports the TTNN-supported dim form: a single reduction over the last
+// logical dimension with keep_dim already forced by the frontend pipeline.
+namespace {
+static bool isSupportedArgMaxInputElementType(Type type) {
+  if (mlir::isa<mlir::Float32Type, mlir::BFloat16Type>(type)) {
+    return true;
+  }
+  auto intType = mlir::dyn_cast<mlir::IntegerType>(type);
+  return intType && intType.getWidth() == 32;
+}
+
+class D2MArgMaxRewriter final
+    : public mlir::OpConversionPattern<ttir::ArgMaxOp>,
+      D2MNamedRewriterCommon {
+public:
+  D2MArgMaxRewriter(const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
+                    ttcore::MemorySpace defaultInputMemSpace,
+                    ttcore::MemorySpace defaultOutputMemSpace, bool ttnnMode,
+                    bool collapseTensors, bool enableMulticastInference)
+      : OpConversionPattern<ttir::ArgMaxOp>(typeConverter, ctx),
+        D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
+                               ttnnMode, collapseTensors,
+                               enableMulticastInference) {}
+
+private:
+  LogicalResult
+  matchAndRewrite(ttir::ArgMaxOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const final {
+    auto inputType =
+        mlir::cast<mlir::RankedTensorType>(op.getInput().getType());
+    auto resultType =
+        mlir::cast<mlir::RankedTensorType>(op.getResult().getType());
+
+    if (!op.getKeepDim()) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax expects TTIRReductionForceKeepDim to run first");
+    }
+
+    if (!inputType.hasStaticShape() || !resultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "D2M argmax requires static shapes");
+    }
+
+    Type inputElementType = inputType.getElementType();
+    if (!isSupportedArgMaxInputElementType(inputElementType)) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax currently supports f32, bf16, or i32 input");
+    }
+
+    auto indexElementType =
+        mlir::dyn_cast<mlir::IntegerType>(resultType.getElementType());
+    if (!indexElementType || indexElementType.getWidth() != 32) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax requires a 32-bit integer result type");
+    }
+
+    std::optional<mlir::ArrayAttr> maybeDimArg = op.getDimArg();
+    if (!maybeDimArg || maybeDimArg->size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax currently supports one explicit dim");
+    }
+
+    const int64_t rank = inputType.getRank();
+    if (rank < 2) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax currently requires rank >= 2");
+    }
+    int64_t dim = mlir::cast<mlir::IntegerAttr>((*maybeDimArg)[0]).getInt();
+    if (dim < 0) {
+      dim += rank;
+    }
+    if (dim != rank - 1) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax currently supports the last dimension only");
+    }
+
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+    llvm::SmallVector<int64_t> rowShape(inputShape.drop_back());
+    int64_t rowWidth = inputShape.back();
+    int64_t numRows = ttmlir::utils::volume(ArrayRef<int64_t>(rowShape));
+    if (rowWidth <= 0 || numRows <= 0) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax requires non-empty static dimensions");
+    }
+
+    mlir::Location loc = op.getLoc();
+    llvm::SmallVector<mlir::Value> inputs{
+        createOptimalLayoutOp(op.getInput(), memorySpaces[0],
+                              /*tiled=*/false, /*noCollapse=*/false, rewriter)};
+    llvm::SmallVector<mlir::Value> origOutputs =
+        createDpsOutputs(loc, rewriter, {resultType});
+    llvm::SmallVector<mlir::Value> outputs{
+        createOptimalLayoutOp(origOutputs[0], memorySpaces[1],
+                              /*tiled=*/false, /*noCollapse=*/false, rewriter)};
+
+    const std::size_t physicalRank =
+        ttcore::getDeviceLayout(outputs[0]).getRank() / 2;
+    if (physicalRank != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M argmax currently requires collapsed 2D layouts");
+    }
+    mlir::AffineExpr d0 = rewriter.getAffineDimExpr(0);
+    mlir::AffineExpr zero = rewriter.getAffineConstantExpr(0);
+    mlir::SmallVector<mlir::AffineMap> indexingMaps = {
+        mlir::AffineMap::get(/*dimCount=*/2, /*symbolCount=*/0, {d0, zero},
+                             rewriter.getContext()),
+        rewriter.getMultiDimIdentityMap(2)};
+    auto parallel = ttcore::IteratorTypeAttr::get(
+        rewriter.getContext(), ttcore::IteratorType::Parallel);
+    mlir::SmallVector<mlir::Attribute> iteratorTypes(physicalRank, parallel);
+
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, inputs, outputs, /*additionalArgs=*/mlir::ValueRange(),
+        rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes), d2m::ThreadType::Datamovement);
+
+    auto insertPoint = rewriter.saveInsertionPoint();
+    rewriter.startOpModification(generic);
+    {
+      mlir::Region &region = generic->getRegion(0);
+      mlir::Block *block = rewriter.createBlock(&region);
+      rewriter.setInsertionPointToStart(block);
+      auto argMax = rewriter.create<d2m::ArgMaxOp>(
+          loc, outputs[0].getType(), inputs[0], outputs[0],
+          rewriter.getI64IntegerAttr(numRows),
+          rewriter.getI64IntegerAttr(rowWidth),
+          rewriter.getDenseI64ArrayAttr(rowShape));
+      rewriter.create<d2m::YieldOp>(loc, argMax.getResult());
+    }
+    rewriter.finalizeOpModification(generic);
+    rewriter.restoreInsertionPoint(insertPoint);
+
+    rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
+                                          op->getResult(0).getType()));
+    return mlir::success();
+  }
+};
+} // namespace
+
+// ----------------------------------------------------------------------------
+//
 // Rewrite a MatmulOp into either a D2M TileMatmulOp or TileMatmulBlockOp
 // (selected by TileOp template).
 namespace {
@@ -4088,6 +4231,11 @@ void populateTTIRToD2MPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // Decompose inner-dim min reductions to neg(max(neg)); runs during
   // TTIRToD2M instead of as a separate pre-pass.
   patterns.add<D2MInnerMinDecompositionRewriter>(typeConverter, ctx);
+
+  // Argmax uses a TTNN-style data-movement reader kernel.
+  patterns.add<D2MArgMaxRewriter>(
+      typeConverter, ctx, defaultInputMemSpace, defaultOutputMemSpace, ttnnMode,
+      collapseTensors, enableMulticastInference);
 
   // ToLayout 1:1 conversion.
   patterns.add<D2MToLayoutOpRewriter>(typeConverter, ctx, ttnnMode);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -1984,14 +1984,6 @@ public:
 // supports the TTNN-supported dim form: a single reduction over the last
 // logical dimension with keep_dim already forced by the frontend pipeline.
 namespace {
-static bool isSupportedArgMaxInputElementType(Type type) {
-  if (mlir::isa<mlir::Float32Type, mlir::BFloat16Type>(type)) {
-    return true;
-  }
-  auto intType = mlir::dyn_cast<mlir::IntegerType>(type);
-  return intType && intType.getWidth() == 32;
-}
-
 class D2MArgMaxRewriter final
     : public mlir::OpConversionPattern<ttir::ArgMaxOp>,
       D2MNamedRewriterCommon {
@@ -2025,7 +2017,7 @@ private:
     }
 
     Type inputElementType = inputType.getElementType();
-    if (!isSupportedArgMaxInputElementType(inputElementType)) {
+    if (!d2m::utils::isSupportedArgMaxInputElementType(inputElementType)) {
       return rewriter.notifyMatchFailure(
           op, "D2M argmax currently supports f32, bf16, or i32 input");
     }

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -199,6 +199,7 @@ void DMAWriteOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 static constexpr int64_t kIndexedRowCopyScratchPageElements = 1024;
+static constexpr int64_t kArgMaxScratchPageElements = 1024;
 
 static MemRefType createIndexedRowCopyScratchType(MLIRContext *ctx,
                                                   ArrayRef<int64_t> shape,
@@ -290,6 +291,181 @@ void IndexedRowCopyOp::getEffects(
                        mlir::SideEffects::DefaultResource::get());
 }
 
+static FailureOr<Value>
+getBufferIfTensor(Value value, RewriterBase &rewriter,
+                  const bufferization::BufferizationOptions &options,
+                  bufferization::BufferizationState &state) {
+  if (!mlir::isa<RankedTensorType>(value.getType())) {
+    return value;
+  }
+  return bufferization::getBuffer(rewriter, value, options, state);
+}
+
+//===----------------------------------------------------------------------===//
+// ArgMax operations
+//===----------------------------------------------------------------------===//
+
+static bool isI32ElementType(Type type) {
+  auto intType = mlir::dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == 32;
+}
+
+static bool isSupportedArgMaxInputElementType(Type type) {
+  return mlir::isa<Float32Type, BFloat16Type>(type) || isI32ElementType(type);
+}
+
+static LogicalResult verifyArgMaxOperands(Operation *op, Value input,
+                                          Value output, int64_t numRows,
+                                          int64_t rowWidth,
+                                          ArrayRef<int64_t> rowShape) {
+  auto inputType = mlir::cast<ShapedType>(input.getType());
+  auto outputType = mlir::cast<ShapedType>(output.getType());
+
+  if (!isSupportedArgMaxInputElementType(inputType.getElementType())) {
+    return op->emitOpError("currently supports f32, bf16, or i32 input only");
+  }
+
+  if (!isI32ElementType(outputType.getElementType())) {
+    return op->emitOpError("output must have 32-bit integer element type");
+  }
+
+  if (numRows <= 0) {
+    return op->emitOpError("num_rows must be positive");
+  }
+  if (rowWidth <= 0) {
+    return op->emitOpError("row_width must be positive");
+  }
+  if (rowShape.empty()) {
+    return op->emitOpError("row_shape must not be empty");
+  }
+  if (llvm::any_of(rowShape, [](int64_t dim) { return dim <= 0; })) {
+    return op->emitOpError("row_shape dimensions must be positive");
+  }
+  if (ttmlir::utils::volume(rowShape) != numRows) {
+    return op->emitOpError("row_shape volume must match num_rows");
+  }
+
+  return success();
+}
+
+LogicalResult ArgMaxInterleavedOp::verify() {
+  auto scratchType = mlir::cast<ShapedType>(getScratch().getType());
+  if (!isI32ElementType(scratchType.getElementType())) {
+    return emitOpError("scratch must have 32-bit integer element type");
+  }
+  return verifyArgMaxOperands(getOperation(), getInput(), getOutput(),
+                              getNumRows(), getRowWidth(), getRowShape());
+}
+
+void ArgMaxInterleavedOp::getEffects(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(mlir::MemoryEffects::Read::get(), &getInputMutable(), 0,
+                       true, mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Write::get(), &getOutputMutable(),
+                       0, true, mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Read::get(), &getScratchMutable(),
+                       0, true, mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Write::get(), &getScratchMutable(),
+                       0, true, mlir::SideEffects::DefaultResource::get());
+}
+
+LogicalResult ArgMaxOp::verify() {
+  if (getResult().getType() != getOutput().getType()) {
+    return emitOpError("result type must match output operand type");
+  }
+
+  return verifyArgMaxOperands(getOperation(), getInput(), getOutput(),
+                              getNumRows(), getRowWidth(), getRowShape());
+}
+
+void ArgMaxOp::getEffects(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(mlir::MemoryEffects::Read::get(), &getInputMutable(), 0,
+                       true, mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Write::get(), &getOutputMutable(),
+                       0, true, mlir::SideEffects::DefaultResource::get());
+}
+
+bool ArgMaxOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getInput();
+}
+
+bool ArgMaxOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getOutput();
+}
+
+mlir::bufferization::AliasingValueList
+ArgMaxOp::getAliasingValues(mlir::OpOperand &operand,
+                            const mlir::bufferization::AnalysisState &) {
+  mlir::bufferization::AliasingValueList aliasList;
+  if (operand.get() == getOutput()) {
+    aliasList.addAlias(
+        {getResult(), mlir::bufferization::BufferRelation::Equivalent});
+  }
+  return aliasList;
+}
+
+mlir::FailureOr<mlir::bufferization::BufferLikeType>
+ArgMaxOp::getBufferType(mlir::Value value,
+                        const mlir::bufferization::BufferizationOptions &,
+                        const mlir::bufferization::BufferizationState &,
+                        ::llvm::SmallVector<mlir::Value> &) {
+  if (value == getResult()) {
+    return ttcore::getBufferType(value.getType(), /*isView=*/false);
+  }
+  return mlir::failure();
+}
+
+bool ArgMaxOp::hasTensorSemantics() { return true; }
+
+static MemRefType createArgMaxScratchType(MLIRContext *ctx) {
+  auto scratchElementType = IntegerType::get(ctx, 32);
+  return createIndexedRowCopyScratchType(ctx, {1, kArgMaxScratchPageElements},
+                                         scratchElementType);
+}
+
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+mlir::LogicalResult
+ArgMaxOp::bufferize(mlir::RewriterBase &rewriter,
+                    const mlir::bufferization::BufferizationOptions &options,
+                    mlir::bufferization::BufferizationState &state) {
+  if (!hasTensorSemantics()) {
+    return mlir::failure();
+  }
+
+  mlir::OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(getOperation());
+
+  FailureOr<Value> input =
+      getBufferIfTensor(getInput(), rewriter, options, state);
+  if (failed(input)) {
+    return input;
+  }
+
+  FailureOr<Value> maybeOutput =
+      getBufferIfTensor(getOutput(), rewriter, options, state);
+  if (failed(maybeOutput)) {
+    return maybeOutput;
+  }
+  Value output = *maybeOutput;
+
+  Value scratch = rewriter.create<memref::AllocOp>(
+      getLoc(), createArgMaxScratchType(getContext()));
+
+  rewriter.create<ArgMaxInterleavedOp>(getLoc(), *input, output, scratch,
+                                       getNumRowsAttr(), getRowWidthAttr(),
+                                       getRowShapeAttr());
+  mlir::bufferization::replaceOpWithBufferizedValues(rewriter, *this, output);
+  return mlir::success();
+}
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
+
 //===----------------------------------------------------------------------===//
 // EmbeddingOp
 //===----------------------------------------------------------------------===//
@@ -350,16 +526,6 @@ EmbeddingOp::getBufferType(mlir::Value value,
 }
 
 bool EmbeddingOp::hasTensorSemantics() { return true; }
-
-static FailureOr<Value>
-getBufferIfTensor(Value value, RewriterBase &rewriter,
-                  const bufferization::BufferizationOptions &options,
-                  bufferization::BufferizationState &state) {
-  if (!mlir::isa<RankedTensorType>(value.getType())) {
-    return value;
-  }
-  return bufferization::getBuffer(rewriter, value, options, state);
-}
 
 static Value createEmbeddingScratch(EmbeddingOp op, MemRefType scratchType,
                                     RewriterBase &rewriter) {

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Utils.h"
@@ -199,11 +200,13 @@ void DMAWriteOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 static constexpr int64_t kIndexedRowCopyScratchPageElements = 1024;
+// Use one tile-sized CB page for the scratch buffers. Argmax only reads/writes
+// 16B packets, but the CB layout needs a concrete page shape.
 static constexpr int64_t kArgMaxScratchPageElements = 1024;
 
-static MemRefType createIndexedRowCopyScratchType(MLIRContext *ctx,
-                                                  ArrayRef<int64_t> shape,
-                                                  Type elementType) {
+static MemRefType createSingleBufferScratchType(MLIRContext *ctx,
+                                                ArrayRef<int64_t> shape,
+                                                Type elementType) {
   auto cbLayout =
       mlir::tt::ttcore::CBLayoutAttr::get(shape, elementType, /*buffers=*/1);
   auto l1MemorySpace = mlir::tt::ttcore::MemorySpaceAttr::get(
@@ -305,15 +308,6 @@ getBufferIfTensor(Value value, RewriterBase &rewriter,
 // ArgMax operations
 //===----------------------------------------------------------------------===//
 
-static bool isI32ElementType(Type type) {
-  auto intType = mlir::dyn_cast<IntegerType>(type);
-  return intType && intType.getWidth() == 32;
-}
-
-static bool isSupportedArgMaxInputElementType(Type type) {
-  return mlir::isa<Float32Type, BFloat16Type>(type) || isI32ElementType(type);
-}
-
 static LogicalResult verifyArgMaxOperands(Operation *op, Value input,
                                           Value output, int64_t numRows,
                                           int64_t rowWidth,
@@ -321,11 +315,12 @@ static LogicalResult verifyArgMaxOperands(Operation *op, Value input,
   auto inputType = mlir::cast<ShapedType>(input.getType());
   auto outputType = mlir::cast<ShapedType>(output.getType());
 
-  if (!isSupportedArgMaxInputElementType(inputType.getElementType())) {
+  if (!mlir::tt::d2m::utils::isSupportedArgMaxInputElementType(
+          inputType.getElementType())) {
     return op->emitOpError("currently supports f32, bf16, or i32 input only");
   }
 
-  if (!isI32ElementType(outputType.getElementType())) {
+  if (!mlir::tt::d2m::utils::isI32ElementType(outputType.getElementType())) {
     return op->emitOpError("output must have 32-bit integer element type");
   }
 
@@ -350,7 +345,7 @@ static LogicalResult verifyArgMaxOperands(Operation *op, Value input,
 
 LogicalResult ArgMaxInterleavedOp::verify() {
   auto scratchType = mlir::cast<ShapedType>(getScratch().getType());
-  if (!isI32ElementType(scratchType.getElementType())) {
+  if (!mlir::tt::d2m::utils::isI32ElementType(scratchType.getElementType())) {
     return emitOpError("scratch must have 32-bit integer element type");
   }
   return verifyArgMaxOperands(getOperation(), getInput(), getOutput(),
@@ -426,8 +421,8 @@ bool ArgMaxOp::hasTensorSemantics() { return true; }
 
 static MemRefType createArgMaxScratchType(MLIRContext *ctx) {
   auto scratchElementType = IntegerType::get(ctx, 32);
-  return createIndexedRowCopyScratchType(ctx, {1, kArgMaxScratchPageElements},
-                                         scratchElementType);
+  return createSingleBufferScratchType(ctx, {1, kArgMaxScratchPageElements},
+                                       scratchElementType);
 }
 
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -563,7 +558,7 @@ EmbeddingOp::bufferize(mlir::RewriterBase &rewriter,
 
   Type indexScratchElementType =
       mlir::cast<ShapedType>((*indices).getType()).getElementType();
-  MemRefType indexScratchType = createIndexedRowCopyScratchType(
+  MemRefType indexScratchType = createSingleBufferScratchType(
       getContext(), {1, kIndexedRowCopyScratchPageElements},
       indexScratchElementType);
   Value indexScratch =
@@ -571,7 +566,7 @@ EmbeddingOp::bufferize(mlir::RewriterBase &rewriter,
 
   Type rowScratchElementType =
       mlir::cast<ShapedType>(output.getType()).getElementType();
-  MemRefType rowScratchType = createIndexedRowCopyScratchType(
+  MemRefType rowScratchType = createSingleBufferScratchType(
       getContext(), {1, kIndexedRowCopyScratchPageElements},
       rowScratchElementType);
   Value rowScratch = createEmbeddingScratch(*this, rowScratchType, rewriter);

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2398,6 +2398,8 @@ static void repairParallelizedRegionTypes(Block *newBlock) {
       }
     } else if (auto embeddingOp = mlir::dyn_cast<d2m::EmbeddingOp>(&clonedOp)) {
       embeddingOp.getResult().setType(embeddingOp.getOutput().getType());
+    } else if (auto argMaxOp = mlir::dyn_cast<d2m::ArgMaxOp>(&clonedOp)) {
+      argMaxOp.getResult().setType(argMaxOp.getOutput().getType());
     } else if (auto dstOp =
                    mlir::dyn_cast<DestinationStyleOpInterface>(&clonedOp)) {
       unsigned numIns = dstOp.getNumDpsInputs();
@@ -2985,6 +2987,23 @@ struct LocalBufferAssociation {
   bool hasRemoteUse = false;
 };
 
+static bool isScratchAlloc(memref::AllocOp allocOp) {
+  Value result = allocOp.getResult();
+  return llvm::any_of(result.getUsers(), [result](Operation *user) {
+    if (mlir::isa<d2m::ScratchInitOp>(user)) {
+      return true;
+    }
+    if (auto copyOp = mlir::dyn_cast<d2m::IndexedRowCopyOp>(user)) {
+      return copyOp.getIndexScratch() == result ||
+             copyOp.getRowScratch() == result;
+    }
+    if (auto argMaxOp = mlir::dyn_cast<d2m::ArgMaxInterleavedOp>(user)) {
+      return argMaxOp.getScratch() == result;
+    }
+    return false;
+  });
+}
+
 static LocalBufferAssociation
 analyzeLocalBufferAssociation(Value localBuffer,
                               Value fallbackOperand = Value()) {
@@ -3050,6 +3069,10 @@ Value d2m::GenericOp::findAssocOperand(memref::AllocOp allocOp) {
   // First check that the memref.alloc is within a generic op
   GenericOp genericOp = allocOp->getParentOfType<GenericOp>();
   if (!genericOp) {
+    return Value();
+  }
+
+  if (isScratchAlloc(allocOp)) {
     return Value();
   }
 
@@ -3178,11 +3201,7 @@ Value d2m::GenericOp::getOperandAlloc(Region &region, unsigned operandIndex) {
         }
       } else if (auto allocOp = mlir::dyn_cast<memref::AllocOp>(&op)) {
         // Scratch buffers are not operand allocs.
-        bool isScratchBuffer =
-            llvm::any_of(allocOp.getResult().getUsers(), [](Operation *user) {
-              return mlir::isa<d2m::ScratchInitOp>(user);
-            });
-        if (isScratchBuffer) {
+        if (isScratchAlloc(allocOp)) {
           continue;
         }
         LocalBufferAssociation assoc =

--- a/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
+++ b/lib/Dialect/D2M/Transforms/NormalizeThreadArgs.cpp
@@ -94,6 +94,20 @@ static void rewriteCapturedIndexedRowCopyOperands(IRRewriter &rewriter,
   }
 }
 
+static void rewriteCapturedArgMaxOperands(IRRewriter &rewriter,
+                                          GenericOp generic,
+                                          ArgMaxInterleavedOp argMaxOp) {
+  for (OpOperand &operand : argMaxOp->getOpOperands()) {
+    if (operand.get() == argMaxOp.getScratch()) {
+      continue;
+    }
+    auto operandIndex = getCapturedOperandIndex(generic, operand.get());
+    if (operandIndex) {
+      rewriteOperand(rewriter, argMaxOp.getOperation(), operand, *operandIndex);
+    }
+  }
+}
+
 // This pass normalizes thread arguments by inserting d2m.get_arg ops inside
 // each thread block, and replacing all in-region uses of those args with the
 // op results. d2m.get_cb ops are left untouched.
@@ -139,6 +153,9 @@ public:
       });
       generic.walk([&](IndexedRowCopyOp copyOp) {
         rewriteCapturedIndexedRowCopyOperands(rewriter, generic, copyOp);
+      });
+      generic.walk([&](ArgMaxInterleavedOp argMaxOp) {
+        rewriteCapturedArgMaxOperands(rewriter, generic, argMaxOp);
       });
 
       int64_t baseIndex = static_cast<int64_t>(generic.getInputs().size() +

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -91,6 +91,15 @@ Type getRegionLargestDstElemTypeOrNull(Region &region) {
   return findLargestDstElemType(region);
 }
 
+bool isI32ElementType(Type type) {
+  auto intType = mlir::dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == 32;
+}
+
+bool isSupportedArgMaxInputElementType(Type type) {
+  return mlir::isa<Float32Type, BFloat16Type>(type) || isI32ElementType(type);
+}
+
 ShapedType reblockShapedType(ShapedType oldType,
                              ArrayRef<int64_t> newGridShape) {
   TT_assert(oldType.hasStaticShape());

--- a/test/python/golden/d2m/test_reductions.py
+++ b/test/python/golden/d2m/test_reductions.py
@@ -519,3 +519,71 @@ def test_reduce_i32_4d_inner(
         device=device,
         atol=_reduction_atol(reduce_type, shape, dim_arg, dtype),
     )
+
+
+def create_argmax_module(
+    shape: Shape,
+    dim_arg: List[int],
+    keep_dim: bool,
+    dtype: torch.dtype,
+):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [dtype])
+        def argmax_fn(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+            return builder.argmax(
+                in0, dim_arg=dim_arg, keep_dim=keep_dim, unit_attrs=unit_attrs
+            )
+
+    return module
+
+
+_ARGMAX_SHAPES = [
+    pytest.param((1, 16), id="2d-single-row-16"),
+    pytest.param((7, 17), id="2d-tail-17"),
+    pytest.param((8, 32), id="2d-one-tile"),
+    pytest.param((32, 64), id="2d-sampling-64"),
+    pytest.param((32, 128), id="2d-sampling-128"),
+    pytest.param((64, 96), id="2d-64x96"),
+    pytest.param((128, 96), id="2d-128x96"),
+    pytest.param((2, 4, 16), id="3d-small-16"),
+    pytest.param((2, 7, 33), id="3d-tail-33"),
+    pytest.param((4, 8, 64), id="3d-64"),
+    pytest.param((2, 16, 96), id="3d-96"),
+    pytest.param((2, 2, 4, 16), id="4d-small-16"),
+    pytest.param((1, 3, 5, 33), id="4d-tail-33"),
+    pytest.param((1, 128256), id="2d-llama-sampling"),
+    pytest.param((128, 128256), id="2d-llama-sampling-128"),
+]
+
+
+@pytest.mark.parametrize("shape", _ARGMAX_SHAPES)
+@pytest.mark.parametrize("keep_dim", [True], ids=["keepdim"])
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float32, torch.int32],
+    ids=["bf16", "f32", "i32"],
+)
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_argmax(
+    shape: Shape,
+    keep_dim: bool,
+    dtype: torch.dtype,
+    target: str,
+    request,
+    device,
+):
+    if shape == (128, 128256) and dtype in (torch.float32, torch.int32):
+        pytest.skip("f32/i32 128x128256 argmax exceeds current L1 allocation")
+
+    compile_and_execute_ttir(
+        create_argmax_module(
+            shape=shape,
+            dim_arg=[len(shape) - 1],
+            keep_dim=keep_dim,
+            dtype=dtype,
+        ),
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        atol=0.0,
+    )

--- a/test/ttmlir/Conversion/D2MToTTKernel/reduce_ops.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/reduce_ops.mlir
@@ -154,3 +154,59 @@ func.func @test_min_i32(%in: !ttype_i32) -> (tensor<128x1xsi32>) {
   %0 = "ttir.min"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<128x1xsi32>
   return %0 : tensor<128x1xsi32>
 }
+
+// -----
+
+// Argmax lowers as a datamovement kernel that scans row-major rows and writes
+// the selected column index.
+
+!ttype_bf16 = tensor<128x96xbf16>
+// CHECK-LABEL: func.func @test_argmax_bf16_R
+func.func @test_argmax_bf16_R(%in: !ttype_bf16) -> (tensor<128x1xsi32>) {
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK-NOT: ttkernel.reduce_tile
+  // CHECK-NOT: ttkernel.sfpu_reduce
+  // CHECK: ttkernel.noc_async_read
+  // CHECK: ttkernel.load_from_l1
+  // CHECK: ttkernel.bitcast {{.*}} : i32 to bf16
+  // CHECK: arith.cmpf ogt
+  // CHECK: ttkernel.store_to_l1
+  // CHECK: ttkernel.noc_async_write
+  %0 = "ttir.argmax"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_bf16) -> tensor<128x1xsi32>
+  return %0 : tensor<128x1xsi32>
+}
+
+// -----
+
+!ttype_f32 = tensor<64x96xf32>
+// CHECK-LABEL: func.func @test_argmax_f32_R
+func.func @test_argmax_f32_R(%in: !ttype_f32) -> (tensor<64x1xsi32>) {
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK-NOT: ttkernel.reduce_tile
+  // CHECK-NOT: ttkernel.sfpu_reduce
+  // CHECK: ttkernel.noc_async_read
+  // CHECK: ttkernel.load_from_l1
+  // CHECK: ttkernel.bitcast {{.*}} : i32 to f32
+  // CHECK: arith.cmpf ogt
+  // CHECK: ttkernel.store_to_l1
+  // CHECK: ttkernel.noc_async_write
+  %0 = "ttir.argmax"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_f32) -> tensor<64x1xsi32>
+  return %0 : tensor<64x1xsi32>
+}
+
+// -----
+
+!ttype_i32 = tensor<32x96xsi32>
+// CHECK-LABEL: func.func @test_argmax_i32_R
+func.func @test_argmax_i32_R(%in: !ttype_i32) -> (tensor<32x1xsi32>) {
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK-NOT: ttkernel.reduce_tile
+  // CHECK-NOT: ttkernel.sfpu_reduce
+  // CHECK: ttkernel.noc_async_read
+  // CHECK: ttkernel.load_from_l1
+  // CHECK: arith.cmpi sgt
+  // CHECK: ttkernel.store_to_l1
+  // CHECK: ttkernel.noc_async_write
+  %0 = "ttir.argmax"(%in) <{dim_arg = [-1 : i32], keep_dim = true}> : (!ttype_i32) -> tensor<32x1xsi32>
+  return %0 : tensor<32x1xsi32>
+}

--- a/test/ttmlir/Conversion/TTIRToD2M/argmax.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/argmax.mlir
@@ -1,0 +1,40 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // CHECK-LABEL: func.func @argmax_last_dim_bf16
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK: d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<datamovement>]
+  // CHECK: d2m.argmax
+  // CHECK-SAME: <128, 96>
+  // CHECK-NOT: d2m.tile_reduce_max
+  func.func @argmax_last_dim_bf16(%arg: tensor<128x96xbf16>) -> tensor<128x1xsi32> {
+    %0 = "ttir.argmax"(%arg) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x96xbf16>) -> tensor<128x1xsi32>
+    return %0 : tensor<128x1xsi32>
+  }
+
+  // CHECK-LABEL: func.func @argmax_last_dim_f32
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK: d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<datamovement>]
+  // CHECK: d2m.argmax
+  // CHECK-SAME: <64, 96>
+  // CHECK-NOT: d2m.tile_reduce_max
+  func.func @argmax_last_dim_f32(%arg: tensor<64x96xf32>) -> tensor<64x1xsi32> {
+    %0 = "ttir.argmax"(%arg) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<64x96xf32>) -> tensor<64x1xsi32>
+    return %0 : tensor<64x1xsi32>
+  }
+
+  // CHECK-LABEL: func.func @argmax_last_dim_i32
+  // CHECK-NOT: "ttir.argmax"
+  // CHECK: d2m.generic
+  // CHECK-SAME: threads = [#d2m.thread<datamovement>]
+  // CHECK: d2m.argmax
+  // CHECK-SAME: <32, 96>
+  // CHECK-NOT: d2m.tile_reduce_max
+  func.func @argmax_last_dim_i32(%arg: tensor<32x96xsi32>) -> tensor<32x1xsi32> {
+    %0 = "ttir.argmax"(%arg) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<32x96xsi32>) -> tensor<32x1xsi32>
+    return %0 : tensor<32x1xsi32>
+  }
+}


### PR DESCRIPTION
### Problem description
Need to support this op

### What's changed
- Lowering supports last-dimension argmax with bf16, f32, and i32 inputs.
- Added new `d2m.argmax` and `d2m.argmax_interleaved` to represent this dm op in tensor and memref land respectively.
- Implemented TTKernel lowering as a data-movement row scan:
      - reads packed bf16/f32/i32 values from L1 through scratch,
      - compares candidates (cmpf ogt for floats, signed cmpi sgt for i32),
      - writes the selected column index as i32.
  - Added D2M bufferization, memory effects, verifier checks, thread-arg normalization, and scratch-buffer handling for argmax.
- Added builder and lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
