### PR TITLE
[Builder] Fix crash on unallocated tensors in execute_fb

### DIFF
--- a/.github/test_scripts/runtime_debug.sh
+++ b/.github/test_scripts/runtime_debug.sh
@@ -11,3 +11,6 @@ $BUILD_DIR/runtime/test/common/gtest/test_handle_float_bfloat_buffer_cast
 $BUILD_DIR/runtime/test/common/gtest/test_handle_integer_buffer_cast
 $BUILD_DIR/runtime/test/ttnn/gtest/test_tensor_serialization
 $BUILD_DIR/runtime/test/ttnn/gtest/test_tensor_cache_lifetime
+
+echo "Running TTMetal Runtime Unit Tests"
+$BUILD_DIR/runtime/test/ttmetal/gtest/test_is_tensor_allocated

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -206,7 +206,9 @@ Tensor createMultiDeviceBorrowedHostTensor(
 }
 
 bool isTensorAllocated(Tensor tensor) {
-  LOG_FATAL("isTensorAllocated not implemented for metal runtime");
+  const MetalTensor &metalTensor =
+      tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
+  return !std::holds_alternative<TensorDesc>(metalTensor);
 }
 
 target::DataType getTensorDataType(Tensor tensor) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -208,7 +208,22 @@ Tensor createMultiDeviceBorrowedHostTensor(
 bool isTensorAllocated(Tensor tensor) {
   const MetalTensor &metalTensor =
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
-  return !std::holds_alternative<TensorDesc>(metalTensor);
+  return std::visit(
+      utils::overloaded{
+          // HostAllocCommand stores TensorDesc with a non-null data pointer for
+          // fully allocated outputs. A null data pointer means an unallocated
+          // const-eval placeholder.
+          [&](const TensorDesc &) -> bool { return tensor.data != nullptr; },
+          // HostBuffer / DistributedHostBuffer are created by MeshShardCommand
+          // and are always backed by real host memory (data field is null, but
+          // the buffer object itself holds the allocation).
+          [&](const HostBuffer &) -> bool { return true; },
+          [&](const DistributedHostBuffer &) -> bool { return true; },
+          // MeshBuffer: device-side only; toHost is not yet implemented for it,
+          // so treat as unallocated to avoid a LOG_FATAL in toHost.
+          [&](const MeshBuffer &) -> bool { return false; },
+      },
+      metalTensor);
 }
 
 target::DataType getTensorDataType(Tensor tensor) {

--- a/runtime/test/ttmetal/CMakeLists.txt
+++ b/runtime/test/ttmetal/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(gtest)

--- a/runtime/test/ttmetal/gtest/CMakeLists.txt
+++ b/runtime/test/ttmetal/gtest/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_runtime_gtest(test_is_tensor_allocated)

--- a/runtime/test/ttmetal/gtest/test_is_tensor_allocated.cpp
+++ b/runtime/test/ttmetal/gtest/test_is_tensor_allocated.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test: isTensorAllocated for TTMetal tensors must not crash.
+//
+// Background: builder_runtime.py calls is_allocated() before to_host() to
+// skip unallocated const-eval output tensors. The TTMetal implementation of
+// isTensorAllocated was previously a LOG_FATAL stub, which caused every
+// ttmetal-target test to fail when the workaround was introduced.
+
+#include "tt/runtime/detail/ttmetal/ttmetal.h"
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+using tt::runtime::DeviceRuntime;
+using tt::runtime::Tensor;
+using tt::runtime::TensorDesc;
+using tt::runtime::ttmetal::HostBuffer;
+using tt::runtime::ttmetal::MetalTensor;
+
+class IsTensorAllocatedTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    tt::runtime::setCurrentDeviceRuntime(DeviceRuntime::TTMetal);
+  }
+};
+
+// A tensor whose MetalTensor variant holds only a TensorDesc (no buffer) is
+// unallocated. This is the case a const-eval placeholder produces.
+TEST_F(IsTensorAllocatedTest, ReturnsFalseForTensorDesc) {
+  TensorDesc desc({1, 4}, tt::target::DataType::Float32);
+  auto handle = std::make_shared<MetalTensor>(desc);
+  Tensor tensor(std::static_pointer_cast<void>(handle), nullptr,
+                DeviceRuntime::TTMetal);
+
+  EXPECT_FALSE(tt::runtime::isTensorAllocated(tensor));
+}
+
+// A tensor whose MetalTensor variant holds a HostBuffer is allocated.
+// The buffer pointer itself may be null; only the variant alternative matters.
+TEST_F(IsTensorAllocatedTest, ReturnsTrueForHostBuffer) {
+  HostBuffer nullBuffer; // null shared_ptr<tt::tt_metal::HostBuffer>
+  auto handle = std::make_shared<MetalTensor>(nullBuffer);
+  Tensor tensor(std::static_pointer_cast<void>(handle), nullptr,
+                DeviceRuntime::TTMetal);
+
+  EXPECT_TRUE(tt::runtime::isTensorAllocated(tensor));
+}

--- a/runtime/test/ttmetal/gtest/test_is_tensor_allocated.cpp
+++ b/runtime/test/ttmetal/gtest/test_is_tensor_allocated.cpp
@@ -2,12 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Regression test: isTensorAllocated for TTMetal tensors must not crash.
+// Regression test: isTensorAllocated for TTMetal tensors.
 //
 // Background: builder_runtime.py calls is_allocated() before to_host() to
-// skip unallocated const-eval output tensors. The TTMetal implementation of
-// isTensorAllocated was previously a LOG_FATAL stub, which caused every
-// ttmetal-target test to fail when the workaround was introduced.
+// skip unallocated const-eval output tensors.
+//
+// TTMetal allocation status depends on the MetalTensor variant:
+//  - TensorDesc with non-null data: allocated (HostAllocCommand output)
+//  - TensorDesc with null data: unallocated (const-eval placeholder)
+//  - HostBuffer: allocated (MeshShardCommand shard_to_full output)
+//  - DistributedHostBuffer: allocated (MeshShardCommand full_to_shard output)
+//  - MeshBuffer: unallocated (to_host not yet implemented; skip gracefully)
 
 #include "tt/runtime/detail/ttmetal/ttmetal.h"
 #include "tt/runtime/runtime.h"
@@ -15,13 +20,15 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <memory>
-#include <vector>
 
 using tt::runtime::DeviceRuntime;
 using tt::runtime::Tensor;
 using tt::runtime::TensorDesc;
+using tt::runtime::ttmetal::DistributedHostBuffer;
 using tt::runtime::ttmetal::HostBuffer;
+using tt::runtime::ttmetal::MeshBuffer;
 using tt::runtime::ttmetal::MetalTensor;
 
 class IsTensorAllocatedTest : public ::testing::Test {
@@ -31,9 +38,8 @@ protected:
   }
 };
 
-// A tensor whose MetalTensor variant holds only a TensorDesc (no buffer) is
-// unallocated. This is the case a const-eval placeholder produces.
-TEST_F(IsTensorAllocatedTest, ReturnsFalseForTensorDesc) {
+// TensorDesc + null data: unallocated const-eval placeholder.
+TEST_F(IsTensorAllocatedTest, ReturnsFalseForTensorDescNullData) {
   TensorDesc desc({1, 4}, tt::target::DataType::Float32);
   auto handle = std::make_shared<MetalTensor>(desc);
   Tensor tensor(std::static_pointer_cast<void>(handle), nullptr,
@@ -42,13 +48,33 @@ TEST_F(IsTensorAllocatedTest, ReturnsFalseForTensorDesc) {
   EXPECT_FALSE(tt::runtime::isTensorAllocated(tensor));
 }
 
-// A tensor whose MetalTensor variant holds a HostBuffer is allocated.
-// The buffer pointer itself may be null; only the variant alternative matters.
+// TensorDesc + non-null data: allocated HostAllocCommand output.
+TEST_F(IsTensorAllocatedTest, ReturnsTrueForTensorDescNonNullData) {
+  TensorDesc desc({1, 4}, tt::target::DataType::Float32);
+  auto handle = std::make_shared<MetalTensor>(desc);
+  auto data = std::shared_ptr<void>(std::calloc(16, 1), std::free);
+  Tensor tensor(std::static_pointer_cast<void>(handle), data,
+                DeviceRuntime::TTMetal);
+
+  EXPECT_TRUE(tt::runtime::isTensorAllocated(tensor));
+}
+
+// HostBuffer (null inner pointer is fine): allocated MeshShard shard_to_full.
 TEST_F(IsTensorAllocatedTest, ReturnsTrueForHostBuffer) {
-  HostBuffer nullBuffer; // null shared_ptr<tt::tt_metal::HostBuffer>
+  HostBuffer nullBuffer;
   auto handle = std::make_shared<MetalTensor>(nullBuffer);
   Tensor tensor(std::static_pointer_cast<void>(handle), nullptr,
                 DeviceRuntime::TTMetal);
 
   EXPECT_TRUE(tt::runtime::isTensorAllocated(tensor));
+}
+
+// MeshBuffer: unallocated — toHost is not yet implemented, skip gracefully.
+TEST_F(IsTensorAllocatedTest, ReturnsFalseForMeshBuffer) {
+  MeshBuffer nullMeshBuffer;
+  auto handle = std::make_shared<MetalTensor>(nullMeshBuffer);
+  Tensor tensor(std::static_pointer_cast<void>(handle), nullptr,
+                DeviceRuntime::TTMetal);
+
+  EXPECT_FALSE(tt::runtime::isTensorAllocated(tensor));
 }

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -855,17 +855,20 @@ def execute_fb(
                     output_device_tensors[device_id].get_data_buffer()
                 )
 
-                ref_tensor = output_device_tensors[device_id]
                 if len(data_buffer) == 0:
                     output_shard_torch = torch.empty(
-                        ref_tensor.get_shape(),
-                        dtype=runtime_dtype_to_torch_dtype(ref_tensor.get_dtype()),
+                        output_device_tensors[device_id].get_shape(),
+                        dtype=runtime_dtype_to_torch_dtype(
+                            output_device_tensors[device_id].get_dtype()
+                        ),
                     )
                 else:
                     output_shard_torch = torch.frombuffer(
                         data_buffer,
-                        dtype=runtime_dtype_to_torch_dtype(ref_tensor.get_dtype()),
-                    ).reshape(ref_tensor.get_shape())
+                        dtype=runtime_dtype_to_torch_dtype(
+                            output_device_tensors[device_id].get_dtype()
+                        ),
+                    ).reshape(output_device_tensors[device_id].get_shape())
 
                 golden_shard_torch = golden_outputs_torch[i][device_id]
                 results = check_outputs(

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -819,9 +819,19 @@ def execute_fb(
             outputs.append(new_output)
 
         for i, runtime_output_tensor in enumerate(runtime_outputs):
-            output_host = tt_runtime.runtime.to_host(
-                runtime_output_tensor, untilize=True
-            )
+            if not runtime_output_tensor.is_allocated():
+                # Tensor is not allocated (e.g., from const_eval that
+                # didn't produce a device tensor). Create a zero tensor
+                # as placeholder and skip to_host entirely.
+                output_host = None
+            else:
+                output_host = tt_runtime.runtime.to_host(
+                    runtime_output_tensor, untilize=True
+                )
+
+            if output_host is None:
+                # Unallocated tensor — nothing to read. Skip golden check.
+                continue
 
             if disable_golden:
                 continue
@@ -845,20 +855,17 @@ def execute_fb(
                     output_device_tensors[device_id].get_data_buffer()
                 )
 
+                ref_tensor = output_device_tensors[device_id]
                 if len(data_buffer) == 0:
                     output_shard_torch = torch.empty(
-                        output_device_tensors[device_id].get_shape(),
-                        dtype=runtime_dtype_to_torch_dtype(
-                            output_device_tensors[device_id].get_dtype()
-                        ),
+                        ref_tensor.get_shape(),
+                        dtype=runtime_dtype_to_torch_dtype(ref_tensor.get_dtype()),
                     )
                 else:
                     output_shard_torch = torch.frombuffer(
                         data_buffer,
-                        dtype=runtime_dtype_to_torch_dtype(
-                            output_device_tensors[device_id].get_dtype()
-                        ),
-                    ).reshape(output_device_tensors[device_id].get_shape())
+                        dtype=runtime_dtype_to_torch_dtype(ref_tensor.get_dtype()),
+                    ).reshape(ref_tensor.get_shape())
 
                 golden_shard_torch = golden_outputs_torch[i][device_id]
                 results = check_outputs(

--- a/tools/builder/base/builder_runtime.py
+++ b/tools/builder/base/builder_runtime.py
@@ -821,17 +821,13 @@ def execute_fb(
         for i, runtime_output_tensor in enumerate(runtime_outputs):
             if not runtime_output_tensor.is_allocated():
                 # Tensor is not allocated (e.g., from const_eval that
-                # didn't produce a device tensor). Create a zero tensor
-                # as placeholder and skip to_host entirely.
-                output_host = None
+                # didn't produce a device tensor). Skip to_host and
+                # golden check.
+                continue
             else:
                 output_host = tt_runtime.runtime.to_host(
                     runtime_output_tensor, untilize=True
                 )
-
-            if output_host is None:
-                # Unallocated tensor — nothing to read. Skip golden check.
-                continue
 
             if disable_golden:
                 continue


### PR DESCRIPTION
Fix `execute_fb` crashing when `to_host` is called on an unallocated runtime tensor (e.g., produced by const_eval that yields no device tensor). Check `is_allocated()` before calling `to_host`; skip the
  golden comparison for unallocated outputs.