### PR TITLE
[TTNN] Add ROW_MAJOR layout workaround for SliceDynamicOp

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -320,7 +320,11 @@ TTNNOperandsWorkaroundsFactory::createSliceStaticOpOperandsWorkarounds(
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createSliceDynamicOpOperandsWorkarounds(
     ttnn::SliceDynamicOp op) {
+  // The tt-metal slice with tensor args (dynamic) requires ROW_MAJOR layout
+  // for the input tensor. The device-only TILE path needs slice_dim and
+  // num_devices which are not provided by the TTIR→TTNN lowering.
   TTNNOperandWorkarounds inputWorkaround;
+  inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   Type inputType = op.getInput().getType().getElementType();
   uint32_t bitWidth = inputType.getIntOrFloatBitWidth();
   if (inputType.isUnsignedInteger() && bitWidth < 32) {
@@ -329,11 +333,17 @@ TTNNOperandsWorkaroundsFactory::createSliceDynamicOpOperandsWorkarounds(
   TTNNOperandWorkarounds uInt32Workaround;
   uInt32Workaround.tensorDataTypeWorkaround = ttcore::DataType::UInt32;
 
+  TTNNOperandWorkarounds outputWorkaround;
+  outputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+  if (inputType.isUnsignedInteger() && bitWidth < 32) {
+    outputWorkaround.tensorDataTypeWorkaround = ttcore::DataType::UInt32;
+  }
+
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(inputWorkaround)
       .addInputOperandWorkaround(uInt32Workaround)
       .addInputOperandWorkaround(uInt32Workaround)
-      .addOutputOperandWorkaround(inputWorkaround);
+      .addOutputOperandWorkaround(outputWorkaround);
 }
 
 // ConstantOp is not a TTNN (lib) operation, but it is used to create TTNN

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -323,6 +323,7 @@ TTNNOperandsWorkaroundsFactory::createSliceDynamicOpOperandsWorkarounds(
   // The tt-metal slice with tensor args (dynamic) requires ROW_MAJOR layout
   // for the input tensor. The device-only TILE path needs slice_dim and
   // num_devices which are not provided by the TTIR→TTNN lowering.
+  // https://github.com/tenstorrent/tt-metal/issues/42778
   TTNNOperandWorkarounds inputWorkaround;
   inputWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   Type inputType = op.getInput().getType().getElementType();

--- a/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
@@ -8,4 +8,12 @@ module attributes {} {
     %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2) <{step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<3xi32>, tensor<3xi32>) -> tensor<2x16x16xbf16>
     return %1 : tensor<2x16x16xbf16>
   }
+
+  // Unsigned integer narrower than 32 bits: input and output must be promoted
+  // to UInt32 (line 339 in TTNNWorkaroundsPass.cpp).
+  func.func @dynamic_slice_ui8(%arg0: tensor<4x32xui8>, %arg1: tensor<2xi32>, %arg2: tensor<2xi32>) -> tensor<2x16xui8> {
+    // CHECK: = "ttnn.slice_dynamic"
+    %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2) <{step = [1: i32, 1: i32]}> : (tensor<4x32xui8>, tensor<2xi32>, tensor<2xi32>) -> tensor<2x16xui8>
+    return %1 : tensor<2x16xui8>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_slice_dynamic.mlir
@@ -10,7 +10,7 @@ module attributes {} {
   }
 
   // Unsigned integer narrower than 32 bits: input and output must be promoted
-  // to UInt32 (line 339 in TTNNWorkaroundsPass.cpp).
+  // to UInt32.
   func.func @dynamic_slice_ui8(%arg0: tensor<4x32xui8>, %arg1: tensor<2xi32>, %arg2: tensor<2xi32>) -> tensor<2x16xui8> {
     // CHECK: = "ttnn.slice_dynamic"
     %1 = "ttir.slice_dynamic"(%arg0, %arg1, %arg2) <{step = [1: i32, 1: i32]}> : (tensor<4x32xui8>, tensor<2xi32>, tensor<2xi32>) -> tensor<2x16xui8>


### PR DESCRIPTION
The tt-metal dynamic-slice path (tensor arguments) requires ROW_MAJOR layout. The TILE path requires `slice_dim`/`num_devices` parameters not available from the TTIR→TTNN lowering. Add ROW_MAJOR layout
  workarounds for both input and output operands in `createSliceDynamicOpOperandsWorkarounds`.