### PR TITLE
[TTNN] Add concat ui8→i32 operand workaround

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1383,6 +1383,13 @@ def TTNN_ConcatOp : TTNN_Op<"concat", [TTNN_MemoryConfigOpInterface]> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createConcatOpOperandsWorkarounds(this->getOperation());
+      }
+    }];
+
     let hasVerifier = 1;
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -285,6 +285,9 @@ public:
   static TTNNOperandsWorkarounds
   createReshapeOpOperandsWorkarounds(RankedTensorType inputType);
 
+  static TTNNOperandsWorkarounds
+  createConcatOpOperandsWorkarounds(mlir::Operation *op);
+
   static TTNNOperandsWorkarounds createDropoutOpOperandsWorkarounds();
 
   static TTNNOperandsWorkarounds

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -419,6 +419,30 @@ TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(
       .addOutputOperandWorkaround(typeWorkarounds);
 }
 
+// Factory method to create a set of workarounds for concat operation operands.
+// Tilize (used internally by concat) doesn't support ui8/i8 tensors.
+// Promote to Int32, same as the reshape workaround.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
+    mlir::Operation *op) {
+  TTNNOperandWorkarounds typeWorkarounds;
+  if (op->getNumOperands() > 0) {
+    auto inputType = mlir::cast<RankedTensorType>(op->getOperand(0).getType());
+    mlir::Type elemType = inputType.getElementType();
+    mlir::tt::ttcore::DataType dataType =
+        mlir::tt::ttcore::elementTypeToDataType(elemType);
+    if (dataType == mlir::tt::ttcore::DataType::UInt8) {
+      typeWorkarounds.tensorDataTypeWorkaround =
+          mlir::tt::ttcore::DataType::Int32;
+    }
+  }
+  auto wa = TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+  for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+    wa = wa.addInputOperandWorkaround(typeWorkarounds);
+  }
+  return wa.addOutputOperandWorkaround(typeWorkarounds);
+}
+
 // Factory method to create a set of workarounds for UpdateCache operation
 // operands. Update index of UpdateCacheOp must be unsigned
 TTNNOperandsWorkarounds

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that ui8 inputs to concat are promoted to i32 by the workaround pass.
+// tilize_with_val_padding (used internally by concat) does not support ui8/i8.
+
+module {
+  func.func @concat_ui8(%arg0: tensor<32x32xui8>, %arg1: tensor<32x32xui8>) -> tensor<32x64xui8> {
+    // CHECK-LABEL: func.func @concat_ui8
+    // CHECK: ttnn.to_layout
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<32x32xui8
+    // CHECK-SAME: tensor<32x32xsi32
+    // CHECK: ttnn.to_layout
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<32x32xui8
+    // CHECK-SAME: tensor<32x32xsi32
+    // CHECK: ttnn.concat
+    // CHECK-SAME: tensor<32x32xsi32
+    // CHECK-SAME: tensor<32x64xsi32
+    // CHECK: ttnn.to_layout
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u8>
+    // CHECK-SAME: tensor<32x64xsi32
+    // CHECK-SAME: tensor<32x64xui8
+    %0 = "ttir.concat"(%arg0, %arg1) <{dim = 1 : si32}> : (tensor<32x32xui8>, tensor<32x32xui8>) -> tensor<32x64xui8>
+    return %0 : tensor<32x64xui8>
+  }
+}


### PR DESCRIPTION
`tilize_with_val_padding` (used internally by ConcatOp) does not support ui8/i8 tensors. Add `createConcatOpOperandsWorkarounds` to promote ui8 inputs and output to Int32, matching the existing reshape
  workaround pattern.