### PR TITLE
[TTNN] Fix where workaround for integer operands — cast to si32

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -279,6 +279,9 @@ public:
   static TTNNOperandsWorkarounds createConstantOpOperandsWorkarounds();
 
   // Create workarounds for WhereOp operands.
+  // tt-metal where only supports si32 and float types natively.
+  // Integer operands (i8, ui8, ui32) are cast to si32.
+  // Float predicate mismatches are cast to match input type.
   static TTNNOperandsWorkarounds
   createWhereOpOperandsWorkarounds(mlir::Operation::operand_range inputs);
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -351,13 +351,10 @@ TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
 }
 
 // Factory method to create a set of workarounds for where op operands.
-// tt-metal uses predicate type for where op operation. If the predicate data
-// type does not match with inputs/output data type; tt-metal can generate
-// incorrect results or other failures. Add a data type workaround if predicate
-// type does not match with input. Also, if predicate is integer, force it to
-// match input data type, unless both are integers, then force both to
-// float32.
-// tt-metal issues to track mixed data types ops bug.
+// tt-metal where only supports si32 and float types natively.
+// Integer operands (i8, ui8, ui32) are cast to si32.
+// Float predicate mismatches are cast to match input type.
+// tt-metal issues:
 // https://github.com/tenstorrent/tt-metal/issues/17998
 // https://github.com/tenstorrent/tt-metal/issues/24511
 TTNNOperandsWorkarounds
@@ -378,15 +375,13 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   if (predicateElementType.isInteger() ||
       predicateElementType != inputElementType) {
     if (inputElementType.isInteger()) {
-      // In an unlikely scenario, we could potentially upcast to float32, if
-      // input is integer and predicate is for example bf16.
-      // More importantly, if both are integers, we force both to float32.
-      predicateTypeWorkaround =
-          TTNNOperandWorkarounds(ttcore::DataType::Float32);
-      inputTypeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Float32);
-      outputTypeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Float32);
+      // tt-metal where only works with si32 among integer types.
+      // Cast all operands to si32 (lossless round-trip for i8/ui8/ui32).
+      predicateTypeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Int32);
+      inputTypeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Int32);
+      outputTypeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Int32);
     } else {
-      // Otherwise, we just force the predicate type to match the input type.
+      // Float input: cast predicate to match input type.
       predicateTypeWorkaround = TTNNOperandWorkarounds(
           ttcore::elementTypeToDataType(inputElementType));
     }

--- a/test/ttmlir/Dialect/TTNN/eltwise/ternary/where/simple_where.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/ternary/where/simple_where.mlir
@@ -19,6 +19,7 @@ module @jit_eltwise_where {
 
   func.func public @where_predicate_different_than_input(%arg0: tensor<13x37xf32>, %arg1: tensor<13x37xbf16>, %arg2: tensor<13x37xbf16>) -> tensor<13x37xbf16> {
     %0 = ttir.empty() : tensor<13x37xbf16>
+    // Predicate (f32) differs from float input (bf16) — typecast predicate.
     // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<bf16>}
     // CHECK: "ttnn.where"{{.*}}
     %1 = "ttir.where"(%arg0, %arg1, %arg2) : (tensor<13x37xf32>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
@@ -27,6 +28,7 @@ module @jit_eltwise_where {
 
   func.func public @where_predicate_integer(%arg0: tensor<13x37xsi32>, %arg1: tensor<13x37xbf16>, %arg2: tensor<13x37xbf16>) -> tensor<13x37xbf16> {
     %0 = ttir.empty() : tensor<13x37xbf16>
+    // Predicate (si32) differs from float input (bf16) — typecast predicate.
     // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<bf16>}
     // CHECK: "ttnn.where"{{.*}}
     %1 = "ttir.where"(%arg0, %arg1, %arg2) : (tensor<13x37xsi32>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
@@ -34,11 +36,19 @@ module @jit_eltwise_where {
   }
 
   func.func public @where_all_operands_integer(%arg0: tensor<13x37xsi32>, %arg1: tensor<13x37xsi32>, %arg2: tensor<13x37xsi32>) -> tensor<13x37xsi32> {
-    // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<f32>}
-    // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<f32>}
-    // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<f32>}
+    // si32 is natively supported — no typecast needed (si32→si32 is no-op).
+    // CHECK-NOT: "ttnn.typecast"
     // CHECK: "ttnn.where"{{.*}}
     %1 = "ttir.where"(%arg0, %arg1, %arg2) : (tensor<13x37xsi32>, tensor<13x37xsi32>, tensor<13x37xsi32>) -> tensor<13x37xsi32>
     return %1 : tensor<13x37xsi32>
+  }
+
+  func.func public @where_all_i8(%arg0: tensor<13x37xi8>, %arg1: tensor<13x37xi8>, %arg2: tensor<13x37xi8>) -> tensor<13x37xi8> {
+    // i8 not natively supported — cast to si32, result cast back.
+    // CHECK: "ttnn.typecast"{{.*}}{dtype = #ttcore.supportedDataTypes<si32>}
+    // CHECK: "ttnn.where"
+    // CHECK: "ttnn.typecast"
+    %1 = "ttir.where"(%arg0, %arg1, %arg2) : (tensor<13x37xi8>, tensor<13x37xi8>, tensor<13x37xi8>) -> tensor<13x37xi8>
+    return %1 : tensor<13x37xi8>
   }
 }


### PR DESCRIPTION
tt-metal `where` only supports si32 and float types natively; i8/ui8/ui32 operands produce wrong results or runtime errors. When any operand is integer, cast all operands to si32 (lossless since `where` only
  selects between values). Float-predicate mismatches continue to be handled by casting the predicate to match the input type.