### PR TITLE
Uplift third_party/tt-metal to b3e8eb62c6494c986aa4174c28b99047bc98481d 2026-05-01

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=a7c30224460a51431c5270cf583229ce73a810ec
+ARG TT_METAL_DEPENDENCIES_COMMIT=b3e8eb62c6494c986aa4174c28b99047bc98481d
 
 # Install dependencies
 RUN <<EOT

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_pack_untilize_llks.h
@@ -37,8 +37,9 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t ocb,
         UNPACK((llk_unpack_A<BroadcastType::NONE, false,
                              EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             icb, r * block_col_tiles + b * cols_per_dst_pass + c)));
-        MATH((llk_math_eltwise_unary_datacopy<
-              A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(c)));
+        MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
+                                              BroadcastType::NONE,
+                                              UnpackToDestEn>(c)));
       }
 
       MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
@@ -49,7 +49,7 @@ ALWI void tilize_block(uint32_t icb, uint32_t ocb, uint32_t block_r,
 
       // Datacopy
       MATH(
-          (llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE,
+          (llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
                                            BroadcastType::NONE, UnpackToDestEn>(
               0 /*dst index*/)));
       PACK((llk_pack<false, false>(0 /*tile index*/, ocb)));

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks.h
@@ -40,7 +40,7 @@ ALWI void untilize_block(uint32_t icb, uint32_t ocb, uint32_t block_r,
       MATH((llk_math_wait_for_dest_available()));
 
       // Datacopy
-      MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE,
+      MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE,
                                             BroadcastType::NONE>(0)));
 
       MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -248,7 +248,9 @@ createKernelDescriptor(const ::tt::target::ttnn::KernelDescriptor &kernelDesc,
       .defines = {},
       .runtime_args = runtimeArgs,
       .common_runtime_args = commonRuntimeArgs,
-      .config = createKernelConfigDescriptor(kernelDesc)};
+      .config = createKernelConfigDescriptor(kernelDesc),
+      .buffer_bindings = {},
+      .common_buffer_bindings = {}};
 
   return kernelDescriptor;
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "a7c30224460a51431c5270cf583229ce73a810ec")
+set(TT_METAL_VERSION "b3e8eb62c6494c986aa4174c28b99047bc98481d")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the b3e8eb62c6494c986aa4174c28b99047bc98481d

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25325001520
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25329058922
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):