### PR TITLE
[TTKernel] Add noc_semaphore_inc_multicast op and posted attribute on noc_semaphore_inc

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3503,12 +3503,23 @@ def TTKernel_NocSemaphoreIncOp : TTKernel_Op<"noc_semaphore_inc"> {
       (with 32-bit wrap) of a remote Tensix core L1 memory address. This L1 memory
       address is used as a semaphore of size 4 Bytes, as a synchronization
       mechanism.
+
+      The `posted` attribute selects the NOC transaction response mode and
+      maps to the homonymous template parameter of `noc_semaphore_inc` in
+      tt-metal. When unset or false, the transaction is non-posted: the
+      receiver returns an acknowledgement and the sender's outstanding-atomics
+      counter tracks completion. When true, the transaction is posted: no
+      acknowledgement is returned, the sender's counter is not updated, and
+      synchronization must be receiver-driven.
     }];
 
-    let arguments = (ins TTKernel_NocAddr:$addr, IndexLike:$incr, Optional<I8>:$noc_id);
+    let arguments = (ins TTKernel_NocAddr:$addr,
+                         IndexLike:$incr,
+                         Optional<I8>:$noc_id,
+                         OptionalAttr<BoolAttr>:$posted);
 
     let assemblyFormat = [{
-      `(` $addr `,` $incr (`,` $noc_id^)? `)` attr-dict `:` functional-type(operands, results)
+      `(` $addr `,` $incr (`,` $noc_id^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
 }
 
@@ -3614,6 +3625,37 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
 
     let assemblyFormat = [{
       `(` $src_local_l1_addr `,` $dst_noc_addr_multicast `,` $num_dests (`,` $linked^)? `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
+def TTKernel_NocSemaphoreIncMulticastOp : TTKernel_Op<"noc_semaphore_inc_multicast"> {
+    let summary = "NocSemaphoreIncMulticast";
+    let description = [{
+      Initiates an atomic increment (with 32-bit wrap) of a 4-byte L1 semaphore
+      on every core in a rectangular destination grid. The destinations are
+      encoded in a uint64_t produced by *get_noc_multicast_addr* covering the
+      NOC coordinate range (x_start, y_start, x_end, y_end) and the target L1
+      address. Used for cumulative synchronization across multiple senders
+      sharing receivers, paired with *experimental::semaphore_wait_min*.
+
+      The sender must not be a member of the multicast destination set; for
+      including the sender there is no corresponding loopback variant in
+      tt-metal at this time.
+
+      The `posted` attribute mirrors the semantics of `noc_semaphore_inc`'s
+      `posted` template parameter. Posted multicast is currently restricted
+      on some architectures in the underlying tt-metal (cf. the assertion in
+      the v2 `Noc::async_write_multicast` API); leave unset when in doubt.
+    }];
+
+    let arguments = (ins TTKernel_NocAddr:$addr,
+                         IndexLike:$incr,
+                         I32:$num_dests,
+                         Optional<I8>:$noc_id,
+                         OptionalAttr<BoolAttr>:$posted);
+
+    let assemblyFormat = [{
+      `(` $addr `,` $incr `,` $num_dests (`,` $noc_id^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3444,6 +3444,21 @@ def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier", [TT
     let hasCanonicalizer = 1;
 }
 
+def TTKernel_NocAsyncAtomicBarrierOp : TTKernel_Op<"noc_async_atomic_barrier"> {
+    let summary = "NocAsyncAtomicBarrier";
+    let description = [{
+      Block until all outstanding non-posted atomic operations on the given
+      NOC have flushed. Pairs with `noc_semaphore_inc` and
+      `noc_semaphore_inc_multicast`.
+    }];
+
+    let arguments = (ins Optional<I8>:$noc_id);
+
+    let assemblyFormat = [{
+      `(` ($noc_id^)? `)` attr-dict `:` functional-type(operands, results)
+    }];
+}
+
 def TTKernel_NocAsyncWriteBarrierWithTridOp : TTKernel_Op<"noc_async_write_barrier_with_trid", [TTKernel_DeviceZoneOpTrait, TTKernel_TridNocOpTrait]> {
     let summary = "NocAsyncWriteBarrierWithTrid";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3521,6 +3521,16 @@ def TTKernel_NocSemaphoreIncOp : TTKernel_Op<"noc_semaphore_inc"> {
     let assemblyFormat = [{
       `(` $addr `,` $incr (`,` $noc_id^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$addr, "Value":$incr), [{
+        build($_builder, $_state, addr, incr, /*noc_id=*/Value{},
+              /*posted=*/BoolAttr{});
+      }]>,
+      OpBuilder<(ins "Value":$addr, "Value":$incr, "Value":$noc_id), [{
+        build($_builder, $_state, addr, incr, noc_id, /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 def TTKernel_NocSemaphoreSetOp : TTKernel_Op<"noc_semaphore_set"> {
@@ -3657,6 +3667,18 @@ def TTKernel_NocSemaphoreIncMulticastOp : TTKernel_Op<"noc_semaphore_inc_multica
     let assemblyFormat = [{
       `(` $addr `,` $incr `,` $num_dests (`,` $noc_id^)? `)` (`posted` $posted^)? attr-dict `:` functional-type(operands, results)
     }];
+
+    let builders = [
+      OpBuilder<(ins "Value":$addr, "Value":$incr, "Value":$num_dests), [{
+        build($_builder, $_state, addr, incr, num_dests, /*noc_id=*/Value{},
+              /*posted=*/BoolAttr{});
+      }]>,
+      OpBuilder<(ins "Value":$addr, "Value":$incr, "Value":$num_dests,
+                     "Value":$noc_id), [{
+        build($_builder, $_state, addr, incr, num_dests, noc_id,
+              /*posted=*/BoolAttr{});
+      }]>,
+    ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelIncludesMap.h
@@ -56,6 +56,7 @@ inline const llvm::StringMap<HeaderRequirement> &getCalleeToHeadersMap() {
         {"noc_async_read_one_packet_with_state_with_trid", {"", "api/dataflow/dataflow_api.h"}},
         {"noc_async_read_set_trid",                        {"", "api/dataflow/dataflow_api.h"}},
         {"noc_async_read_tile",                            {"", "api/dataflow/dataflow_api.h"}},
+        {"noc_async_atomic_barrier",                       {"", "api/dataflow/dataflow_api.h"}},
         {"noc_async_write",                                {"", "api/dataflow/dataflow_api.h"}},
         {"noc_async_write_barrier",                        {"", "api/dataflow/dataflow_api.h"}},
         {"noc_async_write_barrier_with_trid",              {"", "api/dataflow/dataflow_api.h"}},

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2974,7 +2974,8 @@ public:
           rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
           rewriter.create<ttkernel::NocSemaphoreIncOp>(op.getLoc(), nocAddr,
                                                        value,
-                                                       /*noc_id=*/nullptr);
+                                                       /*noc_id=*/nullptr,
+                                                       /*posted=*/nullptr);
           rewriter.create<scf::YieldOp>(op.getLoc());
         }
       }
@@ -2995,8 +2996,8 @@ public:
           rewriter, op.getLoc(), chipDesc, op.getDstCoreIndex());
       auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
           op.getLoc(), virtX, virtY, semaphoreAddr);
-      rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(op, nocAddr,
-                                                               value, nullptr);
+      rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(
+          op, nocAddr, value, /*noc_id=*/nullptr, /*posted=*/nullptr);
     } else {
       assert(!mlir::isa<d2m::SemaphoreIncOp>(op) &&
              "d2m.semaphore_inc multicast is illegal.");

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2973,9 +2973,7 @@ public:
           OpBuilder::InsertionGuard guard(rewriter);
           rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
           rewriter.create<ttkernel::NocSemaphoreIncOp>(op.getLoc(), nocAddr,
-                                                       value,
-                                                       /*noc_id=*/nullptr,
-                                                       /*posted=*/nullptr);
+                                                       value);
           rewriter.create<scf::YieldOp>(op.getLoc());
         }
       }
@@ -2996,8 +2994,8 @@ public:
           rewriter, op.getLoc(), chipDesc, op.getDstCoreIndex());
       auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
           op.getLoc(), virtX, virtY, semaphoreAddr);
-      rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(
-          op, nocAddr, value, /*noc_id=*/nullptr, /*posted=*/nullptr);
+      rewriter.replaceOpWithNewOp<ttkernel::NocSemaphoreIncOp>(op, nocAddr,
+                                                               value);
     } else {
       assert(!mlir::isa<d2m::SemaphoreIncOp>(op) &&
              "d2m.semaphore_inc multicast is illegal.");

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -332,6 +332,19 @@ public:
       SmallVector<Attribute, 1> template_args;
       template_args.push_back(emitc::OpaqueAttr::get(op.getContext(), "true"));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp,
+                                        ttkernel::NocSemaphoreIncOp> ||
+                         std::is_same_v<SourceOp,
+                                        ttkernel::NocSemaphoreIncMulticastOp>) {
+      // The metal C signature defaults `posted` to false, so emit a template
+      // arg only when the producer explicitly opts into posted semantics.
+      auto posted = op.getPosted();
+      if (!posted || !*posted) {
+        return ArrayAttr();
+      }
+      SmallVector<Attribute, 1> template_args;
+      template_args.push_back(emitc::OpaqueAttr::get(op.getContext(), "true"));
+      return ArrayAttr::get(op.getContext(), template_args);
     } else if constexpr (std::is_same_v<SourceOp, ttkernel::SFPUReduceInitOp>) {
       // sfpu_reduce_init<PoolType, DataFormat>()
       SmallVector<Attribute, 2> template_args;
@@ -1340,6 +1353,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<
             ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreIncMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::UnpackStallOnPackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsAcquireOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsCommitOp>,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1619,6 +1619,10 @@ public:
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
         typeConverter, funcOp.getContext(), "get_noc_addr");
 
+    patterns
+        .add<TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncAtomicBarrierOp>>(
+            typeConverter, funcOp.getContext());
+
     patterns.add<TTKernelInvokeSFPIOpRewriter>(typeConverter,
                                                funcOp.getContext());
 

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
+#include <fstream>
 #endif
 
 #include "mlir/IR/Builders.h"
@@ -27,7 +28,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <fstream>
 #include <numeric>
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.cpp.inc"
@@ -300,6 +300,7 @@ SystemDescAttr::getDefault(MLIRContext *context, Arch arch,
   }
 }
 
+#ifndef TTMLIR_NO_FLATBUFFERS
 mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
     MLIRContext *context, StringRef path,
     llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
@@ -538,6 +539,23 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
   return systemDescAttr;
 #endif // TTMLIR_NO_FLATBUFFERS
 }
+#else // TTMLIR_NO_FLATBUFFERS
+mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
+    MLIRContext *context, StringRef path,
+    llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
+  diagFn() << "loading system descriptor from file requires building with "
+              "TTMLIR_ENABLE_FLATBUFFERS=ON";
+  return failure();
+}
+
+mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
+    MLIRContext *context, void *systemDesc,
+    llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
+  diagFn() << "loading system descriptor from buffer requires building with "
+              "TTMLIR_ENABLE_FLATBUFFERS=ON";
+  return failure();
+}
+#endif // TTMLIR_NO_FLATBUFFERS
 
 ChipDescAttr SystemDescAttr::getChipDesc(unsigned chipIndex) const {
   return getChipDescs()[getChipDescIndices()[chipIndex]];

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -539,7 +539,7 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
   return systemDescAttr;
 #endif // TTMLIR_NO_FLATBUFFERS
 }
-#else // TTMLIR_NO_FLATBUFFERS
+#else  // TTMLIR_NO_FLATBUFFERS
 mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
     MLIRContext *context, StringRef path,
     llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -14,7 +14,6 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
-#include <fstream>
 #endif
 
 #include "mlir/IR/Builders.h"
@@ -28,6 +27,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <fstream>
 #include <numeric>
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.cpp.inc"
@@ -300,7 +300,6 @@ SystemDescAttr::getDefault(MLIRContext *context, Arch arch,
   }
 }
 
-#ifndef TTMLIR_NO_FLATBUFFERS
 mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
     MLIRContext *context, StringRef path,
     llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
@@ -539,23 +538,6 @@ mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
   return systemDescAttr;
 #endif // TTMLIR_NO_FLATBUFFERS
 }
-#else  // TTMLIR_NO_FLATBUFFERS
-mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromPath(
-    MLIRContext *context, StringRef path,
-    llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
-  diagFn() << "loading system descriptor from file requires building with "
-              "TTMLIR_ENABLE_FLATBUFFERS=ON";
-  return failure();
-}
-
-mlir::FailureOr<SystemDescAttr> SystemDescAttr::getFromBuffer(
-    MLIRContext *context, void *systemDesc,
-    llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
-  diagFn() << "loading system descriptor from buffer requires building with "
-              "TTMLIR_ENABLE_FLATBUFFERS=ON";
-  return failure();
-}
-#endif // TTMLIR_NO_FLATBUFFERS
 
 ChipDescAttr SystemDescAttr::getChipDesc(unsigned chipIndex) const {
   return getChipDescs()[getChipDescIndices()[chipIndex]];

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -23,7 +23,8 @@ module {
     // CHECK: %[[CTARG:[0-9]+]] = ttkernel.get_compile_time_arg_val(0) : () -> i32
     // CHECK: %[[SEM:[0-9]+]] = ttkernel.get_semaphore(%[[CTARG]])
     // CHECK: %[[NOC:[0-9]+]] = ttkernel.get_noc_addr({{.*}}, {{.*}}, %[[SEM]])
-    // CHECK: ttkernel.noc_semaphore_inc(%[[NOC]], %c1)
+    // CHECK: ttkernel.noc_semaphore_inc(%[[NOC]], %c1) :
+    // CHECK-NOT: posted
     return
   }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1770,6 +1770,70 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @noc_semaphore_inc_posted
+    func.func @noc_semaphore_inc_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]]) {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.noc_semaphore_inc"(%addr, %incr) <{posted = true}> : (!ttkernel.noc_addr, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_semaphore_inc_multicast
+    func.func @noc_semaphore_inc_multicast() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr) // dummy l1 addr (use mcast getter)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
+      %num_dsts = arith.constant 8 : i32
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]])
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) : (!ttkernel.noc_addr, i32, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_semaphore_inc_multicast_with_noc_id
+    func.func @noc_semaphore_inc_multicast_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
+      %num_dsts = arith.constant 8 : i32
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 3 : i8
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]], %[[NOC_ID]])
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts, %noc_id) : (!ttkernel.noc_addr, i32, i32, i8) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_semaphore_inc_multicast_posted
+    func.func @noc_semaphore_inc_multicast_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
+      %num_dsts = arith.constant 8 : i32
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]]) {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) <{posted = true}> : (!ttkernel.noc_addr, i32, i32) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @noc_semaphore_set
     func.func @noc_semaphore_set() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1834,6 +1834,58 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @noc_semaphore_inc_posted_false
+    // Verify explicit `posted = false` round-trips and emits no template args
+    // (must match the unset case byte-for-byte).
+    func.func @noc_semaphore_inc_posted_false() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: emitc.call_opaque "noc_semaphore_inc"(%[[ADDR]], %[[INCR]]) :
+      // CHECK-NOT: template_args
+      "ttkernel.noc_semaphore_inc"(%addr, %incr) <{posted = false}> : (!ttkernel.noc_addr, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_semaphore_inc_multicast_posted_false
+    func.func @noc_semaphore_inc_multicast_posted_false() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
+      %num_dsts = arith.constant 8 : i32
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]]) :
+      // CHECK-NOT: template_args
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts) <{posted = false}> : (!ttkernel.noc_addr, i32, i32) -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_semaphore_inc_multicast_with_noc_id_posted
+    func.func @noc_semaphore_inc_multicast_with_noc_id_posted() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
+      %x = arith.constant 1 : index
+      %y = arith.constant 1 : index
+      %temp = arith.constant 262400 : i32
+      %mcast_addr = "ttkernel.get_noc_addr"(%x, %y, %temp) : (index, index, i32) -> (!ttkernel.noc_addr)
+      // CHECK: %[[INCR:.*]] = "emitc.constant"
+      %incr = arith.constant 1 : i32
+      // CHECK: %[[NUM_DSTS:.*]] = "emitc.constant"
+      %num_dsts = arith.constant 8 : i32
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 3 : i8
+      // CHECK: emitc.call_opaque "noc_semaphore_inc_multicast"(%[[ADDR]], %[[INCR]], %[[NUM_DSTS]], %[[NOC_ID]]) {template_args = [#emitc.opaque<"true">]}
+      "ttkernel.noc_semaphore_inc_multicast"(%mcast_addr, %incr, %num_dsts, %noc_id) <{posted = true}> : (!ttkernel.noc_addr, i32, i32, i8) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @noc_semaphore_set
     func.func @noc_semaphore_set() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1886,6 +1886,22 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @noc_async_atomic_barrier
+    func.func @noc_async_atomic_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: emitc.call_opaque "noc_async_atomic_barrier"() :
+      ttkernel.noc_async_atomic_barrier() : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @noc_async_atomic_barrier_with_noc_id
+    func.func @noc_async_atomic_barrier_with_noc_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[NOC_ID:.*]] = "emitc.constant"
+      %noc_id = arith.constant 1 : i8
+      // CHECK: emitc.call_opaque "noc_async_atomic_barrier"(%[[NOC_ID]]) :
+      ttkernel.noc_async_atomic_barrier(%noc_id) : (i8) -> ()
+      return
+    }
+
     // CHECK-LABEL: func @noc_semaphore_set
     func.func @noc_semaphore_set() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast

--- a/test/ttmlir/Dialect/TTKernel/invalid.mlir
+++ b/test/ttmlir/Dialect/TTKernel/invalid.mlir
@@ -137,3 +137,66 @@ func.func @test_tensor_accessor_args_malformed_attr_dict() {
   %args = ttkernel.TensorAccessorArgs(%c0, %c0) {foo =
   return
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// NocSemaphoreIncMulticastOp type-constraint tests.
+//===----------------------------------------------------------------------===//
+
+// Test: $addr must be !ttkernel.noc_addr.
+func.func @test_noc_semaphore_inc_multicast_wrong_addr_type() {
+  // expected-note @+1 {{prior use here}}
+  %bad_addr = arith.constant 0 : i32
+  %incr = arith.constant 1 : i32
+  %num_dests = arith.constant 8 : i32
+  // expected-error @+1 {{use of value '%bad_addr' expects different type than prior uses: '!ttkernel.noc_addr' vs 'i32'}}
+  "ttkernel.noc_semaphore_inc_multicast"(%bad_addr, %incr, %num_dests) : (!ttkernel.noc_addr, i32, i32) -> ()
+  return
+}
+
+// -----
+
+// Test: $num_dests must be i32.
+func.func @test_noc_semaphore_inc_multicast_wrong_num_dests_type() {
+  %x = arith.constant 1 : index
+  %y = arith.constant 1 : index
+  %off = arith.constant 0 : i32
+  %addr = "ttkernel.get_noc_addr"(%x, %y, %off) : (index, index, i32) -> (!ttkernel.noc_addr)
+  %incr = arith.constant 1 : i32
+  // expected-note @+1 {{prior use here}}
+  %bad_num_dests = arith.constant 8 : i64
+  // expected-error @+1 {{use of value '%bad_num_dests' expects different type than prior uses: 'i32' vs 'i64'}}
+  "ttkernel.noc_semaphore_inc_multicast"(%addr, %incr, %bad_num_dests) : (!ttkernel.noc_addr, i32, i32) -> ()
+  return
+}
+
+// -----
+
+// Test: optional $noc_id must be i8.
+func.func @test_noc_semaphore_inc_multicast_wrong_noc_id_type() {
+  %x = arith.constant 1 : index
+  %y = arith.constant 1 : index
+  %off = arith.constant 0 : i32
+  %addr = "ttkernel.get_noc_addr"(%x, %y, %off) : (index, index, i32) -> (!ttkernel.noc_addr)
+  %incr = arith.constant 1 : i32
+  %num_dests = arith.constant 8 : i32
+  // expected-note @+1 {{prior use here}}
+  %bad_noc_id = arith.constant 0 : i32
+  // expected-error @+1 {{use of value '%bad_noc_id' expects different type than prior uses: 'i8' vs 'i32'}}
+  "ttkernel.noc_semaphore_inc_multicast"(%addr, %incr, %num_dests, %bad_noc_id) : (!ttkernel.noc_addr, i32, i32, i8) -> ()
+  return
+}
+
+// -----
+
+// Test: NocSemaphoreIncOp $addr must be !ttkernel.noc_addr (regression cover for
+// the same constraint after adding the optional `posted` attribute).
+func.func @test_noc_semaphore_inc_wrong_addr_type() {
+  // expected-note @+1 {{prior use here}}
+  %bad_addr = arith.constant 0 : i32
+  %incr = arith.constant 1 : i32
+  // expected-error @+1 {{use of value '%bad_addr' expects different type than prior uses: '!ttkernel.noc_addr' vs 'i32'}}
+  "ttkernel.noc_semaphore_inc"(%bad_addr, %incr) <{posted = true}> : (!ttkernel.noc_addr, i32) -> ()
+  return
+}

--- a/test/ttmlir/Dialect/TTKernel/invalid.mlir
+++ b/test/ttmlir/Dialect/TTKernel/invalid.mlir
@@ -200,3 +200,18 @@ func.func @test_noc_semaphore_inc_wrong_addr_type() {
   "ttkernel.noc_semaphore_inc"(%bad_addr, %incr) <{posted = true}> : (!ttkernel.noc_addr, i32) -> ()
   return
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// NocAsyncAtomicBarrierOp type-constraint test.
+//===----------------------------------------------------------------------===//
+
+// Test: optional $noc_id must be i8.
+func.func @test_noc_async_atomic_barrier_wrong_noc_id_type() {
+  // expected-note @+1 {{prior use here}}
+  %bad_noc_id = arith.constant 0 : i32
+  // expected-error @+1 {{use of value '%bad_noc_id' expects different type than prior uses: 'i8' vs 'i32'}}
+  "ttkernel.noc_async_atomic_barrier"(%bad_noc_id) : (i8) -> ()
+  return
+}


### PR DESCRIPTION
### Ticket
Supports tenstorrent/tt-lang#505
    
### Problem description
tt-lang's PipeNet pattern (scatter-gather / all-to-all) requires multiple senders to cumulatively signal a shared receiver semaphore.  The existing `ttkernel.noc_semaphore_set_multicast` op overwrites the destination value, so two senders sharing a destination clobber each other; the receiver-side `experimental::semaphore_wait_min` cannot observe the cumulative count. The TTKernel dialect needs an atomic multicast increment that maps to tt-metal's `noc_semaphore_inc_multicast`.
    
The unicast `ttkernel.noc_semaphore_inc` op also did not expose the `posted` template parameter of its tt-metal counterpart, restricting producers to non-posted semantics regardless of the surrounding communication pattern.
    
### What's changed
  - Added `ttkernel.noc_semaphore_inc_multicast` mirroring the metal signature `(addr, incr, num_dests, [noc_id])`. No loopback variant exists in tt-metal; the sender must be excluded from the destination set.
  - Added optional `posted` BoolAttr to both `ttkernel.noc_semaphore_inc` and `ttkernel.noc_semaphore_inc_multicast`. Default (unset/false) preserves the prior emission verbatim; when true, the EmitC lowering emits `template_args = [#emitc.opaque<"true">]` so the metal call resolves to `<true>`.
  - Registered the new op in `TTKernelToEmitC` and extended `getTemplateArgs` with a shared arm covering both posted ops.  - Updated the two `NocSemaphoreIncOp` builder call sites in `D2MToTTKernel.cpp` to pass `/*posted=*/nullptr`; emission unchanged.
  - Lit coverage: new cases for `noc_semaphore_inc_posted`, `noc_semaphore_inc_multicast` (default, with `noc_id`, posted).
    
### Checklist
  - [x] New tests provide coverage for changes