### PR TITLE
[runtime] Add scalar tensor support for TTMetal kernel args

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
@@ -218,6 +218,10 @@ inline std::optional<DataType> elementTypeToDataTypeImpl(Type elementType) {
     }
   }
 
+  if (mlir::isa<mlir::IndexType>(elementType)) {
+    return DataType::UInt32;
+  }
+
   return {};
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -3621,7 +3621,7 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
 // TTKernel Compile and runtime arguments operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_ArgResultType : AnyTypeOf<[I32, UI32, TTKernel_CB, TTKernel_L1Addr]>;
+def TTKernel_ArgResultType : AnyTypeOf<[Index, I32, UI32, TTKernel_CB, TTKernel_L1Addr]>;
 
 def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val", [Pure]> {
     let summary = "Get runtime arg value.";

--- a/runtime/include/tt/runtime/detail/python/nanobind_headers.h
+++ b/runtime/include/tt/runtime/detail/python/nanobind_headers.h
@@ -20,6 +20,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
 #pragma clang diagnostic pop

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -28,8 +28,8 @@ using HostBuffer = std::shared_ptr<::tt::tt_metal::HostBuffer>;
 using DistributedHostBuffer =
     std::shared_ptr<::tt::tt_metal::DistributedHostBuffer>;
 using MeshBuffer = std::shared_ptr<::tt::tt_metal::distributed::MeshBuffer>;
-using MetalTensor =
-    std::variant<TensorDesc, HostBuffer, DistributedHostBuffer, MeshBuffer>;
+using MetalTensor = std::variant<TensorDesc, HostBuffer, DistributedHostBuffer,
+                                 MeshBuffer, std::uint32_t>;
 
 Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);
@@ -69,6 +69,8 @@ Tensor createMultiDeviceBorrowedHostTensor(
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
+
+Tensor createScalarTensor(Scalar scalar);
 
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -101,6 +101,8 @@ Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &stride,
                          std::uint32_t itemsize);
 
+Tensor createScalarTensor(Scalar scalar);
+
 inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensor(
       data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <variant>
 #include <vector>
 
 #pragma clang diagnostic push
@@ -53,6 +54,9 @@ enum class DistributedMode {
   // across multiple hosts
   MultiProcess,
 };
+
+using Scalar = std::variant<uint32_t, int32_t, uint16_t, int16_t, uint8_t,
+                            int8_t, bool, float>;
 
 inline std::string toString(DeviceRuntime runtime) {
   return ::tt::runtime::flatbuffer::EnumNameDeviceRuntime(runtime);

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -424,6 +424,22 @@ Tensor createEmptyTensor(Device device, Layout layout,
       });
 }
 
+Tensor createScalarTensor(Scalar scalar) {
+  using RetType = Tensor;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createEmptyTensor", DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createScalarTensor(scalar);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createEmptyTensor",
+                                    HostRuntime::Distributed);
+      });
+}
+
 bool isTensorAllocated(Tensor tensor) {
   using RetType = bool;
   return DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -131,21 +131,10 @@ std::vector<std::uint32_t> processKernelArgs(
       LOG_ASSERT(hostBuffers.find(buffer->global_id()) != hostBuffers.end(),
                  "Scalar id is no longer alive or was never created ",
                  logger::Buffer(buffer->global_id()));
-      const Tensor &scalarTensor = hostBuffers.at(buffer->global_id());
-      LOG_ASSERT(scalarTensor.data != nullptr,
-                 "Scalar tensor data is null for global id ",
-                 buffer->global_id());
-
-      const target::metal::BufferDesc *bufferDesc = buffer->desc();
-      const uint32_t sizeBytes =
-          utils::dataTypeElementSize(bufferDesc->data_type());
-      LOG_ASSERT(sizeBytes <= sizeof(uint32_t),
-                 "Scalar data type is too wide (", sizeBytes,
-                 " bytes) to pack into a uint32_t kernel arg for global id ",
-                 buffer->global_id());
-
-      uint32_t scalarValue = 0;
-      std::memcpy(&scalarValue, scalarTensor.data.get(), sizeBytes);
+      const MetalTensor &metalTensor =
+          hostBuffers.at(buffer->global_id())
+              .as<MetalTensor>(DeviceRuntime::TTMetal);
+      std::uint32_t scalarValue = std::get<std::uint32_t>(metalTensor);
       argsVec.push_back(scalarValue);
       break;
     }

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -117,6 +117,11 @@ MCQExecutor::MCQExecutor(
   for (const Tensor &input : inputs) {
     const target::metal::BufferRef *ref = programInputs->Get(inputIndex++);
     std::visit(utils::overloaded{
+                   [&](const std::uint32_t &) {
+                     auto [_, inserted] =
+                         this->hostBuffers.try_emplace(ref->global_id(), input);
+                     LOG_ASSERT(inserted);
+                   },
                    [&](const TensorDesc &) {
                      auto [_, inserted] =
                          hostBuffers.try_emplace(ref->global_id(), input);

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -297,6 +297,7 @@ inline void writeHostTensorToMeshBuffer(
     std::shared_ptr<distributed::MeshBuffer> meshBuffer, bool blockingCQ) {
   std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
           [&](const TensorDesc &) {
             void *src = input.data.get();
             LOG_ASSERT(src);
@@ -322,6 +323,7 @@ inline void readHostTensorFromMeshBuffer(
     bool blockingCQ) {
   std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
           [&](const TensorDesc &) {
             void *dst = output.data.get();
             LOG_ASSERT(dst);
@@ -345,6 +347,7 @@ inline void checkHostTensorSizeMatchWithMeshBufferSize(
     const Tensor &tensor, std::shared_ptr<distributed::MeshBuffer> meshBuffer) {
   std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
           [&](const TensorDesc &tensorDesc) {
             LOG_ASSERT(meshBuffer.get()->size() == tensorDesc.sizeBytes());
           },

--- a/runtime/lib/ttmetal/meshshard_utils.cpp
+++ b/runtime/lib/ttmetal/meshshard_utils.cpp
@@ -291,6 +291,11 @@ std::shared_ptr<tt_metal::DistributedHostBuffer> tensorFullToShard(
 
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return std::make_shared<tt_metal::DistributedHostBuffer>(
+                tt_metal::DistributedHostBuffer::create(meshShape));
+          },
           [&](const TensorDesc &tensorDesc)
               -> std::shared_ptr<tt_metal::DistributedHostBuffer> {
             void *dst = input.data.get();
@@ -332,6 +337,10 @@ std::shared_ptr<tt_metal::HostBuffer> tensorShardToFull(
 
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return std::make_shared<tt_metal::HostBuffer>();
+          },
           [&](const TensorDesc &tensorDesc)
               -> std::shared_ptr<tt_metal::HostBuffer> {
             LOG_FATAL("tensorShardToFull from TensorDesc not supported.");

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -545,6 +545,9 @@ void wait(const std::vector<Tensor> &tensors, std::optional<uint8_t> cqId) {
 uint32_t getNumShards(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) -> uint32_t {
+            LOG_FATAL("Unsupported variant type");
+          },
           [&](const TensorDesc &) -> uint32_t { return 1; },
           [&](const HostBuffer &) -> uint32_t { return 1; },
           [&](const DistributedHostBuffer &buffer) -> uint32_t {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -44,6 +44,7 @@ Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
 Tensor toLayout(Tensor tensor, Device, Layout layout, std::optional<bool>) {
   std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
           // TODO(#3126): Implement device copy toLayout for metal runtime.
           [&](const TensorDesc &) {},
           [&](const HostBuffer &) {
@@ -205,6 +206,32 @@ Tensor createMultiDeviceBorrowedHostTensor(
       "createMultiDeviceBorrowedHostTensor not implemented for metal runtime");
 }
 
+template <typename T>
+static Tensor createScalarTensorImpl(T scalar) {
+  static_assert(sizeof(T) <= sizeof(std::uint32_t));
+  std::uint32_t scalarPacked = 0;
+  std::memcpy(&scalarPacked, &scalar, sizeof(T));
+  std::shared_ptr<MetalTensor> handle =
+      std::make_shared<MetalTensor>(scalarPacked);
+  return Tensor(static_pointer_cast<void>(handle), nullptr,
+                DeviceRuntime::TTMetal);
+}
+
+Tensor createScalarTensor(Scalar scalar) {
+  return std::visit(
+      utils::overloaded{
+          [&](const uint32_t &s) { return createScalarTensorImpl(s); },
+          [&](const int32_t &s) { return createScalarTensorImpl(s); },
+          [&](const uint16_t &s) { return createScalarTensorImpl(s); },
+          [&](const int16_t &s) { return createScalarTensorImpl(s); },
+          [&](const uint8_t &s) { return createScalarTensorImpl(s); },
+          [&](const int8_t &s) { return createScalarTensorImpl(s); },
+          [&](const bool &s) { return createScalarTensorImpl(s); },
+          [&](const float &s) { return createScalarTensorImpl(s); },
+      },
+      scalar);
+}
+
 bool isTensorAllocated(Tensor tensor) {
   LOG_FATAL("isTensorAllocated not implemented for metal runtime");
 }
@@ -214,6 +241,10 @@ target::DataType getTensorDataType(Tensor tensor) {
       tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return target::DataType::Float32;
+          },
           [&](const TensorDesc &desc) { return desc.dataType; },
           [&](const HostBuffer &buffer) {
             LOG_FATAL("Datatype mapping from HostBuffer not supported yet.");
@@ -530,18 +561,19 @@ uint32_t getNumShards(Tensor tensor) {
 
 std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
   ::tt::runtime::ttmetal::wait(tensor);
-  std::visit(utils::overloaded{
-                 [&](const TensorDesc &) { /* no-op */ },
-                 [&](const HostBuffer &) { /* no-op */ },
-                 [&](const DistributedHostBuffer &) {
-                   LOG_FATAL(
-                       "toHost not yet implemented for DistributedHostBuffer");
-                 },
-                 [&](const MeshBuffer &) {
-                   LOG_FATAL("toHost not yet implemented for MeshBuffer");
-                 },
-             },
-             tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
+  std::visit(
+      utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
+          [&](const TensorDesc &) { /* no-op */ },
+          [&](const HostBuffer &) { /* no-op */ },
+          [&](const DistributedHostBuffer &) {
+            LOG_FATAL("toHost not yet implemented for DistributedHostBuffer");
+          },
+          [&](const MeshBuffer &) {
+            LOG_FATAL("toHost not yet implemented for MeshBuffer");
+          },
+      },
+      tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
   return {tensor};
 }
 
@@ -603,47 +635,49 @@ void memcpy(void *dst, Tensor src,
         ::tt::runtime::utils::isSupportedDataType(dstDataType.value()),
         "dstDataType must be a supported data type if using TTMetal runtime");
   }
-  std::visit(utils::overloaded{
-                 [&](const TensorDesc &tensorDesc) {
-                   std::memcpy(dst, src.data.get(), tensorDesc.sizeBytes());
-                 },
-                 [&](const HostBuffer &hostBuffer) {
-                   auto span = hostBuffer->view_bytes();
-                   std::memcpy(dst, span.data(), span.size_bytes());
-                 },
-                 [&](const DistributedHostBuffer &) {
-                   LOG_FATAL(
-                       "memcpy not yet implemented for DistributedHostBuffer");
-                 },
-                 [&](const MeshBuffer &) {
-                   LOG_FATAL("memcpy not yet implemented for MeshBuffer");
-                 },
-             },
-             src.as<MetalTensor>(DeviceRuntime::TTMetal));
+  std::visit(
+      utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
+          [&](const TensorDesc &tensorDesc) {
+            std::memcpy(dst, src.data.get(), tensorDesc.sizeBytes());
+          },
+          [&](const HostBuffer &hostBuffer) {
+            auto span = hostBuffer->view_bytes();
+            std::memcpy(dst, span.data(), span.size_bytes());
+          },
+          [&](const DistributedHostBuffer &) {
+            LOG_FATAL("memcpy not yet implemented for DistributedHostBuffer");
+          },
+          [&](const MeshBuffer &) {
+            LOG_FATAL("memcpy not yet implemented for MeshBuffer");
+          },
+      },
+      src.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
 void memcpy(Tensor dst, Tensor src) {
   auto &metalDst = dst.as<MetalTensor>(DeviceRuntime::TTMetal);
   auto &dstDesc = std::get<TensorDesc>(metalDst);
-  std::visit(utils::overloaded{
-                 [&](const TensorDesc &srcDesc) {
-                   memcpy(dst, dstDesc, src, srcDesc);
-                 },
-                 [&](const HostBuffer &hostBuffer) {
-                   auto span = hostBuffer->view_bytes();
-                   size_t copyByteSize =
-                       std::min(dstDesc.sizeBytes(), span.size_bytes());
-                   std::memcpy(dst.data.get(), span.data(), copyByteSize);
-                 },
-                 [&](const DistributedHostBuffer &) {
-                   LOG_FATAL(
-                       "memcpy not yet implemented for DistributedHostBuffer");
-                 },
-                 [&](const MeshBuffer &) {
-                   LOG_FATAL("memcpy not yet implemented for MeshBuffer");
-                 },
-             },
-             src.as<MetalTensor>(DeviceRuntime::TTMetal));
+  std::visit(
+      utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
+          [&](const TensorDesc &srcDesc) {
+            memcpy(dst, dstDesc, src, srcDesc);
+          },
+          [&](const HostBuffer &hostBuffer) {
+            auto span = hostBuffer->view_bytes();
+            size_t copyByteSize =
+                std::min(dstDesc.sizeBytes(), span.size_bytes());
+            std::memcpy(dst.data.get(), span.data(), copyByteSize);
+          },
+          [&](const DistributedHostBuffer &) {
+            LOG_FATAL("memcpy not yet implemented for DistributedHostBuffer");
+          },
+          [&](const MeshBuffer &) {
+            LOG_FATAL("memcpy not yet implemented for MeshBuffer");
+          },
+      },
+      src.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
 void memcpy(Tensor dst, TensorDesc dstDesc, Tensor src, TensorDesc srcDesc) {
@@ -658,16 +692,18 @@ void memcpy(Tensor dst, TensorDesc dstDesc, Tensor src, TensorDesc srcDesc) {
                "Padded tensors with different ranks not supported for memcpy");
   }
   void *singleDeviceTensorPtr = nullptr;
-  std::visit(utils::overloaded{
-                 [&](const TensorDesc &srcDesc) {
-                   singleDeviceTensorPtr = src.data.get();
-                 },
-                 [&](const HostBuffer &hostBuffer) {
-                   singleDeviceTensorPtr = hostBuffer->view_bytes().data();
-                 },
-                 [&](const auto &) {},
-             },
-             src.as<MetalTensor>(DeviceRuntime::TTMetal));
+  std::visit(
+      utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
+          [&](const TensorDesc &srcDesc) {
+            singleDeviceTensorPtr = src.data.get();
+          },
+          [&](const HostBuffer &hostBuffer) {
+            singleDeviceTensorPtr = hostBuffer->view_bytes().data();
+          },
+          [&](const auto &) {},
+      },
+      src.as<MetalTensor>(DeviceRuntime::TTMetal));
 
   auto memcpy_fn = [&](void *dst, void *src) {
     if (dstDesc.isPadded() || srcDesc.isPadded()) {
@@ -680,6 +716,7 @@ void memcpy(Tensor dst, TensorDesc dstDesc, Tensor src, TensorDesc srcDesc) {
 
   std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
           [&](const TensorDesc &tensorDesc) {
             memcpy_fn(dst.data.get(), singleDeviceTensorPtr);
           },
@@ -709,16 +746,17 @@ void memcpy(Tensor dst, TensorDesc dstDesc, Tensor src, TensorDesc srcDesc) {
 }
 
 void deallocateTensor(Tensor &tensor, bool) {
-  std::visit(utils::overloaded{
-                 [&](const TensorDesc &) { /* no-op */ },
-                 [&](const HostBuffer &) { /* no-op */ },
-                 [&](const DistributedHostBuffer &) { /* no-op */ },
-                 [&](const MeshBuffer &) {
-                   LOG_FATAL(
-                       "deallocateTensor not yet implemented for MeshBuffer");
-                 },
-             },
-             tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
+  std::visit(
+      utils::overloaded{
+          [&](const std::uint32_t &) { LOG_FATAL("Unsupported variant type"); },
+          [&](const TensorDesc &) { /* no-op */ },
+          [&](const HostBuffer &) { /* no-op */ },
+          [&](const DistributedHostBuffer &) { /* no-op */ },
+          [&](const MeshBuffer &) {
+            LOG_FATAL("deallocateTensor not yet implemented for MeshBuffer");
+          },
+      },
+      tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
 std::string getOpDebugString(OpContext opContextHandle) {
@@ -776,6 +814,10 @@ void updateTensorInPool(CallbackContext programContextHandle,
 std::vector<std::byte> getTensorDataBuffer(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return std::vector<std::byte>{};
+          },
           [&](const TensorDesc &desc) {
             const std::byte *data =
                 static_cast<const std::byte *>(tensor.data.get());
@@ -802,6 +844,10 @@ std::vector<std::byte> getTensorDataBuffer(Tensor tensor) {
 std::vector<std::uint32_t> getTensorShape(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return std::vector<std::uint32_t>{};
+          },
           [&](const TensorDesc &desc) {
             return ttmetal::getTensorDesc(tensor).shape;
           },
@@ -825,6 +871,10 @@ std::vector<std::uint32_t> getTensorShape(Tensor tensor) {
 std::vector<std::uint32_t> getTensorStride(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return std::vector<std::uint32_t>{};
+          },
           [&](const TensorDesc &desc) {
             return ttmetal::getTensorDesc(tensor).stride;
           },
@@ -848,6 +898,10 @@ std::vector<std::uint32_t> getTensorStride(Tensor tensor) {
 std::uint32_t getTensorElementSize(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return static_cast<std::uint32_t>(0);
+          },
           [&](const TensorDesc &desc) {
             return static_cast<std::uint32_t>(
                 ttmetal::getTensorDesc(tensor).elementSize());
@@ -873,6 +927,10 @@ std::uint32_t getTensorElementSize(Tensor tensor) {
 std::uint32_t getTensorVolume(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return static_cast<std::uint32_t>(0);
+          },
           [&](const TensorDesc &desc) {
             return static_cast<std::uint32_t>(
                 ttmetal::getTensorDesc(tensor).volume());
@@ -897,6 +955,10 @@ std::uint32_t getTensorVolume(Tensor tensor) {
 TensorDesc getTensorDesc(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return TensorDesc{};
+          },
           [&](const TensorDesc &desc) { return desc; },
           [&](const HostBuffer &buffer) {
             LOG_FATAL("getTensorDesc from HostBuffer not supported.");
@@ -918,6 +980,10 @@ TensorDesc getTensorDesc(Tensor tensor) {
 HostBuffer getHostBuffer(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return HostBuffer{};
+          },
           [&](const TensorDesc &desc) {
             LOG_FATAL("getHostBuffer from TensorDesc not supported.");
             return HostBuffer{};
@@ -939,6 +1005,10 @@ HostBuffer getHostBuffer(Tensor tensor) {
 DistributedHostBuffer getDistributedHostBuffer(Tensor tensor) {
   return std::visit(
       utils::overloaded{
+          [&](const std::uint32_t &) {
+            LOG_FATAL("Unsupported variant type");
+            return DistributedHostBuffer{};
+          },
           [&](const TensorDesc &desc) {
             LOG_FATAL("getDistributedHostBufferFromMetalTensor from TensorDesc "
                       "not supported.");

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -378,6 +378,8 @@ void registerRuntimeBindings(nb::module_ &m) {
                                               itemsize);
       },
       "Create an empty tensor with the specified layout");
+  m.def("create_scalar_tensor", createScalarTensor,
+        "Create a tensor from single scalar");
   m.def(
       "create_multi_device_host_tensor",
       [](std::vector<std::uintptr_t> &ptrs,

--- a/test/python/golden/d2m/test_scalar_rt_arg.py
+++ b/test/python/golden/d2m/test_scalar_rt_arg.py
@@ -63,9 +63,7 @@ def test_scalar_kernel_arg(target: str, request, device):
     processKernelArgs (arguments.h) and the createScalarTensor runtime API.
     """
     sys_desc = request.config.getoption("--sys-desc")
-    register_device_opts = (
-        f"system-desc-path={sys_desc}" if sys_desc else ""
-    )
+    register_device_opts = f"system-desc-path={sys_desc}" if sys_desc else ""
 
     ctx = Context()
     loc = Location.unknown(ctx)

--- a/test/python/golden/d2m/test_scalar_rt_arg.py
+++ b/test/python/golden/d2m/test_scalar_rt_arg.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Runtime smoke test for the KernelArgScalar flatbuffer path.
+#
+# Standard TTIR→D2M compilation never generates KernelArgScalar; it only
+# arises when a d2m.generic carries scalar additionalArgs that flow through
+# as compile-time arguments.  This test therefore writes a TTMetal-level
+# MLIR module directly (skipping FE/ME) and verifies that:
+#
+#   1. ttmetal_to_flatbuffer_bin produces KernelArgScalar entries, and
+#   2. the runtime KernelArgScalar path in arguments.h does not crash when
+#      submit() is called with scalar tensors.
+
+import pytest
+
+import _ttmlir_runtime as tt_runtime
+from ttmlir.ir import Context, Location, Module
+from ttmlir.passmanager import PassManager
+from ttmlir.passes import ttmetal_to_flatbuffer_bin
+
+pytestmark = pytest.mark.frontend("ttir")
+
+# A minimal TTMetal module whose top-level function takes one i32 scalar.
+# The NOC kernel declares that scalar as compile-time arg 0 (ArgType::Scalar),
+# which causes the flatbuffer generator to emit KernelArgScalar.  The kernel
+# body is empty so no L1 buffers or hardcoded device addresses are needed.
+_SCALAR_MLIR = """\
+module {
+  func.func @test_scalar_kernel_arg(%arg0: i32) {
+    "ttmetal.enqueue_program"(%arg0) <{
+      cb_ports = array<i64>,
+      kernelConfigs = [
+        #ttmetal.noc_config<@scalar_kernel,
+          #ttmetal.core_range<0x0, 1x1>,
+          #ttmetal.kernel_args<ct_args = [<scalar[0]>]>,
+          noc0>
+      ],
+      operandSegmentSizes = array<i32: 1, 0>
+    }> : (i32) -> ()
+    return
+  }
+  func.func private @scalar_kernel() attributes {
+    ttkernel.arg_spec = #ttkernel.arg_spec<
+      ct_args = [<arg_type = scalar, operand_index = 0>]>,
+    ttkernel.thread = #ttkernel.thread<noc>
+  } {
+    return
+  }
+}
+"""
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_scalar_kernel_arg(target: str, request, device):
+    """
+    Smoke-test the KernelArgScalar runtime path.
+
+    Compiles a hand-written TTMetal module that passes an i32 scalar as a
+    kernel compile-time argument, translates it to a flatbuffer, and submits
+    it on device.  This exercises the KernelArgScalar branch in
+    processKernelArgs (arguments.h) and the createScalarTensor runtime API.
+    """
+    sys_desc = request.config.getoption("--sys-desc")
+    register_device_opts = (
+        f"system-desc-path={sys_desc}" if sys_desc else ""
+    )
+
+    ctx = Context()
+    loc = Location.unknown(ctx)
+    with ctx, loc:
+        module = Module.parse(_SCALAR_MLIR)
+
+    pm = PassManager.parse(
+        f"builtin.module("
+        f"ttcore-register-device{{{register_device_opts}}},"
+        f"ttcore-mark-functions-as-forward,"
+        f"ttcore-wrap-device-module"
+        f")",
+        ctx,
+    )
+    pm.run(module.operation)
+
+    capsule = ttmetal_to_flatbuffer_bin(module)
+    fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+
+    scalar = tt_runtime.runtime.create_scalar_tensor(42)
+    outputs = tt_runtime.runtime.submit(device, fbb, 0, [scalar])
+    tt_runtime.runtime.wait(outputs)


### PR DESCRIPTION
Introduce a Scalar variant (uint32/int32/uint16/int16/uint8/int8/bool/float) and a createScalarTensor API that packs a scalar value directly into a MetalTensor handle, instead of going through a host buffer. processKernelArgs now reads the packed uint32_t out of the MetalTensor variant rather than memcpy'ing from a TensorDesc-backed host allocation.

Also:
- Allow IndexType in TTKernel_ArgResultType and map IndexType to DataType::UInt32 so index-typed scalar args can flow through the kernel argument plumbing.
- Add std::uint32_t alternative to the MetalTensor variant and stub out the unsupported callsites (toLayout, toHost, memcpy, mesh shard utils, tensor query helpers, etc.) with LOG_FATAL so the new variant is exhaustively handled.
- Expose create_scalar_tensor through the Python runtime bindings and pull in nanobind/stl/variant.h.