### PR TITLE
[D2M] Add TensorAccessor-based DMA lowering path

### DIFF
--- a/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
+++ b/include/ttmlir/Conversion/D2MToTTKernel/D2MToTTKernel.h
@@ -20,7 +20,8 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode);
+    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode,
+    bool useTensorAccessorDMA = false);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertD2MToTTKernelPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -183,7 +183,9 @@ def ConvertD2MToTTKernel: Pass<"convert-d2m-to-ttkernel", "::mlir::ModuleOp"> {
   let constructor = "createConvertD2MToTTKernelPass()";
   let dependentDialects = ["mlir::tt::d2m::D2MDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect", "mlir::arith::ArithDialect"];
   let options = [
-    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">
+    Option<"ttnnMode", "ttnn-mode", "bool", /*default=*/"false", "Enable TTNN mode">,
+    Option<"useTensorAccessorDMA", "use-tensor-accessor-dma", "bool", /*default=*/"false",
+           "Use TensorAccessor-based DMA lowering for shard-level ops">
   ];
 }
 

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -213,6 +213,16 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
       llvm::cl::desc("Disable L1 accumulation (force reloading from L1 to DST "
                      "instead of accumulating partials in L1)."),
       llvm::cl::init(false)};
+
+  // Option to use TensorAccessor-based DMA lowering instead of the
+  // fully-indexed form. When enabled, D2MLowerDMAToFullyIndexedForm is skipped
+  // and shard-level DMA ops are lowered to TTKernel TensorAccessor ops in
+  // ConvertD2MToTTKernel.
+  Option<bool> useTensorAccessorDMA{
+      *this, "use-tensor-accessor-dma",
+      llvm::cl::desc("Use TensorAccessor-based DMA lowering instead of "
+                     "fully-indexed form."),
+      llvm::cl::init(false)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm,

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4337,6 +4337,58 @@ def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"tensor_accessor.is_loca
   }];
 }
 
+def TTKernel_TensorAccessorDSpecOp : TTKernel_Op<"tensor_accessor.dspec"> {
+  let summary = "Get DSpec from TensorAccessor";
+  let description = [{
+    Returns the DistributionSpec from a TensorAccessor.
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor);
+  let results = (outs TTKernel_DSpec:$result);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def TTKernel_DSpecShardShapeOp : TTKernel_Op<"dspec.shard_shape"> {
+  let summary = "DSpec shard_shape indexed access";
+  let description = [{
+    Returns dspec.shard_shape()[dim] as a uint32_t.
+  }];
+  let arguments = (ins TTKernel_DSpec:$dspec, I32:$dim);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    `(` $dspec `,` $dim `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def TTKernel_DSpecTensorStridesOp : TTKernel_Op<"dspec.tensor_strides"> {
+  let summary = "DSpec tensor_strides indexed access";
+  let description = [{
+    Returns dspec.tensor_strides()[dim] as a uint32_t.
+  }];
+  let arguments = (ins TTKernel_DSpec:$dspec, I32:$dim);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    `(` $dspec `,` $dim `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def TTKernel_DSpecShardStridesOp : TTKernel_Op<"dspec.shard_strides"> {
+  let summary = "DSpec shard_strides indexed access";
+  let description = [{
+    Returns dspec.shard_strides()[dim] as a uint32_t.
+  }];
+  let arguments = (ins TTKernel_DSpec:$dspec, I32:$dim);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    `(` $dspec `,` $dim `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Misc operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -70,6 +70,9 @@ def TTKernel_ArgTypeLocalSemaphore : I32EnumAttrCase<"LocalSemaphore", 2, "local
 def TTKernel_ArgTypeNamedArgument : I32EnumAttrCase<"NamedArgument", 3, "named_argument">;
 def TTKernel_ArgTypeGlobalSemaphore : I32EnumAttrCase<"GlobalSemaphore", 4, "global_semaphore">;
 def TTKernel_ArgTypeScalar : I32EnumAttrCase<"Scalar", 5, "scalar">;
+def TTKernel_ArgTypeTensorAccessor : I32EnumAttrCase<"TensorAccessor", 6, "tensor_accessor">;
+def TTKernel_ArgTypeTensorStride : I32EnumAttrCase<"TensorStride", 7, "tensor_stride">;
+def TTKernel_ArgTypeReserved : I32EnumAttrCase<"Reserved", 8, "reserved">;
 
 def TTKernel_ArgType : I32EnumAttr<"ArgType", "TTKernel Argument Types",
                          [
@@ -78,7 +81,10 @@ def TTKernel_ArgType : I32EnumAttr<"ArgType", "TTKernel Argument Types",
                            TTKernel_ArgTypeLocalSemaphore,
                            TTKernel_ArgTypeNamedArgument,
                            TTKernel_ArgTypeGlobalSemaphore,
-                           TTKernel_ArgTypeScalar
+                           TTKernel_ArgTypeScalar,
+                           TTKernel_ArgTypeTensorAccessor,
+                           TTKernel_ArgTypeTensorStride,
+                           TTKernel_ArgTypeReserved
                          ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -104,6 +104,11 @@ def TTKernel_TensorAccessorPageMapping : TTKernel_Type<"TensorAccessorPageMappin
   let description = "TensorAccessor struct that holds bank_id and bank_page_offset";
 }
 
+def TTKernel_DSpec : TTKernel_Type<"DSpec", "DSpec"> {
+  let summary = "DSpec type";
+  let description = "DistributionSpec that holds tensor distribution metadata";
+}
+
 def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {
     let summary = "TTKernel compute data format type";
     let description = "Data format type in TTKernel dialect";
@@ -164,9 +169,14 @@ def TTKernel_ArgSpecAttr : TTKernel_Attr<"ArgSpec", "arg_spec"> {
   let extraClassDeclaration = [{
     static ArgSpecAttr setArgSpec(func::FuncOp func, ArgSpecAttr argSpec);
     // Returns the appended argument index.
-    static size_t appendCompileTimeArg(func::FuncOp func, ArgAttr arg);
+    // numSlots: number of CTA/CRTA uint32_t slots this arg occupies at
+    // runtime.  Defaults to 1.  When > 1 the implementation reserves
+    // additional placeholder entries so that subsequent indices are correct.
+    static size_t appendCompileTimeArg(func::FuncOp func, ArgAttr arg,
+                                       size_t numSlots = 1);
     // Returns the appended argument index.
-    static size_t appendRuntimeArg(func::FuncOp func, ArgAttr arg);
+    static size_t appendRuntimeArg(func::FuncOp func, ArgAttr arg,
+                                   size_t numSlots = 1);
   }];
 }
 

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -85,6 +85,18 @@ table KernelArgScalar {
   operand_idx: uint32;
 }
 
+table KernelArgTensorAccessor {
+  operand_idx: int32;
+}
+
+table KernelArgTensorStride {
+  operand_idx: int32;
+}
+
+table KernelArgReserved {
+  operand_idx: int32;
+}
+
 union KernelArgType {
   KernelArgCBPort,
   KernelArgBufferAddress,
@@ -92,6 +104,9 @@ union KernelArgType {
   KernelArgNamedArgument,
   KernelArgGlobalSemaphore,
   KernelArgScalar,
+  KernelArgTensorAccessor,
+  KernelArgTensorStride,
+  KernelArgReserved,
 }
 
 table KernelArg {

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2570,7 +2570,8 @@ static size_t getTensorAccessorCTASlots(Value remoteMemref) {
   }
 
   auto shapedType = mlir::cast<ShapedType>(remoteMemref.getType());
-  // Further investigation for sizing numBanks: https://github.com/tenstorrent/tt-mlir/issues/7943
+  // Further investigation for sizing numBanks:
+  // https://github.com/tenstorrent/tt-mlir/issues/7943
   auto chipDesc = ttcore::getOpChipDescAttr(remoteMemref.getDefiningOp());
   ArrayRef<int64_t> gridShape = chipDesc.getGrid();
   ArrayRef<int64_t> shardShape = layout.getShardShape(shapedType);
@@ -2579,7 +2580,8 @@ static size_t getTensorAccessorCTASlots(Value remoteMemref) {
   for (int64_t g : gridShape) {
     numBanks *= static_cast<size_t>(g);
   }
-  numBanks = std::max(numBanks, static_cast<size_t>(chipDesc.getNumDramChannels()));
+  numBanks =
+      std::max(numBanks, static_cast<size_t>(chipDesc.getNumDramChannels()));
 
   // rank + num_banks + tensor_shape[rank] + shard_shape[rank] + packed
   // bank_coords.
@@ -2591,11 +2593,10 @@ static size_t getTensorAccessorCTASlots(Value remoteMemref) {
 /// and return the CT arg index.  Reserves the correct number of CTA slots
 /// so that subsequent arg indices are not shifted.
 static size_t appendTensorAccessorArg(ConversionPatternRewriter &rewriter,
-                                      func::FuncOp entry,
-                                      int64_t operandIndex,
+                                      func::FuncOp entry, int64_t operandIndex,
                                       Value remoteMemref) {
-  ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::TensorAccessor,
-                                          operandIndex);
+  ArgAttr arg =
+      rewriter.getAttr<ArgAttr>(ArgType::TensorAccessor, operandIndex);
   size_t numSlots = getTensorAccessorCTASlots(remoteMemref);
   size_t argIndex;
   rewriter.modifyOpInPlace(entry, [&]() {
@@ -2609,17 +2610,17 @@ static size_t getTensorStrideSlots(Value remoteMemref) {
   assert(layout);
   auto shapedType = mlir::cast<ShapedType>(remoteMemref.getType());
   size_t rank = layout.getShardShape(shapedType).size();
-  assert(rank == 2 && "TensorStride kernel argument only supports rank 2 tensors");
+  assert(rank == 2 &&
+         "TensorStride kernel argument only supports rank 2 tensors");
   return rank;
 }
 
-/// Helper: append the tensor stride to be used at runtime for TensorAccessor indexing calculations.
+/// Helper: append the tensor stride to be used at runtime for TensorAccessor
+/// indexing calculations.
 static size_t appendTensorStrideArg(ConversionPatternRewriter &rewriter,
-                                      func::FuncOp entry,
-                                      int64_t operandIndex,
-                                      Value remoteMemref) {
-  ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::TensorStride,
-                                          operandIndex);
+                                    func::FuncOp entry, int64_t operandIndex,
+                                    Value remoteMemref) {
+  ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::TensorStride, operandIndex);
   size_t numSlots = getTensorStrideSlots(remoteMemref);
   size_t argIndex;
   rewriter.modifyOpInPlace(entry, [&]() {
@@ -2685,18 +2686,18 @@ public:
                         "d2m.get_arg, failing.");
     int64_t operandIndex = getArgOp.getOperandIndex();
 
-    func::FuncOp entry =
-        op->template getParentOfType<func::FuncOp>();
+    func::FuncOp entry = op->template getParentOfType<func::FuncOp>();
 
     // Append a TensorAccessor arg to the ArgSpec, reserving the correct
     // number of CTA slots so subsequent arg indices are not shifted.
     size_t ctaTensorAccessorArgIndex =
         appendTensorAccessorArg(rewriter, entry, operandIndex, remoteMemRef);
-    size_t ctaTensorStrideArgIndex  =
+    size_t ctaTensorStrideArgIndex =
         appendTensorStrideArg(rewriter, entry, operandIndex, remoteMemRef);
 
     // Create TensorAccessorArgs with CTA base offset.
-    Value ctaBase = i32(rewriter, loc, static_cast<int32_t>(ctaTensorAccessorArgIndex));
+    Value ctaBase =
+        i32(rewriter, loc, static_cast<int32_t>(ctaTensorAccessorArgIndex));
     Value crtaBase = i32(rewriter, loc, 0);
     auto argsOp = rewriter.create<ttkernel::TensorAccessorArgsOp>(
         loc, ctaBase, crtaBase, /*prev=*/Value(), /*ctaExpr=*/StringAttr(),
@@ -2704,8 +2705,7 @@ public:
 
     // Get the bank base address from the adapted remote operand.
     Value adaptedRemote = IsRead ? adaptor.getSrc() : adaptor.getDst();
-    Value bankBaseAddress =
-        castCBTypeAsAddress(rewriter, loc, adaptedRemote);
+    Value bankBaseAddress = castCBTypeAsAddress(rewriter, loc, adaptedRemote);
 
     // Create the TensorAccessor.
     Value pageSize = i32(rewriter, loc, static_cast<int32_t>(pageSizeBytes));
@@ -2740,7 +2740,7 @@ public:
     SmallVector<Value> tensorStrideVals(rank);
     SmallVector<Value> shardStrideVals(rank);
     int32_t stride = 1;
-    for (int64_t d = rank-1; d >= 0; --d) {
+    for (int64_t d = rank - 1; d >= 0; --d) {
       shardDimVals[d] = index(rewriter, loc, shardShape[d]);
       shardStrideVals[d] = index(rewriter, loc, stride);
 
@@ -2761,7 +2761,7 @@ public:
     OpBuilder::InsertionGuard guard(rewriter);
     for (int64_t d = 0; d < rank; ++d) {
       auto forOp = rewriter.create<scf::ForOp>(loc, lb, shardDimVals[d], step,
-                                                ValueRange{});
+                                               ValueRange{});
       loops[d] = forOp;
       rewriter.setInsertionPointToStart(forOp.getBody());
     }
@@ -2782,17 +2782,16 @@ public:
         // Absolute coordinate: gridIndices[d] * shardShape[d] + iv.
         Value gridOffset = rewriter.create<arith::MulIOp>(
             innerLoc, gridIndices[d], shardDimVals[d]);
-        Value absDim =
-            rewriter.create<arith::AddIOp>(innerLoc, gridOffset, iv);
+        Value absDim = rewriter.create<arith::AddIOp>(innerLoc, gridOffset, iv);
 
         // Accumulate into pageId with the tensor stride.
-        Value absContrib = rewriter.create<arith::MulIOp>(
-            innerLoc, absDim, tensorStrideVals[d]);
+        Value absContrib = rewriter.create<arith::MulIOp>(innerLoc, absDim,
+                                                          tensorStrideVals[d]);
         pageId = rewriter.create<arith::AddIOp>(innerLoc, pageId, absContrib);
 
         // Accumulate into localIdx with the shard stride.
-        Value localContrib = rewriter.create<arith::MulIOp>(
-            innerLoc, iv, shardStrideVals[d]);
+        Value localContrib =
+            rewriter.create<arith::MulIOp>(innerLoc, iv, shardStrideVals[d]);
         localIdx =
             rewriter.create<arith::AddIOp>(innerLoc, localIdx, localContrib);
       }

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2538,6 +2538,298 @@ public:
     return success();
   }
 };
+
+// ---------------------------------------------------------------------------
+// TensorAccessor-based DMA rewriters for shard-level DMA ops.
+// These patterns match shard-level DMA ops (numElems == 0) and lower them
+// using TTKernel TensorAccessor ops.  They coexist with the existing
+// fully-indexed rewriters above which only match numElems > 0.
+// ---------------------------------------------------------------------------
+
+/// Helper: compute the page size in bytes for a memref element type.
+static int64_t getPageSizeBytes(MemRefType memrefType) {
+  return static_cast<int64_t>(
+      ttcore::getElementSizeBytes(memrefType.getElementType()));
+}
+
+/// Compute the number of CTA uint32_t slots a TensorAccessor occupies for
+/// the given remote memref.  This must match the number of values produced
+/// by tt_metal::TensorAccessorArgs::get_compile_time_args() at runtime.
+///
+/// Interleaved: 2 (args_config + aligned_page_size)
+/// Sharded:     2 + 1 (rank) + 1 (num_banks) + rank (tensor_shape)
+///                + rank (shard_shape) + ceil(num_banks / 2) (bank_coords)
+static size_t getTensorAccessorCTASlots(Value remoteMemref) {
+  // Base: args_config + aligned_page_size.
+  size_t slots = 2;
+
+  auto layout = ttcore::getDeviceLayout(remoteMemref);
+  if (!layout) {
+    // No device layout → interleaved, just the 2-slot base.
+    return slots;
+  }
+
+  auto shapedType = mlir::cast<ShapedType>(remoteMemref.getType());
+  // Further investigation for sizing numBanks: https://github.com/tenstorrent/tt-mlir/issues/7943
+  auto chipDesc = ttcore::getOpChipDescAttr(remoteMemref.getDefiningOp());
+  ArrayRef<int64_t> gridShape = chipDesc.getGrid();
+  ArrayRef<int64_t> shardShape = layout.getShardShape(shapedType);
+  size_t rank = shardShape.size();
+  size_t numBanks = 1;
+  for (int64_t g : gridShape) {
+    numBanks *= static_cast<size_t>(g);
+  }
+  numBanks = std::max(numBanks, static_cast<size_t>(chipDesc.getNumDramChannels()));
+
+  // rank + num_banks + tensor_shape[rank] + shard_shape[rank] + packed
+  // bank_coords.
+  slots += 1 + 1 + rank + rank + numBanks;
+  return slots;
+}
+
+/// Helper: append a TensorAccessor ArgAttr to the parent function's ArgSpec
+/// and return the CT arg index.  Reserves the correct number of CTA slots
+/// so that subsequent arg indices are not shifted.
+static size_t appendTensorAccessorArg(ConversionPatternRewriter &rewriter,
+                                      func::FuncOp entry,
+                                      int64_t operandIndex,
+                                      Value remoteMemref) {
+  ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::TensorAccessor,
+                                          operandIndex);
+  size_t numSlots = getTensorAccessorCTASlots(remoteMemref);
+  size_t argIndex;
+  rewriter.modifyOpInPlace(entry, [&]() {
+    argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg, numSlots);
+  });
+  return argIndex;
+}
+
+static size_t getTensorStrideSlots(Value remoteMemref) {
+  auto layout = ttcore::getDeviceLayout(remoteMemref);
+  assert(layout);
+  auto shapedType = mlir::cast<ShapedType>(remoteMemref.getType());
+  size_t rank = layout.getShardShape(shapedType).size();
+  assert(rank == 2 && "TensorStride kernel argument only supports rank 2 tensors");
+  return rank;
+}
+
+/// Helper: append the tensor stride to be used at runtime for TensorAccessor indexing calculations.
+static size_t appendTensorStrideArg(ConversionPatternRewriter &rewriter,
+                                      func::FuncOp entry,
+                                      int64_t operandIndex,
+                                      Value remoteMemref) {
+  ArgAttr arg = rewriter.getAttr<ArgAttr>(ArgType::TensorStride,
+                                          operandIndex);
+  size_t numSlots = getTensorStrideSlots(remoteMemref);
+  size_t argIndex;
+  rewriter.modifyOpInPlace(entry, [&]() {
+    argIndex = ArgSpecAttr::appendCompileTimeArg(entry, arg, numSlots);
+  });
+  return argIndex;
+}
+
+// Template rewriter for shard-level DMA read/write via TensorAccessor.
+// DMAOpT is either d2m::DMAReadOp or d2m::DMAWriteOp.
+template <typename DMAOpT>
+class D2MDMAViaTensorAccessorRewriter : public OpConversionPattern<DMAOpT> {
+public:
+  static_assert(std::is_same_v<DMAOpT, d2m::DMAReadOp> ||
+                std::is_same_v<DMAOpT, d2m::DMAWriteOp>);
+  static constexpr bool IsRead = std::is_same_v<DMAOpT, d2m::DMAReadOp>;
+
+  D2MDMAViaTensorAccessorRewriter(
+      TypeConverter &typeConverter, MLIRContext *context,
+      const d2m::CBProducerConsumer *cbProducerConsumer)
+      : OpConversionPattern<DMAOpT>(typeConverter, context),
+        cbProducerConsumer(cbProducerConsumer) {}
+
+  LogicalResult
+  matchAndRewrite(DMAOpT op, typename DMAOpT::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Only handle shard-level DMA ops.
+    if (!op.isShardLevel()) {
+      return failure();
+    }
+
+    // Write-only: skip local-to-local transfers (handled by the existing
+    // mcast lowering that uses raw NOC addresses).
+    if constexpr (!IsRead) {
+      if (op.isDstLocal()) {
+        return failure();
+      }
+    }
+
+    Location loc = op.getLoc();
+
+    // Get the remote memref and its properties.  For reads the remote
+    // side is the src; for writes it is the dst.
+    Value remoteMemRef;
+    MemRefType remoteMemRefType;
+    if constexpr (IsRead) {
+      remoteMemRef = op.getSrc();
+      remoteMemRefType = op.getSrcMemRefType();
+    } else {
+      remoteMemRef = op.getDst();
+      remoteMemRefType = op.getDstMemRefType();
+    }
+
+    ArrayRef<int64_t> shardShape = ttcore::getShardShape(remoteMemRef);
+    int64_t pageSizeBytes = getPageSizeBytes(remoteMemRefType);
+
+    // Get the operand index for the remote memref (to set up ArgSpec).
+    auto getArgOp = remoteMemRef.template getDefiningOp<d2m::GetArgOp>();
+    TT_assertv(getArgOp,
+               IsRead ? "Expected shard-level DMA read src to come from "
+                        "d2m.get_arg, failing."
+                      : "Expected shard-level DMA write dst to come from "
+                        "d2m.get_arg, failing.");
+    int64_t operandIndex = getArgOp.getOperandIndex();
+
+    func::FuncOp entry =
+        op->template getParentOfType<func::FuncOp>();
+
+    // Append a TensorAccessor arg to the ArgSpec, reserving the correct
+    // number of CTA slots so subsequent arg indices are not shifted.
+    size_t ctaTensorAccessorArgIndex =
+        appendTensorAccessorArg(rewriter, entry, operandIndex, remoteMemRef);
+    size_t ctaTensorStrideArgIndex  =
+        appendTensorStrideArg(rewriter, entry, operandIndex, remoteMemRef);
+
+    // Create TensorAccessorArgs with CTA base offset.
+    Value ctaBase = i32(rewriter, loc, static_cast<int32_t>(ctaTensorAccessorArgIndex));
+    Value crtaBase = i32(rewriter, loc, 0);
+    auto argsOp = rewriter.create<ttkernel::TensorAccessorArgsOp>(
+        loc, ctaBase, crtaBase, /*prev=*/Value(), /*ctaExpr=*/StringAttr(),
+        /*crtaExpr=*/StringAttr());
+
+    // Get the bank base address from the adapted remote operand.
+    Value adaptedRemote = IsRead ? adaptor.getSrc() : adaptor.getDst();
+    Value bankBaseAddress =
+        castCBTypeAsAddress(rewriter, loc, adaptedRemote);
+
+    // Create the TensorAccessor.
+    Value pageSize = i32(rewriter, loc, static_cast<int32_t>(pageSizeBytes));
+    auto tensorAccessor = rewriter.create<ttkernel::TensorAccessorOp>(
+        loc, argsOp, bankBaseAddress, pageSize);
+
+    // Get the local L1 base address.
+    Value localL1Base;
+    if constexpr (IsRead) {
+      auto dstCBMapping = cbProducerConsumer->get(op.getDst());
+      TT_assertv((dstCBMapping == d2m::ThreadCBOrientation::Producer ||
+                  dstCBMapping == d2m::ThreadCBOrientation::Default),
+                 "Expected dst cb of a read op to have a producer or default "
+                 "orientation, failing.");
+      localL1Base =
+          rewriter.create<ttkernel::GetWritePtrOp>(loc, adaptor.getDst());
+    } else {
+      localL1Base =
+          rewriter.create<ttkernel::GetReadPtrOp>(loc, adaptor.getSrc());
+    }
+
+    // Get grid indices for the remote side.
+    ValueRange gridIndices;
+    if constexpr (IsRead) {
+      gridIndices = op.getSrcIndices();
+    } else {
+      gridIndices = op.getDstIndices();
+    }
+    int64_t rank = static_cast<int64_t>(gridIndices.size());
+
+    SmallVector<Value> shardDimVals(rank);
+    SmallVector<Value> tensorStrideVals(rank);
+    SmallVector<Value> shardStrideVals(rank);
+    int32_t stride = 1;
+    for (int64_t d = rank-1; d >= 0; --d) {
+      shardDimVals[d] = index(rewriter, loc, shardShape[d]);
+      shardStrideVals[d] = index(rewriter, loc, stride);
+
+      tensorStrideVals[d] = rewriter.create<ttkernel::GetCompileArgValOp>(
+          loc, rewriter.getIndexType(), ctaTensorStrideArgIndex + d);
+
+      stride *= shardShape[d];
+    }
+
+    // Generate nested loops over shard dimensions.  The innermost loop body
+    // uses the loop IVs together with the grid indices to compute an absolute
+    // offset in the full tensor shape.
+    Value lb = index(rewriter, loc, 0);
+    Value step = index(rewriter, loc, 1);
+
+    // Build the nest from outermost to innermost dimension.
+    SmallVector<scf::ForOp> loops(rank);
+    OpBuilder::InsertionGuard guard(rewriter);
+    for (int64_t d = 0; d < rank; ++d) {
+      auto forOp = rewriter.create<scf::ForOp>(loc, lb, shardDimVals[d], step,
+                                                ValueRange{});
+      loops[d] = forOp;
+      rewriter.setInsertionPointToStart(forOp.getBody());
+    }
+
+    // Inside the innermost loop: compute page ID and local L1 address.
+    {
+      Location innerLoc = loc;
+
+      // Compute absolute coordinates and linearize into a page ID.
+      // abs[d] = gridIndices[d] * shardShape[d] + loopIV[d]
+      // pageId = sum_d(abs[d] * tensorStrides[d])
+      // localIdx = sum_d(loopIV[d] * shardStrides[d])
+      Value pageId = index(rewriter, innerLoc, 0);
+      Value localIdx = index(rewriter, innerLoc, 0);
+      for (int64_t d = rank - 1; d >= 0; --d) {
+        Value iv = loops[d].getInductionVar();
+
+        // Absolute coordinate: gridIndices[d] * shardShape[d] + iv.
+        Value gridOffset = rewriter.create<arith::MulIOp>(
+            innerLoc, gridIndices[d], shardDimVals[d]);
+        Value absDim =
+            rewriter.create<arith::AddIOp>(innerLoc, gridOffset, iv);
+
+        // Accumulate into pageId with the tensor stride.
+        Value absContrib = rewriter.create<arith::MulIOp>(
+            innerLoc, absDim, tensorStrideVals[d]);
+        pageId = rewriter.create<arith::AddIOp>(innerLoc, pageId, absContrib);
+
+        // Accumulate into localIdx with the shard stride.
+        Value localContrib = rewriter.create<arith::MulIOp>(
+            innerLoc, iv, shardStrideVals[d]);
+        localIdx =
+            rewriter.create<arith::AddIOp>(innerLoc, localIdx, localContrib);
+      }
+
+      Value pageIdI32 = rewriter.create<arith::IndexCastOp>(
+          innerLoc, rewriter.getI32Type(), pageId);
+
+      // local_l1_addr = local_l1_base + localIdx * page_size
+      Value offset = rewriter.create<arith::MulIOp>(
+          innerLoc, localIdx, index(rewriter, innerLoc, pageSizeBytes));
+      Value offsetI32 = rewriter.create<arith::IndexCastOp>(
+          innerLoc, rewriter.getI32Type(), offset);
+      Value localAddr =
+          rewriter.create<arith::AddIOp>(innerLoc, localL1Base, offsetI32);
+
+      if constexpr (IsRead) {
+        rewriter.create<ttkernel::NocAsyncReadTileOp>(
+            innerLoc, pageIdI32, tensorAccessor, localAddr);
+      } else {
+        rewriter.create<ttkernel::NocAsyncWriteTileOp>(
+            innerLoc, pageIdI32, tensorAccessor, localAddr);
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<d2m::NullTxOp>(op, op.getResult().getType());
+    return success();
+  }
+
+private:
+  const d2m::CBProducerConsumer *cbProducerConsumer;
+};
+
+using D2MDMAReadViaTensorAccessorRewriter =
+    D2MDMAViaTensorAccessorRewriter<d2m::DMAReadOp>;
+using D2MDMAWriteViaTensorAccessorRewriter =
+    D2MDMAViaTensorAccessorRewriter<d2m::DMAWriteOp>;
+
 } // namespace
 
 namespace {
@@ -3089,7 +3381,8 @@ namespace mlir::tt {
 
 void populateD2MToTTKernelPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns, TypeConverter &typeConverter,
-    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode) {
+    const d2m::CBProducerConsumer &cbProducerConsumer, bool ttnnMode,
+    bool useTensorAccessorDMA) {
   // clang-format off
   patterns.add<ttkernel::D2MKernelFunctionArgsRewriter,
                ttkernel::PassthroughRewriter<memref::CastOp>,
@@ -3209,6 +3502,12 @@ void populateD2MToTTKernelPatterns(
   patterns.add<ttkernel::D2MGetCBRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);
+  // TensorAccessor-based DMA rewriters for shard-level ops (used when
+  // D2MLowerDMAToFullyIndexedForm is skipped via --use-tensor-accessor-dma).
+  if (useTensorAccessorDMA) {
+    patterns.add<ttkernel::D2MDMAReadViaTensorAccessorRewriter>(typeConverter, ctx, &cbProducerConsumer);
+    patterns.add<ttkernel::D2MDMAWriteViaTensorAccessorRewriter>(typeConverter, ctx, &cbProducerConsumer);
+  }
 
   // Debug op patterns.
   patterns.add<ttkernel::D2MPrintOpRewriter>(typeConverter, ctx);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2744,8 +2744,10 @@ public:
       shardDimVals[d] = index(rewriter, loc, shardShape[d]);
       shardStrideVals[d] = index(rewriter, loc, stride);
 
-      tensorStrideVals[d] = rewriter.create<ttkernel::GetCompileArgValOp>(
-          loc, rewriter.getIndexType(), ctaTensorStrideArgIndex + d);
+      Value strideI32 = rewriter.create<ttkernel::GetCompileArgValOp>(
+          loc, rewriter.getI32Type(), ctaTensorStrideArgIndex + d);
+      tensorStrideVals[d] = rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(), strideI32);
 
       stride *= shardShape[d];
     }

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2180,6 +2180,11 @@ public:
   LogicalResult
   matchAndRewrite(d2m::DMAReadOp op, d2m::DMAReadOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    // Shard-level ops are handled by D2MDMAReadViaTensorAccessorRewriter when
+    // use-tensor-accessor-dma is enabled. Skip them here so they fall through.
+    if (op.isShardLevel()) {
+      return failure();
+    }
 
     auto chipDesc = ttcore::getOpChipDescAttr(op);
     Location loc = op.getLoc();
@@ -2232,6 +2237,11 @@ public:
   LogicalResult
   matchAndRewrite(d2m::DMAWriteOp op, d2m::DMAWriteOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    // Shard-level ops are handled by D2MDMAWriteViaTensorAccessorRewriter when
+    // use-tensor-accessor-dma is enabled. Skip them here so they fall through.
+    if (op.isShardLevel()) {
+      return failure();
+    }
 
     auto chipDesc = ttcore::getOpChipDescAttr(op);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -54,6 +54,7 @@ struct ConvertD2MToTTKernel
     // Workaround: Passes are required to be copy-constructible but autogen'ed
     // base class copy constructors ignore Pass option fields.
     this->ttnnMode = rhs.ttnnMode;
+    this->useTensorAccessorDMA = rhs.useTensorAccessorDMA;
   }
 
   void runOnOperation() final {
@@ -151,7 +152,7 @@ struct ConvertD2MToTTKernel
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
         patterns, typeConverter);
     populateD2MToTTKernelPatterns(&getContext(), patterns, typeConverter,
-                                  cbProducerConsumer, ttnnMode);
+                                  cbProducerConsumer, ttnnMode, useTensorAccessorDMA);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -152,7 +152,8 @@ struct ConvertD2MToTTKernel
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
         patterns, typeConverter);
     populateD2MToTTKernelPatterns(&getContext(), patterns, typeConverter,
-                                  cbProducerConsumer, ttnnMode, useTensorAccessorDMA);
+                                  cbProducerConsumer, ttnnMode,
+                                  useTensorAccessorDMA);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
+++ b/lib/Conversion/D2MToTTNN/D2MToTTNN.cpp
@@ -188,6 +188,15 @@ convertKernelArg(Builder &builder, const ttkernel::ArgAttr &arg,
   case ttkernel::ArgType::Scalar: {
     return builder.getAttr<ttnn::KernelArgScalarAttr>(arg.getOperandIndex());
   }
+  case ttkernel::ArgType::TensorAccessor: {
+    llvm_unreachable("TensorAccessor is not supported in TTNN mode");
+  }
+  case ttkernel::ArgType::TensorStride: {
+    llvm_unreachable("TensorStride is not supported in TTNN mode");
+  }
+  case ttkernel::ArgType::Reserved: {
+    llvm_unreachable("TensorAccessor is not supported in TTNN mode");
+  }
   }
   llvm_unreachable("Invalid ArgType");
 }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1213,9 +1213,9 @@ public:
 
     // Emit: auto dspec_N = ta.dspec();
     std::string code = "auto " + varName + " = {}.dspec();";
-    rewriter.create<emitc::VerbatimOp>(
-        op.getLoc(), rewriter.getStringAttr(code),
-        ValueRange{adaptor.getTensorAccessor()});
+    rewriter.create<emitc::VerbatimOp>(op.getLoc(),
+                                       rewriter.getStringAttr(code),
+                                       ValueRange{adaptor.getTensorAccessor()});
 
     auto resultType =
         this->getTypeConverter()->convertType(op->getResultTypes()[0]);
@@ -1229,8 +1229,9 @@ public:
 } // namespace
 
 namespace {
-// Rewriter for dspec indexed-access ops (dspec.shard_shape, dspec.tensor_strides,
-// dspec.shard_strides).  Emits: `uint32_t varN = dspec.METHOD()[dim];`
+// Rewriter for dspec indexed-access ops (dspec.shard_shape,
+// dspec.tensor_strides, dspec.shard_strides).  Emits: `uint32_t varN =
+// dspec.METHOD()[dim];`
 template <typename SourceOp>
 class TTKernelDSpecIndexedMethodRewriter
     : public OpConversionPattern<SourceOp> {
@@ -1242,7 +1243,8 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    // Extract method name from op name: "ttkernel.dspec.shard_shape" -> "shard_shape"
+    // Extract method name from op name: "ttkernel.dspec.shard_shape" ->
+    // "shard_shape"
     auto [prefix, methodName] =
         op.getOperation()->getName().getStringRef().rsplit('.');
     if (methodName.empty()) {
@@ -1989,11 +1991,11 @@ public:
             ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
                                                            funcOp.getContext());
 
-    patterns.add<
-        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardShapeOp>,
-        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecTensorStridesOp>,
-        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardStridesOp>>(
-        typeConverter, funcOp.getContext());
+    patterns
+        .add<TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardShapeOp>,
+             TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecTensorStridesOp>,
+             TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardStridesOp>>(
+            typeConverter, funcOp.getContext());
 
     patterns.add<ArithFloorDivRewriter, ArithBitcastRewriter,
                  ArithMaxUIRewriter, ArithMinUIRewriter>(typeConverter,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -256,6 +256,9 @@ public:
         [ctx](mlir::tt::ttkernel::TensorAccessorPageMappingType type) -> Type {
           return emitc::OpaqueType::get(ctx, "PageMapping");
         });
+    addConversion([ctx](mlir::tt::ttkernel::DSpecType type) -> Type {
+      return emitc::OpaqueType::get(ctx, "DSpec");
+    });
     addConversion(
         [ctx](mlir::tt::ttkernel::FabricConnectionManagerType type) -> Type {
           return emitc::OpaqueType::get(
@@ -1180,6 +1183,103 @@ public:
 } // namespace
 
 namespace {
+// Rewriter for tensor_accessor.dspec: emits `auto varN = ta.dspec();`
+// Needs a custom rewriter because the return type is `auto` (deduced from
+// the TensorAccessor template) which cannot be spelled as a concrete C++ type.
+class TTKernelTensorAccessorDSpecOpRewriter
+    : public OpConversionPattern<ttkernel::TensorAccessorDSpecOp> {
+  using Op = ttkernel::TensorAccessorDSpecOp;
+
+public:
+  TTKernelTensorAccessorDSpecOpRewriter(const TypeConverter &typeConverter,
+                                        MLIRContext *context)
+      : OpConversionPattern(typeConverter, context) {}
+
+  LogicalResult
+  matchAndRewrite(Op op, ttkernel::TensorAccessorDSpecOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    if (op.getResult().getUses().empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Generate unique variable name from SSA number.
+    std::string ssaName;
+    llvm::raw_string_ostream os(ssaName);
+    mlir::OpPrintingFlags flags;
+    op->getResult(0).printAsOperand(os, flags);
+    os.flush();
+    std::string varName = "dspec_" + ssaName.substr(1);
+
+    // Emit: auto dspec_N = ta.dspec();
+    std::string code = "auto " + varName + " = {}.dspec();";
+    rewriter.create<emitc::VerbatimOp>(
+        op.getLoc(), rewriter.getStringAttr(code),
+        ValueRange{adaptor.getTensorAccessor()});
+
+    auto resultType =
+        this->getTypeConverter()->convertType(op->getResultTypes()[0]);
+    auto literalOp =
+        rewriter.create<emitc::LiteralOp>(op.getLoc(), resultType, varName);
+
+    rewriter.replaceOp(op, literalOp.getResult());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+// Rewriter for dspec indexed-access ops (dspec.shard_shape, dspec.tensor_strides,
+// dspec.shard_strides).  Emits: `uint32_t varN = dspec.METHOD()[dim];`
+template <typename SourceOp>
+class TTKernelDSpecIndexedMethodRewriter
+    : public OpConversionPattern<SourceOp> {
+public:
+  TTKernelDSpecIndexedMethodRewriter(
+      TTKernelToEmitCTypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern<SourceOp>(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    // Extract method name from op name: "ttkernel.dspec.shard_shape" -> "shard_shape"
+    auto [prefix, methodName] =
+        op.getOperation()->getName().getStringRef().rsplit('.');
+    if (methodName.empty()) {
+      return failure();
+    }
+
+    auto operands = adaptor.getOperands();
+    if (operands.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "Expected dspec self and dim as operands");
+    }
+
+    // Generate unique variable name from SSA number.
+    std::string ssaName;
+    llvm::raw_string_ostream os(ssaName);
+    mlir::OpPrintingFlags flags;
+    op->getResult(0).printAsOperand(os, flags);
+    os.flush();
+    std::string varName = "temp_" + ssaName.substr(1);
+
+    // Emit: uint32_t temp_N = dspec.METHOD()[dim];
+    std::string callStr =
+        "uint32_t " + varName + " = {}." + methodName.str() + "()[{}];";
+    rewriter.create<emitc::VerbatimOp>(
+        op->getLoc(), rewriter.getStringAttr(callStr), operands);
+
+    Type resultType =
+        this->getTypeConverter()->convertType(op->getResultTypes()[0]);
+    auto literalOp =
+        rewriter.create<emitc::LiteralOp>(op->getLoc(), resultType, varName);
+    rewriter.replaceOp(op, literalOp.getResult());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class TTKernelCreateFabricConnectionManagerOpRewriter
     : public OpConversionPattern<ttkernel::CreateFabricConnectionManagerOp> {
   using Op = ttkernel::CreateFabricConnectionManagerOp;
@@ -1871,6 +1971,9 @@ public:
     patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter,
                                                        funcOp.getContext());
 
+    patterns.add<TTKernelTensorAccessorDSpecOpRewriter>(typeConverter,
+                                                        funcOp.getContext());
+
     patterns.add<TTKernelCreateFabricConnectionManagerOpRewriter>(
         typeConverter, funcOp.getContext());
 
@@ -1885,6 +1988,12 @@ public:
         TTKernelClassMethodRewriter<
             ttkernel::InterleavedAddrGenFastGetNocAddrOp>>(typeConverter,
                                                            funcOp.getContext());
+
+    patterns.add<
+        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardShapeOp>,
+        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecTensorStridesOp>,
+        TTKernelDSpecIndexedMethodRewriter<ttkernel::DSpecShardStridesOp>>(
+        typeConverter, funcOp.getContext());
 
     patterns.add<ArithFloorDivRewriter, ArithBitcastRewriter,
                  ArithMaxUIRewriter, ArithMinUIRewriter>(typeConverter,

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -244,7 +244,9 @@ void createD2MBackendPipeline(OpPassManager &pm,
   pm.addPass(d2m::createD2MLowerLoadStoreOpsToDMA());
   pm.addPass(d2m::createD2MOptimizeDMA());
   pm.addPass(d2m::createD2MExpandDMAReadCompositeView());
-  pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm());
+  if (!options.useTensorAccessorDMA) {
+    pm.addPass(d2m::createD2MLowerDMAToFullyIndexedForm());
+  }
 
   // Normalize thread argument access by inserting d2m.get_arg ops for any
   // remaining additional arguments and setting resolution_stage on
@@ -283,7 +285,10 @@ void createD2MToTTNNPipeline(OpPassManager &pm,
 static void addD2MToTTKernelPreEmitCPasses(OpPassManager &pm,
                                            const D2MPipelineOptions &options) {
   d2m::ConvertD2MToTTKernelOptions D2MToTTKernelOptions;
-  { D2MToTTKernelOptions.ttnnMode = options.ttnnMode; }
+  {
+    D2MToTTKernelOptions.ttnnMode = options.ttnnMode;
+    D2MToTTKernelOptions.useTensorAccessorDMA = options.useTensorAccessorDMA;
+  }
   pm.addPass(tt::createConvertD2MToTTKernelPass(D2MToTTKernelOptions));
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(ttkernel::createTTKernelControlDstSection());

--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -936,6 +936,12 @@ LogicalResult ExpressionOp::verify() {
 
   // Ensure the terminator is a yield op
   auto yield = cast<YieldOp>(body.getTerminator());
+
+  // Guard against a yield with no operands — getResult() would be OOB.
+  if (yield.getNumOperands() == 0) {
+    return emitOpError("yielded value not defined within expression");
+  }
+
   Value yieldResult = yield.getResult();
 
   // Ensure the yield result is valid

--- a/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
+++ b/lib/Dialect/EmitPy/IR/EmitPyOps.cpp
@@ -938,7 +938,7 @@ LogicalResult ExpressionOp::verify() {
   auto yield = cast<YieldOp>(body.getTerminator());
 
   // Guard against a yield with no operands — getResult() would be OOB.
-  if (yield.getNumOperands() == 0) {
+  if (yield.getOperation()->getNumOperands() == 0) {
     return emitOpError("yielded value not defined within expression");
   }
 

--- a/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
@@ -43,8 +43,10 @@ static size_t appendArgImpl(func::FuncOp op, ArgAttr arg, bool isCompileTime,
   // Reserve additional placeholder slots so that subsequent appends get
   // correct indices.  The runtime will fill all numSlots positions from
   // a single KernelArg entry.
-  ArgAttr reserved = numSlots > 1 ? ArgAttr::get(op.getContext(), ArgType::Reserved,
-                                          arg.getOperandIndex()) : nullptr;
+  ArgAttr reserved = numSlots > 1
+                         ? ArgAttr::get(op.getContext(), ArgType::Reserved,
+                                        arg.getOperandIndex())
+                         : nullptr;
   for (size_t i = 1; i < numSlots; ++i) {
     argSpecVector.push_back(reserved);
   }

--- a/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
@@ -34,11 +34,20 @@ getOrCreateArgSpec(mlir::func::FuncOp op) {
   return {rtArgSpecVector, ctArgSpecVector};
 }
 
-static size_t appendArgImpl(func::FuncOp op, ArgAttr arg, bool isCompileTime) {
+static size_t appendArgImpl(func::FuncOp op, ArgAttr arg, bool isCompileTime,
+                            size_t numSlots) {
   auto [rtArgSpecVector, ctArgSpecVector] = getOrCreateArgSpec(op);
   auto &argSpecVector = isCompileTime ? ctArgSpecVector : rtArgSpecVector;
   size_t nextIndex = argSpecVector.size();
   argSpecVector.push_back(arg);
+  // Reserve additional placeholder slots so that subsequent appends get
+  // correct indices.  The runtime will fill all numSlots positions from
+  // a single KernelArg entry.
+  ArgAttr reserved = numSlots > 1 ? ArgAttr::get(op.getContext(), ArgType::Reserved,
+                                          arg.getOperandIndex()) : nullptr;
+  for (size_t i = 1; i < numSlots; ++i) {
+    argSpecVector.push_back(reserved);
+  }
   auto argSpec =
       ArgSpecAttr::get(arg.getContext(), rtArgSpecVector, ctArgSpecVector);
   op->setAttr(ArgSpecAttr::name, argSpec);
@@ -46,13 +55,15 @@ static size_t appendArgImpl(func::FuncOp op, ArgAttr arg, bool isCompileTime) {
 }
 
 size_t mlir::tt::ttkernel::ArgSpecAttr::appendCompileTimeArg(func::FuncOp op,
-                                                             ArgAttr arg) {
-  return appendArgImpl(op, arg, /*isCompileTime=*/true);
+                                                             ArgAttr arg,
+                                                             size_t numSlots) {
+  return appendArgImpl(op, arg, /*isCompileTime=*/true, numSlots);
 }
 
 size_t mlir::tt::ttkernel::ArgSpecAttr::appendRuntimeArg(func::FuncOp op,
-                                                         ArgAttr arg) {
-  return appendArgImpl(op, arg, /*isCompileTime=*/false);
+                                                         ArgAttr arg,
+                                                         size_t numSlots) {
+  return appendArgImpl(op, arg, /*isCompileTime=*/false, numSlots);
 }
 
 void TTKernelDialect::registerTypes() {

--- a/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -885,7 +885,7 @@ createAndReplaceWithRoPEOp(mlir::PatternRewriter &rewriter, Operation *srcOp,
     int64_t inputSeq = xType.getShape()[xRank - 2];
     int64_t cosSeq = cosType.getShape()[cosRank - 2];
     if (cosSeq < inputSeq) {
-      TTMLIR_DEBUG(ttmlir::LogComponent::FusionValidator,
+      TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
                    "RoPE fusion rejected: cos/sin seq dim ({0}) < input seq "
                    "dim ({1}) — kernel would read padding garbage",
                    cosSeq, inputSeq);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -319,16 +319,21 @@ createBufferDistributionSpecForVirtualGrid(
     FlatbufferObjectCache &cache, ttcore::ShardLayoutAttr shardLayout,
     MemRefType memref, target::Dim2d elementShape, target::Dim2d pageShape,
     bool hasVirtualGridMapping,
-    std::optional<AffineMap> virtualGridForwardMapping) {
-  if (!hasVirtualGridMapping) {
-    return 0;
+    std::optional<AffineMap> virtualGridForwardMapping,
+    ArrayRef<int64_t> physicalGridShape, AffineMap physicalCoreMapping) {
+  if (hasVirtualGridMapping) {
+    TT_assertv(virtualGridForwardMapping.has_value(),
+               "Expected virtual-grid forward mapping");
   }
-  TT_assertv(virtualGridForwardMapping.has_value(),
-             "Expected virtual-grid forward mapping");
 
-  ArrayRef<int64_t> virtualGridShape = shardLayout.getGridShape(memref);
+  // For VGM buffers, use the logical (virtual) grid shape and the provided
+  // forward map (outputs [physY, physX, shardCoords...]).
+  // For non-VGM buffers, use the physical grid shape and the device's
+  // VirtToPhysicalMap (outputs [device, physY, physX]).
+  ArrayRef<int64_t> gridShape =
+      hasVirtualGridMapping ? shardLayout.getGridShape(memref) : physicalGridShape;
   ArrayRef<int64_t> memrefShardShape = shardLayout.getShardShape(memref);
-  TT_assertv(virtualGridShape.size() == memrefShardShape.size(),
+  TT_assertv(gridShape.size() == memrefShardShape.size(),
              "Expected grid rank to match shard rank");
 
   std::vector<uint32_t> shardShapeInPages =
@@ -337,28 +342,46 @@ createBufferDistributionSpecForVirtualGrid(
   std::vector<uint32_t> tensorShapeInPages;
   tensorShapeInPages.reserve(shardShapeInPages.size());
   for (size_t i = 0; i < shardShapeInPages.size(); ++i) {
-    tensorShapeInPages.push_back(static_cast<uint32_t>(virtualGridShape[i]) *
+    tensorShapeInPages.push_back(static_cast<uint32_t>(gridShape[i]) *
                                  shardShapeInPages[i]);
   }
 
-  AffineMap forwardMap = *virtualGridForwardMapping;
-  TT_assertv(forwardMap.getNumDims() >= virtualGridShape.size(),
-             "Expected forward virtual-grid map to accept grid dimensions");
   std::vector<target::Dim2d> cores;
-  cores.reserve(ttmlir::utils::volume<int64_t>(virtualGridShape));
-  ttmlir::utils::sample(
-      virtualGridShape, [&](ArrayRef<int64_t> virtualCoreCoord) {
-        SmallVector<int64_t> operands(forwardMap.getNumDims(), 0);
-        for (size_t i = 0; i < virtualCoreCoord.size(); ++i) {
-          operands[i] = virtualCoreCoord[i];
-        }
+  cores.reserve(ttmlir::utils::volume<int64_t>(gridShape));
 
-        SmallVector<int64_t> physicalCoord = forwardMap.compose(operands);
-        TT_assertv(physicalCoord.size() >= 2u,
-                   "Expected forward virtual-grid map to produce a 2D core");
-        cores.emplace_back(static_cast<int32_t>(physicalCoord[0]),
-                           static_cast<int32_t>(physicalCoord[1]));
-      });
+  if (hasVirtualGridMapping) {
+    AffineMap forwardMap = *virtualGridForwardMapping;
+    TT_assertv(forwardMap.getNumDims() >= gridShape.size(),
+               "Expected forward virtual-grid map to accept grid dimensions");
+    ttmlir::utils::sample(gridShape, [&](ArrayRef<int64_t> coreCoord) {
+      SmallVector<int64_t> operands(forwardMap.getNumDims(), 0);
+      for (size_t i = 0; i < coreCoord.size(); ++i) {
+        operands[i] = coreCoord[i];
+      }
+      SmallVector<int64_t> physicalCoord = forwardMap.compose(operands);
+      TT_assertv(physicalCoord.size() >= 2u,
+                 "Expected forward virtual-grid map to produce a 2D core");
+      cores.emplace_back(static_cast<int32_t>(physicalCoord[0]),
+                         static_cast<int32_t>(physicalCoord[1]));
+    });
+  } else {
+    // physicalCoreMapping maps (row, col) -> [device, core_y, core_x].
+    TT_assertv(physicalCoreMapping.getNumDims() >= gridShape.size(),
+               "Expected physical core mapping to accept grid dimensions");
+    ttmlir::utils::sample(gridShape, [&](ArrayRef<int64_t> coreCoord) {
+      SmallVector<int64_t> operands(physicalCoreMapping.getNumDims(), 0);
+      for (size_t i = 0; i < coreCoord.size(); ++i) {
+        operands[i] = coreCoord[i];
+      }
+      SmallVector<int64_t> physCoord = physicalCoreMapping.compose(operands);
+      TT_assertv(physCoord.size() >=
+                     static_cast<size_t>(ttcore::PhysGridResultIdx::NumIndices),
+                 "Expected physical core mapping to produce [device, y, x]");
+      cores.emplace_back(
+          static_cast<int32_t>(physCoord[ttcore::PhysGridResultIdx::CoreCoordY]),
+          static_cast<int32_t>(physCoord[ttcore::PhysGridResultIdx::CoreCoordX]));
+    });
+  }
 
   return target::metal::CreateBufferDistributionSpecDirect(
       *cache.fbb, &tensorShapeInPages, &shardShapeInPages, &cores);
@@ -424,7 +447,8 @@ createShardedBufferConfigForL1Memref(
       *cache.fbb, shardSpec, &pageShape, &tensorShapeInPages);
   auto bufferDistributionSpec = createBufferDistributionSpecForVirtualGrid(
       cache, shardLayout, memref, elementShape, pageShape,
-      hasVirtualGridMapping, virtualGridForwardMapping);
+      hasVirtualGridMapping, virtualGridForwardMapping, memrefGridShape,
+      extendedMapping);
 
   assert(pageShape.y() % elementShape.y() == 0);
   assert(pageShape.x() % elementShape.x() == 0);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -405,7 +405,15 @@ createShardedBufferConfigForL1Memref(
   auto shardSpec = target::metal::CreateShardSpecDirect(
       *cache.fbb, &coreRangeSet, &shardShape);
 
-  target::Dim2d pageShape(elementShape.y(), shardShape.x());
+  // Calculate ShardSpecBuffer.
+  target::Dim2d pageShape;
+  if (mlir::isa<ttcore::TileType>(memref.getElementType())) {
+    // For tiled tensors, pageShape is tile size.
+    pageShape = target::Dim2d(elementShape.y(), elementShape.x());
+  } else {
+    // For row-major tensors, pageShape is 1xN where N is 1 full row.
+    pageShape = target::Dim2d(elementShape.y(), shardShape.x());
+  }
   std::array<int32_t, 2> tensorShape = {gridShapeExtents[0] * shardShape.y(),
                                         gridShapeExtents[1] * shardShape.x()};
   assert(tensorShape[0] % pageShape.y() == 0);
@@ -824,6 +832,27 @@ toFlatbuffer(FlatbufferObjectCache &cache, KernelArgAttr kernelArg) {
     argType = target::metal::KernelArgType::KernelArgScalar;
     arg = target::metal::CreateKernelArgScalar(*cache.fbb,
                                                kernelArg.getOperandIndex())
+              .Union();
+    break;
+  }
+  case ttkernel::ArgType::TensorAccessor: {
+    argType = target::metal::KernelArgType::KernelArgTensorAccessor;
+    arg = target::metal::CreateKernelArgTensorAccessor(
+              *cache.fbb, kernelArg.getOperandIndex())
+              .Union();
+    break;
+  }
+  case ttkernel::ArgType::TensorStride: {
+    argType = target::metal::KernelArgType::KernelArgTensorStride;
+    arg = target::metal::CreateKernelArgTensorStride(
+              *cache.fbb, kernelArg.getOperandIndex())
+              .Union();
+    break;
+  }
+  case ttkernel::ArgType::Reserved: {
+    argType = target::metal::KernelArgType::KernelArgReserved;
+    arg = target::metal::CreateKernelArgTensorAccessor(
+              *cache.fbb, kernelArg.getOperandIndex())
               .Union();
     break;
   }

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -330,8 +330,9 @@ createBufferDistributionSpecForVirtualGrid(
   // forward map (outputs [physY, physX, shardCoords...]).
   // For non-VGM buffers, use the physical grid shape and the device's
   // VirtToPhysicalMap (outputs [device, physY, physX]).
-  ArrayRef<int64_t> gridShape =
-      hasVirtualGridMapping ? shardLayout.getGridShape(memref) : physicalGridShape;
+  ArrayRef<int64_t> gridShape = hasVirtualGridMapping
+                                    ? shardLayout.getGridShape(memref)
+                                    : physicalGridShape;
   ArrayRef<int64_t> memrefShardShape = shardLayout.getShardShape(memref);
   TT_assertv(gridShape.size() == memrefShardShape.size(),
              "Expected grid rank to match shard rank");
@@ -377,9 +378,10 @@ createBufferDistributionSpecForVirtualGrid(
       TT_assertv(physCoord.size() >=
                      static_cast<size_t>(ttcore::PhysGridResultIdx::NumIndices),
                  "Expected physical core mapping to produce [device, y, x]");
-      cores.emplace_back(
-          static_cast<int32_t>(physCoord[ttcore::PhysGridResultIdx::CoreCoordY]),
-          static_cast<int32_t>(physCoord[ttcore::PhysGridResultIdx::CoreCoordX]));
+      cores.emplace_back(static_cast<int32_t>(
+                             physCoord[ttcore::PhysGridResultIdx::CoreCoordY]),
+                         static_cast<int32_t>(
+                             physCoord[ttcore::PhysGridResultIdx::CoreCoordX]));
     });
   }
 

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -14,6 +14,7 @@
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/program_cache.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
 #include "tt-metalium/tt_metal.hpp"
 
 #include "tt/runtime/types.h"

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -161,17 +161,27 @@ std::vector<std::uint32_t> processKernelArgs(
         auto ctArgs = tensorAccessorArgs.get_compile_time_args();
         argsVec.insert(argsVec.end(), ctArgs.begin(), ctArgs.end());
 
-        LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        LOG_ASSERT(argsVec.size() <= args->size(),
+                   "Not enough TensorAccessor argument slots reverved in "
+                   "kernel argument spec");
         for (size_t i = 1; i < ctArgs.size(); ++i) {
-          LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+          LOG_ASSERT(args->Get(argIdx + i)->arg_type() ==
+                         target::metal::KernelArgType::KernelArgReserved,
+                     "Not enough TensorAccessor argument slots reverved in "
+                     "kernel argument spec");
         }
       } else {
         auto rtArgs = tensorAccessorArgs.get_common_runtime_args();
         argsVec.insert(argsVec.end(), rtArgs.begin(), rtArgs.end());
 
-        LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        LOG_ASSERT(argsVec.size() <= args->size(),
+                   "Not enough TensorAccessor argument slots reverved in "
+                   "kernel argument spec");
         for (size_t i = 1; i < rtArgs.size(); ++i) {
-          LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+          LOG_ASSERT(args->Get(argIdx + i)->arg_type() ==
+                         target::metal::KernelArgType::KernelArgReserved,
+                     "Not enough TensorAccessor argument slots reverved in "
+                     "kernel argument spec");
         }
       }
       break;
@@ -188,19 +198,29 @@ std::vector<std::uint32_t> processKernelArgs(
                  logger::Buffer(buffer->global_id()));
 
       auto meshBuffer = meshBuffers.at(buffer->global_id());
-      std::array<std::uint32_t, 2> tensorShape = meshBuffer->device_local_config().sharding_args.shard_spec()->tensor2d_shape_in_pages;
+      std::array<std::uint32_t, 2> tensorShape =
+          meshBuffer->device_local_config()
+              .sharding_args.shard_spec()
+              ->tensor2d_shape_in_pages;
       std::array<std::uint32_t, 2> stride = {tensorShape[1], 1};
       argsVec.insert(argsVec.end(), stride.begin(), stride.end());
 
-      LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorStride argument slots reverved in kernel argument spec");
+      LOG_ASSERT(argsVec.size() <= args->size(),
+                 "Not enough TensorStride argument slots reverved in kernel "
+                 "argument spec");
       for (size_t i = 1; i < stride.size(); ++i) {
-        LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorStride argument slots reverved in kernel argument spec");
+        LOG_ASSERT(args->Get(argIdx + i)->arg_type() ==
+                       target::metal::KernelArgType::KernelArgReserved,
+                   "Not enough TensorStride argument slots reverved in kernel "
+                   "argument spec");
       }
       break;
     }
 
     case target::metal::KernelArgType::KernelArgReserved: {
-      // Some Reserved users, like TensorAccessor, conservatively reserve space for runtime dependent slots. Just zero fill slots that ended up not being used.
+      // Some Reserved users, like TensorAccessor, conservatively reserve space
+      // for runtime dependent slots. Just zero fill slots that ended up not
+      // being used.
       if (argIdx == argsVec.size()) {
         argsVec.push_back(0);
       }

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -45,7 +45,9 @@ std::vector<std::uint32_t> processKernelArgs(
     return argsVec;
   }
   argsVec.reserve(args->size());
-  for (const auto *kernelArg : *args) {
+  for (uint32_t argIdx = 0; argIdx < args->size(); ++argIdx) {
+    const auto *kernelArg = args->Get(argIdx);
+
     switch (kernelArg->arg_type()) {
     case target::metal::KernelArgType::KernelArgCBPort: {
       const auto *arg = kernelArg->arg_as_KernelArgCBPort();
@@ -138,6 +140,73 @@ std::vector<std::uint32_t> processKernelArgs(
       argsVec.push_back(scalarValue);
       break;
     }
+
+    // For TensorAccessor arg, we construct TensorAccessorArgs from the
+    // referenced buffer and append its compile-time or runtime args.
+    // Unlike other arg types, this pushes multiple uint32_t values.
+    case target::metal::KernelArgType::KernelArgTensorAccessor: {
+      const auto *arg = kernelArg->arg_as_KernelArgTensorAccessor();
+      const target::metal::BufferRef *buffer =
+          reinterpret_cast<const target::metal::BufferRef *>(
+              argRefs->Get(arg->operand_idx()));
+      LOG_ASSERT(meshBuffers.find(buffer->global_id()) != meshBuffers.end(),
+                 "Buffer id referenced by TensorAccessor arg is no longer "
+                 "alive or was never created ",
+                 logger::Buffer(buffer->global_id()));
+
+      auto meshBuffer = meshBuffers.at(buffer->global_id());
+      tt_metal::TensorAccessorArgs tensorAccessorArgs(*meshBuffer);
+
+      if constexpr (isCompileTime) {
+        auto ctArgs = tensorAccessorArgs.get_compile_time_args();
+        argsVec.insert(argsVec.end(), ctArgs.begin(), ctArgs.end());
+
+        LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        for (size_t i = 1; i < ctArgs.size(); ++i) {
+          LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        }
+      } else {
+        auto rtArgs = tensorAccessorArgs.get_common_runtime_args();
+        argsVec.insert(argsVec.end(), rtArgs.begin(), rtArgs.end());
+
+        LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        for (size_t i = 1; i < rtArgs.size(); ++i) {
+          LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorAccessor argument slots reverved in kernel argument spec");
+        }
+      }
+      break;
+    }
+
+    case target::metal::KernelArgType::KernelArgTensorStride: {
+      const auto *arg = kernelArg->arg_as_KernelArgTensorStride();
+      const target::metal::BufferRef *buffer =
+          reinterpret_cast<const target::metal::BufferRef *>(
+              argRefs->Get(arg->operand_idx()));
+      LOG_ASSERT(meshBuffers.find(buffer->global_id()) != meshBuffers.end(),
+                 "Buffer id referenced by TensorStride arg is no longer "
+                 "alive or was never created ",
+                 logger::Buffer(buffer->global_id()));
+
+      auto meshBuffer = meshBuffers.at(buffer->global_id());
+      std::array<std::uint32_t, 2> tensorShape = meshBuffer->device_local_config().sharding_args.shard_spec()->tensor2d_shape_in_pages;
+      std::array<std::uint32_t, 2> stride = {tensorShape[1], 1};
+      argsVec.insert(argsVec.end(), stride.begin(), stride.end());
+
+      LOG_ASSERT(argsVec.size() <= args->size(), "Not enough TensorStride argument slots reverved in kernel argument spec");
+      for (size_t i = 1; i < stride.size(); ++i) {
+        LOG_ASSERT(args->Get(argIdx + i)->arg_type() == target::metal::KernelArgType::KernelArgReserved, "Not enough TensorStride argument slots reverved in kernel argument spec");
+      }
+      break;
+    }
+
+    case target::metal::KernelArgType::KernelArgReserved: {
+      // Some Reserved users, like TensorAccessor, conservatively reserve space for runtime dependent slots. Just zero fill slots that ended up not being used.
+      if (argIdx == argsVec.size()) {
+        argsVec.push_back(0);
+      }
+      break;
+    }
+
     case target::metal::KernelArgType::NONE:
       LOG_FATAL("Unsupported runtime arg type");
     }

--- a/test/python/golden/d2m/test_layout.py
+++ b/test/python/golden/d2m/test_layout.py
@@ -87,13 +87,17 @@ def test_to_layout(
         ):
             to_device = builder.to_layout(
                 in0,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled, grid=input_grid),
+                output_type=builder.get_metal_tensor_layout(
+                    shape, tiled=tiled, grid=input_grid
+                ),
                 unit_attrs=unit_attrs,
                 loc="to_device",
             )
             reblock = builder.to_layout(
                 to_device,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled, grid=output_grid),
+                output_type=builder.get_metal_tensor_layout(
+                    shape, tiled=tiled, grid=output_grid
+                ),
                 unit_attrs=unit_attrs,
                 loc="reblock",
             )

--- a/test/python/golden/d2m/test_layout.py
+++ b/test/python/golden/d2m/test_layout.py
@@ -4,6 +4,7 @@
 
 import pytest
 import torch
+import math
 from conftest import get_request_kwargs
 from typing import List
 
@@ -34,13 +35,26 @@ _D2M_POST_GRID_WITH_VIEW_PIPELINE = (
 )
 
 
+def arange_tile(*shape, tile_size=[32, 32], dtype=None):
+    assert len(shape) >= 2
+    assert shape[-2] % tile_size[-2] == 0
+    assert shape[-1] % tile_size[-1] == 0
+    tiled_shape = list(shape)
+    tiled_shape[-2] //= tile_size[-2]
+    tiled_shape[-1] //= tile_size[-1]
+    tensor = torch.arange(math.prod(tiled_shape), dtype=dtype).reshape(tiled_shape)
+    tensor = tensor.unsqueeze(-1).unsqueeze(-1)
+    tensor = tensor.repeat([1] * len(tiled_shape) + tile_size)
+    return tensor.transpose(-2, -3).reshape(shape)
+
+
 @pytest.mark.parametrize("input_grid_y", [1, 2, 3])
 @pytest.mark.parametrize("input_grid_x", [1, 2, 3])
 @pytest.mark.parametrize("output_grid_y", [2, 3, 4])
 @pytest.mark.parametrize("output_grid_x", [2, 3, 4])
 @pytest.mark.parametrize("shard_mul_y", [3])
 @pytest.mark.parametrize("shard_mul_x", [2])
-@pytest.mark.parametrize("tiled", [False])
+@pytest.mark.parametrize("tiled", [True])
 @pytest.mark.parametrize("target", ["ttmetal"])
 def test_to_layout(
     input_grid_y: int,
@@ -63,7 +77,7 @@ def test_to_layout(
     )
 
     def module(builder: D2MBuilder):
-        golden = torch.randn(shape)
+        golden = arange_tile(*shape, dtype=torch.float32)
 
         @builder.func([shape], [torch.float32])
         def to_layout(
@@ -73,13 +87,13 @@ def test_to_layout(
         ):
             to_device = builder.to_layout(
                 in0,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled),
+                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled, grid=input_grid),
                 unit_attrs=unit_attrs,
                 loc="to_device",
             )
             reblock = builder.to_layout(
                 to_device,
-                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled),
+                output_type=builder.get_metal_tensor_layout(shape, tiled=tiled, grid=output_grid),
                 unit_attrs=unit_attrs,
                 loc="reblock",
             )
@@ -92,11 +106,20 @@ def test_to_layout(
             builder.set_goldens({in0: golden}, {from_device: golden})
             return from_device
 
+    use_tensor_accessor_dma = True
+    pipeline = ",".join(
+        [
+            "d2m-lower-to-layout",
+            f"ttir-to-ttmetal-me-pipeline{{use-tensor-accessor-dma={1 if use_tensor_accessor_dma else 0}}}",
+            f"ttir-to-ttmetal-be-pipeline{{use-tensor-accessor-dma={1 if use_tensor_accessor_dma else 0}}}",
+        ]
+    )
     compile_and_execute_d2m(
         module,
         target=target,
-        custom_pipeline=_D2M_POST_GRID_PIPELINE,
+        custom_pipeline=pipeline,
         device=device,
+        print_ir=True,
         **get_request_kwargs(request),
     )
 

--- a/test/python/golden/d2m/test_layout.py
+++ b/test/python/golden/d2m/test_layout.py
@@ -111,12 +111,15 @@ def test_to_layout(
             return from_device
 
     use_tensor_accessor_dma = True
-    pipeline = ",".join(
-        [
-            "d2m-lower-to-layout",
-            f"ttir-to-ttmetal-me-pipeline{{use-tensor-accessor-dma={1 if use_tensor_accessor_dma else 0}}}",
-            f"ttir-to-ttmetal-be-pipeline{{use-tensor-accessor-dma={1 if use_tensor_accessor_dma else 0}}}",
-        ]
+    ta = f"use-tensor-accessor-dma={1 if use_tensor_accessor_dma else 0}"
+    pipeline = (
+        f"d2m-lower-to-layout,canonicalize,ttir-bufferization-pipeline,"
+        f"d2m-insert-scratch-buffers,d2m-generic-apply-interchange,"
+        f"d2m-generate-outer-loops,d2m-allocate,d2m-lower-multicast-loads,"
+        f"d2m-generic-lower-to-explicit-form,canonicalize,"
+        f"d2m-be-pipeline{{{ta}}},"
+        f"d2m-to-ttkernel-pipeline{{{ta}}},"
+        f"d2m-to-ttmetal-pipeline"
     )
     compile_and_execute_d2m(
         module,

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2141,6 +2141,40 @@ module {
       return
     }
 
+    // TEST: DSpec ops — tensor_accessor.dspec and dspec.{shard_shape,tensor_strides,shard_strides}
+
+    // CHECK-LABEL: func @test_dspec_ops
+    func.func @test_dspec_ops() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      %cta_offset = arith.constant 2 : i32
+      %crta_offset = arith.constant 0 : i32
+      %bank_address = arith.constant 303104 : i32
+      %page_size = arith.constant 32 : i32
+      %tensor_accessor_args = ttkernel.TensorAccessorArgs(%cta_offset, %crta_offset)
+      // CHECK: %[[TA:.*]] = emitc.call_opaque "TensorAccessor"
+      %tensor_accessor = "ttkernel.TensorAccessor"(%tensor_accessor_args, %bank_address, %page_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
+
+      // CHECK: emitc.verbatim "auto [[DSPEC:dspec_[0-9]+]] = {}.dspec();" args %[[TA]] : !emitc.opaque<"TensorAccessor">
+      // CHECK: %[[DSPEC_LIT:.*]] = emitc.literal "[[DSPEC]]" : !emitc.opaque<"DSpec">
+      %dspec = "ttkernel.tensor_accessor.dspec"(%tensor_accessor) : (!ttkernel.TensorAccessor) -> !ttkernel.DSpec
+
+      %dim0 = arith.constant 0 : i32
+      %dim1 = arith.constant 1 : i32
+
+      // CHECK: emitc.verbatim "uint32_t [[SS0:.*]] = {}.shard_shape()[{}];" args %[[DSPEC_LIT]], {{.*}} : !emitc.opaque<"DSpec">, i32
+      // CHECK: emitc.literal "[[SS0]]" : i32
+      %shard_shape_0 = "ttkernel.dspec.shard_shape"(%dspec, %dim0) : (!ttkernel.DSpec, i32) -> i32
+
+      // CHECK: emitc.verbatim "uint32_t [[TS1:.*]] = {}.tensor_strides()[{}];" args %[[DSPEC_LIT]], {{.*}} : !emitc.opaque<"DSpec">, i32
+      // CHECK: emitc.literal "[[TS1]]" : i32
+      %tensor_strides_1 = "ttkernel.dspec.tensor_strides"(%dspec, %dim1) : (!ttkernel.DSpec, i32) -> i32
+
+      // CHECK: emitc.verbatim "uint32_t [[SHS0:.*]] = {}.shard_strides()[{}];" args %[[DSPEC_LIT]], {{.*}} : !emitc.opaque<"DSpec">, i32
+      // CHECK: emitc.literal "[[SHS0]]" : i32
+      %shard_strides_0 = "ttkernel.dspec.shard_strides"(%dspec, %dim0) : (!ttkernel.DSpec, i32) -> i32
+
+      return
+    }
+
     // TEST: Chained TensorAccessorArgs with literal, constexpr, and chained offsets
     // Tests the new functionality for chaining TensorAccessorArgs using
     // prev_args.next_compile_time_args_offset() in template arguments

--- a/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
+++ b/test/ttmlir/Dialect/EmitPy/expression_negative.mlir
@@ -13,7 +13,6 @@ func.func @test_expression_no_terminator(%arg0: !emitpy.opaque<"int">) -> !emitp
 // -----
 
 // Test: Yield must provide a value
-// Note: This test triggers compiler heap overflow since yield is defined within expression
 func.func @test_expression_yield_no_value(%arg0: !emitpy.opaque<"float">) -> !emitpy.opaque<"float"> {
   // expected-error @+1 {{yielded value not defined within expression}}
   %0 = "emitpy.expression"(%arg0) ({


### PR DESCRIPTION
Introduces an alternative shard-level DMA lowering that uses tt-metal's TensorAccessor at runtime instead of the fully-indexed form, gated by a new --use-tensor-accessor-dma option on TTIRToTTMetalPipeline and ConvertD2MToTTKernel. When enabled, D2MLowerDMAToFullyIndexedForm is skipped and shard-level dma_read/dma_write ops are lowered to NocAsyncRead/WriteTile against a TTKernel TensorAccessor.

Compiler:
- New TTKernel ops/types: tensor_accessor.dspec, dspec.shard_shape, dspec.tensor_strides, dspec.shard_strides, and the DSpec type.
- New ArgType cases TensorAccessor, TensorStride, and Reserved.
- ArgSpecAttr::append{CompileTime,Runtime}Arg gain a numSlots parameter so multi-slot kernel args reserve placeholder entries and keep subsequent indices stable.
- D2MDMAViaTensorAccessorRewriter for shard-level DMA reads/writes; computes CTA slot count to match TensorAccessorArgs::get_compile_time_args().
- TTKernelToEmitC support for the new DSpec ops via verbatim emission (the C++ return type is auto-deduced from the TensorAccessor template).
- D2MToTTNN rejects the new arg types (TTNN mode unsupported).
- NormalizeThreadArgs no longer collapses the view-applied memref so the get_arg memref preserves the #ttcore.view layout.

Flatbuffer / runtime:
- program.fbs gains KernelArgTensorAccessor, KernelArgTensorStride, and KernelArgReserved variants.
- runtime/lib/ttmetal/arguments.h constructs tt_metal::TensorAccessorArgs from the referenced mesh buffer and appends its compile-time or common runtime args; TensorStride emits the 2D row stride; Reserved slots zero-fill any unused capacity.
- executor_utils.h builds a BufferDistributionSpec and passes it through BufferShardingArgs for sharded mesh buffers.
- TTMetalToFlatbuffer page shape fix: tiled tensors now use tile size as the page shape rather than a 1xN row.

Tests:
- TTKernelToEmitC ttkernel.mlir gains a DSpec op test case.
- test_layout switches to tiled with arange_tile goldens and exercises the new --use-tensor-accessor-dma pipeline option.
- normalize_thread_args.mlir CHECK updated to reflect the preserved view layout on get_arg.