### PR TITLE
Revert "Paged sdpa p150 core grid setting (#8067)"

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3806,8 +3806,7 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
                        Optional<AnyRankedTensor>:$attention_sink,
                        OptionalAttr<F32Attr>:$scale,
                        OptionalAttr<UI32Attr>:$sliding_window_size,
-                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
-                       OptionalAttr<TTNN_CoreCoordAttr>:$core_grid);
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
   let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -751,8 +751,7 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize,
-      std::optional<CoreCoordAttr> coreGrid, TTNNLayoutAttr outputLayout);
+      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -766,8 +765,7 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize,
-      std::optional<CoreCoordAttr> coreGrid, TTNNLayoutAttr outputLayout);
+      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -118,7 +118,6 @@ table PagedScaledDotProductAttentionDecodeOp {
   sliding_window_size: uint32 = null;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
-  core_grid: tt.target.ttnn.CoreCoord;
 }
 
 table PagedFlashMultiLatentAttentionDecodeOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3404,8 +3404,7 @@ public:
         adaptor.getAttentionMask(), adaptor.getCurPosTensor(),
         adaptor.getAttentionSink(), adaptor.getScaleAttr(),
         adaptor.getSlidingWindowSizeAttr(),
-        /*memory_config=*/nullptr,
-        /*core_grid=*/nullptr);
+        /*memory_config=*/nullptr);
     return success();
   }
 };

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2251,7 +2251,6 @@ struct PagedScaledDotProductAttentionDecodeArgs {
   std::optional<TTNNLayoutAttr> attentionSinkLayout = std::nullopt;
   std::optional<llvm::APFloat> scale = std::nullopt;
   std::optional<uint32_t> slidingWindowSize = std::nullopt;
-  std::optional<CoreCoordAttr> coreGrid = std::nullopt;
 };
 
 static PagedScaledDotProductAttentionDecodeArgs
@@ -2273,7 +2272,6 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   ret.isCausal = op.getIsCausal();
   ret.scale = op.getScale();
   ret.slidingWindowSize = op.getSlidingWindowSize();
-  ret.coreGrid = op.getCoreGrid();
 
   TypedValue<RankedTensorType> attentionMask = op.getAttentionMask();
   TypedValue<RankedTensorType> curPosTensor = op.getCurPosTensor();
@@ -2318,20 +2316,15 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
-  ttcore::GridAttr deviceGrid;
-  if (pagedSdpaArgs.coreGrid) {
-    deviceGrid = ttcore::GridAttr::get(
-        getContext(), {static_cast<int64_t>(pagedSdpaArgs.coreGrid->getX()),
-                       static_cast<int64_t>(pagedSdpaArgs.coreGrid->getY())});
-  } else {
-    llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-    if (!check) {
-      return check.takeError();
-    }
-    deviceGrid = ttcore::lookupDevice(getOperation()).getWorkerGrid();
-  }
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<
@@ -2344,7 +2337,7 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
-      pagedSdpaArgs.coreGrid, opConfig.outputLayout);
+      opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 
@@ -2357,14 +2350,13 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
-  if (!pagedSdpaArgs.coreGrid) {
-    llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-    if (!check) {
-      return check.takeError();
-    }
-  }
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime,
@@ -2376,7 +2368,7 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
       pagedSdpaArgs.curPosTensorShape, pagedSdpaArgs.curPosTensorLayout,
       pagedSdpaArgs.attentionSinkShape, pagedSdpaArgs.attentionSinkLayout,
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
-      pagedSdpaArgs.coreGrid, opConfig.outputLayout);
+      opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -661,41 +661,6 @@ public:
   }
 };
 
-class PagedSDPADecodeP150CoreGridWorkaround
-    : public OpRewritePattern<ttnn::PagedScaledDotProductAttentionDecodeOp> {
-  // Paged SDPA decode crashes with TT_FATAL: Output spatial index 32 out of
-  // bounds (max 32) when batch=32 and num_kv_heads=8 on Blackhole. tt-metal
-  // issue: https://github.com/tenstorrent/tt-metal/issues/40978
-public:
-  using OpRewritePattern<
-      ttnn::PagedScaledDotProductAttentionDecodeOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttnn::PagedScaledDotProductAttentionDecodeOp op,
-                                PatternRewriter &rewriter) const override {
-    if (op.getCoreGrid()) {
-      return failure();
-    }
-
-    ttcore::ChipDescAttr chipDesc = ttcore::getOpChipDescAttr(op);
-    if (chipDesc.getArch().getValue() != ttcore::Arch::Blackhole) {
-      return failure();
-    }
-
-    ttcore::DeviceAttr device = ttcore::lookupDevice(op);
-    for (int64_t dim : device.getMeshShape()) {
-      if (dim != 1) {
-        return failure();
-      }
-    }
-
-    rewriter.modifyOpInPlace(op, [&]() {
-      op->setAttr("core_grid", ttnn::CoreCoordAttr::get(rewriter.getContext(),
-                                                        /*x=*/8, /*y=*/8));
-    });
-    return success();
-  }
-};
-
 // Pass to apply workarounds to the operands of TTNN operations.
 class TTNNWorkarounds : public impl::TTNNWorkaroundsBase<TTNNWorkarounds> {
 public:
@@ -705,7 +670,7 @@ public:
     if (decompositionWorkaroundsEnabled) {
       RewritePatternSet patterns(&getContext());
       patterns.add<
-          GatherSi32Workaround, PagedSDPADecodeP150CoreGridWorkaround,
+          GatherSi32Workaround,
           workarounds::decomposition::TTNNAllGatherWorkarounds,
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2814,8 +2814,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize,
-    std::optional<CoreCoordAttr> coreGrid, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2858,17 +2857,6 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
 
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      sdpaProgramConfig = std::nullopt;
-  if (coreGrid) {
-    sdpaProgramConfig.emplace();
-    sdpaProgramConfig->compute_with_storage_grid_size =
-        ::tt::tt_metal::CoreCoord{coreGrid->getX(), coreGrid->getY()};
-    sdpaProgramConfig->q_chunk_size = 0;
-    sdpaProgramConfig->k_chunk_size = 0;
-    sdpaProgramConfig->max_cores_per_head_batch =
-        coreGrid->getX() * coreGrid->getY();
-  }
 
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -2876,7 +2864,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
+        /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt);
   };
 
@@ -2901,8 +2889,7 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize,
-    std::optional<CoreCoordAttr> coreGrid, TTNNLayoutAttr outputLayout) {
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2947,25 +2934,13 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
-  std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
-      sdpaProgramConfig = std::nullopt;
-  if (coreGrid) {
-    sdpaProgramConfig.emplace();
-    sdpaProgramConfig->compute_with_storage_grid_size =
-        ::tt::tt_metal::CoreCoord{coreGrid->getX(), coreGrid->getY()};
-    sdpaProgramConfig->q_chunk_size = 0;
-    sdpaProgramConfig->k_chunk_size = 0;
-    sdpaProgramConfig->max_cores_per_head_batch =
-        coreGrid->getX() * coreGrid->getY();
-  }
-
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
         ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
         querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
+        /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt);
   };
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3252,12 +3252,6 @@ createOp(FlatbufferObjectCache &cache,
   ::flatbuffers::Optional<uint32_t> slidingWindowSize =
       toFlatbuffer(cache, op.getSlidingWindowSize());
   auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
-  const ::tt::target::ttnn::CoreCoord *coreGridPtr = nullptr;
-  ::tt::target::ttnn::CoreCoord coreGridVal;
-  if (auto coreGridAttr = op.getCoreGrid()) {
-    coreGridVal = toFlatbuffer(cache, *coreGridAttr);
-    coreGridPtr = &coreGridVal;
-  }
 
   auto out =
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
@@ -3266,8 +3260,7 @@ createOp(FlatbufferObjectCache &cache,
 
   return ::tt::target::ttnn::CreatePagedScaledDotProductAttentionDecodeOp(
       *cache.fbb, query, key, value, pageTable, isCausal, attentionMask,
-      curPosTensor, attentionSink, scale, slidingWindowSize, out, memoryConfig,
-      coreGridPtr);
+      curPosTensor, attentionSink, scale, slidingWindowSize, out, memoryConfig);
 }
 
 ::flatbuffers::Offset<

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -42,10 +42,7 @@ static void runPagedScaledDotProductAttentionDecodeOp(
 
   std::optional<float> scale = op->scale();
   std::optional<uint32_t> slidingWindowSize = op->sliding_window_size();
-  auto computeGrid = query.device()->compute_with_storage_grid_size();
-  if (op->core_grid()) {
-    computeGrid = ::tt::runtime::ttnn::utils::toTTNNCoreCoord(*op->core_grid());
-  }
+  const auto computeGrid = query.device()->compute_with_storage_grid_size();
 
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       programConfig = std::nullopt;
@@ -62,12 +59,6 @@ static void runPagedScaledDotProductAttentionDecodeOp(
     programConfig->compute_with_storage_grid_size = computeGrid;
     programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
     programConfig->exp_approx_mode = false;
-  } else if (op->core_grid()) {
-    programConfig.emplace();
-    programConfig->q_chunk_size = 0;
-    programConfig->k_chunk_size = 0;
-    programConfig->compute_with_storage_grid_size = computeGrid;
-    programConfig->max_cores_per_head_batch = computeGrid.x * computeGrid.y;
   }
 
   ::ttnn::Tensor out =

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6581,7 +6581,7 @@ protected:
             valueShape, valueLayout, pageTableShape, pageTableLayout, isCausal,
             attentionMaskShape, attentionMaskLayout, curPosTensorShape,
             curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
-            slidingWindowSize, /*coreGrid=*/std::nullopt, outputLayout);
+            slidingWindowSize, outputLayout);
 
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2173,8 +2173,7 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
           /*attention_sink=*/nullptr,
           /*scale=*/builder.getF32FloatAttr(0.125f),
           /*sliding_window_size=*/nullptr,
-          /*memory_config=*/nullptr,
-          /*core_grid=*/nullptr);
+          /*memory_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(


### PR DESCRIPTION
This reverts commit 02af1682d6bb054489a03c542467e0e641c1a8cd.

### Problem description
This workaround is no longer needed as the issue got fixed in metal https://github.com/tenstorrent/tt-metal/pull/43020 and uplifted to TT-mlir.

### What's changed
Reverted the commit that inserted the workaround and patched the conflicts.
