### PR TITLE
[OpModel] Fix Y/X order in isLayoutLegalForTensorShape

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -550,9 +550,13 @@ bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
   // we return false.
   try {
     auto tensorSpec = conversion::getTensorSpec(tensorShape, layout);
+    // GridAttr.getShape() returns [Y, X] (rows, cols) per createWorkerGrid
+    // convention; CoreCoord(x, y) takes X first.  Pass shape[1]=X to .x and
+    // shape[0]=Y to .y so the validate's worker rectangle has the right
+    // extent on non-square chips (e.g., Blackhole 10x11).
     auto computeGridSize = ::tt::tt_metal::CoreCoord{
-        static_cast<std::size_t>(maxGrid.getShape()[0]),
-        static_cast<std::size_t>(maxGrid.getShape()[1])};
+        static_cast<std::size_t>(maxGrid.getShape()[1]),
+        static_cast<std::size_t>(maxGrid.getShape()[0])};
     return conversion::validateTensorSpec(tensorSpec, computeGridSize);
   } catch (const std::exception &e) {
     return false;


### PR DESCRIPTION
### Bug

GridAttr.getShape() returns [Y, X] (rows, cols) per the createWorkerGrid convention, while ::tt::tt_metal::CoreCoord{x, y} takes X first.  The old code passed shape[0]=Y as .x and shape[1]=X as .y, producing a transposed worker rectangle on non-square chips.  

### Changes 

Swap to {shape[1], shape[0]} so .x = cols and .y = rows.  

