### PR TITLE
SDPADecode rules

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include <vector>
 
@@ -16,6 +17,15 @@ namespace mlir::tt::ttnn::layout_filter_utils {
 inline bool rejectAllSharded(TTNNLayoutAttr layout) {
   auto ml = layout.getMemLayout();
   return !(ml && isShardedMemoryLayout(ml.getValue()));
+}
+
+/// Require DRAM-interleaved: reject sharded and L1 layouts.
+inline bool requireDRAMInterleaved(TTNNLayoutAttr layout) {
+  auto ml = layout.getMemLayout();
+  if (ml && isShardedMemoryLayout(ml.getValue())) {
+    return false;
+  }
+  return isDRAMBufferType(layout.getBufferType());
 }
 
 /// Reject width-sharded layouts. Returns true if the layout should be kept.

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -28,6 +28,19 @@ inline bool requireDRAMInterleaved(TTNNLayoutAttr layout) {
   return isDRAMBufferType(layout.getBufferType());
 }
 
+/// Reject L1-interleaved: keep DRAM (any) and L1-sharded, reject
+/// L1-interleaved. Used for inputs whose kernel requires DRAM when not sharded
+/// (e.g. Q in sdpa_decode: "Q tensor buffer type must be DRAM when not
+/// sharded").
+inline bool rejectL1Interleaved(TTNNLayoutAttr layout) {
+  auto ml = layout.getMemLayout();
+  bool isSharded = ml && isShardedMemoryLayout(ml.getValue());
+  if (isSharded) {
+    return true;
+  }
+  return isDRAMBufferType(layout.getBufferType());
+}
+
 /// Reject width-sharded layouts. Returns true if the layout should be kept.
 inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   auto ml = layout.getMemLayout();

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -45,6 +45,17 @@ struct SDPARuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// ScaledDotProductAttentionDecodeOp / PagedScaledDotProductAttentionDecodeOp:
+/// Like SDPARuleBook, but also rejects sharded inputs.
+/// tt-metal sdpa_decode_device_operation validates that K and V (and all
+/// inputs after Q) reside in DRAM.  The OpModel bypasses this check because
+/// mock tensors in NO_DISPATCH mode lack real device buffers, so without an
+/// explicit input layout filter the optimizer can assign V=L1-block-sharded,
+/// which then fails the TTNN verifier (keyType != valueType).
+struct SDPADecodeRuleBook : SDPARuleBook {
+  LayoutFilterFn getInputLayoutFilter() const override;
+};
+
 /// RotaryEmbedding / RotaryEmbeddingLlama:
 /// NULL hint only, no reshards. Rejects width-sharded and block-sharded
 /// inputs (only height-sharded or interleaved accepted).

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -53,7 +53,7 @@ struct SDPARuleBook : OpRuleBook {
 /// explicit input layout filter the optimizer can assign V=L1-block-sharded,
 /// which then fails the TTNN verifier (keyType != valueType).
 struct SDPADecodeRuleBook : SDPARuleBook {
-  LayoutFilterFn getInputLayoutFilter() const override;
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
 /// RotaryEmbedding / RotaryEmbeddingLlama:

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -46,12 +46,10 @@ struct SDPARuleBook : OpRuleBook {
 };
 
 /// ScaledDotProductAttentionDecodeOp / PagedScaledDotProductAttentionDecodeOp:
-/// Like SDPARuleBook, but also rejects sharded inputs.
-/// tt-metal sdpa_decode_device_operation validates that K and V (and all
-/// inputs after Q) reside in DRAM.  The OpModel bypasses this check because
-/// mock tensors in NO_DISPATCH mode lack real device buffers, so without an
-/// explicit input layout filter the optimizer can assign V=L1-block-sharded,
-/// which then fails the TTNN verifier (keyType != valueType).
+/// Per-operand input layout filtering.
+/// - Q (operand 0): DRAM (any) or L1-sharded -- L1-interleaved rejected
+///   ("Q tensor buffer type must be DRAM when not sharded").
+/// - K, V, and cache tensors (operand >= 1): DRAM-interleaved only.
 struct SDPADecodeRuleBook : SDPARuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -566,6 +566,21 @@ MemoryLayoutPropagation::processOp(Operation *op) {
       fallback.configHint = OpConfig(dramLayout);
       fallback.score = LayoutScore(); // Lowest possible score.
       fallback.outputLayouts.assign(op->getNumResults(), dramLayout);
+      // When all tryHint calls fail (e.g. op model unavailable in NO_DISPATCH
+      // mode) we fall through to this synthetic candidate. It carries no
+      // producerCandidateIndices, so downstream phases implicitly assume the
+      // producer's slot-0 output is in use.  Mirror that assumption here:
+      // propagate the slot-0 forced reshard intent from the input filters
+      // (set by applyInputLayoutFilter) so insertReshardOp still emits the
+      // to_memory_config the op requires (e.g. K/V must be DRAM for
+      // paged_sdpa_decode). insertReshardOp's no-op check handles the case
+      // where the producer's actual output already matches.
+      for (size_t i = 0; i < inputCandidateSets.size(); ++i) {
+        if (!inputCandidateSets[i].empty() &&
+            inputCandidateSets[i][0].isReshard) {
+          fallback.reshardLayouts[i] = inputCandidateSets[i][0].layout;
+        }
+      }
       candidates.push_back(std::move(fallback));
     }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -71,6 +71,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PadRuleBook pad;
   static ConcatenateHeadsRuleBook concatHeads;
   static SDPARuleBook sdpa;
+  static SDPADecodeRuleBook sdpaDecode;
   static EmbeddingRuleBook embedding;
   static TypecastRuleBook typecast;
   static RotaryEmbeddingRuleBook rotaryEmbedding;
@@ -98,9 +99,9 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PadOp::getOperationName(), &pad);
     reg(ConcatenateHeadsOp::getOperationName(), &concatHeads);
     reg(NLPConcatHeadsDecodeOp::getOperationName(), &sdpa);
-    reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpa);
-    reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(), &sdpa);
     reg(ScaledDotProductAttentionOp::getOperationName(), &sdpa);
+    reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
+    reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
     reg(EmbeddingOp::getOperationName(), &embedding);
     reg(TypecastOp::getOperationName(), &typecast);
     reg(WhereOp::getOperationName(), &typecast);

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -101,7 +101,8 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(NLPConcatHeadsDecodeOp::getOperationName(), &sdpa);
     reg(ScaledDotProductAttentionOp::getOperationName(), &sdpa);
     reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
-    reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
+    reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(),
+        &sdpaDecode);
     reg(EmbeddingOp::getOperationName(), &embedding);
     reg(TypecastOp::getOperationName(), &typecast);
     reg(WhereOp::getOperationName(), &typecast);

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -47,6 +47,15 @@ OutputHints SDPARuleBook::getOutputHints(
 }
 
 //===----------------------------------------------------------------------===//
+// SDPADecodeRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn SDPADecodeRuleBook::getInputLayoutFilter() const {
+  // K, V, and cache tensors must be DRAM-interleaved.
+  return layout_filter_utils::requireDRAMInterleaved;
+}
+
+//===----------------------------------------------------------------------===//
 // RotaryEmbeddingRuleBook
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -50,8 +50,12 @@ OutputHints SDPARuleBook::getOutputHints(
 // SDPADecodeRuleBook
 //===----------------------------------------------------------------------===//
 
-LayoutFilterFn SDPADecodeRuleBook::getInputLayoutFilter() const {
-  // K, V, and cache tensors must be DRAM-interleaved.
+LayoutFilterFn SDPADecodeRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Q (operand 0) is unrestricted; K, V, and cache tensors must be
+  // DRAM-interleaved.
+  if (operandIdx == 0) {
+    return nullptr;
+  }
   return layout_filter_utils::requireDRAMInterleaved;
 }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -50,11 +50,13 @@ OutputHints SDPARuleBook::getOutputHints(
 // SDPADecodeRuleBook
 //===----------------------------------------------------------------------===//
 
-LayoutFilterFn SDPADecodeRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
-  // Q (operand 0) is unrestricted; K, V, and cache tensors must be
-  // DRAM-interleaved.
+LayoutFilterFn
+SDPADecodeRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Q (operand 0): kernel asserts "Q tensor buffer type must be DRAM when
+  // not sharded" -- accept DRAM (any) or L1-sharded; reject L1-interleaved.
+  // K, V, and cache tensors (operand >= 1): must be DRAM-interleaved.
   if (operandIdx == 0) {
-    return nullptr;
+    return layout_filter_utils::rejectL1Interleaved;
   }
   return layout_filter_utils::requireDRAMInterleaved;
 }


### PR DESCRIPTION
### Changes

sdpa_decode requires K, V, and cache tensors to be DRAM-interleaved. Add SDPADecodeRuleBook with getInputLayoutFilter()
returning requireDRAMInterleaved (rejects sharded and L1 layouts), and register it for `ScaledDotProductAttentionDecodeOp` and `PagedScaledDotProductAttentionDecodeOp`.