### PR TITLE
[d2m] unpack_stall_on_pack_init

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -42,6 +42,17 @@ def TTKernel_ComputeKernelHWStartupOp : TTKernel_InitOp<"compute_kernel_hw_start
 // TTKernel Register operations
 //===----------------------------------------------------------------------===//
 
+def TTKernel_UnpackStallOnPackInitOp
+    : TTKernel_InitOp<"experimental::unpack_stall_on_pack_init"> {
+  let summary = "Initialize the PACK_DONE semaphore for unpack_stall_on_pack.";
+  let description = [{
+    Initializes the hardware semaphore used by unpack_stall_on_pack. This is a
+    one-time compute-kernel setup operation; individual unpack_stall_on_pack
+    calls only post and wait on the semaphore.
+  }];
+  let assemblyFormat = [{ attr-dict }];
+}
+
 def TTKernel_UnpackStallOnPackOp
     : TTKernel_Op<"experimental::unpack_stall_on_pack"> {
   let summary = "Stall UNPACK thread until previous PACK write is committed to L1.";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -47,8 +47,7 @@ def TTKernel_UnpackStallOnPackInitOp
   let summary = "Initialize the PACK_DONE semaphore for unpack_stall_on_pack.";
   let description = [{
     Initializes the hardware semaphore used by unpack_stall_on_pack. This is a
-    one-time compute-kernel setup operation; individual unpack_stall_on_pack
-    calls only post and wait on the semaphore.
+    one-time compute-kernel setup operation.
   }];
   let assemblyFormat = [{ attr-dict }];
 }

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
@@ -7,6 +7,12 @@
 
 namespace experimental {
 
+// Initializes the PACK_DONE semaphore used by unpack_stall_on_pack. This should
+// run once at compute kernel startup, not at every synchronization point.
+ALWI void unpack_stall_on_pack_init() {
+  PACK(t6_semaphore_init(semaphore::PACK_DONE, 0, 1));
+}
+
 // Stalls the UNPACK thread until the previous PACK cycle's write is
 // committed to L1. Call this before unpacking data that was just packed
 // by the previous linalg.generic to guarantee L1 read-after-write ordering.

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
@@ -8,7 +8,7 @@
 namespace experimental {
 
 // Initializes the PACK_DONE semaphore used by unpack_stall_on_pack. This should
-// run once at compute kernel startup, not at every synchronization point.
+// run once at compute kernel startup.
 ALWI void unpack_stall_on_pack_init() {
   PACK(t6_semaphore_init(semaphore::PACK_DONE, 0, 1));
 }
@@ -17,7 +17,6 @@ ALWI void unpack_stall_on_pack_init() {
 // committed to L1. Call this before unpacking data that was just packed
 // by the previous linalg.generic to guarantee L1 read-after-write ordering.
 ALWI void unpack_stall_on_pack() {
-  PACK(t6_semaphore_init(semaphore::PACK_DONE, 0, 1));
   PACK(t6_semaphore_post<>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_get<>(semaphore::PACK_DONE));

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -433,6 +433,12 @@ static bool hasMatmulInit(func::FuncOp func) {
   });
 }
 
+static bool hasUnpackStallOnPackInit(func::FuncOp func) {
+  return llvm::any_of(func.getBody().front(), [](Operation &op) {
+    return isa<ttkernel::UnpackStallOnPackInitOp>(op);
+  });
+}
+
 } // namespace
 
 namespace {
@@ -514,6 +520,13 @@ public:
   LogicalResult
   matchAndRewrite(d2m::UnpackStallOnPackOp op, d2m::UnpackStallOnPackOpAdaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    if (auto func = op->getParentOfType<func::FuncOp>();
+        func && !hasUnpackStallOnPackInit(func)) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      setInsertionPointToFuncStart(rewriter, func, op);
+      rewriter.create<ttkernel::UnpackStallOnPackInitOp>(op.getLoc());
+    }
+
     rewriter.replaceOpWithNewOp<ttkernel::UnpackStallOnPackOp>(op);
     return success();
   }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -1340,6 +1340,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocSemaphoreSetMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<
             ttkernel::NocSemaphoreSetMulticastLoopbackOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::UnpackStallOnPackInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::UnpackStallOnPackOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsAcquireOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::TileRegsCommitOp>,

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -104,7 +104,8 @@ public:
       }
 
       // Our experimental kernel code snippets.
-      if (callee == "experimental::unpack_stall_on_pack") {
+      if (callee == "experimental::unpack_stall_on_pack_init" ||
+          callee == "experimental::unpack_stall_on_pack") {
         emitLlk(experimental_reg_api_generated,
                 experimental_reg_api_generated_len);
       }

--- a/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/semaphores.mlir
@@ -71,4 +71,17 @@ module {
     return
   }
 
+  // unpack_stall_on_pack initializes PACK_DONE once per compute kernel.
+  func.func private @unpack_stall_on_pack() attributes {d2m.thread = #d2m.thread<compute>} {
+    d2m.unpack_stall_on_pack
+    d2m.unpack_stall_on_pack
+    // CHECK-LABEL: func.func private @unpack_stall_on_pack
+    // CHECK: ttkernel.experimental::unpack_stall_on_pack_init
+    // CHECK: ttkernel.experimental::unpack_stall_on_pack
+    // CHECK-NOT: ttkernel.experimental::unpack_stall_on_pack_init
+    // CHECK: ttkernel.experimental::unpack_stall_on_pack
+    // CHECK: return
+    return
+  }
+
 }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1806,6 +1806,13 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @unpack_stall_on_pack_init
+    func.func @unpack_stall_on_pack_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.call_opaque "experimental::unpack_stall_on_pack_init"()
+      "ttkernel.experimental::unpack_stall_on_pack_init"() : () -> ()
+      return
+    }
+
     // CHECK-LABEL: func @noc_semaphore_set_multicast
     func.func @noc_semaphore_set_multicast() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"


### PR DESCRIPTION
### Ticket
#8144 

### What's changed
Moved `PACK_DONE` semaphore initialization out of `experimental::unpack_stall_on_pack()`.

Added `experimental::unpack_stall_on_pack_init()` plus a corresponding `ttkernel.experimental::unpack_stall_on_pack_init` op, inserted once per compute kernel during D2MToTTKernel lowering. The stall LLK now only performs the per-use post/wait/get synchronization, avoiding repeated semaphore initialization.