### PR TITLE
[TTNN] Fixing encoing incorrect shard shape

### DIFF
--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/Optimizer.cpp
@@ -854,10 +854,16 @@ private:
       TTNNLayoutAttr layoutAttr =
           mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
 
-      // Create a new tensor type with DRAM layout.
+      // Create a new tensor type with DRAM layout. The trailing
+      // .withTensorShape(...) reruns TTNNLayoutAttr::get(tensorShape, ...)
+      // so the memref shard shape is recomputed under the new (bufferType,
+      // memLayout) rather than carrying over the source layout's shard
+      // shape — see calculateLogicalShardShapeForL1Interleaved /
+      // calculateLogicalShardShapeForSharding (TTNNOpsAttrs.cpp).
       TTNNLayoutAttr dramLayout =
           layoutAttr.withBufferType(BufferType::DRAM)
-              .withMemoryLayout(TensorMemoryLayout::Interleaved);
+              .withMemoryLayout(TensorMemoryLayout::Interleaved)
+              .withTensorShape(tensorShape);
       RankedTensorType newTensorType = RankedTensorType::get(
           tensorShape, tensorType.getElementType(), dramLayout);
 
@@ -970,9 +976,16 @@ private:
       TTNNLayoutAttr layoutAttr =
           mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
 
+      // .withTensorShape(...) re-canonicalizes the memref shard shape
+      // through TTNNLayoutAttr::get(tensorShape, ...). For L1 + Interleaved
+      // + RowMajor on a 1x1 grid this produces the canonical
+      // <1 x tensorVolume> form, not the source layout's shape
+      // (which withBufferType / withMemoryLayout would otherwise preserve
+      // verbatim and leave non-canonical).
       TTNNLayoutAttr l1InterleavedLayout =
           layoutAttr.withBufferType(BufferType::L1)
-              .withMemoryLayout(TensorMemoryLayout::Interleaved);
+              .withMemoryLayout(TensorMemoryLayout::Interleaved)
+              .withTensorShape(tensorType.getShape());
       RankedTensorType newTensorType = RankedTensorType::get(
           tensorType.getShape(), tensorType.getElementType(),
           l1InterleavedLayout);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -173,13 +173,17 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
       mlir::cast<RankedTensorType>(opResult.getType());
 
   // Create the new output layout attribute with the updated tensor layout,
-  // buffer type, memory layout and data type.
+  // buffer type, memory layout and data type. Trailing .withTensorShape(...)
+  // re-canonicalizes the memref shard shape under the new (bufferType,
+  // memLayout) — see createToLayoutOp in TransformUtils.cpp for the same
+  // pattern and rationale.
   TTNNLayoutAttr newOutputLayoutAttr =
       opResultLayoutAttr.withElementType(elementType, opResultType.getShape())
           .withBufferType(
               outputWorkaroundResults.tensorBufferTypeResult.targetValue)
           .withMemoryLayout(
-              outputWorkaroundResults.tensorMemoryLayoutResult.targetValue);
+              outputWorkaroundResults.tensorMemoryLayoutResult.targetValue)
+          .withTensorShape(opResultType.getShape());
 
   // Create the new output result type with the updated data type and layout.
   RankedTensorType newOutputResultType = utils::RankedTensorTypeFactory::create(

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -84,12 +84,21 @@ ToLayoutOp createToLayoutOp(Operation *op,
   // Get the input operand type.
   RankedTensorType inputToLayoutOpType = inputValue.getType();
 
-  // Create the new encoding for the output tensor type.
+  // Create the new encoding for the output tensor type. The trailing
+  // .withTensorShape(...) re-runs TTNNLayoutAttr::get(tensorShape, ...) under
+  // the new (bufferType, memLayout) so the memref shard shape is recomputed
+  // (e.g. L1 + Interleaved + RowMajor flattens to
+  // <1 x tensorVolume / numCores>). Without this re-canonicalization the
+  // bare withBufferType / withMemoryLayout chain preserves the prior
+  // layout's shard shape verbatim and produces a non-canonical encoding,
+  // which later fails verification when downstream passes (e.g.
+  // TTNNDecomposeLayouts) rebuild the type via the canonical path.
   TTNNLayoutAttr toLayoutOpResultEncoding =
       inputLayoutAttr
           .withElementType(elementType, inputToLayoutOpType.getShape())
           .withBufferType(targetTensorBufferType)
-          .withMemoryLayout(targetTensorMemoryLayout);
+          .withMemoryLayout(targetTensorMemoryLayout)
+          .withTensorShape(inputToLayoutOpType.getShape());
 
   // Override the grid when a custom target grid is specified.
   if (targetGrid) {

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/to_layout_canonical_l1_interleaved.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/to_layout_canonical_l1_interleaved.mlir
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround -o %t %s --mlir-print-local-scope
+// RUN: FileCheck %s --input-file=%t
+
+// Regression test: when an input-operand workaround flips a tensor from DRAM
+// Interleaved RowMajor to L1 Interleaved RowMajor, the inserted ttnn.to_layout
+// op's result encoding must use the canonical L1-Interleaved memref form
+// (calculateLogicalShardShapeForL1Interleaved -> <1 x tensorVolume / numCores>),
+// not the source layout's shard shape.
+//
+// Without canonicalization the encoding ends up as memref<32x128xbf16, l1>
+// (preserved from source); downstream passes (TTNNDecomposeLayouts)
+// then rebuild the type via the canonical path and produce <1x4096xbf16, l1>,
+// causing function-return verifier failures on const-eval functions.
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+// DRAM Interleaved layouts (canonical: memref shape == tensor shape on 1x1 grid).
+#dram_input  = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<32x128xbf16, #dram>, <interleaved>>
+#dram_idx    = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<32x4xui16, #dram>, <interleaved>>
+#dram_score  = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<32x4xbf16, #dram>, <interleaved>>
+#dram_map    = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x4xui16, #dram>, <interleaved>>
+
+#dram_disp_out = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x128xbf16, #dram>, <interleaved>>
+#dram_idx_out  = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x4xui16, #dram>, <interleaved>>
+#dram_sc_out   = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x4xbf16, #dram>, <interleaved>>
+
+module attributes {} {
+  // CHECK-LABEL: func.func @dispatch_metadata_l1_canonical_form
+
+  // input_tensor: 32 x 128 = 4096 -> memref<1x4096xbf16, l1>
+  // CHECK: "ttnn.to_layout"
+  // CHECK-SAME: memory_config = #ttnn.memory_config<<l1>, <interleaved>>
+  // CHECK-SAME: -> tensor<{{.*}}xbf16, #ttnn.ttnn_layout<{{.*}} memref<1x4096xbf16, #ttnn.buffer_type<l1>>, <interleaved>>>
+
+  // expert_indices: 32 x 4 = 128 -> memref<1x128xui16, l1>
+  // CHECK: "ttnn.to_layout"
+  // CHECK-SAME: memory_config = #ttnn.memory_config<<l1>, <interleaved>>
+  // CHECK-SAME: -> tensor<{{.*}}xui16, #ttnn.ttnn_layout<{{.*}} memref<1x128xui16, #ttnn.buffer_type<l1>>, <interleaved>>>
+
+  // expert_scores: 32 x 4 = 128 -> memref<1x128xbf16, l1>
+  // CHECK: "ttnn.to_layout"
+  // CHECK-SAME: memory_config = #ttnn.memory_config<<l1>, <interleaved>>
+  // CHECK-SAME: -> tensor<{{.*}}xbf16, #ttnn.ttnn_layout<{{.*}} memref<1x128xbf16, #ttnn.buffer_type<l1>>, <interleaved>>>
+  func.func @dispatch_metadata_l1_canonical_form(
+      %input:   tensor<1x1x32x128xbf16, #dram_input>,
+      %indices: tensor<1x1x32x4xui16, #dram_idx>,
+      %scores:  tensor<1x1x32x4xbf16, #dram_score>,
+      %mapping: tensor<8x4xui16, #dram_map>
+  ) -> (tensor<1x32x128xbf16, #dram_disp_out>,
+        tensor<1x32x4xui16, #dram_idx_out>,
+        tensor<1x32x4xbf16, #dram_sc_out>) {
+    %disp, %idx, %sc = "ttnn.all_to_all_dispatch_metadata"(%input, %indices, %scores, %mapping)
+        <{cluster_axis = 0 : i64, num_devices = 1 : i64}>
+        : (tensor<1x1x32x128xbf16, #dram_input>,
+           tensor<1x1x32x4xui16, #dram_idx>,
+           tensor<1x1x32x4xbf16, #dram_score>,
+           tensor<8x4xui16, #dram_map>)
+        -> (tensor<1x32x128xbf16, #dram_disp_out>,
+            tensor<1x32x4xui16, #dram_idx_out>,
+            tensor<1x32x4xbf16, #dram_sc_out>)
+    return %disp, %idx, %sc : tensor<1x32x128xbf16, #dram_disp_out>,
+                              tensor<1x32x4xui16, #dram_idx_out>,
+                              tensor<1x32x4xbf16, #dram_sc_out>
+  }
+}


### PR DESCRIPTION
Issue #8169.

This PR fixes 4 callsites where encoding was or possibly could be generated with incorrect shard shape. This can happen when source encoding (DRAM, Interleaved) is changed into target (L1, Interleaved) using `with` builder from `TTNNLayout` where shard shape is simply copied from source encoding instead of recomputed.


closes #8169