### PR TITLE
Workaround ttnn.embedding via pad+slice on the hidden dim

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPPADHIDDENDIMREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPPADHIDDENDIMREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Workaround for a ttnn.embedding miscompile.
+//
+// Empirical sweep on Blackhole (vocab=256, seq_len=64, bf16 weight,
+// TILE_LAYOUT, DRAM) over ~160 tile_count values found:
+//
+//   raw ttnn.embedding PASSes iff
+//       hidden_dim < 8192   OR   hidden_dim % 2048 == 0
+//
+// Anything else (e.g. Gemma-4 per-layer embedding D=10752, also seen at
+// D=8320, 8704, 9216, 10752, 11008, ...) returns near-uncorrelated output
+// (PCC ~ 0.02 vs torch.nn.functional.embedding).
+//
+// As a temporary workaround this pattern pads the weight's last dim up to
+// the next multiple of 2048 (always in the known-good region for dims
+// >= 8192), runs ttnn.embedding on the padded weight, then slices the
+// output back to the original hidden dim. The proper fix belongs in
+// tt-metal's ttnn::embedding kernel; this rewrite is intended to be
+// removed once that fix lands.
+class EmbeddingOpPadHiddenDimRewritePattern
+    : public OpRewritePattern<ttnn::EmbeddingOp> {
+public:
+  using OpRewritePattern<ttnn::EmbeddingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::EmbeddingOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPPADHIDDENDIMREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/PointToPointOpRewritePattern.cpp
         Workarounds/Decomposition/SplitQueryKeyValueAndSplitHeadsOpRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
+        Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.cpp
         Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.cpp
         Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.cpp
         Workarounds/Decomposition/LinearOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+namespace {
+
+// TT-Metal Issue : https://github.com/tenstorrent/tt-metal/issues/43567
+// True when the embedding hidden dim falls in the regression-prone region.
+//
+// Empirical sweep on a single Blackhole chip (vocab=256, seq_len=64, bf16
+// weight, TILE_LAYOUT, DRAM) over ~160 tile_count values found a clean
+// rule for the raw ttnn.embedding op:
+//
+//   PASS iff  hiddenDim < 8192  OR  hiddenDim % 2048 == 0
+//
+// equivalently in tile_count units (= hiddenDim / 32):
+//
+//   PASS iff  tile_count < 256  OR  tile_count % 64 == 0
+//
+// Below 256 tiles every value tested passed regardless of factorization;
+// at and above 256 only multiples of 64 (320, 384, 448, 512, 576, ...)
+// pass while everything else fails with PCC ~ 0.02.
+//
+// The padding strategy in matchAndRewrite rounds the hidden dim up to
+// the next multiple of 2048, which is always in the "safe" set above
+// 8192. The proper fix belongs in tt-metal's ttnn::embedding kernel; this
+// rewrite is intended to be removed once that fix lands.
+constexpr int64_t kSafeBelowHiddenDim = 8192;
+constexpr int64_t kHiddenDimSafeMultiple = 2048;
+
+bool isBadEmbeddingHiddenDim(int64_t hiddenDim) {
+  if (hiddenDim <= 0 || hiddenDim % 32 != 0) {
+    return false;
+  }
+  if (hiddenDim < kSafeBelowHiddenDim) {
+    return false;
+  }
+  return (hiddenDim % kHiddenDimSafeMultiple) != 0;
+}
+
+// Rounds the hidden dim up to the next multiple of `kHiddenDimSafeMultiple`
+// (= 2048 = 64 tiles), which is in the known-good region for hidden dims
+// >= kSafeBelowHiddenDim.
+int64_t nextSafeHiddenDim(int64_t hiddenDim) {
+  return ((hiddenDim + kHiddenDimSafeMultiple - 1) / kHiddenDimSafeMultiple) *
+         kHiddenDimSafeMultiple;
+}
+
+} // namespace
+
+LogicalResult EmbeddingOpPadHiddenDimRewritePattern::matchAndRewrite(
+    ttnn::EmbeddingOp srcOp, PatternRewriter &rewriter) const {
+  auto weight =
+      mlir::cast<mlir::TypedValue<mlir::RankedTensorType>>(srcOp.getWeight());
+  mlir::RankedTensorType weightType = weight.getType();
+  llvm::ArrayRef<int64_t> weightShape = weightType.getShape();
+  int64_t hiddenDim = weightShape.back();
+
+  if (!isBadEmbeddingHiddenDim(hiddenDim)) {
+    return failure();
+  }
+
+  // The slice that restores the original hidden dim needs static
+  // begins/ends, so bail out if the embedding result has any dynamic dim.
+  mlir::RankedTensorType origResultType = srcOp.getResult().getType();
+  llvm::ArrayRef<int64_t> origResultShape = origResultType.getShape();
+  if (llvm::any_of(origResultShape, mlir::ShapedType::isDynamic)) {
+    return failure();
+  }
+
+  int64_t paddedHiddenDim = nextSafeHiddenDim(hiddenDim);
+  int64_t padAmount = paddedHiddenDim - hiddenDim;
+  // padAmount is bounded by kHiddenDimSafeMultiple - 1 by construction,
+  // so it always fits in i32.
+  assert(padAmount > 0 && padAmount < kHiddenDimSafeMultiple &&
+         "padAmount must be in (0, kHiddenDimSafeMultiple)");
+
+  mlir::Location loc = srcOp.getLoc();
+
+  // Build pad spec [low_0, high_0, low_1, high_1, ...] padding only the
+  // last (hidden) dim on the high side.
+  size_t weightRank = weightShape.size();
+  llvm::SmallVector<int32_t> padding(weightRank * 2, 0);
+  padding[weightRank * 2 - 1] = static_cast<int32_t>(padAmount);
+
+  ttnn::PadOp paddedWeight = ttir_to_ttnn::utils::generatePad(
+      weight, padding, rewriter,
+      ttmlir::utils::appendLocationSuffix(loc, "_pad_weight"));
+
+  // Build the result type for the embedding on the padded weight: same
+  // leading shape as the original result, padded last dim.
+  llvm::SmallVector<int64_t> paddedResultShape(origResultShape.begin(),
+                                               origResultShape.end());
+  paddedResultShape.back() = paddedHiddenDim;
+  mlir::RankedTensorType paddedResultType =
+      ttnn::utils::RankedTensorTypeFactory::create(origResultType,
+                                                   paddedResultShape);
+
+  auto paddedEmbedding = rewriter.create<ttnn::EmbeddingOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_padded"), paddedResultType,
+      srcOp.getInput(), paddedWeight.getResult());
+
+  // Slice the padded output back to the original hidden dim.
+  llvm::SmallVector<int32_t> begins(origResultShape.size(), 0);
+  llvm::SmallVector<int32_t> ends;
+  ends.reserve(origResultShape.size());
+  for (int64_t s : origResultShape) {
+    ends.push_back(static_cast<int32_t>(s));
+  }
+  llvm::SmallVector<int32_t> step(origResultShape.size(), 1);
+
+  rewriter.replaceOpWithNewOp<ttnn::SliceStaticOp>(
+      srcOp, origResultType, paddedEmbedding.getResult(),
+      rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
+      rewriter.getI32ArrayAttr(step));
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dEnableKernelStrideFoldingRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/Conv2dRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpPadHiddenDimRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpOutputShapeRewritePattern.h"
@@ -615,6 +616,7 @@ public:
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,
           workarounds::decomposition::EmbeddingOpSqueezeWeightRewritePattern,
+          workarounds::decomposition::EmbeddingOpPadHiddenDimRewritePattern,
           workarounds::decomposition::GroupNormAffineReshapeRewritePattern,
           workarounds::decomposition::ArgMaxOpDimRewritePattern,
           workarounds::decomposition::UpsampleOpBilinearPaddingRewritePattern,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_pad_hidden_dim_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_pad_hidden_dim_workaround.mlir
@@ -1,0 +1,82 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// EmbeddingOpPadHiddenDimRewritePattern triggers when the weight's last dim
+// is in the regression-prone region:
+//   PASS iff  hidden_dim < 8192  OR  hidden_dim % 2048 == 0
+// On a hit, the weight is high-padded on the last dim up to the next
+// multiple of 2048, ttnn.embedding runs on the padded weight, and the
+// result is sliced back to the original hidden dim.
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_input = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!ttcore.tile<32x32, u32>, #dram>, <interleaved>>
+
+// Bad case: D=10752, tile_count=336. Pads to 12288 (=6*2048, tile_count=384).
+#ttnn_layout_weight_bad = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x336x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_result_bad = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x336x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Good case (large): D=10240, tile_count=320. Multiple of 2048 already; no rewrite.
+#ttnn_layout_weight_large_ok = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x320x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_result_large_ok = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x320x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// Good case (small): D=2560, tile_count=80. Below the 8192 threshold; no
+// rewrite even though tile_count is non-pow2.
+#ttnn_layout_weight_small_ok = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x80x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_result_small_ok = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x80x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module attributes {} {
+  // Bad case: rewrite expected.
+  // CHECK-LABEL: func.func @bad_d10752
+  func.func @bad_d10752(
+      %arg0: tensor<1x64xui32, #ttnn_layout_input>,
+      %arg1: tensor<256x10752xbf16, #ttnn_layout_weight_bad>)
+      -> tensor<1x64x10752xbf16, #ttnn_layout_result_bad> {
+    // Weight is high-padded by 1536 on the last dim up to 12288, the
+    // embedding runs on the padded weight, and the result is sliced back
+    // to 10752 on the last dim. Layout-conversion ops ("ttnn.to_layout")
+    // can sit between these in any order, so we only check that each step
+    // is present with the right attribute / shape.
+    // CHECK: ttnn.pad
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 1536>
+    // CHECK-SAME: -> tensor<256x12288xbf16
+    // CHECK: ttnn.embedding
+    // CHECK-SAME: -> tensor<1x64x12288xbf16
+    // CHECK: ttnn.slice_static
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 64 : i32, 10752 : i32]
+    // CHECK-SAME: step = [1 : i32, 1 : i32, 1 : i32]
+    // CHECK-SAME: -> tensor<1x64x10752xbf16
+    %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<1x64xui32, #ttnn_layout_input>, tensor<256x10752xbf16, #ttnn_layout_weight_bad>) -> tensor<1x64x10752xbf16, #ttnn_layout_result_bad>
+    return %0 : tensor<1x64x10752xbf16, #ttnn_layout_result_bad>
+  }
+
+  // Good case (large, multiple of 2048): pattern must NOT fire.
+  // CHECK-LABEL: func.func @good_d10240_multiple_of_2048
+  func.func @good_d10240_multiple_of_2048(
+      %arg0: tensor<1x64xui32, #ttnn_layout_input>,
+      %arg1: tensor<256x10240xbf16, #ttnn_layout_weight_large_ok>)
+      -> tensor<1x64x10240xbf16, #ttnn_layout_result_large_ok> {
+    // CHECK-NOT: ttnn.pad
+    // CHECK-NOT: ttnn.slice_static
+    // CHECK: ttnn.embedding
+    // CHECK-SAME: -> tensor<1x64x10240xbf16
+    %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<1x64xui32, #ttnn_layout_input>, tensor<256x10240xbf16, #ttnn_layout_weight_large_ok>) -> tensor<1x64x10240xbf16, #ttnn_layout_result_large_ok>
+    return %0 : tensor<1x64x10240xbf16, #ttnn_layout_result_large_ok>
+  }
+
+  // Good case (small, below 8192 threshold): pattern must NOT fire even
+  // though tile_count=80 is non-power-of-two. Below 8192 every shape we
+  // measured passes regardless of factorization.
+  // CHECK-LABEL: func.func @good_d2560_below_threshold
+  func.func @good_d2560_below_threshold(
+      %arg0: tensor<1x64xui32, #ttnn_layout_input>,
+      %arg1: tensor<256x2560xbf16, #ttnn_layout_weight_small_ok>)
+      -> tensor<1x64x2560xbf16, #ttnn_layout_result_small_ok> {
+    // CHECK-NOT: ttnn.pad
+    // CHECK-NOT: ttnn.slice_static
+    // CHECK: ttnn.embedding
+    // CHECK-SAME: -> tensor<1x64x2560xbf16
+    %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<1x64xui32, #ttnn_layout_input>, tensor<256x2560xbf16, #ttnn_layout_weight_small_ok>) -> tensor<1x64x2560xbf16, #ttnn_layout_result_small_ok>
+    return %0 : tensor<1x64x2560xbf16, #ttnn_layout_result_small_ok>
+  }
+}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/43567)

### Problem description
ttnn.embedding produces near-uncorrelated output (PCC ~0.02 vs torch.nn.functional.embedding) for a specific class of weight shapes. An empirical sweep on a singl chip (vocab=256, seq_len=64, bf16 weight, TILE_LAYOUT, DRAM) across ~160 tile_count values gives a clean rule: the op is correct iff hidden_dim < 8192 or hidden_dim % 2048 == 0, and otherwise mis-produces. The rule is invariant to vocab and seq_len in every configuration tested. Tracking issue: tenstorrent/tt-metal#43567.

### What's changed
This adds EmbeddingOpPadHiddenDimRewritePattern to the TTNN decomposition workarounds. On a hit it high-pads the weight's last dim up to the next multiple of 2048 (always in the known-good region above 8192), runs ttnn.embedding on the padded weight, and slices the output back to the original hidden dim. Shapes outside the bad region are left untouched, so for the common case there is zero overhead.

### Checklist
- [ ] New/Existing tests provide coverage for changes
