### PR TITLE
[StableHLOToTTIR] Reject uniform indices in gather→slice/repeat/concat pattern

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5618,6 +5618,13 @@ public:
           srcOp, "Not all indices are present in the original array");
     }
 
+    // Body [0, 1, ..., maxIndex] must be present, i.e. at least one 0 and one
+    // maxIndex. Rejects constant-uniform indices like [1, 1, ..., 1].
+    if (starts == 0 || ends == 0) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "Indices do not contain the body [0, 1, ..., maxIndex]");
+    }
+
     starts--;
     ends--;
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather/gather_to_slice_repeat_concat.mlir
@@ -73,3 +73,17 @@ module @test_gather_repeat_both_multiple {
     return %2 : tensor<1x768x8x60x106xbf16>
   }
 }
+
+// Constant-uniform indices like [1, 1, ..., 1] are not replicate-padding;
+// must fall through to the embedding lowering instead of slice/repeat/concat.
+// CHECK-LABEL: func.func @uniform_max_indices_falls_through
+module @test_gather_uniform_max_indices {
+  func.func @uniform_max_indices_falls_through(%arg0: tensor<2x768xf32>) -> tensor<193x768xf32> {
+    // CHECK-NOT: "ttir.concat"
+    // CHECK: "ttir.embedding"
+    // CHECK-NOT: stablehlo.gather
+    %1 = "stablehlo.constant"() <{value = dense<1> : tensor<193xui32>}> : () -> tensor<193xui32>
+    %2 = "stablehlo.gather"(%arg0, %1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 768>}> : (tensor<2x768xf32>, tensor<193xui32>) -> tensor<193x768xf32>
+    return %2 : tensor<193x768xf32>
+  }
+}


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-mlir/issues/8253

### Problem description

- `StableHLOGatherToSliceRepeatConcatPattern` (`benefit=2`) over-matched gathers with constant-uniform indices like `dense<1> : tensor<193xui32>` (e.g. `nn.Embedding(2, 768)(torch.full_like(mask, 1))` in ViLT's `ViltEmbeddings.forward`). 
- The matcher accepted any sequence ending at `maxIndex`, even when the body `[0, 1, ..., maxIndex]` was absent.
- The rewrite then emitted a malformed `ttir.concat` (output dim `N` vs sum-of-inputs `N+1`), failing SHLO→TTIR with `'ttir.concat' op Output tensor dimension 0 does not match the sum of input tensor dimensions: 193 vs. 194`.

### What's changed

- Tightened the matcher in `lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp` to require both `starts >= 1` and `ends >= 1`, ensuring the body `[0, 1, ..., maxIndex]` is actually present before applying the slice/repeat/concat rewrite. 
- Degenerate constant-uniform indices now fall through to `StableHLOGatherToEmbeddingPattern` (the `ttir.embedding` path), which lowers them correctly. Existing replicate-padding cases (`[0,0,0,1,2,3]`, `[0,1,2,3,3,3]`, etc.) are unaffected since they have at least one leading `0` and one trailing `maxIndex`.

### Checklist
- [x] verify the changes through local testing in N150

### Logs

- [may5_vilt_qa_sanity_before_fix.log](https://github.com/user-attachments/files/27394645/may5_vilt_qa_s1.log)
- [may5_vilt_qa_sanity_after_fix.log](https://github.com/user-attachments/files/27394656/may5_vilt_qa_s_after_fix.log)
