### PR TITLE
[Optimizer] L1 spill: reshape view buffer aliasing

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -37,6 +37,17 @@ struct SumL1MemoryTracker {
 
   uint64_t getOccupiedL1() const;
   void addTensor(Value result, uint64_t l1SizePerCore);
+
+  /// Add a tensor that aliases an existing tensor's address (e.g. a
+  /// `ttnn.reshape` that tt-metal realizes as a zero-copy view). The new
+  /// tensor takes over the source's `tensorAddresses` entry; no `freeList`
+  /// carve happens. The source's `tensorSizes` / `liveValues` lifecycle is
+  /// unchanged — `removeTensor(src)` later becomes a `freeAddress` no-op
+  /// (since src no longer holds the address entry) but still drops src from
+  /// `tensorSizes` / `currentOccupied`.
+  void addTensorAtAddress(Value result, uint64_t l1SizePerCore,
+                          Value srcAtSameAddr);
+
   void removeTensor(Value result);
 
   /// Remove tensor from size tracking only (tensorSizes, currentOccupied).
@@ -84,9 +95,22 @@ struct SumL1MemoryTracker {
   /// Address-only: does not update tensorSizes/currentOccupied.
   void allocateAddress(Value result, uint64_t l1SizePerCore);
 
+  /// Reuse `srcAtSameAddr`'s address slot for `result` (view-style aliasing).
+  /// Moves the `tensorAddresses` entry from src to result; freeList is
+  /// untouched. Address-only: does not update tensorSizes/currentOccupied.
+  void allocateAddressAt(Value result, Value srcAtSameAddr);
+
   /// Free a tensor's address block and merge with adjacent free blocks.
   /// Address-only: does not update tensorSizes/currentOccupied.
   void freeAddress(Value result);
+
+  /// Check whether `result` currently has an entry in `tensorAddresses`
+  /// (i.e. occupies a simulated L1 address slot). Distinct from
+  /// `hasTensor`, which checks `tensorSizes`. The two can disagree after
+  /// `addTensorAtAddress` (src is in sizes but no longer in addresses) or
+  /// during replay (sizes is the original-pass state, addresses is being
+  /// rebuilt).
+  bool hasTensorAddress(Value result) const;
 
 private:
   uint64_t currentOccupied = 0;

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -38,13 +38,18 @@ struct SumL1MemoryTracker {
   uint64_t getOccupiedL1() const;
   void addTensor(Value result, uint64_t l1SizePerCore);
 
-  /// Add a tensor that aliases an existing tensor's address (e.g. a
-  /// `ttnn.reshape` that tt-metal realizes as a zero-copy view). The new
-  /// tensor takes over the source's `tensorAddresses` entry; no `freeList`
-  /// carve happens. The source's `tensorSizes` / `liveValues` lifecycle is
-  /// unchanged — `removeTensor(src)` later becomes a `freeAddress` no-op
-  /// (since src no longer holds the address entry) but still drops src from
-  /// `tensorSizes` / `currentOccupied`.
+  /// Add `result` as an alias of `srcAtSameAddr`'s buffer (e.g. a
+  /// `ttnn.reshape` that tt-metal realizes as a zero-copy view).
+  ///
+  /// Aliasing model: a buffer (address slot) is allocated once at first
+  /// `addTensor` and reclaimed once when the last alias dies. While
+  /// aliased, both src and result have entries in `tensorAddresses`
+  /// pointing to the same `(start, size)`, and `aliasGroups[start].count`
+  /// counts the live aliases. `currentOccupied` is bumped on first
+  /// allocation only; this method does NOT bump it.
+  ///
+  /// `tensorSizes[result]` IS set so `validate`'s inputOverlap accounting
+  /// works for downstream consumers of the view.
   void addTensorAtAddress(Value result, uint64_t l1SizePerCore,
                           Value srcAtSameAddr);
 
@@ -76,40 +81,51 @@ struct SumL1MemoryTracker {
     uint64_t size() const { return end - start; }
   };
 
-  /// Snapshot of the address simulation state (freeList + tensorAddresses).
-  /// Captured before each allocation event so that eviction can replay from
-  /// any point in the schedule.
+  /// Per-slot alias-group bookkeeping. See `addTensorAtAddress`.
+  struct AliasGroup {
+    unsigned count;
+    uint64_t rawSize;
+  };
+
+  /// Snapshot of the address simulation state (freeList + tensorAddresses
+  /// + aliasGroups + currentOccupied). Captured before each allocation
+  /// event so that eviction can replay from any point in the schedule.
   struct Snapshot {
     llvm::SmallVector<FreeBlock> freeList;
     llvm::DenseMap<Value, std::pair<uint64_t, uint64_t>> tensorAddresses;
+    llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
+    uint64_t currentOccupied;
   };
 
   /// Take a snapshot of the current address simulation state.
   Snapshot takeSnapshot() const;
 
-  /// Restore the address simulation state from a snapshot (freeList +
-  /// tensorAddresses). Does NOT change tensorSizes or currentOccupied.
+  /// Restore the address-simulation state from a snapshot. Restores
+  /// freeList, tensorAddresses, aliasGroups, and currentOccupied. Does
+  /// NOT touch tensorSizes — it is the original-sweep mirror that
+  /// eviction maintains directly via `removeTensorFromSizes`.
   void restoreSnapshot(const Snapshot &snapshot);
 
-  /// Allocate an address block for a tensor (top-down first-fit, aligned).
-  /// Address-only: does not update tensorSizes/currentOccupied.
+  /// Allocate an address block for a tensor (top-down first-fit, aligned),
+  /// open a fresh alias group at refcount 1, and bump currentOccupied for
+  /// the new slot. Does not touch tensorSizes (callers set it).
   void allocateAddress(Value result, uint64_t l1SizePerCore);
 
-  /// Reuse `srcAtSameAddr`'s address slot for `result` (view-style aliasing).
-  /// Moves the `tensorAddresses` entry from src to result; freeList is
-  /// untouched. Address-only: does not update tensorSizes/currentOccupied.
+  /// Add `result` to `srcAtSameAddr`'s alias group at the same address
+  /// slot. Bumps the group's refcount only — does not carve a new slot,
+  /// bump currentOccupied, or touch tensorSizes. See `addTensorAtAddress`
+  /// for the full aliasing model.
   void allocateAddressAt(Value result, Value srcAtSameAddr);
 
-  /// Free a tensor's address block and merge with adjacent free blocks.
-  /// Address-only: does not update tensorSizes/currentOccupied.
+  /// Drop `result` from its alias group. When the last alias is freed,
+  /// the slot returns to `freeList` (with adjacent-block merge) and
+  /// currentOccupied is reclaimed. Does not touch tensorSizes.
   void freeAddress(Value result);
 
   /// Check whether `result` currently has an entry in `tensorAddresses`
   /// (i.e. occupies a simulated L1 address slot). Distinct from
-  /// `hasTensor`, which checks `tensorSizes`. The two can disagree after
-  /// `addTensorAtAddress` (src is in sizes but no longer in addresses) or
-  /// during replay (sizes is the original-pass state, addresses is being
-  /// rebuilt).
+  /// `hasTensor`, which checks `tensorSizes`. The two can disagree during
+  /// replay (sizes is the original-pass state, addresses is being rebuilt).
   bool hasTensorAddress(Value result) const;
 
 private:
@@ -122,8 +138,13 @@ private:
 
   llvm::SmallVector<FreeBlock> freeList;
 
-  // Allocated tensor addresses: Value -> (start, alignedSize).
+  // Per-Value -> (start, alignedSize). Multiple Values may map to the same
+  // slot when an alias group is active. See `addTensorAtAddress`.
   llvm::DenseMap<Value, std::pair<uint64_t, uint64_t>> tensorAddresses;
+
+  // Per-slot refcount + raw size, keyed by slot start. See
+  // `addTensorAtAddress` for the aliasing model.
+  llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
 };
 
 /// L1SpillManagement enforces L1 budget constraints using Belady's optimal

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -56,6 +56,11 @@ struct SliceRuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// True if a `ttnn.reshape` is realized by tt-metal as a zero-copy view of
+/// its input (same buffer, same address). Mirrors the `this_is_view`
+/// condition in tt-metal's reshape.cpp.
+bool canReshapeBeView(Operation *op);
+
 /// ReshapeOp, PermuteOp: reject width-sharded inputs, no reshards.
 /// View-eligible reshapes use NULL hint only (inherit input memory config).
 /// Non-view reshapes use non-sharded output hints.

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
@@ -119,6 +120,32 @@ void SumL1MemoryTracker::addTensor(Value result, uint64_t l1SizePerCore) {
   allocateAddress(result, l1SizePerCore);
 }
 
+void SumL1MemoryTracker::allocateAddressAt(Value result,
+                                           Value srcAtSameAddr) {
+  // Mimic tt-metal's view semantics: result inherits src's address slot.
+  // Move src's tensorAddresses entry to result; freeList is not carved a
+  // second time.
+  auto srcIt = tensorAddresses.find(srcAtSameAddr);
+  assert(srcIt != tensorAddresses.end() &&
+         "allocateAddressAt: src must already be in tensorAddresses");
+  tensorAddresses[result] = srcIt->second;
+  tensorAddresses.erase(srcAtSameAddr);
+}
+
+void SumL1MemoryTracker::addTensorAtAddress(Value result,
+                                            uint64_t l1SizePerCore,
+                                            Value srcAtSameAddr) {
+  // Forward pass: address-only inheritance + tensorSizes/currentOccupied
+  // updates so that validate's inputOverlap accounting works for downstream
+  // consumers of `result`. src remains in tensorSizes/liveValues so OOM
+  // accounting and processDeadTensors lifecycle stay unchanged — when
+  // removeTensor(src) later runs, freeAddress(src) is a no-op because
+  // tensorAddresses no longer has src.
+  allocateAddressAt(result, srcAtSameAddr);
+  tensorSizes[result] = l1SizePerCore;
+  currentOccupied += l1SizePerCore;
+}
+
 void SumL1MemoryTracker::freeAddress(Value result) {
   auto addrIt = tensorAddresses.find(result);
   if (addrIt == tensorAddresses.end()) {
@@ -154,14 +181,14 @@ void SumL1MemoryTracker::freeAddress(Value result) {
 
 void SumL1MemoryTracker::logState() const {
   for ([[maybe_unused]] const auto &entry : tensorAddresses) {
-    TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "Tensor {}: address {} - {} (size {})", entry.first,
                  entry.second.first, entry.second.first + entry.second.second,
                  entry.second.second);
   }
 
   for ([[maybe_unused]] const auto &entry : freeList) {
-    TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "Free block: address {} - {} (size {})", entry.start,
                  entry.end, entry.size());
   }
@@ -182,6 +209,10 @@ void SumL1MemoryTracker::removeTensor(Value result) {
 
 bool SumL1MemoryTracker::hasTensor(Value result) const {
   return tensorSizes.count(result);
+}
+
+bool SumL1MemoryTracker::hasTensorAddress(Value result) const {
+  return tensorAddresses.count(result);
 }
 
 uint64_t SumL1MemoryTracker::getTensorSize(Value result) const {
@@ -640,8 +671,20 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
     }
     if (l1EventLog[i].kind == L1Event::kAlloc) {
       addressSnapshots[i] = memoryTracker.takeSnapshot();
-      memoryTracker.allocateAddress(l1EventLog[i].tensor,
-                                    l1EventLog[i].sizePerCore);
+      // View-eligible reshape: re-derive view-aliasing from the IR. If src
+      // is still address-tracked (i.e. its kAlloc was not skipped earlier
+      // in this replay), inherit src's slot. Otherwise fall back to fresh
+      // top-down allocation — the right counterfactual when src was
+      // evicted to DRAM.
+      Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
+      if (defOp && canReshapeBeView(defOp) &&
+          memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
+        memoryTracker.allocateAddressAt(l1EventLog[i].tensor,
+                                        defOp->getOperand(0));
+      } else {
+        memoryTracker.allocateAddress(l1EventLog[i].tensor,
+                                      l1EventLog[i].sizePerCore);
+      }
     } else {
       memoryTracker.freeAddress(l1EventLog[i].tensor);
     }
@@ -882,12 +925,16 @@ bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
   // from transient internal op allocations (ghost holes).
   uint64_t cushionedCBUsage = cbPeakUsage + cbFragCushion;
 
-  TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-               "    CB FRAG CHECK: cbPeakUsage={0}, cushion={1}, "
-               "speculativeOutputAddr={2}, lowestExistingAddr={3}, "
-               "effectiveLowest={4}",
-               cbPeakUsage, cbFragCushion, speculativeOutputAddr,
+  TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+               "    CB FRAG CHECK for {0}: cbPeakUsage={1}, cushion={2}, "
+               "speculativeOutputAddr={3}, lowestExistingAddr={4}, "
+               "effectiveLowest={5}",
+               op->getName(), cbPeakUsage, cbFragCushion, speculativeOutputAddr,
                lowestExistingAddr, effectiveLowest);
+  // [DEBUG] Always dump the simulated allocator state at the moment of the
+  // CB FRAG CHECK, so we can compare against the runtime memory state for
+  // the same op (rms_norm CB-vs-L1 collision investigation).
+  memoryTracker.logState();
 
   if (cushionedCBUsage > effectiveLowest) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1014,7 +1061,19 @@ void L1SpillManagement<MemoryTracker>::run() {
         addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
         l1EventLog.push_back(
             {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
-        memoryTracker.addTensor(val, perResultL1);
+
+        // View-eligible reshape: tt-metal aliases src's buffer (zero-copy
+        // view), so the simulator inherits src's address slot rather than
+        // carving a fresh one. See `addTensorAtAddress` docs.
+        Operation *defOp = val.getDefiningOp();
+        if (defOp && canReshapeBeView(defOp) &&
+            memoryTracker.hasTensor(defOp->getOperand(0))) {
+          memoryTracker.addTensorAtAddress(val, perResultL1,
+                                           defOp->getOperand(0));
+        } else {
+          memoryTracker.addTensor(val, perResultL1);
+        }
+
         liveValues.insert(val);
         liveSet.push({resultLastUse, val});
       }

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -72,15 +72,18 @@ void SumL1MemoryTracker::init(uint64_t l1BudgetPerCore) {
   freeList.clear();
   freeList.push_back({0, l1Budget});
   tensorAddresses.clear();
+  aliasGroups.clear();
 }
 
 SumL1MemoryTracker::Snapshot SumL1MemoryTracker::takeSnapshot() const {
-  return {freeList, tensorAddresses};
+  return {freeList, tensorAddresses, aliasGroups, currentOccupied};
 }
 
 void SumL1MemoryTracker::restoreSnapshot(const Snapshot &snapshot) {
   freeList = snapshot.freeList;
   tensorAddresses = snapshot.tensorAddresses;
+  aliasGroups = snapshot.aliasGroups;
+  currentOccupied = snapshot.currentOccupied;
 }
 
 void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
@@ -96,6 +99,11 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
       // Allocate from the top of this block.
       uint64_t allocStart = freeList[i].end - alignedSize;
       tensorAddresses[result] = {allocStart, alignedSize};
+      // First allocation in this slot: open the alias group at refcount 1
+      // and account the buffer once. Aliases joining via allocateAddressAt
+      // do not re-bump currentOccupied.
+      aliasGroups[allocStart] = {/*count=*/1, /*rawSize=*/l1SizePerCore};
+      currentOccupied += l1SizePerCore;
 
       // Shrink or remove the free block.
       if (freeList[i].size() == alignedSize) {
@@ -114,36 +122,28 @@ void SumL1MemoryTracker::allocateAddress(Value result, uint64_t l1SizePerCore) {
 
 void SumL1MemoryTracker::addTensor(Value result, uint64_t l1SizePerCore) {
   tensorSizes[result] = l1SizePerCore;
-  currentOccupied += l1SizePerCore;
-
-  // Address simulation: top-down allocation with 32-byte alignment.
   allocateAddress(result, l1SizePerCore);
 }
 
-void SumL1MemoryTracker::allocateAddressAt(Value result,
-                                           Value srcAtSameAddr) {
-  // Mimic tt-metal's view semantics: result inherits src's address slot.
-  // Move src's tensorAddresses entry to result; freeList is not carved a
-  // second time.
+void SumL1MemoryTracker::allocateAddressAt(Value result, Value srcAtSameAddr) {
   auto srcIt = tensorAddresses.find(srcAtSameAddr);
   assert(srcIt != tensorAddresses.end() &&
          "allocateAddressAt: src must already be in tensorAddresses");
-  tensorAddresses[result] = srcIt->second;
-  tensorAddresses.erase(srcAtSameAddr);
+  // Snapshot the slot before inserting `result`, since the insert may
+  // rehash and invalidate `srcIt`.
+  auto slot = srcIt->second;
+  tensorAddresses[result] = slot;
+  auto groupIt = aliasGroups.find(slot.first);
+  assert(groupIt != aliasGroups.end() &&
+         "allocateAddressAt: aliasGroups entry missing for src's slot");
+  ++groupIt->second.count;
 }
 
 void SumL1MemoryTracker::addTensorAtAddress(Value result,
                                             uint64_t l1SizePerCore,
                                             Value srcAtSameAddr) {
-  // Forward pass: address-only inheritance + tensorSizes/currentOccupied
-  // updates so that validate's inputOverlap accounting works for downstream
-  // consumers of `result`. src remains in tensorSizes/liveValues so OOM
-  // accounting and processDeadTensors lifecycle stay unchanged — when
-  // removeTensor(src) later runs, freeAddress(src) is a no-op because
-  // tensorAddresses no longer has src.
   allocateAddressAt(result, srcAtSameAddr);
   tensorSizes[result] = l1SizePerCore;
-  currentOccupied += l1SizePerCore;
 }
 
 void SumL1MemoryTracker::freeAddress(Value result) {
@@ -154,6 +154,17 @@ void SumL1MemoryTracker::freeAddress(Value result) {
   auto [freedStart, freedSize] = addrIt->second;
   uint64_t freedEnd = freedStart + freedSize;
   tensorAddresses.erase(addrIt);
+
+  // Last alias of this slot reclaims the buffer; earlier ones just
+  // detach from the alias group.
+  auto groupIt = aliasGroups.find(freedStart);
+  assert(groupIt != aliasGroups.end() &&
+         "freeAddress: aliasGroups entry missing for live slot");
+  if (--groupIt->second.count > 0) {
+    return;
+  }
+  currentOccupied -= groupIt->second.rawSize;
+  aliasGroups.erase(groupIt);
 
   // Find insertion point in sorted freeList (sorted by start address).
   size_t insertIdx = 0;
@@ -195,11 +206,9 @@ void SumL1MemoryTracker::logState() const {
 }
 
 void SumL1MemoryTracker::removeTensorFromSizes(Value result) {
-  auto it = tensorSizes.find(result);
-  if (it != tensorSizes.end()) {
-    currentOccupied -= it->second;
-    tensorSizes.erase(it);
-  }
+  // Size-table-only — used by eviction, which then `restoreSnapshot +
+  // replay` rebuilds currentOccupied. Address-side path is `freeAddress`.
+  tensorSizes.erase(result);
 }
 
 void SumL1MemoryTracker::removeTensor(Value result) {
@@ -671,11 +680,9 @@ void L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(Value victim) {
     }
     if (l1EventLog[i].kind == L1Event::kAlloc) {
       addressSnapshots[i] = memoryTracker.takeSnapshot();
-      // View-eligible reshape: re-derive view-aliasing from the IR. If src
-      // is still address-tracked (i.e. its kAlloc was not skipped earlier
-      // in this replay), inherit src's slot. Otherwise fall back to fresh
-      // top-down allocation — the right counterfactual when src was
-      // evicted to DRAM.
+      // View-eligible reshape: alias if src is still address-tracked in
+      // this replay, otherwise fresh-allocate (the counterfactual when
+      // src was evicted to DRAM).
       Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
       if (defOp && canReshapeBeView(defOp) &&
           memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
@@ -931,10 +938,6 @@ bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
                "effectiveLowest={5}",
                op->getName(), cbPeakUsage, cbFragCushion, speculativeOutputAddr,
                lowestExistingAddr, effectiveLowest);
-  // [DEBUG] Always dump the simulated allocator state at the moment of the
-  // CB FRAG CHECK, so we can compare against the runtime memory state for
-  // the same op (rms_norm CB-vs-L1 collision investigation).
-  memoryTracker.logState();
 
   if (cushionedCBUsage > effectiveLowest) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1062,9 +1065,8 @@ void L1SpillManagement<MemoryTracker>::run() {
         l1EventLog.push_back(
             {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
 
-        // View-eligible reshape: tt-metal aliases src's buffer (zero-copy
-        // view), so the simulator inherits src's address slot rather than
-        // carving a fresh one. See `addTensorAtAddress` docs.
+        // View-eligible reshape: alias src's buffer instead of carving a
+        // fresh slot. See `addTensorAtAddress`.
         Operation *defOp = val.getDefiningOp();
         if (defOp && canReshapeBeView(defOp) &&
             memoryTracker.hasTensor(defOp->getOperand(0))) {

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -165,7 +165,7 @@ SliceRuleBook::getOutputHints(Operation * /*op*/,
 /// NOP optimization (is_permute_nop) with different conditions.
 /// TODO(#7988): Split PermuteOp into its own PermuteRuleBook to avoid this
 /// op-kind check.
-static bool canReshapeBeView(Operation *op) {
+bool canReshapeBeView(Operation *op) {
   if (!mlir::isa<ReshapeOp>(op)) {
     return false;
   }

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/D2MOptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
@@ -33,6 +34,13 @@ public:
       TTNNGreedyL1SpillManagement>::TTNNGreedyL1SpillManagementBase;
 
   void runOnOperation() final {
+#ifndef TTMLIR_ENABLE_OPMODEL
+    llvm::llvm_unreachable_internal(
+        "TTNNGreedyL1SpillManagement pass requires OpModel support to be "
+        "enabled.");
+#else
+    op_model::ScopedSingletonDeviceGuard deviceGuard(getOperation());
+
     ModuleOp moduleOp = getOperation();
 
     // Get L1 budget from system description and usage cap.
@@ -85,6 +93,7 @@ public:
         }
       }
     });
+#endif
   }
 };
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_alias.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_alias.mlir
@@ -1,0 +1,55 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-greedy-l1-spill-management %s -o %t.mlir
+// RUN: FileCheck %s --input-file %t.mlir
+//
+// Test: forked producer with view-eligible reshape. Tensors are sized so
+// that the L1 buffer is ~64 KiB per core (4096x512 bf16 distributed
+// across 64 banks at 32 tiles per bank). With cap=0.14 the per-core
+// budget is ~209 KiB. R1 = relu(P0) is the discriminator op: its
+// overallPeakL1Usage is ~136 KiB (input + output buffers + CB), so:
+//   alias-aware additionalL1 = 64 KiB, totalL1 = ~200 KiB ≤ 209 KiB → no spill.
+//   double-count additionalL1 = 128 KiB, totalL1 = ~264 KiB > 209 KiB → spill.
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+// 4096x512 bf16 tile = 128*16 = 2048 tiles. On <1x1> interleaved L1 the
+// memref is per-bank: 2048 tiles / 64 banks = 32 tiles per core = 64 KiB.
+#ttnn_layout_dram_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_l1_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#ttnn_layout_l1_3d = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 4096 + d1, d2), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+
+module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
+  func.func @forked_view_no_spill(
+      %arg0: tensor<4096x512xbf16, #ttnn_layout_dram_2d>,
+      %arg1: tensor<4096x512xbf16, #ttnn_layout_dram_2d>,
+      %arg2: tensor<4096x512xbf16, #ttnn_layout_dram_2d>,
+      %arg3: tensor<4096x512xbf16, #ttnn_layout_dram_2d>)
+      -> (tensor<4096x512xbf16, #ttnn_layout_l1_2d>, tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    // P0: forked producer in L1. ~64 KiB per core.
+    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+
+    // V: zero-copy view of P0 (last dim unchanged, leading-1 reshape, tile-aligned).
+    %V = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
+
+    // T validates with both P0 and V live.
+    // alias-aware: additionalL1 ≈ 64 KiB.
+    // double-count: additionalL1 ≈ 128 KiB → spill (or eviction of P0 or V).
+    %T = "ttnn.add"(%arg2, %arg3) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+
+    // Single-input consumers keep P0 and T alive past T's validation
+    // without inflating each consumer's overallPeakL1Usage to >budget.
+    %R1 = "ttnn.relu"(%P0) {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+    %R2 = "ttnn.relu"(%T) {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+
+    return %R1, %V : tensor<4096x512xbf16, #ttnn_layout_l1_2d>, tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
+  }
+
+  // CHECK-LABEL: func.func @forked_view_no_spill
+  // No DRAM demotions: alias-aware accounting keeps everything in L1.
+  // CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
+  // L1-usage attributes are stripped by the spill pass at completion.
+  // CHECK-NOT: ttnn.output_l1_usage
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_multi_alias.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy/l1_spill_reshape_view_multi_alias.mlir
@@ -1,0 +1,45 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttcore-register-device --ttcore-mark-functions-as-forward --ttnn-greedy-l1-spill-management %s -o %t.mlir
+// RUN: FileCheck %s --input-file %t.mlir
+//
+// Test: a single forked L1 producer with TWO view-eligible reshape
+// consumers. With alias-group accounting all three Values (P0, V1, V2)
+// share one address slot at refcount=3 and contribute one buffer to
+// `currentOccupied`. With move-based aliasing (the previous design) the
+// second `allocateAddressAt(V2, P0)` would assert because P0 was already
+// erased from tensorAddresses by the first reshape. This test exercises
+// the path that exposed the assertion.
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#ttnn_layout_dram_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_l1_2d = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#ttnn_layout_l1_3d = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 4096 + d1, d2), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+#ttnn_layout_l1_4d = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4096 + d1 * 4096 + d2, d3), <1x1>, memref<128x16x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+
+module attributes {ttnn.tensor_l1_usage_cap = 1.400000e-01 : f32} {
+  func.func @forked_two_views_no_spill(
+      %arg0: tensor<4096x512xbf16, #ttnn_layout_dram_2d>,
+      %arg1: tensor<4096x512xbf16, #ttnn_layout_dram_2d>)
+      -> (tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>, tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+
+    %P0 = "ttnn.add"(%arg0, %arg1) <{dtype = #ttcore.supportedDataTypes<bf16>}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_dram_2d>, tensor<4096x512xbf16, #ttnn_layout_dram_2d>) -> tensor<4096x512xbf16, #ttnn_layout_l1_2d>
+
+    // First view: 2D → 3D, leading-1 inserted (last+second-to-last unchanged).
+    %V1 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>
+
+    // Second view of the SAME producer: 2D → 4D, two leading 1s.
+    // Under move-based aliasing, this `allocateAddressAt(V2, P0)` asserts
+    // because P0 was removed from tensorAddresses by V1's reshape.
+    %V2 = "ttnn.reshape"(%P0) <{shape = [1 : i32, 1 : i32, 4096 : i32, 512 : i32]}> {ttnn.output_l1_usage = 65536 : i64} : (tensor<4096x512xbf16, #ttnn_layout_l1_2d>) -> tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>
+
+    return %V1, %V2 : tensor<1x4096x512xbf16, #ttnn_layout_l1_3d>, tensor<1x1x4096x512xbf16, #ttnn_layout_l1_4d>
+  }
+
+  // CHECK-LABEL: func.func @forked_two_views_no_spill
+  // Both reshape views remain in L1 alongside P0.
+  // CHECK-NOT: "ttnn.to_memory_config"{{.*}}#dram
+  // CHECK-NOT: ttnn.output_l1_usage
+}


### PR DESCRIPTION
## Summary

Two commits that together teach the L1 spill simulator about zero-copy reshape views:

**1. `[Optimizer] L1 spill: reshape view inherits input's address slot`**
The spill simulator allocated every op result fresh via top-down first-fit, mismodelling `ttnn.reshape` ops that tt-metal realizes as zero-copy views (same buffer, same address). On Gemma-4 g1 this caused the CB FRAG check at the rms_norm following a view-eligible reshape to see a fictitious high `lowestExistingAddr` (the simulator's fresh allocation) instead of the producer's actual low address, suppressing the demote that would have prevented a runtime CB-vs-L1 collision.

When `canReshapeBeView(op)` and the input is L1-tracked, the reshape's output takes over the input's address slot instead of carving a new one. Replay re-derives the view decision from the IR via `canReshapeBeView`, so no new event kind is needed.

**2. `[Optimizer] L1 spill: alias-group accounting for reshape views`**
The move-based design of (1) had two latent failure modes for forked producers:

- Two view-eligible reshape consumers of the same src: the second `allocateAddressAt(V2, src)` asserted because src had been erased from `tensorAddresses` by V1's reshape.
- View result dies before src: `freeAddress(view)` returned the slot to the freeList while src was still live at that address. Subsequent allocations could be placed at a "free" but live address in the simulator.

Both stem from the move pretending only one `Value` at a time can own a slot.

The slot is now reference-counted: every Value that aliases the same buffer (src + each view result) keeps its own `tensorAddresses` entry pointing to the shared `(start, size)` range, and the slot carries a count in `aliasGroups[start]`. `allocateAddressAt` increments the count; `freeAddress` decrements and only returns the slot to the freeList when the last alias is freed. `currentOccupied` is now driven address-side (bumped on first allocation, reclaimed when last alias dies), so view aliases no longer double-count against the L1 budget.

`Snapshot` widens to carry `aliasGroups` and `currentOccupied`, so `markEvictedAndRebuild` rebuilds alias state and size accounting consistently during replay. The IR-side predicate (`canReshapeBeView + hasTensorAddress`) at the replay site is unchanged.

`GreedyL1SpillManagement` gains a `ScopedSingletonDeviceGuard` so the pass is self-contained when run standalone (matching every other optimizer pass).

Two lit tests added (TTNN-dialect, `--ttnn-greedy-l1-spill-management` only). Both are sized so alias-aware accounting fits the budget but naive double-counting forces a DRAM demotion:
- `forked_view_no_spill` — forked producer with one view; verified to fail under double-counting and pass under alias accounting.
- `forked_two_views_no_spill` — two view-eligible reshapes of the same src; the second `allocateAddressAt` asserts under move-based aliasing and succeeds under refcounted aliasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)