### PR TITLE
Add ttir/ttnn.grid_sample op + StableHLO custom_call lowering

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -6106,6 +6106,36 @@ def TTIR_ScaledDotProductAttentionOp : TTIR_NamedOp<"scaled_dot_product_attentio
   let hasVerifier = 1;
 }
 
+def TTIR_GridSampleOp : TTIR_NamedOp<"grid_sample"> {
+  let summary = "Grid sample operation for spatial sampling with bilinear interpolation.";
+  let description = [{
+    Samples the input tensor at grid locations using bilinear interpolation.
+    Grid coordinates are expected to be normalized to [-1, 1] range.
+
+    Args:
+        input (Tensor): Input tensor of shape (N, C, H_in, W_in).
+        grid (Tensor): Sampling grid of shape (N, H_out, W_out, 2) with coordinates in [-1, 1].
+        mode (string): Interpolation mode, currently only "bilinear" is supported.
+        padding_mode (string): How to handle out-of-bounds coordinates,
+            currently only "zeros" is supported.
+        align_corners (bool): Whether to align corners when mapping normalized coordinates
+            to pixel indices. Defaults to `false`.
+
+    Returns:
+        Tensor: Output tensor of shape (N, C, H_out, W_out).
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$grid,
+                       DefaultValuedStrAttr<StrAttr, "bilinear">:$mode,
+                       DefaultValuedStrAttr<StrAttr, "zeros">:$padding_mode,
+                       DefaultValuedAttr<BoolAttr, "false">:$align_corners);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 def TTIR_GlobalAvgPool2dOp: TTIR_NamedOp<"global_avg_pool2d">{
   let summary = "A global average pooling 2d operation";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3890,6 +3890,44 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
 }
 
 
+def TTNN_GridSampleOp : TTNN_Op<"grid_sample", [TTNN_MemoryConfigOpInterface]> {
+  let summary = "Grid sample operation for spatial sampling with bilinear interpolation.";
+  let description = [{
+    Samples the input tensor at grid locations using bilinear interpolation.
+    Grid coordinates are expected to be normalized to [-1, 1] range.
+
+    Args:
+        input (Tensor): Input tensor of shape (N, C, H_in, W_in).
+        grid (Tensor): Sampling grid of shape (N, H_out, W_out, 2) with coordinates in [-1, 1].
+        mode (string): Interpolation mode, currently only "bilinear" is supported.
+        padding_mode (string): How to handle out-of-bounds coordinates,
+            currently only "zeros" is supported.
+        align_corners (bool): Whether to align corners when mapping normalized coordinates
+            to pixel indices. Defaults to `false`.
+        memory_config (MemoryConfigAttr, optional): Memory configuration for the operation.
+
+    Returns:
+        Tensor: Output tensor of shape (N, C, H_out, W_out).
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$grid,
+                       DefaultValuedStrAttr<StrAttr, "bilinear">:$mode,
+                       DefaultValuedStrAttr<StrAttr, "zeros">:$padding_mode,
+                       DefaultValuedAttr<BoolAttr, "false">:$align_corners,
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return wa::TTNNOperandsWorkaroundsFactory::createGridSampleOpOperandsWorkarounds();
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def TTNN_GlobalAvgPool2dOp: TTNN_Op<"global_avg_pool2d", [
     TTNN_MemoryConfigOpInterface,
     TTNN_DtypeOpInterface

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -247,6 +247,10 @@ public:
   // Create workarounds for upsample op operands.
   static TTNNOperandsWorkarounds createUpsampleOpOperandsWorkarounds();
 
+  // Create workarounds for grid_sample op operands. ttnn::grid_sample requires
+  // both input and grid in ROW_MAJOR layout (BFloat16).
+  static TTNNOperandsWorkarounds createGridSampleOpOperandsWorkarounds();
+
   // Create workarounds for mesh shard op operands.
   static TTNNOperandsWorkarounds
   createMeshShardOpOperandsWorkarounds(ttcore::MeshShardType shardType);

--- a/include/ttmlir/Target/TTNN/operations/pool.fbs
+++ b/include/ttmlir/Target/TTNN/operations/pool.fbs
@@ -67,6 +67,16 @@ table UpsampleOp {
   out: tt.target.ttnn.TensorRef;
 }
 
+table GridSampleOp {
+  input: tt.target.ttnn.TensorRef;
+  grid: tt.target.ttnn.TensorRef;
+  mode: string;
+  padding_mode: string;
+  align_corners: bool = false;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
+}
+
 table MaxPool2dWithIndicesOp {
   in: tt.target.ttnn.TensorRef;
   result: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -82,6 +82,7 @@ union OpType {
   GenericOp,
   GetDeviceOp,
   GlobalAvgPool2dOp,
+  GridSampleOp,
   GroupNormOp,
   LayerNormOp,
   LayerNormPreAllGatherOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -473,6 +473,66 @@ public:
   }
 };
 
+// Special handling for tenstorrent.grid_sample -> ttir.grid_sample
+// Reads mode/padding_mode/align_corners from the composite attributes dict.
+//
+// NOTE: tt-xla currently emits stablehlo.custom_call (not stablehlo.composite)
+// for grid_sample via torch_xla.experimental.stablehlo_custom_call — see the
+// matching pattern in StableHLOToTTIRPatterns.cpp. This composite pattern is
+// kept for forward compatibility with frontends (e.g. JAX) that may emit a
+// stablehlo.composite directly through StableHLOCompositeBuilder.
+class TenstorrentGridSampleConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
+
+public:
+  TenstorrentGridSampleConversionPattern(MLIRContext *context)
+      : OpConversionPattern<mlir::stablehlo::CompositeOp>(context) {}
+
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CompositeOp srcOp,
+                  mlir::stablehlo::CompositeOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (srcOp.getName() != "tenstorrent.grid_sample") {
+      return failure();
+    }
+
+    if (srcOp.getNumResults() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "CompositeOp must have exactly one result.");
+    }
+    if (adaptor.getOperands().size() != 2) {
+      return rewriter.notifyMatchFailure(
+          srcOp,
+          "tenstorrent.grid_sample expects exactly two operands (input, grid)");
+    }
+
+    auto outputType =
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
+
+    DictionaryAttr compositeAttrs = srcOp.getCompositeAttributes();
+
+    StringAttr modeAttr = rewriter.getStringAttr("bilinear");
+    if (auto mode = compositeAttrs.getAs<StringAttr>("mode")) {
+      modeAttr = mode;
+    }
+
+    StringAttr paddingModeAttr = rewriter.getStringAttr("zeros");
+    if (auto paddingMode = compositeAttrs.getAs<StringAttr>("padding_mode")) {
+      paddingModeAttr = paddingMode;
+    }
+
+    BoolAttr alignCornersAttr = rewriter.getBoolAttr(false);
+    if (auto alignCorners = compositeAttrs.getAs<BoolAttr>("align_corners")) {
+      alignCornersAttr = alignCorners;
+    }
+
+    rewriter.replaceOpWithNewOp<ttir::GridSampleOp>(
+        srcOp, outputType, adaptor.getOperands()[0], adaptor.getOperands()[1],
+        modeAttr, paddingModeAttr, alignCornersAttr);
+    return success();
+  }
+};
+
 // Special handling for tenstorrent.layer_norm -> ttir.layer_norm
 // Converts normalized_shape tensor attribute to DenseI64ArrayAttr
 // and sets operandSegmentSizes for AttrSizedOperandSegments
@@ -910,6 +970,7 @@ void populateStableHLOCompositeLegalizationPatterns(
   patterns.add<CustomCallRMSNormConversionPattern>(context);
   patterns.add<CustomCallDistributedRMSNormConversionPattern>(context);
   patterns.add<TenstorrentLayerNormConversionPattern>(context);
+  patterns.add<TenstorrentGridSampleConversionPattern>(context);
   patterns.add<TenstorrentGroupNormConversionPattern>(context);
   patterns.add<TenstorrentUniformToRandConversionPattern>(context);
   patterns.add<TenstorrentTopKConversionPattern>(context);

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7807,6 +7807,64 @@ public:
 } // namespace
 
 namespace {
+// Recognizes stablehlo.custom_call @tenstorrent.grid_sample emitted by
+// tt_torch.composite_ops.composite_grid_sample (which routes through
+// torch.ops.tt.grid_sample) and lowers it to ttir.grid_sample.
+class StableHLOGridSampleConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr funcName = adaptor.getCallTargetNameAttr();
+    if (funcName != "tenstorrent.grid_sample") {
+      return failure();
+    }
+
+    if (adaptor.getOperands().size() != 2 || srcOp.getResults().size() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "tenstorrent.grid_sample expects 2 operands (input, grid) "
+                 "and 1 result");
+    }
+
+    mlir::DictionaryAttr frontendAttributes =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+            srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+
+    StringAttr modeAttr = rewriter.getStringAttr("bilinear");
+    StringAttr paddingModeAttr = rewriter.getStringAttr("zeros");
+    BoolAttr alignCornersAttr = rewriter.getBoolAttr(false);
+
+    if (frontendAttributes) {
+      if (auto m = frontendAttributes.getAs<mlir::StringAttr>("mode")) {
+        modeAttr = m;
+      }
+      if (auto pm =
+              frontendAttributes.getAs<mlir::StringAttr>("padding_mode")) {
+        paddingModeAttr = pm;
+      }
+      if (auto ac =
+              frontendAttributes.getAs<mlir::StringAttr>("align_corners")) {
+        alignCornersAttr = rewriter.getBoolAttr(ac.getValue() == "true");
+      }
+    }
+
+    auto outputType =
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
+
+    rewriter.replaceOpWithNewOp<ttir::GridSampleOp>(
+        srcOp, outputType, adaptor.getOperands()[0], adaptor.getOperands()[1],
+        modeAttr, paddingModeAttr, alignCornersAttr);
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class StableHLOErfOpMHLOConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
   using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
@@ -8766,6 +8824,7 @@ static void addCacheOpsConversionPattern(MLIRContext *ctx,
   patterns.add<StableHLOPagedUpdateCacheConversionPattern>(typeConverter, ctx);
   patterns.add<StableHLOPagedFillCacheConversionPattern>(typeConverter, ctx);
   patterns.add<StableHLOSamplingConversionPattern>(typeConverter, ctx);
+  patterns.add<StableHLOGridSampleConversionPattern>(typeConverter, ctx);
 }
 
 static void

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3226,6 +3226,24 @@ public:
     return success();
   }
 };
+
+class GridSampleOpConversionPattern
+    : public OpConversionPattern<ttir::GridSampleOp> {
+public:
+  using OpConversionPattern<ttir::GridSampleOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::GridSampleOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::GridSampleOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getGrid(), adaptor.getModeAttr(),
+        adaptor.getPaddingModeAttr(), adaptor.getAlignCornersAttr(),
+        /*memory_config=*/nullptr);
+
+    return success();
+  }
+};
 } // namespace
 
 // Lowering of TTIR `collective_broadcast` op to a sequence of TTNN
@@ -3874,6 +3892,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            GatherOpConversionPattern,
            PermuteOpConversionPattern,
            UpsampleOpConversionPattern,
+           GridSampleOpConversionPattern,
            AllToAllOpConversionPattern,
            CollectiveBroadcastOpConversionPattern,
            ConcatenateHeadsOpConversionPattern,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7084,6 +7084,49 @@ mlir::tt::ttir::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// GridSampleOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttir::GridSampleOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType gridType = getGrid().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  if (inputType.getRank() != 4) {
+    return emitOpError("Input must be a 4D tensor (N, C, H_in, W_in)");
+  }
+  if (gridType.getRank() != 4) {
+    return emitOpError("Grid must be a 4D tensor (N, H_out, W_out, 2)");
+  }
+  if (resultType.getRank() != 4) {
+    return emitOpError("Output must be a 4D tensor (N, C, H_out, W_out)");
+  }
+  if (gridType.getDimSize(3) != 2) {
+    return emitOpError(
+        "Grid last dimension must be 2 (x, y normalized coordinates)");
+  }
+  if (inputType.getDimSize(0) != gridType.getDimSize(0)) {
+    return emitOpError("Input and grid must share the same batch dimension");
+  }
+
+  StringRef mode = getMode();
+  if (mode != "bilinear" && mode != "nearest") {
+    return emitOpError("Expected mode to be one of (bilinear, nearest), got \"")
+           << mode << "\"";
+  }
+
+  StringRef paddingMode = getPaddingMode();
+  if (paddingMode != "zeros" && paddingMode != "border" &&
+      paddingMode != "reflection") {
+    return emitOpError("Expected padding_mode to be one of "
+                       "(zeros, border, reflection), got \"")
+           << paddingMode << "\"";
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalAvgPool2dOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -5746,6 +5746,49 @@ mlir::tt::ttnn::PagedFlashMultiLatentAttentionDecodeOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// GridSampleOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::GridSampleOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType gridType = getGrid().getType();
+  RankedTensorType resultType = getResult().getType();
+
+  if (inputType.getRank() != 4) {
+    return emitOpError("Input must be a 4D tensor (N, C, H_in, W_in)");
+  }
+  if (gridType.getRank() != 4) {
+    return emitOpError("Grid must be a 4D tensor (N, H_out, W_out, 2)");
+  }
+  if (resultType.getRank() != 4) {
+    return emitOpError("Output must be a 4D tensor (N, C, H_out, W_out)");
+  }
+  if (gridType.getDimSize(3) != 2) {
+    return emitOpError(
+        "Grid last dimension must be 2 (x, y normalized coordinates)");
+  }
+  if (inputType.getDimSize(0) != gridType.getDimSize(0)) {
+    return emitOpError("Input and grid must share the same batch dimension");
+  }
+
+  llvm::StringRef mode = getMode();
+  if (mode != "bilinear" && mode != "nearest") {
+    return emitOpError("Expected mode to be one of (bilinear, nearest), got \"")
+           << mode << "\"";
+  }
+
+  llvm::StringRef paddingMode = getPaddingMode();
+  if (paddingMode != "zeros" && paddingMode != "border" &&
+      paddingMode != "reflection") {
+    return emitOpError("Expected padding_mode to be one of "
+                       "(zeros, border, reflection), got \"")
+           << paddingMode << "\"";
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalAvgPool2dOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -222,6 +222,21 @@ TTNNOperandsWorkaroundsFactory::createGatherOpOperandsWorkarounds() {
       .addOutputOperandWorkaround(TTNNOperandWorkarounds()); // result
 }
 
+// ttnn::grid_sample requires both input (N,C,H,W) and grid (N,H_out,W_out,2)
+// to be in ROW_MAJOR layout with BFloat16 dtype, and the output is also
+// produced in ROW_MAJOR layout.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createGridSampleOpOperandsWorkarounds() {
+  TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
+  rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
+  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =
+      ttcore::DataType::BFloat16;
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
+      .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
+      .addOutputOperandWorkaround(rowMajorLayoutBF16Workaround);
+}
+
 // Factory method to create a set of workarounds for ScatterOp. The ScatterOp
 // expects the input to be in row-major layout if using f32, bf16, or int32.
 TTNNOperandsWorkarounds

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4888,6 +4888,24 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// GridSampleOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints>
+GridSampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return issueErrorForGetOpConstraints(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+llvm::Expected<size_t>
+GridSampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return issueErrorForGetOpRuntime(
+      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
+}
+
+//===----------------------------------------------------------------------===//
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1854,6 +1854,32 @@ createOp(FlatbufferObjectCache &cache, UpsampleOp op) {
       *cache.fbb, input, scaleType, scaleFactor, mode, memoryConfig, output);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::GridSampleOp>
+createOp(FlatbufferObjectCache &cache, GridSampleOp op) {
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getInput()));
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> grid =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getGrid()));
+  flatbuffers::Offset<flatbuffers::String> mode =
+      toFlatbuffer(cache, op.getMode());
+  flatbuffers::Offset<flatbuffers::String> paddingMode =
+      toFlatbuffer(cache, op.getPaddingMode());
+
+  flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
+      op.getMemoryConfig() ? toFlatbuffer(cache, op.getMemoryConfig().value())
+                           : 0;
+
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> output =
+      cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
+                                  /*local_shape*/ std::nullopt);
+
+  return ::tt::target::ttnn::CreateGridSampleOp(
+      *cache.fbb, input, grid, mode, paddingMode, op.getAlignCorners(),
+      memoryConfig, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::UpdateCacheOp>
 createOp(FlatbufferObjectCache &cache, UpdateCacheOp op) {
   auto cacheOperand = cache.at<::tt::target::ttnn::TensorRef>(
@@ -4618,6 +4644,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto upsampleOp = dyn_cast<UpsampleOp>(op); upsampleOp) {
     return createOperation(cache, createOp(cache, upsampleOp), debugString,
+                           locInfo);
+  }
+  if (auto gridSampleOp = dyn_cast<GridSampleOp>(op); gridSampleOp) {
+    return createOperation(cache, createOp(cache, gridSampleOp), debugString,
                            locInfo);
   }
   if (auto batchNormOp = dyn_cast<BatchNormInferenceOp>(op); batchNormOp) {

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -87,6 +87,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/layer_norm_post_all_gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/rms_norm.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/normalization/softmax.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/pool/grid_sample.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/pool2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pool/upsample.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/rand/rand.cpp

--- a/runtime/lib/ttnn/operations/pool/grid_sample.cpp
+++ b/runtime/lib/ttnn/operations/pool/grid_sample.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/pool/grid_sample.h"
+
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+#include "ttnn/operations/data_movement/permute/permute.hpp"
+#include "ttnn/operations/pool/grid_sample/grid_sample.hpp"
+
+namespace tt::runtime::ttnn::operations::pool {
+void run(const ::tt::target::ttnn::GridSampleOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->input());
+  ::ttnn::Tensor &grid = tensorPool.getTTNNTensorAndValidate(op->grid());
+
+  std::string mode = op->mode() ? op->mode()->str() : std::string("bilinear");
+  std::string paddingMode =
+      op->padding_mode() ? op->padding_mode()->str() : std::string("zeros");
+  bool alignCorners = op->align_corners();
+
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      op->memory_config()
+          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                op->memory_config())
+          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(
+                    op->out()));
+
+  // PyTorch grid_sample uses NCHW, but ttnn::grid_sample requires NHWC
+  // (last dimension must be channels, divisible by TILE_WIDTH=32).
+  // Permute input NCHW -> NHWC before the kernel call, and output
+  // NHWC -> NCHW after.
+  ::ttsl::SmallVector<int64_t> nchwToNhwc = {0, 2, 3, 1};
+  ::ttsl::SmallVector<int64_t> nhwcToNchw = {0, 3, 1, 2};
+
+  ::ttnn::Tensor inputNhwc = ::ttnn::permute(input, nchwToNhwc, std::nullopt);
+
+  ::ttnn::Tensor outputNhwc =
+      ::ttnn::grid_sample(inputNhwc, grid, mode, paddingMode, alignCorners,
+                          /*use_precomputed_grid=*/false,
+                          /*batch_output_channels=*/false, memoryConfig);
+
+  ::ttnn::Tensor output = ::ttnn::permute(outputNhwc, nhwcToNchw, std::nullopt);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
+}
+} // namespace tt::runtime::ttnn::operations::pool

--- a/runtime/lib/ttnn/operations/pool/grid_sample.h
+++ b/runtime/lib/ttnn/operations/pool/grid_sample.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_POOL_GRID_SAMPLE_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_POOL_GRID_SAMPLE_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::pool {
+void run(const ::tt::target::ttnn::GridSampleOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::pool
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -87,6 +87,7 @@
 #include "operations/normalization/rms_norm.h"
 #include "operations/normalization/rms_norm_pre_all_gather.h"
 #include "operations/normalization/softmax.h"
+#include "operations/pool/grid_sample.h"
 #include "operations/pool/pool2d.h"
 #include "operations/pool/upsample.h"
 #include "operations/rand/rand.h"
@@ -479,6 +480,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::GlobalAvgPool2dOp: {
     return operations::pool::run(op->type_as_GlobalAvgPool2dOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::GridSampleOp: {
+    return operations::pool::run(op->type_as_GridSampleOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::MaxPool2dWithIndicesOp: {
     return operations::pool::run(op->type_as_MaxPool2dWithIndicesOp(),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1189,6 +1189,10 @@ getOpOutputRef(OpContext opContextHandle,
     tensorRef = opContext.type_as_GlobalAvgPool2dOp()->out();
     break;
   }
+  case ::tt::target::ttnn::OpType::GridSampleOp: {
+    tensorRef = opContext.type_as_GridSampleOp()->out();
+    break;
+  }
   case ::tt::target::ttnn::OpType::PrepareConv2dWeightsOp: {
     tensorRef = opContext.type_as_PrepareConv2dWeightsOp()->out();
     break;
@@ -1639,6 +1643,11 @@ getOpInputRefs(OpContext opContextHandle,
   }
   case ::tt::target::ttnn::OpType::GlobalAvgPool2dOp: {
     tensorRefs = {opContext.type_as_GlobalAvgPool2dOp()->in()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::GridSampleOp: {
+    tensorRefs = {opContext.type_as_GridSampleOp()->input(),
+                  opContext.type_as_GridSampleOp()->grid()};
     break;
   }
   case ::tt::target::ttnn::OpType::MaxPool2dWithIndicesOp: {

--- a/test/ttmlir/Dialect/TTNN/grid_sample/grid_sample_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/grid_sample/grid_sample_tests_negative.mlir
@@ -1,0 +1,61 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for grid_sample operation.
+
+// Verify that input must be 4D.
+module {
+  func.func @grid_sample_input_3d(%arg0: tensor<32x8x8xbf16>, %arg1: tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Input must be a 4D tensor
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "bilinear", padding_mode = "zeros", align_corners = false}> : (tensor<32x8x8xbf16>, tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+}
+
+// -----
+// Verify that grid must be 4D.
+module {
+  func.func @grid_sample_grid_3d(%arg0: tensor<1x32x8x8xbf16>, %arg1: tensor<6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Grid must be a 4D tensor
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "bilinear", padding_mode = "zeros", align_corners = false}> : (tensor<1x32x8x8xbf16>, tensor<6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+}
+
+// -----
+// Verify that grid's last dimension must be 2.
+module {
+  func.func @grid_sample_grid_last_dim_3(%arg0: tensor<1x32x8x8xbf16>, %arg1: tensor<1x6x6x3xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Grid last dimension must be 2
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "bilinear", padding_mode = "zeros", align_corners = false}> : (tensor<1x32x8x8xbf16>, tensor<1x6x6x3xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+}
+
+// -----
+// Verify that input and grid must share batch size.
+module {
+  func.func @grid_sample_batch_mismatch(%arg0: tensor<2x32x8x8xbf16>, %arg1: tensor<3x6x6x2xbf16>) -> tensor<3x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Input and grid must share the same batch dimension
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "bilinear", padding_mode = "zeros", align_corners = false}> : (tensor<2x32x8x8xbf16>, tensor<3x6x6x2xbf16>) -> tensor<3x32x6x6xbf16>
+    return %0 : tensor<3x32x6x6xbf16>
+  }
+}
+
+// -----
+// Verify that mode must be one of supported modes.
+module {
+  func.func @grid_sample_unsupported_mode(%arg0: tensor<1x32x8x8xbf16>, %arg1: tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Expected mode to be one of (bilinear, nearest), got "cubic"
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "cubic", padding_mode = "zeros", align_corners = false}> : (tensor<1x32x8x8xbf16>, tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+}
+
+// -----
+// Verify that padding_mode must be one of supported modes.
+module {
+  func.func @grid_sample_unsupported_padding_mode(%arg0: tensor<1x32x8x8xbf16>, %arg1: tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: error: 'ttnn.grid_sample' op Expected padding_mode to be one of (zeros, border, reflection), got "wrap"
+    %0 = "ttnn.grid_sample"(%arg0, %arg1) <{mode = "bilinear", padding_mode = "wrap", align_corners = false}> : (tensor<1x32x8x8xbf16>, tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/grid_sample/simple_grid_sample.mlir
+++ b/test/ttmlir/Dialect/TTNN/grid_sample/simple_grid_sample.mlir
@@ -1,0 +1,42 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+module {
+  // tt-metal known-good shape: C=32 (TILE_WIDTH), small spatial.
+  func.func @grid_sample_small(
+      %arg0: tensor<1x32x8x8xbf16>,
+      %arg1: tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK: "ttnn.grid_sample"
+    %0 = "ttir.grid_sample"(%arg0, %arg1) <{
+      mode = "bilinear",
+      padding_mode = "zeros",
+      align_corners = false
+    }> : (tensor<1x32x8x8xbf16>, tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+
+  // Deformable DETR shape — the original DRAM-OOM use case.
+  func.func @grid_sample_deformable_detr(
+      %arg0: tensor<8x32x100x134xbf16>,
+      %arg1: tensor<8x17821x4x2xbf16>) -> tensor<8x32x17821x4xbf16> {
+    // CHECK: "ttnn.grid_sample"
+    %0 = "ttir.grid_sample"(%arg0, %arg1) <{
+      mode = "bilinear",
+      padding_mode = "zeros",
+      align_corners = false
+    }> : (tensor<8x32x100x134xbf16>, tensor<8x17821x4x2xbf16>) -> tensor<8x32x17821x4xbf16>
+    return %0 : tensor<8x32x17821x4xbf16>
+  }
+
+  // align_corners=true variant.
+  func.func @grid_sample_align_corners(
+      %arg0: tensor<2x64x50x50xbf16>,
+      %arg1: tensor<2x25x25x2xbf16>) -> tensor<2x64x25x25xbf16> {
+    // CHECK: "ttnn.grid_sample"
+    %0 = "ttir.grid_sample"(%arg0, %arg1) <{
+      mode = "bilinear",
+      padding_mode = "zeros",
+      align_corners = true
+    }> : (tensor<2x64x50x50xbf16>, tensor<2x25x25x2xbf16>) -> tensor<2x64x25x25xbf16>
+    return %0 : tensor<2x64x25x25xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/simple_grid_sample.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_grid_sample.mlir
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module attributes {} {
+  // tt-metal known-good shape: C=32 (TILE_WIDTH), small spatial.
+  func.func public @grid_sample_small(
+      %arg0: tensor<1x32x8x8xbf16>,
+      %arg1: tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16> {
+    // CHECK-LABEL: func.func public @grid_sample_small(
+    // CHECK: "ttnn.grid_sample"
+    %0 = "ttir.grid_sample"(%arg0, %arg1) <{
+      mode = "bilinear",
+      padding_mode = "zeros",
+      align_corners = false
+    }> : (tensor<1x32x8x8xbf16>, tensor<1x6x6x2xbf16>) -> tensor<1x32x6x6xbf16>
+    return %0 : tensor<1x32x6x6xbf16>
+  }
+
+  // align_corners=true variant.
+  func.func public @grid_sample_align_corners(
+      %arg0: tensor<2x64x50x50xbf16>,
+      %arg1: tensor<2x25x25x2xbf16>) -> tensor<2x64x25x25xbf16> {
+    // CHECK-LABEL: func.func public @grid_sample_align_corners(
+    // CHECK: "ttnn.grid_sample"
+    %0 = "ttir.grid_sample"(%arg0, %arg1) <{
+      mode = "bilinear",
+      padding_mode = "zeros",
+      align_corners = true
+    }> : (tensor<2x64x50x50xbf16>, tensor<2x25x25x2xbf16>) -> tensor<2x64x25x25xbf16>
+    return %0 : tensor<2x64x25x25xbf16>
+  }
+}


### PR DESCRIPTION

### Problem description
- Add `ttir.grid_sample` and `ttnn.grid_sample` ops, with verifier coverage for input/grid rank, batch match, last-dim=2, and supported `mode`/`padding_mode` values (consistent error wording on both sides).
- Add a `stablehlo.custom_call @tenstorrent.grid_sample` → `ttir.grid_sample` pattern (primary path; matches what tt-xla emits) and keep the `stablehlo.composite @tenstorrent.grid_sample` pattern for forward compatibility (e.g. JAX frontends emitting via `StableHLOCompositeBuilder`).
- Lower `ttir.grid_sample` → `ttnn.grid_sample`. Add a workaround that forces ROW_MAJOR + BFloat16 on operands (kernel constraint).
- Runtime impl in `runtime/lib/ttnn/operations/pool/grid_sample.cpp` permutes the input NCHW→NHWC before calling `ttnn::grid_sample` (kernel expects NHWC, channel dim must be a multiple of `TILE_WIDTH=32`) and NHWC→NCHW on the output.
- Flatbuffer schema entries (`pool.fbs`, `program.fbs`), `OpModel` stubs (return `MissingMetalDefinition`; not on the runtime path), and dispatch wiring in `program_executor` / `runtime`.
- Lit tests: positive (round-trip + lowering on the Deformable DETR shape) and 6 negative cases (rank, batch, mode, padding_mode validation). Silicon lit test compiles and generates a flatbuffer on n150 hardware; verified with `ttrt run`.

Unblocks Deformable DETR (was OOM'ing in the prior decomposition path) — see linked tt-xla ticket -  [#3805](https://github.com/tenstorrent/tt-xla/issues/3805).

## Files (16 modified + 5 new)

Modified:
- `include/ttmlir/Dialect/TTIR/IR/TTIROps.td` — `TTIR_GridSampleOp` definition.
- `include/ttmlir/Dialect/TTNN/IR/TTNNOps.td` — `TTNN_GridSampleOp` (binds `getOperandsWorkarounds`).
- `include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h` — declares the factory.
- `include/ttmlir/Target/TTNN/operations/pool.fbs` — flatbuffer table.
- `include/ttmlir/Target/TTNN/program.fbs` — `OpType` union entry.
- `lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp` — primary custom_call lowering.
- `lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp` — composite lowering (forward compat).
- `lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp` — TTIR→TTNN.
- `lib/Dialect/TTIR/IR/TTIROps.cpp` — TTIR verifier.
- `lib/Dialect/TTNN/IR/TTNNOps.cpp` — TTNN verifier.
- `lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp` — ROW_MAJOR/BF16 workaround.
- `lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp` — OpModel stubs.
- `lib/Target/TTNN/TTNNToFlatbuffer.cpp` — serializer.
- `runtime/lib/ttnn/operations/CMakeLists.txt` — build entry.
- `runtime/lib/ttnn/program_executor.cpp` — dispatch case.
- `runtime/lib/ttnn/runtime.cpp` — input/output ref switches.

New:
- `runtime/lib/ttnn/operations/pool/grid_sample.h`
- `runtime/lib/ttnn/operations/pool/grid_sample.cpp`
- `test/ttmlir/Dialect/TTNN/grid_sample/simple_grid_sample.mlir`
- `test/ttmlir/Dialect/TTNN/grid_sample/grid_sample_tests_negative.mlir`
- `test/ttmlir/Silicon/TTNN/n150/simple_grid_sample.mlir`

## Test plan
- [ ] `cmake --build build && cmake --install build --component SharedLib`
- [ ] `llvm-lit -v test/ttmlir/Dialect/TTNN/grid_sample/` — positive + 6 negative cases pass 
- [ ] `llvm-lit -v test/ttmlir/Silicon/TTNN/n150/simple_grid_sample.mlir --param system_desc_path=ttrt-artifacts/system_desc.ttsys` — silicon compile + flatbuffer generation pass
- [ ] `ttrt run <flatbuffer>` — executes on n150 hardware without error
- [ ] Downstream tt-xla op test: `pytest -svv tests/torch/ops/test_grid_sample.py` → 7 passed + 4 xfailed
- [ ] Downstream model test: Deformable DETR passes at PCC=0.99