### PR TITLE
Uplift third_party/tt-metal to 61e690c25202111b52cbc1fbc9148b6524070c6f 2026-05-05

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=b3e8eb62c6494c986aa4174c28b99047bc98481d
+ARG TT_METAL_DEPENDENCIES_COMMIT=61e690c25202111b52cbc1fbc9148b6524070c6f
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "78197e564f34c476c02a5e806a8db202f5ff3190")
+set(TT_METAL_VERSION "61e690c25202111b52cbc1fbc9148b6524070c6f")
 
 # Suppress install logs to avoid cluttering the build output
 set(CMAKE_INSTALL_MESSAGE NEVER)


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 61e690c25202111b52cbc1fbc9148b6524070c6f

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25439397178
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25439338322
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): N/A
  - [x] **Frontend fix PRs** ready (if needed by this uplift): N/A