### PR TITLE
Conv2dOp to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_CONV_CONV2DOP_H
+#define TTMLIR_OPINVOKE_TTNN_CONV_CONV2DOP_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/TTNN/operations/conv_generated.h"
+#pragma clang diagnostic pop
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using Conv2dOpResult = std::variant<::ttnn::graph::ConstraintQueryResponse,
+                                    ::ttnn::graph::RuntimeQueryResponse,
+                                    ::ttnn::Conv2dResultWithOptions>;
+
+struct Conv2dResolvedParams {
+  std::array<uint32_t, 2> kernelSize;
+  std::array<uint32_t, 2> stride;
+  std::array<uint32_t, 2> dilation;
+  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
+  std::optional<::ttnn::DataType> outputDtype;
+  std::optional<::ttnn::Conv2dConfig> conv2dConfig;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
+};
+
+Conv2dResolvedParams
+resolveConv2dParams(const ::tt::target::ttnn::Conv2dOpT &conv2dOp);
+
+Conv2dOpResult callConv2d(CallType callType,
+                          const ::tt::target::ttnn::Conv2dOpT &conv2dOp,
+                          TensorArg input, TensorArg weight,
+                          std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *targetDevice);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_CONV_CONV2DOP_H

--- a/include/ttmlir/OpInvoke/TTNN/utils/utils.h
+++ b/include/ttmlir/OpInvoke/TTNN/utils/utils.h
@@ -47,6 +47,57 @@ enum class CallType {
   EXECUTE,
 };
 
+using TensorArg = std::variant<const ::ttnn::Tensor *, ::ttnn::TensorSpec>;
+
+struct QueryTag {};
+struct ExecuteTag {};
+
+inline auto resolveTensorArg(TensorArg arg, QueryTag callType) {
+  return std::get<::ttnn::TensorSpec>(arg);
+}
+
+inline auto resolveTensorArg(TensorArg arg, ExecuteTag callType) {
+  return *std::get<const ::ttnn::Tensor *>(arg);
+}
+
+template <typename Result, bool ConstraintsImplemented = true,
+          bool RuntimeImplemented = true>
+Result callOp(auto op, CallType callType, auto makeTuple,
+              ::ttnn::MeshDevice *device) {
+  switch (callType) {
+  case CallType::QUERY_OP_CONSTRAINTS:
+    if constexpr (!ConstraintsImplemented) {
+      llvm_unreachable(
+          "Constraint query invoked for op without OpModel support");
+    } else {
+      return std::apply(
+          [&](auto &&...args) {
+            return ::ttnn::graph::query_op_constraints(op, device, args...);
+          },
+          makeTuple(QueryTag{}));
+    }
+  case CallType::QUERY_OP_RUNTIME:
+    if constexpr (!RuntimeImplemented) {
+      llvm_unreachable("Runtime query invoked for op without OpModel support");
+    } else {
+      return std::apply(
+          [&](auto &&...args) {
+            return ::ttnn::graph::query_op_runtime(op, device, args...);
+          },
+          makeTuple(QueryTag{}));
+    }
+  case CallType::EXECUTE: {
+    auto executeTuple = makeTuple(ExecuteTag{});
+    return std::apply(
+        [&](auto &&...args) {
+          return op(std::forward<decltype(args)>(args)...);
+        },
+        executeTuple);
+  }
+  }
+  llvm_unreachable("unhandled CallType");
+}
+
 } // namespace ttnn_op_invoke
 
 namespace ttnn_op_invoke::operations::utils {
@@ -70,7 +121,16 @@ toTTNNCoreRange(const tt::target::ttnn::CoreRange &coreRange);
 tt::tt_metal::CoreRangeSet
 toTTNNCoreRangeSet(const tt::target::ttnn::CoreRangeSetT &coreRangeSet);
 
+::ttnn::operations::unary::UnaryOpType
+toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType);
+
+::ttnn::operations::unary::UnaryOpType
+toTTNNUnaryOpType(::tt::target::ttnn::EltwiseUnaryOpType unaryOpType);
+
 ::ttnn::DataType getDataType(const ::tt::target::ttnn::TensorRefT &tensorRef);
+
+::ttnn::operations::unary::UnaryWithParam
+toTTNNUnaryWithParam(const ::tt::target::ttnn::UnaryWithParamT &unaryWithParam);
 
 bool inSystemMemory(const ::tt::target::ttnn::TensorRefT &tensorRef);
 
@@ -79,6 +139,12 @@ getTensorRefMemoryConfig(const ::tt::target::ttnn::TensorRefT &tensorRef);
 
 std::optional<::ttnn::MemoryConfig>
 createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfigT &memcfg);
+
+::ttnn::Conv2dConfig
+createConv2dConfig(const ::tt::target::ttnn::Conv2dConfigT &config);
+
+::ttnn::Conv2dSliceConfig
+createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfigT &config);
 
 ::ttnn::DeviceComputeKernelConfig createDeviceComputeKernelConfig(
     const ::tt::target::ttnn::DeviceComputeKernelConfigT &config);

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(TTNNOpInvokeLib STATIC
   utils/utils.cpp
+  Conv/Conv2dOp.cpp
 )
 
 set_property(TARGET TTNNOpInvokeLib PROPERTY CXX_STANDARD 20)

--- a/lib/OpInvoke/TTNN/Conv/Conv2dOp.cpp
+++ b/lib/OpInvoke/TTNN/Conv/Conv2dOp.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
+#include "operations/conv/conv2d/conv2d.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+Conv2dResolvedParams
+resolveConv2dParams(const ::tt::target::ttnn::Conv2dOpT &conv2dOp) {
+  TT_INVOKE_ASSERT(conv2dOp.kernel_size.size() == 2,
+                   "Kernel size expected to have 2 elements");
+  TT_INVOKE_ASSERT(conv2dOp.stride.size() == 2,
+                   "Stride expected to have 2 elements");
+  TT_INVOKE_ASSERT(conv2dOp.padding.size() == 2 || conv2dOp.padding.size() == 4,
+                   "Padding expected to have 2 or 4 elements");
+  TT_INVOKE_ASSERT(conv2dOp.dilation.size() == 2,
+                   "Dilation expected to have 2 elements");
+
+  Conv2dResolvedParams params;
+
+  std::copy_n(conv2dOp.kernel_size.begin(), 2, params.kernelSize.begin());
+  std::copy_n(conv2dOp.stride.begin(), 2, params.stride.begin());
+  std::copy_n(conv2dOp.dilation.begin(), 2, params.dilation.begin());
+
+  if (conv2dOp.padding.size() == 2) {
+    std::array<uint32_t, 2> symPadding;
+    std::copy_n(conv2dOp.padding.begin(), 2, symPadding.begin());
+    params.padding = symPadding;
+  } else {
+    std::array<uint32_t, 4> asymPadding;
+    std::copy_n(conv2dOp.padding.begin(), 4, asymPadding.begin());
+    params.padding = asymPadding;
+  }
+
+  if (conv2dOp.out) {
+    params.outputDtype = operations::utils::getDataType(*conv2dOp.out);
+  } else if (conv2dOp.output_dtype.has_value()) {
+    params.outputDtype =
+        operations::utils::toTTNNDataType(*conv2dOp.output_dtype);
+  }
+
+  if (conv2dOp.conv2d_config) {
+    params.conv2dConfig =
+        operations::utils::createConv2dConfig(*conv2dOp.conv2d_config);
+  }
+
+  if (conv2dOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *conv2dOp.compute_config);
+  }
+
+  if (conv2dOp.conv2d_slice_config) {
+    params.sliceConfig = operations::utils::createConv2dSliceConfig(
+        *conv2dOp.conv2d_slice_config);
+  }
+
+  if (conv2dOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*conv2dOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*conv2dOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createConv2dTuple(Tag tag, const ::tt::target::ttnn::Conv2dOpT &conv2dOp,
+                       TensorArg input, TensorArg weight,
+                       std::optional<TensorArg> bias,
+                       ::ttnn::MeshDevice *targetDevice,
+                       const Conv2dResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), resolveTensorArg(weight, tag), targetDevice,
+      conv2dOp.in_channels, conv2dOp.out_channels, conv2dOp.batch_size,
+      conv2dOp.input_height, conv2dOp.input_width, params.kernelSize,
+      params.stride, params.padding, params.dilation, conv2dOp.groups,
+      params.outputDtype,
+      bias ? std::make_optional(resolveTensorArg(*bias, tag)) : std::nullopt,
+      params.conv2dConfig, params.computeConfig, params.outputMemoryConfig,
+      params.sliceConfig, false, false);
+}
+
+Conv2dOpResult callConv2d(CallType callType,
+                          const ::tt::target::ttnn::Conv2dOpT &conv2dOp,
+                          TensorArg input, TensorArg weight,
+                          std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *device) {
+
+  Conv2dResolvedParams params = resolveConv2dParams(conv2dOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createConv2dTuple(tag, conv2dOp, input, weight, bias, device,
+                             params);
+  };
+
+  return callOp<Conv2dOpResult>(WRAP_OP(::ttnn::conv2d), callType, makeTuple,
+                                device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/utils/utils.cpp
+++ b/lib/OpInvoke/TTNN/utils/utils.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include <llvm/Support/Error.h>
 
 namespace ttnn_op_invoke::operations::utils {
 
@@ -204,8 +205,210 @@ createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfigT &memcfg) {
   return ::ttnn::MemoryConfig{memLayout, ttnnBufferType};
 }
 
+::ttnn::operations::unary::UnaryOpType
+toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType) {
+  using FbUnaryOpType = ::tt::target::ttnn::UnaryOpType;
+  using TTNNUnaryOpType = ::ttnn::operations::unary::UnaryOpType;
+
+  static const std::unordered_map<FbUnaryOpType, TTNNUnaryOpType> opTypeMap = {
+      {FbUnaryOpType::Exp, TTNNUnaryOpType::EXP},
+      {FbUnaryOpType::Recip, TTNNUnaryOpType::RECIP},
+      {FbUnaryOpType::Gelu, TTNNUnaryOpType::GELU},
+      {FbUnaryOpType::Relu, TTNNUnaryOpType::RELU},
+      {FbUnaryOpType::Sqrt, TTNNUnaryOpType::SQRT},
+      {FbUnaryOpType::Sigmoid, TTNNUnaryOpType::SIGMOID},
+      {FbUnaryOpType::Log, TTNNUnaryOpType::LOG},
+      {FbUnaryOpType::Tanh, TTNNUnaryOpType::TANH},
+      {FbUnaryOpType::Log2, TTNNUnaryOpType::LOG2},
+      {FbUnaryOpType::Log10, TTNNUnaryOpType::LOG10},
+      {FbUnaryOpType::Sin, TTNNUnaryOpType::SIN},
+      {FbUnaryOpType::Cos, TTNNUnaryOpType::COS},
+      {FbUnaryOpType::Abs, TTNNUnaryOpType::ABS},
+      {FbUnaryOpType::AbsInt32, TTNNUnaryOpType::ABS_INT32},
+      {FbUnaryOpType::Sign, TTNNUnaryOpType::SIGN},
+      {FbUnaryOpType::Square, TTNNUnaryOpType::SQUARE},
+      {FbUnaryOpType::Eqz, TTNNUnaryOpType::EQZ},
+      {FbUnaryOpType::Nez, TTNNUnaryOpType::NEZ},
+      {FbUnaryOpType::Gtz, TTNNUnaryOpType::GTZ},
+      {FbUnaryOpType::Ltz, TTNNUnaryOpType::LTZ},
+      {FbUnaryOpType::Gez, TTNNUnaryOpType::GEZ},
+      {FbUnaryOpType::Lez, TTNNUnaryOpType::LEZ},
+      {FbUnaryOpType::ReluMax, TTNNUnaryOpType::RELU_MAX},
+      {FbUnaryOpType::ReluMin, TTNNUnaryOpType::RELU_MIN},
+      {FbUnaryOpType::Power, TTNNUnaryOpType::POWER},
+      {FbUnaryOpType::LeakyRelu, TTNNUnaryOpType::LEAKY_RELU},
+      {FbUnaryOpType::Elu, TTNNUnaryOpType::ELU},
+      {FbUnaryOpType::Exp2, TTNNUnaryOpType::EXP2},
+      {FbUnaryOpType::Heaviside, TTNNUnaryOpType::HEAVISIDE},
+      {FbUnaryOpType::Expm1, TTNNUnaryOpType::EXPM1},
+      {FbUnaryOpType::Signbit, TTNNUnaryOpType::SIGNBIT},
+      {FbUnaryOpType::Asin, TTNNUnaryOpType::ASIN},
+      {FbUnaryOpType::Acos, TTNNUnaryOpType::ACOS},
+      {FbUnaryOpType::Rsqrt, TTNNUnaryOpType::RSQRT},
+      {FbUnaryOpType::Relu6, TTNNUnaryOpType::RELU6},
+      {FbUnaryOpType::Hardsigmoid, TTNNUnaryOpType::HARDSIGMOID},
+      {FbUnaryOpType::Atan, TTNNUnaryOpType::ATAN},
+      {FbUnaryOpType::Erf, TTNNUnaryOpType::ERF},
+      {FbUnaryOpType::Erfc, TTNNUnaryOpType::ERFC},
+      {FbUnaryOpType::Isinf, TTNNUnaryOpType::ISINF},
+      {FbUnaryOpType::Isposinf, TTNNUnaryOpType::ISPOSINF},
+      {FbUnaryOpType::Isneginf, TTNNUnaryOpType::ISNEGINF},
+      {FbUnaryOpType::Isnan, TTNNUnaryOpType::ISNAN},
+      {FbUnaryOpType::LogicalNotUnary, TTNNUnaryOpType::LOGICAL_NOT_UNARY},
+      {FbUnaryOpType::Isfinite, TTNNUnaryOpType::ISFINITE},
+      {FbUnaryOpType::Erfinv, TTNNUnaryOpType::ERFINV},
+      {FbUnaryOpType::I0, TTNNUnaryOpType::I0},
+      {FbUnaryOpType::I1, TTNNUnaryOpType::I1},
+      {FbUnaryOpType::Tan, TTNNUnaryOpType::TAN},
+      {FbUnaryOpType::Rsub, TTNNUnaryOpType::RSUB},
+      {FbUnaryOpType::Rdiv, TTNNUnaryOpType::RDIV},
+      {FbUnaryOpType::Silu, TTNNUnaryOpType::SILU},
+      {FbUnaryOpType::Softplus, TTNNUnaryOpType::SOFTPLUS},
+      {FbUnaryOpType::Identity, TTNNUnaryOpType::IDENTITY},
+      {FbUnaryOpType::Neg, TTNNUnaryOpType::NEG},
+      {FbUnaryOpType::AddUnarySfpu, TTNNUnaryOpType::ADD_UNARY_SFPU},
+      {FbUnaryOpType::SubUnarySfpu, TTNNUnaryOpType::SUB_UNARY_SFPU},
+      {FbUnaryOpType::MulUnarySfpu, TTNNUnaryOpType::MUL_UNARY_SFPU},
+      {FbUnaryOpType::DivUnarySfpu, TTNNUnaryOpType::DIV_UNARY_SFPU},
+      {FbUnaryOpType::IdentityUint32, TTNNUnaryOpType::IDENTITY},
+      {FbUnaryOpType::UnaryNe, TTNNUnaryOpType::UNARY_NE},
+      {FbUnaryOpType::UnaryGt, TTNNUnaryOpType::UNARY_GT},
+      {FbUnaryOpType::UnaryLt, TTNNUnaryOpType::UNARY_LT},
+      {FbUnaryOpType::TiledProd, TTNNUnaryOpType::TILED_PROD},
+      {FbUnaryOpType::Typecast, TTNNUnaryOpType::TYPECAST},
+      {FbUnaryOpType::BitwiseXor, TTNNUnaryOpType::BITWISE_XOR},
+      {FbUnaryOpType::BitwiseNot, TTNNUnaryOpType::BITWISE_NOT},
+      {FbUnaryOpType::BitwiseAnd, TTNNUnaryOpType::BITWISE_AND},
+      {FbUnaryOpType::BitwiseOr, TTNNUnaryOpType::BITWISE_OR},
+      {FbUnaryOpType::RightShift, TTNNUnaryOpType::RIGHT_SHIFT},
+      {FbUnaryOpType::Floor, TTNNUnaryOpType::FLOOR},
+      {FbUnaryOpType::Ceil, TTNNUnaryOpType::CEIL},
+      {FbUnaryOpType::Round, TTNNUnaryOpType::ROUND},
+      {FbUnaryOpType::LeftShift, TTNNUnaryOpType::LEFT_SHIFT},
+      {FbUnaryOpType::Remainder, TTNNUnaryOpType::REMAINDER},
+      {FbUnaryOpType::Fmod, TTNNUnaryOpType::FMOD},
+      {FbUnaryOpType::Dropout, TTNNUnaryOpType::DROPOUT},
+      {FbUnaryOpType::Fill, TTNNUnaryOpType::FILL},
+      {FbUnaryOpType::PreluSfpu, TTNNUnaryOpType::PRELU_SFPU},
+      {FbUnaryOpType::ZeroPoint, TTNNUnaryOpType::ZERO_POINT},
+  };
+
+  auto it = opTypeMap.find(unaryOpType);
+  if (it != opTypeMap.end()) {
+    return it->second;
+  }
+
+  llvm::report_fatal_error("Unsupported UnaryOpType");
+}
+
 ::ttnn::DataType getDataType(const ::tt::target::ttnn::TensorRefT &tensorRef) {
   return toTTNNDataType(tensorRef.desc->layout->memory_desc->data_type);
+}
+
+::ttnn::operations::unary::UnaryWithParam toTTNNUnaryWithParam(
+    const ::tt::target::ttnn::UnaryWithParamT &unaryWithParam) {
+  return ::ttnn::operations::unary::UnaryWithParam(
+      toTTNNUnaryOpType(unaryWithParam.op_type),
+      std::vector<float>(unaryWithParam.params.begin(),
+                         unaryWithParam.params.end()));
+}
+
+::ttnn::Conv2dConfig
+createConv2dConfig(const ::tt::target::ttnn::Conv2dConfigT &config) {
+  ::ttnn::Conv2dConfig conv2dConfig;
+
+  if (config.weights_dtype) {
+    conv2dConfig.weights_dtype = toTTNNDataType(*config.weights_dtype);
+  }
+
+  if (config.activation) {
+    conv2dConfig.activation =
+        std::optional<::ttnn::operations::unary::UnaryWithParam>(
+            toTTNNUnaryWithParam(*config.activation));
+  }
+
+  if (config.deallocate_activation) {
+    conv2dConfig.deallocate_activation = *config.deallocate_activation;
+  }
+
+  if (config.reallocate_halo_output) {
+    conv2dConfig.reallocate_halo_output = *config.reallocate_halo_output;
+  }
+
+  if (config.act_block_h_override) {
+    conv2dConfig.act_block_h_override = *config.act_block_h_override;
+  }
+
+  if (config.act_block_w_div) {
+    conv2dConfig.act_block_w_div = *config.act_block_w_div;
+  }
+
+  if (config.reshard_if_not_optimal) {
+    conv2dConfig.reshard_if_not_optimal = *config.reshard_if_not_optimal;
+  }
+
+  if (config.override_sharding_config) {
+    conv2dConfig.override_sharding_config = *config.override_sharding_config;
+  }
+
+  if (config.shard_layout) {
+    conv2dConfig.shard_layout = toTTNNTensorMemoryLayout(*config.shard_layout);
+  }
+
+  if (config.core_grid) {
+    conv2dConfig.core_grid =
+        std::make_optional(toTTNNCoreRangeSet(*config.core_grid));
+  }
+
+  if (config.transpose_shards) {
+    conv2dConfig.transpose_shards = *config.transpose_shards;
+  }
+
+  if (config.output_layout) {
+    conv2dConfig.output_layout = toTTNNLayout(*config.output_layout);
+  }
+
+  if (config.enable_act_double_buffer) {
+    conv2dConfig.enable_act_double_buffer = *config.enable_act_double_buffer;
+  }
+
+  if (config.enable_weights_double_buffer) {
+    conv2dConfig.enable_weights_double_buffer =
+        *config.enable_weights_double_buffer;
+  }
+
+  if (config.enable_kernel_stride_folding) {
+    conv2dConfig.enable_kernel_stride_folding =
+        *config.enable_kernel_stride_folding;
+  }
+
+  if (config.config_tensors_in_dram) {
+    conv2dConfig.config_tensors_in_dram = *config.config_tensors_in_dram;
+  }
+
+  return conv2dConfig;
+}
+
+::ttnn::Conv2dSliceConfig::SliceType
+createConv2dSliceType(::tt::target::ttnn::Conv2dSliceType sliceType) {
+  switch (sliceType) {
+  case ::tt::target::ttnn::Conv2dSliceType::DramHeight:
+    return ::ttnn::Conv2dSliceConfig::SliceType::DRAM_HEIGHT;
+  case ::tt::target::ttnn::Conv2dSliceType::DramWidth:
+    return ::ttnn::Conv2dSliceConfig::SliceType::DRAM_WIDTH;
+  case ::tt::target::ttnn::Conv2dSliceType::L1Full:
+    return ::ttnn::Conv2dSliceConfig::SliceType::L1_FULL;
+  }
+}
+
+::ttnn::Conv2dSliceConfig
+createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfigT &config) {
+  ::ttnn::Conv2dSliceConfig sliceConfig;
+
+  sliceConfig.slice_type = createConv2dSliceType(config.slice_type);
+  sliceConfig.num_slices = config.num_slices;
+
+  return sliceConfig;
 }
 
 ::ttnn::DeviceComputeKernelConfig createDeviceComputeKernelConfig(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -7,11 +7,11 @@
 #include "llvm/ADT/SmallVector.h"
 
 #ifdef TTMLIR_ENABLE_OPMODEL
-
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -4557,6 +4557,58 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+static ::tt::target::ttnn::Conv2dOpT buildConv2dOpTFromMLIR(
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::Conv2dOpT conv2dOp;
+  conv2dOp.in_channels = in_channels;
+  conv2dOp.out_channels = out_channels;
+  conv2dOp.batch_size = batch_size;
+  conv2dOp.input_height = input_height;
+  conv2dOp.input_width = input_width;
+  conv2dOp.kernel_size =
+      std::vector<int32_t>(kernel_size.begin(), kernel_size.end());
+  conv2dOp.stride = std::vector<int32_t>(stride.begin(), stride.end());
+  auto reorderedPadding = detail::reorderPool2dPadding(padding);
+  std::visit(
+      [&conv2dOp](const auto &arr) {
+        conv2dOp.padding.assign(arr.begin(), arr.end());
+      },
+      reorderedPadding);
+  conv2dOp.dilation = std::vector<int32_t>(dilation.begin(), dilation.end());
+  conv2dOp.groups = groups;
+  conv2dOp.out = detail::getOutputTensorRefT(outputLayout);
+  if (conv2dOp.out) {
+    conv2dOp.output_dtype = conv2dOp.out->desc->layout->memory_desc->data_type;
+  }
+  conv2dOp.conv2d_config =
+      (conv2dConfig.has_value() && *conv2dConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dConfigT>(
+                toNative(*conv2dConfig))
+          : nullptr;
+  conv2dOp.compute_config =
+      (deviceComputeKernelConfig.has_value() && *deviceComputeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*deviceComputeKernelConfig))
+          : nullptr;
+  conv2dOp.conv2d_slice_config =
+      (conv2dSliceConfig.has_value() && *conv2dSliceConfig)
+          ? std::make_unique<::tt::target::ttnn::Conv2dSliceConfigT>(
+                toNative(*conv2dSliceConfig))
+          : nullptr;
+
+  return conv2dOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -4605,33 +4657,26 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::tt::tt_metal::DataType> outputDtype =
-      detail::getNullableDataType(outputLayout);
-
-  std::optional<::ttnn::Conv2dConfig> conv2dConfigConverted =
-      conversion::getConv2dConfig(conv2dConfig);
-
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      deviceComputeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig);
-
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
-      conversion::getConv2dSliceConfig(conv2dSliceConfig);
+  ::tt::target::ttnn::Conv2dOpT conv2dOpNative = buildConv2dOpTFromMLIR(
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, dilation, groups, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout);
 
   // Create query closure
   auto conv2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
-        out_channels, batch_size, input_height, input_width,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, outputDtype, biasSpec, conv2dConfigConverted,
-        deviceComputeKernelConfigConverted,
-        detail::getNullableMemoryConfig(outputLayout), sliceConfigConverted,
-        /*return_output_dim=*/false,
-        /*return_weights_and_bias=*/false);
+    ttnn_op_invoke::Conv2dOpResult result = ttnn_op_invoke::callConv2d(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, conv2dOpNative,
+        inputSpec, weightSpec,
+        biasSpec.has_value()
+            ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+            : std::nullopt,
+        device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected Conv2dOp constraints query to return "
+           "ConstraintQueryResponse");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), conv2dOpQuery);
@@ -4689,29 +4734,26 @@ llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  std::optional<::tt::tt_metal::DataType> outputDtype =
-      detail::getNullableDataType(outputLayout);
+  ::tt::target::ttnn::Conv2dOpT conv2dOpNative = buildConv2dOpTFromMLIR(
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, dilation, groups, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout);
 
-  auto conv2dConfigConverted = conversion::getConv2dConfig(conv2dConfig);
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      deviceComputeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(deviceComputeKernelConfig);
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
-      conversion::getConv2dSliceConfig(conv2dSliceConfig);
   // Create query closure
   auto conv2dOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
-        out_channels, batch_size, input_height, input_width,
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
-        detail::reorderPool2dPadding(padding),
-        conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, outputDtype, biasSpec, conv2dConfigConverted,
-        deviceComputeKernelConfigConverted,
-        detail::getNullableMemoryConfig(outputLayout), sliceConfigConverted,
-        /*return_output_dim=*/false,
-        /*return_weights_and_bias=*/false);
+    ttnn_op_invoke::Conv2dOpResult result = ttnn_op_invoke::callConv2d(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, conv2dOpNative, inputSpec,
+        weightSpec,
+        biasSpec.has_value()
+            ? std::optional<ttnn_op_invoke::TensorArg>(*biasSpec)
+            : std::nullopt,
+        device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected Conv2dOp runtime query to return "
+        "RuntimeQueryResponse");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(conv2dOpQuery);

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -5,14 +5,13 @@
 #include "operations/conv/conv2d.h"
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
-
-#include "tt/runtime/detail/ttnn/operations/utils.h"
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/types.hpp"
+#include <variant>
 
 namespace tt::runtime::ttnn::operations::conv {
 using ::ttnn::Conv2dResultWithOptions;
+
 void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input =
@@ -25,70 +24,26 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
           ? std::make_optional(tensorPool.getTTNNTensorAndValidate(op->bias()))
           : std::nullopt;
 
-  LOG_ASSERT(op->kernel_size()->size() == 2,
-             "Kernel size expected to have 2 elements");
-  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
-  LOG_ASSERT(op->padding()->size() == 2 || op->padding()->size() == 4,
-             "Padding expected to have 2 or 4 elements");
-  LOG_ASSERT(op->dilation()->size() == 2,
-             "Dilation expected to have 2 elements");
-
-  std::array<uint32_t, 2> kernelSize, stride, dilation;
-  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
-  std::copy_n(op->stride()->begin(), 2, stride.begin());
-  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
-
-  std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>> padding;
-  if (op->padding()->size() == 2) {
-    std::array<uint32_t, 2> symPadding;
-    std::copy_n(op->padding()->begin(), 2, symPadding.begin());
-    padding = symPadding;
-  } else {
-    std::array<uint32_t, 4> asymPadding;
-    std::copy_n(op->padding()->begin(), 4, asymPadding.begin());
-    padding = asymPadding;
-  }
-
-  std::optional<::ttnn::DataType> outputDtype;
-  if (op->output_dtype()) {
-    outputDtype = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  ::ttnn::Conv2dConfig conv2dConfig;
-  if (op->conv2d_config()) {
-    conv2dConfig = utils::createConv2dConfig(op->conv2d_config());
-  }
+  ::tt::target::ttnn::Conv2dOpT conv2dOpNative;
+  op->UnPackTo(&conv2dOpNative);
 
   ::ttnn::MeshDevice &targetDevice = context.getMeshDevice();
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ttnn_op_invoke::Conv2dOpResult result = ttnn_op_invoke::callConv2d(
+      ttnn_op_invoke::CallType::EXECUTE, conv2dOpNative, &input, &weight,
+      bias.has_value() ? std::optional<ttnn_op_invoke::TensorArg>(&*bias)
+                       : std::nullopt,
+      &targetDevice);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  LOG_ASSERT(std::holds_alternative<::ttnn::Conv2dResultWithOptions>(result),
+             "Expected Conv2dResultWithOptions from callConv2d execution");
 
-  std::optional<::ttnn::Conv2dSliceConfig> sliceConfig;
-  if (op->conv2d_slice_config()) {
-    sliceConfig = utils::createConv2dSliceConfig(op->conv2d_slice_config());
-  }
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(
+                 std::get<::ttnn::Conv2dResultWithOptions>(result)),
+             "Expected output Tensor in Conv2dResultWithOptions");
 
-  Conv2dResultWithOptions result = ::ttnn::conv2d(
-      input, weight, &targetDevice, op->in_channels(), op->out_channels(),
-      op->batch_size(), op->input_height(), op->input_width(), kernelSize,
-      stride, padding, dilation, op->groups(), outputDtype, bias, conv2dConfig,
-      computeConfig, outputMemoryConfig, sliceConfig);
-
-  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result));
-
-  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(result);
+  ::ttnn::Tensor out = std::get<::ttnn::Tensor>(
+      std::get<::ttnn::Conv2dResultWithOptions>(result));
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -5,6 +5,7 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "tt/runtime/workarounds.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 
 namespace tt::runtime::ttnn::operations::utils {
 
@@ -45,108 +46,12 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
   return ttnn_op_invoke::operations::utils::getDataType(tensorRefNative);
 }
 
-::ttnn::operations::unary::UnaryOpType
-toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType) {
-  using FbUnaryOpType = ::tt::target::ttnn::UnaryOpType;
-  using TTNNUnaryOpType = ::ttnn::operations::unary::UnaryOpType;
-
-  static const std::unordered_map<FbUnaryOpType, TTNNUnaryOpType> opTypeMap = {
-      {FbUnaryOpType::Exp, TTNNUnaryOpType::EXP},
-      {FbUnaryOpType::Recip, TTNNUnaryOpType::RECIP},
-      {FbUnaryOpType::Gelu, TTNNUnaryOpType::GELU},
-      {FbUnaryOpType::Relu, TTNNUnaryOpType::RELU},
-      {FbUnaryOpType::Sqrt, TTNNUnaryOpType::SQRT},
-      {FbUnaryOpType::Sigmoid, TTNNUnaryOpType::SIGMOID},
-      {FbUnaryOpType::Log, TTNNUnaryOpType::LOG},
-      {FbUnaryOpType::Tanh, TTNNUnaryOpType::TANH},
-      {FbUnaryOpType::Log2, TTNNUnaryOpType::LOG2},
-      {FbUnaryOpType::Log10, TTNNUnaryOpType::LOG10},
-      {FbUnaryOpType::Sin, TTNNUnaryOpType::SIN},
-      {FbUnaryOpType::Cos, TTNNUnaryOpType::COS},
-      {FbUnaryOpType::Abs, TTNNUnaryOpType::ABS},
-      {FbUnaryOpType::AbsInt32, TTNNUnaryOpType::ABS_INT32},
-      {FbUnaryOpType::Sign, TTNNUnaryOpType::SIGN},
-      {FbUnaryOpType::Square, TTNNUnaryOpType::SQUARE},
-      {FbUnaryOpType::Eqz, TTNNUnaryOpType::EQZ},
-      {FbUnaryOpType::Nez, TTNNUnaryOpType::NEZ},
-      {FbUnaryOpType::Gtz, TTNNUnaryOpType::GTZ},
-      {FbUnaryOpType::Ltz, TTNNUnaryOpType::LTZ},
-      {FbUnaryOpType::Gez, TTNNUnaryOpType::GEZ},
-      {FbUnaryOpType::Lez, TTNNUnaryOpType::LEZ},
-      {FbUnaryOpType::ReluMax, TTNNUnaryOpType::RELU_MAX},
-      {FbUnaryOpType::ReluMin, TTNNUnaryOpType::RELU_MIN},
-      {FbUnaryOpType::Power, TTNNUnaryOpType::POWER},
-      {FbUnaryOpType::LeakyRelu, TTNNUnaryOpType::LEAKY_RELU},
-      {FbUnaryOpType::Elu, TTNNUnaryOpType::ELU},
-      {FbUnaryOpType::Exp2, TTNNUnaryOpType::EXP2},
-      {FbUnaryOpType::Heaviside, TTNNUnaryOpType::HEAVISIDE},
-      {FbUnaryOpType::Expm1, TTNNUnaryOpType::EXPM1},
-      {FbUnaryOpType::Signbit, TTNNUnaryOpType::SIGNBIT},
-      {FbUnaryOpType::Asin, TTNNUnaryOpType::ASIN},
-      {FbUnaryOpType::Acos, TTNNUnaryOpType::ACOS},
-      {FbUnaryOpType::Rsqrt, TTNNUnaryOpType::RSQRT},
-      {FbUnaryOpType::Relu6, TTNNUnaryOpType::RELU6},
-      {FbUnaryOpType::Hardsigmoid, TTNNUnaryOpType::HARDSIGMOID},
-      {FbUnaryOpType::Atan, TTNNUnaryOpType::ATAN},
-      {FbUnaryOpType::Erf, TTNNUnaryOpType::ERF},
-      {FbUnaryOpType::Erfc, TTNNUnaryOpType::ERFC},
-      {FbUnaryOpType::Isinf, TTNNUnaryOpType::ISINF},
-      {FbUnaryOpType::Isposinf, TTNNUnaryOpType::ISPOSINF},
-      {FbUnaryOpType::Isneginf, TTNNUnaryOpType::ISNEGINF},
-      {FbUnaryOpType::Isnan, TTNNUnaryOpType::ISNAN},
-      {FbUnaryOpType::LogicalNotUnary, TTNNUnaryOpType::LOGICAL_NOT_UNARY},
-      {FbUnaryOpType::Isfinite, TTNNUnaryOpType::ISFINITE},
-      {FbUnaryOpType::Erfinv, TTNNUnaryOpType::ERFINV},
-      {FbUnaryOpType::I0, TTNNUnaryOpType::I0},
-      {FbUnaryOpType::I1, TTNNUnaryOpType::I1},
-      {FbUnaryOpType::Tan, TTNNUnaryOpType::TAN},
-      {FbUnaryOpType::Rsub, TTNNUnaryOpType::RSUB},
-      {FbUnaryOpType::Rdiv, TTNNUnaryOpType::RDIV},
-      {FbUnaryOpType::Silu, TTNNUnaryOpType::SILU},
-      {FbUnaryOpType::Softplus, TTNNUnaryOpType::SOFTPLUS},
-      {FbUnaryOpType::Identity, TTNNUnaryOpType::IDENTITY},
-      {FbUnaryOpType::Neg, TTNNUnaryOpType::NEG},
-      {FbUnaryOpType::AddUnarySfpu, TTNNUnaryOpType::ADD_UNARY_SFPU},
-      {FbUnaryOpType::SubUnarySfpu, TTNNUnaryOpType::SUB_UNARY_SFPU},
-      {FbUnaryOpType::MulUnarySfpu, TTNNUnaryOpType::MUL_UNARY_SFPU},
-      {FbUnaryOpType::DivUnarySfpu, TTNNUnaryOpType::DIV_UNARY_SFPU},
-      {FbUnaryOpType::IdentityUint32, TTNNUnaryOpType::IDENTITY},
-      {FbUnaryOpType::UnaryNe, TTNNUnaryOpType::UNARY_NE},
-      {FbUnaryOpType::UnaryGt, TTNNUnaryOpType::UNARY_GT},
-      {FbUnaryOpType::UnaryLt, TTNNUnaryOpType::UNARY_LT},
-      {FbUnaryOpType::TiledProd, TTNNUnaryOpType::TILED_PROD},
-      {FbUnaryOpType::Typecast, TTNNUnaryOpType::TYPECAST},
-      {FbUnaryOpType::BitwiseXor, TTNNUnaryOpType::BITWISE_XOR},
-      {FbUnaryOpType::BitwiseNot, TTNNUnaryOpType::BITWISE_NOT},
-      {FbUnaryOpType::BitwiseAnd, TTNNUnaryOpType::BITWISE_AND},
-      {FbUnaryOpType::BitwiseOr, TTNNUnaryOpType::BITWISE_OR},
-      {FbUnaryOpType::RightShift, TTNNUnaryOpType::RIGHT_SHIFT},
-      {FbUnaryOpType::Floor, TTNNUnaryOpType::FLOOR},
-      {FbUnaryOpType::Ceil, TTNNUnaryOpType::CEIL},
-      {FbUnaryOpType::Round, TTNNUnaryOpType::ROUND},
-      {FbUnaryOpType::LeftShift, TTNNUnaryOpType::LEFT_SHIFT},
-      {FbUnaryOpType::Remainder, TTNNUnaryOpType::REMAINDER},
-      {FbUnaryOpType::Fmod, TTNNUnaryOpType::FMOD},
-      {FbUnaryOpType::Dropout, TTNNUnaryOpType::DROPOUT},
-      {FbUnaryOpType::Fill, TTNNUnaryOpType::FILL},
-      {FbUnaryOpType::PreluSfpu, TTNNUnaryOpType::PRELU_SFPU},
-      {FbUnaryOpType::ZeroPoint, TTNNUnaryOpType::ZERO_POINT},
-  };
-
-  auto it = opTypeMap.find(unaryOpType);
-  if (it != opTypeMap.end()) {
-    return it->second;
-  }
-
-  LOG_FATAL("Unsupported UnaryOpType");
-}
-
 ::ttnn::operations::unary::UnaryWithParam
 toTTNNUnaryWithParam(const ::tt::target::ttnn::UnaryWithParam &unaryWithParam) {
-  return ::ttnn::operations::unary::UnaryWithParam(
-      toTTNNUnaryOpType(unaryWithParam.op_type()),
-      std::vector<float>(unaryWithParam.params()->begin(),
-                         unaryWithParam.params()->end()));
+  ::tt::target::ttnn::UnaryWithParamT unaryWithParamT;
+  unaryWithParam.UnPackTo(&unaryWithParamT);
+  return ttnn_op_invoke::operations::utils::toTTNNUnaryWithParam(
+      unaryWithParamT);
 }
 
 std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
@@ -343,106 +248,18 @@ createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::LinearOp *op) {
 
 ::ttnn::Conv2dConfig
 createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *config) {
-  ::ttnn::Conv2dConfig conv2dConfig;
-
-  if (config->weights_dtype()) {
-    conv2dConfig.weights_dtype =
-        ttnn_op_invoke::operations::utils::toTTNNDataType(
-            *config->weights_dtype());
-  }
-
-  if (config->activation()) {
-    conv2dConfig.activation =
-        std::optional<::ttnn::operations::unary::UnaryWithParam>(
-            toTTNNUnaryWithParam(*config->activation()));
-  }
-
-  if (config->deallocate_activation()) {
-    conv2dConfig.deallocate_activation = *config->deallocate_activation();
-  }
-
-  if (config->reallocate_halo_output()) {
-    conv2dConfig.reallocate_halo_output = *config->reallocate_halo_output();
-  }
-
-  if (config->act_block_h_override()) {
-    conv2dConfig.act_block_h_override = *config->act_block_h_override();
-  }
-
-  if (config->act_block_w_div()) {
-    conv2dConfig.act_block_w_div = *config->act_block_w_div();
-  }
-
-  if (config->reshard_if_not_optimal()) {
-    conv2dConfig.reshard_if_not_optimal = *config->reshard_if_not_optimal();
-  }
-
-  if (config->override_sharding_config()) {
-    conv2dConfig.override_sharding_config = *config->override_sharding_config();
-  }
-
-  if (config->shard_layout()) {
-    conv2dConfig.shard_layout =
-        ttnn_op_invoke::operations::utils::toTTNNTensorMemoryLayout(
-            *config->shard_layout());
-  }
-
-  if (config->core_grid()) {
-    conv2dConfig.core_grid = std::make_optional(
-        ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(*config->core_grid()));
-  }
-
-  if (config->transpose_shards()) {
-    conv2dConfig.transpose_shards = *config->transpose_shards();
-  }
-
-  if (config->output_layout()) {
-    conv2dConfig.output_layout =
-        ttnn_op_invoke::operations::utils::toTTNNLayout(
-            *config->output_layout());
-  }
-
-  if (config->enable_act_double_buffer()) {
-    conv2dConfig.enable_act_double_buffer = *config->enable_act_double_buffer();
-  }
-
-  if (config->enable_weights_double_buffer()) {
-    conv2dConfig.enable_weights_double_buffer =
-        *config->enable_weights_double_buffer();
-  }
-
-  if (config->enable_kernel_stride_folding()) {
-    conv2dConfig.enable_kernel_stride_folding =
-        *config->enable_kernel_stride_folding();
-  }
-
-  if (config->config_tensors_in_dram()) {
-    conv2dConfig.config_tensors_in_dram = *config->config_tensors_in_dram();
-  }
-
-  return conv2dConfig;
-}
-
-::ttnn::Conv2dSliceConfig::SliceType
-createConv2dSliceType(::tt::target::ttnn::Conv2dSliceType sliceType) {
-  switch (sliceType) {
-  case ::tt::target::ttnn::Conv2dSliceType::DramHeight:
-    return ::ttnn::Conv2dSliceConfig::SliceType::DRAM_HEIGHT;
-  case ::tt::target::ttnn::Conv2dSliceType::DramWidth:
-    return ::ttnn::Conv2dSliceConfig::SliceType::DRAM_WIDTH;
-  case ::tt::target::ttnn::Conv2dSliceType::L1Full:
-    return ::ttnn::Conv2dSliceConfig::SliceType::L1_FULL;
-  }
+  ::tt::target::ttnn::Conv2dConfigT conv2dConfigNative;
+  config->UnPackTo(&conv2dConfigNative);
+  return ttnn_op_invoke::operations::utils::createConv2dConfig(
+      conv2dConfigNative);
 }
 
 ::ttnn::Conv2dSliceConfig
 createConv2dSliceConfig(const ::tt::target::ttnn::Conv2dSliceConfig *config) {
-  ::ttnn::Conv2dSliceConfig sliceConfig;
-
-  sliceConfig.slice_type = createConv2dSliceType(config->slice_type());
-  sliceConfig.num_slices = config->num_slices();
-
-  return sliceConfig;
+  ::tt::target::ttnn::Conv2dSliceConfigT conv2dSliceConfigNative;
+  config->UnPackTo(&conv2dSliceConfigNative);
+  return ttnn_op_invoke::operations::utils::createConv2dSliceConfig(
+      conv2dSliceConfigNative);
 }
 
 ::ttnn::DeviceComputeKernelConfig createDeviceComputeKernelConfig(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                           
  OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.
                                             
### What's changed
This is the second PR in the TTNNOpInvokeLib series. It introduces a shared library that unifies conv2d op dispatch across OpModel and runtime.

  Conv2dOpT (the NativeTable type for conv2d) is the interface passed into the library. In OpModel it is constructed from MLIR attributes via buildConv2dOpTFromMLIR; in Runtime it is already available directly from the deserialized flatbuffer. Both call sites then delegate to ttnn_op_invoke::callConv2d, which handles parameter resolution and dispatch for all three call types: constraint query, runtime query, and execution.

Depends on: https://github.com/tenstorrent/tt-mlir/pull/8069
