### PR TITLE
[D2M] Disambiguate ThreadAttr assembly format

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
@@ -30,7 +30,11 @@ def D2M_ThreadAttr : AttrDef<D2M_Dialect, "Thread", [], "::mlir::Attribute"> {
     DefaultValuedParameter<"int32_t", "-1">:$nocIndex
   );
 
-  let assemblyFormat = [{ `<` $threadType (`,` $kernelSymbol^)? (`,` `noc` `=` $nocIndex^)? `>` }];
+  // Format: `<` threadType (`,` kernelSymbol)? (`,` `noc` `=` nocIndex)? `>`.
+  // Both optional groups start with `,`, which the declarative format cannot
+  // disambiguate, so we hand-roll the parser to peek for the `noc` keyword
+  // after a comma and pick the right branch.
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
       static ThreadAttr get(::mlir::MLIRContext *context, ThreadType threadType) {

--- a/lib/Dialect/D2M/IR/D2MDialect.cpp
+++ b/lib/Dialect/D2M/IR/D2MDialect.cpp
@@ -29,6 +29,69 @@
 using namespace mlir;
 using namespace mlir::tt::d2m;
 
+// Custom assembly format for D2M_ThreadAttr.
+//
+// Format:  `<` threadType (`,` kernelSymbol)? (`,` `noc` `=` nocIndex)? `>`
+//
+// The two optional groups both start with `,`, so the declarative tablegen
+// format cannot disambiguate them: it always tries to parse the kernel symbol
+// after the first comma and fails on `#d2m.thread<datamovement, noc = 0>`.
+// We peek for the `noc` keyword to pick the correct branch.
+mlir::Attribute ThreadAttr::parse(::mlir::AsmParser &parser, ::mlir::Type) {
+  if (parser.parseLess()) {
+    return {};
+  }
+
+  ::mlir::FailureOr<ThreadType> threadType =
+      ::mlir::FieldParser<ThreadType>::parse(parser);
+  if (::mlir::failed(threadType)) {
+    return {};
+  }
+
+  SymbolRefAttr kernelSymbol;
+  int32_t nocIndex = -1;
+
+  // First optional: either `, @kernel` or `, noc = N`.
+  if (parser.parseOptionalComma().succeeded()) {
+    if (parser.parseOptionalKeyword("noc").succeeded()) {
+      if (parser.parseEqual() || parser.parseInteger(nocIndex)) {
+        return {};
+      }
+    } else {
+      if (parser.parseAttribute(kernelSymbol)) {
+        return {};
+      }
+      // Second optional: only valid if a kernel symbol was given above.
+      if (parser.parseOptionalComma().succeeded()) {
+        if (parser.parseKeyword("noc") || parser.parseEqual() ||
+            parser.parseInteger(nocIndex)) {
+          return {};
+        }
+      }
+    }
+  }
+
+  if (parser.parseGreater()) {
+    return {};
+  }
+
+  return ThreadAttr::get(parser.getContext(), *threadType, kernelSymbol,
+                         nocIndex);
+}
+
+void ThreadAttr::print(::mlir::AsmPrinter &printer) const {
+  printer << "<";
+  printer.printStrippedAttrOrType(getThreadType());
+  if (getKernelSymbol()) {
+    printer << ", ";
+    printer.printAttribute(getKernelSymbol());
+  }
+  if (getNocIndex() != -1) {
+    printer << ", noc = " << getNocIndex();
+  }
+  printer << ">";
+}
+
 #include "ttmlir/Dialect/D2M/IR/D2MOpsDialect.cpp.inc"
 
 struct D2MDialectFoldInterface : public DialectFoldInterface {

--- a/test/ttmlir/Dialect/D2M/thread_attr_parse.mlir
+++ b/test/ttmlir/Dialect/D2M/thread_attr_parse.mlir
@@ -1,0 +1,34 @@
+// RUN: ttmlir-opt %s | ttmlir-opt | FileCheck %s
+
+// Verify all valid forms of #d2m.thread<...> round-trip.
+// Historically, the assembly format had two optional groups both led by a
+// comma, which caused `#d2m.thread<datamovement, noc = 0>` to be misparsed
+// as if the kernel symbol position contained `noc = 0`.
+
+module {
+  // CHECK: func.func private @no_kernel_no_noc() attributes {d2m.thread = #d2m.thread<compute>}
+  func.func private @no_kernel_no_noc() attributes {d2m.thread = #d2m.thread<compute>} {
+    return
+  }
+
+  // CHECK: func.func private @kernel_only() attributes {d2m.thread = #d2m.thread<datamovement, @some_sym>}
+  func.func private @kernel_only() attributes {d2m.thread = #d2m.thread<datamovement, @some_sym>} {
+    return
+  }
+
+  // The case from the bug report: noc only, no kernel symbol.
+  // CHECK: func.func private @noc_only_0() attributes {d2m.thread = #d2m.thread<datamovement, noc = 0>}
+  func.func private @noc_only_0() attributes {d2m.thread = #d2m.thread<datamovement, noc = 0>} {
+    return
+  }
+
+  // CHECK: func.func private @noc_only_1() attributes {d2m.thread = #d2m.thread<datamovement, noc = 1>}
+  func.func private @noc_only_1() attributes {d2m.thread = #d2m.thread<datamovement, noc = 1>} {
+    return
+  }
+
+  // CHECK: func.func private @kernel_and_noc() attributes {d2m.thread = #d2m.thread<datamovement, @some_sym, noc = 1>}
+  func.func private @kernel_and_noc() attributes {d2m.thread = #d2m.thread<datamovement, @some_sym, noc = 1>} {
+    return
+  }
+}


### PR DESCRIPTION
The declarative format for `#d2m.thread<...>` had two optional groups both led by a comma:

    `<` $threadType (`,` $kernelSymbol^)? (`,` `noc` `=` $nocIndex^)? `>`

The tablegen parser commits to the first optional on seeing `,`, so `#d2m.thread<datamovement, noc = 0>` failed with "expected attribute value" while trying to read `noc` as a SymbolRefAttr. Switch to a hand-rolled parser/printer that peeks for the `noc` keyword after the comma to pick the right branch. The print form is unchanged, so existing IR round-trips identically.
