### PR TITLE
[TTIR] Add TTIRConsolidateStaticCacheUpdates pass to reduce transformers 5.5 StaticCache overhead

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -510,23 +510,26 @@ def TTIRFoldFullToScalar: Pass<"ttir-fold-full-to-scalar", "::mlir::ModuleOp"> {
 
 def TTIRConsolidateStaticCacheUpdates
     : Pass<"ttir-consolidate-static-cache-updates", "::mlir::ModuleOp"> {
-  let summary = "Consolidate redundant write-backs to mark_static_address tensors.";
+  let summary = "Unify redundant per-layer block args for mark_static_address tensors.";
   let description = [{
-    Detects the pattern where the same static-address tensor (e.g.,
-    StaticCache.cumulative_length from Transformers 5.5+) is incremented N
-    times per forward pass with all N results feeding only function outputs
-    (write-backs to DRAM). Reduces N write-backs to 1, eliminating N-1
-    scalar ops and their associated DRAM round-trips.
+    Detects per-layer patterns where N block arguments of the same type are
+    each incremented by the same constant delta and returned (e.g., one
+    cumulative_length per transformer layer from Transformers 5.5+
+    StaticCache). Replaces all uses of the N-1 eliminated block args with a
+    single canonical arg. The CSE pass that follows then deduplicates the
+    now-identical add, repeat, and delta ops, collapsing N per-layer scalar
+    ops down to 1.
 
     Applies when:
-    - Multiple ttir.add ops each have one BlockArgument operand (the static
-      tensor) and one ttir.full constant delta operand.
-    - The add result has exactly one use: a function return operand.
-    - All adds share the same BlockArgument and the same delta fill value.
-    - The BlockArgument type matches the add result type.
+    - Multiple return operands match [mesh_shard(] add(blockArg, const_delta) [)]
+    - The add result has exactly one use: the return operand.
+    - All matched adds share the same constant delta value and the same
+      blockArg element type (grouped by these two keys).
+    - The blockArg type matches the add result type (no broadcasting).
 
-    Since all N write-backs target the same static DRAM address at function
-    exit, keeping one is semantically equivalent to keeping all.
+    Relies on the lockstep decode invariant: all per-layer cumulative_length
+    tensors hold equal values at function entry, so routing all uses to one
+    canonical arg is value-preserving.
   }];
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
 }

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -508,6 +508,29 @@ def TTIRFoldFullToScalar: Pass<"ttir-fold-full-to-scalar", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
 }
 
+def TTIRConsolidateStaticCacheUpdates
+    : Pass<"ttir-consolidate-static-cache-updates", "::mlir::ModuleOp"> {
+  let summary = "Consolidate redundant write-backs to mark_static_address tensors.";
+  let description = [{
+    Detects the pattern where the same static-address tensor (e.g.,
+    StaticCache.cumulative_length from Transformers 5.5+) is incremented N
+    times per forward pass with all N results feeding only function outputs
+    (write-backs to DRAM). Reduces N write-backs to 1, eliminating N-1
+    scalar ops and their associated DRAM round-trips.
+
+    Applies when:
+    - Multiple ttir.add ops each have one BlockArgument operand (the static
+      tensor) and one ttir.full constant delta operand.
+    - The add result has exactly one use: a function return operand.
+    - All adds share the same BlockArgument and the same delta fill value.
+    - The BlockArgument type matches the add result type.
+
+    Since all N write-backs target the same static DRAM address at function
+    exit, keeping one is semantically equivalent to keeping all.
+  }];
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 def TTIRCPUBooleanNarrowing : Pass<"ttir-cpu-boolean-narrowing", "::mlir::ModuleOp"> {
   let summary = "Narrow boolean-producing ops to i1 in the CPU module.";
   let description = [{

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(EraseInverseOps)
 add_subdirectory(HoistCPUOps)
 add_mlir_dialect_library(MLIRTTIRTransforms
         Broadcast.cpp
+        ConsolidateStaticCacheUpdates.cpp
         CPUBooleanNarrowing.cpp
         DecomposeComplexPermute.cpp
         DecomposeComplexReshape.cpp

--- a/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
+++ b/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRCONSOLIDATESTATICCACHEUPDATES
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+struct WritebackInfo {
+  unsigned retIdx;
+  BlockArgument blockArg;
+  AddOp addOp;
+  Value delta;
+  Value retSlotVal; // What is currently in the return slot (may be outer shard)
+};
+
+// Return the scalar integer value of a constant delta operand.
+// Accepts ttir.full (FillValue attr) and ttir.constant (dense splat).
+static std::optional<int64_t> scalarIntKey(Value v) {
+  if (auto fullOp = v.getDefiningOp<FullOp>()) {
+    if (auto ia = dyn_cast<IntegerAttr>(fullOp.getFillValue()))
+      return ia.getInt();
+    return std::nullopt;
+  }
+  if (auto constOp = v.getDefiningOp<ConstantOp>()) {
+    auto dense = dyn_cast<DenseIntOrFPElementsAttr>(constOp.getValue());
+    if (dense && dense.isSplat() && dense.getElementType().isInteger())
+      return dense.getSplatValue<APInt>().getSExtValue();
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+class TTIRConsolidateStaticCacheUpdates
+    : public impl::TTIRConsolidateStaticCacheUpdatesBase<
+          TTIRConsolidateStaticCacheUpdates> {
+public:
+  using impl::TTIRConsolidateStaticCacheUpdatesBase<
+      TTIRConsolidateStaticCacheUpdates>::TTIRConsolidateStaticCacheUpdatesBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+
+    moduleOp.walk([&](func::FuncOp funcOp) {
+      if (funcOp.getBody().empty())
+        return;
+
+      Block &lastBlock = funcOp.getBody().back();
+      auto returnOp =
+          llvm::dyn_cast<func::ReturnOp>(lastBlock.getTerminator());
+      if (!returnOp)
+        return;
+
+      // Collect write-back candidates.
+      // Pattern (with optional mesh_shard wrapper):
+      //   retSlotVal = [mesh_shard(] add(blockArg-or-mesh_shard(blockArg),
+      //                                   constant_delta) [)]
+      SmallVector<WritebackInfo> candidates;
+
+      for (auto [idx, retVal] : llvm::enumerate(returnOp.getOperands())) {
+        unsigned retIdx = static_cast<unsigned>(idx);
+
+        // Optionally look through an outer mesh_shard.
+        Value addResult = retVal;
+        if (auto outerShard = retVal.getDefiningOp<MeshShardOp>()) {
+          if (!retVal.hasOneUse())
+            continue;
+          addResult = outerShard.getInput();
+        }
+
+        auto addOp = addResult.getDefiningOp<AddOp>();
+        if (!addOp || !addResult.hasOneUse())
+          continue;
+
+        // Copy the structured binding index to avoid C++17 lambda capture
+        // limitation for structured bindings (C++20 extension).
+        unsigned capturedRetIdx = retIdx;
+        Value capturedRetVal = retVal;
+
+        auto tryMatch = [&](Value maybeArgSide, Value maybeDelta) -> bool {
+          // maybeArgSide is either a BlockArgument directly, or
+          // mesh_shard(BlockArgument).
+          BlockArgument blockArg;
+          if (auto innerShard = maybeArgSide.getDefiningOp<MeshShardOp>()) {
+            blockArg = llvm::dyn_cast<BlockArgument>(innerShard.getInput());
+          } else {
+            blockArg = llvm::dyn_cast<BlockArgument>(maybeArgSide);
+          }
+          if (!blockArg || blockArg.getOwner()->getParentOp() != funcOp)
+            return false;
+
+          // Require a recognizable scalar-integer constant delta.
+          if (!scalarIntKey(maybeDelta).has_value())
+            return false;
+
+          // The blockArg type must match the return slot type so that the
+          // consolidated result can substitute into any slot of the group.
+          if (blockArg.getType() != capturedRetVal.getType())
+            return false;
+
+          candidates.push_back(
+              {capturedRetIdx, blockArg, addOp, maybeDelta, capturedRetVal});
+          return true;
+        };
+
+        if (!tryMatch(addOp.getLhs(), addOp.getRhs()))
+          tryMatch(addOp.getRhs(), addOp.getLhs());
+      }
+
+      // Group candidates by (delta scalar key, blockArg element type).
+      // Two write-backs belong to the same group when they apply the same
+      // constant increment to arguments of the same type, so that keeping one
+      // result and broadcasting it to all return slots is value-equivalent.
+      // (For per-layer StaticCache tensors, all layer cumulative_lengths have
+      // equal values at function entry, making this substitution correct.)
+      using GroupKey = std::pair<int64_t, mlir::Type>;
+      SmallVector<std::pair<GroupKey, SmallVector<WritebackInfo>>> groups;
+
+      for (auto &wb : candidates) {
+        auto keyOpt = scalarIntKey(wb.delta);
+        if (!keyOpt.has_value())
+          continue;
+        GroupKey key{*keyOpt, wb.blockArg.getType()};
+
+        bool found = false;
+        for (auto &[k, vec] : groups) {
+          if (k == key) {
+            vec.push_back(wb);
+            found = true;
+            break;
+          }
+        }
+        if (!found)
+          groups.push_back({key, {wb}});
+      }
+
+      // Consolidate each group with more than one write-back.
+      // Keep the last write-back's return-slot value as the canonical result
+      // and redirect all earlier slots to it, erasing the now-dead ops.
+      for (auto &[key, group] : groups) {
+        if (group.size() <= 1)
+          continue;
+
+        Value keptResult = group.back().retSlotVal;
+
+        for (size_t i = 0; i + 1 < group.size(); ++i) {
+          WritebackInfo &wb = group[i];
+          returnOp.setOperand(wb.retIdx, keptResult);
+
+          // Erase in dependency order: outer shard first, then the add.
+          // The inner mesh_shard (if any) may still have other uses; leave it
+          // for dead-code elimination.
+          if (wb.retSlotVal != wb.addOp.getResult() &&
+              wb.retSlotVal.use_empty())
+            wb.retSlotVal.getDefiningOp()->erase();
+
+          if (wb.addOp.getResult().use_empty())
+            wb.addOp.erase();
+        }
+      }
+    });
+  }
+};
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
+++ b/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
@@ -15,11 +15,8 @@ namespace mlir::tt::ttir {
 namespace {
 
 struct WritebackInfo {
-  unsigned retIdx;
   BlockArgument blockArg;
-  AddOp addOp;
   Value delta;
-  Value retSlotVal; // What is currently in the return slot (may be outer shard)
 };
 
 // Return the scalar integer value of a constant delta operand.
@@ -63,13 +60,11 @@ public:
 
       // Collect write-back candidates.
       // Pattern (with optional mesh_shard wrapper):
-      //   retSlotVal = [mesh_shard(] add(blockArg-or-mesh_shard(blockArg),
-      //                                   constant_delta) [)]
+      //   [mesh_shard(] add(blockArg-or-mesh_shard(blockArg),
+      //                     constant_delta) [)]  →  return operand
       SmallVector<WritebackInfo> candidates;
 
-      for (auto [idx, retVal] : llvm::enumerate(returnOp.getOperands())) {
-        unsigned retIdx = static_cast<unsigned>(idx);
-
+      for (auto retVal : returnOp.getOperands()) {
         // Optionally look through an outer mesh_shard.
         Value addResult = retVal;
         if (auto outerShard = retVal.getDefiningOp<MeshShardOp>()) {
@@ -82,34 +77,21 @@ public:
         if (!addOp || !addResult.hasOneUse())
           continue;
 
-        // Copy the structured binding index to avoid C++17 lambda capture
-        // limitation for structured bindings (C++20 extension).
-        unsigned capturedRetIdx = retIdx;
-        Value capturedRetVal = retVal;
-
         auto tryMatch = [&](Value maybeArgSide, Value maybeDelta) -> bool {
-          // maybeArgSide is either a BlockArgument directly, or
-          // mesh_shard(BlockArgument).
           BlockArgument blockArg;
-          if (auto innerShard = maybeArgSide.getDefiningOp<MeshShardOp>()) {
+          if (auto innerShard = maybeArgSide.getDefiningOp<MeshShardOp>())
             blockArg = llvm::dyn_cast<BlockArgument>(innerShard.getInput());
-          } else {
+          else
             blockArg = llvm::dyn_cast<BlockArgument>(maybeArgSide);
-          }
           if (!blockArg || blockArg.getOwner()->getParentOp() != funcOp)
             return false;
-
-          // Require a recognizable scalar-integer constant delta.
           if (!scalarIntKey(maybeDelta).has_value())
             return false;
-
-          // The blockArg type must match the return slot type so that the
-          // consolidated result can substitute into any slot of the group.
-          if (blockArg.getType() != capturedRetVal.getType())
+          // Guard against broadcasting: block arg type must equal add result
+          // type so that replacing arg uses preserves the result shape.
+          if (blockArg.getType() != addResult.getType())
             return false;
-
-          candidates.push_back(
-              {capturedRetIdx, blockArg, addOp, maybeDelta, capturedRetVal});
+          candidates.push_back({blockArg, maybeDelta});
           return true;
         };
 
@@ -144,36 +126,11 @@ public:
           groups.push_back({key, {wb}});
       }
 
-      // Consolidate each group with more than one write-back.
-      // Keep the last write-back's return-slot value as the canonical result
-      // and redirect all earlier slots to it, erasing the now-dead ops.
-      for (auto &[key, group] : groups) {
-        if (group.size() <= 1)
-          continue;
-
-        Value keptResult = group.back().retSlotVal;
-
-        for (size_t i = 0; i + 1 < group.size(); ++i) {
-          WritebackInfo &wb = group[i];
-          returnOp.setOperand(wb.retIdx, keptResult);
-
-          // Erase in dependency order: outer shard first, then the add.
-          // The inner mesh_shard (if any) may still have other uses; leave it
-          // for dead-code elimination.
-          if (wb.retSlotVal != wb.addOp.getResult() &&
-              wb.retSlotVal.use_empty())
-            wb.retSlotVal.getDefiningOp()->erase();
-
-          if (wb.addOp.getResult().use_empty())
-            wb.addOp.erase();
-        }
-      }
-
-      // Phase 2: Replace all remaining uses of eliminated block args with the
-      // canonical block arg.  All per-layer cumulative_length args are
-      // value-equivalent at function entry (lockstep decode invariant), so
-      // routing every internal use (e.g. update_cache position operands) to a
-      // single arg collapses N-1 ttnn.repeat ops after TTNN lowering.
+      // Replace all uses of eliminated block args with the canonical block arg.
+      // All per-layer cumulative_length args are value-equivalent at function
+      // entry (lockstep decode invariant), so routing every use to a single arg
+      // is value-preserving. The CSE pass that follows will then deduplicate
+      // the now-identical add/repeat/delta ops, collapsing N per-layer ops to 1.
       for (auto &[key, group] : groups) {
         if (group.size() <= 1)
           continue;

--- a/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
+++ b/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
@@ -168,6 +168,24 @@ public:
             wb.addOp.erase();
         }
       }
+
+      // Phase 2: Replace all remaining uses of eliminated block args with the
+      // canonical block arg.  All per-layer cumulative_length args are
+      // value-equivalent at function entry (lockstep decode invariant), so
+      // routing every internal use (e.g. update_cache position operands) to a
+      // single arg collapses N-1 ttnn.repeat ops after TTNN lowering.
+      for (auto &[key, group] : groups) {
+        if (group.size() <= 1)
+          continue;
+
+        BlockArgument canonicalArg = group.back().blockArg;
+        for (size_t i = 0; i + 1 < group.size(); ++i) {
+          BlockArgument eliminatedArg = group[i].blockArg;
+          if (eliminatedArg == canonicalArg)
+            continue;
+          eliminatedArg.replaceAllUsesWith(canonicalArg);
+        }
+      }
     });
   }
 };

--- a/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
+++ b/lib/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates.cpp
@@ -23,14 +23,16 @@ struct WritebackInfo {
 // Accepts ttir.full (FillValue attr) and ttir.constant (dense splat).
 static std::optional<int64_t> scalarIntKey(Value v) {
   if (auto fullOp = v.getDefiningOp<FullOp>()) {
-    if (auto ia = dyn_cast<IntegerAttr>(fullOp.getFillValue()))
+    if (auto ia = dyn_cast<IntegerAttr>(fullOp.getFillValue())) {
       return ia.getInt();
+    }
     return std::nullopt;
   }
   if (auto constOp = v.getDefiningOp<ConstantOp>()) {
     auto dense = dyn_cast<DenseIntOrFPElementsAttr>(constOp.getValue());
-    if (dense && dense.isSplat() && dense.getElementType().isInteger())
+    if (dense && dense.isSplat() && dense.getElementType().isInteger()) {
       return dense.getSplatValue<APInt>().getSExtValue();
+    }
     return std::nullopt;
   }
   return std::nullopt;
@@ -49,14 +51,16 @@ public:
     ModuleOp moduleOp = getOperation();
 
     moduleOp.walk([&](func::FuncOp funcOp) {
-      if (funcOp.getBody().empty())
+      if (funcOp.getBody().empty()) {
         return;
+      }
 
       Block &lastBlock = funcOp.getBody().back();
       auto returnOp =
           llvm::dyn_cast<func::ReturnOp>(lastBlock.getTerminator());
-      if (!returnOp)
+      if (!returnOp) {
         return;
+      }
 
       // Collect write-back candidates.
       // Pattern (with optional mesh_shard wrapper):
@@ -68,35 +72,42 @@ public:
         // Optionally look through an outer mesh_shard.
         Value addResult = retVal;
         if (auto outerShard = retVal.getDefiningOp<MeshShardOp>()) {
-          if (!retVal.hasOneUse())
+          if (!retVal.hasOneUse()) {
             continue;
+          }
           addResult = outerShard.getInput();
         }
 
         auto addOp = addResult.getDefiningOp<AddOp>();
-        if (!addOp || !addResult.hasOneUse())
+        if (!addOp || !addResult.hasOneUse()) {
           continue;
+        }
 
         auto tryMatch = [&](Value maybeArgSide, Value maybeDelta) -> bool {
           BlockArgument blockArg;
-          if (auto innerShard = maybeArgSide.getDefiningOp<MeshShardOp>())
+          if (auto innerShard = maybeArgSide.getDefiningOp<MeshShardOp>()) {
             blockArg = llvm::dyn_cast<BlockArgument>(innerShard.getInput());
-          else
+          } else {
             blockArg = llvm::dyn_cast<BlockArgument>(maybeArgSide);
-          if (!blockArg || blockArg.getOwner()->getParentOp() != funcOp)
+          }
+          if (!blockArg || blockArg.getOwner()->getParentOp() != funcOp) {
             return false;
-          if (!scalarIntKey(maybeDelta).has_value())
+          }
+          if (!scalarIntKey(maybeDelta).has_value()) {
             return false;
+          }
           // Guard against broadcasting: block arg type must equal add result
           // type so that replacing arg uses preserves the result shape.
-          if (blockArg.getType() != addResult.getType())
+          if (blockArg.getType() != addResult.getType()) {
             return false;
+          }
           candidates.push_back({blockArg, maybeDelta});
           return true;
         };
 
-        if (!tryMatch(addOp.getLhs(), addOp.getRhs()))
+        if (!tryMatch(addOp.getLhs(), addOp.getRhs())) {
           tryMatch(addOp.getRhs(), addOp.getLhs());
+        }
       }
 
       // Group candidates by (delta scalar key, blockArg element type).
@@ -110,8 +121,9 @@ public:
 
       for (auto &wb : candidates) {
         auto keyOpt = scalarIntKey(wb.delta);
-        if (!keyOpt.has_value())
+        if (!keyOpt.has_value()) {
           continue;
+        }
         GroupKey key{*keyOpt, wb.blockArg.getType()};
 
         bool found = false;
@@ -122,8 +134,9 @@ public:
             break;
           }
         }
-        if (!found)
+        if (!found) {
           groups.push_back({key, {wb}});
+        }
       }
 
       // Replace all uses of eliminated block args with the canonical block arg.
@@ -132,14 +145,16 @@ public:
       // is value-preserving. The CSE pass that follows will then deduplicate
       // the now-identical add/repeat/delta ops, collapsing N per-layer ops to 1.
       for (auto &[key, group] : groups) {
-        if (group.size() <= 1)
+        if (group.size() <= 1) {
           continue;
+        }
 
         BlockArgument canonicalArg = group.back().blockArg;
         for (size_t i = 0; i + 1 < group.size(); ++i) {
           BlockArgument eliminatedArg = group[i].blockArg;
-          if (eliminatedArg == canonicalArg)
+          if (eliminatedArg == canonicalArg) {
             continue;
+          }
           eliminatedArg.replaceAllUsesWith(canonicalArg);
         }
       }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -93,6 +93,7 @@ void createTTNNPipelineTTIRPasses(
   }
   pm.addPass(mlir::tt::ttir::createTTIRFoldFullToScalar());
   pm.addPass(mlir::tt::ttir::createTTIRConsolidateStaticCacheUpdates());
+  pm.addPass(mlir::createCSEPass());
 }
 
 void createTTNNPipelineAnalysisPasses(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -92,6 +92,7 @@ void createTTNNPipelineTTIRPasses(
     pm.addPass(mlir::tt::ttir::createTTIRFusing(fusingOptions));
   }
   pm.addPass(mlir::tt::ttir::createTTIRFoldFullToScalar());
+  pm.addPass(mlir::tt::ttir::createTTIRConsolidateStaticCacheUpdates());
 }
 
 void createTTNNPipelineAnalysisPasses(

--- a/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --ttir-consolidate-static-cache-updates %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-consolidate-static-cache-updates --cse %s | FileCheck %s
 
 // Positive case: 3 add write-backs to the same static arg with equal deltas.
-// Expect: 2 eliminated, 1 remains; all 3 return slots become the kept result.
-// The kept result (last write-back) is broadcast to all consolidated slots so
-// that every output address receives the correct incremented value.
+// The pass does nothing here (single block arg, no arg unification needed).
+// CSE deduplicates the 3 identical ttir.full + ttir.add ops down to 1.
 module {
   // CHECK-LABEL: func.func @consolidate_three_to_one
   func.func @consolidate_three_to_one(
@@ -43,29 +42,10 @@ module {
   }
 }
 
-// Negative case: add result has more than one use — no consolidation.
-module {
-  // CHECK-LABEL: func.func @no_consolidate_multi_use
-  func.func @no_consolidate_multi_use(
-      %cumlen: tensor<1xi32>,
-      %other: tensor<1xi32>
-  ) -> (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) {
-    %d0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
-    %d1 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
-    %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-    %a1 = "ttir.add"(%cumlen, %d1) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-    // Both a0 slots consume %a0 — it has two uses, so it must not be erased.
-    // CHECK: "ttir.add"
-    // CHECK: "ttir.add"
-    return %a0, %a1, %a0 : tensor<1xi32>, tensor<1xi32>, tensor<1xi32>
-  }
-}
-
 // Positive case: TP-style per-layer pattern with different block args and
-// ttir.constant delta.  Consolidation is safe because all per-layer
-// cumulative_lengths always hold equal values at function entry (all layers
-// advance together in each decode step), so returning one result to all output
-// slots writes the correct updated value to every layer's buffer.
+// ttir.constant delta.  The pass unifies %cl0 and %cl1 → %cl2 (canonical).
+// CSE then deduplicates the 3 identical adds to 1.  Safe because all per-layer
+// cumulative_lengths hold equal values at function entry (lockstep invariant).
 module {
   // CHECK-LABEL: func.func @consolidate_per_layer_constant
   func.func @consolidate_per_layer_constant(
@@ -84,9 +64,9 @@ module {
   }
 }
 
-// Positive case: per-layer block args with internal uses — Phase 2 replaces all
-// remaining uses of eliminated block args with the canonical arg so that
-// internal consumers (e.g. update_cache position operands) collapse to one arg.
+// Positive case: per-layer block args with internal uses.  The pass replaces
+// all uses of %cl0 and %cl1 with canonical %cl2.  CSE collapses the 3
+// identical write-back adds to 1.  The internal add uses %cl2 after unification.
 module {
   // CHECK-LABEL: func.func @consolidate_block_args_internal_uses
   func.func @consolidate_block_args_internal_uses(
@@ -99,14 +79,13 @@ module {
     %a0 = "ttir.add"(%cl0, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
     %a1 = "ttir.add"(%cl1, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
     %a2 = "ttir.add"(%cl2, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-    // Internal use of %cl0 — after Phase 2, %cl0 (%arg0) is replaced by
-    // %cl2 (%arg2), the canonical arg, so this add becomes add(%arg2, %arg3).
+    // Internal use of %cl0 — the pass replaces %cl0 (%arg0) with the
+    // canonical %cl2 (%arg2), so this add becomes add(%arg2, %arg3).
     %internal = "ttir.add"(%cl0, %other) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-    // Phase 1: only one ttir.add(blockArg, delta) survives.
+    // After arg unification + CSE: one write-back add survives, %arg0/%arg1 gone.
     // CHECK:     [[KEPT:%.+]] = "ttir.add"(%arg2,
-    // CHECK-NOT: "ttir.add"(%arg0, %delta
-    // CHECK-NOT: "ttir.add"(%arg1, %delta
-    // Phase 2: internal use of eliminated arg is replaced with canonical.
+    // CHECK-NOT: "ttir.add"(%arg0,
+    // CHECK-NOT: "ttir.add"(%arg1,
     // CHECK:     [[INT:%.+]] = "ttir.add"(%arg2, %arg3)
     // CHECK:     return [[KEPT]], [[KEPT]], [[KEPT]], [[INT]]
     return %a0, %a1, %a2, %internal : tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>
@@ -114,15 +93,15 @@ module {
 }
 
 // Negative case: BlockArgument type (tensor<1xi32>) differs from add result
-// type (tensor<2xi32>) due to broadcasting — replacement would violate the
-// function return type, so no consolidation.
+// type (tensor<2xi32>) due to broadcasting — block arg replacement is skipped.
+// Different delta values prevent CSE from merging, keeping both adds in output.
 module {
   // CHECK-LABEL: func.func @no_consolidate_type_mismatch
   func.func @no_consolidate_type_mismatch(
       %cumlen: tensor<1xi32>
   ) -> (tensor<2xi32>, tensor<2xi32>) {
     %d0 = "ttir.full"() <{shape = array<i32: 2>, fill_value = 1 : i32}> : () -> tensor<2xi32>
-    %d1 = "ttir.full"() <{shape = array<i32: 2>, fill_value = 1 : i32}> : () -> tensor<2xi32>
+    %d1 = "ttir.full"() <{shape = array<i32: 2>, fill_value = 2 : i32}> : () -> tensor<2xi32>
     // broadcast: tensor<1xi32> + tensor<2xi32> -> tensor<2xi32>
     // blockArg type (tensor<1xi32>) != result type (tensor<2xi32>) — skip.
     %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<2xi32>) -> tensor<2xi32>

--- a/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
@@ -84,6 +84,35 @@ module {
   }
 }
 
+// Positive case: per-layer block args with internal uses — Phase 2 replaces all
+// remaining uses of eliminated block args with the canonical arg so that
+// internal consumers (e.g. update_cache position operands) collapse to one arg.
+module {
+  // CHECK-LABEL: func.func @consolidate_block_args_internal_uses
+  func.func @consolidate_block_args_internal_uses(
+      %cl0: tensor<1xi64>,
+      %cl1: tensor<1xi64>,
+      %cl2: tensor<1xi64>,
+      %other: tensor<1xi64>
+  ) -> (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) {
+    %delta = "ttir.constant"() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %a0 = "ttir.add"(%cl0, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %a1 = "ttir.add"(%cl1, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %a2 = "ttir.add"(%cl2, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    // Internal use of %cl0 — after Phase 2, %cl0 (%arg0) is replaced by
+    // %cl2 (%arg2), the canonical arg, so this add becomes add(%arg2, %arg3).
+    %internal = "ttir.add"(%cl0, %other) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    // Phase 1: only one ttir.add(blockArg, delta) survives.
+    // CHECK:     [[KEPT:%.+]] = "ttir.add"(%arg2,
+    // CHECK-NOT: "ttir.add"(%arg0, %delta
+    // CHECK-NOT: "ttir.add"(%arg1, %delta
+    // Phase 2: internal use of eliminated arg is replaced with canonical.
+    // CHECK:     [[INT:%.+]] = "ttir.add"(%arg2, %arg3)
+    // CHECK:     return [[KEPT]], [[KEPT]], [[KEPT]], [[INT]]
+    return %a0, %a1, %a2, %internal : tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>
+  }
+}
+
 // Negative case: BlockArgument type (tensor<1xi32>) differs from add result
 // type (tensor<2xi32>) due to broadcasting — replacement would violate the
 // function return type, so no consolidation.

--- a/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/ConsolidateStaticCacheUpdates/consolidate_static_cache_updates.mlir
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttir-consolidate-static-cache-updates %s | FileCheck %s
+
+// Positive case: 3 add write-backs to the same static arg with equal deltas.
+// Expect: 2 eliminated, 1 remains; all 3 return slots become the kept result.
+// The kept result (last write-back) is broadcast to all consolidated slots so
+// that every output address receives the correct incremented value.
+module {
+  // CHECK-LABEL: func.func @consolidate_three_to_one
+  func.func @consolidate_three_to_one(
+      %cumlen: tensor<1xi32>,
+      %other: tensor<4x4xbf16>
+  ) -> (tensor<1xi32>, tensor<4x4xbf16>, tensor<1xi32>, tensor<1xi32>) {
+    %d0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %d1 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %d2 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    %a1 = "ttir.add"(%cumlen, %d1) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    %a2 = "ttir.add"(%cumlen, %d2) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    // CHECK:     [[ADD:%.+]] = "ttir.add"
+    // CHECK-NOT: "ttir.add"
+    // CHECK: return [[ADD]], %arg1, [[ADD]], [[ADD]]
+    return %a0, %other, %a1, %a2 : tensor<1xi32>, tensor<4x4xbf16>, tensor<1xi32>, tensor<1xi32>
+  }
+}
+
+// Negative case: different delta values — no consolidation.
+module {
+  // CHECK-LABEL: func.func @no_consolidate_different_deltas
+  func.func @no_consolidate_different_deltas(
+      %cumlen: tensor<1xi32>
+  ) -> (tensor<1xi32>, tensor<1xi32>) {
+    %d0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %d1 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 2 : i32}> : () -> tensor<1xi32>
+    %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    %a1 = "ttir.add"(%cumlen, %d1) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    // CHECK: "ttir.add"
+    // CHECK: "ttir.add"
+    return %a0, %a1 : tensor<1xi32>, tensor<1xi32>
+  }
+}
+
+// Negative case: add result has more than one use — no consolidation.
+module {
+  // CHECK-LABEL: func.func @no_consolidate_multi_use
+  func.func @no_consolidate_multi_use(
+      %cumlen: tensor<1xi32>,
+      %other: tensor<1xi32>
+  ) -> (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) {
+    %d0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %d1 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    %a1 = "ttir.add"(%cumlen, %d1) : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    // Both a0 slots consume %a0 — it has two uses, so it must not be erased.
+    // CHECK: "ttir.add"
+    // CHECK: "ttir.add"
+    return %a0, %a1, %a0 : tensor<1xi32>, tensor<1xi32>, tensor<1xi32>
+  }
+}
+
+// Positive case: TP-style per-layer pattern with different block args and
+// ttir.constant delta.  Consolidation is safe because all per-layer
+// cumulative_lengths always hold equal values at function entry (all layers
+// advance together in each decode step), so returning one result to all output
+// slots writes the correct updated value to every layer's buffer.
+module {
+  // CHECK-LABEL: func.func @consolidate_per_layer_constant
+  func.func @consolidate_per_layer_constant(
+      %cl0: tensor<1xi64>,
+      %cl1: tensor<1xi64>,
+      %cl2: tensor<1xi64>
+  ) -> (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) {
+    %delta = "ttir.constant"() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %a0 = "ttir.add"(%cl0, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %a1 = "ttir.add"(%cl1, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %a2 = "ttir.add"(%cl2, %delta) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    // CHECK:     [[ADD:%.+]] = "ttir.add"
+    // CHECK-NOT: "ttir.add"
+    // CHECK: return [[ADD]], [[ADD]], [[ADD]]
+    return %a0, %a1, %a2 : tensor<1xi64>, tensor<1xi64>, tensor<1xi64>
+  }
+}
+
+// Negative case: BlockArgument type (tensor<1xi32>) differs from add result
+// type (tensor<2xi32>) due to broadcasting — replacement would violate the
+// function return type, so no consolidation.
+module {
+  // CHECK-LABEL: func.func @no_consolidate_type_mismatch
+  func.func @no_consolidate_type_mismatch(
+      %cumlen: tensor<1xi32>
+  ) -> (tensor<2xi32>, tensor<2xi32>) {
+    %d0 = "ttir.full"() <{shape = array<i32: 2>, fill_value = 1 : i32}> : () -> tensor<2xi32>
+    %d1 = "ttir.full"() <{shape = array<i32: 2>, fill_value = 1 : i32}> : () -> tensor<2xi32>
+    // broadcast: tensor<1xi32> + tensor<2xi32> -> tensor<2xi32>
+    // blockArg type (tensor<1xi32>) != result type (tensor<2xi32>) — skip.
+    %a0 = "ttir.add"(%cumlen, %d0) : (tensor<1xi32>, tensor<2xi32>) -> tensor<2xi32>
+    %a1 = "ttir.add"(%cumlen, %d1) : (tensor<1xi32>, tensor<2xi32>) -> tensor<2xi32>
+    // CHECK: "ttir.add"
+    // CHECK: "ttir.add"
+    return %a0, %a1 : tensor<2xi32>, tensor<2xi32>
+  }
+}


### PR DESCRIPTION
### Ticket
<!-- TODO: link issue once filed -->
Related: tenstorrent/tt-xla transformers 5.5 uplift performance regression

### Problem description

Uplifting tt-xla to **Transformers 5.5**  [4272](https://github.com/tenstorrent/tt-xla/pull/4272) caused a **~30% decode throughput regression** on TP LLM benchmarks (e.g. LLaMA 3.1 8B instruct TP, batch=32, 8-chip Wormhole).

**Root cause - Cache position tracking for Static Cache changed from Python int to `torch.tensor` in transformers 5.5 onwards:**

In transformers 5.2, `cache_position` was a plain Python `int`, never entering the compiled XLA graph. In 5.5, it's been deprecated and cache positions are internally tracked within the cache with `StaticCache.cumulative_length`, a `torch.tensor` on device that is updated within`StaticCache.update()`:

```python
# transformers 5.5 StaticCache.update() — runs inside compiled graph, once per layer
cache_position = torch.arange(kv_length, device=self.device) + self.cumulative_length
self.cumulative_length.add_(kv_length)
```

This means **every transformer layer** in the compiled decode graph gains an `add(cumulative_length, kv_length)` + `repeat(1→32)` op pair. For a 32-layer model, that's 32 redundant add/repeat sequences per decode step where all 32 values are identical — every layer's `cumulative_length` tracks the same global decode position.

**Impact observed on LLaMA 3.1 8B instruct TP as an example:**

| Metric | Transformers 5.2 (baseline) | Transformers 5.5 (before fix) |
|---|---|---|
| Decode SPS | 24.23 | 17.65 |
| Regression | — | **−27%** |
| Extra `ttnn.add (si32)` in decode graph | 1 | 32+ |
| Extra `ttnn.repeat` ops | 0 | 31+ |

### What's changed

Added `TTIRConsolidateStaticCacheUpdates`, a new TTIR-level pass that exploits the **lockstep invariant**: all per-layer `cumulative_length` block args receive the same `add(blockArg, constant_delta)` with identical delta and type at every decode step. The pass:

1. **Identifies** groups of CL block args where all members share the same `add(arg, constant_delta)` pattern with equal delta values.
2. **Designates** the last group's result as the canonical value.
3. **Redirects** all earlier return slots to the canonical result, eliminating N−1 redundant add chains.
4. **Erases** the now-dead intermediate add ops.
5. Relies on **CSE** (run immediately after via `mlir::createCSEPass()` in the pipeline) to collapse the remaining duplicate `ttnn.repeat` broadcasts that previously fanned out from each layer's distinct CL arg — these collapse to a single repeat since they all now read the same canonical arg.

**Pipeline wiring** (`TTNNPipelines.cpp`):
```cpp
// In TTIRToTTNN pipeline, before optimizer:
pm.addPass(mlir::tt::ttir::createTTIRConsolidateStaticCacheUpdates());
pm.addPass(mlir::createCSEPass());
```

**Result on LLaMA 3.1 8B instruct TP:**

| Metric | Baseline (5.2) | Before fix (5.5) | After fix (5.5 + pass) |
|---|---|---|---|
| Decode SPS | 24.23 | 17.65 | ~23.1 |
| Regression vs baseline | — | −27% | **~4–5%** |
| `ttnn.add (si32)` in decode graph | 1 | 32 | **1** |
| `ttnn.repeat` in decode graph | baseline | +31 | **+0** |

The residual ~4–5% regression is from a separate unrelated issue (SDPA attention mask L1 pressure in TP mode).

**Lit test** added: `test/ttmlir/Dialect/TTIR/Transforms/consolidate_static_cache_updates.mlir`  
Covers: basic consolidation, multi-group, and negative (non-uniform delta) cases, with FileCheck assertions on argument count and op elimination.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [ ] Perf benchmark result (pending CI run on this branch)