### PR TITLE
[L1SpillManagement] Include sink ops in schedule for correct lastUse

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
@@ -34,7 +34,7 @@ inline bool opHasTensorResult(mlir::Operation *op) {
 /// Returns true for in-place ops with no tensor result that still need
 /// input layout validation and upstream reshard propagation in the beam search.
 inline bool isSinkOp(mlir::Operation *op) {
-  return llvm::isa<FillCacheOp, PagedUpdateCacheOp>(op);
+  return llvm::isa<FillCacheOp, PagedFillCacheOp, PagedUpdateCacheOp>(op);
 }
 
 /// Returns true if this op should participate in the greedy beam search —

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
 #include "ttmlir/Support/Logger.h"
@@ -467,18 +468,14 @@ typename L1SpillManagement<MemoryTracker>::ScheduleData
 L1SpillManagement<MemoryTracker>::buildScheduleData() {
   ScheduleData data;
 
-  // Build schedule (ops in IR order = topological order).
+  // Build schedule (ops in IR order = topological order). Include sink ops
+  // (paged_fill_cache / paged_update_cache / fill_cache) even though they
+  // have no tensor result — their operand uses must be visible to
+  // computeLastUsePositions so that values consumed only by a cache write
+  // (e.g. per-layer KV typecasts) are kept alive in L1 until the cache
+  // write actually executes, not freed at the layer-local to_memory_config.
   func->walk([&](Operation *op) {
-    if (op->getNumResults() == 0) {
-      return;
-    }
-    if (isa<EmptyOp>(op)) {
-      return;
-    }
-    bool hasTensorResult = llvm::any_of(op->getResults(), [](OpResult r) {
-      return mlir::isa<RankedTensorType>(r.getType());
-    });
-    if (!hasTensorResult) {
+    if (!optimizer_utils::isBeamSearchTarget(op)) {
       return;
     }
     data.schedule.push_back(op);
@@ -935,6 +932,15 @@ void L1SpillManagement<MemoryTracker>::run() {
     Operation *op = data.schedule[pos];
 
     processDeadTensors(pos, data);
+
+    // Sink ops (paged_fill_cache / paged_update_cache / fill_cache) are in
+    // the schedule only so computeLastUsePositions sees their operand uses
+    // (which keeps their L1-resident input tensors alive in the tracker
+    // until the cache write actually executes). They have no tensor result,
+    // so addResultsToLiveSet / extractOpConfigFromIR / validate do not apply.
+    if (optimizer_utils::isSinkOp(op)) {
+      continue;
+    }
 
     // ToLayoutOp with L1 output: workaround-inserted and always immediately
     // consumed by the target op. MemoryLayoutPropagation skips these, so


### PR DESCRIPTION
## Summary

Cache-write sink ops (`PagedFillCacheOp`, `PagedUpdateCacheOp`, `FillCacheOp`) were excluded from the L1 spill simulator's schedule, so their operand uses landed outside `positionMap` and `lastUse` got truncated to earlier consumers — freeing L1 slots while runtime still pinned them.

- `buildScheduleData` now uses `isBeamSearchTarget` (matches `MemoryLayoutPropagation`) so sink ops contribute to `positionMap`.
- `run()` skips sink ops after `processDeadTensors` since they have no tensor result (avoids `extractOpConfigFromIR`'s `op->getResult(0)` assert).
- `isSinkOp` extended to cover `PagedFillCacheOp` (the prefill-time variant Gemma-4 emits).