### PR TITLE
Matmul/Linear/SparseMatmul ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_MATMUL_MATMULOP_H
+#define TTMLIR_OPINVOKE_TTNN_MATMUL_MATMULOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using MatmulOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+using LinearOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+using SparseMatmulOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct MatmulResolvedParams {
+  std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+      matmulProgramConfig;
+  std::optional<std::string> activation;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDType;
+};
+
+MatmulResolvedParams
+resolveMatmulParams(const ::tt::target::ttnn::MatmulOpT &matmulOp);
+
+MatmulOpResult callMatmul(CallType callType,
+                          const ::tt::target::ttnn::MatmulOpT &matmulOp,
+                          TensorArg lhs, TensorArg rhs,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+struct LinearResolvedParams {
+  std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+      matmulProgramConfig;
+  std::optional<std::string> activation;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDType;
+};
+
+LinearResolvedParams
+resolveLinearParams(const ::tt::target::ttnn::LinearOpT &linearOp);
+
+LinearOpResult callLinear(CallType callType,
+                          const ::tt::target::ttnn::LinearOpT &linearOp,
+                          TensorArg lhs, TensorArg rhs,
+                          std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *device = nullptr);
+
+struct SparseMatmulResolvedParams {
+  ::ttnn::operations::matmul::MatmulProgramConfig matmulProgramConfig;
+  std::optional<uint32_t> nnz;
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDType;
+};
+
+SparseMatmulResolvedParams resolveSparseMatmulParams(
+    const ::tt::target::ttnn::SparseMatmulOpT &sparseMatmulOp);
+
+SparseMatmulOpResult
+callSparseMatmul(CallType callType,
+                 const ::tt::target::ttnn::SparseMatmulOpT &sparseMatmulOp,
+                 TensorArg a, TensorArg b, TensorArg sparsity,
+                 ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_MATMUL_MATMULOP_H

--- a/include/ttmlir/OpInvoke/TTNN/utils/utils.h
+++ b/include/ttmlir/OpInvoke/TTNN/utils/utils.h
@@ -137,6 +137,16 @@ bool inSystemMemory(const ::tt::target::ttnn::TensorRefT &tensorRef);
 const ::tt::target::ttnn::MemoryConfigT
 getTensorRefMemoryConfig(const ::tt::target::ttnn::TensorRefT &tensorRef);
 
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOpT &op);
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::LinearOpT &op);
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(
+    const ::tt::target::ttnn::SparseMatmulOpT &op);
+
 std::optional<::ttnn::MemoryConfig>
 createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfigT &memcfg);
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1054,12 +1054,16 @@ struct OpModel<LinearOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-               std::optional<llvm::ArrayRef<int64_t>> biasShape,
-               std::optional<TTNNLayoutAttr> biasLayout,
-               TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+      bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+          std::nullopt);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1077,10 +1081,14 @@ struct OpModel<MatmulOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
-  static llvm::Expected<size_t>
-  getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-               llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-               TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB);
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation = std::nullopt,
+      std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+          std::nullopt);
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2897,10 +2897,19 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
+  // Convert activation attribute to optional StringRef
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+
+  // Get matmul program config from opConfig if present, otherwise from op.
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<LinearOp>::getOpRuntime, *this, inputShapeA, inputs[0],
       inputShapeB, inputs[1], biasShape, biasLayout, opConfig.outputLayout,
-      getTransposeA(), getTransposeB());
+      getTransposeA(), getTransposeB(), activation, attr.matmulProgramConfig,
+      attr.computeKernelConfig);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2938,10 +2947,19 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getA().getType().getShape();
   const auto inputShapeB = getB().getType().getShape();
 
+  // Convert activation attribute to optional StringRef
+  std::optional<llvm::StringRef> activation =
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
+
+  // Get matmul program config from opConfig if present, otherwise from op.
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<MatmulOp>::getOpRuntime, *this, inputShapeA, inputs[0],
       inputShapeB, inputs[1], opConfig.outputLayout, getTransposeA(),
-      getTransposeB());
+      getTransposeB(), activation, attr.matmulProgramConfig,
+      attr.computeKernelConfig);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(TTNNOpInvokeLib STATIC
   utils/utils.cpp
   Conv/Conv2dOp.cpp
+  Matmul/MatmulOp.cpp
 )
 
 set_property(TARGET TTNNOpInvokeLib PROPERTY CXX_STANDARD 20)

--- a/lib/OpInvoke/TTNN/Matmul/MatmulOp.cpp
+++ b/lib/OpInvoke/TTNN/Matmul/MatmulOp.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttmlir/Target/TTNN/operations/matmul_generated.h"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+// Returns true if the matmul program config already carries a fused
+// activation.
+static bool programCarriesFusedActivation(
+    const std::optional<::ttnn::operations::matmul::MatmulProgramConfig> &pc) {
+  if (!pc) {
+    return false;
+  }
+  return std::visit(
+      [](const auto &cfg) -> bool {
+        using T = std::decay_t<decltype(cfg)>;
+        if constexpr (
+            std::is_same_v<T, ::ttnn::operations::matmul::
+                                  MatmulMultiCoreReuseMultiCastProgramConfig> ||
+            std::is_same_v<T,
+                           ::ttnn::operations::matmul::
+                               MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
+            std::is_same_v<
+                T, ::ttnn::operations::matmul::
+                       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+            std::is_same_v<
+                T,
+                ::ttnn::operations::matmul::
+                    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+          return cfg.fused_activation.has_value();
+        }
+        return false;
+      },
+      *pc);
+}
+
+MatmulResolvedParams
+resolveMatmulParams(const ::tt::target::ttnn::MatmulOpT &matmulOp) {
+
+  MatmulResolvedParams params;
+
+  if (matmulOp.out) {
+    params.outputDType = operations::utils::getDataType(*matmulOp.out);
+  }
+  params.matmulProgramConfig =
+      operations::utils::createMatmulProgramConfigIfNeeded(matmulOp);
+  if (!matmulOp.activation.empty() &&
+      !programCarriesFusedActivation(params.matmulProgramConfig)) {
+    params.activation = std::make_optional(matmulOp.activation);
+  }
+  if (matmulOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *matmulOp.compute_config);
+  }
+
+  if (matmulOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*matmulOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*matmulOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createMatmulTuple(Tag tag, const ::tt::target::ttnn::MatmulOpT &matmulOp,
+                       TensorArg lhs, TensorArg rhs,
+                       const MatmulResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(lhs, tag), resolveTensorArg(rhs, tag),
+      matmulOp.transpose_a, matmulOp.transpose_b, params.outputMemoryConfig,
+      params.outputDType, params.matmulProgramConfig, params.activation,
+      params.computeConfig, /*core_grid=*/std::nullopt,
+      /*output_tile=*/std::nullopt, /*optional_output_tensor=*/std::nullopt,
+      /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
+}
+
+MatmulOpResult callMatmul(CallType callType,
+                          const ::tt::target::ttnn::MatmulOpT &matmulOp,
+                          TensorArg lhs, TensorArg rhs,
+                          ::ttnn::MeshDevice *device) {
+
+  MatmulResolvedParams params = resolveMatmulParams(matmulOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createMatmulTuple(tag, matmulOp, lhs, rhs, params);
+  };
+
+  return callOp<MatmulOpResult>(WRAP_OP(::ttnn::matmul), callType, makeTuple,
+                                device);
+}
+
+LinearResolvedParams
+resolveLinearParams(const ::tt::target::ttnn::LinearOpT &linearOp) {
+
+  LinearResolvedParams params;
+
+  if (linearOp.out) {
+    params.outputDType = operations::utils::getDataType(*linearOp.out);
+  }
+  params.matmulProgramConfig =
+      operations::utils::createMatmulProgramConfigIfNeeded(linearOp);
+  if (!linearOp.activation.empty() &&
+      !programCarriesFusedActivation(params.matmulProgramConfig)) {
+    params.activation = std::make_optional(linearOp.activation);
+  }
+  if (linearOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *linearOp.compute_config);
+  }
+
+  if (linearOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*linearOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*linearOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createLinearTuple(Tag tag, const ::tt::target::ttnn::LinearOpT &linearOp,
+                       TensorArg a, TensorArg b,
+                       const std::optional<TensorArg> bias,
+                       const LinearResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(a, tag), resolveTensorArg(b, tag),
+      bias.has_value()
+          ? std::make_optional(*std::get<const ::ttnn::Tensor *>(bias.value()))
+          : std::nullopt,
+      linearOp.transpose_a, linearOp.transpose_b, params.outputMemoryConfig,
+      params.outputDType, params.matmulProgramConfig, params.activation,
+      params.computeConfig,
+      /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
+      /*optional_output_tensor=*/std::nullopt,
+      /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
+}
+
+LinearOpResult callLinear(CallType callType,
+                          const ::tt::target::ttnn::LinearOpT &linearOp,
+                          TensorArg a, TensorArg b,
+                          const std::optional<TensorArg> bias,
+                          ::ttnn::MeshDevice *device) {
+  LinearResolvedParams params = resolveLinearParams(linearOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createLinearTuple(tag, linearOp, a, b, bias, params);
+  };
+
+  return callOp<LinearOpResult>(WRAP_OP(::ttnn::linear), callType, makeTuple,
+                                device);
+}
+
+SparseMatmulResolvedParams resolveSparseMatmulParams(
+    const ::tt::target::ttnn::SparseMatmulOpT &sparseMatmulOp) {
+
+  SparseMatmulResolvedParams params;
+
+  if (sparseMatmulOp.nnz) {
+    params.nnz = std::make_optional(static_cast<uint32_t>(*sparseMatmulOp.nnz));
+  }
+
+  auto matmulProgramConfig =
+      operations::utils::createMatmulProgramConfigIfNeeded(sparseMatmulOp);
+  TT_INVOKE_ASSERT(
+      matmulProgramConfig.has_value(),
+      "SparseMatmulOp requires program_config to be set at compile "
+      "time");
+  params.matmulProgramConfig = matmulProgramConfig.value();
+
+  if (sparseMatmulOp.compute_config) {
+    params.computeConfig = operations::utils::createDeviceComputeKernelConfig(
+        *sparseMatmulOp.compute_config);
+  }
+
+  if (sparseMatmulOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*sparseMatmulOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*sparseMatmulOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createSparseMatmulTuple(
+    Tag tag, const ::tt::target::ttnn::SparseMatmulOpT &sparseMatmulOp,
+    TensorArg a, TensorArg b, TensorArg sparsity,
+    const SparseMatmulResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(a, tag), resolveTensorArg(b, tag),
+      resolveTensorArg(sparsity, tag), params.matmulProgramConfig, params.nnz,
+      sparseMatmulOp.is_input_a_sparse, sparseMatmulOp.is_input_b_sparse,
+      params.outputMemoryConfig, /*dtype=*/std::nullopt, params.computeConfig,
+      /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt);
+}
+
+SparseMatmulOpResult
+callSparseMatmul(CallType callType,
+                 const ::tt::target::ttnn::SparseMatmulOpT &sparseMatmulOp,
+                 TensorArg a, TensorArg b, TensorArg sparsity,
+                 ::ttnn::MeshDevice *device) {
+  SparseMatmulResolvedParams params = resolveSparseMatmulParams(sparseMatmulOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createSparseMatmulTuple(tag, sparseMatmulOp, a, b, sparsity, params);
+  };
+
+  return callOp<SparseMatmulOpResult, false, false>(
+      WRAP_OP(::ttnn::sparse_matmul), callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/utils/utils.cpp
+++ b/lib/OpInvoke/TTNN/utils/utils.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
-#include <llvm/Support/Error.h>
 
 namespace ttnn_op_invoke::operations::utils {
 
@@ -311,6 +310,127 @@ toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType) {
       toTTNNUnaryOpType(unaryWithParam.op_type),
       std::vector<float>(unaryWithParam.params.begin(),
                          unaryWithParam.params.end()));
+}
+
+static std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(
+    const ::tt::target::ttnn::MatmulProgramConfigUnion &matmul_program_config) {
+  if (matmul_program_config.type ==
+      ::tt::target::ttnn::MatmulProgramConfig::NONE) {
+    return std::nullopt;
+  }
+
+  ::ttnn::operations::matmul::MatmulProgramConfig matmulProgramConfig;
+  switch (matmul_program_config.type) {
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseProgramConfig: {
+    auto *config = matmul_program_config.AsMatmulMultiCoreReuseProgramConfig();
+    return ::ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{
+        .compute_with_storage_grid_size =
+            ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
+                *config->compute_with_storage_grid_size),
+        .in0_block_w = config->in0_block_w,
+        .out_subblock_h = config->out_subblock_h,
+        .out_subblock_w = config->out_subblock_w,
+        .per_core_M = config->per_core_m,
+        .per_core_N = config->per_core_n};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCastProgramConfig: {
+    auto *config =
+        matmul_program_config.AsMatmulMultiCoreReuseMultiCastProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastProgramConfig{
+            .compute_with_storage_grid_size =
+                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
+                    *config->compute_with_storage_grid_size),
+            .in0_block_w = config->in0_block_w,
+            .out_subblock_h = config->out_subblock_h,
+            .out_subblock_w = config->out_subblock_w,
+            .out_block_h = config->out_block_h,
+            .out_block_w = config->out_block_w,
+            .per_core_M = config->per_core_m,
+            .per_core_N = config->per_core_n,
+            .transpose_mcast = config->transpose_mcast,
+            .fused_activation =
+                config->fused_activation
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          ttnn_op_invoke::operations::utils::
+                              toTTNNUnaryWithParam(*config->fused_activation))
+                    : std::nullopt,
+            .fuse_batch = config->fuse_batch};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCast1DProgramConfig: {
+    auto *config =
+        matmul_program_config.AsMatmulMultiCoreReuseMultiCast1DProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCast1DProgramConfig{
+            .compute_with_storage_grid_size =
+                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
+                    *config->compute_with_storage_grid_size),
+            .in0_block_w = config->in0_block_w,
+            .out_subblock_h = config->out_subblock_h,
+            .out_subblock_w = config->out_subblock_w,
+            .out_block_h = config->out_block_h,
+            .out_block_w = config->out_block_w,
+            .per_core_M = config->per_core_m,
+            .per_core_N = config->per_core_n,
+            .fuse_batch = config->fuse_batch,
+            .fused_activation =
+                config->fused_activation
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          ttnn_op_invoke::operations::utils::
+                              toTTNNUnaryWithParam(*config->fused_activation))
+                    : std::nullopt,
+            .mcast_in0 = config->mcast_in0,
+            .gather_in0 = config->gather_in0,
+            .hop_cores = ttnn_op_invoke::operations::utils::toTTNNCoreRangeSet(
+                *config->hop_cores),
+            .num_global_cb_receivers = config->num_global_cb_receivers,
+            .untilize_out = config->untilize_out};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig: {
+    auto *config =
+        matmul_program_config
+            .AsMatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig{
+            .in0_block_w = config->in0_block_w,
+            .per_core_M = config->per_core_m,
+            .per_core_N = config->per_core_n,
+            .fused_activation =
+                config->fused_activation
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          ttnn_op_invoke::operations::utils::
+                              toTTNNUnaryWithParam(*config->fused_activation))
+                    : std::nullopt,
+        };
+  }
+  default:
+    llvm::report_fatal_error("Unsupported MatmulProgramConfig type");
+  }
+}
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOpT &op) {
+  return createMatmulProgramConfigIfNeeded(op.matmul_program_config);
+}
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::LinearOpT &op) {
+  return createMatmulProgramConfigIfNeeded(op.matmul_program_config);
+}
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(
+    const ::tt::target::ttnn::SparseMatmulOpT &op) {
+  ::tt::target::ttnn::MatmulProgramConfigUnion matmul_program_config;
+  if (op.program_config) {
+    matmul_program_config.Set(*op.program_config);
+  }
+  return createMatmulProgramConfigIfNeeded(matmul_program_config);
 }
 
 ::ttnn::Conv2dConfig

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -538,36 +539,6 @@ auto getOpSymbol() {
     static_assert(ttmlir::utils::always_false(),
                   "add mapping from TTNN dialect to TTNN lib op");
   }
-}
-
-// Returns true if the matmul program config already carries a fused
-// activation.
-inline bool programCarriesFusedActivation(
-    const std::optional<::ttnn::operations::matmul::MatmulProgramConfig> &pc) {
-  if (!pc) {
-    return false;
-  }
-  return std::visit(
-      [](const auto &cfg) -> bool {
-        using T = std::decay_t<decltype(cfg)>;
-        if constexpr (
-            std::is_same_v<T, ::ttnn::operations::matmul::
-                                  MatmulMultiCoreReuseMultiCastProgramConfig> ||
-            std::is_same_v<T,
-                           ::ttnn::operations::matmul::
-                               MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
-            std::is_same_v<
-                T, ::ttnn::operations::matmul::
-                       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
-            std::is_same_v<
-                T,
-                ::ttnn::operations::matmul::
-                    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-          return cfg.fused_activation.has_value();
-        }
-        return false;
-      },
-      *pc);
 }
 
 } // namespace detail
@@ -3996,6 +3967,44 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+static ::tt::target::ttnn::LinearOpT buildLinearOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+
+  ::tt::target::ttnn::LinearOpT linearOp;
+
+  linearOp.transpose_a = transposeA;
+  linearOp.transpose_b = transposeB;
+
+  if (activation) {
+    linearOp.activation = activation->str();
+  }
+
+  if (programConfigAttr.has_value()) {
+    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
+        .Case<MatmulMultiCoreReuseProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            [&](auto config) {
+              linearOp.matmul_program_config.Set(toNative(config));
+            });
+  }
+  linearOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+
+  linearOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return linearOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -4023,34 +4032,24 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     biasTensor = ::tt::tt_metal::create_device_tensor(biasSpec, device);
   }
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
-
-  // Convert program config attribute
-  auto programConfig =
-      programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
-                        : std::nullopt;
-
-  std::optional<std::string> activationStr;
-  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
-    activationStr = activation->str();
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      computeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
+  ::tt::target::ttnn::LinearOpT linearOpNative = buildLinearOpTFromMLIR(
+      transposeA, transposeB, activation, programConfigAttr,
+      computeKernelConfig, outputLayout);
 
   // Create query closure
   auto linearOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
-        transposeB, outputMemoryConfig, outputDType, programConfig,
-        activationStr, computeKernelConfigConverted,
-        /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
-        /*optional_output_tensor=*/std::nullopt,
-        /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
+    ttnn_op_invoke::LinearOpResult result = ttnn_op_invoke::callLinear(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, linearOpNative,
+        inputSpecA, inputSpecB,
+        biasTensor.has_value() ? std::make_optional(&biasTensor.value())
+                               : std::nullopt,
+        device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from LinearOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), linearOpQuery);
@@ -4064,7 +4063,9 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
-    bool transposeA, bool transposeB) {
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4084,21 +4085,23 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
     biasTensor = ::tt::tt_metal::create_device_tensor(biasSpec, device);
   }
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::LinearOpT linearOpNative = buildLinearOpTFromMLIR(
+      transposeA, transposeB, activation, programConfigAttr,
+      computeKernelConfig, outputLayout);
 
   // Create query closure
   auto linearOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
-        transposeB, outputMemoryConfig, outputDType,
-        /*program_config=*/std::nullopt,
-        /*activation=*/std::nullopt, /*compute_kernel_config=*/std::nullopt,
-        /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
-        /*optional_output_tensor=*/std::nullopt,
-        /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
+    ttnn_op_invoke::LinearOpResult result = ttnn_op_invoke::callLinear(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, linearOpNative, inputSpecA,
+        inputSpecB,
+        biasTensor.has_value() ? std::make_optional(&biasTensor.value())
+                               : std::nullopt,
+        device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from LinearOp query");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(linearOpQuery);
@@ -4110,6 +4113,44 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+static ::tt::target::ttnn::MatmulOpT buildMatmulOpTFromMLIR(
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    TTNNLayoutAttr outputLayout) {
+
+  ::tt::target::ttnn::MatmulOpT matmulOp;
+
+  matmulOp.transpose_a = transposeA;
+  matmulOp.transpose_b = transposeB;
+
+  if (activation) {
+    matmulOp.activation = activation->str();
+  }
+
+  if (programConfigAttr.has_value()) {
+    mlir::TypeSwitch<mlir::Attribute>(*programConfigAttr)
+        .Case<MatmulMultiCoreReuseProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
+              MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            [&](auto config) {
+              matmulOp.matmul_program_config.Set(toNative(config));
+            });
+  }
+  matmulOp.compute_config =
+      (computeKernelConfig.has_value() && *computeKernelConfig)
+          ? std::make_unique<::tt::target::ttnn::DeviceComputeKernelConfigT>(
+                toNative(*computeKernelConfig))
+          : nullptr;
+
+  matmulOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return matmulOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -4129,33 +4170,21 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
-
-  // Convert program config attribute
-  auto programConfig =
-      programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
-                        : std::nullopt;
-
-  std::optional<std::string> activationStr;
-  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
-    activationStr = activation->str();
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig>
-      computeKernelConfigConverted =
-          conversion::getDeviceComputeKernelConfig(computeKernelConfig);
+  ::tt::target::ttnn::MatmulOpT matmulOpNative = buildMatmulOpTFromMLIR(
+      transposeA, transposeB, activation, programConfigAttr,
+      computeKernelConfig, outputLayout);
 
   // Create query closure
   auto matmulOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
-        outputMemoryConfig, outputDType, programConfig, activationStr,
-        computeKernelConfigConverted, /*core_grid=*/std::nullopt,
-        /*output_tile=*/std::nullopt, /*optional_output_tensor=*/std::nullopt,
-        /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
+    ttnn_op_invoke::MatmulOpResult result = ttnn_op_invoke::callMatmul(
+        ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS, matmulOpNative,
+        inputSpecA, inputSpecB, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from MatmulOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), matmulOpQuery);
@@ -4167,7 +4196,10 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
 llvm::Expected<size_t> OpModel<MatmulOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB) {
+    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+    std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4180,24 +4212,20 @@ llvm::Expected<size_t> OpModel<MatmulOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::MatmulOpT matmulOpNative = buildMatmulOpTFromMLIR(
+      transposeA, transposeB, activation, programConfigAttr,
+      computeKernelConfig, outputLayout);
 
   // Create query closure
   auto matmulOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::matmul, device, inputSpecA, inputSpecB,
-                            transposeA, transposeB, outputMemoryConfig,
-                            outputDType,
-                            /*program_config=*/std::nullopt,
-                            /*activation=*/std::nullopt,
-                            /*compute_kernel_config=*/std::nullopt,
-                            /*core_grid=*/std::nullopt,
-                            /*output_tile=*/std::nullopt,
-                            /*optional_output_tensor=*/std::nullopt,
-                            /*global_cb=*/std::nullopt,
-                            /*sub_device_id=*/std::nullopt);
+    ttnn_op_invoke::MatmulOpResult result = ttnn_op_invoke::callMatmul(
+        ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, matmulOpNative, inputSpecA,
+        inputSpecB, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from MatmulOp query");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(matmulOpQuery);

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -5,43 +5,16 @@
 #include "operations/matmul/matmul.h"
 
 #include "tt/runtime/detail/common/logger.h"
-#include "tt/runtime/detail/ttnn/ttnn.h"
-
 #include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 
 #include <algorithm>
 #include <optional>
 
 namespace tt::runtime::ttnn::operations::matmul {
-
-static bool programCarriesFusedActivation(
-    const std::optional<::ttnn::operations::matmul::MatmulProgramConfig> &pc) {
-  if (!pc) {
-    return false;
-  }
-  return std::visit(
-      [](const auto &cfg) -> bool {
-        using T = std::decay_t<decltype(cfg)>;
-        if constexpr (
-            std::is_same_v<T, ::ttnn::operations::matmul::
-                                  MatmulMultiCoreReuseMultiCastProgramConfig> ||
-            std::is_same_v<T,
-                           ::ttnn::operations::matmul::
-                               MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
-            std::is_same_v<
-                T, ::ttnn::operations::matmul::
-                       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
-            std::is_same_v<
-                T,
-                ::ttnn::operations::matmul::
-                    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
-          return cfg.fused_activation.has_value();
-        }
-        return false;
-      },
-      *pc);
-}
 
 // ANCHOR: adding_an_op_matmul_runtime_operations
 void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
@@ -49,35 +22,16 @@ void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &lhs = tensorPool.getTTNNTensorAndValidate(op->a());
   const ::ttnn::Tensor &rhs = tensorPool.getTTNNTensorAndValidate(op->b());
 
-  auto outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig,
-             "Memory config must exist for device tensors");
+  target::ttnn::MatmulOpT matmulOpNative;
+  op->UnPackTo(&matmulOpNative);
 
-  ::ttnn::DataType outputDataType = utils::getDataType(op->out());
+  ttnn_op_invoke::MatmulOpResult result = ttnn_op_invoke::callMatmul(
+      ttnn_op_invoke::CallType::EXECUTE, matmulOpNative, &lhs, &rhs);
 
-  std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
-      matmulProgramConfig = utils::createMatmulProgramConfigIfNeeded(op);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callMatmul execution");
 
-  std::optional<std::string> activation;
-  if (op->activation() && !programCarriesFusedActivation(matmulProgramConfig)) {
-    activation = op->activation()->str();
-  }
-
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
-
-  ::ttnn::Tensor output = ::ttnn::matmul(
-      lhs, rhs, op->transpose_a(), op->transpose_b(), outputMemoryConfig,
-      outputDataType, matmulProgramConfig,
-      /*activation=*/activation, /*compute_kernel_config=*/computeConfig,
-      /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
-      /* optional_output_tensor=*/std::nullopt);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
@@ -92,34 +46,17 @@ void run(const ::tt::target::ttnn::LinearOp *op, ProgramContext &context) {
           ? std::make_optional(tensorPool.getTTNNTensorAndValidate(op->bias()))
           : std::nullopt;
 
-  auto outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig,
-             "Memory config must exist for device tensors");
+  target::ttnn::LinearOpT linearOpNative;
+  op->UnPackTo(&linearOpNative);
 
-  ::ttnn::DataType outputDataType = utils::getDataType(op->out());
+  ttnn_op_invoke::LinearOpResult result = ttnn_op_invoke::callLinear(
+      ttnn_op_invoke::CallType::EXECUTE, linearOpNative, &lhs, &rhs,
+      bias.has_value() ? std::make_optional(&bias.value()) : std::nullopt);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callLinear execution");
 
-  auto programConfig = utils::createMatmulProgramConfigIfNeeded(op);
-
-  std::optional<std::string> activation;
-  if (op->activation() && !programCarriesFusedActivation(programConfig)) {
-    activation = op->activation()->str();
-  }
-
-  ::ttnn::Tensor output = ::ttnn::linear(
-      lhs, rhs, bias, op->transpose_a(), op->transpose_b(), outputMemoryConfig,
-      outputDataType, programConfig,
-      /*activation=*/activation, /*compute_kernel_config=*/computeConfig,
-      /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
-      /* optional_output_tensor=*/std::nullopt);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
@@ -132,66 +69,17 @@ void run(const ::tt::target::ttnn::SparseMatmulOp *op,
   const ::ttnn::Tensor &sparsity =
       tensorPool.getTTNNTensorAndValidate(op->sparsity());
 
-  auto outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig,
-             "Memory config must exist for device tensors");
+  target::ttnn::SparseMatmulOpT sparseMatmulOpNative;
+  op->UnPackTo(&sparseMatmulOpNative);
 
-  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
-  if (op->compute_config()) {
-    computeConfig =
-        utils::createDeviceComputeKernelConfig(op->compute_config());
-  }
+  ttnn_op_invoke::SparseMatmulOpResult result =
+      ttnn_op_invoke::callSparseMatmul(ttnn_op_invoke::CallType::EXECUTE,
+                                       sparseMatmulOpNative, &a, &b, &sparsity);
 
-  std::optional<uint32_t> nnz =
-      op->nnz() ? std::make_optional(static_cast<uint32_t>(*op->nnz()))
-                : std::nullopt;
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callSparseMatmul execution");
 
-  // Read program config from the flatbuffer (populated at compile time by
-  // TTIRToTTNN lowering).
-  LOG_ASSERT(op->program_config(),
-             "SparseMatmulOp requires program_config to be set at compile "
-             "time");
-  auto *config = op->program_config();
-  ::ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig
-      programConfig{
-          .compute_with_storage_grid_size =
-              ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                  *config->compute_with_storage_grid_size()),
-          .in0_block_w = config->in0_block_w(),
-          .out_subblock_h = config->out_subblock_h(),
-          .out_subblock_w = config->out_subblock_w(),
-          .out_block_h = config->out_block_h(),
-          .out_block_w = config->out_block_w(),
-          .per_core_M = config->per_core_m(),
-          .per_core_N = config->per_core_n(),
-          .fuse_batch = config->fuse_batch(),
-          .fused_activation =
-              config->fused_activation()
-                  ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                        utils::toTTNNUnaryWithParam(
-                            *config->fused_activation()))
-                  : std::nullopt,
-          .mcast_in0 = config->mcast_in0(),
-          .gather_in0 = config->gather_in0(),
-          .hop_cores = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
-              *config->hop_cores()),
-          .num_global_cb_receivers = config->num_global_cb_receivers(),
-          .untilize_out = config->untilize_out()};
-
-  ::ttnn::Tensor output =
-      ::ttnn::sparse_matmul(a, b, sparsity,
-                            /*program_config=*/programConfig,
-                            /*nnz=*/nnz,
-                            /*is_input_a_sparse=*/op->is_input_a_sparse(),
-                            /*is_input_b_sparse=*/op->is_input_b_sparse(),
-                            /*memory_config=*/outputMemoryConfig,
-                            /*dtype=*/std::nullopt,
-                            /*compute_kernel_config=*/computeConfig,
-                            /*core_grid=*/std::nullopt,
-                            /*output_tile=*/std::nullopt);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -48,202 +48,26 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
 
 ::ttnn::operations::unary::UnaryWithParam
 toTTNNUnaryWithParam(const ::tt::target::ttnn::UnaryWithParam &unaryWithParam) {
-  ::tt::target::ttnn::UnaryWithParamT unaryWithParamT;
-  unaryWithParam.UnPackTo(&unaryWithParamT);
+  ::tt::target::ttnn::UnaryWithParamT unaryWithParamNative;
+  unaryWithParam.UnPackTo(&unaryWithParamNative);
   return ttnn_op_invoke::operations::utils::toTTNNUnaryWithParam(
-      unaryWithParamT);
+      unaryWithParamNative);
 }
 
 std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
 createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op) {
-  if (!op->matmul_program_config()) {
-    return std::nullopt;
-  }
-
-  ::ttnn::operations::matmul::MatmulProgramConfig matmulProgramConfig;
-  switch (op->matmul_program_config_type()) {
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseProgramConfig();
-    return ::ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{
-        .compute_with_storage_grid_size =
-            ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                *config->compute_with_storage_grid_size()),
-        .in0_block_w = config->in0_block_w(),
-        .out_subblock_h = config->out_subblock_h(),
-        .out_subblock_w = config->out_subblock_w(),
-        .per_core_M = config->per_core_m(),
-        .per_core_N = config->per_core_n()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCastProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCastProgramConfig{
-            .compute_with_storage_grid_size =
-                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                    *config->compute_with_storage_grid_size()),
-            .in0_block_w = config->in0_block_w(),
-            .out_subblock_h = config->out_subblock_h(),
-            .out_subblock_w = config->out_subblock_w(),
-            .out_block_h = config->out_block_h(),
-            .out_block_w = config->out_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .transpose_mcast = config->transpose_mcast(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-            .fuse_batch = config->fuse_batch()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCast1DProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCast1DProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCast1DProgramConfig{
-            .compute_with_storage_grid_size =
-                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                    *config->compute_with_storage_grid_size()),
-            .in0_block_w = config->in0_block_w(),
-            .out_subblock_h = config->out_subblock_h(),
-            .out_subblock_w = config->out_subblock_w(),
-            .out_block_h = config->out_block_h(),
-            .out_block_w = config->out_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .fuse_batch = config->fuse_batch(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-            .mcast_in0 = config->mcast_in0(),
-            .gather_in0 = config->gather_in0(),
-            .hop_cores = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
-                *config->hop_cores()),
-            .num_global_cb_receivers = config->num_global_cb_receivers(),
-            .untilize_out = config->untilize_out()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig{
-            .in0_block_w = config->in0_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-        };
-  }
-  default:
-    LOG_FATAL("Unsupported MatmulProgramConfig type");
-  }
+  ::tt::target::ttnn::MatmulOpT matmulOpNative;
+  op->UnPackTo(&matmulOpNative);
+  return ttnn_op_invoke::operations::utils::createMatmulProgramConfigIfNeeded(
+      matmulOpNative);
 }
 
 std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
 createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::LinearOp *op) {
-  if (!op->matmul_program_config()) {
-    return std::nullopt;
-  }
-
-  ::ttnn::operations::matmul::MatmulProgramConfig matmulProgramConfig;
-  switch (op->matmul_program_config_type()) {
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseProgramConfig();
-    return ::ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{
-        .compute_with_storage_grid_size =
-            ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                *config->compute_with_storage_grid_size()),
-        .in0_block_w = config->in0_block_w(),
-        .out_subblock_h = config->out_subblock_h(),
-        .out_subblock_w = config->out_subblock_w(),
-        .per_core_M = config->per_core_m(),
-        .per_core_N = config->per_core_n()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCastProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCastProgramConfig{
-            .compute_with_storage_grid_size =
-                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                    *config->compute_with_storage_grid_size()),
-            .in0_block_w = config->in0_block_w(),
-            .out_subblock_h = config->out_subblock_h(),
-            .out_subblock_w = config->out_subblock_w(),
-            .out_block_h = config->out_block_h(),
-            .out_block_w = config->out_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .transpose_mcast = config->transpose_mcast(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-            .fuse_batch = config->fuse_batch()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCast1DProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCast1DProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCast1DProgramConfig{
-            .compute_with_storage_grid_size =
-                ttnn_op_invoke::operations::utils::toTTNNCoreCoord(
-                    *config->compute_with_storage_grid_size()),
-            .in0_block_w = config->in0_block_w(),
-            .out_subblock_h = config->out_subblock_h(),
-            .out_subblock_w = config->out_subblock_w(),
-            .out_block_h = config->out_block_h(),
-            .out_block_w = config->out_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .fuse_batch = config->fuse_batch(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-            .mcast_in0 = config->mcast_in0(),
-            .gather_in0 = config->gather_in0(),
-            .hop_cores = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
-                *config->hop_cores()),
-            .num_global_cb_receivers = config->num_global_cb_receivers(),
-            .untilize_out = config->untilize_out()};
-  }
-  case ::tt::target::ttnn::MatmulProgramConfig::
-      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig: {
-    auto *config =
-        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig();
-    return ::ttnn::operations::matmul::
-        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig{
-            .in0_block_w = config->in0_block_w(),
-            .per_core_M = config->per_core_m(),
-            .per_core_N = config->per_core_n(),
-            .fused_activation =
-                config->fused_activation()
-                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
-                          toTTNNUnaryWithParam(*config->fused_activation()))
-                    : std::nullopt,
-        };
-  }
-  default:
-    LOG_FATAL("Unsupported MatmulProgramConfig type");
-  }
+  ::tt::target::ttnn::LinearOpT linearOpNative;
+  op->UnPackTo(&linearOpNative);
+  return ttnn_op_invoke::operations::utils::createMatmulProgramConfigIfNeeded(
+      linearOpNative);
 }
 
 ::ttnn::Conv2dConfig

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -2268,7 +2268,7 @@ TEST_P(OpModelLinearParam, LinearParam) {
 
   auto runtimeExp = OpModel<LinearOp>::getOpRuntime(
       inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
-      biasLayout, outputLayout, false, false);
+      biasLayout, outputLayout, false, false, /*activation=*/std::nullopt);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (expectedLegal) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -2487,9 +2487,9 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
     llvm::consumeError(constraintsExp.takeError());
   }
 
-  auto runtimeExp =
-      OpModel<MatmulOp>::getOpRuntime(inputShapeA, inputLayoutA, inputShapeB,
-                                      inputLayoutB, outputLayout, false, false);
+  auto runtimeExp = OpModel<MatmulOp>::getOpRuntime(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputLayout, false,
+      false, /*activation=*/std::nullopt);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (expectedLegal) {
     EXPECT_TRUE(runtimeExp.get() > 0);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.

### What's changed
This is the third PR in the TTNNOpInvokeLib series. It introduces shared dispatch for MatmulOp, LinearOp, and SparseMatmulOp across OpModel and Runtime.
                                                                                                                                                                                                                                                           
  MatmulOpT, LinearOpT, and SparseMatmulOpT (the NativeTable types for these ops) are the interfaces passed into the library. In OpModel they are constructed from MLIR attributes via buildMatmulOpTFromMLIR / buildLinearOpTFromMLIR; in Runtime they are already available directly from the deserialized flatbuffer. Both call sites then delegate to ttnn_op_invoke::callMatmul / ttnn_op_invoke::callLinear / ttnn_op_invoke::callSparseMatmul, which handle parameter resolution and dispatch for all three call types: constraint query, runtime query, and execution.


