### PR TITLE
Eltwise-unary ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYCOMPOSITEOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYCOMPOSITEOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+using EltwiseUnaryCompositeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseUnaryCompositeResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  bool fastApproxMode = false;
+};
+
+EltwiseUnaryCompositeResolvedParams resolveEltwiseUnaryCompositeParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp);
+
+template <typename Tag>
+auto createEltwiseUnaryCompositeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, const EltwiseUnaryCompositeResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryCompositeOpResult callEltwiseUnaryComposite(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    Fn ttnnOp, TensorArg input, ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryCompositeResolvedParams params =
+      resolveEltwiseUnaryCompositeParams(eltwiseUnaryCompositeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryCompositeTuple(tag, eltwiseUnaryCompositeOp, input,
+                                            params);
+  };
+
+  return callOp<EltwiseUnaryCompositeOpResult>(ttnnOp, callType, makeTuple,
+                                               device);
+}
+
+template <typename Tag>
+auto createEltwiseUnaryCompositeWithFastAndApproximateModeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, const EltwiseUnaryCompositeResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(input, tag), /*approx=*/params.fastApproxMode,
+      params.outputMemoryConfig, /*optional_output_tensor=*/std::nullopt,
+      /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryCompositeOpResult
+callEltwiseUnaryCompositeWithFastAndApproximateMode(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    Fn ttnnOp, TensorArg input, ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryCompositeResolvedParams params =
+      resolveEltwiseUnaryCompositeParams(eltwiseUnaryCompositeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryCompositeWithFastAndApproximateModeTuple(
+        tag, eltwiseUnaryCompositeOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryCompositeOpResult>(ttnnOp, callType, makeTuple,
+                                               device);
+}
+
+struct EltwiseUnaryCompositeClampScalarResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<std::variant<float, int32_t>> min;
+  std::optional<std::variant<float, int32_t>> max;
+};
+
+struct EltwiseUnaryCompositeClampTensorResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+EltwiseUnaryCompositeClampScalarResolvedParams
+resolveEltwiseUnaryCompositeClampScalarParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp);
+
+EltwiseUnaryCompositeClampTensorResolvedParams
+resolveEltwiseUnaryCompositeClampTensorParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp);
+
+EltwiseUnaryCompositeOpResult callEltwiseUnaryCompositeClampScalar(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+EltwiseUnaryCompositeOpResult callEltwiseUnaryCompositeClampTensor(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, TensorArg min, TensorArg max,
+    ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYCOMPOSITEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYOP_H
+
+#include "operations/eltwise/unary/unary.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+using EltwiseUnaryOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseUnaryResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  bool fastApproxMode = false;
+  std::optional<bool> approx;
+  std::optional<::ttnn::operations::unary::SigmoidMode> sigmoidMode;
+  std::optional<int32_t> vecMode;
+  std::optional<float> parameter;
+};
+
+EltwiseUnaryResolvedParams resolveEltwiseUnaryParams(
+    const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp);
+
+template <typename Tag>
+auto createEltwiseUnaryTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+    TensorArg input, const EltwiseUnaryResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryOpResult
+callEltwiseUnary(CallType callType,
+                 const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+                 Fn ttnnOp, TensorArg input,
+                 ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryResolvedParams params = resolveEltwiseUnaryParams(eltwiseUnaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryTuple(tag, eltwiseUnaryOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryOpResult>(ttnnOp, callType, makeTuple, device);
+}
+
+template <typename Tag>
+auto createEltwiseUnaryTanhTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+    TensorArg input, const EltwiseUnaryResolvedParams &params) {
+  TT_INVOKE_ASSERT(params.approx.has_value(), "approx parameter not resolved");
+  return std::make_tuple(
+      resolveTensorArg(input, tag), params.outputMemoryConfig,
+      /*optional_output_tensor=*/std::nullopt, *params.approx,
+      /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryOpResult
+callEltwiseUnaryTanh(CallType callType,
+                     const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+                     Fn ttnnOp, TensorArg input,
+                     ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryResolvedParams params = resolveEltwiseUnaryParams(eltwiseUnaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryTanhTuple(tag, eltwiseUnaryOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryOpResult>(ttnnOp, callType, makeTuple, device);
+}
+
+template <typename Tag>
+auto createEltwiseUnaryWithFastAndApproximateModeTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+    TensorArg input, const EltwiseUnaryResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         /*approx=*/params.fastApproxMode,
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryOpResult callEltwiseUnaryWithFastAndApproximateMode(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp, Fn ttnnOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryResolvedParams params = resolveEltwiseUnaryParams(eltwiseUnaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryWithFastAndApproximateModeTuple(
+        tag, eltwiseUnaryOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryOpResult>(ttnnOp, callType, makeTuple, device);
+}
+
+template <typename Tag>
+auto createEltwiseUnarySigmoidTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+    TensorArg input, const EltwiseUnaryResolvedParams &params) {
+  TT_INVOKE_ASSERT(params.vecMode.has_value() && params.sigmoidMode.has_value(),
+                   "sigmoid params (vecMode, sigmoidMode) not resolved");
+  return std::make_tuple(resolveTensorArg(input, tag), *params.vecMode,
+                         *params.sigmoidMode, params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryOpResult callEltwiseUnarySigmoid(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp, Fn ttnnOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryResolvedParams params = resolveEltwiseUnaryParams(eltwiseUnaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnarySigmoidTuple(tag, eltwiseUnaryOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryOpResult>(ttnnOp, callType, makeTuple, device);
+}
+
+template <typename Tag>
+auto createEltwiseUnaryWithFloatParameterTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp,
+    TensorArg input, const EltwiseUnaryResolvedParams &params) {
+  TT_INVOKE_ASSERT(params.parameter.has_value(),
+                   "float parameter not resolved");
+  return std::make_tuple(resolveTensorArg(input, tag), *params.parameter,
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt,
+                         /*sub_core_grids=*/std::nullopt);
+}
+
+template <typename Fn>
+EltwiseUnaryOpResult callEltwiseUnaryWithFloatParameter(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp, Fn ttnnOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseUnaryResolvedParams params = resolveEltwiseUnaryParams(eltwiseUnaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryWithFloatParameterTuple(tag, eltwiseUnaryOp, input,
+                                                     params);
+  };
+
+  return callOp<EltwiseUnaryOpResult>(ttnnOp, callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_UNARY_ELTWISEUNARYOP_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -74,6 +74,28 @@ struct UnaryEltwiseWithFastApproxModeOpModel {
                                              TTNNLayoutAttr outputLayout);
 };
 
+template <typename OpT>
+struct UnaryCompositeEltwiseOpModel {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
+};
+
+template <typename OpT>
+struct UnaryCompositeEltwiseWithFastApproxModeOpModel {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
+};
+
 template <>
 struct OpModel<ReluOp> : UnaryEltwiseOpModel<ReluOp> {};
 
@@ -104,9 +126,6 @@ template <>
 struct OpModel<AcosOp> : UnaryEltwiseOpModel<AcosOp> {};
 
 template <>
-struct OpModel<TanhOp> : UnaryEltwiseOpModel<TanhOp> {};
-
-template <>
 struct OpModel<LogOp> : UnaryEltwiseWithFastApproxModeOpModel<LogOp> {};
 
 template <>
@@ -134,7 +153,8 @@ template <>
 struct OpModel<AtanOp> : UnaryEltwiseOpModel<AtanOp> {};
 
 template <>
-struct OpModel<Log1pOp> : UnaryEltwiseWithFastApproxModeOpModel<Log1pOp> {};
+struct OpModel<Log1pOp>
+    : UnaryCompositeEltwiseWithFastApproxModeOpModel<Log1pOp> {};
 
 template <>
 struct OpModel<Expm1Op> : UnaryEltwiseOpModel<Expm1Op> {};
@@ -143,7 +163,7 @@ template <>
 struct OpModel<ReciprocalOp> : UnaryEltwiseOpModel<ReciprocalOp> {};
 
 template <>
-struct OpModel<CbrtOp> : UnaryEltwiseOpModel<CbrtOp> {};
+struct OpModel<CbrtOp> : UnaryCompositeEltwiseOpModel<CbrtOp> {};
 
 template <>
 struct OpModel<BitwiseNotOp> : UnaryEltwiseOpModel<BitwiseNotOp> {};
@@ -168,6 +188,21 @@ struct OpModel<ErfOp> : UnaryEltwiseWithFastApproxModeOpModel<ErfOp> {};
 
 template <>
 struct OpModel<ErfcOp> : UnaryEltwiseOpModel<ErfcOp> {};
+
+//===----------------------------------------------------------------------===//
+// TanhOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<TanhOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                             TTNNLayoutAttr inputLayout,
+                                             TTNNLayoutAttr outputLayout);
+};
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(TTNNOpInvokeLib STATIC
   utils/utils.cpp
   Conv/Conv2dOp.cpp
+  Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
+  Eltwise/Unary/EltwiseUnaryOp.cpp
   Matmul/MatmulOp.cpp
 )
 

--- a/lib/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
+
+#include <optional>
+#include <tuple>
+
+namespace ttnn_op_invoke {
+
+EltwiseUnaryCompositeResolvedParams resolveEltwiseUnaryCompositeParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp) {
+
+  EltwiseUnaryCompositeResolvedParams params;
+
+  params.fastApproxMode = false;
+
+  if (eltwiseUnaryCompositeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseUnaryCompositeOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*eltwiseUnaryCompositeOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+EltwiseUnaryCompositeClampScalarResolvedParams
+resolveEltwiseUnaryCompositeClampScalarParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp) {
+
+  EltwiseUnaryCompositeClampScalarResolvedParams params;
+
+  const ::tt::target::ttnn::ClampScalarOpParamsT *clampParams =
+      eltwiseUnaryCompositeOp.params.AsClampScalarOpParams();
+
+  TT_INVOKE_ASSERT(clampParams->min.type == clampParams->max.type,
+                   "Clamp scalar min/max types must match");
+
+  switch (clampParams->min.type) {
+  case ::tt::target::ttnn::NumberType::FP:
+    params.min = clampParams->min.AsFP()->value;
+    params.max = clampParams->max.AsFP()->value;
+    break;
+  case ::tt::target::ttnn::NumberType::I32:
+    params.min = clampParams->min.AsI32()->value;
+    params.max = clampParams->max.AsI32()->value;
+    break;
+  default:
+    llvm::report_fatal_error("unknown clamp scalar min/max type");
+  }
+
+  if (eltwiseUnaryCompositeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseUnaryCompositeOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*eltwiseUnaryCompositeOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+EltwiseUnaryCompositeClampTensorResolvedParams
+resolveEltwiseUnaryCompositeClampTensorParams(
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+        &eltwiseUnaryCompositeOp) {
+
+  EltwiseUnaryCompositeClampTensorResolvedParams params;
+
+  if (eltwiseUnaryCompositeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseUnaryCompositeOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*eltwiseUnaryCompositeOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createEltwiseUnaryCompositeClampScalarTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input,
+    const EltwiseUnaryCompositeClampScalarResolvedParams &params) {
+  TT_INVOKE_ASSERT(params.min.has_value() && params.max.has_value(),
+                   "clamp scalar min/max not resolved");
+  return std::make_tuple(resolveTensorArg(input, tag), *params.min, *params.max,
+                         params.outputMemoryConfig);
+}
+
+EltwiseUnaryCompositeOpResult callEltwiseUnaryCompositeClampScalar(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, ::ttnn::MeshDevice *device) {
+
+  EltwiseUnaryCompositeClampScalarResolvedParams params =
+      resolveEltwiseUnaryCompositeClampScalarParams(eltwiseUnaryCompositeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryCompositeClampScalarTuple(
+        tag, eltwiseUnaryCompositeOp, input, params);
+  };
+
+  return callOp<EltwiseUnaryCompositeOpResult>(WRAP_OP(::ttnn::clamp), callType,
+                                               makeTuple, device);
+}
+
+template <typename Tag>
+auto createEltwiseUnaryCompositeClampTensorTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, TensorArg min, TensorArg max,
+    const EltwiseUnaryCompositeClampTensorResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(input, tag),
+                         resolveTensorArg(min, tag), resolveTensorArg(max, tag),
+                         params.outputMemoryConfig);
+}
+
+EltwiseUnaryCompositeOpResult callEltwiseUnaryCompositeClampTensor(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseUnaryCompositeOpT &eltwiseUnaryCompositeOp,
+    TensorArg input, TensorArg min, TensorArg max, ::ttnn::MeshDevice *device) {
+
+  EltwiseUnaryCompositeClampTensorResolvedParams params =
+      resolveEltwiseUnaryCompositeClampTensorParams(eltwiseUnaryCompositeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseUnaryCompositeClampTensorTuple(
+        tag, eltwiseUnaryCompositeOp, input, min, max, params);
+  };
+
+  return callOp<EltwiseUnaryCompositeOpResult>(WRAP_OP(::ttnn::clamp), callType,
+                                               makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+EltwiseUnaryResolvedParams resolveEltwiseUnaryParams(
+    const ::tt::target::ttnn::EltwiseUnaryOpT &eltwiseUnaryOp) {
+
+  EltwiseUnaryResolvedParams params;
+
+  // Preserving the hard-coded constant from runtime.
+  params.fastApproxMode = false;
+
+  if (eltwiseUnaryOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*eltwiseUnaryOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*eltwiseUnaryOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  switch (eltwiseUnaryOp.type) {
+  case ::tt::target::ttnn::EltwiseUnaryOpType::Tanh: {
+    params.approx = false;
+    break;
+  }
+  case ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid: {
+    params.sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
+    params.vecMode =
+        static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
+    break;
+  }
+  case ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu: {
+    params.parameter =
+        eltwiseUnaryOp.params.AsEltwiseOpWithFloatParams()->parameter;
+    break;
+  }
+  default:
+    break;
+  }
+
+  return params;
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -12,6 +12,8 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
 #include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
@@ -808,6 +810,31 @@ getPrepareConv2dBiasOpOutputTensorSpec(
 //===----------------------------------------------------------------------===//
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseUnaryOpT buildEltwiseUnaryOpTFromMLIR(
+    TTNNLayoutAttr outputLayout,
+    std::optional<llvm::APFloat> slope = std::nullopt) {
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOp;
+
+  if (std::is_same_v<OpTy, TanhOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Tanh;
+  } else if (std::is_same_v<OpTy, SigmoidOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid;
+  } else if (std::is_same_v<OpTy, LeakyReluOp>) {
+    eltwiseUnaryOp.type = ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu;
+    assert(slope.has_value() && "LeakyReluOp requires a slope value");
+    ::tt::target::ttnn::EltwiseOpWithFloatParamsT
+        eltwiseOpWithFloatParamsNative;
+    eltwiseOpWithFloatParamsNative.parameter = slope.value().convertToFloat();
+    eltwiseUnaryOp.params.Set(eltwiseOpWithFloatParamsNative);
+  }
+
+  eltwiseUnaryOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints>
@@ -823,11 +850,22 @@ UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<OpTy>(outputLayout);
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnary(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryOpNative, detail::getOpSymbol<OpTy>(), inputSpec,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from EltwiseUnaryOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -849,11 +887,21 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<OpTy>(outputLayout);
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        detail::getOpSymbol<OpTy>(), device, inputSpec,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnary(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseUnaryOpNative,
+            detail::getOpSymbol<OpTy>(), inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnaryOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -875,13 +923,23 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  bool fastApproxMode = true;
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, fastApproxMode,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryWithFastAndApproximateMode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryOpNative, detail::getOpSymbol<OpTy>(), inputSpec,
+            device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseUnaryWithFastAndApproximateModeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -903,13 +961,200 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  bool fastApproxMode = true;
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, fastApproxMode,
-        detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryWithFastAndApproximateMode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseUnaryOpNative,
+            detail::getOpSymbol<OpTy>(), inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from "
+        "EltwiseUnaryWithFastAndApproximateModeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// Unary Composite Eltwise Ops
+//===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryCompositeEltwiseOpModel<OpTy>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeOpTFromMLIR<OpTy>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryComposite(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+            result) &&
+        "Expected ConstraintQueryResponse from EltwiseUnaryCompositeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+template <typename OpTy>
+llvm::Expected<size_t> UnaryCompositeEltwiseOpModel<OpTy>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeOpTFromMLIR<OpTy>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryComposite(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseUnaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnaryCompositeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryCompositeEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeOpTFromMLIR<OpTy>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeWithFastAndApproximateMode(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseUnaryCompositeWithFastAndApproximateModeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+template <typename OpTy>
+llvm::Expected<size_t>
+UnaryCompositeEltwiseWithFastApproxModeOpModel<OpTy>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeOpTFromMLIR<OpTy>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeWithFastAndApproximateMode(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseUnaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from "
+        "EltwiseUnaryCompositeWithFastAndApproximateModeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -926,7 +1171,6 @@ template struct UnaryEltwiseWithFastApproxModeOpModel<SqrtOp>;
 template struct UnaryEltwiseOpModel<SinOp>;
 template struct UnaryEltwiseOpModel<AbsOp>;
 template struct UnaryEltwiseOpModel<CosOp>;
-template struct UnaryEltwiseOpModel<TanhOp>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<LogOp>;
 template struct UnaryEltwiseOpModel<CeilOp>;
 template struct UnaryEltwiseOpModel<SignOp>;
@@ -940,17 +1184,97 @@ template struct UnaryEltwiseOpModel<AsinOp>;
 template struct UnaryEltwiseOpModel<AsinhOp>;
 template struct UnaryEltwiseOpModel<AcosOp>;
 template struct UnaryEltwiseOpModel<ReciprocalOp>;
-template struct UnaryEltwiseOpModel<CbrtOp>;
+template struct UnaryCompositeEltwiseOpModel<CbrtOp>;
 template struct UnaryEltwiseOpModel<BitwiseNotOp>;
 template struct UnaryEltwiseOpModel<SiluOp>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<MishOp>;
-template struct UnaryEltwiseWithFastApproxModeOpModel<Log1pOp>;
+template struct UnaryCompositeEltwiseWithFastApproxModeOpModel<Log1pOp>;
 template struct UnaryEltwiseOpModel<Expm1Op>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<RsqrtOp>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<ErfOp>;
 template struct UnaryEltwiseOpModel<ErfcOp>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<ExpOp>;
 template struct UnaryEltwiseWithFastApproxModeOpModel<GeluOp>;
+
+//===----------------------------------------------------------------------===//
+// TanhOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints>
+OpModel<TanhOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                  TTNNLayoutAttr inputLayout,
+                                  TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<TanhOp>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryTanh(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryOpNative, ::ttnn::tanh, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from EltwiseUnaryTanhOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
+  };
+
+  return operation::getOpConstraints(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+OpModel<TanhOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                              TTNNLayoutAttr inputLayout,
+                              TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<TanhOp>(outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryTanh(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseUnaryOpNative,
+            ::ttnn::tanh, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnaryTanhOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
 
 //===----------------------------------------------------------------------===//
 // SigmoidOp
@@ -967,16 +1291,22 @@ OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Add default parameters
-  int32_t vectorMode =
-      static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
-  auto sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<SigmoidOp>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sigmoid, device, inputSpec, vectorMode,
-                                sigmoidMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnarySigmoid(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryOpNative, ::ttnn::sigmoid, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseUnarySigmoidOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(), query);
@@ -997,16 +1327,21 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Add default parameters
-  int32_t vectorMode =
-      static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
-  auto sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<SigmoidOp>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::sigmoid, device, inputSpec, vectorMode,
-                            sigmoidMode,
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnarySigmoid(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseUnaryOpNative,
+            ::ttnn::sigmoid, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnarySigmoidOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -1029,11 +1364,22 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<LeakyReluOp>(outputLayout, slope);
+
   // Create query closure
   auto leakyReluOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::leaky_relu, device, inputSpec,
-                                slope.convertToFloat(),
-                                detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryWithFloatParameter(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryOpNative, ::ttnn::leaky_relu, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "runEltwiseUnaryWithFloatParameterOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -1054,11 +1400,22 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  ::tt::target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative =
+      buildEltwiseUnaryOpTFromMLIR<LeakyReluOp>(outputLayout, slope);
+
   // Create query closure
   auto leakyReluOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::leaky_relu, device, inputSpec,
-                            slope.convertToFloat(),
-                            detail::getNullableMemoryConfig(outputLayout));
+    ttnn_op_invoke::EltwiseUnaryOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryWithFloatParameter(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseUnaryOpNative,
+            ::ttnn::leaky_relu, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from "
+        "runEltwiseUnaryWithFloatParameterOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(leakyReluOpQuery);
@@ -6562,17 +6919,45 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
 // ClampScalar
 //===----------------------------------------------------------------------===//
 #ifdef TTMLIR_ENABLE_OPMODEL
-/// Convert a clamp min/max mlir::Attribute (F32Attr or I32Attr) to the
-/// std::variant tt-metal expects, mirroring the runtime's NumberType dispatch.
-static std::optional<std::variant<float, int32_t>>
-clampAttrToVariant(mlir::Attribute attr) {
-  if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(attr)) {
-    return static_cast<int32_t>(intAttr.getValue().getSExtValue());
+static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(mlir::Attribute min,
+                                                 mlir::Attribute max,
+                                                 TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+  eltwiseUnaryCompositeOp.type =
+      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampScalar;
+
+  ::tt::target::ttnn::ClampScalarOpParamsT params;
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(min)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    params.min.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(min)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    params.min.Set(i32);
+  } else {
+    llvm_unreachable("Invalid clamp min attribute");
   }
-  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(attr)) {
-    return static_cast<float>(floatAttr.getValueAsDouble());
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(max)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    params.max.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(max)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    params.max.Set(i32);
+  } else {
+    llvm_unreachable("Invalid clamp max attribute");
   }
-  return std::nullopt;
+
+  eltwiseUnaryCompositeOp.params.Set(params);
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
 }
 #endif // TTMLIR_ENABLE_OPMODEL
 
@@ -6588,17 +6973,24 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto memConfig = detail::getNullableMemoryConfig(outputLayout);
-  auto minVariant = clampAttrToVariant(min);
-  auto maxVariant = clampAttrToVariant(max);
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(min, max, outputLayout);
 
-  auto clampScalarQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minVariant,
-                                maxVariant, memConfig);
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeClampScalar(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryCompositeOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseUnaryCompositeClampScalar query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampScalarQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6616,16 +7008,24 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto memConfig = detail::getNullableMemoryConfig(outputLayout);
-  auto minVariant = clampAttrToVariant(min);
-  auto maxVariant = clampAttrToVariant(max);
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeClampScalarOpTFromMLIR(min, max, outputLayout);
 
-  auto clampScalarQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::clamp, device, inputSpec, minVariant,
-                            maxVariant, memConfig);
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeClampScalar(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseUnaryCompositeOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnaryCompositeClampScalar "
+        "query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
-  return operation::getOpRuntime(clampScalarQuery);
+  return operation::getOpRuntime(query);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6634,6 +7034,19 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampTensor
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+static ::tt::target::ttnn::EltwiseUnaryCompositeOpT
+buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOp;
+  eltwiseUnaryCompositeOp.type =
+      ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampTensor;
+
+  eltwiseUnaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseUnaryCompositeOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
@@ -6654,15 +7067,24 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
                    detail::convertToTensorSpec(device, maxShape, maxLayout));
 
-  // Create query closure
-  auto clampTensorQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minSpec,
-                                maxSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(outputLayout);
+
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeClampTensor(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseUnaryCompositeOpNative, inputSpec, minSpec, maxSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseUnaryCompositeClampTensor query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampTensorQuery);
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6688,13 +7110,24 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
   ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
                    detail::convertToTensorSpec(device, maxShape, maxLayout));
 
-  // Create query closure
-  auto clampTensorQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::clamp, device, inputSpec, minSpec, maxSpec,
-                            detail::getNullableMemoryConfig(outputLayout));
+  ::tt::target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative =
+      buildEltwiseUnaryCompositeClampTensorOpTFromMLIR(outputLayout);
+
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+        ttnn_op_invoke::callEltwiseUnaryCompositeClampTensor(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseUnaryCompositeOpNative, inputSpec, minSpec, maxSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseUnaryCompositeClampTensor "
+        "query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
-  return operation::getOpRuntime(clampTensorQuery);
+  return operation::getOpRuntime(query);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -6,6 +6,8 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
@@ -13,121 +15,118 @@
 
 namespace tt::runtime::ttnn::operations::eltwise::unary {
 
-static void runEltwiseUnaryOp(
-    const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &, const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::Tensor> &,
-        const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+template <typename Fn>
+static void runEltwiseUnaryOp(const ::tt::target::ttnn::EltwiseUnaryOp *op,
+                              ProgramTensorPool &tensorPool, Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out =
-      ttnnOp(in, outputMemoryConfig, /*optional_output_tensor=*/std::nullopt,
-             /*sub_core_grids=*/std::nullopt);
+  target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative;
+  op->UnPackTo(&eltwiseUnaryOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EltwiseUnaryOpResult result =
+      ttnn_op_invoke::callEltwiseUnary(ttnn_op_invoke::CallType::EXECUTE,
+                                       eltwiseUnaryOpNative,
+                                       std::forward<Fn>(ttnnOp), &in);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnary execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
-static void runEltwiseUnaryTanhOp(
-    const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &, const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::Tensor> &, bool,
-        const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+template <typename Fn>
+static void runEltwiseUnaryTanhOp(const ::tt::target::ttnn::EltwiseUnaryOp *op,
+                                  ProgramTensorPool &tensorPool, Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out =
-      ttnnOp(in, outputMemoryConfig, /*optional_output_tensor=*/std::nullopt,
-             /*approx=*/false, /*sub_core_grids=*/std::nullopt);
+  target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative;
+  op->UnPackTo(&eltwiseUnaryOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EltwiseUnaryOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryTanh(ttnn_op_invoke::CallType::EXECUTE,
+                                           eltwiseUnaryOpNative,
+                                           std::forward<Fn>(ttnnOp), &in);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnaryTanh execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
+template <typename Fn>
 static void runEltwiseUnaryWithFastAndApproximateModeOp(
     const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
-    const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, const bool,
-                       const std::optional<::ttnn::MemoryConfig> &,
-                       const std::optional<::ttnn::Tensor> &,
-                       const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+    Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out = ttnnOp(in, /*parameter=*/false, outputMemoryConfig,
-                              /*optional_output_tensor=*/std::nullopt,
-                              /*sub_core_grids=*/std::nullopt);
+  target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative;
+  op->UnPackTo(&eltwiseUnaryOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EltwiseUnaryOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryWithFastAndApproximateMode(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryOpNative,
+          std::forward<Fn>(ttnnOp), &in);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from "
+             "callEltwiseUnaryWithFastAndApproximateMode execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
-static void runEltwiseUnarySigmoidOp(
-    const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
-    const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, const int,
-                       const ::ttnn::operations::unary::SigmoidMode,
-                       const std::optional<::ttnn::MemoryConfig> &,
-                       const std::optional<::ttnn::Tensor> &,
-                       const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+template <typename Fn>
+static void
+runEltwiseUnarySigmoidOp(const ::tt::target::ttnn::EltwiseUnaryOp *op,
+                         ProgramTensorPool &tensorPool, Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
 
-  auto sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
-  ::ttnn::Tensor out = ttnnOp(
-      in, static_cast<int>(::ttnn::operations::unary::VecMode::RC), sigmoidMode,
-      outputMemoryConfig, /*optional_output_tensor=*/std::nullopt,
-      /*sub_core_grids=*/std::nullopt);
+  target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative;
+  op->UnPackTo(&eltwiseUnaryOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EltwiseUnaryOpResult result =
+      ttnn_op_invoke::callEltwiseUnarySigmoid(ttnn_op_invoke::CallType::EXECUTE,
+                                              eltwiseUnaryOpNative,
+                                              std::forward<Fn>(ttnnOp), &in);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnarySigmoid execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
+template <typename Fn>
 static void runEltwiseUnaryWithFloatParameterOp(
     const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
-    const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, float,
-                       const std::optional<::ttnn::MemoryConfig> &,
-                       const std::optional<::ttnn::Tensor> &,
-                       const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+    Fn ttnnOp) {
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  float parameter = op->params_as_EltwiseOpWithFloatParams()->parameter();
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseUnaryOpT eltwiseUnaryOpNative;
+  op->UnPackTo(&eltwiseUnaryOpNative);
 
-  ::ttnn::Tensor out = ttnnOp(in, parameter, outputMemoryConfig,
-                              /*optional_output_tensor=*/std::nullopt,
-                              /*sub_core_grids=*/std::nullopt);
+  ttnn_op_invoke::EltwiseUnaryOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryWithFloatParameter(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryOpNative,
+          std::forward<Fn>(ttnnOp), &in);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnaryWithFloatParameter "
+             "execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::EltwiseUnaryOp *op,
@@ -135,135 +134,139 @@ void run(const ::tt::target::ttnn::EltwiseUnaryOp *op,
   ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseUnaryOpType::Abs: {
-    runEltwiseUnaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::abs(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::abs));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Ceil: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::ceil);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::ceil));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Cos: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::cos);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::cos));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Acos: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::acos);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::acos));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Floor: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::floor);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::floor));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Gelu: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::gelu);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::gelu));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::IsFinite: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::isfinite);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::isfinite));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::LogicalNot: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::logical_not);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::logical_not));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Neg: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::neg);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::neg));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Relu: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::relu);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::relu));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Relu6: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::relu6);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::relu6));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Hardsigmoid: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::hardsigmoid);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::hardsigmoid));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sqrt: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::sqrt);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::sqrt));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Rsqrt: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::rsqrt);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::rsqrt));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid: {
-    runEltwiseUnarySigmoidOp(op, tensorPool, ::ttnn::sigmoid);
+    runEltwiseUnarySigmoidOp(op, tensorPool, WRAP_OP(::ttnn::sigmoid));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Silu: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::silu);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::silu));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Mish: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::mish);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::mish));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sin: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::sin);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::sin));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Asin: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::asin);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::asin));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Asinh: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::asinh);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::asinh));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Reciprocal: {
-    runEltwiseUnaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::reciprocal(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::reciprocal));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sign: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::sign);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::sign));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Tan: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::tan);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::tan));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Tanh: {
-    runEltwiseUnaryTanhOp(op, tensorPool, ::ttnn::tanh);
+    runEltwiseUnaryTanhOp(op, tensorPool, WRAP_OP(::ttnn::tanh));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Atan: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::atan);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::atan));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Exp: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::exp);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::exp));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Log: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::log);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::log));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Expm1: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::expm1);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::expm1));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::LeakyRelu: {
-    runEltwiseUnaryWithFloatParameterOp(op, tensorPool, ::ttnn::leaky_relu);
+    runEltwiseUnaryWithFloatParameterOp(op, tensorPool,
+                                        WRAP_OP(::ttnn::leaky_relu));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::BitwiseNot: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::bitwise_not);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::bitwise_not));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Erf: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool, ::ttnn::erf);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                WRAP_OP(::ttnn::erf));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Erfc: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::erfc);
+    runEltwiseUnaryOp(op, tensorPool, WRAP_OP(::ttnn::erfc));
     break;
   }
   }

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
@@ -6,31 +6,31 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttnn/operations/eltwise/unary/unary_composite.hpp"
 
 namespace tt::runtime::ttnn::operations::eltwise::unary {
 
+template <typename Fn>
 static void runEltwiseUnaryCompositeOp(
     const ::tt::target::ttnn::EltwiseUnaryCompositeOp *op,
-    ProgramTensorPool &tensorPool,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &, const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::Tensor> &,
-        const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+    ProgramTensorPool &tensorPool, Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative;
+  op->UnPackTo(&eltwiseUnaryCompositeOpNative);
 
-  ::ttnn::Tensor out =
-      ttnnOp(in, outputMemoryConfig, std::nullopt, std::nullopt);
+  ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryComposite(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryCompositeOpNative,
+          std::forward<Fn>(ttnnOp), &in);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnaryComposite execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 static void runEltwiseUnaryCompositeClampScalarOp(
@@ -39,28 +39,20 @@ static void runEltwiseUnaryCompositeClampScalarOp(
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  const auto *params = op->params_as_ClampScalarOpParams();
+  target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative;
+  op->UnPackTo(&eltwiseUnaryCompositeOpNative);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryCompositeClampScalar(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryCompositeOpNative,
+          &in);
 
-  // Use the union type to determine whether to use int or float clamp
-  ::ttnn::Tensor out;
-  if (params->min_type() == ::tt::target::ttnn::NumberType::I32) {
-    int32_t min = params->min_as_I32()->value();
-    int32_t max = params->max_as_I32()->value();
-    out = ::ttnn::clamp(in, min, max, outputMemoryConfig);
-  } else {
-    float min = params->min_as_FP()->value();
-    float max = params->max_as_FP()->value();
-    out = ::ttnn::clamp(in, min, max, outputMemoryConfig);
-  }
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnaryCompositeClampScalar "
+             "execution");
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 static void runEltwiseUnaryCompositeClampTensorOp(
@@ -74,40 +66,43 @@ static void runEltwiseUnaryCompositeClampTensorOp(
   ::ttnn::Tensor max = tensorPool.getTTNNTensorAndValidate(
       op->params_as_ClampTensorOpParams()->max());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative;
+  op->UnPackTo(&eltwiseUnaryCompositeOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::clamp(in, min, max, outputMemoryConfig);
+  ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryCompositeClampTensor(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryCompositeOpNative, &in,
+          &min, &max);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseUnaryCompositeClampTensor "
+             "execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
+template <typename Fn>
 static void runEltwiseUnaryCompositeWithFastAndApproximateModeOp(
     const ::tt::target::ttnn::EltwiseUnaryCompositeOp *op,
-    ProgramTensorPool &tensorPool,
-    const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, const bool,
-                       const std::optional<::ttnn::MemoryConfig> &,
-                       const std::optional<::ttnn::Tensor> &,
-                       const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+    ProgramTensorPool &tensorPool, Fn ttnnOp) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseUnaryCompositeOpT eltwiseUnaryCompositeOpNative;
+  op->UnPackTo(&eltwiseUnaryCompositeOpNative);
 
-  ::ttnn::Tensor out = ttnnOp(in, /*fast_and_approximate_mode=*/false,
-                              outputMemoryConfig, std::nullopt, std::nullopt);
+  ttnn_op_invoke::EltwiseUnaryCompositeOpResult result =
+      ttnn_op_invoke::callEltwiseUnaryCompositeWithFastAndApproximateMode(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseUnaryCompositeOpNative,
+          std::forward<Fn>(ttnnOp), &in);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from "
+             "callEltwiseUnaryCompositeWithFastAndApproximateMode execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::EltwiseUnaryCompositeOp *op,
@@ -115,7 +110,7 @@ void run(const ::tt::target::ttnn::EltwiseUnaryCompositeOp *op,
   ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseUnaryCompositeOpType::Cbrt: {
-    runEltwiseUnaryCompositeOp(op, tensorPool, ::ttnn::cbrt);
+    runEltwiseUnaryCompositeOp(op, tensorPool, WRAP_OP(::ttnn::cbrt));
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryCompositeOpType::ClampScalar: {
@@ -127,8 +122,8 @@ void run(const ::tt::target::ttnn::EltwiseUnaryCompositeOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryCompositeOpType::Log1p: {
-    runEltwiseUnaryCompositeWithFastAndApproximateModeOp(op, tensorPool,
-                                                         ::ttnn::log1p);
+    runEltwiseUnaryCompositeWithFastAndApproximateModeOp(
+        op, tensorPool, WRAP_OP(::ttnn::log1p));
     break;
   }
   }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                           
  OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.
                                                                                                                                                                                                                                                           
### What's changed
This is the fourth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for eltwise unary and eltwise unary composite ops across OpModel and Runtime.                                                                                          
                  
  EltwiseUnaryOpT and EltwiseUnaryCompositeOpT (the NativeTable types for these ops) are the interfaces passed into the library. In OpModel they are constructed from MLIR attributes; in Runtime they are already available directly from the deserialized flatbuffer. Both call sites then delegate to ttnn_op_invoke::callEltwiseUnary / ttnn_op_invoke::callEltwiseUnaryComposite, which handle parameter resolution and dispatch for all three call types: constraint query, runtime query, and execution. 
