### PR TITLE
[ttnn] Route integer reductions through fp32 instead of bf16 to avoid precision loss (e.g. 8400→8384)

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -911,6 +911,9 @@ TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(T op) {
 //    float32 data types only.
 // 3. Reduction ops generates incorrect output for integer input tensor.
 //    tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/21071
+//    Route through Float32 (not BFloat16) so integer values up to 2^24 are
+//    preserved exactly; BFloat16 silently rounds (e.g. 8400 -> 8384).
+//    tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/8279
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(
     mlir::Operation *op) {
@@ -920,7 +923,7 @@ TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(
   TTNNOperandWorkarounds operandWorkaround;
   if (!inputType.isF32() && !inputType.isBF16()) {
     operandWorkaround.tensorDataTypeWorkaround =
-        mlir::tt::ttcore::DataType::BFloat16;
+        mlir::tt::ttcore::DataType::Float32;
   }
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()

--- a/test/python/golden/ttir_ops/reduction/test_reduction.py
+++ b/test/python/golden/ttir_ops/reduction/test_reduction.py
@@ -44,7 +44,21 @@ dim_arg_options = [
 
 
 @pytest.mark.parametrize("shapes", [[(32, 128, 128)], [(1, 1, 1)]], ids=shapes_list_str)
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float32,
+        torch.bfloat16,
+        torch.int32
+        | Marks(
+            pytest.mark.xfail(
+                reason="Integer reductions route through fp32 workaround; full-range int32 inputs (~±2^31) exceed fp32's exact-int range (2^24). Needs native int reduction (tt-metal#21071).",
+                strict=False,
+            )
+        ),
+    ],
+    ids=["f32", "bf16", "i32"],
+)
 @pytest.mark.parametrize("keep_dim", keep_dim_options)
 @pytest.mark.parametrize("dim_arg", dim_arg_options)
 @pytest.mark.parametrize("reduction_op_name", reduction_op_names)

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -7,17 +7,17 @@
 func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_max
   // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
-  // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
+  // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>,
   // CHECK-SAME: tensor<128x32xsi32,
-  // CHECK-SAME: -> tensor<128x32xbf16,
+  // CHECK-SAME: -> tensor<128x32xf32,
   // CHECK: %[[MAX:[0-9]+]] = "ttnn.max"(%[[ARG0]])
   // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
-  // CHECK-SAME: tensor<128x32xbf16,
-  // CHECK-SAME: -> tensor<128xbf16,
+  // CHECK-SAME: tensor<128x32xf32,
+  // CHECK-SAME: -> tensor<128xf32,
   %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
   // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]])
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
-  // CHECK-SAME: tensor<128xbf16,
+  // CHECK-SAME: tensor<128xf32,
   // CHECK-SAME: -> tensor<128xsi32,
   return %0 : tensor<128xsi32, #ttnn_layout1>
 }
@@ -25,17 +25,17 @@ func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> t
 func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_sum
   // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
-  // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
+  // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>,
   // CHECK-SAME: tensor<128x10xsi32,
-  // CHECK-SAME: -> tensor<128x10xbf16,
+  // CHECK-SAME: -> tensor<128x10xf32,
   // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"(%[[ARG0]])
   // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
-  // CHECK-SAME: tensor<128x10xbf16,
-  // CHECK-SAME: -> tensor<128xbf16,
+  // CHECK-SAME: tensor<128x10xf32,
+  // CHECK-SAME: -> tensor<128xf32,
   %0 = "ttnn.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
   // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[SUM]])
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
-  // CHECK-SAME: tensor<128xbf16,
+  // CHECK-SAME: tensor<128xf32,
   // CHECK-SAME: -> tensor<128xsi32,
   return %0 : tensor<128xsi32, #ttnn_layout1>
 }


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-mlir/issues/8279

### Problem description

- `createReductionOpOperandsWorkarounds` casts integer-input reductions to bf16 before `ttnn.sum` to work around [#21071](https://github.com/tenstorrent/tt-metal/issues/21071). 
- bf16's 7-bit mantissa silently rounds — e.g. `sum([6400, 1600, 400])` returns `8384` instead of `8400` 

### What's changed

- Switched the workaround target dtype from `BFloat16` to `Float32`. fp32 satisfies the same padding/transpose constraints and represents all integers up to 2^24 exactly, so int reductions now round-trip without precision loss.

### Checklist
- [x] verify the changes through local testing in N150

### Logs

- [may6_sum_sanity_before_fix.log](https://github.com/user-attachments/files/27433233/may6_sum_sanity.log)
- [may6_sum_sanity_after_fix.log](https://github.com/user-attachments/files/27433235/may6_sum_sanity_after_fix.log)

