### PR TITLE
Eltwise-binary ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYCOMPOSITEOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYCOMPOSITEOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using EltwiseBinaryCompositeOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+using EltwiseBinaryCompositeScalarOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseBinaryCompositeResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+EltwiseBinaryCompositeResolvedParams resolveEltwiseBinaryCompositeParams(
+    const ::tt::target::ttnn::EltwiseBinaryCompositeOpT
+        &eltwiseBinaryCompositeOp);
+
+template <typename Tag>
+auto createEltwiseBinaryCompositeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseBinaryCompositeOpT
+        &eltwiseBinaryCompositeOp,
+    TensorArg lhs, TensorArg rhs,
+    const EltwiseBinaryCompositeResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(lhs, tag), resolveTensorArg(rhs, tag),
+                         params.outputMemoryConfig);
+}
+
+template <typename Fn>
+EltwiseBinaryCompositeOpResult callEltwiseBinaryComposite(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseBinaryCompositeOpT
+        &eltwiseBinaryCompositeOp,
+    Fn opFn, TensorArg lhs, TensorArg rhs, ::ttnn::MeshDevice *device = nullptr,
+    std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt) {
+
+  EltwiseBinaryCompositeResolvedParams params =
+      resolveEltwiseBinaryCompositeParams(eltwiseBinaryCompositeOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseBinaryCompositeTuple(tag, eltwiseBinaryCompositeOp, lhs,
+                                             rhs, params);
+  };
+
+  return callOp<EltwiseBinaryCompositeOpResult>(opFn, callType, makeTuple,
+                                                device);
+}
+
+struct EltwiseBinaryCompositeScalarResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::variant<float, int32_t> exponent;
+};
+
+EltwiseBinaryCompositeScalarResolvedParams
+resolveEltwiseBinaryCompositeScalarParams(
+    const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+        &eltwiseBinaryCompositeScalarOp);
+
+EltwiseBinaryCompositeScalarOpResult callEltwiseBinaryCompositeScalar(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+        &eltwiseBinaryCompositeScalarOp,
+    TensorArg input, ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYCOMPOSITEOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using EltwiseBinaryOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseBinaryResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDType;
+};
+
+EltwiseBinaryResolvedParams resolveEltwiseBinaryParams(
+    const ::tt::target::ttnn::EltwiseBinaryOpT &eltwiseBinaryOp);
+
+template <typename Tag>
+auto createEltwiseBinaryTuple(
+    Tag tag, const ::tt::target::ttnn::EltwiseBinaryOpT &eltwiseBinaryOp,
+    TensorArg lhs, TensorArg rhs, const EltwiseBinaryResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(lhs, tag), resolveTensorArg(rhs, tag),
+                         params.outputDType, params.outputMemoryConfig);
+}
+
+template <typename Fn>
+EltwiseBinaryOpResult
+callEltwiseBinary(CallType callType,
+                  const ::tt::target::ttnn::EltwiseBinaryOpT &eltwiseBinaryOp,
+                  Fn opFn, TensorArg lhs, TensorArg rhs,
+                  ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseBinaryResolvedParams params =
+      resolveEltwiseBinaryParams(eltwiseBinaryOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseBinaryTuple(tag, eltwiseBinaryOp, lhs, rhs, params);
+  };
+
+  return callOp<EltwiseBinaryOpResult>(opFn, callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_BINARY_ELTWISEBINARYOP_H

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(TTNNOpInvokeLib STATIC
   utils/utils.cpp
   Conv/Conv2dOp.cpp
+  Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
+  Eltwise/Binary/EltwiseBinaryOp.cpp
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
   Matmul/MatmulOp.cpp

--- a/lib/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+EltwiseBinaryCompositeResolvedParams resolveEltwiseBinaryCompositeParams(
+    const ::tt::target::ttnn::EltwiseBinaryCompositeOpT
+        &eltwiseBinaryCompositeOp) {
+
+  EltwiseBinaryCompositeResolvedParams params;
+
+  if (eltwiseBinaryCompositeOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseBinaryCompositeOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*eltwiseBinaryCompositeOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+EltwiseBinaryCompositeScalarResolvedParams
+resolveEltwiseBinaryCompositeScalarParams(
+    const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+        &eltwiseBinaryCompositeScalarOp) {
+
+  EltwiseBinaryCompositeScalarResolvedParams params;
+
+  TT_INVOKE_ASSERT(eltwiseBinaryCompositeScalarOp.rhs.type ==
+                           ::tt::target::ttnn::NumberType::FP ||
+                       eltwiseBinaryCompositeScalarOp.rhs.type ==
+                           ::tt::target::ttnn::NumberType::I32,
+                   "Exponent must be either FP or I32");
+
+  if (eltwiseBinaryCompositeScalarOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseBinaryCompositeScalarOp.out));
+
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(
+                         *eltwiseBinaryCompositeScalarOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag, typename Scalar>
+auto createEltwiseBinaryCompositeScalarTuple(
+    Tag tag, TensorArg lhs, Scalar rhs,
+    const EltwiseBinaryCompositeScalarResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(lhs, tag), rhs,
+                         params.outputMemoryConfig);
+}
+
+EltwiseBinaryCompositeScalarOpResult callEltwiseBinaryCompositeScalar(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+        &eltwiseBinaryCompositeScalarOp,
+    TensorArg lhs, ::ttnn::MeshDevice *device) {
+
+  EltwiseBinaryCompositeScalarResolvedParams params =
+      resolveEltwiseBinaryCompositeScalarParams(eltwiseBinaryCompositeScalarOp);
+
+  auto invokeWithScalar =
+      [&](auto scalar) -> EltwiseBinaryCompositeScalarOpResult {
+    auto makeTuple = [&](auto tag) {
+      return createEltwiseBinaryCompositeScalarTuple(tag, lhs, scalar, params);
+    };
+
+    return callOp<EltwiseBinaryCompositeScalarOpResult>(
+        WRAP_OP(::ttnn::pow), callType, makeTuple, device);
+  };
+
+  const auto &rhs = eltwiseBinaryCompositeScalarOp.rhs;
+  if (rhs.type == ::tt::target::ttnn::NumberType::FP) {
+    return invokeWithScalar(rhs.AsFP()->value);
+  }
+  return invokeWithScalar(rhs.AsI32()->value);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+EltwiseBinaryResolvedParams resolveEltwiseBinaryParams(
+    const ::tt::target::ttnn::EltwiseBinaryOpT &eltwiseBinaryOp) {
+
+  EltwiseBinaryResolvedParams params;
+
+  if (eltwiseBinaryOp.out) {
+    params.outputDType = operations::utils::getDataType(*eltwiseBinaryOp.out);
+  } else if (eltwiseBinaryOp.output_dtype.has_value()) {
+    params.outputDType =
+        operations::utils::toTTNNDataType(eltwiseBinaryOp.output_dtype.value());
+  }
+
+  if (eltwiseBinaryOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*eltwiseBinaryOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*eltwiseBinaryOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -12,6 +12,8 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
@@ -1427,6 +1429,29 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Binary Eltwise Ops
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseBinaryOpT
+buildEltwiseBinaryOpTFromMLIR(TTNNLayoutAttr outputLayout,
+                              ttcore::DataTypeAttr opDtypeAttr = nullptr) {
+  ::tt::target::ttnn::EltwiseBinaryOpT eltwiseBinaryOp;
+
+  eltwiseBinaryOp.out = detail::getOutputTensorRefT(outputLayout);
+  if (eltwiseBinaryOp.out) {
+    eltwiseBinaryOp.output_dtype =
+        eltwiseBinaryOp.out->desc->layout->memory_desc->data_type;
+  }
+  if (opDtypeAttr) {
+    eltwiseBinaryOp.output_dtype = toNative(opDtypeAttr.getValue());
+    if (eltwiseBinaryOp.out && eltwiseBinaryOp.output_dtype.has_value()) {
+      eltwiseBinaryOp.out->desc->layout->memory_desc->data_type =
+          eltwiseBinaryOp.output_dtype.value();
+    }
+  }
+
+  return eltwiseBinaryOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
@@ -1445,19 +1470,22 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  if (!outputDType && opDtypeAttr) {
-    outputDType = conversion::getDataType(opDtypeAttr.getValue());
-  }
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseBinaryOpT eltwiseBinaryOpNative =
+      buildEltwiseBinaryOpTFromMLIR<OpTy>(outputLayout, opDtypeAttr);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputDType, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseBinaryOpResult result =
+        ttnn_op_invoke::callEltwiseBinary(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseBinaryOpNative, detail::getOpSymbol<OpTy>(), inputSpecA,
+            inputSpecB, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from EltwiseBinaryOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), query);
@@ -1483,16 +1511,21 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::DataType> outputDType =
-      detail::getNullableDataType(outputLayout);
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseBinaryOpT eltwiseBinaryOpNative =
+      buildEltwiseBinaryOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(detail::getOpSymbol<OpTy>(), device,
-                                           inputSpecA, inputSpecB, outputDType,
-                                           outputMemoryConfig);
+    ttnn_op_invoke::EltwiseBinaryOpResult result =
+        ttnn_op_invoke::callEltwiseBinary(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME, eltwiseBinaryOpNative,
+            detail::getOpSymbol<OpTy>(), inputSpecA, inputSpecB, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseBinaryOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -1500,6 +1533,18 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
 }
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseBinaryCompositeOpT
+buildEltwiseBinaryCompositeOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOp;
+
+  eltwiseBinaryCompositeOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseBinaryCompositeOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
@@ -1518,14 +1563,23 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOpNative =
+      buildEltwiseBinaryCompositeOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputMemoryConfig);
+    ttnn_op_invoke::EltwiseBinaryOpResult result =
+        ttnn_op_invoke::callEltwiseBinaryComposite(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseBinaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpecA, inputSpecB, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+            result) &&
+        "Expected ConstraintQueryResponse from EltwiseBinaryCompositeOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), query);
@@ -1551,14 +1605,22 @@ llvm::Expected<size_t> BinaryCompositeOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec inputSpecB,
       detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOpNative =
+      buildEltwiseBinaryCompositeOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(detail::getOpSymbol<OpTy>(), device,
-                                           inputSpecA, inputSpecB,
-                                           outputMemoryConfig);
+    ttnn_op_invoke::EltwiseBinaryOpResult result =
+        ttnn_op_invoke::callEltwiseBinaryComposite(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseBinaryCompositeOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpecA, inputSpecB, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseBinaryCompositeOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -1664,6 +1726,34 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PowScalar
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+static ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+buildEltwiseBinaryCompositeScalarOpTFromMLIR(mlir::Attribute exponent,
+                                             TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+      eltwiseBinaryCompositeScalarOp;
+  eltwiseBinaryCompositeScalarOp.type =
+      ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpType::PowScalar;
+
+  if (auto floatAttr = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
+    ::tt::target::ttnn::FloatingPointTypeT fp;
+    fp.value = floatAttr.getValue().convertToFloat();
+    eltwiseBinaryCompositeScalarOp.rhs.Set(fp);
+  } else if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
+    ::tt::target::ttnn::IntegralTypeT i32;
+    i32.value = static_cast<int32_t>(intAttr.getInt());
+    eltwiseBinaryCompositeScalarOp.rhs.Set(i32);
+  } else {
+    llvm::report_fatal_error("Invalid exponent");
+  }
+
+  eltwiseBinaryCompositeScalarOp.out =
+      detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseBinaryCompositeScalarOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
+
 llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute exponent, TTNNLayoutAttr outputLayout) {
@@ -1676,28 +1766,26 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Helper lambda to create the query with any exponent value type.
-  auto powScalarQuery = [=](auto convertedExponent) {
-    return [=]() {
-      return QUERY_OP_CONSTRAINTS(
-          ::ttnn::pow, device, inputSpec, convertedExponent,
-          detail::getNullableMemoryConfig(outputLayout));
-    };
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+      eltwiseBinaryCompositeScalarOpNative =
+          buildEltwiseBinaryCompositeScalarOpTFromMLIR(exponent, outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseBinaryCompositeScalarOpResult result =
+        ttnn_op_invoke::callEltwiseBinaryCompositeScalar(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseBinaryCompositeScalarOpNative, inputSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from "
+           "EltwiseBinaryCompositeScalarOp query");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
-  // The invoke function of PowScalarOp is templated over the exponent value
-  // type. That's why the following code is arranged in this way.
-  if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
-    int32_t convertedExponent = static_cast<int32_t>(value.getInt());
-    auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
-  }
-  if (auto value = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
-    float convertedExponent = value.getValue().convertToFloat();
-    auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
-  }
-  return llvm::createStringError("Invalid exponent");
+  return operation::getOpConstraints(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1715,28 +1803,26 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
       ::ttnn::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // Helper lambda to create the query with any exponent value type.
-  auto powScalarQuery = [=](auto convertedExponent) {
-    return [=]() {
-      return QUERY_OP_RUNTIME(::ttnn::pow, device, inputSpec, convertedExponent,
-                              detail::getNullableMemoryConfig(outputLayout));
-    };
+  ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpT
+      eltwiseBinaryCompositeScalarOpNative =
+          buildEltwiseBinaryCompositeScalarOpTFromMLIR(exponent, outputLayout);
+
+  // Create query closure
+  auto query = [=]() {
+    ttnn_op_invoke::EltwiseBinaryCompositeScalarOpResult result =
+        ttnn_op_invoke::callEltwiseBinaryCompositeScalar(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseBinaryCompositeScalarOpNative, inputSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from "
+        "EltwiseBinaryCompositeScalarOp query");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
-  // The invoke function of PowScalarOp is templated over the exponent value
-  // type. That's why the following code is arranged in this way.
-  if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
-    int32_t convertedExponent = static_cast<int32_t>(value.getInt());
-    auto query = powScalarQuery(convertedExponent);
-    return operation::getOpRuntime(query);
-  }
-  if (auto value = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
-    float convertedExponent = value.getValue().convertToFloat();
-    auto query = powScalarQuery(convertedExponent);
-    return operation::getOpRuntime(query);
-  }
-
-  return llvm::createStringError("Invalid exponent");
+  return operation::getOpRuntime(query);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -6,121 +6,89 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
 
 template <typename Fn>
 static void runEltwiseBinaryOp(const ::tt::target::ttnn::EltwiseBinaryOp *op,
                                ProgramTensorPool &tensorPool, Fn &&ttnnOp) {
+  const ::ttnn::Tensor &lhs = tensorPool.getTTNNTensorAndValidate(op->lhs());
+  const ::ttnn::Tensor &rhs = tensorPool.getTTNNTensorAndValidate(op->rhs());
 
-  ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
-  ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));
+  target::ttnn::EltwiseBinaryOpT eltwiseBinaryOpNative;
+  op->UnPackTo(&eltwiseBinaryOpNative);
 
-  std::optional<::ttnn::DataType> outputDataType = std::nullopt;
-  if (op->output_dtype()) {
-    outputDataType = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
+  ttnn_op_invoke::EltwiseBinaryOpResult result =
+      ttnn_op_invoke::callEltwiseBinary(ttnn_op_invoke::CallType::EXECUTE,
+                                        eltwiseBinaryOpNative,
+                                        std::forward<Fn>(ttnnOp), &lhs, &rhs);
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseBinary execution");
 
-  ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputDataType, outputMemoryConfig);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
-  /* Eltwise Binary */
   case ::tt::target::ttnn::EltwiseBinaryOpType::Add: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::add(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::add));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Multiply: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::multiply(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::multiply));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LogicalRightShift: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::logical_right_shift(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::logical_right_shift));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Subtract: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::subtract(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::subtract));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Equal: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::eq(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::eq));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::NotEqual: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::ne(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::ne));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::GreaterEqual: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::ge(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::ge));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::GreaterThan: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::gt(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::gt));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LessEqual: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::le(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::le));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LessThan: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::lt(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::lt));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Divide: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::divide(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::divide));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LogicalAnd: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::logical_and(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::logical_and));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LogicalOr: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::logical_or(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::logical_or));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::LogicalXor: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::logical_xor(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryOp(op, tensorPool, WRAP_OP(::ttnn::logical_xor));
     break;
   }
   }

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
 
@@ -17,34 +18,43 @@ static void runEltwiseBinaryCompositeOp(
   ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
   ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseBinaryCompositeOpT eltwiseBinaryCompositeOpNative;
+  op->UnPackTo(&eltwiseBinaryCompositeOpNative);
 
-  ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputMemoryConfig);
+  ttnn_op_invoke::EltwiseBinaryCompositeOpResult result =
+      ttnn_op_invoke::callEltwiseBinaryComposite(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseBinaryCompositeOpNative,
+          std::forward<Fn>(ttnnOp), lhs, rhs);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(
+      std::holds_alternative<::ttnn::Tensor>(result),
+      "Expected output Tensor from callEltwiseBinaryComposite execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 static void
 runPowScalarOp(const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOp *op,
-               auto &&exponent, ProgramContext &context) {
+               ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   ::ttnn::Tensor *input = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
 
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
+  target::ttnn::EltwiseBinaryCompositeScalarOpT
+      eltwiseBinaryCompositeScalarOpNative;
+  op->UnPackTo(&eltwiseBinaryCompositeScalarOpNative);
 
-  ::ttnn::Tensor out = ::ttnn::pow(*input, exponent, outputMemoryConfig);
+  ttnn_op_invoke::EltwiseBinaryCompositeScalarOpResult result =
+      ttnn_op_invoke::callEltwiseBinaryCompositeScalar(
+          ttnn_op_invoke::CallType::EXECUTE,
+          eltwiseBinaryCompositeScalarOpNative, input);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  LOG_ASSERT(
+      std::holds_alternative<::ttnn::Tensor>(result),
+      "Expected output Tensor from callEltwiseBinaryCompositeScalar execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 // Handles the binary composite ops with LHS=tensor and RHS=tensor.
@@ -71,9 +81,8 @@ void run(const ::tt::target::ttnn::EltwiseBinaryCompositeOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::LogicalLeftShift: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::logical_left_shift(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryCompositeOp(op, tensorPool,
+                                WRAP_OP(::ttnn::logical_left_shift));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Remainder: {
@@ -95,27 +104,19 @@ void run(const ::tt::target::ttnn::EltwiseBinaryCompositeOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Atan2: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::atan2(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryCompositeOp(op, tensorPool, WRAP_OP(::ttnn::atan2));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::BitwiseAnd: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::bitwise_and(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryCompositeOp(op, tensorPool, WRAP_OP(::ttnn::bitwise_and));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::BitwiseOr: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::bitwise_or(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryCompositeOp(op, tensorPool, WRAP_OP(::ttnn::bitwise_or));
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::BitwiseXor: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::bitwise_xor(std::forward<decltype(args)>(args)...);
-    });
+    runEltwiseBinaryCompositeOp(op, tensorPool, WRAP_OP(::ttnn::bitwise_xor));
     break;
   }
   }
@@ -126,16 +127,7 @@ void run(const ::tt::target::ttnn::EltwiseBinaryCompositeScalarOp *op,
          ProgramContext &context) {
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseBinaryCompositeScalarOpType::PowScalar: {
-    switch (op->rhs_type()) {
-    case ::tt::target::ttnn::NumberType::FP:
-      runPowScalarOp(op, op->rhs_as_FP()->value(), context);
-      break;
-    case ::tt::target::ttnn::NumberType::I32:
-      runPowScalarOp(op, op->rhs_as_I32()->value(), context);
-      break;
-    default:
-      LOG_FATAL("unknown exponent type");
-    }
+    runPowScalarOp(op, context);
     break;
   }
   }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                           
  OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.
                                                                                                                                                                                                                                                           
### What's changed

This is the fifth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for eltwise binary, eltwise binary composite, and eltwise binary composite scalar ops across OpModel and Runtime.                                                       
  
  EltwiseBinaryOpT, EltwiseBinaryCompositeOpT, and EltwiseBinaryCompositeScalarOpT (the NativeTable types for these ops) are the interfaces passed into the library. In OpModel they are constructed from MLIR attributes; in Runtime they are already available directly from the deserialized flatbuffer. Both call sites then delegate to ttnn_op_invoke::callEltwiseBinary / ttnn_op_invoke::callEltwiseBinaryComposite / ttnn_op_invoke::callEltwiseBinaryCompositeScalar, which handle parameter resolution and dispatch for all three call types: constraint query, runtime query, and execution.  
