### PR TITLE
Eltwise ternary and quantization ops to InvokeOpLib

### DIFF
--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_QUANTIZATION_ELTWISEQUANTIZATIONOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_QUANTIZATION_ELTWISEQUANTIZATIONOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <cstdint>
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+template <typename T>
+using TensorVariantArg =
+    std::variant<std::variant<::ttnn::Tensor, T>, ::ttnn::TensorSpec>;
+
+template <typename T>
+inline auto resolveTensorVariantArg(TensorVariantArg<T> arg,
+                                    QueryTag callType) {
+  return std::get<::ttnn::TensorSpec>(arg);
+}
+
+template <typename T>
+inline auto resolveTensorVariantArg(TensorVariantArg<T> arg,
+                                    ExecuteTag callType) {
+  return std::get<std::variant<::ttnn::Tensor, T>>(arg);
+}
+
+using EltwiseQuantizationOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseQuantizationResolvedParams {
+  std::optional<int32_t> axis = std::nullopt;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+  std::optional<::tt::tt_metal::DataType> outputDataType;
+};
+
+EltwiseQuantizationResolvedParams resolveEltwiseQuantizationParams(
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp);
+
+EltwiseQuantizationOpResult callEltwiseQuantizeDequantize(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg input, TensorVariantArg<float> scale,
+    TensorVariantArg<int32_t> zeroPoint, ::ttnn::MeshDevice *device = nullptr);
+
+EltwiseQuantizationOpResult callEltwiseRequantize(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg input, TensorVariantArg<float> in_scale,
+    TensorVariantArg<int32_t> in_zero_point, TensorVariantArg<float> out_scale,
+    TensorVariantArg<int32_t> out_zero_point,
+    ::ttnn::MeshDevice *device = nullptr);
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_QUANTIZATION_ELTWISEQUANTIZATIONOP_H

--- a/include/ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h
+++ b/include/ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_OPINVOKE_TTNN_ELTWISE_TERNARY_ELTWISETERNARYOP_H
+#define TTMLIR_OPINVOKE_TTNN_ELTWISE_TERNARY_ELTWISETERNARYOP_H
+
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
+
+#include <optional>
+
+namespace ttnn_op_invoke {
+
+using EltwiseTernaryOpResult =
+    std::variant<::ttnn::graph::ConstraintQueryResponse,
+                 ::ttnn::graph::RuntimeQueryResponse, ::ttnn::Tensor>;
+
+struct EltwiseTernaryResolvedParams {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig;
+};
+
+EltwiseTernaryResolvedParams resolveEltwiseTernaryParams(
+    const tt::target::ttnn::EltwiseTernaryWhereOpT &eltwiseTernaryOp);
+
+template <typename Tag>
+auto createEltwiseTernaryTuple(
+    Tag tag,
+    const tt::target::ttnn::EltwiseTernaryWhereOpT &eltwiseTernaryWhereOp,
+    TensorArg first, TensorArg second, TensorArg third,
+    const EltwiseTernaryResolvedParams &params) {
+  return std::make_tuple(
+      resolveTensorArg(first, tag), resolveTensorArg(second, tag),
+      resolveTensorArg(third, tag), params.outputMemoryConfig);
+}
+
+template <typename Fn>
+EltwiseTernaryOpResult callEltwiseTernary(
+    CallType callType,
+    const tt::target::ttnn::EltwiseTernaryWhereOpT &eltwiseTernaryWhereOp,
+    Fn opFn, TensorArg first, TensorArg second, TensorArg third,
+    ::ttnn::MeshDevice *device = nullptr) {
+
+  EltwiseTernaryResolvedParams params =
+      resolveEltwiseTernaryParams(eltwiseTernaryWhereOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseTernaryTuple(tag, eltwiseTernaryWhereOp, first, second,
+                                     third, params);
+  };
+
+  return callOp<EltwiseTernaryOpResult>(opFn, callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke
+
+#endif // TTMLIR_OPINVOKE_TTNN_ELTWISE_TERNARY_ELTWISETERNARYOP_H

--- a/lib/OpInvoke/TTNN/CMakeLists.txt
+++ b/lib/OpInvoke/TTNN/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(TTNNOpInvokeLib STATIC
   Conv/Conv2dOp.cpp
   Eltwise/Binary/EltwiseBinaryCompositeOp.cpp
   Eltwise/Binary/EltwiseBinaryOp.cpp
+  Eltwise/Quantization/EltwiseQuantizationOp.cpp
+  Eltwise/Ternary/EltwiseTernaryOp.cpp
   Eltwise/Unary/EltwiseUnaryCompositeOp.cpp
   Eltwise/Unary/EltwiseUnaryOp.cpp
   Matmul/MatmulOp.cpp

--- a/lib/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h"
+#include "operations/eltwise/quantization/quantization.hpp"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+#include "ttnn/operations/functions.hpp"
+
+#include <optional>
+#include <variant>
+
+namespace ttnn_op_invoke {
+
+EltwiseQuantizationResolvedParams resolveEltwiseQuantizationParams(
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp) {
+
+  EltwiseQuantizationResolvedParams params;
+
+  if (eltwiseQuantizationOp.axis) {
+    params.axis = *(eltwiseQuantizationOp.axis);
+  }
+
+  if (eltwiseQuantizationOp.out) {
+    params.outputDataType =
+        operations::utils::getDataType(*eltwiseQuantizationOp.out);
+  }
+
+  if (eltwiseQuantizationOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(
+            *eltwiseQuantizationOp.out));
+    TT_INVOKE_ASSERT(
+        operations::utils::inSystemMemory(*eltwiseQuantizationOp.out) ||
+            params.outputMemoryConfig.has_value(),
+        "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+template <typename Tag>
+auto createEltwiseQuantizeDequantizeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg inputParam, TensorVariantArg<float> scaleParam,
+    TensorVariantArg<int32_t> zeroPointParam,
+    const EltwiseQuantizationResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(inputParam, tag),
+                         resolveTensorVariantArg(scaleParam, tag),
+                         resolveTensorVariantArg(zeroPointParam, tag),
+                         params.axis, params.outputDataType,
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt);
+}
+
+EltwiseQuantizationOpResult callEltwiseQuantizeDequantize(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg inputParam, TensorVariantArg<float> scaleParam,
+    TensorVariantArg<int32_t> zeroPointParam, ::ttnn::MeshDevice *device) {
+
+  EltwiseQuantizationResolvedParams params =
+      resolveEltwiseQuantizationParams(eltwiseQuantizationOp);
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseQuantizeDequantizeTuple(tag, eltwiseQuantizationOp,
+                                                inputParam, scaleParam,
+                                                zeroPointParam, params);
+  };
+
+  auto invokeQuantization = [&](auto op) -> EltwiseQuantizationOpResult {
+    return callOp<EltwiseQuantizationOpResult>(op, callType, makeTuple, device);
+  };
+
+  if (eltwiseQuantizationOp.type ==
+      ::tt::target::ttnn::EltwiseQuantizationOpType::Quantize) {
+    return invokeQuantization(WRAP_OP(::ttnn::quantize));
+  }
+  if (eltwiseQuantizationOp.type ==
+      ::tt::target::ttnn::EltwiseQuantizationOpType::Dequantize) {
+    return invokeQuantization(WRAP_OP(::ttnn::dequantize));
+  }
+  llvm::report_fatal_error(
+      "EltwiseQuantizationOpType must be Quantize or Dequantize");
+}
+
+template <typename Tag>
+auto createEltwiseRequantizeTuple(
+    Tag tag,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg inputParam, TensorVariantArg<float> inScaleParam,
+    TensorVariantArg<int32_t> inZeroPointParam,
+    TensorVariantArg<float> outScaleParam,
+    TensorVariantArg<int32_t> outZeroPointParam,
+    const EltwiseQuantizationResolvedParams &params) {
+  return std::make_tuple(resolveTensorArg(inputParam, tag),
+                         resolveTensorVariantArg(inScaleParam, tag),
+                         resolveTensorVariantArg(inZeroPointParam, tag),
+                         resolveTensorVariantArg(outScaleParam, tag),
+                         resolveTensorVariantArg(outZeroPointParam, tag),
+                         params.axis, params.outputDataType,
+                         params.outputMemoryConfig,
+                         /*optional_output_tensor=*/std::nullopt);
+}
+
+EltwiseQuantizationOpResult callEltwiseRequantize(
+    CallType callType,
+    const ::tt::target::ttnn::EltwiseQuantizationOpT &eltwiseQuantizationOp,
+    TensorArg inputParam, TensorVariantArg<float> inScaleParam,
+    TensorVariantArg<int32_t> inZeroPointParam,
+    TensorVariantArg<float> outScaleParam,
+    TensorVariantArg<int32_t> outZeroPointParam, ::ttnn::MeshDevice *device) {
+
+  EltwiseQuantizationResolvedParams params =
+      resolveEltwiseQuantizationParams(eltwiseQuantizationOp);
+
+  TT_INVOKE_ASSERT(
+      eltwiseQuantizationOp.type ==
+          ::tt::target::ttnn::EltwiseQuantizationOpType::Requantize,
+      "EltwiseQuantizationOpType must be Requantize");
+
+  auto makeTuple = [&](auto tag) {
+    return createEltwiseRequantizeTuple(
+        tag, eltwiseQuantizationOp, inputParam, inScaleParam, inZeroPointParam,
+        outScaleParam, outZeroPointParam, params);
+  };
+
+  return callOp<EltwiseQuantizationOpResult>(WRAP_OP(::ttnn::requantize),
+                                             callType, makeTuple, device);
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.cpp
+++ b/lib/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/utils/utils.h"
+
+#include <optional>
+namespace ttnn_op_invoke {
+
+// template <>
+EltwiseTernaryResolvedParams resolveEltwiseTernaryParams(
+    const ::tt::target::ttnn::EltwiseTernaryWhereOpT &eltwiseTernaryOp) {
+
+  EltwiseTernaryResolvedParams params;
+
+  if (eltwiseTernaryOp.out) {
+    params.outputMemoryConfig = operations::utils::createMemoryConfigIfNeeded(
+        operations::utils::getTensorRefMemoryConfig(*eltwiseTernaryOp.out));
+    TT_INVOKE_ASSERT(operations::utils::inSystemMemory(*eltwiseTernaryOp.out) ||
+                         params.outputMemoryConfig.has_value(),
+                     "Memory config must exist for device tensors");
+  }
+
+  return params;
+}
+
+} // namespace ttnn_op_invoke

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -14,6 +14,8 @@
 #include "ttmlir/OpInvoke/TTNN/Conv/Conv2dOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Binary/EltwiseBinaryOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryCompositeOp.h"
 #include "ttmlir/OpInvoke/TTNN/Eltwise/Unary/EltwiseUnaryOp.h"
 #include "ttmlir/OpInvoke/TTNN/Matmul/MatmulOp.h"
@@ -2014,6 +2016,17 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Ternary Eltwise Ops
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseTernaryWhereOpT
+buildEltwiseTernaryOpTFromMLIR(TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOp;
+
+  eltwiseTernaryWhereOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseTernaryWhereOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
@@ -2037,14 +2050,21 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec inputSpecC,
       detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOpNative =
+      buildEltwiseTernaryOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               inputSpecC, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseTernaryOpResult result =
+        ttnn_op_invoke::callEltwiseTernary(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseTernaryWhereOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpecA, inputSpecB, inputSpecC, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from EltwiseTernaryOp query");
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayoutA.getContext(), query);
@@ -2075,14 +2095,21 @@ llvm::Expected<size_t> TernaryEltwiseOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec inputSpecC,
       detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOpNative =
+      buildEltwiseTernaryOpTFromMLIR<OpTy>(outputLayout);
 
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(detail::getOpSymbol<OpTy>(), device,
-                                           inputSpecA, inputSpecB, inputSpecC,
-                                           outputMemoryConfig);
+    ttnn_op_invoke::EltwiseTernaryOpResult result =
+        ttnn_op_invoke::callEltwiseTernary(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseTernaryWhereOpNative, detail::getOpSymbol<OpTy>(),
+            inputSpecA, inputSpecB, inputSpecC, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from EltwiseTernaryOp query");
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(query);
@@ -4522,6 +4549,36 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
 //===----------------------------------------------------------------------===//
 // Quantization Ops
 //===----------------------------------------------------------------------===//
+#ifdef TTMLIR_ENABLE_OPMODEL
+template <typename OpTy>
+static ::tt::target::ttnn::EltwiseQuantizationOpT
+buildEltwiseQuantizationOpTFromMLIR(std::optional<int32_t> axis,
+                                    std::optional<ttcore::DataType> outputDtype,
+                                    TTNNLayoutAttr outputLayout) {
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOp;
+
+  if constexpr (std::is_same_v<OpTy, QuantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Quantize;
+  } else if constexpr (std::is_same_v<OpTy, DequantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Dequantize;
+  } else if constexpr (std::is_same_v<OpTy, RequantizeOp>) {
+    eltwiseQuantizationOp.type =
+        ::tt::target::ttnn::EltwiseQuantizationOpType::Requantize;
+  } else {
+    static_assert(ttmlir::utils::always_false(), "Unsupported OpTy");
+  }
+
+  eltwiseQuantizationOp.axis =
+      axis.has_value() ? ::flatbuffers::Optional<int32_t>(axis.value())
+                       : ::flatbuffers::nullopt;
+
+  eltwiseQuantizationOp.out = detail::getOutputTensorRefT(outputLayout);
+
+  return eltwiseQuantizationOp;
+}
+#endif // TTMLIR_ENABLE_OPMODEL
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
@@ -4546,22 +4603,24 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
       ::ttnn::TensorSpec zeroPointSpec,
       detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
 
-  // Use the explicit outputDtype parameter if provided, otherwise infer from
-  // layout
-  std::optional<::tt::tt_metal::DataType> outputDType;
-  if (outputDtype.has_value()) {
-    outputDType = conversion::getDataType(outputDtype.value());
-  } else {
-    outputDType = detail::getNullableDataType(outputLayout);
-  }
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative =
+      buildEltwiseQuantizationOpTFromMLIR<OpTy>(axis, outputDtype,
+                                                outputLayout);
 
   // Create query closure
   auto quantizationOpQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, scaleSpec,
-        zeroPointSpec, axis, outputDType, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseQuantizationOpResult result =
+        ttnn_op_invoke::callEltwiseQuantizeDequantize(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseQuantizationOpNative, inputSpec, scaleSpec, zeroPointSpec,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+            result) &&
+        "Expected ConstraintQueryResponse from callEltwiseQuantizeDequantize");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -4595,22 +4654,23 @@ llvm::Expected<size_t> QuantizationOpModel<OpTy>::getOpRuntime(
       ::ttnn::TensorSpec zeroPointSpec,
       detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
 
-  // Use the explicit outputDtype parameter if provided, otherwise infer from
-  // layout
-  std::optional<::tt::tt_metal::DataType> outputDType;
-  if (outputDtype.has_value()) {
-    outputDType = conversion::getDataType(outputDtype.value());
-  } else {
-    outputDType = detail::getNullableDataType(outputLayout);
-  }
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative =
+      buildEltwiseQuantizationOpTFromMLIR<OpTy>(axis, outputDtype,
+                                                outputLayout);
 
   // Create query closure
   auto quantizationOpQuery = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, scaleSpec,
-        zeroPointSpec, axis, outputDType, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseQuantizationOpResult result =
+        ttnn_op_invoke::callEltwiseQuantizeDequantize(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseQuantizationOpNative, inputSpec, scaleSpec, zeroPointSpec,
+            device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from callEltwiseQuantizeDequantize");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(quantizationOpQuery);
@@ -4659,23 +4719,23 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
                    detail::convertToTensorSpec(device, outZeroPointShape,
                                                outZeroPointLayout));
 
-  // Use the explicit outputDtype parameter if provided, otherwise infer from
-  // layout
-  std::optional<::tt::tt_metal::DataType> outputDType;
-  if (outputDtype.has_value()) {
-    outputDType = conversion::getDataType(outputDtype.value());
-  } else {
-    outputDType = detail::getNullableDataType(outputLayout);
-  }
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative =
+      buildEltwiseQuantizationOpTFromMLIR<RequantizeOp>(axis, outputDtype,
+                                                        outputLayout);
 
   // Create query closure
-
   auto requantizeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::requantize, device, inputSpec, inScaleSpec, inZeroPointSpec,
-        outScaleSpec, outZeroPointSpec, axis, outputDType, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseQuantizationOpResult result =
+        ttnn_op_invoke::callEltwiseRequantize(
+            ttnn_op_invoke::CallType::QUERY_OP_CONSTRAINTS,
+            eltwiseQuantizationOpNative, inputSpec, inScaleSpec,
+            inZeroPointSpec, outScaleSpec, outZeroPointSpec, device);
+
+    assert(std::holds_alternative<::ttnn::graph::ConstraintQueryResponse>(
+               result) &&
+           "Expected ConstraintQueryResponse from callEltwiseRequantize");
+
+    return std::get<::ttnn::graph::ConstraintQueryResponse>(result);
   };
 
   return operation::getOpConstraints(inputLayout.getContext(),
@@ -4718,22 +4778,23 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
                    detail::convertToTensorSpec(device, outZeroPointShape,
                                                outZeroPointLayout));
 
-  // Use the explicit outputDtype parameter if provided, otherwise infer from
-  // layout
-  std::optional<::tt::tt_metal::DataType> outputDType;
-  if (outputDtype.has_value()) {
-    outputDType = conversion::getDataType(outputDtype.value());
-  } else {
-    outputDType = detail::getNullableDataType(outputLayout);
-  }
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      detail::getNullableMemoryConfig(outputLayout);
+  ::tt::target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative =
+      buildEltwiseQuantizationOpTFromMLIR<RequantizeOp>(axis, outputDtype,
+                                                        outputLayout);
 
   // Create query closure
   auto requantizeOpQuery = [=]() {
-    return QUERY_OP_RUNTIME(::ttnn::requantize, device, inputSpec, inScaleSpec,
-                            inZeroPointSpec, outScaleSpec, outZeroPointSpec,
-                            axis, outputDType, outputMemoryConfig);
+    ttnn_op_invoke::EltwiseQuantizationOpResult result =
+        ttnn_op_invoke::callEltwiseRequantize(
+            ttnn_op_invoke::CallType::QUERY_OP_RUNTIME,
+            eltwiseQuantizationOpNative, inputSpec, inScaleSpec,
+            inZeroPointSpec, outScaleSpec, outZeroPointSpec, device);
+
+    assert(
+        std::holds_alternative<::ttnn::graph::RuntimeQueryResponse>(result) &&
+        "Expected RuntimeQueryResponse from callEltwiseRequantize");
+
+    return std::get<::ttnn::graph::RuntimeQueryResponse>(result);
   };
 
   return operation::getOpRuntime(requantizeOpQuery);

--- a/runtime/lib/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -8,6 +8,8 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Quantization/EltwiseQuantizationOp.h"
+#include "ttmlir/Target/TTNN/operations/eltwise_generated.h"
 
 #include <optional>
 #include <variant>
@@ -53,58 +55,31 @@ getZeroPointValueFromQuantizationParams(
   LOG_FATAL("Invalid zero point type.");
 }
 
-// Helper function to handle common logic.
-template <typename OpType, typename QuantizationFunc>
-static void runQuantizationOp(const OpType *op, ProgramContext &context,
-                              QuantizationFunc quantizationFunc) {
-  ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
-
-  std::optional<int32_t> axis = std::nullopt;
-  if (op->axis()) {
-    axis = *(op->axis());
-  }
-
-  std::optional<::ttnn::DataType> outputDataType = std::nullopt;
-  if (op->output_dtype()) {
-    outputDataType = ttnn_op_invoke::operations::utils::toTTNNDataType(
-        *(op->output_dtype()));
-  }
-
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
-
-  // Call the specific quantization function.
-  ::ttnn::Tensor output =
-      quantizationFunc(input, axis, outputDataType, outputMemoryConfig);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
-}
-
 // Helper to unify Quantize and Dequantize
-static void runQuantizeDequantize(
-    const ::tt::target::ttnn::EltwiseQuantizationOp *op,
-    ProgramContext &context,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &, const std::variant<::ttnn::Tensor, float> &,
-        const std::variant<::ttnn::Tensor, int32_t> &, std::optional<int32_t>,
-        std::optional<::ttnn::DataType>, std::optional<::ttnn::MemoryConfig>,
-        std::optional<::ttnn::Tensor>)> &func) {
+static void
+runQuantizeDequantize(const ::tt::target::ttnn::EltwiseQuantizationOp *op,
+                      ProgramContext &context) {
   const auto *const params = op->params_as_QuantizeDequantizeOpParams();
   auto scale = getScaleValueFromQuantizationParams(params, context);
   auto zeroPoint = getZeroPointValueFromQuantizationParams(params, context);
-  runQuantizationOp(op, context,
-                    [&](const ::ttnn::Tensor &input,
-                        std::optional<int32_t> axis,
-                        std::optional<::ttnn::DataType> outputDataType,
-                        std::optional<::ttnn::MemoryConfig> memoryConfig) {
-                      return func(input, scale, zeroPoint, axis, outputDataType,
-                                  memoryConfig, std::nullopt);
-                    });
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
+
+  target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative;
+  op->UnPackTo(&eltwiseQuantizationOpNative);
+
+  ttnn_op_invoke::EltwiseQuantizationOpResult result =
+      ttnn_op_invoke::callEltwiseQuantizeDequantize(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseQuantizationOpNative,
+          &input, scale, zeroPoint);
+
+  LOG_ASSERT(
+      std::holds_alternative<::ttnn::Tensor>(result),
+      "Expected output Tensor from callEltwiseQuantizeDequantize execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 // Helper to unify Requantize
@@ -159,15 +134,24 @@ static void runRequantize(const ::tt::target::ttnn::EltwiseQuantizationOp *op,
     }
     LOG_FATAL("Invalid output zero point type.");
   }();
-  runQuantizationOp(
-      op, context,
-      [&](const ::ttnn::Tensor &input, std::optional<int32_t> axis,
-          std::optional<::ttnn::DataType> outputDataType,
-          std::optional<::ttnn::MemoryConfig> memoryConfig) {
-        return ::ttnn::requantize(input, inScale, inZeroPoint, outScale,
-                                  outZeroPoint, axis, outputDataType,
-                                  memoryConfig, std::nullopt);
-      });
+
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &input = tensorPool.getTTNNTensorAndValidate(op->in());
+
+  target::ttnn::EltwiseQuantizationOpT eltwiseQuantizationOpNative;
+  op->UnPackTo(&eltwiseQuantizationOpNative);
+
+  ttnn_op_invoke::EltwiseQuantizationOpResult result =
+      ttnn_op_invoke::callEltwiseRequantize(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseQuantizationOpNative,
+          &input, inScale, inZeroPoint, outScale, outZeroPoint);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseRequantize execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::EltwiseQuantizationOp *op,
@@ -175,10 +159,10 @@ void run(const ::tt::target::ttnn::EltwiseQuantizationOp *op,
   using namespace ::tt::target::ttnn;
   switch (op->type()) {
   case EltwiseQuantizationOpType::Quantize:
-    runQuantizeDequantize(op, context, ::ttnn::quantize);
+    runQuantizeDequantize(op, context);
     break;
   case EltwiseQuantizationOpType::Dequantize:
-    runQuantizeDequantize(op, context, ::ttnn::dequantize);
+    runQuantizeDequantize(op, context);
     break;
   case EltwiseQuantizationOpType::Requantize:
     runRequantize(op, context);

--- a/runtime/lib/ttnn/operations/eltwise/ternary/where.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/ternary/where.cpp
@@ -7,6 +7,8 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttmlir/OpInvoke/TTNN/Eltwise/Ternary/EltwiseTernaryOp.h"
+#include "ttmlir/Target/TTNN/operations/eltwise_generated.h"
 
 namespace tt::runtime::ttnn::operations::eltwise::ternary {
 
@@ -20,16 +22,21 @@ runEltwiseTernaryWhereOp(const ::tt::target::ttnn::EltwiseTernaryWhereOp *op,
       tensorPool.getTTNNTensorAndValidate(op->second());
   const ::ttnn::Tensor &third =
       tensorPool.getTTNNTensorAndValidate(op->third());
-  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
-  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
-                 outputMemoryConfig.has_value(),
-             "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out = ::ttnn::where(first, second, third, outputMemoryConfig);
+  target::ttnn::EltwiseTernaryWhereOpT eltwiseTernaryWhereOpNative;
+  op->UnPackTo(&eltwiseTernaryWhereOpNative);
 
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+  ttnn_op_invoke::EltwiseTernaryOpResult result =
+      ttnn_op_invoke::callEltwiseTernary(
+          ttnn_op_invoke::CallType::EXECUTE, eltwiseTernaryWhereOpNative,
+          WRAP_OP(::ttnn::where), &first, &second, &third);
+
+  LOG_ASSERT(std::holds_alternative<::ttnn::Tensor>(result),
+             "Expected output Tensor from callEltwiseTernary execution");
+
+  ::ttnn::Tensor output = std::get<::ttnn::Tensor>(result);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }
 
 void run(const ::tt::target::ttnn::EltwiseTernaryWhereOp *op,

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -5795,8 +5795,8 @@ TEST_F(OpModelBase, QuantizeOpInterface) {
 
   // Test QuantizeOp interface
   OpModel backend = dyn_cast<OpModel>(quantizeOp.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(quantizeOp), OpConfig(getOutputLayout(quantizeOp)));
+  auto constraintsExp = backend.getOpConstraints(getInputLayouts(quantizeOp),
+                                                 OpConfig(int32Layout));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
@@ -5811,8 +5811,8 @@ TEST_F(OpModelBase, QuantizeOpInterface) {
   EXPECT_EQ(outputLayouts[0].getLayout(), Layout::Tile);
   EXPECT_TRUE(outputLayouts[0].hasInterleavedL1TensorMemoryLayout());
 
-  auto runtimeExp = backend.getOpRuntime(getInputLayouts(quantizeOp),
-                                         OpConfig(getOutputLayout(quantizeOp)));
+  auto runtimeExp =
+      backend.getOpRuntime(getInputLayouts(quantizeOp), OpConfig(int32Layout));
   EXPECT_EQ(static_cast<bool>(runtimeExp), true);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
@@ -5920,8 +5920,8 @@ TEST_F(OpModelBase, RequantizeOpInterface) {
 
   // Test RequantizeOp interface
   OpModel backend = dyn_cast<OpModel>(requantizeOp.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(requantizeOp), OpConfig(getOutputLayout(requantizeOp)));
+  auto constraintsExp = backend.getOpConstraints(getInputLayouts(requantizeOp),
+                                                 OpConfig(int32Layout));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
@@ -5936,8 +5936,8 @@ TEST_F(OpModelBase, RequantizeOpInterface) {
   EXPECT_EQ(outputLayouts[0].getLayout(), Layout::Tile);
   EXPECT_TRUE(outputLayouts[0].hasInterleavedL1TensorMemoryLayout());
 
-  auto runtimeExp = backend.getOpRuntime(
-      getInputLayouts(requantizeOp), OpConfig(getOutputLayout(requantizeOp)));
+  auto runtimeExp = backend.getOpRuntime(getInputLayouts(requantizeOp),
+                                         OpConfig(int32Layout));
   EXPECT_EQ(static_cast<bool>(runtimeExp), true);
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                           
  OpModel and Runtime each had their own parameter resolution and op-calling logic for TTNN operations, duplicating the same code in two places. Any change to how an op's parameters are handled had to be applied twice, and divergences between the two paths caused bugs.
                                                                                                                                                                                                                                                           
### What's changed

This is the sixth PR in the TTNNOpInvokeLib series. It introduces shared dispatch for eltwise ternary (where) and eltwise quantization (quantize, dequantize, requantize) ops across OpModel and Runtime.                                                 
  
  EltwiseTernaryWhereOpT and EltwiseQuantizationOpT (the NativeTable types for these ops) are the interfaces passed into the library. In OpModel they are constructed from MLIR attributes; in Runtime they are already available directly from the deserialized flatbuffer. Both call sites then delegate to ttnn_op_invoke::callEltwiseTernary / ttnn_op_invoke::callEltwiseQuantizeDequantize / ttnn_op_invoke::callEltwiseRequantize, which handle parameter resolution and dispatch for all three call types: constraint query, runtime query, and execution. 
