### PR TITLE
Fix tt-triage install

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -129,7 +129,6 @@ jobs:
         mkdir -p tt-triage
         curl -L "https://github.com/tenstorrent/tt-metal/archive/${TT_METAL_VERSION}.tar.gz" \
           | tar -xz -C tt-triage --strip-components=1 \
-              tt-metal-${TT_METAL_VERSION}/scripts/ttexalens_ref.txt \
               tt-metal-${TT_METAL_VERSION}/tools/tt-triage.py \
               tt-metal-${TT_METAL_VERSION}/tools/triage \
               tt-metal-${TT_METAL_VERSION}/tt_metal

--- a/env/install-tt-triage.sh
+++ b/env/install-tt-triage.sh
@@ -8,12 +8,7 @@ TT_METAL_VERSION=$(grep 'set(TT_METAL_VERSION' $PROJECT_ROOT/third_party/CMakeLi
 mkdir temp
 cd temp
 
-wget -O install_debugger.sh "https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_VERSION}/scripts/install_debugger.sh"
-wget -O ttexalens_ref.txt "https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_VERSION}/scripts/ttexalens_ref.txt"
 wget -O requirements.txt "https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_VERSION}/tools/triage/requirements.txt"
-
-chmod u+x install_debugger.sh
-./install_debugger.sh
 
 pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
### Ticket
/

### Problem description
tt-triage has changed it's install process and it isn't backwards compatible.

### What's changed
- Adjust the install for tt-triage to accomodate the new process they've defined

### Checklist
- [ ] New/Existing tests provide coverage for changes
