### PR TITLE
[Matmul,Linear] Drop top-level activation when program config carries fused activation

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -539,6 +539,36 @@ auto getOpSymbol() {
   }
 }
 
+// Returns true if the matmul program config already carries a fused
+// activation.
+inline bool programCarriesFusedActivation(
+    const std::optional<::ttnn::operations::matmul::MatmulProgramConfig> &pc) {
+  if (!pc) {
+    return false;
+  }
+  return std::visit(
+      [](const auto &cfg) -> bool {
+        using T = std::decay_t<decltype(cfg)>;
+        if constexpr (
+            std::is_same_v<T, ::ttnn::operations::matmul::
+                                  MatmulMultiCoreReuseMultiCastProgramConfig> ||
+            std::is_same_v<T,
+                           ::ttnn::operations::matmul::
+                               MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
+            std::is_same_v<
+                T, ::ttnn::operations::matmul::
+                       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+            std::is_same_v<
+                T,
+                ::ttnn::operations::matmul::
+                    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+          return cfg.fused_activation.has_value();
+        }
+        return false;
+      },
+      *pc);
+}
+
 } // namespace detail
 #endif // TTMLIR_ENABLE_OPMODEL
 
@@ -4549,14 +4579,15 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
-  // Convert activation string to optional
-  std::optional<std::string> activationStr =
-      activation ? std::make_optional(activation->str()) : std::nullopt;
-
   // Convert program config attribute
   auto programConfig =
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
+
+  std::optional<std::string> activationStr;
+  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
+    activationStr = activation->str();
+  }
 
   std::optional<::ttnn::DeviceComputeKernelConfig>
       computeKernelConfigConverted =
@@ -4667,14 +4698,15 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
-  // Convert activation string to optional
-  std::optional<std::string> activationStr =
-      activation ? std::make_optional(activation->str()) : std::nullopt;
-
   // Convert program config attribute
   auto programConfig =
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
+
+  std::optional<std::string> activationStr;
+  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
+    activationStr = activation->str();
+  }
 
   std::optional<::ttnn::DeviceComputeKernelConfig>
       computeKernelConfigConverted =

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -15,6 +15,34 @@
 
 namespace tt::runtime::ttnn::operations::matmul {
 
+static bool programCarriesFusedActivation(
+    const std::optional<::ttnn::operations::matmul::MatmulProgramConfig> &pc) {
+  if (!pc) {
+    return false;
+  }
+  return std::visit(
+      [](const auto &cfg) -> bool {
+        using T = std::decay_t<decltype(cfg)>;
+        if constexpr (
+            std::is_same_v<T, ::ttnn::operations::matmul::
+                                  MatmulMultiCoreReuseMultiCastProgramConfig> ||
+            std::is_same_v<T,
+                           ::ttnn::operations::matmul::
+                               MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
+            std::is_same_v<
+                T, ::ttnn::operations::matmul::
+                       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> ||
+            std::is_same_v<
+                T,
+                ::ttnn::operations::matmul::
+                    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
+          return cfg.fused_activation.has_value();
+        }
+        return false;
+      },
+      *pc);
+}
+
 // ANCHOR: adding_an_op_matmul_runtime_operations
 void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -33,9 +61,10 @@ void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
   std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
       matmulProgramConfig = utils::createMatmulProgramConfigIfNeeded(op);
 
-  std::optional<std::string> activation =
-      op->activation() ? std::make_optional(op->activation()->str())
-                       : std::nullopt;
+  std::optional<std::string> activation;
+  if (op->activation() && !programCarriesFusedActivation(matmulProgramConfig)) {
+    activation = op->activation()->str();
+  }
 
   std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
   if (op->compute_config()) {
@@ -72,10 +101,6 @@ void run(const ::tt::target::ttnn::LinearOp *op, ProgramContext &context) {
 
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());
 
-  std::optional<std::string> activation =
-      op->activation() ? std::make_optional(op->activation()->str())
-                       : std::nullopt;
-
   std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig;
   if (op->compute_config()) {
     computeConfig =
@@ -83,6 +108,11 @@ void run(const ::tt::target::ttnn::LinearOp *op, ProgramContext &context) {
   }
 
   auto programConfig = utils::createMatmulProgramConfigIfNeeded(op);
+
+  std::optional<std::string> activation;
+  if (op->activation() && !programCarriesFusedActivation(programConfig)) {
+    activation = op->activation()->str();
+  }
 
   ::ttnn::Tensor output = ::ttnn::linear(
       lhs, rhs, bias, op->transpose_a(), op->transpose_b(), outputMemoryConfig,


### PR DESCRIPTION
## Summary
- When the matmul program config (`MatmulMultiCoreReuseMultiCast{,1D}` or the two `DRAMSharded` variants) already carries a `fused_activation`, also passing a top-level activation trips tt-metal's `!parameters.user_fused_activation.has_value()` `TT_FATAL` for sharded inputs (`ttnn/operations/matmul/matmul.cpp:163`). On the OpModel side the beam search spuriously rejects every sharded matmul candidate; at runtime the op crashes once beam search picks the sharded path.
- Add a `programCarriesFusedActivation` helper in both OpModel (`namespace detail`, shared by `OpModel<MatmulOp>` and `OpModel<LinearOp>`) and runtime (duplicated because it links a separate translation unit of the same `MatmulProgramConfig` types) that suppresses the top-level activation string when the program config already carries one.
- Linear goes through the same `bound_matmul()` path as Matmul (`matmul.cpp:382`), so it needs the same fix in both OpModel and runtime. Sparse matmul is unaffected: its public API takes no `activation`, it bypasses `bound_matmul`, and pins `user_fused_activation` to `nullopt` internally.

Effect on Gemma-4 31B vLLM (Blackhole BHQB 4-chip): matmul/linear candidates with sharded operand 0 + fused activation are no longer rejected during op-model validation, and the runtime no longer crashes when beam search picks them.

## Test plan
- [x] `TestMatmulBlockShardedConstraint` — 2/2 passed (`MatmulBlockShardedInputWithPadding`, `MatmulActivationWithIgnorePhysicalLayout`)
- [x] `TestOpModelInterface --gtest_filter="*Linear*:*Matmul*"` — 6/6 passed
- [x] `TestOpModelLib --gtest_filter="*Linear*:*Matmul*"` — 30/30 passed
- [ ] CI: full unit + lit suites
- [ ] tt-xla validation against this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)