### PR TITLE
[d2m] stale virtual grid fixes

### DIFF
--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -456,8 +456,9 @@ static void applyEmptyOpUpdate(const OperandGridInfo &info,
       emptyType, info.targetGrid, ttnnMode, info.selectedGrid);
   builder.setInsertionPoint(emptyOp);
 
-  // The selected grid may differ from the EmptyOp's previous grid. Recompute
-  // VGM attrs instead of preserving stale mappings from the old layout.
+  // The selected grid may differ from the EmptyOp's previous grid.
+  // TODO (#8301): Avoid creating placeholder EmptyOp VGMs before grid
+  // selection so this rewrite does not need to repair stale mappings.
   auto [virtualGridInverseMapping, virtualGridForwardMapping] =
       deriveVirtualGridAttrs(emptyOp, info.selectedGrid, effectiveTargetGrid,
                              builder);

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -35,6 +35,30 @@ namespace mlir::tt::d2m {
 // Transform helpers — these modify the IR to apply grid decisions.
 // ----------------------------------------------------------------------------
 
+static std::pair<mlir::AffineMapAttr, mlir::AffineMapAttr>
+deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
+                       ArrayRef<int64_t> effectiveTargetGrid,
+                       OpBuilder &builder) {
+  auto device = ttcore::lookupDevice(anchorOp);
+  auto workerGridShape = device.getWorkerGrid().getShape();
+  bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
+      selectedGrid, workerGridShape);
+  if (!isVirtual) {
+    return {mlir::AffineMapAttr(), mlir::AffineMapAttr()};
+  }
+
+  auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
+      ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGrid);
+  TT_assertv(!physicalGridShape.empty(),
+             "Unable to find 2D rect that can fit virtual grid {} within "
+             "device grid {}",
+             ttmlir::utils::formatIterable(selectedGrid, "x"),
+             ttmlir::utils::formatIterable(effectiveTargetGrid, "x"));
+  auto [forwardMap, inverseMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
+      builder.getContext(), selectedGrid, physicalGridShape);
+  return {AffineMapAttr::get(inverseMap), AffineMapAttr::get(forwardMap)};
+}
+
 // Update a ToLayoutOp and its associated EmptyOp to use a specified grid by
 // recreating the MetalLayoutAttr with the given grid and proper dimension
 // alignments.
@@ -77,30 +101,12 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
       outputType, targetGrid, ttnnMode, optimalGrid);
   builder.setInsertionPoint(emptyOp);
 
-  // Determine if the chosen grid is virtual (exceeds 2D device bounds or is
-  // ND). Note: VGM is NOT propagated from the to_layout's input here — the
-  // output EmptyOp has its own grid/shard strategy. VGM for DMA addresses
-  // is traced through the stream's input at DMA lowering time.
-  mlir::AffineMapAttr virtualGridInverseMapping;
-  mlir::AffineMapAttr virtualGridForwardMapping;
-  auto device = ttcore::lookupDevice(toLayoutOp);
-  auto workerGridShape = device.getWorkerGrid().getShape();
-  bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-      optimalGrid, workerGridShape);
-  if (isVirtual) {
-    auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-        ttmlir::utils::volume<int64_t>(optimalGrid), effectiveTargetGrid);
-    TT_assertv(!physicalGridShape.empty(),
-               "Unable to find 2D rect that can fit virtual grid {} within "
-               "device grid {}",
-               ttmlir::utils::formatIterable(optimalGrid, "x"),
-               ttmlir::utils::formatIterable(effectiveTargetGrid, "x"));
-    auto [forwardMap, inverseMap] =
-        ttmlir::d2m::utils::grids::createCoreVirtMaps(
-            builder.getContext(), optimalGrid, physicalGridShape);
-    virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
-    virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
-  }
+  // VGM is NOT propagated from the to_layout's input here — the output EmptyOp
+  // has its own grid/shard strategy. VGM for DMA addresses is traced through
+  // the stream's input at DMA lowering time.
+  auto [virtualGridInverseMapping, virtualGridForwardMapping] =
+      deriveVirtualGridAttrs(toLayoutOp, optimalGrid, effectiveTargetGrid,
+                             builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
       emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
@@ -450,28 +456,11 @@ static void applyEmptyOpUpdate(const OperandGridInfo &info,
       emptyType, info.targetGrid, ttnnMode, info.selectedGrid);
   builder.setInsertionPoint(emptyOp);
 
-  mlir::AffineMapAttr virtualGridInverseMapping =
-      emptyOp.getVirtualGridInverseMappingAttr();
-  mlir::AffineMapAttr virtualGridForwardMapping =
-      emptyOp.getVirtualGridForwardMappingAttr();
-  if (!virtualGridInverseMapping) {
-    auto device = ttcore::lookupDevice(emptyOp);
-    auto workerGridShape = device.getWorkerGrid().getShape();
-    bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-        info.selectedGrid, workerGridShape);
-    if (isVirtual) {
-      auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-          ttmlir::utils::volume<int64_t>(info.selectedGrid),
-          effectiveTargetGrid);
-      TT_assertv(!physicalGridShape.empty(),
-                 "Unable to find 2D rect that can fit virtual grid");
-      auto [forwardMap, inverseMap] =
-          ttmlir::d2m::utils::grids::createCoreVirtMaps(
-              builder.getContext(), info.selectedGrid, physicalGridShape);
-      virtualGridInverseMapping = AffineMapAttr::get(inverseMap);
-      virtualGridForwardMapping = AffineMapAttr::get(forwardMap);
-    }
-  }
+  // The selected grid may differ from the EmptyOp's previous grid. Recompute
+  // VGM attrs instead of preserving stale mappings from the old layout.
+  auto [virtualGridInverseMapping, virtualGridForwardMapping] =
+      deriveVirtualGridAttrs(emptyOp, info.selectedGrid, effectiveTargetGrid,
+                             builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
       emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -65,6 +65,17 @@ struct TensorInfo {
   }
 };
 
+static bool isVGMCompatibleWithType(RankedTensorType type,
+                                    ttcore::MetalLayoutAttr layout,
+                                    AffineMap inverseMap,
+                                    AffineMap forwardMap) {
+  size_t gridRank = layout.getGridShape(type).size();
+  return forwardMap.getNumDims() == gridRank * 2 &&
+         forwardMap.getNumResults() == gridRank + 2 &&
+         inverseMap.getNumInputs() == 2 &&
+         inverseMap.getNumResults() == gridRank + 1;
+}
+
 // Helper to extract scalar type from potentially tiled type.
 static Type getScalarType(Type type) {
   if (auto tileType = mlir::dyn_cast<ttcore::TileType>(type)) {
@@ -825,7 +836,8 @@ public:
         auto fwd = utils::getVirtualGridForwardMapping(source);
         if (!(sourceLayout && inv && fwd &&
               llvm::equal(typeLayout.getGridShape(type),
-                          sourceLayout.getGridShape(sourceTy)))) {
+                          sourceLayout.getGridShape(sourceTy)) &&
+              isVGMCompatibleWithType(type, typeLayout, *inv, *fwd))) {
           return Value();
         }
         return rewriter

--- a/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerToLayout.cpp
@@ -69,6 +69,9 @@ static bool isVGMCompatibleWithType(RankedTensorType type,
                                     ttcore::MetalLayoutAttr layout,
                                     AffineMap inverseMap,
                                     AffineMap forwardMap) {
+  // TODO (#8303): Rework LowerToLayout VGM propagation so intermediates derive
+  // virtual-grid mappings directly from their destination type instead of
+  // filtering copied maps for compatibility.
   size_t gridRank = layout.getGridShape(type).size();
   return forwardMap.getNumDims() == gridRank * 2 &&
          forwardMap.getNumResults() == gridRank + 2 &&

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection.mlir
@@ -58,6 +58,39 @@ module {
 
  // -----
 
+ #stale_forward = affine_map<(d0, d1, d2, d3) -> (0, 0, d2, d3)>
+ #stale_inverse = affine_map<(d0, d1) -> (0, 0, 0)>
+ #layout_stale_vgm = #ttcore.metal_layout<logical_shape = 256x256, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+
+ module {
+   func.func @test_update_empty_drops_stale_vgm() -> (tensor<256x256xf32>) {
+     // CHECK-AFTER-LABEL: func.func @test_update_empty_drops_stale_vgm
+     // CHECK-AFTER: d2m.empty() : tensor<8x8x1x1x!ttcore.tile<32x32, f32>
+     // CHECK-AFTER: d2m.generic {{{.*}}grid = #ttcore.grid<8x8>
+     %0 = d2m.empty() {virtualGridForwardMapping = #stale_forward, virtualGridInverseMapping = #stale_inverse} : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_stale_vgm>
+
+     %1 = d2m.generic {
+       block_factors = [1, 1],
+       grid = #ttcore.grid<1x1>,
+       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>],
+       threads = [#d2m.thread<unified>]
+     }
+     ins() outs(%0 : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_stale_vgm>)  {
+     ^unified0:
+       %out = tensor.empty() : tensor<8x8x!ttcore.tile<32x32, f32>>
+       d2m.yield %out : (tensor<8x8x!ttcore.tile<32x32, f32>>)
+     } : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_stale_vgm>
+
+     %2 = d2m.empty() : tensor<256x256xf32>
+     %3 = d2m.to_layout %1, %2 : tensor<1x1x8x8x!ttcore.tile<32x32, f32>, #layout_stale_vgm> into tensor<256x256xf32> -> tensor<256x256xf32>
+
+     return %3 : tensor<256x256xf32>
+   }
+ }
+
+ // -----
+
  #layout_tm_device_input = #ttcore.metal_layout<logical_shape = 33x2x8, dim_alignments = 1x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
  #layout_tm_stream_map = #ttcore.metal_layout<logical_shape = 2x264, dim_alignments = 32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
 

--- a/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/D2M/lower_to_layout.mlir
@@ -260,6 +260,24 @@ func.func @complex_tiled_mapping_preserves_untilize_shape(%arg0: tensor<1x1x1x5x
   return %1 : tensor<1x32x2x5x1x1x!ttcore.tile<32x32, f32>, #layout_tm_dst>
 }
 
+#rank6_vgm_forward = affine_map<(d0, d1, d2, d3, d4, d5) -> (0, 0, d3, d4, d5)>
+#rank6_vgm_inverse = affine_map<(d0, d1) -> (0, 0, 0, 0)>
+#rank8_view = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d1, d2, d3, (d4 * 524288 + d5 * 4096 + d6 * 128 + d7) floordiv 524288, ((d4 * 524288 + d5 * 4096 + d6 * 128 + d7) mod 524288) floordiv 4096, (d4 * 524288 + d5 * 4096 + d6 * 128 + d7) mod 4096)>
+#rank_incompatible_vgm_src = #ttcore.metal_layout<logical_shape = 1x128x4096, dim_alignments = 1x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#rank_incompatible_vgm_view = #ttcore.metal_layout<logical_shape = 1x128x32x128, dim_alignments = 1x1x32x32, collapsed_intervals = dense<> : tensor<0x2xi64>, undef, l1, sharded>
+#rank_incompatible_vgm_dst = #ttcore.metal_layout<logical_shape = 1x128x32x128, dim_alignments = 256x1x32x32, collapsed_intervals = dense<[[0, 3], [3, 4]]> : tensor<2x2xi64>, undef, l1, sharded>
+
+func.func @tilize_ignores_rank_incompatible_input_vgm() -> tensor<8x4x16x1x!ttcore.tile<32x32, f32>, #rank_incompatible_vgm_dst> {
+  // CHECK-LABEL: @tilize_ignores_rank_incompatible_input_vgm
+  // CHECK: d2m.empty() {virtualGridForwardMapping = #map{{[0-9]+}}, virtualGridInverseMapping = #map{{[0-9]+}}} : tensor<1x1x1x1x1x128x1x4x!ttcore.tile<32x32, f32>, #layout{{[0-9]+}}>
+  // CHECK: d2m.tile_tilize_block
+  %0 = d2m.empty() {virtualGridForwardMapping = #rank6_vgm_forward, virtualGridInverseMapping = #rank6_vgm_inverse} : tensor<1x1x1x1x128x4096xf32, #rank_incompatible_vgm_src>
+  %view = d2m.view_layout %0 remapping = #rank8_view : tensor<1x1x1x1x128x4096xf32, #rank_incompatible_vgm_src> -> tensor<1x1x1x1x1x128x32x128xf32, #rank_incompatible_vgm_view>
+  %1 = d2m.empty() : tensor<8x4x16x1x!ttcore.tile<32x32, f32>, #rank_incompatible_vgm_dst>
+  %2 = d2m.to_layout %view, %1 : tensor<1x1x1x1x1x128x32x128xf32, #rank_incompatible_vgm_view> into tensor<8x4x16x1x!ttcore.tile<32x32, f32>, #rank_incompatible_vgm_dst> -> tensor<8x4x16x1x!ttcore.tile<32x32, f32>, #rank_incompatible_vgm_dst>
+  return %2 : tensor<8x4x16x1x!ttcore.tile<32x32, f32>, #rank_incompatible_vgm_dst>
+}
+
 
 #layer_tile_with_vgm_dst = #ttcore.metal_layout<logical_shape = 32x32, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
 func.func @tilize_with_vgm(%arg0: tensor<32x32xbf16>) -> tensor<1x1x1x1x!ttcore.tile<32x32, bf16>, #layer_tile_with_vgm_dst> {


### PR DESCRIPTION
### Problem description
Ran into problems with stale virtual grid metadata in grid selection and lower to layout.

### What's changed
- Added a helper that derives the new virtual grid mapping from the selected grid at rewrite.
- In `lowerToLayout.cpp`, don't use stale vgm attributes just when just grid shape matches. Only copy the vgm attrs if the maps structurally match the new type or just rederive the vgm.
- Added lit tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
