### PR TITLE
Add embedding op canonicalizer to squeeze unsqueezed index tensor.

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3046,6 +3046,7 @@ def TTIR_EmbeddingOp : TTIR_NamedOp<"embedding"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_EmbeddingBackwardOp : TTIR_NamedOp<"embedding_backward"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3722,6 +3722,79 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
   return success();
 }
 
+// EmbeddingOp canonicalization
+//
+// Squeeze unit dimensions out of the index tensor before the embedding lookup,
+// then reshape the result back to the original output shape.
+//
+// This applies regardless of which dimensions are 1 and is not restricted to
+// 2-D index tensors.  Examples:
+//   Embedding([A,1],   [N,B]) -> Reshape(Embedding([A],   [N,B]), [A,1,B])
+//   Embedding([1,A],   [N,B]) -> Reshape(Embedding([A],   [N,B]), [1,A,B])
+//   Embedding([1,A,1], [N,B]) -> Reshape(Embedding([A],   [N,B]), [1,A,1,B])
+//
+// The pattern does not run when:
+//   - The input has no unit dimensions (nothing to squeeze).
+//   - Squeezing all unit dims would produce a rank-0 (scalar) index tensor.
+//
+void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  patterns.add(+[](mlir::tt::ttir::EmbeddingOp op,
+                   mlir::PatternRewriter &rewriter) -> LogicalResult {
+    RankedTensorType inputType = op.getInput().getType();
+
+    // Compute the squeezed shape by dropping all unit dimensions.
+    SmallVector<int64_t> squeezedShape;
+    for (int64_t dim : inputType.getShape()) {
+      if (dim != 1) {
+        squeezedShape.push_back(dim);
+      }
+    }
+
+    // Nothing to do when there are no unit dimensions to remove.
+    if (static_cast<int64_t>(squeezedShape.size()) == inputType.getRank()) {
+      return failure();
+    }
+
+    // Index tensor is made up of unit dimensions only, so nothing to do.
+    if (squeezedShape.empty()) {
+      return failure();
+    }
+
+    RankedTensorType resultType = op.getType();
+    int64_t B = resultType.getDimSize(resultType.getRank() - 1);
+
+    // Reshape input to the squeezed index shape.
+    auto squeezedInputType =
+        RankedTensorType::get(squeezedShape, inputType.getElementType());
+    SmallVector<int32_t> squeezedInputShapeAttr(squeezedShape.begin(),
+                                                squeezedShape.end());
+    auto squeezedInput = rewriter.create<mlir::tt::ttir::ReshapeOp>(
+        op.getLoc(), squeezedInputType, op.getInput(),
+        rewriter.getI32ArrayAttr(squeezedInputShapeAttr));
+
+    // Create a new embedding op with result shape: squeezedShape + [B].
+    SmallVector<int64_t> newResultShape(squeezedShape);
+    newResultShape.push_back(B);
+    auto newResultType =
+        RankedTensorType::get(newResultShape, resultType.getElementType());
+    auto newEmbedding = rewriter.create<mlir::tt::ttir::EmbeddingOp>(
+        op.getLoc(), newResultType, squeezedInput.getResult(), op.getWeight());
+
+    // Reshape back to the original result shape so all consumers are
+    // unaffected.
+    SmallVector<int32_t> origResultShape;
+    for (int64_t dim : resultType.getShape()) {
+      origResultShape.push_back(static_cast<int32_t>(dim));
+    }
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ReshapeOp>(
+        op, resultType, newEmbedding.getResult(),
+        rewriter.getI32ArrayAttr(origResultShape));
+
+    return success();
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // EmbeddingBackwardOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3727,17 +3727,19 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 // Squeeze unit dimensions out of the index tensor before the embedding lookup,
 // then reshape the result back to the original output shape.
 //
-// This applies regardless of which dimensions are 1 and is not restricted to
-// 2-D index tensors.  Examples:
+//   Examples:
 //   Embedding([A,1],   [N,B]) -> Reshape(Embedding([A],   [N,B]), [A,1,B])
 //   Embedding([1,A],   [N,B]) -> Reshape(Embedding([A],   [N,B]), [1,A,B])
 //   Embedding([1,A,1], [N,B]) -> Reshape(Embedding([A],   [N,B]), [1,A,1,B])
 //
 // The pattern does not run when:
 //   - The input has no unit dimensions (nothing to squeeze).
-//   - Squeezing all unit dims would produce a rank-0 (scalar) index tensor.
 //   - The input is not produced by a ReshapeOp or the output is not connected
 //   to a ReshapeOp.
+//
+// If index tensor is all unit dimensions, it is reshaped to a scalar index
+// tensor.
+//   Embedding([1,1,1], [N,B]) -> Reshape(Embedding([1], [N,B]), [1,B])
 //
 void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3736,15 +3736,15 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 // The pattern does not run when:
 //   - The input has no unit dimensions (nothing to squeeze).
 //   - Squeezing all unit dims would produce a rank-0 (scalar) index tensor.
+//   - The input is not produced by a ReshapeOp or the output is not connected
+//   to a ReshapeOp.
 //
 void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
   patterns.add(+[](mlir::tt::ttir::EmbeddingOp op,
                    mlir::PatternRewriter &rewriter) -> LogicalResult {
-    // Do not apply when the indices are already produced by a ReshapeOp *and*
-    // every consumer of the result is a ReshapeOp.  Both conditions together
-    // indicate that this canonicalization has already fired, so re-running
-    // would only produce redundant reshape chains.
+    // Do not apply when the indices are not produced by a ReshapeOp or when the
+    // output is not connected to a ReshapeOp.
     bool inputFromReshape =
         op.getInput().getDefiningOp<mlir::tt::ttir::ReshapeOp>() != nullptr;
     bool outputToReshape =
@@ -3752,7 +3752,7 @@ void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
         llvm::all_of(op->getUsers(), [](mlir::Operation *user) {
           return mlir::isa<mlir::tt::ttir::ReshapeOp>(user);
         });
-    if (!inputFromReshape && !outputToReshape) {
+    if (!inputFromReshape || !outputToReshape) {
       return failure();
     }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3741,6 +3741,21 @@ void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
   patterns.add(+[](mlir::tt::ttir::EmbeddingOp op,
                    mlir::PatternRewriter &rewriter) -> LogicalResult {
+    // Do not apply when the indices are already produced by a ReshapeOp *and*
+    // every consumer of the result is a ReshapeOp.  Both conditions together
+    // indicate that this canonicalization has already fired, so re-running
+    // would only produce redundant reshape chains.
+    bool inputFromReshape =
+        op.getInput().getDefiningOp<mlir::tt::ttir::ReshapeOp>() != nullptr;
+    bool outputToReshape =
+        !op->use_empty() &&
+        llvm::all_of(op->getUsers(), [](mlir::Operation *user) {
+          return mlir::isa<mlir::tt::ttir::ReshapeOp>(user);
+        });
+    if (!inputFromReshape && !outputToReshape) {
+      return failure();
+    }
+
     RankedTensorType inputType = op.getInput().getType();
 
     // Compute the squeezed shape by dropping all unit dimensions.
@@ -3751,17 +3766,19 @@ void mlir::tt::ttir::EmbeddingOp::getCanonicalizationPatterns(
       }
     }
 
+    // Index tensor is made up of unit dimensions only, so push back a 1.
+    if (squeezedShape.empty()) {
+      squeezedShape.push_back(1);
+    }
+
     // Nothing to do when there are no unit dimensions to remove.
     if (static_cast<int64_t>(squeezedShape.size()) == inputType.getRank()) {
       return failure();
     }
 
-    // Index tensor is made up of unit dimensions only, so nothing to do.
-    if (squeezedShape.empty()) {
-      return failure();
-    }
-
     RankedTensorType resultType = op.getType();
+    assert(!resultType.getEncoding() && "EmbeddingOp should not have a layout");
+
     int64_t B = resultType.getDimSize(resultType.getRank() - 1);
 
     // Reshape input to the squeezed index shape.

--- a/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
@@ -16,6 +16,7 @@ module {
     %2 = "ttir.reshape"(%1) <{shape = [4 : i32, 8 : i32]}> : (tensor<4x1x8xf32>) -> tensor<4x8xf32>
     return %2 : tensor<4x8xf32>
   }
+
   // [1, A] – leading unit dimension.
   func.func @embedding_1xa(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
     // CHECK-LABEL: func.func @embedding_1xa
@@ -27,7 +28,8 @@ module {
     %2 = "ttir.reshape"(%1) <{shape = [4 : i32, 8 : i32]}> : (tensor<1x4x8xf32>) -> tensor<4x8xf32>
     return %2 : tensor<4x8xf32>
   }
-  // Large realistic dimensions – same pattern applies.
+
+  // Large dimensions from customer model.
   func.func @embedding_ax1_large(%input: tensor<1836732xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x80xf32> {
     // CHECK-LABEL: func.func @embedding_ax1_large
     // CHECK-NOT:   "ttir.reshape"
@@ -50,7 +52,8 @@ module {
     %2 = "ttir.reshape"(%1) <{shape = [2 : i32, 2 : i32, 8 : i32]}> : (tensor<4x8xf32>) -> tensor<2x2x8xf32>
     return %2 : tensor<2x2x8xf32>
   }
-  // Indices does not come from reshape, output does not go to reshape, pattern must NOT fire.
+
+  // Indices do not come from reshape, output does not go to reshape, pattern must NOT fire.
   func.func @embedding_1d_no_canonicalize_reshapes(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
     // CHECK-LABEL: func.func @embedding_1d_no_canonicalize_reshapes
     // CHECK-NOT:   "ttir.reshape"
@@ -71,7 +74,4 @@ module {
     %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 8 : i32]}> : (tensor<1x1x8xf32>) -> tensor<1x8xf32>
     return %2 : tensor<1x8xf32>
   }
-
-
-
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
@@ -6,43 +6,39 @@
 
 module {
   // [A, 1] – trailing unit dimension.
-  func.func @embedding_ax1(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
+  func.func @embedding_ax1(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
     // CHECK-LABEL: func.func @embedding_ax1
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<4x1xi32>) -> tensor<4xi32>
+    // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<4x8xf32>) -> tensor<4x1x8xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<4x1xi32>, tensor<10x8xf32>) -> tensor<4x1x8xf32>
-    return %0 : tensor<4x1x8xf32>
+    %0 = "ttir.reshape"(%input) <{shape = [4 : i32, 1 : i32]}> : (tensor<4xi32>) -> tensor<4x1xi32>
+    %1 = "ttir.embedding"(%0, %weight) : (tensor<4x1xi32>, tensor<10x8xf32>) -> tensor<4x1x8xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [4 : i32, 8 : i32]}> : (tensor<4x1x8xf32>) -> tensor<4x8xf32>
+    return %2 : tensor<4x8xf32>
   }
-
   // [1, A] – leading unit dimension.
-  func.func @embedding_1xa(%input: tensor<1x4xi32>, %weight: tensor<10x8xf32>) -> tensor<1x4x8xf32> {
+  func.func @embedding_1xa(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<1x4x8xf32> {
     // CHECK-LABEL: func.func @embedding_1xa
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<1x4xi32>) -> tensor<4xi32>
+    // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<4x8xf32>) -> tensor<1x4x8xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<1x4xi32>, tensor<10x8xf32>) -> tensor<1x4x8xf32>
-    return %0 : tensor<1x4x8xf32>
+    %0 = "ttir.reshape"(%input) <{shape = [1 : i32, 4 : i32]}> : (tensor<4xi32>) -> tensor<1x4xi32>
+    %1 = "ttir.embedding"(%0, %weight) : (tensor<1x4xi32>, tensor<10x8xf32>) -> tensor<1x4x8xf32>
+    return %1 : tensor<1x4x8xf32>
   }
 
   // Large realistic dimensions – same pattern applies.
-  func.func @embedding_ax1_large(%input: tensor<1836732x1xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32> {
+  func.func @embedding_ax1_large(%input: tensor<1836732x1xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x80xf32> {
     // CHECK-LABEL: func.func @embedding_ax1_large
     // CHECK:       "ttir.reshape"
     // CHECK-SAME:  tensor<1836732x1xi64>) -> tensor<1836732xi64>
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<1836732xi64>, tensor<1993728x80xf32>) -> tensor<1836732x80xf32>
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<1836732x80xf32>) -> tensor<1836732x1x80xf32>
     %0 = "ttir.embedding"(%input, %weight) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32>
-    return %0 : tensor<1836732x1x80xf32>
+    %1 = "ttir.reshape"(%0) <{shape = [1836732 : i32, 80 : i32]}> : (tensor<1836732x1x80xf32>) -> tensor<1836732x80xf32>
+    return %1 : tensor<1836732x80xf32>
   }
+
 
   // 1-D index tensor with no unit dims – pattern must NOT fire.
   func.func @embedding_1d_no_canonicalize(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
@@ -54,23 +50,26 @@ module {
     return %0 : tensor<4x8xf32>
   }
 
-  // 2-D index tensor with no unit dims – pattern must NOT fire.
-  func.func @embedding_ax3_no_canonicalize(%input: tensor<4x3xi32>, %weight: tensor<10x8xf32>) -> tensor<4x3x8xf32> {
-    // CHECK-LABEL: func.func @embedding_ax3_no_canonicalize
+  // Indices does not come from reshape, output does not go to reshape, pattern must NOT fire.
+  func.func @embedding_1d_no_canonicalize_reshapes(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
+    // CHECK-LABEL: func.func @embedding_1d_no_canonicalize_reshapes
     // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
-    // CHECK-SAME:  (tensor<4x3xi32>, tensor<10x8xf32>) -> tensor<4x3x8xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<4x3xi32>, tensor<10x8xf32>) -> tensor<4x3x8xf32>
-    return %0 : tensor<4x3x8xf32>
+    // CHECK-SAME:  (tensor<4x1xi32>, tensor<10x8xf32>) -> tensor<4x1x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<4x1xi32>, tensor<10x8xf32>) -> tensor<4x1x8xf32>
+    return %0 : tensor<4x1x8xf32>
   }
 
-  // All-ones input [1, 1] – would produce scalar index, pattern must NOT fire.
-  func.func @embedding_1x1_no_canonicalize(%input: tensor<1x1xi32>, %weight: tensor<10x8xf32>) -> tensor<1x1x8xf32> {
-    // CHECK-LABEL: func.func @embedding_1x1_no_canonicalize
-    // CHECK-NOT:   "ttir.reshape"
+  // All-ones input [1, 1] – would produce scalar index.
+  func.func @embedding_1x1_canonicalize(%input: tensor<1x1xi32>, %weight: tensor<10x8xf32>) -> tensor<1x8xf32> {
+    // CHECK-LABEL: func.func @embedding_1x1_canonicalize
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<1x1xi32>) -> tensor<1xi32>
     // CHECK:       "ttir.embedding"
-    // CHECK-SAME:  (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
+    // CHECK-SAME:  (tensor<1xi32>, tensor<10x8xf32>) -> tensor<1x8xf32>
     %0 = "ttir.embedding"(%input, %weight) : (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
-    return %0 : tensor<1x1x8xf32>
+    %1 = "ttir.reshape"(%0) <{shape = [1 : i32, 8 : i32]}> : (tensor<1x1x8xf32>) -> tensor<1x8xf32>
+    return %1 : tensor<1x8xf32>
   }
+
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
@@ -1,0 +1,76 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Verify that an embedding whose index tensor contains any unit dimension(s)
+// is rewritten to: reshape(squeeze units) + embedding + reshape(restore shape).
+
+module {
+  // [A, 1] – trailing unit dimension.
+  func.func @embedding_ax1(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
+    // CHECK-LABEL: func.func @embedding_ax1
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<4x1xi32>) -> tensor<4xi32>
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<4x8xf32>) -> tensor<4x1x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<4x1xi32>, tensor<10x8xf32>) -> tensor<4x1x8xf32>
+    return %0 : tensor<4x1x8xf32>
+  }
+
+  // [1, A] – leading unit dimension.
+  func.func @embedding_1xa(%input: tensor<1x4xi32>, %weight: tensor<10x8xf32>) -> tensor<1x4x8xf32> {
+    // CHECK-LABEL: func.func @embedding_1xa
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<1x4xi32>) -> tensor<4xi32>
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<4x8xf32>) -> tensor<1x4x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<1x4xi32>, tensor<10x8xf32>) -> tensor<1x4x8xf32>
+    return %0 : tensor<1x4x8xf32>
+  }
+
+  // Large realistic dimensions – same pattern applies.
+  func.func @embedding_ax1_large(%input: tensor<1836732x1xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32> {
+    // CHECK-LABEL: func.func @embedding_ax1_large
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<1836732x1xi64>) -> tensor<1836732xi64>
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<1836732xi64>, tensor<1993728x80xf32>) -> tensor<1836732x80xf32>
+    // CHECK:       "ttir.reshape"
+    // CHECK-SAME:  tensor<1836732x80xf32>) -> tensor<1836732x1x80xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32>
+    return %0 : tensor<1836732x1x80xf32>
+  }
+
+  // 1-D index tensor with no unit dims – pattern must NOT fire.
+  func.func @embedding_1d_no_canonicalize(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
+    // CHECK-LABEL: func.func @embedding_1d_no_canonicalize
+    // CHECK-NOT:   "ttir.reshape"
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
+    return %0 : tensor<4x8xf32>
+  }
+
+  // 2-D index tensor with no unit dims – pattern must NOT fire.
+  func.func @embedding_ax3_no_canonicalize(%input: tensor<4x3xi32>, %weight: tensor<10x8xf32>) -> tensor<4x3x8xf32> {
+    // CHECK-LABEL: func.func @embedding_ax3_no_canonicalize
+    // CHECK-NOT:   "ttir.reshape"
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<4x3xi32>, tensor<10x8xf32>) -> tensor<4x3x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<4x3xi32>, tensor<10x8xf32>) -> tensor<4x3x8xf32>
+    return %0 : tensor<4x3x8xf32>
+  }
+
+  // All-ones input [1, 1] – would produce scalar index, pattern must NOT fire.
+  func.func @embedding_1x1_no_canonicalize(%input: tensor<1x1xi32>, %weight: tensor<10x8xf32>) -> tensor<1x1x8xf32> {
+    // CHECK-LABEL: func.func @embedding_1x1_no_canonicalize
+    // CHECK-NOT:   "ttir.reshape"
+    // CHECK:       "ttir.embedding"
+    // CHECK-SAME:  (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
+    %0 = "ttir.embedding"(%input, %weight) : (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
+    return %0 : tensor<1x1x8xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/embedding_op_canonicalize_tests.mlir
@@ -17,39 +17,39 @@ module {
     return %2 : tensor<4x8xf32>
   }
   // [1, A] – leading unit dimension.
-  func.func @embedding_1xa(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<1x4x8xf32> {
+  func.func @embedding_1xa(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
     // CHECK-LABEL: func.func @embedding_1xa
     // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
     %0 = "ttir.reshape"(%input) <{shape = [1 : i32, 4 : i32]}> : (tensor<4xi32>) -> tensor<1x4xi32>
     %1 = "ttir.embedding"(%0, %weight) : (tensor<1x4xi32>, tensor<10x8xf32>) -> tensor<1x4x8xf32>
-    return %1 : tensor<1x4x8xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [4 : i32, 8 : i32]}> : (tensor<1x4x8xf32>) -> tensor<4x8xf32>
+    return %2 : tensor<4x8xf32>
   }
-
   // Large realistic dimensions – same pattern applies.
-  func.func @embedding_ax1_large(%input: tensor<1836732x1xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x80xf32> {
+  func.func @embedding_ax1_large(%input: tensor<1836732xi64>, %weight: tensor<1993728x80xf32>) -> tensor<1836732x80xf32> {
     // CHECK-LABEL: func.func @embedding_ax1_large
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<1836732x1xi64>) -> tensor<1836732xi64>
+    // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<1836732xi64>, tensor<1993728x80xf32>) -> tensor<1836732x80xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32>
-    %1 = "ttir.reshape"(%0) <{shape = [1836732 : i32, 80 : i32]}> : (tensor<1836732x1x80xf32>) -> tensor<1836732x80xf32>
-    return %1 : tensor<1836732x80xf32>
+    %0 = "ttir.reshape"(%input) <{shape = [1836732 : i32, 1 : i32]}> : (tensor<1836732xi64>) -> tensor<1836732x1xi64>
+    %1 = "ttir.embedding"(%0, %weight) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [1836732 : i32, 80 : i32]}> : (tensor<1836732x1x80xf32>) -> tensor<1836732x80xf32>
+    return %2 : tensor<1836732x80xf32>
   }
 
 
   // 1-D index tensor with no unit dims – pattern must NOT fire.
-  func.func @embedding_1d_no_canonicalize(%input: tensor<4xi32>, %weight: tensor<10x8xf32>) -> tensor<4x8xf32> {
+  func.func @embedding_1d_no_canonicalize(%input: tensor<2x2xi32>, %weight: tensor<10x8xf32>) -> tensor<2x2x8xf32> {
     // CHECK-LABEL: func.func @embedding_1d_no_canonicalize
-    // CHECK-NOT:   "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
-    return %0 : tensor<4x8xf32>
+    %0 = "ttir.reshape"(%input) <{shape = [4 : i32]}> : (tensor<2x2xi32>) -> tensor<4xi32>
+    %1 = "ttir.embedding"(%0, %weight) : (tensor<4xi32>, tensor<10x8xf32>) -> tensor<4x8xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [2 : i32, 2 : i32, 8 : i32]}> : (tensor<4x8xf32>) -> tensor<2x2x8xf32>
+    return %2 : tensor<2x2x8xf32>
   }
-
   // Indices does not come from reshape, output does not go to reshape, pattern must NOT fire.
   func.func @embedding_1d_no_canonicalize_reshapes(%input: tensor<4x1xi32>, %weight: tensor<10x8xf32>) -> tensor<4x1x8xf32> {
     // CHECK-LABEL: func.func @embedding_1d_no_canonicalize_reshapes
@@ -61,15 +61,17 @@ module {
   }
 
   // All-ones input [1, 1] – would produce scalar index.
-  func.func @embedding_1x1_canonicalize(%input: tensor<1x1xi32>, %weight: tensor<10x8xf32>) -> tensor<1x8xf32> {
+  func.func @embedding_1x1_canonicalize(%input: tensor<1xi32>, %weight: tensor<10x8xf32>) -> tensor<1x8xf32> {
     // CHECK-LABEL: func.func @embedding_1x1_canonicalize
-    // CHECK:       "ttir.reshape"
-    // CHECK-SAME:  tensor<1x1xi32>) -> tensor<1xi32>
+    // CHECK-NOT:       "ttir.reshape"
     // CHECK:       "ttir.embedding"
     // CHECK-SAME:  (tensor<1xi32>, tensor<10x8xf32>) -> tensor<1x8xf32>
-    %0 = "ttir.embedding"(%input, %weight) : (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
-    %1 = "ttir.reshape"(%0) <{shape = [1 : i32, 8 : i32]}> : (tensor<1x1x8xf32>) -> tensor<1x8xf32>
-    return %1 : tensor<1x8xf32>
+    %0 = "ttir.reshape"(%input) <{shape = [1 : i32, 1 : i32]}> : (tensor<1xi32>) -> tensor<1x1xi32>
+    %1 = "ttir.embedding"(%0, %weight) : (tensor<1x1xi32>, tensor<10x8xf32>) -> tensor<1x1x8xf32>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 8 : i32]}> : (tensor<1x1x8xf32>) -> tensor<1x8xf32>
+    return %2 : tensor<1x8xf32>
   }
+
+
 
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/gather_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/gather_op.mlir
@@ -9,16 +9,16 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_0
   func.func @gather_0(%operand: tensor<32000x1024xbf16>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<32xui32, {{.+}}>, tensor<32000x1024xbf16, {{.+}}>) -> tensor<32x1024xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x32xui32, {{.+}}>, tensor<32000x1024xbf16, {{.+}}>) -> tensor<1x32x1024xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1024>}> : (tensor<32000x1024xbf16>, tensor<1x32xi32>) -> tensor<1x32x1024xbf16>
     return %1 : tensor<1x32x1024xbf16>
   }
 
   // CHECK-LABEL: func.func @gather_1
   func.func @gather_1(%operand: tensor<448x384xbf16>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x384xbf16> {
-    // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
     // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<2x384xbf16, {{.+}}>
+    // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<448x384xbf16>, tensor<1x2x1xi32>) -> tensor<1x2x384xbf16>
     return %1 : tensor<1x2x384xbf16>
   }
@@ -26,7 +26,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_2
   func.func @gather_2(%operand: tensor<51864x384xbf16>, %start_indices: tensor<1x2xi32>) -> tensor<1x2x384xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<51864x384xbf16, {{.+}}>) -> tensor<2x384xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<51864x384xbf16, {{.+}}>) -> tensor<1x2x384xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<51864x384xbf16>, tensor<1x2xi32>) -> tensor<1x2x384xbf16>
     return %1 : tensor<1x2x384xbf16>
   }
@@ -34,8 +34,8 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_3
   func.func @gather_3(%operand: tensor<732x12xf32>, %start_indices: tensor<38809x1xi32>) -> tensor<38809x12xf32> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<38809xui32, {{.+}}>, tensor<732x12xbf16, {{.+}}>) -> tensor<38809x12xbf16, {{.+}}>
-    // CHECK: "ttnn.typecast"
+    // CHECK-SAME: (tensor<38809x1xui32, {{.+}}>, tensor<732x12xbf16, {{.+}}>) -> tensor<38809x1x12xbf16, {{.+}}>
+    // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 12>}> : (tensor<732x12xf32>, tensor<38809x1xi32>) -> tensor<38809x12xf32>
     return %1 : tensor<38809x12xf32>
   }
@@ -57,8 +57,8 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<14x512xbf16, {{.+}}>) -> tensor<2x512xbf16, {{.+}}>
-    // CHECK: "ttnn.typecast"
+    // CHECK-SAME: (tensor<2x1xui32, {{.+}}>, tensor<14x512xbf16, {{.+}}>) -> tensor<2x1x512xbf16, {{.+}}>
+    // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 512>}> : (tensor<2x7x512xf32>, tensor<2x2xi32>) -> tensor<2x512xf32>
     return %1 : tensor<2x512xf32>
   }
@@ -67,9 +67,8 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_6
   func.func @gather_6(%operand: tensor<6xbf16>, %start_indices: tensor<1xi32>) -> (tensor<1xbf16> {jax.result_info = "result"}) {
     // CHECK: "ttnn.reshape"
-    // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x1xui32, {{.+}}>, tensor<6x1xbf16, {{.+}}>) -> tensor<1x1x1xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1xui32, {{.+}}>, tensor<6x1xbf16, {{.+}}>) -> tensor<1x1xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<6xbf16>, tensor<1xi32>) -> tensor<1xbf16>
     return %1 : tensor<1xbf16>
@@ -78,7 +77,8 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_7
   func.func @gather_7(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
+    // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x4xbf16>
     return %1 : tensor<3x4xbf16>
   }
@@ -86,7 +86,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_8
   func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x1x4xbf16>
     return %1 : tensor<3x1x4xbf16>
   }
@@ -170,7 +170,7 @@ module attributes {} {
   func.func @gather_15(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<4xui32, {{.+}}>, tensor<5x6xbf16, {{.+}}>) -> tensor<4x6xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<4x1xui32, {{.+}}>, tensor<5x6xbf16, {{.+}}>) -> tensor<4x1x6xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 1, 2], collapsed_slice_dims = [3], start_index_map = [3], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2, 3, 1>}> : (tensor<1x2x3x5xf32>, tensor<4x1xi32>) -> tensor<1x2x3x4xf32>
     return %1 : tensor<1x2x3x4xf32>
@@ -183,7 +183,7 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<35x2xbf16, {{.+}}>) -> tensor<3x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<35x2xbf16, {{.+}}>) -> tensor<3x1x2xbf16, {{.+}}>
     // CHECK: "ttnn.permute"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 1], collapsed_slice_dims = [2, 3], start_index_map = [2, 3], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2, 1, 1>}> : (tensor<1x2x5x7xf32>, tensor<3x2xi32>) -> tensor<1x2x3xf32>
     return %1 : tensor<1x2x3xf32>
@@ -193,7 +193,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_17
   func.func @gather_17(%operand: tensor<32128x512xbf16>, %start_indices: tensor<1x15xi64>) -> tensor<1x15x512xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<15xui32, {{.+}}>, tensor<32128x512xbf16, {{.+}}>) -> tensor<15x512xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<1x15xui32, {{.+}}>, tensor<32128x512xbf16, {{.+}}>) -> tensor<1x15x512xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 512>}> : (tensor<32128x512xbf16>, tensor<1x15xi64>) -> tensor<1x15x512xbf16>
     return %1 : tensor<1x15x512xbf16>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/gather_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/gather_op.mlir
@@ -9,7 +9,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_0
   func.func @gather_0(%operand: tensor<32000x1024xbf16>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x32xui32, {{.+}}>, tensor<32000x1024xbf16, {{.+}}>) -> tensor<1x32x1024xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<32xui32, {{.+}}>, tensor<32000x1024xbf16, {{.+}}>) -> tensor<32x1024xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1024>}> : (tensor<32000x1024xbf16>, tensor<1x32xi32>) -> tensor<1x32x1024xbf16>
     return %1 : tensor<1x32x1024xbf16>
   }
@@ -18,7 +18,7 @@ module attributes {} {
   func.func @gather_1(%operand: tensor<448x384xbf16>, %start_indices: tensor<1x2x1xi32>) -> tensor<1x2x384xbf16> {
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<1x2x384xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<448x384xbf16, {{.+}}>) -> tensor<2x384xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<448x384xbf16>, tensor<1x2x1xi32>) -> tensor<1x2x384xbf16>
     return %1 : tensor<1x2x384xbf16>
   }
@@ -26,7 +26,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_2
   func.func @gather_2(%operand: tensor<51864x384xbf16>, %start_indices: tensor<1x2xi32>) -> tensor<1x2x384xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<51864x384xbf16, {{.+}}>) -> tensor<1x2x384xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<51864x384xbf16, {{.+}}>) -> tensor<2x384xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<51864x384xbf16>, tensor<1x2xi32>) -> tensor<1x2x384xbf16>
     return %1 : tensor<1x2x384xbf16>
   }
@@ -34,8 +34,8 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_3
   func.func @gather_3(%operand: tensor<732x12xf32>, %start_indices: tensor<38809x1xi32>) -> tensor<38809x12xf32> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<38809x1xui32, {{.+}}>, tensor<732x12xbf16, {{.+}}>) -> tensor<38809x1x12xbf16, {{.+}}>
-    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: (tensor<38809xui32, {{.+}}>, tensor<732x12xbf16, {{.+}}>) -> tensor<38809x12xbf16, {{.+}}>
+    // CHECK: "ttnn.typecast"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 12>}> : (tensor<732x12xf32>, tensor<38809x1xi32>) -> tensor<38809x12xf32>
     return %1 : tensor<38809x12xf32>
   }
@@ -45,7 +45,7 @@ module attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<1x2x200xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<2048x200xbf16, {{.+}}>) -> tensor<2x200xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2, 3], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 200>}> : (tensor<2048x1x200xf32>, tensor<1x2x1xi32>) -> tensor<1x2x1x200xf32>
     return %1 : tensor<1x2x1x200xf32>
@@ -57,8 +57,8 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<2x1xui32, {{.+}}>, tensor<14x512xbf16, {{.+}}>) -> tensor<2x1x512xbf16, {{.+}}>
-    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<14x512xbf16, {{.+}}>) -> tensor<2x512xbf16, {{.+}}>
+    // CHECK: "ttnn.typecast"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 512>}> : (tensor<2x7x512xf32>, tensor<2x2xi32>) -> tensor<2x512xf32>
     return %1 : tensor<2x512xf32>
   }
@@ -78,8 +78,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_7
   func.func @gather_7(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x4xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
-    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x4xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x4xbf16>
     return %1 : tensor<3x4xbf16>
   }
@@ -87,7 +86,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_8
   func.func @gather_8(%operand: tensor<6x4xbf16>, %start_indices: tensor<3x1xi32>) -> tensor<3x1x4xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x1x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<6x4xbf16, {{.+}}>) -> tensor<3x4xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 4>}> : (tensor<6x4xbf16>, tensor<3x1xi32>) -> tensor<3x1x4xbf16>
     return %1 : tensor<3x1x4xbf16>
   }
@@ -112,7 +111,7 @@ module attributes {} {
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x4xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<1x4x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<4xui32, {{.+}}>, tensor<56x2xbf16, {{.+}}>) -> tensor<4x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 2>}> : (tensor<7x8x2xf32>, tensor<2x2x2xi32>) -> tensor<2x2x2xf32>
     return %1 : tensor<2x2x2xf32>
@@ -125,7 +124,7 @@ module attributes {} {
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x9xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<1x9x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<9xui32, {{.+}}>, tensor<306x2xbf16, {{.+}}>) -> tensor<9x2xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [3], collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 3>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 2>}> : (tensor<18x17x2xf32>, tensor<3x1x3x2xi32>) -> tensor<3x1x3x2xf32>
     return %1 : tensor<3x1x3x2xf32>
@@ -138,7 +137,7 @@ module attributes {} {
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x2xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<1x2x4xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<2xui32, {{.+}}>, tensor<20x4xbf16, {{.+}}>) -> tensor<2x4xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [3, 4], collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 3>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 2, 2>}> : (tensor<4x5x2x2xf32>, tensor<2x1x1x2xi32>) -> tensor<2x1x1x2x2xf32>
     return %1 : tensor<2x1x1x2x2xf32>
@@ -171,7 +170,7 @@ module attributes {} {
   func.func @gather_15(%operand: tensor<1x2x3x5xf32>, %start_indices: tensor<4x1xi32>) -> (tensor<1x2x3x4xf32> {jax.result_info = "result"}) {
     // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<4x1xui32, {{.+}}>, tensor<5x6xbf16, {{.+}}>) -> tensor<4x1x6xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<4xui32, {{.+}}>, tensor<5x6xbf16, {{.+}}>) -> tensor<4x6xbf16, {{.+}}>
     // CHECK: "ttnn.reshape"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 1, 2], collapsed_slice_dims = [3], start_index_map = [3], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2, 3, 1>}> : (tensor<1x2x3x5xf32>, tensor<4x1xi32>) -> tensor<1x2x3x4xf32>
     return %1 : tensor<1x2x3x4xf32>
@@ -184,7 +183,7 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK: "ttnn.matmul"
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<3x1xui32, {{.+}}>, tensor<35x2xbf16, {{.+}}>) -> tensor<3x1x2xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<3xui32, {{.+}}>, tensor<35x2xbf16, {{.+}}>) -> tensor<3x2xbf16, {{.+}}>
     // CHECK: "ttnn.permute"
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 1], collapsed_slice_dims = [2, 3], start_index_map = [2, 3], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 2, 1, 1>}> : (tensor<1x2x5x7xf32>, tensor<3x2xi32>) -> tensor<1x2x3xf32>
     return %1 : tensor<1x2x3xf32>
@@ -194,7 +193,7 @@ module attributes {} {
   // CHECK-LABEL: func.func @gather_17
   func.func @gather_17(%operand: tensor<32128x512xbf16>, %start_indices: tensor<1x15xi64>) -> tensor<1x15x512xbf16> {
     // CHECK: "ttnn.embedding"
-    // CHECK-SAME: (tensor<1x15xui32, {{.+}}>, tensor<32128x512xbf16, {{.+}}>) -> tensor<1x15x512xbf16, {{.+}}>
+    // CHECK-SAME: (tensor<15xui32, {{.+}}>, tensor<32128x512xbf16, {{.+}}>) -> tensor<15x512xbf16, {{.+}}>
     %1 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 512>}> : (tensor<32128x512xbf16>, tensor<1x15xi64>) -> tensor<1x15x512xbf16>
     return %1 : tensor<1x15x512xbf16>
   }


### PR DESCRIPTION
### Ticket
#8300 

### Problem description
Embedding op index tensor can cause DRAM OOM when unsqueezed. For example:
```
%9 = "ttir.embedding"(%6, %8) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32> loc(#loc8)
 ```

This is an embedding op with batch size 1836732 and sequence length 1. However, it can be rewritten as:

```
%9 = "ttir.embedding"(%5, %8) : (tensor<1836732xi64>, tensor<1993728x80xf32>) -> tensor<1836732x80xf32>
```

### What's changed
When the index tensor is unsqueezed, this is what will happen: squeeze(index_tensor) --> embedding op --> unsqueeze 

Added embedding op canonicalizer which adds reshapes before and after embedding op to squeeze the index tensor and unsqueeze the output. In a lot of graphs, the inserted reshapes will be folded anyways. For example:
```
func.func @main(%arg0: tensor<1836732x1xi64> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1836732x1xi64>>, ttcore.shard_status = #ttcore.shard_status<unsharded>} loc("p0.1"), %arg1: tensor<1993728x80xf32> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1993728x80xf32>>, ttcore.shard_status = #ttcore.shard_status<unsharded>} loc("p1.16")) -> (tensor<1836732x80xf32> {ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1836732x80xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) {
        %0 = "ttir.constant"() <{value = dense<1993728> : tensor<1836732xi64>}> : () -> tensor<1836732xi64> loc(#loc)
        %1 = "ttir.constant"() <{value = dense<0> : tensor<1836732xi64>}> : () -> tensor<1836732xi64> loc(#loc)
        %2 = "ttir.reshape"(%arg0) <{shape = [1836732 : i32]}> : (tensor<1836732x1xi64>) -> tensor<1836732xi64> loc(#loc3)
        %3 = "ttir.lt"(%2, %1) : (tensor<1836732xi64>, tensor<1836732xi64>) -> tensor<1836732xi1> loc(#loc4)
        %4 = "ttir.add"(%2, %0) : (tensor<1836732xi64>, tensor<1836732xi64>) -> tensor<1836732xi64> loc(#loc5)
        %5 = "ttir.where"(%3, %4, %2) : (tensor<1836732xi1>, tensor<1836732xi64>, tensor<1836732xi64>) -> tensor<1836732xi64> loc(#loc6)
        %6 = "ttir.reshape"(%5) <{shape = [1836732 : i32, 1 : i32]}> : (tensor<1836732xi64>) -> tensor<1836732x1xi64> loc(#loc7)
        %7 = "ttir.permute"(%arg1) <{permutation = array<i64: 0, 1>}> : (tensor<1993728x80xf32>) -> tensor<1993728x80xf32> loc(#loc9)
        %8 = "ttir.reshape"(%7) <{shape = [1993728 : i32, 80 : i32]}> : (tensor<1993728x80xf32>) -> tensor<1993728x80xf32> loc(#loc10)
        %9 = "ttir.embedding"(%6, %8) : (tensor<1836732x1xi64>, tensor<1993728x80xf32>) -> tensor<1836732x1x80xf32> loc(#loc8)
        %10 = "ttir.reshape"(%9) <{shape = [1836732 : i32, 80 : i32]}> : (tensor<1836732x1x80xf32>) -> tensor<1836732x80xf32> loc(#loc11)
        %11 = "ttir.permute"(%10) <{permutation = array<i64: 0, 1>}> : (tensor<1836732x80xf32>) -> tensor<1836732x80xf32> loc(#loc12)
        return %11 : tensor<1836732x80xf32> loc(#loc)
      } loc(#loc)
```
The canonicalizer will insert a reshape on %6 which converts 1836732x1 -> 1836732. The canonicalizer will insert a reshape on %9 which converts 1836732x80 -> 1836732x1x80. Afterwards, these reshapes will be folded away with operations %6 and %10.

- [x] tt-xla model-test-passing: https://github.com/tenstorrent/tt-xla/actions/runs/25663687668 
