### PR TITLE
Uplift third_party/tt-metal to 89883e453b9c0ee182fea67a26cbb8b493622144 2026-05-07

### DIFF
--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
@@ -16,7 +16,7 @@
   per_core_m = 8,
   per_core_n = 6,
   fuse_batch = true,
-  fused_activation = #ttnn.unary_with_param<op_type = sub_unary_sfpu, params = [1.0 : f32]>,
+  fused_activation = #ttnn.unary_with_param<op_type = silu, params = [1.0 : f32]>,
   mcast_in0 = true,
   gather_in0 = false,
   hop_cores = #ttnn.core_range_set<>,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "61e690c25202111b52cbc1fbc9148b6524070c6f")
+set(TT_METAL_VERSION "89883e453b9c0ee182fea67a26cbb8b493622144")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 89883e453b9c0ee182fea67a26cbb8b493622144



### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25505605973
          - Note: there is one failure in this test, but that's an existing one. The [onPR on tt-forge-onnx main](https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25524408676) (without this uplift) is also failing the same test.
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25522308417/job/74929242871
          - Note: the above CI run was based off of the latest commit from the [hshah/uplift-latest-tt-xla-rebase](https://github.com/tenstorrent/tt-mlir/tree/hshah/uplift-latest-tt-xla-rebase) tt-mlir branch. This was to isolate test failures caused by the latest tt-mlir HEAD
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): N/A
  - [x] **Frontend fix PRs** ready (if needed by this uplift): N/A