### PR TITLE
[L1SpillManagement] Run CB/L1 overlap check for DRAM-output ops

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -536,8 +536,14 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(
     l1Size = handleNoFit(op, pos, data, opL1Usage, l1Size);
     speculativeAddr = memoryTracker.wouldAllocateAt(l1Size);
   }
-  if (l1Size > 0 && speculativeAddr &&
-      wouldCBsOverlapTensors(op, pos, cbPeakUsage, *speculativeAddr)) {
+  // Always run the overlap check when the op declares a non-zero CB peak;
+  // pass UINT64_MAX as the "no L1 output" sentinel so wouldCBsOverlapTensors
+  // compares cushionedCBUsage strictly against the lowest-existing tensor
+  // address.
+  uint64_t addrForCheck =
+      speculativeAddr.value_or(std::numeric_limits<uint64_t>::max());
+  if (cbPeakUsage > 0 &&
+      wouldCBsOverlapTensors(op, pos, cbPeakUsage, addrForCheck)) {
     l1Size = handleFragmentation(op, pos, data, opL1Usage, cbPeakUsage, l1Size);
   }
   return l1Size;
@@ -574,10 +580,7 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
   if (result.isSuccess()) {
     uint64_t l1Size =
         result.outputL1Usage > 0 ? result.outputL1Usage : opL1Usage;
-    if (l1Size > 0) {
-      l1Size =
-          ensureFitsL1(op, pos, data, opL1Usage, result.cbPeakUsage, l1Size);
-    }
+    l1Size = ensureFitsL1(op, pos, data, opL1Usage, result.cbPeakUsage, l1Size);
     if (l1Size > 0) {
       addResultsToLiveSet(l1Size);
       observer_->onLiveAdded(op, pos, l1Size, pos,


### PR DESCRIPTION
### Problem 

ensureFitsL1 and handleOOM previously skipped wouldCBsOverlapTensors when the candidate output l1Size was zero (i.e. the op writes to DRAM or has no L1 output tensor).  But many DRAM-output ops still allocate non-trivial circular buffers in L1 -- e.g., a softmax with sharded L1 input + DRAM output reports outputL1=0 while cbPeakUsage is hundreds of KB.  Those CBs occupy bottom-up L1 at runtime and can collide with existing low-address L1 input tensors that the simulator still has live.

Specifically, on Gemma-4 with optimization_level=2 we observed softmax program 46 with WS 1x110 inputs and DRAM output crashing in runtime with "Statically allocated circular buffers ... clash with L1 buffers", because ensureFitsL1's `l1Size > 0` guard short-circuited the FRAG check before the CB overlap was evaluated.

### Fix 

Drop the `l1Size > 0` guard in ensureFitsL1 and check on `cbPeakUsage > 0` instead, passing UINT64_MAX as the speculativeOutputAddr sentinel so wouldCBsOverlapTensors compares cushionedCBUsage strictly against the lowest-existing tensor address (no max() collapse).  Also drop the matching `l1Size > 0` guard around ensureFitsL1's call site in handleOOM's post-eviction success path so the overlap check still runs after eviction selects a DRAM-output op.
