### PR TITLE
Fuse `ttir.pad` into `ttir.conv3d`

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -2992,6 +2992,77 @@ public:
   }
 };
 
+// Fuse a `ttir.pad` followed by `ttir.conv3d` into a single conv3d that
+// absorbs the pad into its `padding` attribute.
+//
+// Conv3d only supports symmetric, zero-valued padding (mode "zeros"), so the
+// fusion only fires when the producing pad is symmetric, has value 0.0, and
+// pads only the spatial (depth/height/width) dimensions.
+class PadConv3dFusionPattern : public mlir::OpRewritePattern<Conv3dOp> {
+  using mlir::OpRewritePattern<Conv3dOp>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(Conv3dOp convOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    auto padOp = convOp.getInput().getDefiningOp<PadOp>();
+    if (!padOp || !padOp->hasOneUse()) {
+      return mlir::failure();
+    }
+
+    if (convOp.getPaddingMode() != "zeros") {
+      return mlir::failure();
+    }
+
+    if (!padOp.getValue().isZero()) {
+      return mlir::failure();
+    }
+
+    auto inputRank = padOp.getInput().getType().getRank();
+    llvm::ArrayRef<int32_t> padArr = padOp.getPadding();
+    assert(padArr.size() == 2ul * inputRank && "Invalid padding array size");
+
+    int64_t batchDim = convOp.getBatchDim();
+    int64_t channelDim = convOp.getChannelDim();
+    int64_t depthDim = convOp.getDepthDim();
+    int64_t heightDim = convOp.getHeightDim();
+    int64_t widthDim = convOp.getWidthDim();
+
+    // Conv3dOp only supports symmetric padding for spatial dimensions.
+    for (int64_t dim = 0; dim < inputRank; ++dim) {
+      int32_t low = padArr[2 * dim];
+      int32_t high = padArr[2 * dim + 1];
+      // Padding must be symmetric.
+      if (low != high) {
+        return mlir::failure();
+      }
+      // Padding must be zero for batch and channel dimensions.
+      if ((dim == batchDim || dim == channelDim) && low != 0) {
+        return mlir::failure();
+      }
+    }
+
+    auto existing =
+        ttmlir::utils::getTripleOfInteger<int32_t>(convOp.getPaddingAttr());
+    if (auto err = existing.takeError()) {
+      llvm::consumeError(std::move(err));
+      return mlir::failure();
+    }
+    auto [curD, curH, curW] = *existing;
+
+    auto newPaddingAttr = rewriter.getDenseI32ArrayAttr(
+        {curD + padArr[2 * depthDim], curH + padArr[2 * heightDim],
+         curW + padArr[2 * widthDim]});
+
+    rewriter.modifyOpInPlace(convOp, [&]() {
+      convOp.getInputMutable().assign(padOp.getInput());
+      convOp.setPaddingAttr(newPaddingAttr);
+    });
+
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
@@ -3013,6 +3084,7 @@ public:
       patterns.add<ConvAddBias<Conv2dOp>>(&getContext());
       patterns.add<ConvAddBias<ConvTranspose2dOp>>(&getContext());
       patterns.add<ConvAddBias<Conv3dOp>>(&getContext());
+      patterns.add<PadConv3dFusionPattern>(&getContext());
 
       // Add patterns for each reduction op type.
       patterns.add<ReductionWithReshapePattern<SumOp>>(&getContext());

--- a/test/ttmlir/Dialect/TTIR/fusing/pad_conv3d_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/pad_conv3d_fusing.mlir
@@ -1,0 +1,92 @@
+// RUN: ttmlir-opt --ttir-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Positive: symmetric, zero-valued pad on spatial dims fuses into conv3d.
+// Layout is NCDHW (matches the StableHLO -> TTIR conv3d lowering).
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_fuse
+  func.func @pad_conv3d_fuse(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16> {
+    // CHECK-NOT: ttir.pad
+    // CHECK: %[[CONV:.*]] = "ttir.conv3d"(%arg0, %arg1)
+    // CHECK-SAME: padding = array<i32: 0, 1, 1>
+    // CHECK-SAME: padding_mode = "zeros"
+    // CHECK-SAME: stride = array<i32: 1, 1, 1>
+    // CHECK-NEXT: return %[[CONV]]
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16>
+    return %1 : tensor<1x512x4x120x208xbf16>
+  }
+}
+
+// Positive: pad amounts add to existing conv3d padding.
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_sum
+  func.func @pad_conv3d_sum(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x6x122x210xbf16> {
+    // CHECK-NOT: ttir.pad
+    // CHECK: "ttir.conv3d"
+    // CHECK-SAME: padding = array<i32: 1, 2, 2>
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 1, 1, 1>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x6x122x210xbf16>
+    return %1 : tensor<1x512x6x122x210xbf16>
+  }
+}
+
+// Negative: asymmetric pad cannot be folded into conv3d (which requires symmetric padding).
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_asymmetric
+  func.func @pad_conv3d_asymmetric(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x119x207xbf16> {
+    // CHECK: ttir.pad
+    // CHECK: ttir.conv3d
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 0, 1, 0>, value = 0.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x121x209xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x121x209xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x119x207xbf16>
+    return %1 : tensor<1x512x4x119x207xbf16>
+  }
+}
+
+// Negative: nonzero pad value is incompatible with conv3d "zeros" padding mode.
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_nonzero_value
+  func.func @pad_conv3d_nonzero_value(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16> {
+    // CHECK: ttir.pad
+    // CHECK: ttir.conv3d
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 1, 1, 1>, value = 1.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16>
+    return %1 : tensor<1x512x4x120x208xbf16>
+  }
+}
+
+// Negative: padding the channel dim cannot be folded into conv3d.
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_channel_pad
+  func.func @pad_conv3d_channel_pad(%arg0: tensor<1x510x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16> {
+    // CHECK: ttir.pad
+    // CHECK: ttir.conv3d
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 1, 1, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x510x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16>
+    return %1 : tensor<1x512x4x120x208xbf16>
+  }
+}
+
+// Negative: conv3d padding mode "replicate" cannot absorb a zero pad.
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_replicate_mode
+  func.func @pad_conv3d_replicate_mode(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16> {
+    // CHECK: ttir.pad
+    // CHECK: ttir.conv3d
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "replicate", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16>
+    return %1 : tensor<1x512x4x120x208xbf16>
+  }
+}
+
+// Negative: pad with multiple uses cannot be fused (would still leave the pad alive).
+module {
+  // CHECK-LABEL: func.func @pad_conv3d_multiple_uses
+  func.func @pad_conv3d_multiple_uses(%arg0: tensor<1x512x6x120x208xbf16>, %arg1: tensor<512x512x3x3x3xbf16>) -> (tensor<1x512x4x120x208xbf16>, tensor<1x512x6x122x210xbf16>) {
+    // CHECK: ttir.pad
+    // CHECK: ttir.conv3d
+    %0 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x512x6x120x208xbf16>) -> tensor<1x512x6x122x210xbf16>
+    %1 = "ttir.conv3d"(%0, %arg1) <{batch_dim = 0 : i64, channel_dim = 1 : i64, depth_dim = 2 : i64, groups = 1 : i32, height_dim = 3 : i64, padding = array<i32: 0, 0, 0>, padding_mode = "zeros", stride = array<i32: 1, 1, 1>, width_dim = 4 : i64}> : (tensor<1x512x6x122x210xbf16>, tensor<512x512x3x3x3xbf16>) -> tensor<1x512x4x120x208xbf16>
+    return %1, %0 : tensor<1x512x4x120x208xbf16>, tensor<1x512x6x122x210xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8296

### Problem description
The `ttir.conv3d` op supports symmetrical zero-padding of spatiotemporal dimensions. In standard lowering through StableHLO padding and conv3d are separate ops, which are lowered separately to `ttir.pad` and `ttir.conv3d`, respectively.

### What's changed
Added a fusing pattern when `ttir.pad` symmetrically zero-pads spatiotemporal dimensions.

### Checklist
- [x] New/Existing tests provide coverage for changes
