### PR TITLE
Fix(stablehlo-to-ttir): peel artificial bf16->wider upcast on compare ops

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3462,14 +3462,87 @@ private:
   matchAndRewriteInternal(mlir::stablehlo::CompareOp srcOp,
                           mlir::stablehlo::CompareOp::Adaptor adaptor,
                           ConversionPatternRewriter &rewriter) const {
-    mlir::RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(this->getTypeConverter()->convertType(
-            srcOp->getResults()[0].getType()));
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    rewriter.replaceOpWithNewOp<DestOp>(srcOp, outputType, adaptor.getLhs(),
-                                        adaptor.getRhs());
+    // If one operand is a `stablehlo.convert(narrow -> wider)` and the other
+    // is a `stablehlo.constant<wider>` whose elements fit in the narrow
+    // type, replace both with the narrow input and a freshly-narrowed
+    // constant so the compare runs in the narrow dtype.
+    Value lhs = srcOp.getLhs();
+    Value rhs = srcOp.getRhs();
+    if (auto peeled = tryPeelUpcast(lhs, rhs, rewriter); succeeded(peeled)) {
+      std::tie(lhs, rhs) = *peeled;
+    }
 
+    rewriter.replaceOpWithNewOp<DestOp>(srcOp, outputType, lhs, rhs);
     return success();
+  }
+
+  // Returns the new `(lhs, rhs)` pair when one of the operands is
+  // `stablehlo.convert(narrow -> wider)` and the other is a
+  // `stablehlo.constant<wider>` whose elements convert to `narrow` via
+  // rmNearestTiesToEven. Tries both lhs/rhs orderings; preserves operand
+  // order on success. Returns failure when the pattern does not apply.
+  static mlir::FailureOr<std::pair<Value, Value>>
+  tryPeelUpcast(Value lhs, Value rhs, ConversionPatternRewriter &rewriter) {
+    auto lhsCvt = lhs.getDefiningOp<mlir::stablehlo::ConvertOp>();
+    auto rhsCvt = rhs.getDefiningOp<mlir::stablehlo::ConvertOp>();
+    auto lhsCst = lhs.getDefiningOp<mlir::stablehlo::ConstantOp>();
+    auto rhsCst = rhs.getDefiningOp<mlir::stablehlo::ConstantOp>();
+
+    mlir::stablehlo::ConvertOp cvt;
+    mlir::stablehlo::ConstantOp cst;
+    bool cvtIsLhs = false;
+    if (lhsCvt && rhsCst) {
+      cvt = lhsCvt;
+      cst = rhsCst;
+      cvtIsLhs = true;
+    } else if (rhsCvt && lhsCst) {
+      cvt = rhsCvt;
+      cst = lhsCst;
+    } else {
+      return mlir::failure();
+    }
+
+    auto narrowTy =
+        mlir::dyn_cast<RankedTensorType>(cvt.getOperand().getType());
+    auto widerTy = mlir::dyn_cast<RankedTensorType>(cvt.getType());
+    auto narrowEt = narrowTy
+                        ? mlir::dyn_cast<FloatType>(narrowTy.getElementType())
+                        : nullptr;
+    auto widerEt =
+        widerTy ? mlir::dyn_cast<FloatType>(widerTy.getElementType()) : nullptr;
+    if (!narrowEt || !widerEt || narrowEt.getWidth() >= widerEt.getWidth()) {
+      return mlir::failure();
+    }
+    auto attr = mlir::dyn_cast<mlir::DenseFPElementsAttr>(cst.getValue());
+    if (!attr) {
+      return mlir::failure();
+    }
+
+    llvm::SmallVector<llvm::APFloat> vals;
+    vals.reserve(attr.getNumElements());
+    for (const llvm::APFloat &v : attr.getValues<llvm::APFloat>()) {
+      llvm::APFloat narrow = v;
+      bool lose = false;
+      auto st = narrow.convert(narrowEt.getFloatSemantics(),
+                               llvm::APFloat::rmNearestTiesToEven, &lose);
+      if (st != llvm::APFloat::opOK && st != llvm::APFloat::opInexact) {
+        return mlir::failure();
+      }
+      vals.push_back(narrow);
+    }
+    auto narrowCstTy = RankedTensorType::get(narrowTy.getShape(), narrowEt,
+                                             narrowTy.getEncoding());
+    Value narrowInput = cvt.getOperand();
+    Value narrowConst = rewriter.create<mlir::stablehlo::ConstantOp>(
+        cst.getLoc(), narrowCstTy,
+        mlir::DenseElementsAttr::get(narrowCstTy, vals));
+    if (cvtIsLhs) {
+      return std::make_pair(narrowInput, narrowConst);
+    }
+    return std::make_pair(narrowConst, narrowInput);
   }
 };
 } // namespace

--- a/test/ttmlir/Conversion/StableHLOToTTIR/binary/compare_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/binary/compare_op.mlir
@@ -49,4 +49,22 @@ module @jit_eltwise_compare attributes {} {
     return %0 : tensor<13x31xi1>
     // CHECK: return %0 : tensor<13x31xi1>
   }
+
+  // Frontends (e.g. PyTorch/XLA) lower `bf16_tensor < python_scalar` by
+  // upcasting the tensor to a wider type and emitting the compare in the
+  // wider type. This drops PyTorch eager semantics (which compares in bf16)
+  // and flips the result at bf16-rounding boundaries. The conversion should
+  // peel the artificial upcast and narrow the constant.
+  func.func public @test_lt_bf16_through_f64_upcast(%arg0: tensor<1x2000x4xbf16>) -> tensor<1x2000x4xi1> {
+    // CHECK-LABEL: func.func public @test_lt_bf16_through_f64_upcast
+    // CHECK-NOT: ttir.typecast
+    // CHECK-NOT: tensor<{{.*}}xf64>
+    // CHECK: "ttir.constant"() <{value = dense<{{.*}}> : tensor<1x2000x4xbf16>}>
+    // CHECK: = "ttir.lt"(%arg0, %{{[^)]+}})
+    // CHECK-SAME: (tensor<1x2000x4xbf16>, tensor<1x2000x4xbf16>) -> tensor<1x2000x4xi1>
+    %cst = stablehlo.constant dense<0.99> : tensor<1x2000x4xf64>
+    %0 = stablehlo.convert %arg0 : (tensor<1x2000x4xbf16>) -> tensor<1x2000x4xf64>
+    %1 = stablehlo.compare  LT, %0, %cst : (tensor<1x2000x4xf64>, tensor<1x2000x4xf64>) -> tensor<1x2000x4xi1>
+    return %1 : tensor<1x2000x4xi1>
+  }
 }


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4554

### Problem description

- `bf16_tensor < python_scalar` (and other compare ops) get an artificial `bf16 → f64` upcast inserted by torch-xla. After tt-mlir's `ElementTypeNormalization` collapses f64 → fp32, the compare runs on device in **fp32** instead of **bf16** — diverging from PyTorch eager semantics at bf16-rounding boundaries leading to nan pcc
- For complete details, pls checkout [#4554](https://github.com/tenstorrent/tt-xla/issues/4554)

### What's changed

- In `StableHLOToTTIRCompareOpConversionPattern`, peel the artificial upcast when one operand is `stablehlo.convert(narrow → wider)` and the other is a matching `stablehlo.constant<wider>`:
  - Narrow the constant elementwise via `rmNearestTiesToEven` (matching PyTorch eager scalar promotion).
  - Drop the `convert` and emit the `ttir.{lt,gt,le,ge,eq,ne}` directly in the narrow dtype.
- Post this changes, sanity's PCC become `1.0` 

### Checklist
- [x] Verify the changes through local testing in N150

### Logs

- [may8_lt_before_fix.log](https://github.com/user-attachments/files/27511426/may8_lt_before_fix.log)
- [may8_lt_after_fix.log](https://github.com/user-attachments/files/27511423/may8_lt_after_fix.log)



