### PR TITLE
Reapply "[OpModel] Introduce opModelExempt and ASSIGN_OR_RETURN macro (#7925)"

### DIFF
--- a/docs/src/ttnn-op-constraints.md
+++ b/docs/src/ttnn-op-constraints.md
@@ -147,9 +147,17 @@ llvm::Expected<OpConstraints>
 OpModel<YourOp>::getOpConstraints(
     ttcore::GridAttr deviceGrid,
     // operation-specific parameters
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
   #ifdef TTMLIR_ENABLE_OPMODEL
-  // 1. Perform necessary conversions, create Tensor objects, etc.
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  // 1. Convert inputs to TensorSpecs using ASSIGN_OR_RETURN.
+  //    This macro unwraps llvm::Expected and returns the error
+  //    on failure, avoiding repetitive error-checking boilerplate.
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // 2. Create query closure
   // Here the ultimate goal is to enable the optimizer to call the
@@ -165,12 +173,13 @@ OpModel<YourOp>::getOpConstraints(
   //      inputs are expected to match the invoke function of the
   //      op in metal.
   auto yourOpQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::yourOp, device, /* other converted parameters */);
+    return QUERY_OP_CONSTRAINTS(
+        ::ttnn::yourOp, device, inputSpec,
+        /* other converted parameters */);
   };
 
   // 3. Call getOpConstraints and pass the callable.
-  return operation::getOpConstraints(getContext(), deviceGrid,
+  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
                                      yourOpQuery);
 #else
   return OpConstraints{};
@@ -180,13 +189,19 @@ OpModel<YourOp>::getOpConstraints(
 llvm::Expected<size_t>
 OpModel<YourOp>::getOpRuntime(
     // operation-specific parameters
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  // Similar to the previous function.
-  // Create query closure
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+
   auto yourOpQuery = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::yourOp, device, /* other converted parameters */);
+    return QUERY_OP_RUNTIME(
+        ::ttnn::yourOp, device, inputSpec,
+        /* other converted parameters */);
   };
 
   return operation::getOpRuntime(yourOpQuery);
@@ -326,45 +341,36 @@ INSTANTIATE_TEST_SUITE_P(
 
 ## Key Considerations
 
-### Error handling: Operations Not Supported
-For operations that cannot support these APIs, use the provided error helpers in `TTNNOpModelInterface.cpp`.
-We're keeping track of such ops in [this issue](https://github.com/tenstorrent/tt-mlir/issues/4392).
-So please either update the issue or add comments to it.
+### Operations Not Supported by OpModel
 
-```cpp
-llvm::Expected<op_model::OpConstraints>
-YourOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::/*..*/);
-}
+If an operation does not need OpModel support (e.g., it has no metal backend
+implementation, requires multi-device support, or simply doesn't benefit from
+constraint analysis), mark it with the `OpModelExempt` trait in its TableGen
+definition:
 
-llvm::Expected<size_t>
-YourOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                     const OpConfig &opConfig) {
-  return detail::issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::/*..*/);
+```tablegen
+def TTNN_YourOp : TTNN_Op<"your_op", [OpModelExempt]> {
+  // ...
 }
 ```
 
-Available error reasons:
-- `NeedsMemoryIO`: Operation requires memory I/O during trace capture
-- `MissingMetalDefinition`: Metal backend implementation is missing
-- `NeedsMultiDevice`: Operation requires multi-device support
-- `NoNeedForConstraintAPI`: Operation doesn't benefit from constraint analysis
-- `ArchitecturalMismatch`: Mismatch in Operation's definition in metal and mlir
+The `OpModelExempt` trait prevents the base op class from adding
+`DeclareOpInterfaceMethods<TTNN_OpModelInterface>`, so no stub
+implementation in `TTNNOpModelInterface.cpp` is needed.
+
+We're keeping track of ops that lack OpModel support in
+[this issue](https://github.com/tenstorrent/tt-mlir/issues/4392).
+Please either update the issue or add comments to it when exempting an op.
 
 ### Device Grid Validation
 
-Validate the device worker grid before proceeding:
+Validate the device worker grid before proceeding using the
+`ASSIGN_OR_RETURN` macro (defined in `ttmlir/OpModel/TTNN/TTNNOpModel.h`)
+combined with `detail::getValidatedDeviceGrid`:
 
 ```cpp
-llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-if (!check) {
-  return check.takeError();
-}
-ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+    detail::getValidatedDeviceGrid(op.getOperation()));
 ```
 
 ### Caching

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
@@ -43,23 +43,35 @@ def TTNN_Dialect : Dialect {
 }
 
 //===----------------------------------------------------------------------===//
+// TTNN traits definition for OpModel.
+//===----------------------------------------------------------------------===//
+
+// Returns [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ...>] when
+// OpModelExempt is absent from traits, or [] when present.
+class IfOpModelRequired<list<Trait> traits> {
+  list<Trait> value = !if(!empty(!filter(t, traits, !eq(t, OpModelExempt))),
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface,
+        ["getOpConstraints", "getOpRuntime"]>], []);
+}
+
+//===----------------------------------------------------------------------===//
 // Base TTNN operation definition.
 //===----------------------------------------------------------------------===//
 
 class TTNN_Op<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [Pure, CheckTileTypeTrait, TTNN_WorkaroundInterface,
-        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
+        Op<TTNN_Dialect, mnemonic, [Pure, CheckTileTypeTrait, TTNN_WorkaroundInterface] #
+        IfOpModelRequired<traits>.value # traits>;
 
 class TTNN_InplaceOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemWrite]>, TTNN_WorkaroundInterface,
-        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
+        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemWrite]>, TTNN_WorkaroundInterface] #
+        IfOpModelRequired<traits>.value # traits>;
 
 class TTNN_MemFreeOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemFree]>, TTNN_WorkaroundInterface,
-        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
+        Op<TTNN_Dialect, mnemonic, [MemoryEffects<[MemFree]>, TTNN_WorkaroundInterface] #
+        IfOpModelRequired<traits>.value # traits>;
 
 class TTNN_MemoryEffectOp<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, TTNN_WorkaroundInterface,
-        DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>] # traits>;
+        Op<TTNN_Dialect, mnemonic, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, TTNN_WorkaroundInterface] #
+        IfOpModelRequired<traits>.value # traits>;
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -23,7 +23,7 @@ include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/CommonAttrConstraints.td"
 
-def TTNN_GetDeviceOp : TTNN_Op<"get_device", [TTCore_DuplicateConstEvalTrait]> {
+def TTNN_GetDeviceOp : TTNN_Op<"get_device", [TTCore_DuplicateConstEvalTrait, OpModelExempt]> {
     let summary = "Get Device op.";
     let description = [{
       This op returns a submesh carved out from the parent runtime device.
@@ -122,7 +122,7 @@ def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
     let hasVerifier = 1;
 }
 
-def TTNN_ToDeviceOp : TTNN_Op<"to_device"> {
+def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
     let summary = "ToDevice op.";
     let description = [{
       This op sends the input tensor to the given device with the given memory config.
@@ -134,7 +134,7 @@ def TTNN_ToDeviceOp : TTNN_Op<"to_device"> {
     let results = (outs AnyRankedTensor:$result);
 }
 
-def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
+def TTNN_FromDeviceOp : TTNN_Op<"from_device", [OpModelExempt]> {
     let summary = "FromDevice op.";
     let description = [{
       This op retrieves the input tensor from the given device.
@@ -1597,7 +1597,7 @@ def TTNN_MatmulOp : TTNN_Op<"matmul", [TTNN_ComputeKernelConfigOpInterface]> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
-def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul"> {
+def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul", [OpModelExempt]> {
     let summary = "Sparse block matrix multiplication with sparsity mask.";
     let description = [{
       The `sparse_matmul` operation performs batched matrix multiplication where
@@ -1648,7 +1648,7 @@ def TTNN_SparseMatmulOp : TTNN_Op<"sparse_matmul"> {
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch"> {
+def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch", [OpModelExempt]> {
     let summary = "Dispatch tokens to expert devices for MoE computation.";
     let description = [{
       Routes tokens to devices holding their selected experts via all-to-all
@@ -1673,7 +1673,7 @@ def TTNN_AllToAllDispatchOp : TTNN_Op<"all_to_all_dispatch"> {
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata"> {
+def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata", [OpModelExempt]> {
     let summary = "Dispatch tokens with metadata to expert devices for MoE computation.";
     let description = [{
       Routes tokens along with expert scores to devices holding their selected
@@ -1720,7 +1720,7 @@ def TTNN_AllToAllDispatchMetadataOp : TTNN_Op<"all_to_all_dispatch_metadata"> {
     let hasVerifier = 1;
 }
 
-def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine"> {
+def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine", [OpModelExempt]> {
     let summary = "Combine expert outputs back to original token positions.";
     let description = [{
       Inverse of dispatch: gathers expert computation results from expert devices
@@ -1747,7 +1747,7 @@ def TTNN_AllToAllCombineOp : TTNN_Op<"all_to_all_combine"> {
     let hasVerifier = 1;
 }
 
-def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine"> {
+def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine", [OpModelExempt]> {
     let summary = "Reduce and combine phase of the MoE pipeline.";
     let description = [{
       Takes dense blocks of expert-computed tokens from the MoE compute kernel,
@@ -1770,7 +1770,7 @@ def TTNN_SelectiveReduceCombineOp : TTNN_Op<"selective_reduce_combine"> {
     let hasVerifier = 1;
 }
 
-def TTNN_MoeExpertTokenRemapOp : TTNN_Op<"moe_expert_token_remap"> {
+def TTNN_MoeExpertTokenRemapOp : TTNN_Op<"moe_expert_token_remap", [OpModelExempt]> {
     let summary = "Remap global expert routing to local device experts with sparsity.";
     let description = [{
       Converts global expert routing scores to local per-device expert mapping
@@ -2402,7 +2402,7 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_MemoryC
 }
 
 def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
-    [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface]> {
+    [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
     let summary = "Distributed RMS normalization with all-gather op.";
     let description = [{
       Fused distributed RMS normalization operation across mesh devices.
@@ -2525,7 +2525,7 @@ def TTNN_RMSNormPreAllGatherOp :  TTNN_Op<"rms_norm_pre_all_gather",
 }
 
 def TTNN_DistributedLayerNormOp : TTNN_Op<"distributed_layer_norm",
-    [AttrSizedOperandSegments]> {
+    [AttrSizedOperandSegments, OpModelExempt]> {
     let summary = "Distributed layer normalization with all-gather op.";
     let description = [{
       Intermediate TTNN op for distributed layer normalization across mesh devices.
@@ -2989,7 +2989,7 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
     let hasVerifier = 1;
 }
 
-def TTNN_AllocOp : TTNN_Op<"alloc", [TTCore_CreationOpTrait]> {
+def TTNN_AllocOp : TTNN_Op<"alloc", [TTCore_CreationOpTrait, OpModelExempt]> {
     let summary = "Alloc op.";
     let description = [{
       Tensor Alloc operation
@@ -3071,7 +3071,7 @@ def TTNN_GatherOp : TTNN_Op<"gather", [TTNN_MemoryConfigOpInterface]> {
     }];
 }
 
-def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface]> {
+def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
     let summary = "All gather op.";
     let description = [{
         Tensor All Gather operation
@@ -3094,7 +3094,7 @@ def TTNN_AllGatherOp: TTNN_Op<"all_gather", [TTNN_MemoryConfigOpInterface]> {
 
 def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
     [TTNN_MemoryConfigOpInterface,
-     TTNN_ComputeKernelConfigOpInterface]> {
+     TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
     let summary = "Reduce scatter op.";
     let description = [{
         Tensor Reduce Scatter operation
@@ -3117,7 +3117,7 @@ def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
     let hasFolder = 1;
 }
 
-def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface]> {
+def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
     let summary = "All reduce op.";
     let description = [{
         Tensor All Reduce operation
@@ -3138,7 +3138,7 @@ def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [TTNN_MemoryConfigOpInterface]> {
     let hasFolder = 1;
 }
 
-def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInterface]> {
+def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInterface, OpModelExempt]> {
     let summary = "Asynchronous all reduce op.";
     let description = [{
         Asynchronous all-reduce collective communication operation. Performs a
@@ -3160,7 +3160,7 @@ def TTNN_AllReduceAsyncOp: TTNN_Op<"all_reduce_async", [TTNN_MemoryConfigOpInter
     let hasVerifier = 1;
 }
 
-def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {
+def TTNN_MeshShardOp: TTNN_Op<"mesh_shard", [OpModelExempt]> {
     let summary = "Mesh shard op.";
     let description = [{
         Tensor Mesh Shard operation
@@ -3388,7 +3388,7 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
     let hasVerifier = 1;
 }
 
-def TTNN_PointToPointOp: TTNN_Op<"point_to_point"> {
+def TTNN_PointToPointOp: TTNN_Op<"point_to_point", [OpModelExempt]> {
   let summary = "Point To Point operation.";
   let description = [{
     Performs point-to-point communication by copying a tensor shard from one device to another
@@ -3410,7 +3410,7 @@ def TTNN_PointToPointOp: TTNN_Op<"point_to_point"> {
   let hasVerifier = 1;
 }
 
-def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor"> {
+def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor", [OpModelExempt]> {
   let summary = "Write tensor op.";
   let description = [{
     Copies host_tensor data into device_tensor through cq_id.
@@ -3430,7 +3430,7 @@ def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor"> {
   let hasVerifier = 1;
 }
 
-def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture"> {
+def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture", [OpModelExempt]> {
   let summary = "Begin trace capture.";
   let description = [{
     Begins trace capture. Returns a scalar tensor containing the trace id.
@@ -3449,7 +3449,7 @@ def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture"> {
   let hasVerifier = 1;
 }
 
-def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture"> {
+def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture", [OpModelExempt]> {
   let summary = "End trace capture.";
   let description = [{
     Ends trace capture for the given trace id. Consumes a scalar tensor containing the trace id.
@@ -3469,7 +3469,7 @@ def TTNN_EndTraceCaptureOp : TTNN_MemoryEffectOp<"end_trace_capture"> {
   let hasVerifier = 1;
 }
 
-def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace"> {
+def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace", [OpModelExempt]> {
   let summary = "Execute trace.";
   let description = [{
     Executes the captured trace. Consumes a scalar tensor containing the trace id.
@@ -3490,7 +3490,7 @@ def TTNN_ExecuteTraceOp : TTNN_MemoryEffectOp<"execute_trace"> {
   let hasVerifier = 1;
 }
 
-def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace"> {
+def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace", [OpModelExempt]> {
   let summary = "Capture or execute trace.";
   let description = [{
     Captures or executes the trace. Will have read/write memory effects on the cached trace data.
@@ -3516,7 +3516,7 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
   let hasVerifier = 1;
 }
 
-def TTNN_GenericOp : TTNN_Op<"generic", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, MemoryEffects<[MemRead, MemWrite]>, TTCore_NonCacheableTrait]> {
+def TTNN_GenericOp : TTNN_Op<"generic", [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, MemoryEffects<[MemRead, MemWrite]>, TTCore_NonCacheableTrait, OpModelExempt]> {
     let summary = "Generic operation.";
     let description = [{
       Generic operation capable of running a program with custom kernels. Each kernel is described with a
@@ -3678,7 +3678,7 @@ def TTNN_NLPConcatHeadsOp : TTNN_Op<"nlp_concat_heads", [TTNN_MemoryConfigOpInte
   let hasVerifier = 1;
 }
 
-def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor"> {
+def TTNN_DumpTensorOp : TTNN_InplaceOp<"dump_tensor", [OpModelExempt]> {
   let summary = "Saves a tensor to disk in the TTNN binary format";
   let description = [{
     Saves a tensor to disk in the TTNN binary format. Files must use the `.tensorbin` extension.
@@ -3718,7 +3718,7 @@ def NLPCreateQKVHeadsDecodeOp : TTNN_Op<"nlp_create_qkv_heads_decode", [TTNN_Mem
   let hasVerifier = 1;
 }
 
-def TTNN_LoadTensorOp : TTNN_Op<"load_tensor"> {
+def TTNN_LoadTensorOp : TTNN_Op<"load_tensor", [OpModelExempt]> {
   let summary = "Loads a tensor from disk";
   let description = [{
     Loads a tensor from disk, optionally placing it directly on a device.
@@ -3977,7 +3977,7 @@ def TTNN_AssignOp : TTNN_Op<"assign", [TTNN_MemoryConfigOpInterface, TTNN_DtypeO
     let hasVerifier = 1;
 }
 
-def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor"> {
+def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor", [OpModelExempt]> {
   let summary = "Distribute tensor across mesh devices";
   let description = [{
     Distributes a host-side tensor across multiple devices in a mesh
@@ -4013,7 +4013,7 @@ def TTNN_DistributeTensorOp : TTNN_Op<"distribute_tensor"> {
   let results = (outs AnyRankedTensor:$result); // Distributed tensor
 }
 
-def TTNN_AggregateTensorOp : TTNN_Op<"aggregate_tensor"> {
+def TTNN_AggregateTensorOp : TTNN_Op<"aggregate_tensor", [OpModelExempt]> {
   let summary = "Aggregate distributed tensor back to host";
   let description = [{
     Aggregates a multi-device tensor back into a single host-side tensor
@@ -4149,7 +4149,7 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
   let hasVerifier = 1;
 }
 
-def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore"> {
+def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore", [OpModelExempt]> {
     let summary = "Create global semaphore op.";
     let description = [{
       Creates a global semaphore with the specified core range and initial value.
@@ -4179,7 +4179,7 @@ def TTNN_CreateGlobalSemaphoreOp : TTNN_Op<"create_global_semaphore"> {
     let results = (outs TTNN_GlobalSemaphore:$result);
 }
 
-def TTNN_ResetGlobalSemaphoreOp : TTNN_Op<"reset_global_semaphore"> {
+def TTNN_ResetGlobalSemaphoreOp : TTNN_Op<"reset_global_semaphore", [OpModelExempt]> {
     let summary = "Reset global semaphore op.";
     let description = [{
       Resets a global semaphore to the specified value.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -53,6 +53,11 @@ public:
 template <typename ConcreteType>
 class CanExecuteOnHostTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, CanExecuteOnHostTrait> {};
+
+// Marker trait to exempt an op from implementing the OpModel interface.
+template <typename ConcreteType>
+class OpModelExempt
+    : public mlir::OpTrait::TraitBase<ConcreteType, OpModelExempt> {};
 } // namespace mlir::tt::ttnn
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -24,4 +24,12 @@ def CanExecuteOnHostTrait : NativeOpTrait<"CanExecuteOnHostTrait">
   let cppNamespace = "::mlir::tt::ttnn";
 }
 
+// Trait to exempt an op from implementing the OpModel interface.
+// Ops tagged with this trait will not have DeclareOpInterfaceMethods<TTNN_OpModelInterface>
+// added by the base op classes (TTNN_Op, TTNN_InplaceOp, etc.).
+def OpModelExempt : NativeOpTrait<"OpModelExempt">
+{
+  let cppNamespace = "::mlir::tt::ttnn";
+}
+
 #endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNN_TRAITS_TD

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -12,6 +12,32 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
+// Unwrap an llvm::Expected<T> expression: on success assign the value to `lhs`,
+// on failure propagate the error by returning it from the enclosing function.
+//
+// `lhs` may be either an existing l-value or a new variable declaration
+// (e.g. `Foo foo`). The macro expands to a single statement of the form
+// `lhs = (...);` so it is safe to use inside unbraced `if`/`else`/`for`/`while`
+// bodies. Implementation uses Clang's statement-expression extension
+// (`({ ... })`) — required because the unwrapped value must escape the macro's
+// scope while still allowing an early `return` on the error path. tt-mlir is
+// a clang-only build (see top-level CMakeLists.txt); porting to GCC would
+// need a parallel definition that silences -Wpedantic the same way.
+// clang-format off
+#define TTMLIR_CONCAT_IMPL_(a, b) a##b
+#define TTMLIR_CONCAT_(a, b) TTMLIR_CONCAT_IMPL_(a, b)
+#define ASSIGN_OR_RETURN(lhs, expr)                                            \
+  _Pragma("clang diagnostic push")                                             \
+  _Pragma("clang diagnostic ignored \"-Wgnu-statement-expression-from-macro-expansion\"") \
+  lhs = ({                                                                     \
+    auto TTMLIR_CONCAT_(_tt_expected_, __LINE__) = (expr);                     \
+    if (!TTMLIR_CONCAT_(_tt_expected_, __LINE__))                              \
+      return TTMLIR_CONCAT_(_tt_expected_, __LINE__).takeError();              \
+    std::move(TTMLIR_CONCAT_(_tt_expected_, __LINE__).get());                  \
+  });                                                                          \
+  _Pragma("clang diagnostic pop")
+// clang-format on
+
 namespace mlir::tt::ttnn::op_model {
 
 // Checks if the tensor layout is legal for the given tensor shape.

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1068,13 +1068,14 @@ void L1SpillManagement<MemoryTracker>::run() {
 
     // Ops with L1 output annotation get full processing.
     // DRAM-output ops (no annotation) still need CB overlap checking against
-    // live L1 tensors -- skip only if the op can't be validated or there are
-    // no live L1 tensors that could clash.
+    // live L1 tensors -- skip only if there are no live L1 tensors that could
+    // clash. Ops that can't be checked return NotImplemented from validation,
+    // which triggers a full spill regardless of live set size.
     auto l1Attr = op->getAttrOfType<IntegerAttr>("ttnn.output_l1_usage");
     uint64_t opL1Usage = l1Attr ? l1Attr.getValue().getZExtValue() : 0;
 
     if (!l1Attr) {
-      if (!mlir::dyn_cast<OpModel>(op) || liveValues.empty()) {
+      if (liveValues.empty()) {
         continue;
       }
     }

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -2155,8 +2155,7 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "7 input tensors");
 
   ttcore::GridAttr deviceGrid;
-  ASSIGN_OR_RETURN(deviceGrid,
-                     detail::getValidatedDeviceGrid(getOperation()));
+  ASSIGN_OR_RETURN(deviceGrid, detail::getValidatedDeviceGrid(getOperation()));
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2982,24 +2981,6 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShapeA = getA().getType().getShape();
   const auto inputShapeB = getB().getType().getShape();
-
-  // Skip getOpConstraints for matmul with block sharded first operand if height
-  // or width is less than tile size
-  // TODO (mvasiljevic): remove once the fix in metal is merged and uplifted:
-  // https://github.com/tenstorrent/tt-metal/pull/33777
-  if (!inputs.empty() && inputs[0].getMemLayout() &&
-      inputs[0].getMemLayout().getValue() == TensorMemoryLayout::BlockSharded &&
-      inputShapeA.size() >= 2) {
-    int64_t height = inputShapeA[inputShapeA.size() - 2];
-    int64_t width = inputShapeA[inputShapeA.size() - 1];
-    if (height < static_cast<int64_t>(TILE_HEIGHT) ||
-        width < static_cast<int64_t>(TILE_WIDTH)) {
-      return llvm::createStringError(
-          llvm::inconvertibleErrorCode(),
-          "Matmul with block sharded first operand having logical "
-          "shape less than tile size is not supported");
-    }
-  }
 
   ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
                    detail::getValidatedDeviceGrid(getOperation()));

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -14,7 +14,6 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/OpModel/TTNN/D2MOpCostModel.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
-#include "ttmlir/Utils.h"
 
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -86,6 +85,14 @@ llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
   return op_model::Device::getDeviceConstraints(deviceAttr.getWorkerGrid());
 }
 
+llvm::Expected<ttcore::GridAttr> getValidatedDeviceGrid(mlir::Operation *op) {
+  auto check = checkDeviceWorkerGrid(op);
+  if (!check) {
+    return check.takeError();
+  }
+  return ttcore::lookupDevice(op).getWorkerGrid();
+}
+
 llvm::SmallVector<int64_t>
 convertArrayAttrToSmallVec(mlir::ArrayAttr arrayAttr) {
   llvm::SmallVector<int64_t> result;
@@ -111,12 +118,8 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
       inputs[0], opConfig.outputLayout);
@@ -144,12 +147,8 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = op.getLhs().getType().getShape();
   const auto inputShapeB = op.getRhs().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   ttcore::DataTypeAttr opDtypeAttr = nullptr;
   if (auto dtypeOp = mlir::dyn_cast<TTNNDtypeOpInterface>(op.getOperation())) {
@@ -185,12 +184,8 @@ getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShapeA,
@@ -219,12 +214,8 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
       inputs[0], detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
@@ -251,12 +242,8 @@ getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -291,12 +278,8 @@ getMaxPool2dWithIndicesOpConstraints(OpT op,
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -331,12 +314,8 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   const mlir::tt::ttnn::ShapeAttr shape = op.getShape();
   const std::optional<mlir::tt::ttcore::DataType> dtype = op.getDtype();
@@ -358,12 +337,8 @@ getQuantizationOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   const auto scaleShape = op.getScale().getType().getShape();
   const auto zeroPointShape = op.getZeroPoint().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(op.getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<OpT>::getOpConstraints, op, deviceGrid, inputShape,
@@ -926,12 +901,8 @@ LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, deviceGrid,
@@ -1123,12 +1094,8 @@ ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
@@ -1152,11 +1119,6 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto indexShape = getIndex().getType().getShape();
   const auto sourceShape = getSource().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
   std::optional<ttcore::ReduceTypeAttr> reduceType =
       ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
   if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
@@ -1179,12 +1141,8 @@ GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
   const auto indexShape = getIndex().getType().getShape();
@@ -1237,12 +1195,8 @@ GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getLhs().getType().getShape();
   const auto inputShapeB = getRhs().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GeluBackwardOp>::getOpConstraints, getOperation(),
@@ -1310,12 +1264,8 @@ PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getLhs().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PowScalarOp>::getOpConstraints, *this, deviceGrid,
@@ -1585,12 +1535,8 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, deviceGrid,
       inputShape, inputs[0], getDimension(), getNumericStable(),
@@ -1622,12 +1568,8 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ReshapeOp>::getOpConstraints, *this, deviceGrid,
@@ -1658,12 +1600,8 @@ SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, deviceGrid,
@@ -1699,12 +1637,8 @@ SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto beginsShape = getBegins().getType().getShape();
   const auto endsShape = getEnds().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, deviceGrid,
@@ -1739,12 +1673,8 @@ BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, deviceGrid,
@@ -1779,12 +1709,8 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<TypecastOp>::getOpConstraints, *this, deviceGrid,
@@ -1821,13 +1747,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, deviceGrid,
@@ -1859,12 +1780,8 @@ ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, deviceGrid,
@@ -1884,60 +1801,6 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// GetDeviceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-GetDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-GetDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// FromDeviceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-FromDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
-}
-
-llvm::Expected<size_t>
-FromDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
-}
-
-//===----------------------------------------------------------------------===//
-// ToDeviceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-ToDeviceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
-}
-
-llvm::Expected<size_t>
-ToDeviceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
-}
-
-//===----------------------------------------------------------------------===//
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -1953,12 +1816,8 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     inputShapes.push_back(inputType.getShape());
   }
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConcatOp>::getOpConstraints, *this, deviceGrid,
@@ -1993,12 +1852,8 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<TransposeOp>::getOpConstraints, *this, deviceGrid,
@@ -2028,12 +1883,8 @@ CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<CumSumOp>::getOpConstraints, *this, deviceGrid,
@@ -2061,12 +1912,8 @@ ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -2177,12 +2024,8 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
          "4, 5, or 6 input tensors");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
       unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2208,11 +2051,6 @@ llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
   assert(inputs.size() >= 3 && inputs.size() <= 6 &&
          "ttnn::transformer::scaled_dot_product_attention_decode can have 3, "
          "4, 5, or 6 input tensors");
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
       unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2316,12 +2154,9 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid;
+  ASSIGN_OR_RETURN(deviceGrid,
+                     detail::getValidatedDeviceGrid(getOperation()));
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2349,11 +2184,6 @@ llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
   assert(inputs.size() >= 4 && inputs.size() <= 7 &&
          "ttnn::paged_scaled_dot_product_attention_decode can have 4, 5, 6, or "
          "7 input tensors");
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
       unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
@@ -2454,12 +2284,8 @@ llvm::Expected<op_model::OpConstraints>
 PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
       unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
@@ -2479,11 +2305,6 @@ PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
   PagedFlashMultiLatentAttentionDecodeArgs args =
       unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
 
@@ -2509,12 +2330,8 @@ ScaledDotProductAttentionOp::getOpConstraints(
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto queryShape = getQuery().getType().getShape();
   const auto keyShape = getKey().getType().getShape();
@@ -2548,11 +2365,6 @@ llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 5 &&
          "ttnn::scaled_dot_product_attention can have 3 to 5 input tensors");
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
 
   const auto queryShape = getQuery().getType().getShape();
   const auto keyShape = getKey().getType().getShape();
@@ -2591,13 +2403,8 @@ RotaryEmbeddingLlamaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 4);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
   auto sinShape = getSinCache().getType().getShape();
@@ -2636,13 +2443,8 @@ RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto inputShape = getInput().getType().getShape();
   auto cosShape = getCosCache().getType().getShape();
@@ -2680,13 +2482,8 @@ NLPCreateQKVHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto inputShape = getInput().getType().getShape();
 
@@ -2733,13 +2530,8 @@ NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   auto inputShape = getInput().getType().getShape();
 
   return opConstraintsCache().getOrCompute(
@@ -2767,13 +2559,8 @@ NLPConcatHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
   uint32_t numHeads = getNumHeads();
@@ -2802,12 +2589,8 @@ llvm::Expected<op_model::OpConstraints>
 SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto inputShape = getInputTensor().getType().getShape();
 
@@ -2854,12 +2637,8 @@ RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatInterleaveOp>::getOpConstraints, *this,
@@ -2890,12 +2669,8 @@ RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RepeatOp>::getOpConstraints, *this, deviceGrid,
@@ -2925,12 +2700,8 @@ PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PadOp>::getOpConstraints, *this, deviceGrid, inputShape,
@@ -2961,12 +2732,8 @@ SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<SortOp>::getOpConstraints, *this, deviceGrid,
@@ -2997,12 +2764,8 @@ ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, deviceGrid,
@@ -3033,12 +2796,8 @@ ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ProdOp>::getOpConstraints, *this, deviceGrid,
@@ -3098,12 +2857,8 @@ RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outScaleShape = getOutScale().getType().getShape();
   const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<RequantizeOp>::getOpConstraints, *this, deviceGrid,
@@ -3176,12 +2931,8 @@ LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
@@ -3232,12 +2983,26 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeA = getA().getType().getShape();
   const auto inputShapeB = getB().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
+  // Skip getOpConstraints for matmul with block sharded first operand if height
+  // or width is less than tile size
+  // TODO (mvasiljevic): remove once the fix in metal is merged and uplifted:
+  // https://github.com/tenstorrent/tt-metal/pull/33777
+  if (!inputs.empty() && inputs[0].getMemLayout() &&
+      inputs[0].getMemLayout().getValue() == TensorMemoryLayout::BlockSharded &&
+      inputShapeA.size() >= 2) {
+    int64_t height = inputShapeA[inputShapeA.size() - 2];
+    int64_t width = inputShapeA[inputShapeA.size() - 1];
+    if (height < static_cast<int64_t>(TILE_HEIGHT) ||
+        width < static_cast<int64_t>(TILE_WIDTH)) {
+      return llvm::createStringError(
+          llvm::inconvertibleErrorCode(),
+          "Matmul with block sharded first operand having logical "
+          "shape less than tile size is not supported");
+    }
   }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
@@ -3269,111 +3034,6 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// SparseMatmulOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-SparseMatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-SparseMatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// AllToAllDispatchOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllToAllDispatchOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllToAllDispatchOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// AllToAllDispatchMetadataOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllToAllDispatchMetadataOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t> AllToAllDispatchMetadataOp::getOpRuntime(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// AllToAllCombineOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllToAllCombineOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllToAllCombineOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// SelectiveReduceCombineOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-SelectiveReduceCombineOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t> SelectiveReduceCombineOp::getOpRuntime(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// MoeExpertTokenRemapOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints> MoeExpertTokenRemapOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-MoeExpertTokenRemapOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3382,12 +3042,8 @@ TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
   assert(inputs.size() == 3);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
@@ -3438,24 +3094,6 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// AllocOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllocOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllocOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -3463,12 +3101,8 @@ llvm::Expected<op_model::OpConstraints>
 FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(inputs.size() == 2);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3500,12 +3134,8 @@ llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
   assert(inputs.size() == 3);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3536,12 +3166,8 @@ PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3586,12 +3212,8 @@ PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   auto cacheShape = getCache().getType().getShape();
   auto inputShape = getInput().getType().getShape();
@@ -3638,12 +3260,8 @@ llvm::Expected<op_model::OpConstraints>
 SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 5);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpConstraints, *this,
       deviceGrid, getInputValues().getType().getShape(), inputs[0],
@@ -3664,24 +3282,6 @@ SamplingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getK().getType().getShape(), inputs[2], getP().getType().getShape(),
       inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
       opConfig.outputLayout);
-}
-
-//===----------------------------------------------------------------------===//
-// WriteTensorOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-WriteTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-WriteTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3723,12 +3323,8 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return opConstraintsCache().getOrCompute(
@@ -3785,12 +3381,8 @@ Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<Conv3dOp>::getOpConstraints, *this, deviceGrid,
@@ -3865,12 +3457,8 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     biasLayout = inputs[2];
   }
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   // If a conv config has been specified, use that. If not, read the op property
   Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
@@ -3919,12 +3507,8 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -3956,12 +3540,8 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -3992,12 +3572,8 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> weightShape =
       getWeightTensor().getType().getShape();
@@ -4028,12 +3604,8 @@ llvm::Expected<op_model::OpConstraints>
 PrepareConvTranspose2dBiasOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const ::llvm::ArrayRef<int64_t> biasShape =
       getBiasTensor().getType().getShape();
@@ -4143,12 +3715,8 @@ llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4199,12 +3767,8 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
          "usage of this op with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4280,12 +3844,8 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4324,25 +3884,6 @@ RMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// DistributedRMSNormOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-// DistributedRMSNormOp is a fused CCL operation that requires multi-device
-// support and is not supported in the op model.
-
-llvm::Expected<op_model::OpConstraints> DistributedRMSNormOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
-}
-
-llvm::Expected<size_t>
-DistributedRMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
-}
-
-//===----------------------------------------------------------------------===//
 // RMSNormPreAllGatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -4369,14 +3910,8 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-
-  if (!check) {
-    return check.takeError();
-  }
-
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4403,27 +3938,6 @@ RMSNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], optionalArgs.residualInputShape,
       optionalArgs.residualInputLayout, getDtype(), getUse_2dCoreGrid(),
       opConfig.outputLayout);
-}
-
-//===----------------------------------------------------------------------===//
-// DistributedLayerNormOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-// DistributedLayerNormOp decomposes into multiple ops (CCL + layer norm), and
-// there is no equivalent fused op in the TTNN library, so op model is not
-// supported.
-
-llvm::Expected<op_model::OpConstraints>
-DistributedLayerNormOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
-}
-
-llvm::Expected<size_t>
-DistributedLayerNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4461,12 +3975,8 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4530,12 +4040,8 @@ unpackLayerNormPreAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4599,12 +4105,8 @@ unpackLayerNormPostAllGatherOptionalArgs(
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
   const auto statsShape = getStats().getType().getShape();
@@ -4679,12 +4181,8 @@ llvm::Expected<op_model::OpConstraints>
 GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
   assert(!inputs.empty() && "GroupNormOp requires at least input layout");
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -4728,12 +4226,8 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, deviceGrid,
@@ -4763,12 +4257,8 @@ ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, deviceGrid,
@@ -4800,12 +4290,8 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<PermuteOp>::getOpConstraints, *this, deviceGrid,
@@ -4836,12 +4322,8 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<UpsampleOp>::getOpConstraints, *this, deviceGrid,
@@ -4873,12 +4355,8 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
   const auto weightShape = getWeight().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, deviceGrid,
@@ -4911,12 +4389,8 @@ EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto weightShape = getWeight().getType().getShape();
   const auto inGradientShape = getInGradient().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
@@ -4953,12 +4427,8 @@ EmptyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const mlir::tt::ttnn::Layout layout = getLayoutAttr().getValue();
   const mlir::tt::ttnn::MemoryConfigAttr memoryConfig = getMemoryConfigAttr();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints, *this,
       deviceGrid, shape, dtype, layout, memoryConfig, opConfig.outputLayout);
@@ -5045,12 +4515,8 @@ llvm::Expected<op_model::OpConstraints>
 FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const mlir::tt::ttnn::ShapeAttr shape = getShape();
   const mlir::Attribute fillValue = getFillValue();
@@ -5073,44 +4539,6 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// AllGatherOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-// AllGatherOp and ReduceScatterOp are not supported, since they have been
-// removed from metal. See
-// https://github.com/tenstorrent/tt-metal/commit/1ccd1c6480
-llvm::Expected<op_model::OpConstraints>
-AllGatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// ReduceScatterOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-ReduceScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                  const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-ReduceScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -5121,12 +4549,8 @@ MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, deviceGrid,
@@ -5146,62 +4570,6 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// PointToPointOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-// PointToPointOp is not supported rn. The reason is that the metal definition
-// requires semaphore and multi-device, which is not available at the moment.
-llvm::Expected<op_model::OpConstraints>
-PointToPointOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
-}
-
-llvm::Expected<size_t>
-PointToPointOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NeedsMultiDevice);
-}
-
-//===----------------------------------------------------------------------===//
-// AllReduceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllReduceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllReduceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// AllReduceAsyncOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AllReduceAsyncOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AllReduceAsyncOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -5210,12 +4578,8 @@ ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<ConstantOp>::getOpConstraints, *this, deviceGrid,
@@ -5238,12 +4602,8 @@ RandOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 0);
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::RandOp>::getOpConstraints, *this,
@@ -5269,12 +4629,8 @@ DropoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<DropoutOp>::getOpConstraints, *this, deviceGrid,
@@ -5296,150 +4652,6 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// MeshShardOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-MeshShardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-MeshShardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// GenericOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-GenericOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-GenericOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// BeginTraceCaptureOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-BeginTraceCaptureOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-BeginTraceCaptureOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                  const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// EndTraceCaptureOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-EndTraceCaptureOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-EndTraceCaptureOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// ExecuteTraceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-ExecuteTraceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-ExecuteTraceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// CaptureOrExecuteTraceOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-CaptureOrExecuteTraceOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-CaptureOrExecuteTraceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// DumpTensorOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-DumpTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-DumpTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// LoadTensorOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-LoadTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-LoadTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -5450,12 +4662,8 @@ GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, deviceGrid,
@@ -5482,12 +4690,8 @@ llvm::Expected<op_model::OpConstraints>
 AssignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -5505,42 +4709,6 @@ AssignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime, *this,
       inputShape, inputs[0], getMemoryConfig(), getDtype());
-}
-
-//===----------------------------------------------------------------------===//
-// DistributeTensorOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-DistributeTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-DistributeTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-//===----------------------------------------------------------------------===//
-// AggregateTensorOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-AggregateTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
-}
-
-llvm::Expected<size_t>
-AggregateTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
 }
 
 //===----------------------------------------------------------------------===//
@@ -5736,12 +4904,8 @@ llvm::Expected<op_model::OpConstraints>
 TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
   const auto inputShape = getInputTensor().getType().getShape();
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
@@ -5759,40 +4923,4 @@ TopKOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
       opConfig.outputLayout);
 }
-//===----------------------------------------------------------------------===//
-// CreateGlobalSemaphoreOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-CreateGlobalSemaphoreOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-CreateGlobalSemaphoreOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-//===----------------------------------------------------------------------===//
-// ResetGlobalSemaphoreOp - TTNN Op Model Interface
-//===----------------------------------------------------------------------===//
-
-llvm::Expected<op_model::OpConstraints>
-ResetGlobalSemaphoreOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return issueErrorForGetOpConstraints(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
-llvm::Expected<size_t>
-ResetGlobalSemaphoreOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return issueErrorForGetOpRuntime(
-      getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
-}
-
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4410,6 +4410,7 @@ EmptyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
                    detail::getValidatedDeviceGrid(getOperation()));
+
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints, *this,
       deviceGrid, shape, dtype, layout, memoryConfig, opConfig.outputLayout);
@@ -4437,8 +4438,8 @@ ArangeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   std::optional<mlir::tt::ttcore::DataType> dtype = getDtype();
   std::optional<mlir::tt::ttnn::MemoryConfigAttr> memConfig = getMemoryConfig();
 
-  const mlir::tt::ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+  ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
+                   detail::getValidatedDeviceGrid(getOperation()));
 
   return opConstraintsCache().getOrCompute(
       op_model::OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints, *this,

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/OpModelError.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Support/Logger.h"
@@ -172,6 +173,17 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   // Check that operation supports OpModel interface.
   auto backend = mlir::dyn_cast<OpModel>(op);
   if (!backend) {
+    // Ops marked with the OpModelExempt trait deliberately do not implement
+    // the OpModel interface (e.g. CCL/multi-device, trace, generic, or other
+    // ops without a metal-side definition). The optimizer relies on observing
+    // a NotImplemented result for such ops so it can fall back gracefully
+    // (e.g. evict L1 state) instead of treating the op as analyzable.
+    if (op->hasTrait<OpModelExempt>()) {
+      return ValidationResult::notImplemented(
+          (llvm::Twine("OpModel interface not implemented for op ") +
+           op->getName().getStringRef() + " (OpModelExempt)")
+              .str());
+    }
     llvm::reportFatalInternalError(llvm::Twine("Backend constraints are not "
                                                "implemented for op ")
                                        .concat(op->getName().getStringRef()));

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6101,8 +6101,9 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
-                   detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6142,8 +6143,9 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
-                   detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -7630,8 +7632,9 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
   llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
                                              inputIndicesShape[1]};
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec valuesSpec,
-                   detail::convertToTensorSpec(device, values4D, inputValuesLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valuesSpec,
+      detail::convertToTensorSpec(device, values4D, inputValuesLayout));
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec indicesSpec,
       detail::convertToTensorSpec(device, indices4D, inputIndicesLayout));
@@ -7673,8 +7676,9 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
   llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
                                              inputIndicesShape[1]};
 
-  ASSIGN_OR_RETURN(::ttnn::TensorSpec valuesSpec,
-                   detail::convertToTensorSpec(device, values4D, inputValuesLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valuesSpec,
+      detail::convertToTensorSpec(device, values4D, inputValuesLayout));
   ASSIGN_OR_RETURN(
       ::ttnn::TensorSpec indicesSpec,
       detail::convertToTensorSpec(device, indices4D, inputIndicesLayout));

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -669,12 +669,9 @@ llvm::Expected<::ttnn::TensorSpec> getPrepareConv2dWeightsOpOutputTensorSpec(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> inputDtype =
       detail::getNullableDataType(inputLayout);
@@ -766,12 +763,9 @@ getPrepareConv2dBiasOpOutputTensorSpec(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> inputDtype =
       detail::getNullableDataType(inputLayout);
@@ -871,12 +865,9 @@ llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto query = [=]() {
@@ -901,12 +892,9 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto query = [=]() {
@@ -930,12 +918,9 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   bool fastApproxMode = true;
 
@@ -962,12 +947,9 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   bool fastApproxMode = true;
 
@@ -1028,12 +1010,9 @@ llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Add default parameters
   int32_t vectorMode =
@@ -1062,12 +1041,9 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Add default parameters
   int32_t vectorMode =
@@ -1098,12 +1074,9 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto leakyReluOpQuery = [=]() {
@@ -1126,12 +1099,9 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto leakyReluOpQuery = [=]() {
@@ -1160,19 +1130,13 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -1205,19 +1169,13 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -1247,19 +1205,13 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1287,19 +1239,13 @@ llvm::Expected<size_t> BinaryCompositeOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1356,19 +1302,13 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1395,19 +1335,13 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1437,12 +1371,9 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
@@ -1481,12 +1412,9 @@ llvm::Expected<size_t> OpModel<PowScalarOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
@@ -1529,26 +1457,17 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  auto inputSpecCExp =
-      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC);
-  if (!inputSpecCExp) {
-    return inputSpecCExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecC = inputSpecCExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecC,
+      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1577,26 +1496,17 @@ llvm::Expected<size_t> TernaryEltwiseOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
-  auto inputSpecCExp =
-      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC);
-  if (!inputSpecCExp) {
-    return inputSpecCExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecC = inputSpecCExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecC,
+      detail::convertToTensorSpec(device, inputShapeC, inputLayoutC));
 
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
@@ -1630,12 +1540,9 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
@@ -1671,12 +1578,9 @@ llvm::Expected<size_t> ReductionOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
@@ -1767,12 +1671,9 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto softmaxOpQuery = [=]() {
@@ -1796,12 +1697,9 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto softmaxOpQuery = [=]() {
@@ -1831,26 +1729,17 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto indexSpecExp =
-      detail::convertToTensorSpec(device, indexShape, indexLayout);
-  if (!indexSpecExp) {
-    return indexSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indexSpec,
+      detail::convertToTensorSpec(device, indexShape, indexLayout));
 
-  auto sourceSpecExp =
-      detail::convertToTensorSpec(device, sourceShape, sourceLayout);
-  if (!sourceSpecExp) {
-    return sourceSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec sourceSpec = sourceSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec sourceSpec,
+      detail::convertToTensorSpec(device, sourceShape, sourceLayout));
 
   // Convert optReduction to ScatterReductionType enum
   auto optReductionType = conversion::getScatterReductionType(optReduction);
@@ -1880,26 +1769,17 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto indexSpecExp =
-      detail::convertToTensorSpec(device, indexShape, indexLayout);
-  if (!indexSpecExp) {
-    return indexSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indexSpec,
+      detail::convertToTensorSpec(device, indexShape, indexLayout));
 
-  auto sourceSpecExp =
-      detail::convertToTensorSpec(device, sourceShape, sourceLayout);
-  if (!sourceSpecExp) {
-    return sourceSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec sourceSpec = sourceSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec sourceSpec,
+      detail::convertToTensorSpec(device, sourceShape, sourceLayout));
 
   auto optReductionType = conversion::getScatterReductionType(optReduction);
 
@@ -1928,12 +1808,9 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto reshapeOpQuery = [=]() {
@@ -1956,12 +1833,9 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto reshapeOpQuery = [=]() {
@@ -1988,12 +1862,9 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // convert arrays
   ::ttsl::SmallVector<int> beginsVec =
@@ -2030,12 +1901,9 @@ llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert arrays
   ::ttsl::SmallVector<int> beginsVec =
@@ -2076,12 +1944,9 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // It is not possible to use the dynamic version of slice in tt-metal since
   // the validity of the op depends on the actual data that is stored in the
@@ -2125,12 +1990,9 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // It is not possible to use the dynamic version of slice in tt-metal since
   // the validity of the op depends on the actual data that is stored in the
@@ -2174,12 +2036,9 @@ llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto bitcastOpQuery = [=]() {
@@ -2202,12 +2061,9 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto bitcastOpQuery = [=]() {
@@ -2233,12 +2089,9 @@ llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto typecastOpQuery = [=]() {
@@ -2261,12 +2114,9 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto typecastOpQuery = [=]() {
@@ -2292,12 +2142,9 @@ llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> dtype;
   if (outputDtype) {
@@ -2327,12 +2174,9 @@ llvm::Expected<size_t> OpModel<ToLayoutOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> dtype;
   if (outputDtype) {
@@ -2366,12 +2210,9 @@ llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
@@ -2393,12 +2234,9 @@ llvm::Expected<size_t> OpModel<ToMemoryConfigOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
@@ -2429,12 +2267,10 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
 
   std::vector<::ttnn::TensorSpec> inputSpecs;
   for (size_t i = 0; i < numInputs; ++i) {
-    auto inputSpecExp =
-        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]);
-    if (!inputSpecExp) {
-      return inputSpecExp.takeError();
-    }
-    inputSpecs.push_back(inputSpecExp.get());
+    ASSIGN_OR_RETURN(
+        auto _push_tmp,
+        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]));
+    inputSpecs.push_back(std::move(_push_tmp));
   }
 
   // Create query closure
@@ -2463,12 +2299,10 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 
   std::vector<::ttnn::TensorSpec> inputSpecs;
   for (size_t i = 0; i < numInputs; ++i) {
-    auto inputSpecExp =
-        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]);
-    if (!inputSpecExp) {
-      return inputSpecExp.takeError();
-    }
-    inputSpecs.push_back(inputSpecExp.get());
+    ASSIGN_OR_RETURN(
+        auto _push_tmp,
+        detail::convertToTensorSpec(device, inputShapes[i], inputLayouts[i]));
+    inputSpecs.push_back(std::move(_push_tmp));
   }
 
   // Create query closure
@@ -2494,12 +2328,9 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto transposeOpQuery = [=]() {
@@ -2523,12 +2354,9 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto transposeOpQuery = [=]() {
@@ -2555,12 +2383,9 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
   if (dtype) {
@@ -2590,12 +2415,9 @@ OpModel<CumSumOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::DataType> ttnnDtype = std::nullopt;
   if (dtype) {
@@ -2626,12 +2448,9 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
@@ -2655,12 +2474,9 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
@@ -2698,24 +2514,14 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2772,24 +2578,14 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2850,30 +2646,17 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -2924,30 +2707,17 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -3002,24 +2772,14 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> valueSpec =
       detail::convertToOptionalTensorSpec(device, valueShape, valueLayout);
@@ -3072,24 +2832,14 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> valueSpec =
       detail::convertToOptionalTensorSpec(device, valueShape, valueLayout);
@@ -3143,24 +2893,14 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -3203,24 +2943,14 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto querySpecExp =
-      detail::convertToTensorSpec(device, queryShape, queryLayout);
-  if (!querySpecExp) {
-    return querySpecExp.takeError();
-  }
-  auto keySpecExp = detail::convertToTensorSpec(device, keyShape, keyLayout);
-  if (!keySpecExp) {
-    return keySpecExp.takeError();
-  }
-  auto valueSpecExp =
-      detail::convertToTensorSpec(device, valueShape, valueLayout);
-  if (!valueSpecExp) {
-    return valueSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec querySpec = querySpecExp.get();
-  ::ttnn::TensorSpec keySpec = keySpecExp.get();
-  ::ttnn::TensorSpec valueSpec = valueSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
 
   std::optional<::ttnn::TensorSpec> attentionMaskSpec =
       detail::convertToOptionalTensorSpec(device, attentionMaskShape,
@@ -3261,29 +2991,16 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
-  if (!cosSpecExp) {
-    return cosSpecExp.takeError();
-  }
-  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
-  if (!sinSpecExp) {
-    return sinSpecExp.takeError();
-  }
-  auto transMatSpecExp =
-      detail::convertToTensorSpec(device, transMatShape, transMatLayout);
-  if (!transMatSpecExp) {
-    return transMatSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
-  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
-  ::ttnn::TensorSpec transMatSpec = transMatSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
+                   detail::convertToTensorSpec(device, cosShape, cosLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
+                   detail::convertToTensorSpec(device, sinShape, sinLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec transMatSpec,
+      detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding_llama,
@@ -3309,28 +3026,16 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingLlamaOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
-  if (!cosSpecExp) {
-    return cosSpecExp.takeError();
-  }
-  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
-  if (!sinSpecExp) {
-    return sinSpecExp.takeError();
-  }
-  auto transMatSpecExp =
-      detail::convertToTensorSpec(device, transMatShape, transMatLayout);
-  if (!transMatSpecExp) {
-    return transMatSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
-  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
-  ::ttnn::TensorSpec transMatSpec = transMatSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
+                   detail::convertToTensorSpec(device, cosShape, cosLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
+                   detail::convertToTensorSpec(device, sinShape, sinLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec transMatSpec,
+      detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
   // Create query closure
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
@@ -3360,26 +3065,13 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-
-  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
-  if (!cosSpecExp) {
-    return cosSpecExp.takeError();
-  }
-
-  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
-  if (!sinSpecExp) {
-    return sinSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
-  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
+                   detail::convertToTensorSpec(device, cosShape, cosLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
+                   detail::convertToTensorSpec(device, sinShape, sinLayout));
 
   auto rotaryEmbeddingOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding, device,
@@ -3403,26 +3095,13 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-
-  auto cosSpecExp = detail::convertToTensorSpec(device, cosShape, cosLayout);
-  if (!cosSpecExp) {
-    return cosSpecExp.takeError();
-  }
-
-  auto sinSpecExp = detail::convertToTensorSpec(device, sinShape, sinLayout);
-  if (!sinSpecExp) {
-    return sinSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec cosSpec = cosSpecExp.get();
-  ::ttnn::TensorSpec sinSpec = sinSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec cosSpec,
+                   detail::convertToTensorSpec(device, cosShape, cosLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec sinSpec,
+                   detail::convertToTensorSpec(device, sinShape, sinLayout));
 
   // Create query closure
   auto rotaryEmbeddingOpQuery = [=]() {
@@ -3452,23 +3131,15 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-
   std::optional<::ttnn::TensorSpec> batchOffsetSpec = std::nullopt;
   if (batchOffsetShape && batchOffsetLayout) {
-    auto batchOffsetSpecExp = detail::convertToTensorSpec(
-        device, batchOffsetShape.value(), batchOffsetLayout.value());
-    if (!batchOffsetSpecExp) {
-      return batchOffsetSpecExp.takeError();
-    }
-    batchOffsetSpec = batchOffsetSpecExp.get();
+    ASSIGN_OR_RETURN(batchOffsetSpec, detail::convertToTensorSpec(
+                                          device, batchOffsetShape.value(),
+                                          batchOffsetLayout.value()));
   }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
@@ -3499,23 +3170,15 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-
   std::optional<::ttnn::TensorSpec> batchOffsetSpec = std::nullopt;
   if (batchOffsetShape && batchOffsetLayout) {
-    auto batchOffsetSpecExp = detail::convertToTensorSpec(
-        device, batchOffsetShape.value(), batchOffsetLayout.value());
-    if (!batchOffsetSpecExp) {
-      return batchOffsetSpecExp.takeError();
-    }
-    batchOffsetSpec = batchOffsetSpecExp.get();
+    ASSIGN_OR_RETURN(batchOffsetSpec, detail::convertToTensorSpec(
+                                          device, batchOffsetShape.value(),
+                                          batchOffsetLayout.value()));
   }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
@@ -3549,21 +3212,15 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> inputKVSpec = std::nullopt;
   if (inputKVShape && inputKVLayout) {
-    auto inputKVSpecExp = detail::convertToTensorSpec(
-        device, inputKVShape.value(), inputKVLayout.value());
-    if (!inputKVSpecExp) {
-      return inputKVSpecExp.takeError();
-    }
-    inputKVSpec = inputKVSpecExp.get();
+    ASSIGN_OR_RETURN(inputKVSpec,
+                     detail::convertToTensorSpec(device, inputKVShape.value(),
+                                                 inputKVLayout.value()));
   }
 
   // Create query closure
@@ -3591,21 +3248,15 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> inputKVSpec = std::nullopt;
   if (inputKVShape && inputKVLayout) {
-    auto inputKVSpecExp = detail::convertToTensorSpec(
-        device, inputKVShape.value(), inputKVLayout.value());
-    if (!inputKVSpecExp) {
-      return inputKVSpecExp.takeError();
-    }
-    inputKVSpec = inputKVSpecExp.get();
+    ASSIGN_OR_RETURN(inputKVSpec,
+                     detail::convertToTensorSpec(device, inputKVShape.value(),
+                                                 inputKVLayout.value()));
   }
 
   // Create query closure
@@ -3632,12 +3283,9 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
@@ -3661,12 +3309,9 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
@@ -3692,12 +3337,9 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // tt-metal's nlp_concat_heads_decode infers on_subcoregrids from the input
   // shard grid: if the CoreRangeSet has multiple ranges or doesn't start at
@@ -3737,12 +3379,9 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Pass sub_core_grids when the input shard grid would trigger subcoregrids
   // (see getOpConstraints above for rationale).
@@ -3782,12 +3421,9 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
@@ -3810,12 +3446,9 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
@@ -3841,12 +3474,9 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert repeats to ttnn::Shape
   ::ttnn::Shape repeatShape = conversion::getShape(repeats);
@@ -3879,12 +3509,9 @@ llvm::Expected<size_t> OpModel<RepeatOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert repeats to SmallVector<uint32_t> to use overload with memory_config
   ::ttsl::SmallVector<uint32_t> repeatVec;
@@ -3949,12 +3576,9 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
@@ -3981,12 +3605,9 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
@@ -4015,12 +3636,9 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto sortOpQuery = [=]() {
@@ -4043,12 +3661,9 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto sortOpQuery = [=]() {
@@ -4077,25 +3692,16 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto biasSpecExp = detail::convertToTensorSpec(device, biasShape, biasLayout);
-  if (!biasSpecExp) {
-    return biasSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec biasSpec = biasSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
+                   detail::convertToTensorSpec(device, biasShape, biasLayout));
 
   auto topKRouterGptQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_router_gpt, device,
@@ -4118,25 +3724,16 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto biasSpecExp = detail::convertToTensorSpec(device, biasShape, biasLayout);
-  if (!biasSpecExp) {
-    return biasSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec biasSpec = biasSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec biasSpec,
+                   detail::convertToTensorSpec(device, biasShape, biasLayout));
 
   auto topKRouterGptQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::experimental::topk_router_gpt, device,
@@ -4160,12 +3757,9 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto argMaxOpQuery = [=]() {
@@ -4190,12 +3784,9 @@ OpModel<ArgMaxOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto argMaxOpQuery = [=]() {
@@ -4221,12 +3812,9 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto prodOpQuery = [=]() {
@@ -4256,26 +3844,17 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto scaleSpecExp =
-      detail::convertToTensorSpec(device, scaleShape, scaleLayout);
-  if (!scaleSpecExp) {
-    return scaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec scaleSpec = scaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec scaleSpec,
+      detail::convertToTensorSpec(device, scaleShape, scaleLayout));
 
-  auto zeroPointSpecExp =
-      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout);
-  if (!zeroPointSpecExp) {
-    return zeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec zeroPointSpec = zeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec zeroPointSpec,
+      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -4314,26 +3893,17 @@ llvm::Expected<size_t> QuantizationOpModel<OpTy>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto scaleSpecExp =
-      detail::convertToTensorSpec(device, scaleShape, scaleLayout);
-  if (!scaleSpecExp) {
-    return scaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec scaleSpec = scaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec scaleSpec,
+      detail::convertToTensorSpec(device, scaleShape, scaleLayout));
 
-  auto zeroPointSpecExp =
-      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout);
-  if (!zeroPointSpecExp) {
-    return zeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec zeroPointSpec = zeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec zeroPointSpec,
+      detail::convertToTensorSpec(device, zeroPointShape, zeroPointLayout));
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -4379,40 +3949,25 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto inScaleSpecExp =
-      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout);
-  if (!inScaleSpecExp) {
-    return inScaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inScaleSpec = inScaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inScaleSpec,
+      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout));
 
-  auto inZeroPointSpecExp =
-      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout);
-  if (!inZeroPointSpecExp) {
-    return inZeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inZeroPointSpec = inZeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inZeroPointSpec,
+      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout));
 
-  auto outScaleSpecExp =
-      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout);
-  if (!outScaleSpecExp) {
-    return outScaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec outScaleSpec = outScaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec outScaleSpec,
+      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout));
 
-  auto outZeroPointSpecExp = detail::convertToTensorSpec(
-      device, outZeroPointShape, outZeroPointLayout);
-  if (!outZeroPointSpecExp) {
-    return outZeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec outZeroPointSpec = outZeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec outZeroPointSpec,
+                   detail::convertToTensorSpec(device, outZeroPointShape,
+                                               outZeroPointLayout));
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -4453,40 +4008,25 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto inScaleSpecExp =
-      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout);
-  if (!inScaleSpecExp) {
-    return inScaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inScaleSpec = inScaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inScaleSpec,
+      detail::convertToTensorSpec(device, inScaleShape, inScaleLayout));
 
-  auto inZeroPointSpecExp =
-      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout);
-  if (!inZeroPointSpecExp) {
-    return inZeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inZeroPointSpec = inZeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inZeroPointSpec,
+      detail::convertToTensorSpec(device, inZeroPointShape, inZeroPointLayout));
 
-  auto outScaleSpecExp =
-      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout);
-  if (!outScaleSpecExp) {
-    return outScaleSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec outScaleSpec = outScaleSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec outScaleSpec,
+      detail::convertToTensorSpec(device, outScaleShape, outScaleLayout));
 
-  auto outZeroPointSpecExp = detail::convertToTensorSpec(
-      device, outZeroPointShape, outZeroPointLayout);
-  if (!outZeroPointSpecExp) {
-    return outZeroPointSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec outZeroPointSpec = outZeroPointSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec outZeroPointSpec,
+                   detail::convertToTensorSpec(device, outZeroPointShape,
+                                               outZeroPointLayout));
 
   // Use the explicit outputDtype parameter if provided, otherwise infer from
   // layout
@@ -4528,19 +4068,13 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::Tensor> biasTensor;
   if (biasShape && biasLayout) {
@@ -4596,19 +4130,13 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::Tensor> biasTensor;
   if (biasShape && biasLayout) {
@@ -4654,19 +4182,13 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -4712,19 +4234,13 @@ llvm::Expected<size_t> OpModel<MatmulOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecAExp =
-      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA);
-  if (!inputSpecAExp) {
-    return inputSpecAExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecA = inputSpecAExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecA,
+      detail::convertToTensorSpec(device, inputShapeA, inputLayoutA));
 
-  auto inputSpecBExp =
-      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB);
-  if (!inputSpecBExp) {
-    return inputSpecBExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpecB,
+      detail::convertToTensorSpec(device, inputShapeB, inputLayoutB));
 
   std::optional<::tt::tt_metal::DataType> outputDType =
       detail::getNullableDataType(outputLayout);
@@ -4762,12 +4278,9 @@ OpModel<DeallocateOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto deallocateOpQuery = [=]() {
@@ -4792,19 +4305,13 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   auto fillCacheOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::fill_cache, device, cacheSpec,
@@ -4826,19 +4333,13 @@ llvm::Expected<size_t> OpModel<FillCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   auto fillCacheOpQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::fill_cache, device, cacheSpec, inputSpec,
@@ -4864,19 +4365,13 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // TODO(#1510): modify the ttnn::update_cache to take a tensor for
   // updateIndex.
@@ -4915,19 +4410,13 @@ llvm::Expected<size_t> OpModel<UpdateCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // TODO(#1510): modify the ttnn::update_cache to take a tensor for
   // updateIndex.
@@ -4962,35 +4451,23 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto updateIndexSpecExp =
-      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout);
-  if (!updateIndexSpecExp) {
-    return updateIndexSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec updateIndexSpec = updateIndexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec updateIndexSpec,
+      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout));
 
   std::optional<::ttnn::TensorSpec> pageTableSpec;
   if (pageTableShape && pageTableLayout) {
-    auto pageTableSpecExp =
-        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout);
-    if (!pageTableSpecExp) {
-      return pageTableSpecExp.takeError();
-    }
-    pageTableSpec = pageTableSpecExp.get();
+    ASSIGN_OR_RETURN(
+        pageTableSpec,
+        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
   std::vector<uint32_t> emptyUpdateIndex = {};
@@ -5020,35 +4497,23 @@ llvm::Expected<size_t> OpModel<PagedUpdateCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto updateIndexSpecExp =
-      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout);
-  if (!updateIndexSpecExp) {
-    return updateIndexSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec updateIndexSpec = updateIndexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec updateIndexSpec,
+      detail::convertToTensorSpec(device, updateIndexShape, updateIndexLayout));
 
   std::optional<::ttnn::TensorSpec> pageTableSpec;
   if (pageTableShape && pageTableLayout) {
-    auto pageTableSpecExp =
-        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout);
-    if (!pageTableSpecExp) {
-      return pageTableSpecExp.takeError();
-    }
-    pageTableSpec = pageTableSpecExp.get();
+    ASSIGN_OR_RETURN(
+        pageTableSpec,
+        detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
   std::vector<uint32_t> emptyUpdateIndex = {};
@@ -5079,35 +4544,23 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> batchIdxSpec;
   if (batchIdxShape && batchIdxLayout) {
-    auto batchIdxSpecExp =
-        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout);
-    if (!batchIdxSpecExp) {
-      return batchIdxSpecExp.takeError();
-    }
-    batchIdxSpec = batchIdxSpecExp.get();
+    ASSIGN_OR_RETURN(
+        batchIdxSpec,
+        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
   auto pagedFillCacheOpQuery = [=]() {
@@ -5134,35 +4587,23 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
-  auto cacheSpecExp =
-      detail::convertToTensorSpec(device, cacheShape, cacheLayout);
-  if (!cacheSpecExp) {
-    return cacheSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec cacheSpec = cacheSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec cacheSpec,
+      detail::convertToTensorSpec(device, cacheShape, cacheLayout));
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto pageTableSpecExp =
-      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout);
-  if (!pageTableSpecExp) {
-    return pageTableSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec pageTableSpec = pageTableSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec pageTableSpec,
+      detail::convertToTensorSpec(device, pageTableShape, pageTableLayout));
 
   std::optional<::ttnn::TensorSpec> batchIdxSpec;
   if (batchIdxShape && batchIdxLayout) {
-    auto batchIdxSpecExp =
-        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout);
-    if (!batchIdxSpecExp) {
-      return batchIdxSpecExp.takeError();
-    }
-    batchIdxSpec = batchIdxSpecExp.get();
+    ASSIGN_OR_RETURN(
+        batchIdxSpec,
+        detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
   auto pagedFillCacheOpQuery = [=]() {
@@ -5227,12 +4668,9 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5315,12 +4753,9 @@ llvm::Expected<size_t> OpModel<Conv2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5389,30 +4824,20 @@ llvm::Expected<Conv3dSpecs> prepareConv3dSpecs(
     TTNNLayoutAttr outputLayout) {
 
   // Convert input layout to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert weight layout to TensorSpec
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
   // Convert bias if present
   std::optional<::ttnn::TensorSpec> biasSpec;
   if (biasShape && biasLayout) {
-    auto biasSpecExp =
-        detail::convertToTensorSpec(device, *biasShape, *biasLayout);
-    if (!biasSpecExp) {
-      return biasSpecExp.takeError();
-    }
-    biasSpec = biasSpecExp.get();
+    ASSIGN_OR_RETURN(
+        biasSpec, detail::convertToTensorSpec(device, *biasShape, *biasLayout));
   }
 
   std::optional<::ttnn::experimental::prim::Conv3dConfig> config;
@@ -5613,12 +5038,9 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5698,12 +5120,9 @@ llvm::Expected<size_t> OpModel<ConvTranspose2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDtype =
       detail::getNullableDataType(outputLayout);
@@ -5998,12 +5417,9 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto maxPool2DQuery = [=]() {
@@ -6048,12 +5464,9 @@ llvm::Expected<size_t> OpModel<MaxPool2dOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto maxPool2DQuery = [=]() {
@@ -6103,12 +5516,9 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
@@ -6154,12 +5564,9 @@ llvm::Expected<size_t> OpModel<MaxPool2dWithIndicesOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
@@ -6208,12 +5615,9 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // default values for the variables that are received by the op's invoke
   // method in tt-metal but do not exist in the op's definition in TTNNOps.td:
@@ -6264,12 +5668,9 @@ llvm::Expected<size_t> OpModel<AvgPool2dOp>::getOpRuntime(
 
   uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // default values for the variables that are received by the op's invoke
   // method in tt-metal but do not exist in the op's definition in TTNNOps.td:
@@ -6312,12 +5713,9 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDType;
   if (dtype.has_value()) {
@@ -6348,12 +5746,9 @@ llvm::Expected<size_t> OpModel<GlobalAvgPool2dOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::tt::tt_metal::DataType> outputDType;
   if (dtype.has_value()) {
@@ -6395,12 +5790,9 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -6452,12 +5844,9 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -6514,12 +5903,9 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -6570,12 +5956,9 @@ llvm::Expected<size_t> OpModel<BatchNormTrainingOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> runningMeanSpec =
       detail::convertToOptionalTensorSpec(device, runningMeanShape,
@@ -6628,12 +6011,9 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6675,12 +6055,9 @@ llvm::Expected<size_t> OpModel<RMSNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6724,13 +6101,8 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
+                   detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6770,13 +6142,8 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec inputSpec,
+                   detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6819,12 +6186,9 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6860,12 +6224,9 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -6907,12 +6268,9 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -6954,12 +6312,9 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> residualInputSpec =
       detail::convertToOptionalTensorSpec(device, residualInputShape,
@@ -7007,19 +6362,13 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto statsSpecExp =
-      detail::convertToTensorSpec(device, statsShape, statsLayout);
-  if (!statsSpecExp) {
-    return statsSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec statsSpec,
+      detail::convertToTensorSpec(device, statsShape, statsLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -7055,19 +6404,13 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto statsSpecExp =
-      detail::convertToTensorSpec(device, statsShape, statsLayout);
-  if (!statsSpecExp) {
-    return statsSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec statsSpec = statsSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec statsSpec,
+      detail::convertToTensorSpec(device, statsShape, statsLayout));
 
   std::optional<::ttnn::TensorSpec> weightSpec =
       detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
@@ -7109,12 +6452,9 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> inputMaskSpec =
       detail::convertToOptionalTensorSpec(device, inputMaskShape,
@@ -7168,12 +6508,9 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   std::optional<::ttnn::TensorSpec> inputMaskSpec =
       detail::convertToOptionalTensorSpec(device, inputMaskShape,
@@ -7239,12 +6576,9 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   auto memConfig = detail::getNullableMemoryConfig(outputLayout);
   auto minVariant = clampAttrToVariant(min);
@@ -7270,12 +6604,9 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   auto memConfig = detail::getNullableMemoryConfig(outputLayout);
   auto minVariant = clampAttrToVariant(min);
@@ -7305,24 +6636,15 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto minSpecExp = detail::convertToTensorSpec(device, minShape, minLayout);
-  if (!minSpecExp) {
-    return minSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec minSpec = minSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec minSpec,
+                   detail::convertToTensorSpec(device, minShape, minLayout));
 
-  auto maxSpecExp = detail::convertToTensorSpec(device, maxShape, maxLayout);
-  if (!maxSpecExp) {
-    return maxSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec maxSpec = maxSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
+                   detail::convertToTensorSpec(device, maxShape, maxLayout));
 
   // Create query closure
   auto clampTensorQuery = [=]() {
@@ -7348,24 +6670,15 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto minSpecExp = detail::convertToTensorSpec(device, minShape, minLayout);
-  if (!minSpecExp) {
-    return minSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec minSpec = minSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec minSpec,
+                   detail::convertToTensorSpec(device, minShape, minLayout));
 
-  auto maxSpecExp = detail::convertToTensorSpec(device, maxShape, maxLayout);
-  if (!maxSpecExp) {
-    return maxSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec maxSpec = maxSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec maxSpec,
+                   detail::convertToTensorSpec(device, maxShape, maxLayout));
 
   // Create query closure
   auto clampTensorQuery = [=]() {
@@ -7396,12 +6709,9 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
 
   float defaultedPadValue = padValue.convertToFloat();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto permuteQuery = [=]() {
@@ -7432,12 +6742,9 @@ llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
   // Convert float
   float defaultedPadValue = padValue.convertToFloat();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto permuteQuery = [=]() {
@@ -7481,12 +6788,9 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
     return llvm::createStringError("Invalid scaleFactor");
   }
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto upsampleQuery = [=]() {
@@ -7529,12 +6833,9 @@ llvm::Expected<size_t> OpModel<UpsampleOp>::getOpRuntime(
     return llvm::createStringError("Invalid scaleFactor");
   }
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto upsampleQuery = [=]() {
@@ -7564,19 +6865,13 @@ llvm::Expected<EmbeddingOpArgs> getEmbeddingOpArgs(
     ::tt::tt_metal::distributed::MeshDevice *device,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout) {
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
   return EmbeddingOpArgs{inputSpec, weightSpec};
 }
@@ -7680,26 +6975,17 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto inGradientSpecExp =
-      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout);
-  if (!inGradientSpecExp) {
-    return inGradientSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inGradientSpec = inGradientSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inGradientSpec,
+      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
   auto embeddingBackwardOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -7725,26 +7011,17 @@ OpModel<mlir::tt::ttnn::EmbeddingBackwardOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  auto weightSpecExp =
-      detail::convertToTensorSpec(device, weightShape, weightLayout);
-  if (!weightSpecExp) {
-    return weightSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec weightSpec = weightSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec weightSpec,
+      detail::convertToTensorSpec(device, weightShape, weightLayout));
 
-  auto inGradientSpecExp =
-      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout);
-  if (!inGradientSpecExp) {
-    return inGradientSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inGradientSpec = inGradientSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inGradientSpec,
+      detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
   auto embeddingBackwardOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
@@ -7771,19 +7048,12 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  auto indexSpecExp =
-      detail::convertToTensorSpec(device, indexShape, indexLayout);
-  if (!indexSpecExp) {
-    return indexSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indexSpec,
+      detail::convertToTensorSpec(device, indexShape, indexLayout));
 
   auto gatherOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(
@@ -7808,19 +7078,12 @@ llvm::Expected<size_t> OpModel<GatherOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  auto indexSpecExp =
-      detail::convertToTensorSpec(device, indexShape, indexLayout);
-  if (!indexSpecExp) {
-    return indexSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-  ::ttnn::TensorSpec indexSpec = indexSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indexSpec,
+      detail::convertToTensorSpec(device, indexShape, indexLayout));
 
   auto gatherOpQuery = [=]() {
     return QUERY_OP_RUNTIME(
@@ -8041,12 +7304,9 @@ OpModel<mlir::tt::ttnn::DropoutOp>::getOpConstraints(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   float probVal = prob.convertToFloat();
   float scaleVal = scale.convertToFloat();
@@ -8074,12 +7334,9 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::DropoutOp>::getOpRuntime(
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   float probVal = prob.convertToFloat();
   float scaleVal = scale.convertToFloat();
@@ -8225,12 +7482,9 @@ OpModel<mlir::tt::ttnn::AssignOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert output memory config
   ::tt::tt_metal::MemoryConfig metalMemConfig =
@@ -8264,12 +7518,9 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Convert output memory config
   ::tt::tt_metal::MemoryConfig metalMemConfig =
@@ -8307,12 +7558,9 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto topKQuery = [=]() {
@@ -8338,12 +7586,9 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto topKQuery = [=]() {
@@ -8385,35 +7630,17 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
   llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
                                              inputIndicesShape[1]};
 
-  auto valuesSpecExp =
-      detail::convertToTensorSpec(device, values4D, inputValuesLayout);
-  if (!valuesSpecExp) {
-    return valuesSpecExp.takeError();
-  }
-  auto indicesSpecExp =
-      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout);
-  if (!indicesSpecExp) {
-    return indicesSpecExp.takeError();
-  }
-  auto kSpecExp = detail::convertToTensorSpec(device, kShape, kLayout);
-  if (!kSpecExp) {
-    return kSpecExp.takeError();
-  }
-  auto pSpecExp = detail::convertToTensorSpec(device, pShape, pLayout);
-  if (!pSpecExp) {
-    return pSpecExp.takeError();
-  }
-  auto tempSpecExp = detail::convertToTensorSpec(device, tempShape, tempLayout);
-  if (!tempSpecExp) {
-    return tempSpecExp.takeError();
-  }
-
-  // Extract TensorSpecs before lambda capture (Expected is not copyable).
-  ::ttnn::TensorSpec valuesSpec = valuesSpecExp.get();
-  ::ttnn::TensorSpec indicesSpec = indicesSpecExp.get();
-  ::ttnn::TensorSpec kSpec = kSpecExp.get();
-  ::ttnn::TensorSpec pSpec = pSpecExp.get();
-  ::ttnn::TensorSpec tempSpec = tempSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec valuesSpec,
+                   detail::convertToTensorSpec(device, values4D, inputValuesLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indicesSpec,
+      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec kSpec,
+                   detail::convertToTensorSpec(device, kShape, kLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec pSpec,
+                   detail::convertToTensorSpec(device, pShape, pLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec tempSpec,
+                   detail::convertToTensorSpec(device, tempShape, tempLayout));
 
   auto samplingQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::sampling, device, valuesSpec,
@@ -8446,34 +7673,17 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
   llvm::SmallVector<int64_t, 4> indices4D = {1, 1, inputIndicesShape[0],
                                              inputIndicesShape[1]};
 
-  auto valuesSpecExp =
-      detail::convertToTensorSpec(device, values4D, inputValuesLayout);
-  if (!valuesSpecExp) {
-    return valuesSpecExp.takeError();
-  }
-  auto indicesSpecExp =
-      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout);
-  if (!indicesSpecExp) {
-    return indicesSpecExp.takeError();
-  }
-  auto kSpecExp = detail::convertToTensorSpec(device, kShape, kLayout);
-  if (!kSpecExp) {
-    return kSpecExp.takeError();
-  }
-  auto pSpecExp = detail::convertToTensorSpec(device, pShape, pLayout);
-  if (!pSpecExp) {
-    return pSpecExp.takeError();
-  }
-  auto tempSpecExp = detail::convertToTensorSpec(device, tempShape, tempLayout);
-  if (!tempSpecExp) {
-    return tempSpecExp.takeError();
-  }
-
-  ::ttnn::TensorSpec valuesSpec = valuesSpecExp.get();
-  ::ttnn::TensorSpec indicesSpec = indicesSpecExp.get();
-  ::ttnn::TensorSpec kSpec = kSpecExp.get();
-  ::ttnn::TensorSpec pSpec = pSpecExp.get();
-  ::ttnn::TensorSpec tempSpec = tempSpecExp.get();
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec valuesSpec,
+                   detail::convertToTensorSpec(device, values4D, inputValuesLayout));
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec indicesSpec,
+      detail::convertToTensorSpec(device, indices4D, inputIndicesLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec kSpec,
+                   detail::convertToTensorSpec(device, kShape, kLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec pSpec,
+                   detail::convertToTensorSpec(device, pShape, pLayout));
+  ASSIGN_OR_RETURN(::ttnn::TensorSpec tempSpec,
+                   detail::convertToTensorSpec(device, tempShape, tempLayout));
 
   auto samplingQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::sampling, device, valuesSpec, indicesSpec,
@@ -8500,12 +7710,9 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto meshPartitionOpQuery = [=]() {
@@ -8529,12 +7736,9 @@ llvm::Expected<size_t> OpModel<MeshPartitionOp>::getOpRuntime(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert input tensor to TensorSpec
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
+  ASSIGN_OR_RETURN(
+      ::ttnn::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
 
   // Create query closure
   auto meshPartitionOpQuery = [=]() {

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -250,7 +251,13 @@ TEST_F(OpConstraintValidationTest, UpdateCacheOpWithInvalidUpdateIndexType) {
 }
 
 // Test ValidationStatus::NotImplemented
-// AllocOp returns MissingMetalDefinition which maps to NotImplemented
+// AllocOp carries the OpModelExempt trait and therefore does not implement
+// the OpModel interface. validateOperation must surface this as a
+// NotImplemented ValidationResult so the optimizer can fall back gracefully
+// (see GreedyMemoryLayoutPropagation / L1SpillManagement, which both branch
+// on result.isNotImplemented()). Regressing this contract — e.g. by removing
+// the OpModelExempt special case in OpConstraintValidation::validateConstraints
+// — would crash the optimizer at runtime via reportFatalInternalError.
 TEST_F(OpConstraintValidationTest, ValidationStatusNotImplemented) {
   llvm::SmallVector<int64_t> tensorShape = {1, 1, 32, 32};
   auto layout = createTiledLayout(tensorShape, BufferType::L1,
@@ -276,6 +283,89 @@ TEST_F(OpConstraintValidationTest, ValidationStatusNotImplemented) {
   EXPECT_TRUE(result.isError());
   EXPECT_FALSE(result.isSuccess());
   EXPECT_FALSE(result.errorMessage.empty());
+}
+
+// Regression test for "OpModelExempt -> NotImplemented" optimizer contract.
+//
+// Background: ops that opt out of the OpModel interface via the OpModelExempt
+// trait (e.g. CCL ops, trace ops, host/alloc ops, GetDeviceOp...) do not
+// implement TTNN_OpModelInterface at all. The optimizer's L1 spill / memory
+// layout propagation passes call op_constraint_validation::validateOperation
+// on every op in the IR and rely on observing isNotImplemented() for ops
+// they cannot analyze, so they can fall back (e.g. evict L1) instead of
+// taking layout decisions on bogus data.
+//
+// Before the OpModelExempt change, these ops had explicit stub
+// getOpConstraints / getOpRuntime overrides returning OpNotSupportedError,
+// which validateOperation translated to NotImplemented via handleAllErrors.
+// After OpModelExempt removed those stubs, dyn_cast<OpModel>(op) returns
+// nullptr for exempt ops and the original code path called
+// llvm::reportFatalInternalError, crashing the compiler.
+//
+// This test asserts the contract using two independent OpModelExempt ops:
+//   - GetDeviceOp: a trivial OpModelExempt op with no tensor inputs.
+//   - AllocOp:    an OpModelExempt op with a tensor result.
+// Both must be observed as NotImplemented (never crash, never silently
+// succeed). If someone removes the OpModelExempt fallback in
+// validateConstraints, both calls will hit reportFatalInternalError and
+// abort this test process.
+TEST_F(OpConstraintValidationTest,
+       OpModelExemptOpsReturnNotImplementedNotFatal) {
+  // Sanity: the trait-driven contract we are asserting.
+  static_assert(GetDeviceOp::hasTrait<OpModelExempt>(),
+                "GetDeviceOp must carry the OpModelExempt trait for this "
+                "regression test to be meaningful.");
+  static_assert(AllocOp::hasTrait<OpModelExempt>(),
+                "AllocOp must carry the OpModelExempt trait for this "
+                "regression test to be meaningful.");
+
+  // GetDeviceOp: zero tensor inputs, just produces a device value.
+  auto getDeviceOp = builder.create<GetDeviceOp>(
+      builder.getUnknownLoc(), builder.getType<DeviceType>(),
+      MeshShapeAttr::get(&context, 1, 1), MeshOffsetAttr::get(&context, 0, 0));
+
+  // Ensure the op truly does not implement the OpModel interface.
+  ASSERT_FALSE(mlir::isa<OpModel>(getDeviceOp.getOperation()))
+      << "GetDeviceOp unexpectedly implements OpModel; the OpModelExempt -> "
+         "NotImplemented fallback would never be exercised by this test.";
+
+  OpConfig config = createTestConfig();
+  auto getDeviceResult = op_constraint_validation::validateOperation(
+      getDeviceOp, /*inputLayouts=*/{}, config);
+
+  EXPECT_TRUE(getDeviceResult.isNotImplemented())
+      << "OpModelExempt op (GetDeviceOp) must surface NotImplemented to "
+         "preserve the optimizer fallback path. Status="
+      << op_constraint_validation::validationStatusToString(
+             getDeviceResult.status)
+             .str();
+  EXPECT_FALSE(getDeviceResult.isSuccess());
+  EXPECT_FALSE(getDeviceResult.errorMessage.empty());
+
+  // AllocOp: same contract via a second exempt op with different shape.
+  llvm::SmallVector<int64_t> tensorShape = {1, 1, 32, 32};
+  auto layout = createTiledLayout(tensorShape, BufferType::L1,
+                                  TensorMemoryLayout::Interleaved);
+  auto tensorType =
+      mlir::RankedTensorType::get(tensorShape, builder.getBF16Type(), layout);
+  auto allocOp = builder.create<AllocOp>(
+      builder.getUnknownLoc(), tensorType, builder.getI64IntegerAttr(0),
+      builder.getI64IntegerAttr(2048),
+      BufferTypeAttr::get(&context, BufferType::L1));
+
+  ASSERT_FALSE(mlir::isa<OpModel>(allocOp.getOperation()))
+      << "AllocOp unexpectedly implements OpModel; the OpModelExempt -> "
+         "NotImplemented fallback would never be exercised by this test.";
+
+  auto allocLayouts = ttnn::utils::extractInputLayouts(allocOp);
+  auto allocResult = op_constraint_validation::validateOperation(
+      allocOp, allocLayouts, config);
+
+  EXPECT_TRUE(allocResult.isNotImplemented())
+      << "OpModelExempt op (AllocOp) must surface NotImplemented to preserve "
+         "the optimizer fallback path. Status="
+      << op_constraint_validation::validationStatusToString(allocResult.status)
+             .str();
 }
 
 // Test ValidationStatus::MetalBackendError


### PR DESCRIPTION
## Ticket
closes #8065

## Summary
- Reapplies #7925 ("Introduce `OpModelExempt` and `ASSIGN_OR_RETURN` macro"), which was reverted in #8066 after surfacing a latent L1 OOM bug in the greedy optimizer's spill management pass. Net effect: removes ~1500 lines of stub OpModel boilerplate by allowing 24 ops (CCLs, traces, MoE ops, host/device transfers, etc.) to opt out of declaring the OpModel interface.
- Fixes the underlying L1 OOM. Before #7925, `L1SpillManagement::run()` used `!dyn_cast<OpModel>(op)` to split two groups: ops with no stubs at all (e.g. `ToDeviceOp`, `FromDeviceOp`) were correctly skipped, while ops that had stubs returning `NotImplemented` (e.g. CCLs) passed the check and reached the `isNotImplemented()` branch which evicted all live L1 tensors. After #7925 removed the stubs, both groups failed the `dyn_cast` and were skipped — so CCLs stopped triggering the evict-all path, leaving their live L1 inputs un-spilled and causing OOM. The fix removes the `dyn_cast` guard and lets all DRAM-output ops proceed to validation: truly no-op host/device transfer ops still bail out at `liveValues.empty()` (nothing to spill), while CCLs with live L1 tensors correctly reach `isNotImplemented()` and evict everything.

## Test plan
- [x] `cmake --build build --target check-ttmlir` passes
- [x] Verify no models that previously OOM'd in the original reapply attempt regress https://github.com/tenstorrent/tt-xla/actions/runs/25547401437 (qwen_3_32b_tp, qwen_3_8b_tp)
after edit: https://github.com/tenstorrent/tt-xla/actions/runs/25865192580

## Notes for reviewers
- Op coverage audited: 20+ ops marked `OpModelExempt`, remaining 100+ ops all retain OpModel impls (direct or templated). No leftover stubs on exempt ops.
- The L1 spill fix is a one-line change in `lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`; the comment above was updated to match the new behavior.