### PR TITLE
Fix create-main-for-test bug

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -723,6 +723,16 @@ public:
       return;
     }
 
+    // main_for_test currently assumes that forward function has a single
+    // tuple input (plus the device that this pass injects). When
+    // TTNNSplitForwardFuncArgsByType has split the forward function's
+    // inputs into an activations tuple and/or a weights dict, that
+    // assumption no longer holds, so skip wrapper creation in that case.
+    //
+    if (ttmlir::utils::hasSplitForwardFuncArgsByType(forwardFuncOp)) {
+      return;
+    }
+
     // Inject device argument into the forward function, replacing GetDeviceOp
     // uses. This follows the same pattern as TTNNPrepareModuleForExport so
     // that the EmitPy LoadCachedOpConversionPattern can find the device arg


### PR DESCRIPTION
### Problem description
tt-mlir uplift into tt-xla exposed a bug when `create-main-for-test` pipeline flag is set to true. Namely, `TTNNCreateMainForTest` pass assumes that a forward function has a single input tensor argument (plus the device argument that this pass injects). However, when `TTNNSplitForwardFuncArgsByType`  is performed (this pass is before `TTNNCreateMainForTest` in the pipeline), a forward function signature is changed so that it has a tuple argument for activations and/or a weight dictionary argument. 

### What's changed
As a hot-fix, `TTNNCreateMainForTest` is skipped on all forward functions on which `TTNNSplitForwardFuncArgsByType` pass was performed. A long-term solution will come as a follow-up.

### Checklist
- [ ] New/Existing tests provide coverage for changes
