### PR TITLE
Handle sdy.return during ComplexDataTypeConversion pass

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -424,7 +424,7 @@ public:
 
 // Rewrites `sdy.return` to use dialect-converted operand values (same role as
 // `populateReturnOpTypeConversionPattern` for `func.return`).
-class SdyReturnOpTypeConversionPattern
+class ShardyReturnOpTypeConversionPattern
     : public OpConversionPattern<mlir::sdy::ReturnOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -503,7 +503,8 @@ struct StableHLOComplexDataTypeConversionPass
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConcatenateOp>,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
         ShardyManualComputationComplexConversionPattern,
-        SdyReturnOpTypeConversionPattern, StablehloComplexToDecomposedPattern,
+        ShardyReturnOpTypeConversionPattern,
+        StablehloComplexToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
         typeConverter, &getContext());

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -421,6 +421,23 @@ public:
     return success();
   }
 };
+
+// Rewrites `sdy.return` to use dialect-converted operand values (same role as
+// `populateReturnOpTypeConversionPattern` for `func.return`). 
+class SdyReturnOpTypeConversionPattern
+    : public OpConversionPattern<mlir::sdy::ReturnOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::sdy::ReturnOp op,
+                  mlir::sdy::ReturnOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::sdy::ReturnOp>(op,
+                                                       adaptor.getOperands());
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -488,6 +505,7 @@ struct StableHLOComplexDataTypeConversionPass
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConcatenateOp>,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
         ShardyManualComputationComplexConversionPattern,
+        SdyReturnOpTypeConversionPattern,
         StablehloComplexToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
@@ -502,6 +520,8 @@ struct StableHLOComplexDataTypeConversionPass
     populateReturnOpTypeConversionPattern(patterns, typeConverter);
     target.addDynamicallyLegalOp<func::ReturnOp>(
         [&](func::ReturnOp op) { return typeConverter.isLegal(op); });
+    target.addDynamicallyLegalOp<mlir::sdy::ReturnOp>(
+        [&](mlir::sdy::ReturnOp op) { return typeConverter.isLegal(op); });
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ComplexDataTypeConversion.cpp
@@ -423,18 +423,16 @@ public:
 };
 
 // Rewrites `sdy.return` to use dialect-converted operand values (same role as
-// `populateReturnOpTypeConversionPattern` for `func.return`). 
+// `populateReturnOpTypeConversionPattern` for `func.return`).
 class SdyReturnOpTypeConversionPattern
     : public OpConversionPattern<mlir::sdy::ReturnOp> {
   using OpConversionPattern::OpConversionPattern;
 
 public:
   LogicalResult
-  matchAndRewrite(mlir::sdy::ReturnOp op,
-                  mlir::sdy::ReturnOp::Adaptor adaptor,
+  matchAndRewrite(mlir::sdy::ReturnOp op, mlir::sdy::ReturnOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<mlir::sdy::ReturnOp>(op,
-                                                       adaptor.getOperands());
+    rewriter.replaceOpWithNewOp<mlir::sdy::ReturnOp>(op, adaptor.getOperands());
     return success();
   }
 };
@@ -505,8 +503,7 @@ struct StableHLOComplexDataTypeConversionPass
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ConcatenateOp>,
         ComplexTypeDefaultConversionPattern<mlir::stablehlo::ReshapeOp>,
         ShardyManualComputationComplexConversionPattern,
-        SdyReturnOpTypeConversionPattern,
-        StablehloComplexToDecomposedPattern,
+        SdyReturnOpTypeConversionPattern, StablehloComplexToDecomposedPattern,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::RealOp>,
         StablehloRealImagToDecomposedPattern<mlir::stablehlo::ImagOp>>(
         typeConverter, &getContext());

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
@@ -143,8 +143,10 @@ sdy.mesh @mesh = <["_axis_0_aux"=1, "_axis_0"=2]>
 // CHECK-SAME: %arg1: tensor<1024x22xf64>
 func.func @test_sdy_return_complex(%arg0: tensor<1024x22xf64>, %arg1: tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>> ) {
   // CHECK: sdy.manual_computation
-  // CHECK-SAME: (%arg2: tensor<1024x22xf64>, %arg3: tensor<512x22xf64>) {
-  // CHECK: sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0x2xf64>
+  // CHECK-SAME: (%[[ARG2:.*]]: tensor<1024x22xf64>, %[[ARG3:.*]]: tensor<512x22xf64>) {
+  // CHECK: %[[CST:.*]] = stablehlo.constant
+  // CHECK: sdy.return %[[RET0:.*]], %[[RET1:.*]], %[[CST]] : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0x2xf64>
+  // CHECK-NOT: complex<f64>
   %0:3 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>] out_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>, <@mesh, [{}]>] manual_axes={"_axis_0_aux", "_axis_0"} (%arg2: tensor<1024x22xf64> loc("p0.1"), %arg3: tensor<512x22xf64> loc("p1.5")) {
     %cst = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<0xcomplex<f64>>
     %1 = stablehlo.reshape %arg2 : (tensor<1024x22xf64>) -> tensor<1x1024x22xf64>

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion %s | FileCheck %s
+// RUN: ttmlir-opt -split-input-file --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion %s | FileCheck %s
 // REQUIRES: stablehlo
 
 // Test that ComplexDataTypeConversion handles complex types inside
@@ -134,3 +134,24 @@ func.func @test_complex_created_inside_manual_computation(
   } : (tensor<1x16x1x32xf32>, tensor<1x16x16x2xf32>) -> tensor<1x16x32xf32>
   return %0 : tensor<1x16x32xf32>
 }
+
+// -----
+
+sdy.mesh @mesh = <["_axis_0_aux"=1, "_axis_0"=2]> 
+// CHECK-LABEL: func.func @test_sdy_return_complex
+// CHECK-SAME: %arg0: tensor<1024x22xf64>
+// CHECK-SAME: %arg1: tensor<1024x22xf64>
+func.func @test_sdy_return_complex(%arg0: tensor<1024x22xf64>, %arg1: tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>> ) {
+  // CHECK: sdy.manual_computation
+  // CHECK-SAME: (%arg2: tensor<1024x22xf64>, %arg3: tensor<512x22xf64>) {
+  // CHECK: sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0x2xf64> 
+  %0:3 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>] out_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>, <@mesh, [{}]>] manual_axes={"_axis_0_aux", "_axis_0"} (%arg2: tensor<1024x22xf64> loc("p0.1"), %arg3: tensor<512x22xf64> loc("p1.5")) {
+    %cst = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<0xcomplex<f64>> 
+    %1 = stablehlo.reshape %arg2 : (tensor<1024x22xf64>) -> tensor<1x1024x22xf64> 
+    %2 = stablehlo.reshape %1 : (tensor<1x1024x22xf64>) -> tensor<1024x22xf64> 
+    %3 = stablehlo.reshape %arg3 : (tensor<512x22xf64>) -> tensor<1x512x22xf64> 
+    %4 = stablehlo.reshape %3 : (tensor<1x512x22xf64>) -> tensor<512x22xf64> 
+    sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0xcomplex<f64>> 
+  } : (tensor<1024x22xf64>, tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>>) 
+  return %0#0, %0#1, %0#2 : tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>> 
+} 

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_manual_computation.mlir
@@ -137,21 +137,21 @@ func.func @test_complex_created_inside_manual_computation(
 
 // -----
 
-sdy.mesh @mesh = <["_axis_0_aux"=1, "_axis_0"=2]> 
+sdy.mesh @mesh = <["_axis_0_aux"=1, "_axis_0"=2]>
 // CHECK-LABEL: func.func @test_sdy_return_complex
 // CHECK-SAME: %arg0: tensor<1024x22xf64>
 // CHECK-SAME: %arg1: tensor<1024x22xf64>
 func.func @test_sdy_return_complex(%arg0: tensor<1024x22xf64>, %arg1: tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>> ) {
   // CHECK: sdy.manual_computation
   // CHECK-SAME: (%arg2: tensor<1024x22xf64>, %arg3: tensor<512x22xf64>) {
-  // CHECK: sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0x2xf64> 
+  // CHECK: sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0x2xf64>
   %0:3 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>] out_shardings=[<@mesh, [{}, {}]>, <@mesh, [{"_axis_0"}, {}]>, <@mesh, [{}]>] manual_axes={"_axis_0_aux", "_axis_0"} (%arg2: tensor<1024x22xf64> loc("p0.1"), %arg3: tensor<512x22xf64> loc("p1.5")) {
-    %cst = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<0xcomplex<f64>> 
-    %1 = stablehlo.reshape %arg2 : (tensor<1024x22xf64>) -> tensor<1x1024x22xf64> 
-    %2 = stablehlo.reshape %1 : (tensor<1x1024x22xf64>) -> tensor<1024x22xf64> 
-    %3 = stablehlo.reshape %arg3 : (tensor<512x22xf64>) -> tensor<1x512x22xf64> 
-    %4 = stablehlo.reshape %3 : (tensor<1x512x22xf64>) -> tensor<512x22xf64> 
-    sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0xcomplex<f64>> 
-  } : (tensor<1024x22xf64>, tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>>) 
-  return %0#0, %0#1, %0#2 : tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>> 
-} 
+    %cst = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<0xcomplex<f64>>
+    %1 = stablehlo.reshape %arg2 : (tensor<1024x22xf64>) -> tensor<1x1024x22xf64>
+    %2 = stablehlo.reshape %1 : (tensor<1x1024x22xf64>) -> tensor<1024x22xf64>
+    %3 = stablehlo.reshape %arg3 : (tensor<512x22xf64>) -> tensor<1x512x22xf64>
+    %4 = stablehlo.reshape %3 : (tensor<1x512x22xf64>) -> tensor<512x22xf64>
+    sdy.return %2, %4, %cst : tensor<1024x22xf64>, tensor<512x22xf64>, tensor<0xcomplex<f64>>
+  } : (tensor<1024x22xf64>, tensor<1024x22xf64>) -> (tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>>)
+  return %0#0, %0#1, %0#2 : tensor<1024x22xf64>, tensor<1024x22xf64>, tensor<0xcomplex<f64>>
+}


### PR DESCRIPTION
### Ticket
#8291 

### Problem description
ComplexDataTypeConversionPass was not handling sdy.return op type.

### What's changed
Added sdy.return op type conversion pattern and wrote a test case.

### Checklist
- [X] New/Existing tests provide coverage for changes
