### PR TITLE
Uplift third_party/tt-metal to 08ce2dc1594c264f262cdce6c56fc014af1f6bfd 2026-05-08

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "89883e453b9c0ee182fea67a26cbb8b493622144")
+set(TT_METAL_VERSION "08ce2dc1594c264f262cdce6c56fc014af1f6bfd")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 08ce2dc1594c264f262cdce6c56fc014af1f6bfd



### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25538214536
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25538175455
      - Note, the [tests/examples/test_examples.py::test_script_examples[jax/codegen/python/emitpy_execute.py]](https://github.com/tenstorrent/tt-xla/actions/runs/25538175455/job/75017038923) test failed in the above run, but this is a known issue with [tt-mlir](https://github.com/tenstorrent/tt-mlir/issues/8325), not due to tt-metal.
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): N/A
  - [x] **Frontend fix PRs** ready (if needed by this uplift): N/A