### PR TITLE
d2m: enable aliasing for reblocked ops

### DIFF
--- a/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h
@@ -23,7 +23,6 @@ struct BlockFactorAnalysis {
   struct Options {
     BufferSizePolicy policy = BufferSizePolicy::Auto;
     uint32_t numBuffers = 2;
-    bool allowAliasedEltwiseBlocking = true;
   };
 
   struct Result {

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -572,10 +572,6 @@ def D2MAllocate: Pass<"d2m-allocate", "::mlir::ModuleOp"> {
           "test-buffer-size-policy",
           "std::string", /*default=*/"\"auto\"",
           "Set policy for sizing stream buffers ('auto', 'min', 'max').">,
-    Option<"testAllowAliasedEltwiseBlocking",
-          "test-allow-aliased-eltwise-blocking",
-          "bool", /*default=*/"true",
-          "Allow auto reblocking for eltwise generics even when blocked outputs must leave alias mode.">,
   ];
 }
 

--- a/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/BlockFactorAnalysis.cpp
@@ -48,40 +48,6 @@ static llvm::BitVector getDimMask(std::size_t rank,
   return mask;
 }
 
-// @return true if the operand needs a dedicated CB by existing rules.
-static bool operandNeedsDedicatedCBByExistingRules(GenericOp genericOp,
-                                                   uint32_t operandIndex) {
-  Value operand = genericOp.getInputsAndOutputs()[operandIndex];
-
-  if (hasNonTrivialView(operand)) {
-    return true;
-  }
-
-  auto operandType = mlir::dyn_cast<MemRefType>(operand.getType());
-  if (!operandType) {
-    return false;
-  }
-  if (ttcore::getMemorySpace(operandType) == ttcore::MemorySpace::DeviceDRAM) {
-    return true;
-  }
-
-  const AffineMap indexingMap = genericOp.getIndexingMap(operandIndex);
-  const auto broadcastDims = indexingMap.getBroadcastDims();
-  const auto iteratorTypes = genericOp.getIteratorTypesValue();
-  for (std::size_t resultIndex = 0; resultIndex < indexingMap.getNumResults();
-       ++resultIndex) {
-    if (llvm::is_contained(broadcastDims, resultIndex)) {
-      return true;
-    }
-    if (iteratorTypes[indexingMap.getDimPosition(resultIndex)] ==
-        ttcore::IteratorType::Reduction) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 /// Classify a generic op's iteration shape for auto-policy search.
 /// @return the search config or nullopt if auto-blocking is not applicable.
 static std::optional<AutoSearchConfig>
@@ -200,8 +166,7 @@ static std::optional<CandidateScore> evaluateCandidate(
     ArrayRef<int64_t> shardExtents, ArrayRef<int64_t> shardFactors,
     ArrayRef<int64_t> originalBlockFactors, ArrayRef<int64_t> dimScales,
     ttcore::DeviceAttr device, ttcore::MemorySpaceAttr l1Attr,
-    uint32_t numBuffers, bool allowAliasedEltwiseBlocking,
-    bool allowIdentityCandidate = false) {
+    uint32_t numBuffers, bool allowIdentityCandidate = false) {
   SmallVector<int64_t> candidateGridExtents(gridExtents.begin(),
                                             gridExtents.end());
   SmallVector<int64_t> candidateShardExtents(shardExtents.begin(),
@@ -245,14 +210,6 @@ static std::optional<CandidateScore> evaluateCandidate(
 
     // Reject candidates that would result in a too small operand shard shape.
     if (ttmlir::utils::volume<int64_t>(operandShardShape) < 4) {
-      return std::nullopt;
-    }
-
-    // Reject candidates that would result in a dedicated CB being needed for
-    // output operands if aliased eltwise blocking is not allowed.
-    if (genericOp.isOutputOperandIdx(operandIndex) &&
-        !operandNeedsDedicatedCBByExistingRules(genericOp, operandIndex) &&
-        !allowAliasedEltwiseBlocking) {
       return std::nullopt;
     }
 
@@ -343,8 +300,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
                 ArrayRef<ttcore::IteratorType> iteratorTypes,
                 ArrayRef<int64_t> gridExtents, ArrayRef<int64_t> shardExtents,
                 ArrayRef<int64_t> shardFactors, ttcore::DeviceAttr device,
-                ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers,
-                bool allowAliasedEltwiseBlocking) {
+                ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers) {
   const SmallVector<int64_t> originalBlockFactors =
       genericOp.getBlockFactorsValue();
 
@@ -374,8 +330,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
     bestCandidate = evaluateCandidate(
         genericOp, config->candidateDims, indexingMaps, gridExtents,
         shardExtents, shardFactors, originalBlockFactors, currentDimScales,
-        device, l1Attr, numBuffers, allowAliasedEltwiseBlocking,
-        /*allowIdentityCandidate=*/true);
+        device, l1Attr, numBuffers, /*allowIdentityCandidate=*/true);
   }
 
   std::function<void(std::size_t)> enumerateCandidates =
@@ -385,8 +340,7 @@ applyAutoPolicy(GenericOp genericOp, ArrayRef<AffineMap> indexingMaps,
           auto candidate = evaluateCandidate(
               genericOp, config->candidateDims, indexingMaps, gridExtents,
               shardExtents, shardFactors, originalBlockFactors,
-              currentDimScales, device, l1Attr, numBuffers,
-              allowAliasedEltwiseBlocking);
+              currentDimScales, device, l1Attr, numBuffers);
           if (candidate && (!bestCandidate ||
                             isBetterCandidate(config->shapeClass, *candidate,
                                               *bestCandidate))) {
@@ -425,8 +379,7 @@ static SmallVector<int64_t> chooseReblockedFactors(
     ArrayRef<ttcore::IteratorType> iteratorTypes, ArrayRef<int64_t> gridExtents,
     ArrayRef<int64_t> shardExtents, ttcore::DeviceAttr device,
     BlockFactorAnalysis::BufferSizePolicy policy,
-    ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers,
-    bool allowAliasedEltwiseBlocking) {
+    ttcore::MemorySpaceAttr l1Attr, uint32_t numBuffers) {
   const SmallVector<int64_t> shardFactors = getShardBlockFactors(genericOp);
   switch (policy) {
   case BlockFactorAnalysis::BufferSizePolicy::Max:
@@ -436,7 +389,7 @@ static SmallVector<int64_t> chooseReblockedFactors(
   case BlockFactorAnalysis::BufferSizePolicy::Auto:
     return applyAutoPolicy(genericOp, indexingMaps, iteratorTypes, gridExtents,
                            shardExtents, shardFactors, device, l1Attr,
-                           numBuffers, allowAliasedEltwiseBlocking);
+                           numBuffers);
   }
 
   llvm_unreachable("unknown buffer size policy");
@@ -468,8 +421,7 @@ BlockFactorAnalysis::BlockFactorAnalysis(Operation *op, const Options &opts) {
 
     SmallVector<int64_t> reblockedFactors = chooseReblockedFactors(
         genericOp, indexingMaps, iteratorTypes, gridExtents, shardExtents,
-        device, opts.policy, l1Attr, opts.numBuffers,
-        opts.allowAliasedEltwiseBlocking);
+        device, opts.policy, l1Attr, opts.numBuffers);
 
     results[genericOp.getOperation()] = Result{std::move(reblockedFactors)};
   });

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -282,8 +282,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
       << asSeq(llvm::to_vector(obj.availableL1AddrRange)) << "\n";
     s << "\ttest-assume-l1-capacity: " << obj.testAssumeL1Capacity << "\n";
     s << "\ttest-buffer-size-policy: " << obj.testBufferSizePolicy << "\n";
-    s << "\ttest-allow-aliased-eltwise-blocking: "
-      << obj.testAllowAliasedEltwiseBlocking << "\n";
     s << "}";
     return s.str();
   }
@@ -963,7 +961,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     BlockFactorAnalysis::Options bfOpts;
     bfOpts.policy = bufferSizePolicy;
     bfOpts.numBuffers = numStreamBuffers;
-    bfOpts.allowAliasedEltwiseBlocking = testAllowAliasedEltwiseBlocking;
     BlockFactorAnalysis blockFactorAnalysis(funcOp, bfOpts);
 
     [[maybe_unused]] int32_t genericsInExplicitDatamovementForm = 0;
@@ -1867,80 +1864,13 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     return Value();
   }
 
-  static bool isPurePermutationIndexingMap(AffineMap map) {
-    return map.getNumSymbols() == 0 &&
-           map.getNumResults() == map.getNumDims() && map.isPermutation();
-  }
-
-  bool canAliasBlockedAllParallelEltwiseOutput(
-      d2m::GenericOp genericOp, const GenericOpContext &genericCtx,
-      const OperandContext &operandCtx, MemorySpace memspace) const {
-    if (!operandCtx.isOutput || genericCtx.isExplicitDatamovement ||
-        genericOp.isDMAOnlyForm() ||
-        !isOperandExemptFromStreaming(operandCtx, memspace)) {
-      return false;
-    }
-
-    if (!llvm::all_of(genericOp.getIteratorTypesValue(),
-                      [](ttcore::IteratorType iteratorType) {
-                        return iteratorType == ttcore::IteratorType::Parallel;
-                      })) {
-      return false;
-    }
-
-    bool hasTile = false;
-    bool hasNonTile = false;
-    for (auto [operandIndex, operand] :
-         llvm::enumerate(genericOp.getInputsAndOutputs())) {
-      if (allocation::hasNonTrivialView(operand)) {
-        return false;
-      }
-
-      auto memrefType = mlir::dyn_cast<MemRefType>(operand.getType());
-      if (!memrefType ||
-          ttcore::getMemorySpace(memrefType) != MemorySpace::DeviceL1) {
-        return false;
-      }
-
-      if (mlir::isa<ttcore::TileType>(memrefType.getElementType())) {
-        hasTile = true;
-      } else {
-        hasNonTile = true;
-      }
-
-      AffineMap indexingMap = genericOp.getIndexingMap(operandIndex);
-      if (!isPurePermutationIndexingMap(indexingMap)) {
-        return false;
-      }
-    }
-
-    return !(hasTile && hasNonTile);
-  }
-
   bool requiresCBAllocation(d2m::GenericOp genericOp,
                             const GenericOpContext &genericCtx,
                             const OperandContext &operandCtx,
                             MemorySpace memspace) const {
-
-    // Blocked operands must be registered with the memory planner so their
-    // in-generic allocs receive an L1 address. This runs before
-    // reblockGenerics, so the view doesn't exist yet and
-    // isOperandExemptFromStreaming would incorrectly skip the alloc.
-    // Explicit DM generics have no indexing maps and are never reblocked.
-    if (!genericCtx.isExplicitDatamovement &&
-        allocation::isOperandBlocked(genericOp, operandCtx.operandIndex(),
-                                     genericCtx.reblockedFactors)) {
-      if (canAliasBlockedAllParallelEltwiseOutput(genericOp, genericCtx,
-                                                  operandCtx, memspace)) {
-        return false;
-      }
-      return true;
-    }
-
     if (isOperandExemptFromStreaming(operandCtx, memspace)) {
       return false;
     }
-
     return inferStreamRequirement(genericOp, genericCtx, operandCtx, memspace);
   }
 
@@ -2008,22 +1938,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                               const GenericOpContext &genericCtx,
                               const OperandContext &operandCtx,
                               MemorySpace memspace) const {
-    const bool baseNeedsStream =
-        inferBaseStreamRequirement(genericOp, operandCtx, memspace);
-
-    const bool blocked =
-        !genericCtx.isExplicitDatamovement &&
-        allocation::isOperandBlocked(genericOp, operandCtx.operandIndex(),
-                                     genericCtx.reblockedFactors);
-
-    if (blocked) {
-      if (!operandCtx.isOutput) {
-        return true;
-      }
-      return baseNeedsStream || testAllowAliasedEltwiseBlocking;
-    }
-
-    if (!baseNeedsStream) {
+    if (!inferBaseStreamRequirement(genericOp, operandCtx, memspace)) {
       return false;
     }
 

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1867,6 +1867,72 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     return Value();
   }
 
+  static bool isPurePermutationIndexingMap(AffineMap map) {
+    if (map.getNumSymbols() != 0 || map.getNumResults() != map.getNumDims()) {
+      return false;
+    }
+
+    llvm::BitVector seenDims(map.getNumDims(), false);
+    for (AffineExpr expr : map.getResults()) {
+      auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
+      if (!dimExpr) {
+        return false;
+      }
+      unsigned dim = dimExpr.getPosition();
+      if (dim >= map.getNumDims() || seenDims[dim]) {
+        return false;
+      }
+      seenDims[dim] = true;
+    }
+
+    return seenDims.all();
+  }
+
+  bool canAliasBlockedAllParallelEltwiseOutput(
+      d2m::GenericOp genericOp, const GenericOpContext &genericCtx,
+      const OperandContext &operandCtx, MemorySpace memspace) const {
+    if (!operandCtx.isOutput || genericCtx.isExplicitDatamovement ||
+        genericOp.isDMAOnlyForm() ||
+        !isOperandExemptFromStreaming(operandCtx, memspace)) {
+      return false;
+    }
+
+    if (!llvm::all_of(genericOp.getIteratorTypesValue(),
+                      [](ttcore::IteratorType iteratorType) {
+                        return iteratorType == ttcore::IteratorType::Parallel;
+                      })) {
+      return false;
+    }
+
+    bool hasTile = false;
+    bool hasNonTile = false;
+    for (auto [operandIndex, operand] :
+         llvm::enumerate(genericOp.getInputsAndOutputs())) {
+      if (allocation::hasNonTrivialView(operand)) {
+        return false;
+      }
+
+      auto memrefType = mlir::dyn_cast<MemRefType>(operand.getType());
+      if (!memrefType ||
+          ttcore::getMemorySpace(memrefType) != MemorySpace::DeviceL1) {
+        return false;
+      }
+
+      if (mlir::isa<ttcore::TileType>(memrefType.getElementType())) {
+        hasTile = true;
+      } else {
+        hasNonTile = true;
+      }
+
+      AffineMap indexingMap = genericOp.getIndexingMap(operandIndex);
+      if (!isPurePermutationIndexingMap(indexingMap)) {
+        return false;
+      }
+    }
+
+    return !(hasTile && hasNonTile);
+  }
+
   bool requiresCBAllocation(d2m::GenericOp genericOp,
                             const GenericOpContext &genericCtx,
                             const OperandContext &operandCtx,
@@ -1880,6 +1946,10 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
     if (!genericCtx.isExplicitDatamovement &&
         allocation::isOperandBlocked(genericOp, operandCtx.operandIndex(),
                                      genericCtx.reblockedFactors)) {
+      if (canAliasBlockedAllParallelEltwiseOutput(genericOp, genericCtx,
+                                                  operandCtx, memspace)) {
+        return false;
+      }
       return true;
     }
 

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1868,24 +1868,8 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
   }
 
   static bool isPurePermutationIndexingMap(AffineMap map) {
-    if (map.getNumSymbols() != 0 || map.getNumResults() != map.getNumDims()) {
-      return false;
-    }
-
-    llvm::BitVector seenDims(map.getNumDims(), false);
-    for (AffineExpr expr : map.getResults()) {
-      auto dimExpr = mlir::dyn_cast<AffineDimExpr>(expr);
-      if (!dimExpr) {
-        return false;
-      }
-      unsigned dim = dimExpr.getPosition();
-      if (dim >= map.getNumDims() || seenDims[dim]) {
-        return false;
-      }
-      seenDims[dim] = true;
-    }
-
-    return seenDims.all();
+    return map.getNumSymbols() == 0 &&
+           map.getNumResults() == map.getNumDims() && map.isPermutation();
   }
 
   bool canAliasBlockedAllParallelEltwiseOutput(
@@ -1962,7 +1946,7 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
 
   /// @return `true` if `operandCtx` is an output that is exempt from stream
   /// insertion. Currently, this is true for outputs when L1 output spilling is
-  /// disabled and the output is not a non-trivial view.
+  /// disabled and the output is a trivial view.
   bool isOperandExemptFromStreaming(const OperandContext &operandCtx,
                                     MemorySpace memspace) const {
     if (isNonTrivialView(operandCtx)) {

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
@@ -2,8 +2,6 @@
 // RUN: FileCheck %s --check-prefix=CHECK-MAX --input-file=%t.max
 // RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608" -o %t.auto %s
 // RUN: FileCheck %s --check-prefix=CHECK-AUTO --input-file=%t.auto
-// RUN: ttmlir-opt --ttcore-register-device "--d2m-allocate=test-assume-l1-capacity=8388608 test-allow-aliased-eltwise-blocking=false" -o %t.override %s
-// RUN: FileCheck %s --check-prefix=CHECK-OVERRIDE --input-file=%t.override
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -141,13 +139,10 @@ module {
     return %out : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #dram>
   }
 
-  // Default reblocks to [8, 2] while preserving the L1 output alias.
-  // Override with false preserves aliased output at [1, 1].
+  // Auto reblocks to [8, 2] while preserving the L1 output alias.
   // CHECK-AUTO-LABEL: func.func @eltwise_auto_preserves_aliased_output_by_default()
   // CHECK-AUTO: d2m.generic {block_factors = [8, 2], grid = #ttcore.grid<1x1>
   // CHECK-AUTO-COUNT-2: memref.alloc(){{.*}} : memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
-  // CHECK-OVERRIDE-LABEL: func.func @eltwise_auto_preserves_aliased_output_by_default()
-  // CHECK-OVERRIDE: d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
   func.func @eltwise_auto_preserves_aliased_output_by_default() -> memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1> {
     %lhs = memref.alloc() : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1>
     %rhs = memref.alloc() : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1>
@@ -165,30 +160,6 @@ module {
       %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     }
     return %out : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1>
-  }
-
-  // Pure permutation indexing maps are still safe for the L1 output alias path.
-  // CHECK-AUTO-LABEL: func.func @eltwise_auto_preserves_permuted_aliased_output()
-  // CHECK-AUTO: d2m.generic {block_factors = [8, 8], grid = #ttcore.grid<1x1>
-  // CHECK-AUTO: outs(%{{.*}} : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
-  // CHECK-AUTO-COUNT-2: memref.alloc(){{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-  func.func @eltwise_auto_preserves_permuted_aliased_output() -> memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
-    %lhs = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
-    %rhs = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
-    %out = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
-    d2m.generic {block_factors = [8, 8], grid = #ttcore.grid<1x1>, indexing_maps = [#eltwisePermuted, #eltwisePermuted, #eltwisePermuted], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<compute>]}
-        ins(%lhs, %rhs : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
-        outs(%out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
-    ^compute0():
-      %tmp_in0 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %tmp_in1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %tmp_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %c0 = arith.constant 0 : index
-      %t0 = memref.load %tmp_in0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %t1 = memref.load %tmp_in1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
-    }
-    return %out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
   }
 
   // Auto reblocking applies to unary eltwise ops too.

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
@@ -170,6 +170,7 @@ module {
   // Pure permutation indexing maps are still safe for the L1 output alias path.
   // CHECK-AUTO-LABEL: func.func @eltwise_auto_preserves_permuted_aliased_output()
   // CHECK-AUTO: d2m.generic {block_factors = [8, 8], grid = #ttcore.grid<1x1>
+  // CHECK-AUTO: outs(%{{.*}} : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
   // CHECK-AUTO-COUNT-2: memref.alloc(){{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
   func.func @eltwise_auto_preserves_permuted_aliased_output() -> memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
     %lhs = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_auto.mlir
@@ -11,6 +11,7 @@
 #mapR = affine_map<(d0, d1, d2) -> (d2, d1)>
 #mapO = affine_map<(d0, d1, d2) -> (d0, d1)>
 #eltwise = affine_map<(d0, d1) -> (d0, d1)>
+#eltwisePermuted = affine_map<(d0, d1) -> (d1, d0)>
 #eltwise3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #tail3d = affine_map<(d0, d1, d2) -> (d1, d2)>
 #broadcast = affine_map<(d0, d1) -> (0, 0)>
@@ -140,11 +141,11 @@ module {
     return %out : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #dram>
   }
 
-  // Default (allowAliasedEltwiseBlocking=true) reblocks to [8, 2].
+  // Default reblocks to [8, 2] while preserving the L1 output alias.
   // Override with false preserves aliased output at [1, 1].
   // CHECK-AUTO-LABEL: func.func @eltwise_auto_preserves_aliased_output_by_default()
   // CHECK-AUTO: d2m.generic {block_factors = [8, 2], grid = #ttcore.grid<1x1>
-  // CHECK-AUTO-COUNT-3: memref.alloc(){{.*}} : memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+  // CHECK-AUTO-COUNT-2: memref.alloc(){{.*}} : memref<1x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
   // CHECK-OVERRIDE-LABEL: func.func @eltwise_auto_preserves_aliased_output_by_default()
   // CHECK-OVERRIDE: d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
   func.func @eltwise_auto_preserves_aliased_output_by_default() -> memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1> {
@@ -164,6 +165,29 @@ module {
       %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
     }
     return %out : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x32768, 1>, #l1>
+  }
+
+  // Pure permutation indexing maps are still safe for the L1 output alias path.
+  // CHECK-AUTO-LABEL: func.func @eltwise_auto_preserves_permuted_aliased_output()
+  // CHECK-AUTO: d2m.generic {block_factors = [8, 8], grid = #ttcore.grid<1x1>
+  // CHECK-AUTO-COUNT-2: memref.alloc(){{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
+  func.func @eltwise_auto_preserves_permuted_aliased_output() -> memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> {
+    %lhs = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %rhs = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %out = memref.alloc() : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    d2m.generic {block_factors = [8, 8], grid = #ttcore.grid<1x1>, indexing_maps = [#eltwisePermuted, #eltwisePermuted, #eltwisePermuted], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<compute>]}
+        ins(%lhs, %rhs : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    ^compute0():
+      %tmp_in0 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %tmp_in1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %tmp_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %c0 = arith.constant 0 : index
+      %t0 = memref.load %tmp_in0[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %t1 = memref.load %tmp_in1[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+      %add = "d2m.tile_add"(%t0, %t1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
+    }
+    return %out : memref<8x8x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
   }
 
   // Auto reblocking applies to unary eltwise ops too.


### PR DESCRIPTION
Instead of conservatively streaming for ops during reblocking, we can safely alias them provided the existing requirements (e.g. no nontrivial views are met). This will reduce the memory pressure. 