### PR TITLE
Uplift third_party/tt-metal to a33dac6e4e042da0cf4aff48159b8f94ebaf9230 2026-05-12

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=61e690c25202111b52cbc1fbc9148b6524070c6f
+ARG TT_METAL_DEPENDENCIES_COMMIT=a33dac6e4e042da0cf4aff48159b8f94ebaf9230
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "08ce2dc1594c264f262cdce6c56fc014af1f6bfd")
+set(TT_METAL_VERSION "a33dac6e4e042da0cf4aff48159b8f94ebaf9230")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the a33dac6e4e042da0cf4aff48159b8f94ebaf9230

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):