### PR TITLE
[L1SpillManagement] Drop outputLayout hint for multi-output ops in extractOpConfigFromIR

### DIFF
--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -308,7 +308,17 @@ L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
         attrs.computeKernelConfig = matmulOp.getComputeConfig();
         config.opSpecificAttrs = std::move(attrs);
       })
-      .Default([](Operation *) {});
+      .Default([&](Operation *defaultOp) {
+        // Drop the output layout hint for multi-output ops. This is needed
+        // because those ops don't have 1:1 relationship between memory config
+        // and outputs, which can create weird bugs in op validation. It is
+        // safest to ignore the hint in this case.
+        if (llvm::count_if(defaultOp->getResults(), [](Value r) {
+              return mlir::isa<RankedTensorType>(r.getType());
+            }) > 1) {
+          config.outputLayout = TTNNLayoutAttr{};
+        }
+      });
 
   return config;
 }


### PR DESCRIPTION
## Summary

For ops like `ttnn.nlp_create_qkv_heads_decode` the tt-metal kernel uses the passed `memory_config.shard_spec` only as a constraint on the **shared output scratchpad grid for ALL outputs** — not as the layout of `result(0)`. Forwarding the IR layout of `result(0)` back as a hint can artificially shrink that scratchpad and trigger spurious `target_num_cores > sub_core_grids.num_cores()` constraint failures during the L1 spill pass's re-validation, even though beam search accepted the same op earlier with the natural (null / full-grid) hint.

The op then gets unnecessarily spilled to DRAM, which in turn breaks downstream consumers that require sharded inputs (e.g. `paged_update_cache`'s `is_sharded()` requirement).

## Root cause

A direct OpModel probe with the failing config confirms the hint sensitivity:

| outputHint | Result |
|---|---|
| null | ✅ SUCCESS — `actualOutputLayouts` returns `%query` on `(0,0)-(7,3)`, `%key` on `(0,4)-(7,7)`, `%value` on `(0,0)-(7,3)` |
| L1 height_sharded `<32x1>` cores `(0,0)-(7,3)` (= the IR layout of `result(0)`) | ❌ FAIL — `target_num_cores 33 > 32` |
| DRAM interleaved | ✅ SUCCESS |

In `nlp_create_qkv_heads_decode.cpp:34-46`, tt-metal does:
```cpp
if (memory_config.has_value() and memory_config.value().shard_spec().has_value()) {
    output_core_grid = memory_config.value().shard_spec().value().grid;
} else {
    output_core_grid = full device grid;
}
```
The hint's `shard_spec().grid` becomes the bound on the shared output scratchpad, not a per-output layout.

## Fix

In `extractOpConfigFromIR`'s `Default` branch (i.e. ops without specialized `OpConfig` handling), drop the `outputLayout` hint when the op has more than one tensor result. This lets the OpModel fall back to the device's full grid for the scratchpad, matching what beam search effectively used.

## Verification

- Llama 3.2 1B prefill (g0) and decode (g1) compile cleanly at `optimization-level=2`
- Both flatbuffers translate and **PASS** on n150 via `ttrt run --ignore-version`
- Existing greedy optimizer lit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)