### PR TITLE
Add createUnsafeBorrowedHostTensor runtime API

### DIFF
--- a/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/command_factory.h
@@ -75,6 +75,11 @@ public:
       const std::unordered_map<std::string, std::string> &strategy,
       const std::vector<uint32_t> &meshShape);
 
+  static uint64_t buildCreateUnsafeBorrowedHostTensorCommand(
+      ::flatbuffers::FlatBufferBuilder &fbb,
+      const ::tt::runtime::Tensor &sourceHostTensor,
+      const ::tt::runtime::Tensor &outputTensor);
+
   static uint64_t
   buildIsTensorAllocatedCommand(::flatbuffers::FlatBufferBuilder &fbb,
                                 const ::tt::runtime::Tensor &tensor);

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -122,6 +122,9 @@ public:
       const std::unordered_map<std::string, std::string> &strategy,
       const std::vector<uint32_t> &meshShape);
 
+  ::tt::runtime::Tensor createUnsafeBorrowedHostTensor(
+      const ::tt::runtime::Tensor &ownedHostTensor);
+
   bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle);
 
   std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);
@@ -252,6 +255,10 @@ private:
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 
   void handleCreateMultiDeviceHostTensorFromShardsResponse(
+      const std::vector<SizedBuffer> &responseBuffers,
+      std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
+
+  void handleCreateUnsafeBorrowedHostTensorResponse(
       const std::vector<SizedBuffer> &responseBuffers,
       std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse);
 

--- a/runtime/include/tt/runtime/detail/distributed/controller/controller.h
+++ b/runtime/include/tt/runtime/detail/distributed/controller/controller.h
@@ -122,8 +122,8 @@ public:
       const std::unordered_map<std::string, std::string> &strategy,
       const std::vector<uint32_t> &meshShape);
 
-  ::tt::runtime::Tensor createUnsafeBorrowedHostTensor(
-      const ::tt::runtime::Tensor &ownedHostTensor);
+  ::tt::runtime::Tensor
+  createUnsafeBorrowedHostTensor(const ::tt::runtime::Tensor &ownedHostTensor);
 
   bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle);
 

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -54,6 +54,11 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     const std::unordered_map<std::string, std::string> &strategy,
     const std::vector<uint32_t> &meshShape);
 
+// RPC to workers: create a borrowed host tensor aliasing the tensor registered
+// as `ownedHostTensor`'s global id. Wire payload is ids only.
+::tt::runtime::Tensor
+createUnsafeBorrowedHostTensor(const ::tt::runtime::Tensor &ownedHostTensor);
+
 bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle);
 
 std::uint32_t getTensorVolume(const ::tt::runtime::Tensor &tensorHandle);

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -49,6 +49,13 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType);
 
+// Builds a TTNN owned host tensor in the controller process; does not touch
+// workers.
+::tt::runtime::Tensor createOwnedHostTensorOnController(
+    const void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType);
+
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -42,6 +42,13 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
+// Builds a TTNN borrowed host tensor in the controller process; does not touch
+// workers.
+::tt::runtime::Tensor createBorrowedHostTensorOnController(
+    void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType);
+
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -42,13 +42,6 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
-// Builds a TTNN borrowed host tensor in the controller process; does not touch
-// workers.
-::tt::runtime::Tensor createBorrowedHostTensorOnController(
-    void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType);
-
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/include/tt/runtime/detail/distributed/distributed.h
+++ b/runtime/include/tt/runtime/detail/distributed/distributed.h
@@ -49,13 +49,6 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType);
 
-// Builds a TTNN owned host tensor in the controller process; does not touch
-// workers.
-::tt::runtime::Tensor createOwnedHostTensorOnController(
-    const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType);
-
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/command.fbs
@@ -77,6 +77,13 @@ table CreateMultiDeviceHostTensorFromShardsCommand {
   mesh_shape: [uint32];
 }
 
+// Worker looks up `source_tensor_global_id` in the tensor pool and registers a
+// borrowed host tensor as `output_global_id`. No tensor bytes are sent.
+table CreateUnsafeBorrowedHostTensorCommand {
+  source_tensor_global_id: uint64;
+  output_global_id: uint64;
+}
+
 table IsTensorAllocatedCommand {
   tensor_global_id: uint64;
 }
@@ -191,6 +198,7 @@ union CommandType {
   HasLayoutCommand,
   IsProgramCacheEnabledCommand,
   ClearProgramCacheCommand,
+  CreateUnsafeBorrowedHostTensorCommand,
 }
 
 table Command {

--- a/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
+++ b/runtime/include/tt/runtime/detail/distributed/flatbuffer/response.fbs
@@ -51,6 +51,9 @@ table CreateHostTensorResponse {
 table CreateMultiDeviceHostTensorFromShardsResponse {
 }
 
+table CreateUnsafeBorrowedHostTensorResponse {
+}
+
 table IsTensorAllocatedResponse {
   allocated: bool;
 }
@@ -144,7 +147,8 @@ union ResponseType {
   GetTensorDescResponse,
   HasLayoutResponse,
   IsProgramCacheEnabledResponse,
-  ClearProgramCacheResponse
+  ClearProgramCacheResponse,
+  CreateUnsafeBorrowedHostTensorResponse
 }
 
 table Response {

--- a/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/command_executor.h
@@ -111,6 +111,10 @@ private:
                const ::tt::runtime::distributed::flatbuffer::
                    CreateMultiDeviceHostTensorFromShardsCommand *command);
 
+  void execute(uint64_t commandId,
+               const ::tt::runtime::distributed::flatbuffer::
+                   CreateUnsafeBorrowedHostTensorCommand *command);
+
   void
   execute(uint64_t commandId,
           const ::tt::runtime::distributed::flatbuffer::IsTensorAllocatedCommand

--- a/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
+++ b/runtime/include/tt/runtime/detail/distributed/worker/response_factory.h
@@ -55,6 +55,9 @@ public:
   static void buildCreateMultiDeviceHostTensorFromShardsResponse(
       ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId);
 
+  static void buildCreateUnsafeBorrowedHostTensorResponse(
+      ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId);
+
   static void
   buildReleaseSubMeshDeviceResponse(::flatbuffers::FlatBufferBuilder &fbb,
                                     uint64_t commandId);

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -97,6 +97,11 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
+// Creates a borrowed host tensor that aliases the buffer of `ownedHostTensor`.
+// `ownedHostTensor` must remain valid for the lifetime of uses of the result.
+::tt::runtime::Tensor
+createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor);
+
 // Creates multi-device host tensor with owned storage (buffers of the tensor
 // are on the host and their allocation/deallocation is owned by this tensor
 // instance).

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -75,6 +75,13 @@ Tensor createOwnedHostTensor(const void *data,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType);
 
+// Creates a host tensor with borrowed storage that aliases the same allocation
+// as `ownedHostTensor` (no copy). The returned tensor must not outlive
+// `ownedHostTensor`, and the caller must keep `ownedHostTensor` valid for the
+// lifetime of any use of the returned tensor. Only implemented for the local
+// TTNN device runtime; other runtimes report not implemented.
+Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor);
+
 // Creates multi-device host tensor with owned storage (buffers of the tensor
 // are on the host and their allocation/deallocation is owned by this tensor
 // instance).

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -66,6 +66,14 @@ Tensor createBorrowedHostTensorOnController(
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType);
 
+// When using HostRuntime::Distributed, creates an owned TTNN host tensor on the
+// controller process only (no commands are sent to workers). Requires
+// launchDistributedRuntime. For Local host runtime, use createOwnedHostTensor.
+Tensor createOwnedHostTensorOnController(
+    const void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType);
+
 // Creates host tensor with a owned copy of the data (the buffer of the tensor
 // is on the host and its allocation/deallocation is owned by this tensor
 // instance).
@@ -124,6 +132,12 @@ inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
 inline Tensor createBorrowedHostTensorOnController(void *data,
                                                    const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensorOnController(
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
+}
+
+inline Tensor createOwnedHostTensorOnController(const void *data,
+                                                const TensorDesc &desc) {
+  return ::tt::runtime::createOwnedHostTensorOnController(
       data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
 }
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -58,6 +58,14 @@ Tensor createBorrowedHostTensor(void *data,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType);
 
+// When using HostRuntime::Distributed, creates a borrowed TTNN host tensor on
+// the controller process only (no commands are sent to workers). Requires
+// launchDistributedRuntime. For Local host runtime, use createBorrowedHostTensor.
+Tensor createBorrowedHostTensorOnController(
+    void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType);
+
 // Creates host tensor with a owned copy of the data (the buffer of the tensor
 // is on the host and its allocation/deallocation is owned by this tensor
 // instance).
@@ -104,6 +112,12 @@ Tensor createEmptyTensor(Device device, Layout layout,
 inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensor(
       data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
+}
+
+inline Tensor createBorrowedHostTensorOnController(void *data,
+                                                   const TensorDesc &desc) {
+  return ::tt::runtime::createBorrowedHostTensorOnController(
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
 }
 
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -132,13 +132,13 @@ inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
 inline Tensor createBorrowedHostTensorOnController(void *data,
                                                    const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensorOnController(
-      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
+      data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
 }
 
 inline Tensor createOwnedHostTensorOnController(const void *data,
                                                 const TensorDesc &desc) {
   return ::tt::runtime::createOwnedHostTensorOnController(
-      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
+      data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
 }
 
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -66,14 +66,6 @@ Tensor createBorrowedHostTensorOnController(
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType);
 
-// When using HostRuntime::Distributed, creates an owned TTNN host tensor on the
-// controller process only (no commands are sent to workers). Requires
-// launchDistributedRuntime. For Local host runtime, use createOwnedHostTensor.
-Tensor createOwnedHostTensorOnController(
-    const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType);
-
 // Creates host tensor with a owned copy of the data (the buffer of the tensor
 // is on the host and its allocation/deallocation is owned by this tensor
 // instance).
@@ -132,12 +124,6 @@ inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
 inline Tensor createBorrowedHostTensorOnController(void *data,
                                                    const TensorDesc &desc) {
   return ::tt::runtime::createBorrowedHostTensorOnController(
-      data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
-}
-
-inline Tensor createOwnedHostTensorOnController(const void *data,
-                                                const TensorDesc &desc) {
-  return ::tt::runtime::createOwnedHostTensorOnController(
       data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
 }
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -58,14 +58,6 @@ Tensor createBorrowedHostTensor(void *data,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType);
 
-// When using HostRuntime::Distributed, creates a borrowed TTNN host tensor on
-// the controller process only (no commands are sent to workers). Requires
-// launchDistributedRuntime. For Local host runtime, use createBorrowedHostTensor.
-Tensor createBorrowedHostTensorOnController(
-    void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType);
-
 // Creates host tensor with a owned copy of the data (the buffer of the tensor
 // is on the host and its allocation/deallocation is owned by this tensor
 // instance).

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -113,12 +113,6 @@ inline Tensor createBorrowedHostTensor(void *data, const TensorDesc &desc) {
       data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
 }
 
-inline Tensor createBorrowedHostTensorOnController(void *data,
-                                                   const TensorDesc &desc) {
-  return ::tt::runtime::createBorrowedHostTensorOnController(
-      data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);
-}
-
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
   return ::tt::runtime::createOwnedHostTensor(
       data, desc.shape, desc.stride, desc.elementSize(), desc.dataType);

--- a/runtime/lib/distributed/CMakeLists.txt
+++ b/runtime/lib/distributed/CMakeLists.txt
@@ -21,4 +21,8 @@ target_include_directories(TTRuntimeDistributed SYSTEM PRIVATE "$<BUILD_INTERFAC
 
 target_link_libraries(TTRuntimeDistributed PRIVATE TTRuntimeDistributedController TTRuntimeDistributedUtils)
 
+if (TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN)
+  target_link_libraries(TTRuntimeDistributed PRIVATE TTRuntimeTTNN)
+endif()
+
 add_dependencies(TTRuntimeDistributed RUNTIME_FBS_GENERATION)

--- a/runtime/lib/distributed/CMakeLists.txt
+++ b/runtime/lib/distributed/CMakeLists.txt
@@ -21,8 +21,4 @@ target_include_directories(TTRuntimeDistributed SYSTEM PRIVATE "$<BUILD_INTERFAC
 
 target_link_libraries(TTRuntimeDistributed PRIVATE TTRuntimeDistributedController TTRuntimeDistributedUtils)
 
-if (TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN)
-  target_link_libraries(TTRuntimeDistributed PRIVATE TTRuntimeTTNN)
-endif()
-
 add_dependencies(TTRuntimeDistributed RUNTIME_FBS_GENERATION)

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -263,6 +263,20 @@ uint64_t CommandFactory::buildCreateMultiDeviceHostTensorFromShardsCommand(
   return commandId;
 }
 
+uint64_t CommandFactory::buildCreateUnsafeBorrowedHostTensorCommand(
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    const ::tt::runtime::Tensor &sourceHostTensor,
+    const ::tt::runtime::Tensor &outputTensor) {
+
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  uint64_t commandId = BUILD_COMMAND(
+      CreateUnsafeBorrowedHostTensor, fbb, sourceHostTensor.getGlobalId(),
+      outputTensor.getGlobalId());
+
+  return commandId;
+}
+
 uint64_t CommandFactory::buildIsTensorAllocatedCommand(
     ::flatbuffers::FlatBufferBuilder &fbb,
     const ::tt::runtime::Tensor &tensor) {

--- a/runtime/lib/distributed/controller/command_factory.cpp
+++ b/runtime/lib/distributed/controller/command_factory.cpp
@@ -270,9 +270,9 @@ uint64_t CommandFactory::buildCreateUnsafeBorrowedHostTensorCommand(
 
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
 
-  uint64_t commandId = BUILD_COMMAND(
-      CreateUnsafeBorrowedHostTensor, fbb, sourceHostTensor.getGlobalId(),
-      outputTensor.getGlobalId());
+  uint64_t commandId =
+      BUILD_COMMAND(CreateUnsafeBorrowedHostTensor, fbb,
+                    sourceHostTensor.getGlobalId(), outputTensor.getGlobalId());
 
   return commandId;
 }

--- a/runtime/lib/distributed/controller/controller.cpp
+++ b/runtime/lib/distributed/controller/controller.cpp
@@ -431,6 +431,24 @@ Controller::getMeshShape(const ::tt::runtime::Device &deviceHandle) {
   return outputTensorHandle;
 }
 
+::tt::runtime::Tensor Controller::createUnsafeBorrowedHostTensor(
+    const ::tt::runtime::Tensor &ownedHostTensor) {
+
+  auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
+
+  ::tt::runtime::Tensor outputTensorHandle;
+
+  uint64_t commandId =
+      CommandFactory::buildCreateUnsafeBorrowedHostTensorCommand(
+          *commandBuilder, ownedHostTensor, outputTensorHandle);
+
+  pushToCommandAndResponseQueues(
+      commandId, fb::CommandType::CreateUnsafeBorrowedHostTensorCommand,
+      std::move(commandBuilder));
+
+  return outputTensorHandle;
+}
+
 bool Controller::isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle) {
   auto commandBuilder = std::make_unique<::flatbuffers::FlatBufferBuilder>();
 
@@ -1177,6 +1195,20 @@ void Controller::handleCreateMultiDeviceHostTensorFromShardsResponse(
                                "CreateMultiDeviceHostTensorFromShards");
 }
 
+void Controller::handleCreateUnsafeBorrowedHostTensorResponse(
+    const std::vector<SizedBuffer> &responseBuffers,
+    std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
+
+  debug::checkResponsesIdentical(responseBuffers);
+
+  debug::checkResponseTypes(
+      responseBuffers,
+      fb::ResponseType::CreateUnsafeBorrowedHostTensorResponse);
+
+  debug::assertNoAwaitingState(*awaitingResponse,
+                               "CreateUnsafeBorrowedHostTensor");
+}
+
 void Controller::handleIsTensorAllocatedResponse(
     const std::vector<SizedBuffer> &responseBuffers,
     std::unique_ptr<AwaitingResponseQueueEntry> awaitingResponse) {
@@ -1530,6 +1562,10 @@ void Controller::handleResponse(
   }
   case fb::CommandType::CreateMultiDeviceHostTensorFromShardsCommand: {
     return handleCreateMultiDeviceHostTensorFromShardsResponse(
+        responseBuffers, std::move(awaitingResponse));
+  }
+  case fb::CommandType::CreateUnsafeBorrowedHostTensorCommand: {
+    return handleCreateUnsafeBorrowedHostTensorResponse(
         responseBuffers, std::move(awaitingResponse));
   }
   case fb::CommandType::GetLayoutCommand: {

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -138,6 +138,19 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 #endif
 }
 
+::tt::runtime::Tensor createOwnedHostTensorOnController(
+    const void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType) {
+  assertControllerLaunched();
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
+  return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
+                                                    itemsize, dataType);
+#else
+  LOG_FATAL("createOwnedHostTensorOnController requires TTNN runtime");
+#endif
+}
+
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -6,6 +6,10 @@
 #include "tt/runtime/detail/distributed/controller/controller.h"
 #include "tt/runtime/detail/distributed/distributed.h"
 
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
+#include "tt/runtime/detail/ttnn/ttnn.h"
+#endif
+
 namespace tt::runtime::distributed {
 
 using Controller = tt::runtime::distributed::controller::Controller;
@@ -119,6 +123,19 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,
                                                           itemsize, dataType);
+}
+
+::tt::runtime::Tensor createBorrowedHostTensorOnController(
+    void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType) {
+  assertControllerLaunched();
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
+  return ::tt::runtime::ttnn::createBorrowedHostTensor(data, shape, stride,
+                                                       itemsize, dataType);
+#else
+  LOG_FATAL("createBorrowedHostTensorOnController requires TTNN runtime");
+#endif
 }
 
 ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -147,6 +147,13 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
       tensorShards, strategy, meshShape);
 }
 
+::tt::runtime::Tensor
+createUnsafeBorrowedHostTensor(const ::tt::runtime::Tensor &ownedHostTensor) {
+  assertControllerLaunched();
+  return ControllerSingleton::get().createUnsafeBorrowedHostTensor(
+      ownedHostTensor);
+}
+
 bool isTensorAllocated(const ::tt::runtime::Tensor &tensorHandle) {
   assertControllerLaunched();
   return ControllerSingleton::get().isTensorAllocated(tensorHandle);

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -6,10 +6,6 @@
 #include "tt/runtime/detail/distributed/controller/controller.h"
 #include "tt/runtime/detail/distributed/distributed.h"
 
-#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
-#include "tt/runtime/detail/ttnn/ttnn.h"
-#endif
-
 namespace tt::runtime::distributed {
 
 using Controller = tt::runtime::distributed::controller::Controller;
@@ -123,19 +119,6 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   assertControllerLaunched();
   return ControllerSingleton::get().createOwnedHostTensor(data, shape, stride,
                                                           itemsize, dataType);
-}
-
-::tt::runtime::Tensor createBorrowedHostTensorOnController(
-    void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType) {
-  assertControllerLaunched();
-#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
-  return ::tt::runtime::ttnn::createBorrowedHostTensor(data, shape, stride,
-                                                       itemsize, dataType);
-#else
-  LOG_FATAL("createBorrowedHostTensorOnController requires TTNN runtime");
-#endif
 }
 
 ::tt::runtime::Tensor createMultiDeviceHostTensor(

--- a/runtime/lib/distributed/runtime.cpp
+++ b/runtime/lib/distributed/runtime.cpp
@@ -138,19 +138,6 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 #endif
 }
 
-::tt::runtime::Tensor createOwnedHostTensorOnController(
-    const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType) {
-  assertControllerLaunched();
-#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
-  return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
-                                                    itemsize, dataType);
-#else
-  LOG_FATAL("createOwnedHostTensorOnController requires TTNN runtime");
-#endif
-}
-
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy,

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -386,6 +386,25 @@ void CommandExecutor::execute(
   responseQueue_.push(std::move(responseBuilder));
 }
 
+void CommandExecutor::execute(
+    uint64_t commandId,
+    const fb::CreateUnsafeBorrowedHostTensorCommand *command) {
+  uint64_t sourceGlobalId = command->source_tensor_global_id();
+  uint64_t outputGlobalId = command->output_global_id();
+
+  ::tt::runtime::Tensor sourceTensor = tensorPool_.at(sourceGlobalId);
+  ::tt::runtime::Tensor borrowedTensor =
+      ::tt::runtime::createUnsafeBorrowedHostTensor(sourceTensor);
+  borrowedTensor.setGlobalId(outputGlobalId);
+  tensorPool_.insert_or_assign(outputGlobalId, borrowedTensor);
+
+  std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
+      buildResponse(ResponseFactory::buildCreateUnsafeBorrowedHostTensorResponse,
+                    commandId);
+
+  responseQueue_.push(std::move(responseBuilder));
+}
+
 void CommandExecutor::execute(uint64_t commandId,
                               const fb::IsTensorAllocatedCommand *command) {
   uint64_t tensorGlobalId = command->tensor_global_id();
@@ -749,6 +768,10 @@ void CommandExecutor::executeCommand(const fb::Command *command) {
     return execute(
         command->command_id(),
         command->type_as_CreateMultiDeviceHostTensorFromShardsCommand());
+  }
+  case fb::CommandType::CreateUnsafeBorrowedHostTensorCommand: {
+    return execute(command->command_id(),
+                   command->type_as_CreateUnsafeBorrowedHostTensorCommand());
   }
   case fb::CommandType::IsTensorAllocatedCommand: {
     return execute(command->command_id(),

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -393,7 +393,8 @@ void CommandExecutor::execute(
   uint64_t outputGlobalId = command->output_global_id();
 
   LOG_ASSERT(tensorPool_.contains(sourceGlobalId),
-             "Source tenso with global id ", sourceGlobalId, " not found in tensor pool");
+             "Source tenso with global id ", sourceGlobalId,
+             " not found in tensor pool");
 
   ::tt::runtime::Tensor sourceTensor = tensorPool_.at(sourceGlobalId);
   ::tt::runtime::Tensor borrowedTensor =

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -399,8 +399,9 @@ void CommandExecutor::execute(
   tensorPool_.insert_or_assign(outputGlobalId, borrowedTensor);
 
   std::unique_ptr<::flatbuffers::FlatBufferBuilder> responseBuilder =
-      buildResponse(ResponseFactory::buildCreateUnsafeBorrowedHostTensorResponse,
-                    commandId);
+      buildResponse(
+          ResponseFactory::buildCreateUnsafeBorrowedHostTensorResponse,
+          commandId);
 
   responseQueue_.push(std::move(responseBuilder));
 }

--- a/runtime/lib/distributed/worker/command_executor.cpp
+++ b/runtime/lib/distributed/worker/command_executor.cpp
@@ -392,6 +392,9 @@ void CommandExecutor::execute(
   uint64_t sourceGlobalId = command->source_tensor_global_id();
   uint64_t outputGlobalId = command->output_global_id();
 
+  LOG_ASSERT(tensorPool_.contains(sourceGlobalId),
+             "Source tenso with global id ", sourceGlobalId, " not found in tensor pool");
+
   ::tt::runtime::Tensor sourceTensor = tensorPool_.at(sourceGlobalId);
   ::tt::runtime::Tensor borrowedTensor =
       ::tt::runtime::createUnsafeBorrowedHostTensor(sourceTensor);

--- a/runtime/lib/distributed/worker/response_factory.cpp
+++ b/runtime/lib/distributed/worker/response_factory.cpp
@@ -147,6 +147,13 @@ void ResponseFactory::buildCreateMultiDeviceHostTensorFromShardsResponse(
   BUILD_RESPONSE(CreateMultiDeviceHostTensorFromShards, fbb, commandId);
 }
 
+void ResponseFactory::buildCreateUnsafeBorrowedHostTensorResponse(
+    ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId) {
+  LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");
+
+  BUILD_RESPONSE(CreateUnsafeBorrowedHostTensor, fbb, commandId);
+}
+
 void ResponseFactory::buildIsTensorAllocatedResponse(
     ::flatbuffers::FlatBufferBuilder &fbb, uint64_t commandId, bool allocated) {
   LOG_ASSERT(fbb.GetSize() == 0, "Flatbuffer builder must be empty");

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -360,8 +360,8 @@ Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor) {
                                     DeviceRuntime::TTMetal);
       },
       [&]() -> RetType {
-        detail::fatalNotImplemented("createUnsafeBorrowedHostTensor",
-                                    HostRuntime::Distributed);
+        return ::tt::runtime::distributed::createUnsafeBorrowedHostTensor(
+            ownedHostTensor);
       });
 }
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -302,6 +302,28 @@ Tensor createBorrowedHostTensor(void *data,
       });
 }
 
+Tensor createBorrowedHostTensorOnController(
+    void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType) {
+  using RetType = Tensor;
+  LOG_ASSERT(itemsize > 0);
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createBorrowedHostTensorOnController",
+                                    DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createBorrowedHostTensorOnController",
+                                    DeviceRuntime::TTMetal);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::distributed::createBorrowedHostTensorOnController(
+            data, shape, stride, itemsize, dataType);
+      });
+}
+
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -347,6 +347,24 @@ Tensor createOwnedHostTensor(const void *data,
       });
 }
 
+Tensor createUnsafeBorrowedHostTensor(Tensor ownedHostTensor) {
+  using RetType = Tensor;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createUnsafeBorrowedHostTensor(
+            std::move(ownedHostTensor));
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createUnsafeBorrowedHostTensor",
+                                    DeviceRuntime::TTMetal);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createUnsafeBorrowedHostTensor",
+                                    HostRuntime::Distributed);
+      });
+}
+
 Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data,
     const std::vector<std::uint32_t> &shape,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -324,6 +324,28 @@ Tensor createBorrowedHostTensorOnController(
       });
 }
 
+Tensor createOwnedHostTensorOnController(
+    const void *data, const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType) {
+  using RetType = Tensor;
+  LOG_ASSERT(itemsize > 0);
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createOwnedHostTensorOnController",
+                                    DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("createOwnedHostTensorOnController",
+                                    DeviceRuntime::TTMetal);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::distributed::createOwnedHostTensorOnController(
+            data, shape, stride, itemsize, dataType);
+      });
+}
+
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -324,28 +324,6 @@ Tensor createBorrowedHostTensorOnController(
       });
 }
 
-Tensor createOwnedHostTensorOnController(
-    const void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType) {
-  using RetType = Tensor;
-  LOG_ASSERT(itemsize > 0);
-  return DISPATCH_TO_CURRENT_RUNTIME(
-      RetType,
-      [&]() -> RetType {
-        detail::fatalNotImplemented("createOwnedHostTensorOnController",
-                                    DeviceRuntime::TTNN);
-      },
-      [&]() -> RetType {
-        detail::fatalNotImplemented("createOwnedHostTensorOnController",
-                                    DeviceRuntime::TTMetal);
-      },
-      [&]() -> RetType {
-        return ::tt::runtime::distributed::createOwnedHostTensorOnController(
-            data, shape, stride, itemsize, dataType);
-      });
-}
-
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -302,28 +302,6 @@ Tensor createBorrowedHostTensor(void *data,
       });
 }
 
-Tensor createBorrowedHostTensorOnController(
-    void *data, const std::vector<std::uint32_t> &shape,
-    const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-    ::tt::target::DataType dataType) {
-  using RetType = Tensor;
-  LOG_ASSERT(itemsize > 0);
-  return DISPATCH_TO_CURRENT_RUNTIME(
-      RetType,
-      [&]() -> RetType {
-        detail::fatalNotImplemented("createBorrowedHostTensorOnController",
-                                    DeviceRuntime::TTNN);
-      },
-      [&]() -> RetType {
-        detail::fatalNotImplemented("createBorrowedHostTensorOnController",
-                                    DeviceRuntime::TTMetal);
-      },
-      [&]() -> RetType {
-        return ::tt::runtime::distributed::createBorrowedHostTensorOnController(
-            data, shape, stride, itemsize, dataType);
-      });
-}
-
 Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &shape,
                              const std::vector<std::uint32_t> &stride,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -209,6 +209,29 @@ createBorrowedHostTensor(void *data, const std::vector<std::uint32_t> &shape,
 }
 
 ::tt::runtime::Tensor
+createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor) {
+  const ::ttnn::Tensor &ttnnTensor =
+      utils::getTTNNTensorFromRuntimeTensor(ownedHostTensor);
+  LOG_ASSERT(utils::isOnHost(ttnnTensor.storage_type()),
+             "createUnsafeBorrowedHostTensor requires a host tensor");
+
+  std::vector<::ttnn::Tensor> hostShards =
+      ::ttnn::distributed::get_device_tensors(ttnnTensor);
+  LOG_ASSERT(hostShards.size() == 1,
+             "createUnsafeBorrowedHostTensor only supports tensors backed by a "
+             "single host buffer");
+
+  const ::ttnn::Tensor &hostShard = hostShards.front();
+  LOG_ASSERT(hostShard.layout() == ::ttnn::Layout::ROW_MAJOR,
+             "createUnsafeBorrowedHostTensor requires ROW_MAJOR layout");
+
+  void *data = utils::getRawHostDataPtr(hostShard);
+  TensorDesc desc = getTensorDesc(ownedHostTensor);
+  return createBorrowedHostTensor(data, desc.shape, desc.stride, desc.itemsize,
+                                  desc.dataType);
+}
+
+::tt::runtime::Tensor
 createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -227,8 +227,8 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor) {
 
   void *data = utils::getRawHostDataPtr(hostShard);
   TensorDesc desc = getTensorDesc(ownedHostTensor);
-  return createBorrowedHostTensor(data, desc.shape, desc.stride, desc.elementSize(),
-                                  desc.dataType);
+  return createBorrowedHostTensor(data, desc.shape, desc.stride,
+                                  desc.elementSize(), desc.dataType);
 }
 
 ::tt::runtime::Tensor

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -227,7 +227,7 @@ createUnsafeBorrowedHostTensor(::tt::runtime::Tensor ownedHostTensor) {
 
   void *data = utils::getRawHostDataPtr(hostShard);
   TensorDesc desc = getTensorDesc(ownedHostTensor);
-  return createBorrowedHostTensor(data, desc.shape, desc.stride, desc.itemsize,
+  return createBorrowedHostTensor(data, desc.shape, desc.stride, desc.elementSize(),
                                   desc.dataType);
 }
 

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -370,6 +370,17 @@ void registerRuntimeBindings(nb::module_ &m) {
       "Create a borrowed TTNN host tensor on the distributed controller only "
       "(no worker RPC)");
   m.def(
+      "create_owned_host_tensor_on_controller",
+      [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
+         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         ::tt::target::DataType dataType) {
+        return tt::runtime::createOwnedHostTensorOnController(
+            reinterpret_cast<const void *>(ptr), shape, stride, itemsize,
+            dataType);
+      },
+      "Create an owned TTNN host tensor on the distributed controller only "
+      "(no worker RPC)");
+  m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -360,6 +360,16 @@ void registerRuntimeBindings(nb::module_ &m) {
       },
       "Create a host tensor with borrowed memory");
   m.def(
+      "create_borrowed_host_tensor_on_controller",
+      [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
+         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
+         ::tt::target::DataType dataType) {
+        return tt::runtime::createBorrowedHostTensorOnController(
+            reinterpret_cast<void *>(ptr), shape, stride, itemsize, dataType);
+      },
+      "Create a borrowed TTNN host tensor on the distributed controller only "
+      "(no worker RPC)");
+  m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -380,6 +380,11 @@ void registerRuntimeBindings(nb::module_ &m) {
       },
       "Create a tensor with owned memory");
   m.def(
+      "create_unsafe_borrowed_host_tensor",
+      &::tt::runtime::createUnsafeBorrowedHostTensor, nb::arg("owned_host_tensor"),
+      "Create a borrowed host tensor that aliases the buffer of an owned host "
+      "tensor; the owned tensor must outlive the result");
+  m.def(
       "create_empty_tensor",
       [](::tt::runtime::Device device, ::tt::runtime::Layout layout,
          const std::vector<std::uint32_t> &shape,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -370,17 +370,6 @@ void registerRuntimeBindings(nb::module_ &m) {
       "Create a borrowed TTNN host tensor on the distributed controller only "
       "(no worker RPC)");
   m.def(
-      "create_owned_host_tensor_on_controller",
-      [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-         ::tt::target::DataType dataType) {
-        return tt::runtime::createOwnedHostTensorOnController(
-            reinterpret_cast<const void *>(ptr), shape, stride, itemsize,
-            dataType);
-      },
-      "Create an owned TTNN host tensor on the distributed controller only "
-      "(no worker RPC)");
-  m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -371,7 +371,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       "Create a tensor with owned memory");
   m.def(
       "create_unsafe_borrowed_host_tensor",
-      &::tt::runtime::createUnsafeBorrowedHostTensor, nb::arg("owned_host_tensor"),
+      &::tt::runtime::createUnsafeBorrowedHostTensor,
+      nb::arg("owned_host_tensor"),
       "Create a borrowed host tensor that aliases the buffer of an owned host "
       "tensor; the owned tensor must outlive the result");
   m.def(

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -360,16 +360,6 @@ void registerRuntimeBindings(nb::module_ &m) {
       },
       "Create a host tensor with borrowed memory");
   m.def(
-      "create_borrowed_host_tensor_on_controller",
-      [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
-         const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
-         ::tt::target::DataType dataType) {
-        return tt::runtime::createBorrowedHostTensorOnController(
-            reinterpret_cast<void *>(ptr), shape, stride, itemsize, dataType);
-      },
-      "Create a borrowed TTNN host tensor on the distributed controller only "
-      "(no worker RPC)");
-  m.def(
       "create_owned_host_tensor",
       [](std::uintptr_t ptr, const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,

--- a/runtime/test/ttnn/gtest/CMakeLists.txt
+++ b/runtime/test/ttnn/gtest/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_runtime_gtest(test_tensor_serialization)
 add_runtime_gtest(test_tensor_cache_lifetime)
+add_runtime_gtest(test_unsafe_borrowed_host_tensor)

--- a/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
+++ b/runtime/test/ttnn/gtest/test_unsafe_borrowed_host_tensor.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
+#include "tt/runtime/utils.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+class UnsafeBorrowedHostTensorTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    tt::runtime::setCurrentDeviceRuntime(tt::runtime::DeviceRuntime::TTNN);
+  }
+};
+
+} // namespace
+
+TEST_F(UnsafeBorrowedHostTensorTest, AliasesOwnedBuffer) {
+  std::vector<uint32_t> shape = {2, 2};
+  std::vector<uint32_t> stride = tt::runtime::utils::calculateStride(shape);
+  tt::target::DataType dataType = tt::target::DataType::Float32;
+  uint32_t itemSize = sizeof(float);
+
+  std::vector<float> testData = {1.0f, 2.0f, 3.0f, 4.0f};
+
+  tt::runtime::Tensor owned = tt::runtime::createOwnedHostTensor(
+      testData.data(), shape, stride, itemSize, dataType);
+
+  tt::runtime::Tensor borrowed =
+      tt::runtime::createUnsafeBorrowedHostTensor(owned);
+
+  const ::ttnn::Tensor &ownedTtnn =
+      tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(owned);
+  const ::ttnn::Tensor &borrowedTtnn =
+      tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(borrowed);
+
+  EXPECT_EQ(tt::runtime::ttnn::utils::getRawHostDataPtr(ownedTtnn),
+            tt::runtime::ttnn::utils::getRawHostDataPtr(borrowedTtnn));
+  EXPECT_EQ(tt::runtime::getTensorShape(owned),
+            tt::runtime::getTensorShape(borrowed));
+  EXPECT_EQ(tt::runtime::getTensorDataType(owned),
+            tt::runtime::getTensorDataType(borrowed));
+}

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -250,9 +250,7 @@ def test_create_unsafe_borrowed_host_tensor(shape, dtype):
     ttrt.runtime.memcpy(owned_tensor, updated_owned_tensor)
 
     output_from_borrowed_after_update = torch.zeros(shape, dtype=dtype)
-    ttrt.runtime.memcpy(
-        output_from_borrowed_after_update.data_ptr(), borrowed_tensor
-    )
+    ttrt.runtime.memcpy(output_from_borrowed_after_update.data_ptr(), borrowed_tensor)
 
     assert torch.allclose(output_from_borrowed_after_update, updated_torch_tensor)
 

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -212,7 +212,7 @@ def test_get_tensor_volume():
         ((1, 3, 224, 224), torch.bfloat16),
     ],
 )
-def test_createUnsafeBorrowedHostTensor(shape, dtype):
+def test_create_unsafe_borrowed_host_tensor(shape, dtype):
     launch_distributed_runtime()
 
     reference_torch_tensor = torch.randn(shape, dtype=dtype)
@@ -240,6 +240,21 @@ def test_createUnsafeBorrowedHostTensor(shape, dtype):
 
     assert torch.allclose(output_from_owned, output_from_borrowed)
     assert torch.allclose(output_from_owned, reference_torch_tensor)
+
+    # Mutate owned tensor after borrowed tensor is created and verify borrowed
+    # tensor observes the update, ensuring this is aliasing (not a copy).
+    updated_torch_tensor = torch.randn(shape, dtype=dtype)
+    updated_owned_tensor = get_runtime_tensor_from_torch(
+        updated_torch_tensor, storage=Storage.Owned
+    )
+    ttrt.runtime.memcpy(owned_tensor, updated_owned_tensor)
+
+    output_from_borrowed_after_update = torch.zeros(shape, dtype=dtype)
+    ttrt.runtime.memcpy(
+        output_from_borrowed_after_update.data_ptr(), borrowed_tensor
+    )
+
+    assert torch.allclose(output_from_borrowed_after_update, updated_torch_tensor)
 
     shutdown_distributed_runtime()
 

--- a/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
+++ b/runtime/test/ttnn/python/distributed/llmbox/test_multiprocess.py
@@ -203,6 +203,47 @@ def test_get_tensor_volume():
     shutdown_distributed_runtime()
 
 
+@pytest.mark.parametrize(
+    "shape,dtype",
+    [
+        ((2, 2), torch.float32),
+        ((177, 211), torch.float32),
+        ((32, 64), torch.bfloat16),
+        ((1, 3, 224, 224), torch.bfloat16),
+    ],
+)
+def test_createUnsafeBorrowedHostTensor(shape, dtype):
+    launch_distributed_runtime()
+
+    reference_torch_tensor = torch.randn(shape, dtype=dtype)
+    owned_tensor = get_runtime_tensor_from_torch(
+        reference_torch_tensor, storage=Storage.Owned
+    )
+
+    borrowed_tensor = ttrt.runtime.create_unsafe_borrowed_host_tensor(owned_tensor)
+
+    # Verify shape and dtype match
+    owned_desc = owned_tensor.get_tensor_desc()
+    borrowed_desc = borrowed_tensor.get_tensor_desc()
+
+    assert owned_desc.shape == borrowed_desc.shape
+    assert owned_desc.dtype == borrowed_desc.dtype
+    assert owned_desc.item_size == borrowed_desc.item_size
+
+    # Verify that borrowed tensor aliases the owned tensor's buffer by
+    # copying data out and checking they match
+    output_from_owned = torch.zeros(shape, dtype=dtype)
+    output_from_borrowed = torch.zeros(shape, dtype=dtype)
+
+    ttrt.runtime.memcpy(output_from_owned.data_ptr(), owned_tensor)
+    ttrt.runtime.memcpy(output_from_borrowed.data_ptr(), borrowed_tensor)
+
+    assert torch.allclose(output_from_owned, output_from_borrowed)
+    assert torch.allclose(output_from_owned, reference_torch_tensor)
+
+    shutdown_distributed_runtime()
+
+
 def test_memcpy():
     launch_distributed_runtime()
 

--- a/tools/ttrt/runtime/__init__.py
+++ b/tools/ttrt/runtime/__init__.py
@@ -48,6 +48,7 @@ try:
         create_multi_device_host_tensor,
         create_multi_device_borrowed_host_tensor,
         create_multi_device_host_tensor_from_shards,
+        create_unsafe_borrowed_host_tensor,
         set_fabric_config,
         wait,
         to_host,


### PR DESCRIPTION
### Ticket
Related: https://github.com/tenstorrent/tt-xla/issues/4011

### Problem description
We want to mirror the memory borrowing/ownership in singledevice to multihost workers but have no way to alias two runtime tensors to each other.

### What's changed
- Add createUnsafeBorrowedHostTensor runtime API to create a runtime tensor that borrows memory from an existing runtime tensor. Similar to an aliasing constructor for shared_ptr.   
- Add stanalone API gtest
- Add multihost API pytest

### Checklist
- [x] New/Existing tests provide coverage for changes
