### PR TITLE
Fix RoPE fusion PCC regression when cos/sin seq dim < input seq dim

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -870,6 +870,29 @@ createAndReplaceWithRoPEOp(mlir::PatternRewriter &rewriter, Operation *srcOp,
                            ArrayRef<int64_t> outPermutation,
                            DeviceComputeKernelConfigAttr computeConfig,
                            const FusionValidationConfig &validationConfig) {
+  // The metal rotary_embedding kernel indexes into cos/sin along the sequence
+  // dimension (dim -2) for each input position — it does not broadcast.
+  // If cos/sin have fewer sequence positions than the input, the kernel reads
+  // tile padding garbage for positions beyond the cos/sin cache size.
+  // Bail out and keep the decomposed form which broadcasts correctly.
+  // This guard can be removed once RoPE fusion is moved before the
+  // EraseInverseOps pass (https://github.com/tenstorrent/tt-mlir/issues/8341).
+  auto xType = mlir::cast<RankedTensorType>(x.getType());
+  auto cosType = mlir::cast<RankedTensorType>(cos.getType());
+  int64_t xRank = xType.getRank();
+  int64_t cosRank = cosType.getRank();
+  if (xRank >= 2 && cosRank >= 2) {
+    int64_t inputSeq = xType.getShape()[xRank - 2];
+    int64_t cosSeq = cosType.getShape()[cosRank - 2];
+    if (cosSeq < inputSeq) {
+      TTMLIR_DEBUG(ttmlir::LogComponent::FusionValidator,
+                   "RoPE fusion rejected: cos/sin seq dim ({0}) < input seq "
+                   "dim ({1}) — kernel would read padding garbage",
+                   cosSeq, inputSeq);
+      return failure();
+    }
+  }
+
   op_model::ScopedSingletonDeviceGuard deviceGuard(srcOp);
 
   // Validate in an isolated module before committing to fusion.

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -87,7 +87,7 @@ def build_ttir(
 
 
 @pytest.mark.skip(
-    "Causes segfault during pipeline, see https://github.com/tenstorrent/tt-mlir/issues/5283"
+    "TTNN fusing is only available when optimizer is enabled, but currently optimizer isn't enabled in builder tests: https://github.com/tenstorrent/tt-mlir/issues/5909"
 )
 @pytest.mark.parametrize(
     "shapes",
@@ -103,6 +103,29 @@ def build_ttir(
             (1, 1, 64),  # cos input
             (1, 1, 64),  # sin input
         ],
+        # Phi decode: query path (seq=1, head_dim=32 partial rotary)
+        [
+            (32, 32, 1, 32),  # input [num_heads, batch, seq=1, head_dim/2]
+            (1, 1, 32),  # cos input
+            (1, 1, 32),  # sin input
+        ],
+        # Phi decode: key path after EIO commute pushes reshape back through
+        # RoPE, folding batch into seq: [1, nH=32, B*S=32, D/2=32].
+        # cos/sin seq=1 < input seq=32 so fusion is correctly rejected.
+        # Should fuse once RoPE fusion moves before EIO pass.
+        # https://github.com/tenstorrent/tt-mlir/issues/8341
+        pytest.param(
+            [
+                (1, 32, 32, 32),  # input [1, num_heads, batch, head_dim/2]
+                (1, 1, 32),  # cos input
+                (1, 1, 32),  # sin input
+            ],
+            marks=pytest.mark.xfail(
+                reason="cos/sin seq < input seq — fusion rejected until "
+                "RoPE fusion moves before EIO "
+                "(https://github.com/tenstorrent/tt-mlir/issues/8341)"
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("dtypes", [[torch.bfloat16] * 3])

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttnn_fusing/rotary_embedding/rope.mlir
@@ -401,4 +401,28 @@ module {
     %result = "ttir.concat"(%sub, %add) <{dim = 3 : si32}> : (tensor<16x8x1x32xbf16>, tensor<16x8x1x32xbf16>) -> tensor<16x8x1x64xbf16>
     return %result : tensor<16x8x1x64xbf16>
   }
+
+  // cos/sin seq dim (1) < input seq dim (32): the metal kernel indexes into
+  // cos/sin per sequence position without broadcasting, so positions beyond
+  // the cache size read tile padding garbage. Must NOT fuse.
+  // This pattern appears in Phi decode when the EIO commute pass pushes a
+  // reshape (needed by paged_update_cache) back through the RoPE elementwise
+  // ops, folding batch into the apparent seq dimension.
+  // CHECK-LABEL: @rope_cos_sin_seq_too_small_no_fuse
+  // CHECK-NOT: ttnn.rotary_embedding"
+  // CHECK: ttnn.add"
+  func.func @rope_cos_sin_seq_too_small_no_fuse(%x: tensor<1x32x32x64xbf16>, %cos: tensor<1x1x1x64xbf16>, %sin: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
+    %cos_bc = "ttir.broadcast"(%cos) <{broadcast_dimensions = array<i64: 1, 32, 32, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16>
+    %x_cos = "ttir.multiply"(%x, %cos_bc) : (tensor<1x32x32x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+
+    %x_hi = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 32:i32], ends = [1:i32, 32:i32, 32:i32, 64:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x32x32x32xbf16>
+    %neg_hi = "ttir.neg"(%x_hi) : (tensor<1x32x32x32xbf16>) -> tensor<1x32x32x32xbf16>
+    %x_lo = "ttir.slice_static"(%x) <{begins = [0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 32:i32, 32:i32, 32:i32], step = [1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x32x32x32xbf16>
+    %rotated = "ttir.concat"(%neg_hi, %x_lo) <{dim = 3 : si32}> : (tensor<1x32x32x32xbf16>, tensor<1x32x32x32xbf16>) -> tensor<1x32x32x64xbf16>
+
+    %sin_bc = "ttir.broadcast"(%sin) <{broadcast_dimensions = array<i64: 1, 32, 32, 1>}> : (tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16>
+    %rot_sin = "ttir.multiply"(%rotated, %sin_bc) : (tensor<1x32x32x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+    %result = "ttir.add"(%x_cos, %rot_sin) : (tensor<1x32x32x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+    return %result : tensor<1x32x32x64xbf16>
+  }
 }


### PR DESCRIPTION
### Ticket
Closes #8336

### Summary
- Reject RoPE fusion when cos/sin cache has fewer sequence positions than the input tensor, preventing the metal kernel from reading tile padding garbage (PCC drops from ~0.999 to ~0.17)
- Add lit test and Python test coverage for the Phi decode shapes that trigger this issue
- Track long-term fix (move RoPE fusion before EIO pass) in #8341
### Context
The metal rotary_embedding kernel indexes into cos/sin along the sequence dimension per position — it does not broadcast. In Phi decode, cos/sin are computed on-the-fly for a single position ([1,1,1,D]), while the EraseInverseOps commute pass pushes a reshape (needed by paged_update_cache) backward through the decomposed RoPE elementwise ops, folding batch into the apparent seq dimension ([1, nH, B*S, D]). This makes the input look like seq=32 while cos/sin only have seq=1 — positions 1-31 read tile padding garbage.

The fix adds a precondition check in createAndReplaceWithRoPEOp: if cosSeq < inputSeq, bail out and keep the decomposed form (which broadcasts correctly via elementwise multiply).

Perf benchmark:
https://github.com/tenstorrent/tt-xla/actions/runs/25566291828

<h2 data-line="36" class="code-line" dir="auto" id="performance-results" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid rgba(255, 255, 255, 0.18); border-top-color: rgba(255, 255, 255, 0.18); border-right-color: rgba(255, 255, 255, 0.18); border-left-color: rgba(255, 255, 255, 0.18); position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Performance Results</h2><p data-line="38" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Compared against previous nightly<span> </span><a href="https://github.com/tenstorrent/tt-xla/actions/runs/25529490187" data-href="https://github.com/tenstorrent/tt-xla/actions/runs/25529490187" style="color: rgb(72, 160, 199); text-decoration: none;">run 25529490187</a><span> </span>(2026-05-08).</p><h3 data-line="40" class="code-line" dir="auto" id="n150-models" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">n150 Models</h3>
Model | Samples/sec | Diff | Device FW (s) | Job
-- | -- | -- | -- | --
mnist | 14854.09 | +9.4% | — | link
ministral_8b | 15.53 | -5.6% | — | link
phi1_5 | 23.71 | new | — | link
phi2 | 11.56 | new | — | link

<p data-line="49" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><em>31 stable models omitted (&lt;5% change in Samples/sec).</em></p><p data-line="51" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><em>15 multi-chip models (llmbox/galaxy) absent from this run — this was an n150-only Performance Benchmark, not the full nightly.</em></p><h2 data-line="53" class="code-line" dir="auto" id="run-info" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid rgba(255, 255, 255, 0.18); border-top-color: rgba(255, 255, 255, 0.18); border-right-color: rgba(255, 255, 255, 0.18); border-left-color: rgba(255, 255, 255, 0.18); position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Run Info</h2><ul data-line="55" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 0.7em; position: relative; color: rgb(187, 190, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li data-line="55" class="code-line" dir="auto" style="position: relative;"><strong>Workflow</strong>: Performance Benchmark</li><li data-line="56" class="code-line" dir="auto" style="position: relative;"><strong>Branch</strong>: main</li><li data-line="57" class="code-line" dir="auto" style="position: relative;"><strong>URL</strong>:<span> </span><a href="https://github.com/tenstorrent/tt-xla/actions/runs/25566291828" data-href="https://github.com/tenstorrent/tt-xla/actions/runs/25566291828" style="color: rgb(72, 160, 199); text-decoration: none;">https://github.com/tenstorrent/tt-xla/actions/runs/25566291828</a></li><li data-line="58" class="code-line" dir="auto" style="position: relative;"><strong>Previous nightly</strong>:<span> </span><a href="https://github.com/tenstorrent/tt-xla/actions/runs/25529490187" data-href="https://github.com/tenstorrent/tt-xla/actions/runs/25529490187" style="color: rgb(72, 160, 199); text-decoration: none;">https://github.com/tenstorrent/tt-xla/actions/runs/25529490187</a></li></ul><br class="Apple-interchange-newline">Performance Results
Compared against previous nightly [run 25529490187](https://github.com/tenstorrent/tt-xla/actions/runs/25529490187) (2026-05-08).

n150 Models
Model	Samples/sec	Diff	Device FW (s)	Job
mnist	14854.09	+9.4%	—	[link](https://github.com/tenstorrent/tt-xla/actions/runs/25566291828/job/75052940766)
ministral_8b	15.53	-5.6%	—	[link](https://github.com/tenstorrent/tt-xla/actions/runs/25566291828/job/75052940620)
phi1_5	23.71	new	—	[link](https://github.com/tenstorrent/tt-xla/actions/runs/25566291828/job/75052940606)
phi2	11.56	new	—	[link](https://github.com/tenstorrent/tt-xla/actions/runs/25566291828/job/75052940757)
31 stable models omitted (<5% change in Samples/sec).

15 multi-chip models (llmbox/galaxy) absent from this run — this was an n150-only Performance Benchmark, not the full nightly.

Run Info
Workflow: Performance Benchmark
Branch: main
URL: https://github.com/tenstorrent/tt-xla/actions/runs/25566291828
Previous nightly: https://github.com/tenstorrent/tt-xla/actions/runs/25529490187

### Checklist
- [x] New/Existing tests provide coverage for changes
