### PR TITLE
Extended support for ttnn.group_norm and maxpool3d

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2486,11 +2486,12 @@ def TTIR_GroupNormOp : TTIR_NamedOp<"group_norm", [AttrSizedOperandSegments]> {
     is normalized by subtracting the mean and dividing by the standard deviation,
     then optionally scaled and shifted by weight (gamma) and bias (beta).
 
-    Input tensor is expected to have shape [N, 1, H*W, C], where C is the dimension
-    along which groups are formed. Groups are formed using the tensor's last dimension.
+    Input tensor must be at least 4D. Common shapes include [N, C, H, W] (4D) and
+    [N, C, D, H, W] (5D for 3D convolutions). During TTIR-to-TTNN conversion, inputs
+    are permuted and reshaped to [N, 1, H*W, C] based on the channel_dim attribute.
 
     Inputs:
-    - `input` (Tensor): The input tensor to be normalized (4D, shape [N, 1, H*W, C]).
+    - `input` (Tensor): The input tensor to be normalized (at least 4D).
     - `input_mask` (Optional Tensor): When processing the inputs, the mask is used to
       only look at the elements of the current group. Defaults to None.
     - `weight` (Optional Tensor): The scale parameter (gamma). If provided, the

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2602,8 +2602,7 @@ def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments]> {
                        Optional<AnyRankedTensor>:$weight,
                        Optional<AnyRankedTensor>:$bias,
                        I64Attr:$num_groups,
-                       DefaultValuedAttr<F32Attr, "1e-12">:$epsilon,
-                       OptionalAttr<TTNN_CoreCoordAttr>:$core_grid);
+                       DefaultValuedAttr<F32Attr, "1e-12">:$epsilon);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_GROUPNORMCHANNELPADREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_GROUPNORMCHANNELPADREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Pad the channel dimension (last dim) of GroupNormOp inputs to the nearest
+// multiple of TILE_WIDTH (32) when it is not already aligned. The num_groups
+// attribute is scaled proportionally so that channels_per_group remains
+// unchanged, preserving mathematical correctness. Weight and bias operands
+// are similarly padded. A SliceStaticOp is inserted after the padded
+// GroupNormOp to restore the original channel size.
+class GroupNormChannelPadRewritePattern
+    : public OpRewritePattern<ttnn::GroupNormOp> {
+public:
+  using OpRewritePattern<ttnn::GroupNormOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::GroupNormOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_GROUPNORMCHANNELPADREWRITEPATTERN_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1720,8 +1720,7 @@ struct OpModel<GroupNormOp> {
                    std::optional<TTNNLayoutAttr> weightLayout,
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
-                   std::optional<CoreCoordAttr> coreGrid = std::nullopt);
+                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1731,8 +1730,7 @@ struct OpModel<GroupNormOp> {
                std::optional<TTNNLayoutAttr> weightLayout,
                std::optional<llvm::ArrayRef<int64_t>> biasShape,
                std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-               llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
-               std::optional<CoreCoordAttr> coreGrid = std::nullopt);
+               llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/TTNN/operations/normalization.fbs
+++ b/include/ttmlir/Target/TTNN/operations/normalization.fbs
@@ -125,5 +125,4 @@ table GroupNormOp {
   epsilon: float;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
-  core_grid: tt.target.ttnn.CoreCoord;
 }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -720,17 +720,17 @@ public:
     namedAttrs.push_back(rewriter.getNamedAttr(
         "operandSegmentSizes", rewriter.getDenseI32ArrayAttr(segmentSizes)));
 
-    // ttir.group_norm requires 4D; reshape rank<4 to 4D by appending
+    // ttir.group_norm requires rank >= 4; reshape rank<4 to 4D by appending
     // trailing unit dims (keeps channel_dim at the same index), then
     // reshape the result back to the original rank.
     Value input = adaptor.getOperands()[0];
     auto inputType = mlir::cast<RankedTensorType>(input.getType());
     int64_t inputRank = inputType.getRank();
-    if (inputRank > 4) {
-      return rewriter.notifyMatchFailure(srcOp, "input rank must be <= 4");
+    if (inputRank > 5) {
+      return rewriter.notifyMatchFailure(srcOp, "input rank must be <= 5");
     }
 
-    if (inputRank == 4) {
+    if (inputRank >= 4) {
       rewriter.replaceOpWithNewOp<ttir::GroupNormOp>(
           srcOp, outputType, adaptor.getOperands(), namedAttrs);
       return success();

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2881,15 +2881,22 @@ private:
       RankedTensorType originalResultType = cast<RankedTensorType>(
           getTypeConverter()->convertType(srcOp.getResult(i).getType()));
 
+      // NDHWC input is already in the layout used for pooling; canonicalizing
+      // to NCDHW and permuting back would be a no-op transpose pair.
+      SmallVector<int64_t> permNDHWCToNCDHW = {0, 4, 1, 2, 3};
+      bool inputIsNDHWC = needsPermute && permToCanonical == permNDHWCToNCDHW;
+
       // Permute to canonical NCDHW layout if needed.
       SmallVector<int64_t> canonShape;
       if (needsPermute) {
         canonShape = ttmlir::utils::applyPermutation(inputType.getShape(),
                                                      permToCanonical);
-        input = rewriter.create<ttir::PermuteOp>(
-            srcOp.getLoc(),
-            RankedTensorType::get(canonShape, elemType, encoding), input,
-            permToCanonical);
+        if (!inputIsNDHWC) {
+          input = rewriter.create<ttir::PermuteOp>(
+              srcOp.getLoc(),
+              RankedTensorType::get(canonShape, elemType, encoding), input,
+              permToCanonical);
+        }
       } else {
         canonShape = SmallVector<int64_t>(inputType.getShape());
       }
@@ -2917,10 +2924,14 @@ private:
       // [N, C, D, H, W] -> permute -> [N, D, H, W, C] -> reshape ->
       // [N*D, H, W, C].
       SmallVector<int64_t> permNCDHWToNDHWC = {0, 2, 3, 4, 1};
-      SmallVector<int64_t> shapeNDHWC = {N, D, H, W, C};
-      Value ndhwc = rewriter.create<ttir::PermuteOp>(
-          srcOp.getLoc(), RankedTensorType::get(shapeNDHWC, elemType, encoding),
-          input, permNCDHWToNDHWC);
+      Value ndhwc = input;
+      if (!inputIsNDHWC) {
+        SmallVector<int64_t> shapeNDHWC = {N, D, H, W, C};
+        ndhwc = rewriter.create<ttir::PermuteOp>(
+            srcOp.getLoc(),
+            RankedTensorType::get(shapeNDHWC, elemType, encoding), input,
+            permNCDHWToNDHWC);
+      }
 
       int64_t batchND = N * D;
       SmallVector<int64_t> shapeForHW = {batchND, H, W, C};

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2530,8 +2530,9 @@ public:
       }
     }
 
-    // Handle 5D input (3D pooling) by decomposing into two 2D pooling passes.
-    // This works because max is associative: max(i,j,k) = max_i(max(j,k)).
+    // Handle 5D input (3D max pooling) by decomposing into two 2D max pooling
+    // passes.
+    // This works because max is associative: max(d,h,w) = max_d(max(h,w)).
     if (inputRank == 5) {
       return lowerReduceWindow5D(srcOp, adaptor, rewriter, *initValues,
                                  reductionOps, windowDimensions, windowStrides,
@@ -2760,9 +2761,9 @@ public:
 private:
   // Decompose a 5D reduce_window (3D pooling) into two sequential 2D max pool
   // operations. The 3D pooling window [kD, kH, kW] is factored as:
-  //   Pass 1: MaxPool2d over (H, W) with kernel [kH, kW]
-  //   Pass 2: MaxPool2d over (D)    with kernel [kD, 1]
-  // This is valid because max is associative: max(i,j,k) = max_i(max(j,k)).
+  //   Pass 1: Permute to [N,D,H,W,C], reshape to [N*D,H,W,C], MaxPool2d [kH,kW]
+  //   Pass 2: Reshape to [N,D,Hout*Wout,C], MaxPool2d [kD,1]
+  // This is valid because max is associative: max(d,h,w) = max_d(max(h,w)).
   LogicalResult
   lowerReduceWindow5D(mlir::stablehlo::ReduceWindowOp srcOp,
                       mlir::stablehlo::ReduceWindowOp::Adaptor adaptor,
@@ -2800,9 +2801,9 @@ private:
       }
     }
 
-    // Non-spatial dimensions are folded into batch, so they must have trivial
-    // window attributes. Stride > 1 would subsample, padding would change the
-    // output size - neither is handled by the batch-folding reshapes.
+    // Non-spatial dimensions (N and C) must use trivial windowing: stride 1 and
+    // no padding. Stride > 1 or non-zero padding on N or C would subsample or
+    // resize those axes; this decomposition only pools over D, H, and W.
     for (size_t dim : nonSpatialDims) {
       if (windowStrides[dim] != 1 || padding[dim * 2] != 0 ||
           padding[dim * 2 + 1] != 0) {
@@ -2912,17 +2913,23 @@ private:
       int64_t Hout = canonResultShape[3];
       int64_t Wout = canonResultShape[4];
 
-      // Pass 1: Pool over H, W.
-      // Reshape [N, C, D, H, W] -> [N*C*D, H, W, 1].
-      int64_t batchHW = N * C * D;
-      SmallVector<int64_t> shapeForHW = {batchHW, H, W, 1};
-      SmallVector<int32_t> shapeForHW32(shapeForHW.begin(), shapeForHW.end());
+      // Pass 1: Pool over H, W with channels preserved (NHWC).
+      // [N, C, D, H, W] -> permute -> [N, D, H, W, C] -> reshape ->
+      // [N*D, H, W, C].
+      SmallVector<int64_t> permNCDHWToNDHWC = {0, 2, 3, 4, 1};
+      SmallVector<int64_t> shapeNDHWC = {N, D, H, W, C};
+      Value ndhwc = rewriter.create<ttir::PermuteOp>(
+          srcOp.getLoc(), RankedTensorType::get(shapeNDHWC, elemType, encoding),
+          input, permNCDHWToNDHWC);
 
+      int64_t batchND = N * D;
+      SmallVector<int64_t> shapeForHW = {batchND, H, W, C};
+      SmallVector<int32_t> shapeForHW32(shapeForHW.begin(), shapeForHW.end());
       Value reshapedHW = rewriter.create<ttir::ReshapeOp>(
           srcOp.getLoc(), RankedTensorType::get(shapeForHW, elemType, encoding),
-          input, rewriter.getI32ArrayAttr(shapeForHW32));
+          ndhwc, rewriter.getI32ArrayAttr(shapeForHW32));
 
-      SmallVector<int64_t> resultShapeHW = {batchHW, Hout, Wout, 1};
+      SmallVector<int64_t> resultShapeHW = {batchND, Hout, Wout, C};
       Value pooledHW =
           rewriter
               .create<ttir::MaxPool2dOp>(
@@ -2933,17 +2940,15 @@ private:
               .getResult();
 
       // Pass 2: Pool over D.
-      // Reshape [N*C*D, Hout, Wout, 1] -> [N*C, D, Hout*Wout, 1].
-      int64_t batchD = N * C;
+      // [N*D, Hout, Wout, C] -> [N, D, Hout*Wout, C].
       int64_t flatHW = Hout * Wout;
-      SmallVector<int64_t> shapeForD = {batchD, D, flatHW, 1};
+      SmallVector<int64_t> shapeForD = {N, D, flatHW, C};
       SmallVector<int32_t> shapeForD32(shapeForD.begin(), shapeForD.end());
-
       Value reshapedD = rewriter.create<ttir::ReshapeOp>(
           srcOp.getLoc(), RankedTensorType::get(shapeForD, elemType, encoding),
           pooledHW, rewriter.getI32ArrayAttr(shapeForD32));
 
-      SmallVector<int64_t> resultShapeD = {batchD, Dout, flatHW, 1};
+      SmallVector<int64_t> resultShapeD = {N, Dout, flatHW, C};
       Value pooledD =
           rewriter
               .create<ttir::MaxPool2dOp>(
@@ -2952,13 +2957,19 @@ private:
                   reshapedD, kernelD, strideD, dilationD, paddingD, ceilMode)
               .getResult();
 
-      // Reshape back to canonical 5D: [N*C, Dout, Hout*Wout, 1] ->
-      //                                [N, C, Dout, Hout, Wout].
+      // [N, Dout, Hout*Wout, C] (NHWC) -> permute -> [N, C, Dout, Hout*Wout] ->
+      // reshape -> canonical [N, C, Dout, Hout, Wout].
+      SmallVector<int64_t> permNHWCToNCDF = {0, 3, 1, 2};
+      SmallVector<int64_t> shapeNCDF = {N, C, Dout, flatHW};
+      Value ncdf = rewriter.create<ttir::PermuteOp>(
+          srcOp.getLoc(), RankedTensorType::get(shapeNCDF, elemType, encoding),
+          pooledD, permNHWCToNCDF);
+
       SmallVector<int32_t> canonResultShape32(canonResultShape.begin(),
                                               canonResultShape.end());
       Value result = rewriter.create<ttir::ReshapeOp>(
           srcOp.getLoc(),
-          RankedTensorType::get(canonResultShape, elemType, encoding), pooledD,
+          RankedTensorType::get(canonResultShape, elemType, encoding), ncdf,
           rewriter.getI32ArrayAttr(canonResultShape32));
 
       // Permute back to original layout if needed.

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1358,47 +1358,6 @@ public:
 namespace {
 class GroupNormOpConversionPattern
     : public OpConversionPattern<ttir::GroupNormOp> {
-private:
-  // Compute a valid core grid for group_norm.
-  // This mirrors tt-metal's find_expected_dram_grid.
-  // ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
-  // metal issue: https://github.com/tenstorrent/tt-metal/issues/40916
-  static std::pair<uint64_t, uint64_t>
-  computeGroupNormCoreGrid(int64_t deviceGridX, int64_t deviceGridY,
-                           int64_t numChannels, int64_t numGroups,
-                           int64_t inputNHW, int64_t numBatches) {
-    assert(numBatches >= 1 && "group_norm numBatches must be >= 1");
-    constexpr int64_t tileSize = ttcore::TileType::getDefaultShape()[0];
-    int64_t Ht = llvm::divideCeil(inputNHW, tileSize);
-
-    for (int64_t gx = deviceGridX; gx >= 1; --gx) {
-      int64_t nvc = std::min(gx, numGroups);
-      while (nvc > 0 &&
-             ((numChannels / nvc) % tileSize != 0 || (numGroups % nvc) != 0)) {
-        --nvc;
-      }
-      if (nvc == 0) {
-        continue;
-      }
-
-      int64_t rowsPerY = gx / nvc;
-      if (rowsPerY == 0) {
-        continue;
-      }
-
-      int64_t maxGy = std::min(Ht / rowsPerY, deviceGridY);
-      for (int64_t gy = maxGy; gy >= 1; --gy) {
-        int64_t numVirtualRows = rowsPerY * gy;
-        if (Ht % numVirtualRows == 0 &&
-            (numVirtualRows < numBatches || numVirtualRows % numBatches == 0)) {
-          return {static_cast<uint64_t>(gx), static_cast<uint64_t>(gy)};
-        }
-      }
-    }
-
-    return {1, 1};
-  }
-
 public:
   using OpConversionPattern<ttir::GroupNormOp>::OpConversionPattern;
 
@@ -1472,30 +1431,11 @@ public:
       input = rewriter.create<ttnn::ReshapeOp>(
           loc, reshapedType, input, rewriter.getI32ArrayAttr(reshapedShapeI32));
     }
-    // Compute core_grid from the device worker grid and input dimensions.
     // Input is now in [N, 1, H*W, C] form.
-
     RankedTensorType groupNormInputType =
         mlir::cast<RankedTensorType>(input.getType());
 
-    llvm::SmallVector<int64_t> paddedGnShape =
-        ttnn::utils::getTilePaddedShape(groupNormInputType.getShape());
-    int64_t inputNHW = paddedGnShape[0] * paddedGnShape[1] * paddedGnShape[2];
-    int64_t numChannels = paddedGnShape[3];
-    int64_t numGroups = adaptor.getNumGroups();
-    int64_t numBatches = paddedGnShape[0];
-
-    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
-    auto workerGridShape = deviceAttr.getWorkerGrid().getShape();
-    // GridAttr shape is [y, x].
-    int64_t deviceGridX = workerGridShape[1];
-    int64_t deviceGridY = workerGridShape[0];
-
-    auto [gridX, gridY] = computeGroupNormCoreGrid(
-        deviceGridX, deviceGridY, numChannels, numGroups, inputNHW, numBatches);
-
-    auto coreGridAttr =
-        ttnn::CoreCoordAttr::get(rewriter.getContext(), gridX, gridY);
+    int64_t numChannels = groupNormInputType.getShape().back();
 
     // Materialize missing affine parameters to avoid runtime issues in
     // optional-weight/bias GroupNorm paths.
@@ -1546,7 +1486,7 @@ public:
     Value groupNormResult = rewriter.create<ttnn::GroupNormOp>(
         loc, this->getTypeConverter()->convertType(groupNormInputType), input,
         adaptor.getInputMask(), weight, bias, adaptor.getNumGroups(),
-        adaptor.getEpsilon(), coreGridAttr);
+        adaptor.getEpsilon());
 
     // Reshape back to original shape if reshaped.
     if (needsReshape) {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1414,12 +1414,11 @@ public:
     Location loc = op.getLoc();
     Value input = adaptor.getInput();
 
-    assert(inputType.getRank() == 4 && "input must be a 4D tensor");
-
     int64_t channelDimIdx = adaptor.getChannelDim();
 
     // If channel_dim is not the last dimension, permute to move it
     // there. E.g. for NCHW (channel_dim=1), permute [0,2,3,1] -> NHWC.
+    // Works for any rank >= 4, e.g. NCDHW -> NDHWC with [0,2,3,4,1].
     bool needsPermute = channelDimIdx != rank - 1;
     llvm::SmallVector<int64_t> permutation;
     llvm::SmallVector<int64_t> inversePermutation;
@@ -1450,16 +1449,21 @@ public:
 
     // TTNN group_norm requires [N, 1, H*W, C].
     // Reshape to [N, 1, H*W, C] if not already in that form.
+    // For >4D inputs (e.g. 5D [N, D, H, W, C] after permute), collapse all
+    // spatial dimensions (dims 1..rank-2) into one.
     llvm::SmallVector<int64_t> preNormShape(inputShape.begin(),
                                             inputShape.end());
 
-    bool needsReshape = inputShape[1] != 1;
+    bool needsReshape = rank > 4 || inputShape[1] != 1;
     if (needsReshape) {
       int64_t n = inputShape[0];
-      int64_t c = inputShape[3];
-      int64_t hw = inputShape[1] * inputShape[2];
+      int64_t c = inputShape[rank - 1];
+      int64_t spatialProduct = 1;
+      for (int64_t i = 1; i < rank - 1; ++i) {
+        spatialProduct *= inputShape[i];
+      }
 
-      llvm::SmallVector<int64_t> reshapedShape = {n, 1, hw, c};
+      llvm::SmallVector<int64_t> reshapedShape = {n, 1, spatialProduct, c};
       llvm::SmallVector<int32_t> reshapedShapeI32(reshapedShape.begin(),
                                                   reshapedShape.end());
       RankedTensorType reshapedType =

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3839,20 +3839,6 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::GroupNormOp> emitter(
         srcOp, adaptor, rewriter);
 
-    // ttnn::group_norm requires core_grid to be explicitly specified.
-    // If the op doesn't have it set, derive it from the device's worker grid.
-    mlir::Attribute coreGridArg;
-    if (srcOp.getCoreGrid()) {
-      coreGridArg = emitter.emit<::ttnn::CoreGrid>(srcOp.getCoreGrid());
-    } else {
-      ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(srcOp);
-      auto gridShape = deviceAttr.getWorkerGrid().getShape();
-      // GridAttr shape is [y, x], CoreCoordAttr takes (x, y).
-      auto defaultCoreGrid = mlir::tt::ttnn::CoreCoordAttr::get(
-          rewriter.getContext(), gridShape[1], gridShape[0]);
-      coreGridArg = emitter.emit<::ttnn::CoreGrid>(defaultCoreGrid);
-    }
-
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getNumGroups()),
@@ -3863,10 +3849,10 @@ public:
         emitter.emit(/* reciprocals= */ std::nullopt),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         emitter.emit(/* dtype= */ std::nullopt),
-        coreGridArg,
+        emitter.emit(/* core_grid= */ std::nullopt),
         emitter.emit(/* inplace= */ std::nullopt),
         emitter.emit(/* output_layout= */ std::nullopt),
-        emitter.emit(/* num_out_blocks= */ -1),
+        emitter.emit(/* num_out_blocks= */ std::nullopt),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4052,19 +4052,6 @@ public:
     ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::GroupNormOp> emitter(
         srcOp, adaptor, rewriter);
 
-    // ttnn::group_norm requires core_grid to be explicitly specified.
-    // If the op doesn't have it set, derive it from the device's worker grid.
-    mlir::tt::ttnn::CoreCoordAttr coreGridValue;
-    if (srcOp.getCoreGrid()) {
-      coreGridValue = *srcOp.getCoreGrid();
-    } else {
-      ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(srcOp);
-      auto gridShape = deviceAttr.getWorkerGrid().getShape();
-      // GridAttr shape is [y, x], CoreCoordAttr takes (x, y).
-      coreGridValue = mlir::tt::ttnn::CoreCoordAttr::get(
-          rewriter.getContext(), gridShape[1], gridShape[0]);
-    }
-
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getInputMask(), "input_mask"),
@@ -4073,9 +4060,9 @@ public:
         emitter.emit(srcOp.getNumGroups(), "num_groups"),
         emitter.emit(srcOp.getEpsilon(), "epsilon"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
-        emitter.emit<::ttnn::CoreGrid>(coreGridValue, "core_grid"),
+        emitter.emit(std::nullopt, "core_grid"),
         emitter.emit(false, "inplace"),
-        emitter.emit(-1, "num_out_blocks"),
+        emitter.emit(std::nullopt, "num_out_blocks"),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7171,9 +7171,9 @@ mlir::tt::ttir::SplitQueryKeyValueAndSplitHeadsOp::verify() {
     return emitOpError("input and output must have the same shape");
   }
 
-  // Input must be 4D.
-  if (inputType.getRank() != 4) {
-    return emitOpError("input must be a 4D tensor, got rank ")
+  // Input must be at least 4D (e.g. 4D [N, C, H, W] or 5D [N, C, D, H, W]).
+  if (inputType.getRank() < 4) {
+    return emitOpError("input must be at least a 4D tensor, got rank ")
            << inputType.getRank();
   }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3605,6 +3605,14 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
            << channelDim << ", num_groups=" << numGroups;
   }
 
+  // input_mask is sized against (C, num_groups), so the channel-padding
+  // workaround cannot fix a non-tile-aligned C when input_mask is present.
+  if (getInputMask() && channelDim % 32 != 0) {
+    return emitOpError("input_mask is not supported when channel dimension is "
+                       "not tile-aligned (multiple of 32); got C=")
+           << channelDim;
+  }
+
   if (getWeight()) {
     RankedTensorType weightType = getWeight().getType();
     if (weightType.getRank() == 1) {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3599,12 +3599,6 @@ void mlir::tt::ttnn::DistributedRMSNormOp::allocateSemaphores(
 
   int64_t channelDim = inputShape[3];
 
-  if (channelDim % 32 != 0) {
-    return emitOpError("channel dimension (last dim) must be divisible by 32, "
-                       "got C=")
-           << channelDim;
-  }
-
   if (channelDim % numGroups != 0) {
     return emitOpError("channel dimension (last dim) must be divisible by "
                        "num_groups; got C=")

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4205,7 +4205,7 @@ GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       optionalArgs.inputMaskLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
       optionalArgs.biasLayout, getNumGroups(), getEpsilon(),
-      opConfig.outputLayout, getCoreGrid());
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4222,7 +4222,7 @@ GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputs[0], optionalArgs.inputMaskShape, optionalArgs.inputMaskLayout,
       optionalArgs.weightShape, optionalArgs.weightLayout,
       optionalArgs.biasShape, optionalArgs.biasLayout, getNumGroups(),
-      getEpsilon(), opConfig.outputLayout, getCoreGrid());
+      getEpsilon(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -60,6 +60,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/SplitQueryKeyValueAndSplitHeadsOpRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
         Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.cpp
+        Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
         Workarounds/Decomposition/LinearOpRewritePattern.cpp
         Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.cpp
         Workarounds/Decomposition/ReduceScatterOpRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.cpp
@@ -32,7 +32,7 @@ LogicalResult GroupNormDecompositionRewritePattern::matchAndRewrite(
     auto validationResult = validator.validateOp<ttnn::GroupNormOp>(
         op.getOperation(), op.getLoc(), {resultType}, op.getInput(),
         op.getInputMask(), op.getWeight(), op.getBias(), op.getNumGroupsAttr(),
-        op.getEpsilonAttr(), op.getCoreGridAttr());
+        op.getEpsilonAttr());
 
     if (validationResult.isSuccess()) {
       return failure();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.cpp
@@ -44,7 +44,7 @@ LogicalResult GroupNormAffineReshapeRewritePattern::matchAndRewrite(
   auto newOp = rewriter.create<ttnn::GroupNormOp>(
       srcOp.getLoc(), srcOp.getResult().getType(), srcOp.getInput(),
       srcOp.getInputMask(), newWeight, newBias, srcOp.getNumGroupsAttr(),
-      srcOp.getEpsilonAttr(), srcOp.getCoreGridAttr());
+      srcOp.getEpsilonAttr());
 
   rewriter.replaceOp(srcOp, newOp.getResult());
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <numeric>
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// Pad a 1D affine parameter (weight or bias) from originalC to paddedC by
+// inserting a PadOp that zero-pads along the single dimension.
+static Value padAffine1D(Value affine, int64_t originalC, int64_t paddedC,
+                         StringRef suffix, Location loc,
+                         PatternRewriter &rewriter) {
+  if (!affine) {
+    return affine;
+  }
+
+  auto affineType = mlir::cast<RankedTensorType>(affine.getType());
+  if (affineType.getRank() != 1 || affineType.getShape()[0] != originalC) {
+    return affine;
+  }
+
+  SmallVector<int32_t> padding = {0, static_cast<int32_t>(paddedC - originalC)};
+  SmallVector<int64_t> paddedShape = {paddedC};
+  auto paddedType =
+      ttnn::utils::RankedTensorTypeFactory::create(affineType, paddedShape);
+
+  return rewriter.create<ttnn::PadOp>(
+      ttmlir::utils::appendLocationSuffix(loc, suffix), paddedType, affine,
+      padding, /*pad_value=*/mlir::APFloat(0.0f),
+      /*use_multicore=*/false,
+      /*memory_config=*/nullptr);
+}
+
+LogicalResult GroupNormChannelPadRewritePattern::matchAndRewrite(
+    ttnn::GroupNormOp srcOp, PatternRewriter &rewriter) const {
+  constexpr int64_t tileWidth = ttcore::TileType::getDefaultShape()[1];
+
+  RankedTensorType inputType = srcOp.getInput().getType();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+
+  if (inputType.getRank() != 4) {
+    return failure();
+  }
+
+  int64_t originalC = inputShape[3];
+
+  if (originalC % tileWidth == 0) {
+    return failure();
+  }
+
+  // input_mask is sized against the original (C, num_groups); we can't scale
+  // it to the new (paddedC, paddedNumGroups), so bail out if it's present.
+  if (srcOp.getInputMask()) {
+    return rewriter.notifyMatchFailure(
+        srcOp, "channel padding workaround does not support input_mask");
+  }
+
+  // Only 1D weight/bias are supported. As of right now the 4D [1,1,C/32,32]
+  // form requires C to already be tile-aligned.
+  auto is1DOrAbsent = [](Value v) {
+    return !v || mlir::cast<RankedTensorType>(v.getType()).getRank() == 1;
+  };
+  if (!is1DOrAbsent(srcOp.getWeight()) || !is1DOrAbsent(srcOp.getBias())) {
+    return rewriter.notifyMatchFailure(
+        srcOp, "channel padding workaround only supports 1D weight/bias");
+  }
+
+  int64_t numGroups = srcOp.getNumGroups();
+  // group_norm verification guarantees C is divisible by num_groups.
+  int64_t channelsPerGroup = originalC / numGroups;
+
+  // Pad C to a multiple of both tile_width and channels_per_group so the
+  // zero-padded channels form entirely new trailing groups (later sliced away)
+  // instead of mixing into the statistics of the original groups.
+  int64_t alignment = std::lcm(tileWidth, channelsPerGroup);
+  int64_t paddedC = llvm::divideCeil(originalC, alignment) * alignment;
+
+  int64_t paddedNumGroups = paddedC / channelsPerGroup;
+
+  Location loc = srcOp.getLoc();
+
+  // Pad input: [N, 1, H*W, C] -> [N, 1, H*W, paddedC].
+  SmallVector<int32_t> inputPadding(inputType.getRank() * 2, 0);
+  inputPadding.back() = paddedC - originalC;
+
+  SmallVector<int64_t> paddedInputShape(inputShape);
+  paddedInputShape[3] = paddedC;
+
+  auto paddedInputType =
+      ttnn::utils::RankedTensorTypeFactory::create(inputType, paddedInputShape);
+
+  auto paddedInput = rewriter.create<ttnn::PadOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_pad_input"), paddedInputType,
+      srcOp.getInput(), inputPadding, /*pad_value=*/mlir::APFloat(0.0f),
+      /*use_multicore=*/false,
+      /*memory_config=*/nullptr);
+
+  // Pad weight and bias from [originalC] to [paddedC].
+  Value paddedWeight = padAffine1D(srcOp.getWeight(), originalC, paddedC,
+                                   "_pad_weight", loc, rewriter);
+  Value paddedBias = padAffine1D(srcOp.getBias(), originalC, paddedC,
+                                 "_pad_bias", loc, rewriter);
+
+  // Create padded GroupNormOp with scaled num_groups.
+  RankedTensorType outputType = srcOp.getResult().getType();
+  SmallVector<int64_t> paddedOutputShape(outputType.getShape());
+  paddedOutputShape[3] = paddedC;
+
+  auto paddedOutputType = ttnn::utils::RankedTensorTypeFactory::create(
+      outputType, paddedOutputShape);
+
+  auto paddedGroupNorm = rewriter.create<ttnn::GroupNormOp>(
+      loc, paddedOutputType, paddedInput, srcOp.getInputMask(), paddedWeight,
+      paddedBias, rewriter.getI64IntegerAttr(paddedNumGroups),
+      srcOp.getEpsilonAttr(), srcOp.getMemoryConfigAttr(),
+      srcOp.getCoreGridAttr());
+
+  // Slice output back: [N, 1, H*W, paddedC] -> [N, 1, H*W, originalC].
+  SmallVector<int32_t> begins(outputType.getRank(), 0);
+  SmallVector<int32_t> ends(outputType.getShape());
+  SmallVector<int32_t> steps(outputType.getRank(), 1);
+
+  auto sliceOp = rewriter.create<ttnn::SliceStaticOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_slice_output"), outputType,
+      paddedGroupNorm, rewriter.getI32ArrayAttr(begins),
+      rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
+
+  rewriter.replaceOp(srcOp, sliceOp);
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.cpp
@@ -40,8 +40,7 @@ static Value padAffine1D(Value affine, int64_t originalC, int64_t paddedC,
   return rewriter.create<ttnn::PadOp>(
       ttmlir::utils::appendLocationSuffix(loc, suffix), paddedType, affine,
       padding, /*pad_value=*/mlir::APFloat(0.0f),
-      /*use_multicore=*/false,
-      /*memory_config=*/nullptr);
+      /*use_multicore=*/false);
 }
 
 LogicalResult GroupNormChannelPadRewritePattern::matchAndRewrite(
@@ -62,11 +61,9 @@ LogicalResult GroupNormChannelPadRewritePattern::matchAndRewrite(
   }
 
   // input_mask is sized against the original (C, num_groups); we can't scale
-  // it to the new (paddedC, paddedNumGroups), so bail out if it's present.
-  if (srcOp.getInputMask()) {
-    return rewriter.notifyMatchFailure(
-        srcOp, "channel padding workaround does not support input_mask");
-  }
+  // it to the new (paddedC, paddedNumGroups)
+  assert(!srcOp.getInputMask() &&
+         "GroupNormOp verifier should have rejected input_mask + unaligned C");
 
   // Only 1D weight/bias are supported. As of right now the 4D [1,1,C/32,32]
   // form requires C to already be tile-aligned.
@@ -105,8 +102,7 @@ LogicalResult GroupNormChannelPadRewritePattern::matchAndRewrite(
   auto paddedInput = rewriter.create<ttnn::PadOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_pad_input"), paddedInputType,
       srcOp.getInput(), inputPadding, /*pad_value=*/mlir::APFloat(0.0f),
-      /*use_multicore=*/false,
-      /*memory_config=*/nullptr);
+      /*use_multicore=*/false);
 
   // Pad weight and bias from [originalC] to [paddedC].
   Value paddedWeight = padAffine1D(srcOp.getWeight(), originalC, paddedC,
@@ -125,8 +121,7 @@ LogicalResult GroupNormChannelPadRewritePattern::matchAndRewrite(
   auto paddedGroupNorm = rewriter.create<ttnn::GroupNormOp>(
       loc, paddedOutputType, paddedInput, srcOp.getInputMask(), paddedWeight,
       paddedBias, rewriter.getI64IntegerAttr(paddedNumGroups),
-      srcOp.getEpsilonAttr(), srcOp.getMemoryConfigAttr(),
-      srcOp.getCoreGridAttr());
+      srcOp.getEpsilonAttr());
 
   // Slice output back: [N, 1, H*W, paddedC] -> [N, 1, H*W, originalC].
   SmallVector<int32_t> begins(outputType.getRank(), 0);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -19,6 +19,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/DistributedRMSNormWidthShardInputRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormAffineReshapeRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/GroupNormChannelPadRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/LinearOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/NLPConcatHeadsDecodeInputRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/PadHighDimRewritePattern.h"
@@ -646,6 +647,7 @@ public:
           workarounds::decomposition::TTNNReduceScatterWorkarounds,
           workarounds::decomposition::TTNNScatterWorkarounds,
           workarounds::decomposition::EmbeddingOpSqueezeWeightRewritePattern,
+          workarounds::decomposition::GroupNormChannelPadRewritePattern,
           workarounds::decomposition::GroupNormAffineReshapeRewritePattern,
           workarounds::decomposition::ArgMaxOpDimRewritePattern,
           workarounds::decomposition::UpsampleOpBilinearPaddingRewritePattern,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -6498,8 +6498,7 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
-    std::optional<CoreCoordAttr> coreGrid) {
+    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6518,10 +6517,6 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
 
   int numGroupsInt = static_cast<int>(numGroups);
   float epsilonFloat = epsilon.convertToFloat();
-  std::optional<::ttnn::types::CoreGrid> coreGridCoord = std::nullopt;
-  if (coreGrid) {
-    coreGridCoord = ::ttnn::CoreGrid(coreGrid->getX(), coreGrid->getY());
-  }
 
   auto groupNormQuery = [=]() {
     return QUERY_OP_CONSTRAINTS(::ttnn::group_norm, device, inputSpec,
@@ -6530,10 +6525,10 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
                                 /*reciprocals=*/std::nullopt,
                                 detail::getNullableMemoryConfig(outputLayout),
                                 /*dtype=*/std::nullopt,
-                                /*core_grid=*/coreGridCoord,
+                                /*core_grid=*/std::nullopt,
                                 /*inplace=*/std::nullopt,
                                 /*output_layout=*/std::nullopt,
-                                /*num_out_blocks=*/-1,
+                                /*num_out_blocks=*/std::nullopt,
                                 /*compute_kernel_config=*/std::nullopt,
                                 /*negative_mask=*/std::nullopt,
                                 /*use_welford=*/false);
@@ -6554,8 +6549,7 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
-    std::optional<CoreCoordAttr> coreGrid) {
+    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6574,22 +6568,17 @@ llvm::Expected<size_t> OpModel<GroupNormOp>::getOpRuntime(
 
   int numGroupsInt = static_cast<int>(numGroups);
   float epsilonFloat = epsilon.convertToFloat();
-  std::optional<::ttnn::types::CoreGrid> coreGridCoord = std::nullopt;
-  if (coreGrid) {
-    coreGridCoord = ::ttnn::CoreGrid(coreGrid->getX(), coreGrid->getY());
-  }
 
-  // Create query closure
   auto groupNormQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttnn::group_norm, device, inputSpec, numGroupsInt,
                             epsilonFloat, inputMaskSpec, weightSpec, biasSpec,
                             /*reciprocals=*/std::nullopt,
                             detail::getNullableMemoryConfig(outputLayout),
                             /*dtype=*/std::nullopt,
-                            /*core_grid=*/coreGridCoord,
+                            /*core_grid=*/std::nullopt,
                             /*inplace=*/std::nullopt,
                             /*output_layout=*/std::nullopt,
-                            /*num_out_blocks=*/-1,
+                            /*num_out_blocks=*/std::nullopt,
                             /*compute_kernel_config=*/std::nullopt,
                             /*negative_mask=*/std::nullopt,
                             /*use_welford=*/false);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1740,17 +1740,9 @@ createOp(FlatbufferObjectCache &cache, GroupNormOp op) {
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       toFlatbuffer(cache, op.getMemoryConfigAttr());
 
-  // Handle optional core_grid attribute
-  const ::tt::target::ttnn::CoreCoord *coreGridPtr = nullptr;
-  ::tt::target::ttnn::CoreCoord coreGridVal;
-  if (auto coreGridAttr = op.getCoreGrid()) {
-    coreGridVal = toFlatbuffer(cache, *coreGridAttr);
-    coreGridPtr = &coreGridVal;
-  }
-
   return ::tt::target::ttnn::CreateGroupNormOp(
       *cache.fbb, input, inputMask, weight, bias, op.getNumGroups(),
-      op.getEpsilon().convertToFloat(), memoryConfig, output, coreGridPtr);
+      op.getEpsilon().convertToFloat(), memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::UpsampleOp>

--- a/runtime/lib/ttnn/operations/normalization/group_norm.cpp
+++ b/runtime/lib/ttnn/operations/normalization/group_norm.cpp
@@ -36,21 +36,14 @@ void run(const ::tt::target::ttnn::GroupNormOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           op->memory_config());
 
-  // Get core_grid: use compile-time value from flatbuffer if present,
-  // otherwise fallback to device grid size (required by ttnn::group_norm)
-  const auto *coreGridFb = op->core_grid();
-  auto grid_size =
-      coreGridFb ? tt::tt_metal::CoreCoord(coreGridFb->x(), coreGridFb->y())
-                 : input.device()->compute_with_storage_grid_size();
-  ::ttnn::CoreGrid core_grid(grid_size.x, grid_size.y);
-
   // Call TTNN group norm operation
   ::ttnn::Tensor output = ::ttnn::group_norm(
       input, num_groups, epsilon, input_mask, weight, bias,
       /*reciprocals=*/std::nullopt, memoryConfig,
-      /*dtype=*/std::nullopt, core_grid,
+      /*dtype=*/std::nullopt, /*core_grid=*/std::nullopt,
       /*inplace=*/std::nullopt, /*output_layout=*/std::nullopt,
-      /*num_out_blocks=*/-1, /*compute_kernel_config=*/std::nullopt,
+      /*num_out_blocks=*/std::nullopt,
+      /*compute_kernel_config=*/std::nullopt,
       /*negative_mask=*/std::nullopt,
       /*use_welford=*/false);
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/maxpool3d_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/maxpool3d_op.mlir
@@ -2,29 +2,29 @@
 // RUN: ttmlir-opt --split-input-file --stablehlo-to-ttir-pipeline -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// 5D NCDHW max_pool3d decomposed into two max_pool2d passes.
+// 5D NCDHW max_pool3d decomposed into two max_pool2d passes (channel-preserving).
+// [N,C,D,H,W] -> permute -> [N,D,H,W,C] -> reshape [N*D,H,W,C] -> MaxPool2d HW ->
+// reshape [N,D,Hout*Wout,C] -> MaxPool2d [kD,1] -> permute -> [N,C,Dout,flat] ->
+// reshape [N,C,Dout,Hout,Wout].
 // Input: [1, 2, 4, 8, 8], kernel: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1]
-// Pass 1 (HW): reshape [1,2,4,8,8]->[8,8,8,1], pool2d kernel=[3,3] -> [8,4,4,1]
-// Pass 2 (D):  reshape [8,4,4,1]->[2,4,16,1],  pool2d kernel=[3,1] -> [2,2,16,1]
-// Final:       reshape [2,2,16,1]->[1,2,2,4,4]
 func.func public @test_maxpool3d_ncdhw(%arg0: tensor<1x2x4x8x8xbf16>) -> tensor<1x2x2x4x4xbf16> {
   %0 = stablehlo.constant dense<0xFF80> : tensor<bf16>
-  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%arg0)
-  // CHECK-SAME: (tensor<1x2x4x8x8xbf16>) -> tensor<8x8x8x1xbf16>
-  // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 3>
-  // CHECK-SAME: padding = array<i32: 1, 1, 1, 1>
-  // CHECK-SAME: stride = array<i32: 2, 2>
-  // CHECK-SAME: (tensor<8x8x8x1xbf16>) -> tensor<8x4x4x1xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%arg0)
+  // CHECK-SAME: (tensor<1x2x4x8x8xbf16>) -> tensor<1x4x8x8x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<8x4x4x1xbf16>) -> tensor<2x4x16x1xbf16>
+  // CHECK-SAME: (tensor<1x4x8x8x2xbf16>) -> tensor<4x8x8x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 1>
-  // CHECK-SAME: padding = array<i32: 1, 0, 1, 0>
-  // CHECK-SAME: stride = array<i32: 2, 1>
-  // CHECK-SAME: (tensor<2x4x16x1xbf16>) -> tensor<2x2x16x1xbf16>
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 3>, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 2, 2>
+  // CHECK-SAME: (tensor<4x8x8x2xbf16>) -> tensor<4x4x4x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<2x2x16x1xbf16>) -> tensor<1x2x2x4x4xbf16>
+  // CHECK-SAME: (tensor<4x4x4x2xbf16>) -> tensor<1x4x16x2xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 1>, padding = array<i32: 1, 0, 1, 0>, stride = array<i32: 2, 1>
+  // CHECK-SAME: (tensor<1x4x16x2xbf16>) -> tensor<1x2x16x2xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x2x16x2xbf16>) -> tensor<1x2x2x16xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x2x2x16xbf16>) -> tensor<1x2x2x4x4xbf16>
   %2 = "stablehlo.reduce_window"(%arg0, %0) <{
     padding = dense<[[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]]> : tensor<5x2xi64>,
     window_dimensions = array<i64: 1, 1, 3, 3, 3>,
@@ -39,27 +39,28 @@ func.func public @test_maxpool3d_ncdhw(%arg0: tensor<1x2x4x8x8xbf16>) -> tensor<
 
 // -----
 
-// 5D NDHWC max_pool3d with permutation to canonical NCDHW layout.
+// 5D NDHWC max_pool3d: permute to NCDHW, then same decomposition, permute back.
 // Input: [1, 4, 8, 8, 2] (NDHWC), kernel: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1]
-// Permute NDHWC -> NCDHW: [1, 2, 4, 8, 8]
-// Then same decomposition as NCDHW case.
-// Permute NCDHW -> NDHWC at the end.
 func.func public @test_maxpool3d_ndhwc(%arg0: tensor<1x4x8x8x2xbf16>) -> tensor<1x2x4x4x2xbf16> {
   %0 = stablehlo.constant dense<0xFF80> : tensor<bf16>
   // CHECK: %{{[0-9]+}} = "ttir.permute"(%arg0)
   // CHECK-SAME: (tensor<1x4x8x8x2xbf16>) -> tensor<1x2x4x8x8xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x2x4x8x8xbf16>) -> tensor<1x4x8x8x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<1x2x4x8x8xbf16>) -> tensor<8x8x8x1xbf16>
+  // CHECK-SAME: (tensor<1x4x8x8x2xbf16>) -> tensor<4x8x8x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 3>
-  // CHECK-SAME: (tensor<8x8x8x1xbf16>) -> tensor<8x4x4x1xbf16>
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 3>, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 2, 2>
+  // CHECK-SAME: (tensor<4x8x8x2xbf16>) -> tensor<4x4x4x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<8x4x4x1xbf16>) -> tensor<2x4x16x1xbf16>
+  // CHECK-SAME: (tensor<4x4x4x2xbf16>) -> tensor<1x4x16x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 1>
-  // CHECK-SAME: (tensor<2x4x16x1xbf16>) -> tensor<2x2x16x1xbf16>
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 1>, padding = array<i32: 1, 0, 1, 0>, stride = array<i32: 2, 1>
+  // CHECK-SAME: (tensor<1x4x16x2xbf16>) -> tensor<1x2x16x2xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x2x16x2xbf16>) -> tensor<1x2x2x16xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<2x2x16x1xbf16>) -> tensor<1x2x2x4x4xbf16>
+  // CHECK-SAME: (tensor<1x2x2x16xbf16>) -> tensor<1x2x2x4x4xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
   // CHECK-SAME: (tensor<1x2x2x4x4xbf16>) -> tensor<1x2x4x4x2xbf16>
   %2 = "stablehlo.reduce_window"(%arg0, %0) <{
@@ -81,20 +82,22 @@ func.func public @test_maxpool3d_ndhwc(%arg0: tensor<1x4x8x8x2xbf16>) -> tensor<
 // padding: [1, 1, 1], dilation: [1, 1, 1]
 func.func public @test_maxpool3d_dense_unet(%arg0: tensor<1x96x16x128x128xbf16>) -> tensor<1x96x8x64x64xbf16> {
   %0 = stablehlo.constant dense<0xFF80> : tensor<bf16>
-  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%arg0)
-  // CHECK-SAME: (tensor<1x96x16x128x128xbf16>) -> tensor<1536x128x128x1xbf16>
-  // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 3>
-  // CHECK-SAME: stride = array<i32: 2, 2>
-  // CHECK-SAME: (tensor<1536x128x128x1xbf16>) -> tensor<1536x64x64x1xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%arg0)
+  // CHECK-SAME: (tensor<1x96x16x128x128xbf16>) -> tensor<1x16x128x128x96xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<1536x64x64x1xbf16>) -> tensor<96x16x4096x1xbf16>
+  // CHECK-SAME: (tensor<1x16x128x128x96xbf16>) -> tensor<16x128x128x96xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
-  // CHECK-SAME: kernel = array<i32: 3, 1>
-  // CHECK-SAME: stride = array<i32: 2, 1>
-  // CHECK-SAME: (tensor<96x16x4096x1xbf16>) -> tensor<96x8x4096x1xbf16>
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 3>, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 2, 2>
+  // CHECK-SAME: (tensor<16x128x128x96xbf16>) -> tensor<16x64x64x96xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<96x8x4096x1xbf16>) -> tensor<1x96x8x64x64xbf16>
+  // CHECK-SAME: (tensor<16x64x64x96xbf16>) -> tensor<1x16x4096x96xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
+  // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 1>, padding = array<i32: 1, 0, 1, 0>, stride = array<i32: 2, 1>
+  // CHECK-SAME: (tensor<1x16x4096x96xbf16>) -> tensor<1x8x4096x96xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x8x4096x96xbf16>) -> tensor<1x96x8x4096xbf16>
+  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
+  // CHECK-SAME: (tensor<1x96x8x4096xbf16>) -> tensor<1x96x8x64x64xbf16>
   %2 = "stablehlo.reduce_window"(%arg0, %0) <{
     padding = dense<[[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]]> : tensor<5x2xi64>,
     window_dimensions = array<i64: 1, 1, 3, 3, 3>,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/maxpool3d_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/maxpool3d_op.mlir
@@ -39,15 +39,11 @@ func.func public @test_maxpool3d_ncdhw(%arg0: tensor<1x2x4x8x8xbf16>) -> tensor<
 
 // -----
 
-// 5D NDHWC max_pool3d: permute to NCDHW, then same decomposition, permute back.
+// 5D NDHWC max_pool3d: skip redundant input NDHWC->NCDHW->NDHWC permutes.
 // Input: [1, 4, 8, 8, 2] (NDHWC), kernel: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1]
 func.func public @test_maxpool3d_ndhwc(%arg0: tensor<1x4x8x8x2xbf16>) -> tensor<1x2x4x4x2xbf16> {
   %0 = stablehlo.constant dense<0xFF80> : tensor<bf16>
-  // CHECK: %{{[0-9]+}} = "ttir.permute"(%arg0)
-  // CHECK-SAME: (tensor<1x4x8x8x2xbf16>) -> tensor<1x2x4x8x8xbf16>
-  // CHECK: %{{[0-9]+}} = "ttir.permute"(%{{[0-9]+}})
-  // CHECK-SAME: (tensor<1x2x4x8x8xbf16>) -> tensor<1x4x8x8x2xbf16>
-  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%{{[0-9]+}})
+  // CHECK: %{{[0-9]+}} = "ttir.reshape"(%arg0)
   // CHECK-SAME: (tensor<1x4x8x8x2xbf16>) -> tensor<4x8x8x2xbf16>
   // CHECK: %{{[0-9]+}} = "ttir.max_pool2d"(%{{[0-9]+}})
   // CHECK-SAME: ceil_mode = false, dilation = array<i32: 1, 1>, kernel = array<i32: 3, 3>, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 2, 2>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/group_norm_channel_pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/group_norm_channel_pad_workaround.mlir
@@ -1,0 +1,95 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-ttnn-decomposition-pass=false" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Tests for GroupNormChannelPadRewritePattern: when the GroupNorm channel
+// dimension is not a multiple of the tile width (32), the workaround pads
+// the input/weight/bias along C up to lcm(tile_width, channels_per_group),
+// scales num_groups proportionally so channels_per_group is preserved, and
+// slices the output back to the original channel size.
+
+module {
+  // Workaround SHOULD apply: C=16, num_groups=2 -> channels_per_group=8,
+  // alignment=lcm(32, 8)=32, paddedC=32, paddedNumGroups=4.
+  func.func @group_norm_unaligned_c16(
+      %arg0: tensor<1x1x64x16xbf16>,
+      %arg1: tensor<16xbf16>,
+      %arg2: tensor<16xbf16>) -> tensor<1x1x64x16xbf16> {
+    // CHECK-LABEL: func.func @group_norm_unaligned_c16
+    // Input C is padded from 16 to 32.
+    // CHECK: "ttnn.pad"(%arg0)
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 16>
+    // CHECK-SAME: -> tensor<1x1x64x32xbf16
+    // Weight and bias are 1D-padded from 16 to 32.
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: padding = array<i32: 0, 16>
+    // CHECK-SAME: tensor<16xbf16
+    // CHECK-SAME: -> tensor<32xbf16
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: padding = array<i32: 0, 16>
+    // CHECK-SAME: tensor<16xbf16
+    // CHECK-SAME: -> tensor<32xbf16
+    // GroupNorm runs on the padded shape with num_groups scaled 2 -> 4.
+    // CHECK: "ttnn.group_norm"
+    // CHECK-SAME: num_groups = 4
+    // CHECK-SAME: -> tensor<1x1x64x32xbf16
+    // Output is sliced back to the original C=16.
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 1 : i32, 64 : i32, 16 : i32]
+    // CHECK-SAME: step = [1 : i32, 1 : i32, 1 : i32, 1 : i32]
+    // CHECK-SAME: -> tensor<1x1x64x16xbf16
+    %0 = "ttir.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 2 : i64, epsilon = 1.000000e-12 : f32, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<1x1x64x16xbf16>, tensor<16xbf16>, tensor<16xbf16>) -> tensor<1x1x64x16xbf16>
+    return %0 : tensor<1x1x64x16xbf16>
+  }
+
+  // Workaround SHOULD apply with non-trivial pad: C=80, num_groups=5 ->
+  // channels_per_group=16, alignment=lcm(32, 16)=32, paddedC=96,
+  // paddedNumGroups=6.
+  func.func @group_norm_unaligned_c80(
+      %arg0: tensor<1x1x64x80xbf16>,
+      %arg1: tensor<80xbf16>,
+      %arg2: tensor<80xbf16>) -> tensor<1x1x64x80xbf16> {
+    // CHECK-LABEL: func.func @group_norm_unaligned_c80
+    // Input C is padded from 80 to 96 (next multiple of lcm(32, 16) = 32).
+    // CHECK: "ttnn.pad"(%arg0)
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 16>
+    // CHECK-SAME: -> tensor<1x1x64x96xbf16
+    // Weight and bias padded 80 -> 96.
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: padding = array<i32: 0, 16>
+    // CHECK-SAME: tensor<80xbf16
+    // CHECK-SAME: -> tensor<96xbf16
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: padding = array<i32: 0, 16>
+    // CHECK-SAME: tensor<80xbf16
+    // CHECK-SAME: -> tensor<96xbf16
+    // GroupNorm with num_groups scaled 5 -> 6.
+    // CHECK: "ttnn.group_norm"
+    // CHECK-SAME: num_groups = 6
+    // CHECK-SAME: -> tensor<1x1x64x96xbf16
+    // Output sliced back to original C=80.
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [1 : i32, 1 : i32, 64 : i32, 80 : i32]
+    // CHECK-SAME: -> tensor<1x1x64x80xbf16
+    %0 = "ttir.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 5 : i64, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<1x1x64x80xbf16>, tensor<80xbf16>, tensor<80xbf16>) -> tensor<1x1x64x80xbf16>
+    return %0 : tensor<1x1x64x80xbf16>
+  }
+
+  // Workaround should NOT apply: C=480 is already tile-aligned. No pad on
+  // the input feeds into group_norm and no slice_static on the output.
+  func.func @group_norm_aligned_no_workaround(
+      %arg0: tensor<1x1x64x480xbf16>,
+      %arg1: tensor<480xbf16>,
+      %arg2: tensor<480xbf16>) -> tensor<1x1x64x480xbf16> {
+    // CHECK-LABEL: func.func @group_norm_aligned_no_workaround
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice_static"
+    // CHECK: "ttnn.group_norm"
+    // CHECK-SAME: num_groups = 8
+    // CHECK-SAME: -> tensor<1x1x64x480xbf16
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice_static"
+    %0 = "ttir.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 8 : i64, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<1x1x64x480xbf16>, tensor<480xbf16>, tensor<480xbf16>) -> tensor<1x1x64x480xbf16>
+    return %0 : tensor<1x1x64x480xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/group_norm/simple_group_norm.mlir
+++ b/test/ttmlir/Dialect/TTNN/group_norm/simple_group_norm.mlir
@@ -93,4 +93,39 @@ module {
     %1 = "ttir.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 8 : i64, epsilon = 1.000000e-05 : f32, channel_dim = 1 : i64, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<1x480x1x64xbf16>, tensor<480xbf16>, tensor<480xbf16>) -> tensor<1x480x1x64xbf16>
     return %1 : tensor<1x480x1x64xbf16>
   }
+
+  // Test 5D group norm with NDHWC input (channel_dim=4): only spatial collapse,
+  // no permute needed. Spatial dims D*H*W = 4*8*8 = 256 are flattened.
+  func.func @forward_5d_ndhwc(%arg0: tensor<1x4x8x8x480xbf16>) -> tensor<1x4x8x8x480xbf16> {
+    // CHECK-NOT: "ttnn.permute"
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.group_norm"
+    // CHECK: "ttnn.reshape"
+    // CHECK-NOT: "ttnn.permute"
+    %1 = "ttir.group_norm"(%arg0) <{num_groups = 8 : i64, epsilon = 1.000000e-12 : f32, channel_dim = 4 : i64, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<1x4x8x8x480xbf16>) -> tensor<1x4x8x8x480xbf16>
+    return %1 : tensor<1x4x8x8x480xbf16>
+  }
+
+  // Test 5D group norm with NCDHW input (channel_dim=1): needs both permute
+  // (NCDHW -> NDHWC) and reshape (collapse spatial dims).
+  func.func @forward_5d_ncdhw(%arg0: tensor<1x480x4x8x8xbf16>) -> tensor<1x480x4x8x8xbf16> {
+    // CHECK: "ttnn.permute"
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.group_norm"
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.permute"
+    %1 = "ttir.group_norm"(%arg0) <{num_groups = 8 : i64, epsilon = 1.000000e-12 : f32, channel_dim = 1 : i64, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<1x480x4x8x8xbf16>) -> tensor<1x480x4x8x8xbf16>
+    return %1 : tensor<1x480x4x8x8xbf16>
+  }
+
+  // Test 5D group norm with NCDHW input and weight/bias.
+  func.func @forward_5d_ncdhw_weight_bias(%arg0: tensor<1x480x4x8x8xbf16>, %arg1: tensor<480xbf16>, %arg2: tensor<480xbf16>) -> tensor<1x480x4x8x8xbf16> {
+    // CHECK: "ttnn.permute"
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.group_norm"
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.permute"
+    %1 = "ttir.group_norm"(%arg0, %arg1, %arg2) <{num_groups = 8 : i64, epsilon = 1.000000e-05 : f32, channel_dim = 1 : i64, operandSegmentSizes = array<i32: 1, 0, 1, 1>}> : (tensor<1x480x4x8x8xbf16>, tensor<480xbf16>, tensor<480xbf16>) -> tensor<1x480x4x8x8xbf16>
+    return %1 : tensor<1x480x4x8x8xbf16>
+  }
 }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5099,14 +5099,11 @@ TEST_P(OpModelGroupNormParam, GroupNormParam) {
     biasLayout = CreateRowMajorLayout(shape, bufferType, layout, virtualGrid);
   }
 
-  // group_norm requires explicit core_grid; use a fixed test value.
-  auto coreGrid = CoreCoordAttr::get(&context, 1, 1);
-
   // Test getOpConstraints
   auto constraintsExp = op_model::OpModel<GroupNormOp>::getOpConstraints(
       CreateWorkerGrid(), inputShape, inputLayout, inputMaskShape,
       inputMaskLayout, weightShape, weightLayout, biasShape, biasLayout,
-      numGroups, epsilon, outputLayout, coreGrid);
+      numGroups, epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
@@ -5123,8 +5120,7 @@ TEST_P(OpModelGroupNormParam, GroupNormParam) {
   // Test getOpRuntime
   auto runtimeExp = op_model::OpModel<GroupNormOp>::getOpRuntime(
       inputShape, inputLayout, inputMaskShape, inputMaskLayout, weightShape,
-      weightLayout, biasShape, biasLayout, numGroups, epsilon, outputLayout,
-      coreGrid);
+      weightLayout, biasShape, biasLayout, numGroups, epsilon, outputLayout);
 
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4973,12 +4973,9 @@ TEST_F(OpModelBase, groupNormOp) {
   int64_t numGroups = 8;
   llvm::APFloat epsilon(1e-12f);
 
-  // group_norm requires explicit core_grid; use a fixed test value.
-  auto coreGrid = CoreCoordAttr::get(&context, 1, 1);
-
   GroupNormOp groupNormOp = builder.create<GroupNormOp>(
       builder.getUnknownLoc(), outputType, input,
-      /*input_mask=*/inputMask, weight, bias, numGroups, epsilon, coreGrid);
+      /*input_mask=*/inputMask, weight, bias, numGroups, epsilon);
   groupNormOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
   auto constraintsExp = getOpConstraints(groupNormOp.getOperation());
@@ -5028,12 +5025,9 @@ TEST_F(OpModelBase, groupNormOpL1Memory) {
   int64_t numGroups = 8;
   llvm::APFloat epsilon(1e-12f);
 
-  // group_norm requires explicit core_grid; use a fixed test value.
-  auto coreGrid = CoreCoordAttr::get(&context, 1, 1);
-
   GroupNormOp groupNormOp = builder.create<GroupNormOp>(
       builder.getUnknownLoc(), outputType, input,
-      /*input_mask=*/inputMask, weight, bias, numGroups, epsilon, coreGrid);
+      /*input_mask=*/inputMask, weight, bias, numGroups, epsilon);
   groupNormOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
   auto constraintsExp = getOpConstraints(groupNormOp.getOperation());


### PR DESCRIPTION
### Ticket
unet3D model bing up

### Problem description
Compile failures + OOM during runtime due to several limitations in tt-mlir. ttnn.group_norm has no support for 5D inputs (3D conv models), and it is limited to only working on inputs that are tile aligned on it's C dim (plus other requirments). Also, our current decomp for maxpool3D support was causing OOM failures during runtime, both decomp passes, leave the last dim hardcoded to 1 and if the reshape that performs this is tilized it 32x's the memory needed.

### What's changed
- Added support to 5D inputs to ttnn.group_norm by relaxing the requirements on ttir and folding all three spatial dimensions into a single dim. We go from only supporting `[N, 1, H*W, C]` to `[N, 1, D*H*W, C]`
- Added a group norm workaround to pad C dim to be tile aligned, had to increase the number of groups proportionally to keep mathematical equivalency. Opened an issue on tt-metal to see if we can remove this workaround and handle it internally in https://github.com/tenstorrent/tt-metal/issues/43826
- Remove core grid attribute from group norm as it will be chosen during runtime since it's been enabled on tt-metal https://github.com/tenstorrent/tt-metal/pull/41515
- Changed maxpool3D decomp to move the C dim to the last dim instead of hard-coding it to 1:

Before
```
Pass 1 (H,W): Reshape [N,C,D,H,W] → [NCD, H, W, 1], MaxPool2d with [kH, kW]
Pass 2 (D): Reshape [NCD, Hout, Wout, 1] → [NC, D, HoutWout, 1], MaxPool2d with [kD, 1]
```
After
```
Pass 1 (H,W): Reshape and Permute [N,C,D,H,W] → [ND, H, W, C], MaxPool2d with [kH, kW]
Pass 2 (D): Reshape [ND, Hout, Wout, C] → [N, D, HoutWout, C], MaxPool2d with [kD, 1]
```

### Checklist
- [x] New/Existing tests provide coverage for changes