### PR TITLE
Decompose DistributedRMSNorm using rms_norm_pre_all_gather op

### DIFF
--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -3914,11 +3914,6 @@ namespace {
 class RMSNormPreAllGatherOpConversionPattern
     : public TTNNToEmitPyBaseOpConversionPattern<
           mlir::tt::ttnn::RMSNormPreAllGatherOp> {
-private:
-  std::string getPrefixSearchPattern() const override {
-    return "ttnn.rms_norm_pre_all_gather";
-  }
-
 public:
   using TTNNToEmitPyBaseOpConversionPattern<
       mlir::tt::ttnn::RMSNormPreAllGatherOp>::
@@ -3937,10 +3932,12 @@ public:
         emitter.emit(srcOp.getDtype(), "dtype"),
         emitter.emit(srcOp.getResidual(), "residual_input_tensor"),
         emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
-        emitter.emit(srcOp.getProgramConfig()),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
         emitter.emit(srcOp.getUse_2dCoreGrid(), "use_2d_core_grid"),
     };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -193,14 +193,9 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   }
 
   // --- Pre all-gather: compute local E(x^2) ---
-
-  // x_sq = multiply(x, x)
-  auto xSqOp = rewriter.create<ttnn::MultiplyOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_square"), inputType, x, x);
-
-  // local_stats = mean(x_sq, dim=-1, keep_dim=true)
+  // Output shape has last dim = TTNN::TILE_WIDTH (32)
   SmallVector<int64_t> statsShape(inputShape.begin(), inputShape.end());
-  statsShape.back() = 1;
+  statsShape.back() = ttnn::TILE_WIDTH;
   auto inputEncoding =
       mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
   ttnn::TTNNLayoutAttr statsEncoding =
@@ -208,15 +203,24 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   RankedTensorType statsType = RankedTensorType::get(
       statsShape, inputType.getElementType(), statsEncoding);
 
-  ArrayAttr dimArg = rewriter.getI32ArrayAttr({static_cast<int32_t>(rank - 1)});
-  auto localMeanOp = rewriter.create<ttnn::MeanOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_local_mean"), statsType,
-      xSqOp.getResult(), /*keep_dim=*/true, dimArg);
+  auto dtypeAttr = ttcore::DataTypeAttr::get(
+      rewriter.getContext(),
+      ttcore::elementTypeToDataType(inputType.getElementType()));
+
+  auto preAllGatherOp = rewriter.create<ttnn::RMSNormPreAllGatherOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_pre_all_gather"), statsType,
+      /*input*/ x,
+      /*residual_input=*/mlir::Value{},
+      /*memory_config=*/nullptr,
+      /*compute_config=*/nullptr,
+      /*program_config=*/nullptr,
+      /*dtype=*/dtypeAttr,
+      /*use_2d_core_grid*/ nullptr);
 
   // --- All-gather: gather local stats across devices ---
 
   SmallVector<int64_t> gatheredShape(statsShape.begin(), statsShape.end());
-  gatheredShape.back() = numDevices;
+  gatheredShape.back() = ttnn::TILE_WIDTH * numDevices;
   ttnn::TTNNLayoutAttr gatheredEncoding =
       ttnn::TTNNLayoutAttr::Builder(inputEncoding, gatheredShape);
   RankedTensorType gatheredType = RankedTensorType::get(
@@ -224,7 +228,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
   auto allGatherOp = rewriter.create<ttnn::AllGatherOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_all_gather"), gatheredType,
-      localMeanOp.getResult(),
+      preAllGatherOp.getResult(),
       /*all_gather_dim=*/static_cast<int32_t>(rank - 1),
       /*cluster_axis=*/clusterAxis,
       /*sub_device_id=*/nullptr,
@@ -233,25 +237,128 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
   // --- Post all-gather: normalize using global stats ---
 
-  // global_stats = mean(gathered_stats, dim=-1, keep_dim=true)
+  // TODO: Replace the below primitive, reshape and slice ops with the
+  // rms_norm_post_all_gather
+  //
+  // rms_norm_pre_all_gather produces per-device statistics with shape
+  // [..., TILE_WIDTH], where only column 0 stores E(x^2) and the remaining
+  // columns are padding/unused.
+  //
+  // After all_gather, the stats tensor becomes:
+  // [..., numDevices * TILE_WIDTH]
+  //
+  // We cannot directly apply MeanOp over the last dimension because that would
+  // incorrectly average across both valid statistics and padded columns,
+  // resulting in normalization by (numDevices * TILE_WIDTH).
+  //
+  // To recover the per-device statistics, reshape:
+  // [..., numDevices * TILE_WIDTH] -> [..., numDevices, TILE_WIDTH]
+  //
+  // Then slice column 0 to extract the valid E(x^2) values from each device:
+  // [..., numDevices, TILE_WIDTH] -> [..., numDevices, 1]
+  //
+  // Flatten [..., numDevices, 1] back to [..., numDevices]
+  //
+  // Finally, compute the mean across the last dimension to obtain the global
+  // E(x^2) used for RMS normalization.
+
+  // [..., numDevices * TILE_WIDTH] -> [..., numDevices, TILE_WIDTH]
+  SmallVector<int64_t> reshapedStatsShape(statsType.getShape().begin(),
+                                          statsType.getShape().end());
+  reshapedStatsShape.back() = numDevices;
+  reshapedStatsShape.push_back(ttnn::TILE_WIDTH);
+  int64_t reshapedRank = static_cast<int64_t>(reshapedStatsShape.size());
+
+  auto reshapedStatsEncoding =
+      ttnn::TTNNLayoutAttr::Builder(inputEncoding, reshapedStatsShape);
+
+  RankedTensorType reshapedStatsType = RankedTensorType::get(
+      reshapedStatsShape, inputType.getElementType(), reshapedStatsEncoding);
+
+  SmallVector<int32_t> reshapedStatsShape32(reshapedStatsShape.begin(),
+                                            reshapedStatsShape.end());
+  auto reshapedStats = rewriter.create<ttnn::ReshapeOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_reshape_stats"),
+      reshapedStatsType, allGatherOp.getResult(),
+      rewriter.getI32ArrayAttr(reshapedStatsShape32),
+      /*memory_config=*/nullptr);
+
+  // Slice column 0: [..., numDevices, TILE_WIDTH] -> [..., numDevices, 1]
+  SmallVector<int64_t> slicedShape(reshapedStatsShape);
+  slicedShape.back() = 1;
+
+  auto slicedEncoding =
+      ttnn::TTNNLayoutAttr::Builder(inputEncoding, slicedShape);
+
+  RankedTensorType slicedType = RankedTensorType::get(
+      slicedShape, inputType.getElementType(), slicedEncoding);
+
+  SmallVector<int32_t> sliceBegins(reshapedRank, 0);
+  SmallVector<int32_t> sliceEnds;
+  for (int64_t dim : slicedShape) {
+    sliceEnds.push_back(static_cast<int32_t>(dim));
+  }
+  SmallVector<int32_t> sliceSteps(reshapedRank, 1);
+
+  auto sliceEx2 = rewriter.create<ttnn::SliceStaticOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_slice_ex2"), slicedType,
+      reshapedStats.getResult(), rewriter.getI32ArrayAttr(sliceBegins),
+      rewriter.getI32ArrayAttr(sliceEnds),
+      rewriter.getI32ArrayAttr(sliceSteps));
+
+  // Now we have the [..., numDevices, 1], we could either sum across numDevices
+  // (reshapedRankDim - 2) then reshape, or we could just reshape [...,
+  // numDevices, 1] to [..., numDevices * 1] and pass it to existing
+  // globalMeanOp.
+  // Flatten [..., numDevices, 1] back to [..., numDevices]
+  SmallVector<int64_t> flattenedStatsShape(slicedShape.begin(),
+                                           slicedShape.end() - 1);
+
+  auto flattenedEncoding =
+      ttnn::TTNNLayoutAttr::Builder(inputEncoding, flattenedStatsShape);
+
+  RankedTensorType flattenedStatsType = RankedTensorType::get(
+      flattenedStatsShape, inputType.getElementType(), flattenedEncoding);
+
+  SmallVector<int32_t> flattenedStatsShapeI32(flattenedStatsShape.begin(),
+                                              flattenedStatsShape.end());
+
+  auto flattenedStats = rewriter.create<ttnn::ReshapeOp>(
+      ttmlir::utils::appendLocationSuffix(loc, "_flatten_stats"),
+      flattenedStatsType, sliceEx2.getResult(),
+      rewriter.getI32ArrayAttr(flattenedStatsShapeI32), nullptr);
+
+  // Mean across device dimension (now last dim).
+  // [..., numDevices] to [..., 1]
+  SmallVector<int64_t> scalarRowShape(inputShape.begin(), inputShape.end());
+  scalarRowShape.back() = 1;
+
+  auto scalarEncoding =
+      ttnn::TTNNLayoutAttr::Builder(inputEncoding, scalarRowShape);
+
+  RankedTensorType scalarRowType = RankedTensorType::get(
+      scalarRowShape, inputType.getElementType(), scalarEncoding);
+
+  ArrayAttr dimArg = rewriter.getI32ArrayAttr({static_cast<int32_t>(rank - 1)});
+  // global_stats = mean(flattened per-device E(x^2), dim=-1, keep_dim=true)
   auto globalMeanOp = rewriter.create<ttnn::MeanOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_global_mean"), statsType,
-      allGatherOp.getResult(), /*keep_dim=*/true, dimArg);
+      ttmlir::utils::appendLocationSuffix(loc, "_global_mean"), scalarRowType,
+      flattenedStats.getResult(), /*keep_dim=*/true, dimArg);
 
   // eps_tensor = full(epsilon)
   auto epsTensor = rewriter.create<ttnn::FullOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_epsilon"), statsType,
+      ttmlir::utils::appendLocationSuffix(loc, "_epsilon"), scalarRowType,
       rewriter.getF32FloatAttr(op.getEpsilon().convertToFloat()),
       op.getDevice());
 
   // stabilized = add(global_stats, eps_tensor)
   auto addEpsOp = rewriter.create<ttnn::AddOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_add_eps"), statsType,
+      ttmlir::utils::appendLocationSuffix(loc, "_add_eps"), scalarRowType,
       globalMeanOp.getResult(), epsTensor.getResult());
 
   // inv_rms = rsqrt(stabilized)
   auto rsqrtOp = rewriter.create<ttnn::RsqrtOp>(
-      ttmlir::utils::appendLocationSuffix(loc, "_rsqrt"), statsType,
+      ttmlir::utils::appendLocationSuffix(loc, "_rsqrt"), scalarRowType,
       addEpsOp.getResult());
 
   // normalized = multiply(x, inv_rms) — broadcasts inv_rms across last dim

--- a/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
@@ -86,6 +86,47 @@ mlir::Value maybeReshapeWeightToTileWidth(PatternRewriter &rewriter,
   return reshapeTo(rewriter, loc, weight, reshapedShape);
 }
 
+LogicalResult rewriteDistributedRMSNormWithReshape(
+    ttnn::DistributedRMSNormOp op, PatternRewriter &rewriter,
+    ArrayRef<int64_t> targetShape, mlir::Value weight) {
+  Location loc = op.getLoc();
+  RankedTensorType resultType =
+      mlir::cast<RankedTensorType>(op.getResult().getType());
+
+  mlir::Value reshapedInput =
+      ttir_to_ttnn::utils::generateReshape(
+          mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput()),
+          targetShape, rewriter, loc)
+          .getResult();
+
+  mlir::Value reshapedResidual = op.getResidual();
+  if (reshapedResidual) {
+    reshapedResidual =
+        ttir_to_ttnn::utils::generateReshape(
+            mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapedResidual),
+            targetShape, rewriter, loc)
+            .getResult();
+  }
+
+  RankedTensorType canonicalResultType =
+      utils::RankedTensorTypeFactory::create(resultType, targetShape);
+
+  auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
+      loc, canonicalResultType, reshapedInput, weight, reshapedResidual,
+      op.getStats(), op.getSemaphore(), op.getDevice(), op.getClusterAxis(),
+      op.getEpsilon(), op.getSubDeviceIdAttr(), op.getNumLinksAttr(),
+      op.getTopologyAttr(), op.getComputeConfigAttr(),
+      op.getProgramConfigAttr());
+
+  mlir::Value reshapedResult =
+      ttir_to_ttnn::utils::generateReshape(newOp.getResult(),
+                                           resultType.getShape(), rewriter, loc)
+          .getResult();
+
+  rewriter.replaceOp(op, reshapedResult);
+  return success();
+}
+
 } // namespace
 
 LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
@@ -127,44 +168,25 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
     // Reshape to canonical (1,1,32,M), forward to the fused kernel, then
     // reshape the result back to the original shape.
-    SmallVector<int64_t> canonicalShape = {1, 1, 32, inputShape.back()};
+    SmallVector<int64_t> canonicalShapeForFusedKernel = {1, 1, 32,
+                                                         inputShape.back()};
+    return rewriteDistributedRMSNormWithReshape(
+        op, rewriter, canonicalShapeForFusedKernel, reshapedWeight);
+  }
 
-    mlir::Value reshapedInput =
-        ttir_to_ttnn::utils::generateReshape(
-            mlir::cast<mlir::TypedValue<RankedTensorType>>(op.getInput()),
-            canonicalShape, rewriter, loc)
-            .getResult();
-
-    mlir::Value reshapedResidual = op.getResidual();
-    if (reshapedResidual) {
-      reshapedResidual =
-          ttir_to_ttnn::utils::generateReshape(
-              mlir::cast<mlir::TypedValue<RankedTensorType>>(reshapedResidual),
-              canonicalShape, rewriter, loc)
-              .getResult();
-    }
-
-    RankedTensorType canonicalResultType =
-        utils::RankedTensorTypeFactory::create(resultType, canonicalShape);
-
-    auto newOp = rewriter.create<ttnn::DistributedRMSNormOp>(
-        loc, canonicalResultType, reshapedInput, reshapedWeight,
-        reshapedResidual, op.getStats(), op.getSemaphore(), op.getDevice(),
-        op.getClusterAxis(), op.getEpsilon(), op.getSubDeviceIdAttr(),
-        op.getNumLinksAttr(), op.getTopologyAttr(), op.getComputeConfigAttr(),
-        op.getProgramConfigAttr());
-
-    mlir::Value reshapedResult =
-        ttir_to_ttnn::utils::generateReshape(
-            newOp.getResult(), resultType.getShape(), rewriter, loc)
-            .getResult();
-
-    rewriter.replaceOp(op, reshapedResult);
-    return success();
+  int64_t rank = inputType.getRank();
+  // The fallback decomposition lowers through rms_norm_pre_all_gather, whose
+  // runtime expects a rank-4 tensor. Left-pad lower-rank shapes with ones so
+  // HxW and 1xHxW become 1x1xHxW before decomposition.
+  if (rank < 4) {
+    SmallVector<int64_t> canonicalShapeForPreAllGather;
+    canonicalShapeForPreAllGather.append(4 - rank, 1);
+    canonicalShapeForPreAllGather.append(inputShape.begin(), inputShape.end());
+    return rewriteDistributedRMSNormWithReshape(
+        op, rewriter, canonicalShapeForPreAllGather, op.getWeight());
   }
 
   Location loc = op.getLoc();
-  int64_t rank = inputType.getRank();
   uint32_t clusterAxis = op.getClusterAxis();
   mlir::Value input = op.getInput();
 
@@ -211,7 +233,6 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
       ttmlir::utils::appendLocationSuffix(loc, "_pre_all_gather"), statsType,
       /*input*/ x,
       /*residual_input=*/mlir::Value{},
-      /*memory_config=*/nullptr,
       /*compute_config=*/nullptr,
       /*program_config=*/nullptr,
       /*dtype=*/dtypeAttr,
@@ -237,9 +258,6 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
 
   // --- Post all-gather: normalize using global stats ---
 
-  // TODO: Replace the below primitive, reshape and slice ops with the
-  // rms_norm_post_all_gather
-  //
   // rms_norm_pre_all_gather produces per-device statistics with shape
   // [..., TILE_WIDTH], where only column 0 stores E(x^2) and the remaining
   // columns are padding/unused.
@@ -280,8 +298,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   auto reshapedStats = rewriter.create<ttnn::ReshapeOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_reshape_stats"),
       reshapedStatsType, allGatherOp.getResult(),
-      rewriter.getI32ArrayAttr(reshapedStatsShape32),
-      /*memory_config=*/nullptr);
+      rewriter.getI32ArrayAttr(reshapedStatsShape32));
 
   // Slice column 0: [..., numDevices, TILE_WIDTH] -> [..., numDevices, 1]
   SmallVector<int64_t> slicedShape(reshapedStatsShape);
@@ -326,7 +343,7 @@ LogicalResult DistributedRMSNormDecompositionRewritePattern::matchAndRewrite(
   auto flattenedStats = rewriter.create<ttnn::ReshapeOp>(
       ttmlir::utils::appendLocationSuffix(loc, "_flatten_stats"),
       flattenedStatsType, sliceEx2.getResult(),
-      rewriter.getI32ArrayAttr(flattenedStatsShapeI32), nullptr);
+      rewriter.getI32ArrayAttr(flattenedStatsShapeI32));
 
   // Mean across device dimension (now last dim).
   // [..., numDevices] to [..., 1]

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -6,6 +6,7 @@
 #ttnn_layout_weight = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout_supported = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1 + d1, d2 * 128 + d3), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout_supported_rank3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout_supported_rank3_h64 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout_unsupported_leading = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2 + d1, d2 * 128 + d3), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 // Test: Non-(1,1,32,M) shape decomposes into primitive ops.
@@ -107,5 +108,27 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
     %1 = "ttnn.distributed_rms_norm"(%arg0, %arg1, %arg2, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 1>}> : (tensor<1x1x64x128xbf16, #ttnn_layout>, tensor<128xbf16, #ttnn_layout_weight>, tensor<1x1x64x128xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x64x128xbf16, #ttnn_layout>
     return %1 : tensor<1x1x64x128xbf16, #ttnn_layout>
+  }
+
+  func.func public @test_reshape_rank3_non_fused_to_pre_all_gather_shape(
+      %arg0: tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>) -> tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64> {
+    // CHECK-LABEL: func.func public @test_reshape_rank3_non_fused_to_pre_all_gather_shape
+    // CHECK-NOT: "ttnn.distributed_rms_norm"
+    // Rank-3 input with no weight is not eligible for the fused kernel, so it will lower through
+    // rms_norm_pre_all_gather. That runtime expects rank-4 input, so the pass
+    // first rewrites distributed_rms_norm at shape (1,1,64,M), then reshapes the
+    // result back to (1,64,M).
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 64 : i32, 128 : i32]
+    // CHECK-SAME: -> tensor<1x1x64x128
+    // CHECK: "ttnn.rms_norm_pre_all_gather"
+    // CHECK-SAME: tensor<1x1x64x128
+    // CHECK: "ttnn.all_gather"
+    // Result is reshaped back to (1, 64, 128).
+    // CHECK: "ttnn.reshape"({{.*}}) <{shape = [1 : i32, 64 : i32, 128 : i32]}> : (tensor<1x1x64x128
+    // CHECK-SAME: -> tensor<1x64x128
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.distributed_rms_norm"(%arg0, %0) <{cluster_axis = 1 : ui32, epsilon = 1.000000e-05 : f32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0, 1>}> : (tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>, !ttnn.device) -> tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>
+    return %1 : tensor<1x64x128xbf16, #ttnn_layout_supported_rank3_h64>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir
@@ -14,12 +14,14 @@ module @test_distributed_rms_norm_decomposition attributes {} {
       %arg0: tensor<1x1x64x128xbf16, #ttnn_layout>,
       %arg1: tensor<128xbf16, #ttnn_layout_weight>) -> tensor<1x1x64x128xbf16, #ttnn_layout> {
     // CHECK-LABEL: func.func public @test_decompose_non_supported_shape
-    // Pre all-gather: square and local mean
-    // CHECK: "ttnn.multiply"
-    // CHECK: "ttnn.mean"
+    // Pre all-gather:
+    // CHECK: "ttnn.rms_norm_pre_all_gather"
     // All-gather
     // CHECK: "ttnn.all_gather"
     // Post all-gather: global mean, add epsilon, rsqrt, normalize, apply weight
+    // CHECK: "ttnn.reshape"
+    // CHECK: "ttnn.slice_static"
+    // CHECK: "ttnn.reshape"
     // CHECK: "ttnn.mean"
     // CHECK: "ttnn.full"
     // CHECK: "ttnn.add"
@@ -84,8 +86,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK-LABEL: func.func public @test_decompose_unsupported_leading_dim
     // Leading dim != 1 means the input cannot be reshaped to (1,1,32,M)
     // without data movement, so the op must be decomposed here.
-    // CHECK: "ttnn.multiply"
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.rms_norm_pre_all_gather"
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.distributed_rms_norm"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
@@ -100,8 +101,7 @@ module @test_distributed_rms_norm_decomposition attributes {} {
     // CHECK-LABEL: func.func public @test_decompose_with_residual
     // With residual: first op must be add(input, residual).
     // CHECK: "ttnn.add"
-    // CHECK: "ttnn.multiply"
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.rms_norm_pre_all_gather"
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.distributed_rms_norm"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -49,6 +49,7 @@
 #include "operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
 #include "operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"
 #include "operations/normalization/rmsnorm/rmsnorm.hpp"
+#include "operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp"
 #include "operations/normalization/softmax/softmax.hpp"
 #include "operations/pool/generic/generic_pools.hpp"
 #include "operations/pool/upsample/upsample.hpp"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/7829)

### Problem description
DistributedRMSNorm will be decomposed into pre_all_gather, all_gather and post_all_gather ops. This patch address the changes to replace the existing primitive ops with the rms_norm_pre_all_gather.

Since, rms_norm_pre_all_gather produces [..., TILE_WIDTH] as the stats tensor, all_gather results in the shape
[num_devices * TILE_WIDTH]. As a result, we add additional ops to re-shape, and slice the stats value E(x^2).

Then perform the meanOp.

### What's changed
- Replace the Primitive Ops with `rms_norm_pre_all_gather`
- Add workarounds for the `post_all_gather` as pre_all_gather returns `[...., TILE_WIDTH`, which results in all_gather shape being `[..., num_devices * TILE_WIDTH]`

### Checklist
- [X] New/Existing tests provide coverage for changes

```
:~/workspace/tt-mlir$ llvm-lit -sv ./test/ttmlir/Dialect/TTNN/Transforms/Decomposition/distributed_rms_norm_decomposition.mlir

Testing Time: 0.07s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

```
:~/workspace/tt-mlir$ pre-commit run --show-diff-on-failure --color=always --all-files
black....................................................................Passed
clang-format.............................................................Passed
Check copyright notices..................................................Passed
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for added large files..............................................Passed
Fix include style........................................................Passed
```

### Workarounds

-  Decomposition lowers through rms_norm_pre_all_gather, whose runtime expects a rank-4 tensor.  Left-pad lower-rank shapes with ones so `HxW` and `1xHxW` become `1x1xHxW` before decomposition.
- Post All Gather Op is not landed yet, hence, keep it in primitive ops.
- Refactor the `reshape --> distributed rms norm --> reshape` to a common function `rewriteDistributedRMSNormWithReshape`, so that it can used by both fused kernel and lower rank pre all gather inputs.