### PR TITLE
Uplift third_party/tt-metal to 91a90e1b59290ca6bbcd7b03600379b513fe2a1e 2026-05-10

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=61e690c25202111b52cbc1fbc9148b6524070c6f
+ARG TT_METAL_DEPENDENCIES_COMMIT=91a90e1b59290ca6bbcd7b03600379b513fe2a1e
 
 # Install dependencies
 RUN <<EOT

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -249,6 +249,7 @@ createKernelDescriptor(const ::tt::target::ttnn::KernelDescriptor &kernelDesc,
       .runtime_args = runtimeArgs,
       .common_runtime_args = commonRuntimeArgs,
       .config = createKernelConfigDescriptor(kernelDesc),
+      .compiler_include_paths = {},
       .buffer_bindings = {},
       .common_buffer_bindings = {}};
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "08ce2dc1594c264f262cdce6c56fc014af1f6bfd")
+set(TT_METAL_VERSION "91a90e1b59290ca6bbcd7b03600379b513fe2a1e")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
DO NOT SUBMIT - https://github.com/tenstorrent/tt-metal/pull/43968 needs to be submitted and the metal commit in this PR needs to be changed appropriately.

Note: the commit in this PR is based off of `hshah/fix-profiler-mock-latest` branch in tt-metal, which contains the fix for https://github.com/tenstorrent/tt-metal/issues/43964, which is blocking the uplift. All CI runs in this PR description have been run based off of this commit with the fix.

This PR uplifts the third_party/tt-metal to the 91a90e1b59290ca6bbcd7b03600379b513fe2a1e

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25644735624
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25644771858
      - Note: this tt-xla CI runs has failures due to issues within tt-mlir, not tt-metal. This [verification CI run](https://github.com/tenstorrent/tt-xla/actions/runs/25646883969) (with the latest tt-mlir commit, but previous tt-metal commit also has the same failures).
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): N/A
  - [ ] **Frontend fix PRs** ready (if needed by this uplift): N/A