### PR TITLE
[golden] add chisel mappings for TTNN op goldens

### DIFF
--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -40,7 +40,7 @@ _KNOWN_NOT_IMPLEMENTED_OPS: frozenset[str] = (
             "ttnn.nlp_concat_heads_decode",
             "ttnn.bitcast_convert",
             "ttnn.group_norm",
-            "ttnn.batch_norm_training"
+            "ttnn.batch_norm_training",
         }
     )
     | QUANTIZE_OP_NAMES

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -40,6 +40,7 @@ _KNOWN_NOT_IMPLEMENTED_OPS: frozenset[str] = (
             "ttnn.nlp_concat_heads_decode",
             "ttnn.bitcast_convert",
             "ttnn.group_norm",
+            "ttnn.batch_norm_training"
         }
     )
     | QUANTIZE_OP_NAMES

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -9,7 +9,6 @@ Ops without a registered golden are skipped, not failed.
 import pytest
 import torch
 
-from chisel.exceptions import GoldenNotImplementedError
 from chisel.executor import (
     build_role_keyed_inputs,
     execute_golden,
@@ -41,6 +40,7 @@ _KNOWN_NOT_IMPLEMENTED_OPS: frozenset[str] = (
             "ttnn.nlp_concat_heads",
             "ttnn.nlp_concat_heads_decode",
             "ttnn.bitcast_convert",
+            "ttnn.group_norm",
         }
     )
     | QUANTIZE_OP_NAMES
@@ -54,6 +54,15 @@ def _has_quantized_type(op) -> bool:
         if quant.QuantizedType.isinstance(value.type.element_type):
             return True
     return False
+
+
+@pytest.fixture(autouse=True)
+def _default_meta_device():
+    # Goldens may internally allocate tensors (e.g. SDPA causal mask,
+    # ttnn.arange/full/ones/zeros). Running them on the meta device keeps
+    # the test allocation-free and avoids per-golden device plumbing.
+    with torch.device("meta"):
+        yield
 
 
 def test_golden_execution(subtests, ir_module, binary, binary_path):
@@ -85,12 +94,7 @@ def test_golden_execution(subtests, ir_module, binary, binary_path):
                     inputs[name] = GoldenMapTensor({0: tensor}, (1, 1))
 
                 golden_inputs = build_role_keyed_inputs(op.opview, inputs, asm_state)
-                try:
-                    result = execute_golden(op.opview, golden_inputs)
-                except GoldenNotImplementedError as e:
-                    if e.op_name in _KNOWN_NOT_IMPLEMENTED_OPS:
-                        pytest.skip(str(e))
-                    raise
+                result = execute_golden(op.opview, golden_inputs)
 
                 op_outputs = get_op_outputs(op)
                 for i, op_out in enumerate(op_outputs):

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Execute every TTNN op in a flatbuffer through the golden system on meta
+tensors (shape/dtype only) and verify each output matches the MLIR op type.
+Ops without a registered golden are skipped, not failed.
+"""
+import pytest
+import torch
+
+from chisel.exceptions import GoldenNotImplementedError
+from chisel.executor import (
+    build_role_keyed_inputs,
+    execute_golden,
+    get_provided_inplace_vals,
+)
+from chisel.ops import (
+    get_inplace_operands,
+    get_op_inputs,
+    get_op_outputs,
+    is_non_executable_op,
+    is_tensor_value,
+)
+from golden import GoldenMapTensor, get_chisel_golden_function
+from golden.mapping import mlir_type_to_torch_dtype
+from ttmlir.dialects import quant
+from utils import iterate_programs, QUANTIZE_OP_NAMES
+
+# Ops without a registered golden - skipped instead of failed. Remove an entry
+# once its golden lands. Quantization ops are included via QUANTIZE_OP_NAMES.
+_KNOWN_NOT_IMPLEMENTED_OPS: frozenset[str] = (
+    frozenset(
+        {
+            "ttnn.generic",
+            "ttnn.nlp_create_qkv_heads_decode",
+            "ttnn.rotary_embedding_llama",
+            "ttnn.constant",
+            "ttnn.mesh_shard",
+            "ttnn.mesh_partition",
+            "ttnn.nlp_concat_heads",
+            "ttnn.nlp_concat_heads_decode",
+            "ttnn.bitcast_convert",
+        }
+    )
+    | QUANTIZE_OP_NAMES
+)
+
+
+def _has_quantized_type(op) -> bool:
+    for value in list(op.operands) + list(op.results):
+        if not is_tensor_value(value):
+            continue
+        if quant.QuantizedType.isinstance(value.type.element_type):
+            return True
+    return False
+
+
+def test_golden_execution(subtests, ir_module, binary, binary_path):
+    asm_state = ir_module.get_asm_state()
+
+    for _prog_idx, prog_name in iterate_programs(binary):
+        for op in ir_module.get_function_ops(prog_name):
+            with subtests.test(prog=prog_name, op=op.name):
+                if is_non_executable_op(type(op.opview)):
+                    pytest.skip(f"golden not applicable for {type(op.opview).__name__}")
+
+                if _has_quantized_type(op):
+                    pytest.skip(
+                        f"quantized tensor types not yet supported (op: {op.name})"
+                    )
+
+                if (
+                    get_chisel_golden_function(type(op.opview)) is None
+                    and op.name in _KNOWN_NOT_IMPLEMENTED_OPS
+                ):
+                    pytest.skip(f"{op.name}: no golden registered")
+
+                inputs = {}
+                for operand in get_op_inputs(op):
+                    name = operand.get_name(asm_state)
+                    shape = list(operand.type.shape)
+                    dtype = mlir_type_to_torch_dtype(operand.type.element_type)
+                    tensor = torch.empty(shape, dtype=dtype, device="meta")
+                    inputs[name] = GoldenMapTensor({0: tensor}, (1, 1))
+
+                golden_inputs = build_role_keyed_inputs(op.opview, inputs, asm_state)
+                try:
+                    result = execute_golden(op.opview, golden_inputs)
+                except GoldenNotImplementedError as e:
+                    if e.op_name in _KNOWN_NOT_IMPLEMENTED_OPS:
+                        pytest.skip(str(e))
+                    raise
+
+                op_outputs = get_op_outputs(op)
+                for i, op_out in enumerate(op_outputs):
+                    expected_shape = list(op_out.type.shape)
+                    expected_dtype = mlir_type_to_torch_dtype(op_out.type.element_type)
+                    assert list(result[i].shape) == expected_shape, (
+                        f"output[{i}] shape mismatch: got {list(result[i].shape)}, expected {expected_shape}"
+                        f"\nbinary: {binary_path}"
+                    )
+                    assert result[i].dtype == expected_dtype, (
+                        f"output[{i}] dtype mismatch: got {result[i].dtype}, expected {expected_dtype}"
+                        f"\nbinary: {binary_path}"
+                    )
+
+                inplace_vals = get_provided_inplace_vals(
+                    op.opview, get_inplace_operands(type(op.opview))
+                )
+                for out, (role, val) in zip(result[len(op_outputs) :], inplace_vals):
+                    expected_shape = list(val.type.shape)
+                    expected_dtype = mlir_type_to_torch_dtype(val.type.element_type)
+                    assert list(out.shape) == expected_shape, (
+                        f"inplace:{role} shape mismatch: got {list(out.shape)}, expected {expected_shape}"
+                        f"\nbinary: {binary_path}"
+                    )
+                    assert out.dtype == expected_dtype, (
+                        f"inplace:{role} dtype mismatch: got {out.dtype}, expected {expected_dtype}"
+                        f"\nbinary: {binary_path}"
+                    )

--- a/test/python/chisel/test_golden_execution.py
+++ b/test/python/chisel/test_golden_execution.py
@@ -12,10 +12,9 @@ import torch
 from chisel.executor import (
     build_role_keyed_inputs,
     execute_golden,
-    get_provided_inplace_vals,
 )
 from chisel.ops import (
-    get_inplace_operands,
+    get_flat_inplace_vals,
     get_op_inputs,
     get_op_outputs,
     is_non_executable_op,
@@ -109,9 +108,7 @@ def test_golden_execution(subtests, ir_module, binary, binary_path):
                         f"\nbinary: {binary_path}"
                     )
 
-                inplace_vals = get_provided_inplace_vals(
-                    op.opview, get_inplace_operands(type(op.opview))
-                )
+                inplace_vals = get_flat_inplace_vals(op.opview)
                 for out, (role, val) in zip(result[len(op_outputs) :], inplace_vals):
                     expected_shape = list(val.type.shape)
                     expected_dtype = mlir_type_to_torch_dtype(val.type.element_type)

--- a/test/python/chisel/test_ir_module.py
+++ b/test/python/chisel/test_ir_module.py
@@ -5,18 +5,12 @@
 Cross-validate IRModule against the flatbuffer binary: op walk order,
 tensor shapes, and element types.
 """
-from utils import json_string_as_dict
-
-
-def _iterate_programs(binary):
-    """Yield (index, name) for each program."""
-    for i in range(binary.get_num_programs()):
-        yield i, binary.get_program_name(i)
+from utils import iterate_programs, json_string_as_dict
 
 
 def test_ops(ir_module, binary):
     """Cross-validate walk order, debug info, and tensor shapes against the flatbuffer."""
-    for prog_idx, prog_name in _iterate_programs(binary):
+    for prog_idx, prog_name in iterate_programs(binary):
         mlir_ops = ir_module.get_function_ops(prog_name)
         fb_ops = json_string_as_dict(binary.get_program_ops_as_json(prog_idx))
 

--- a/test/python/chisel/test_walk_program.py
+++ b/test/python/chisel/test_walk_program.py
@@ -5,23 +5,19 @@ import pytest
 import _ttmlir_runtime as tt_runtime
 
 from chisel.ops import get_op_inputs, get_op_outputs
-
-
-# For now skipping quantization OPS
-_SKIP_OPS = {"ttnn.quantize", "ttnn.dequantize", "ttnn.requantize"}
+from utils import iterate_programs, QUANTIZE_OP_NAMES
 
 
 def test_walk_program_shapes_match_ir(binary, ir_module, subtests):
     """TensorRef shapes from walk_program must match shapes in the IR module."""
 
-    for prog_idx in range(binary.get_num_programs()):
-        prog_name = binary.get_program_name(prog_idx)
+    for prog_idx, prog_name in iterate_programs(binary):
         mlir_ops = iter(ir_module.get_function_ops(prog_name))
 
         def _check(op_ctx):
             mlir_op = next(mlir_ops)
 
-            if mlir_op.name in _SKIP_OPS:
+            if mlir_op.name in QUANTIZE_OP_NAMES:
                 return
 
             with subtests.test(op=mlir_op.name, side="inputs"):

--- a/test/python/chisel/utils.py
+++ b/test/python/chisel/utils.py
@@ -5,6 +5,12 @@ import json
 import re
 
 
+# Quantization ops are not yet supported by chisel goldens; tests skip them.
+QUANTIZE_OP_NAMES: frozenset[str] = frozenset(
+    {"ttnn.quantize", "ttnn.dequantize", "ttnn.requantize"}
+)
+
+
 def json_string_as_dict(s: str) -> dict:
     """Parse a flatbuffer-emitted JSON string, normalizing nan/inf for json.loads."""
     if not s:
@@ -12,3 +18,9 @@ def json_string_as_dict(s: str) -> dict:
     s = re.sub(r"\bnan\b", "NaN", s)
     s = re.sub(r"\binf\b", "Infinity", s)
     return json.loads(s)
+
+
+def iterate_programs(binary):
+    """Yield (index, name) for each program in the binary."""
+    for i in range(binary.get_num_programs()):
+        yield i, binary.get_program_name(i)

--- a/tools/chisel/CMakeLists.txt
+++ b/tools/chisel/CMakeLists.txt
@@ -4,6 +4,8 @@ declare_mlir_python_sources(ChiselSources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/chisel"
   SOURCES
     __init__.py
+    executor.py
+    exceptions.py
     ops.py
 )
 

--- a/tools/chisel/chisel/__init__.py
+++ b/tools/chisel/chisel/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from .exceptions import GoldenNotImplementedError
+
+__all__ = ["GoldenNotImplementedError"]

--- a/tools/chisel/chisel/exceptions.py
+++ b/tools/chisel/chisel/exceptions.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class GoldenNotImplementedError(NotImplementedError):
+    """Raised by execute_golden when no golden is registered for an op."""
+
+    def __init__(self, op):
+        op_name = op.name
+        op_type_name = type(op).__name__
+        super().__init__(f"{op_name}: no golden registered for {op_type_name}")
+        self.op = op
+        self.op_name = op_name
+        self.op_type_name = op_type_name

--- a/tools/chisel/chisel/exceptions.py
+++ b/tools/chisel/chisel/exceptions.py
@@ -7,9 +7,5 @@ class GoldenNotImplementedError(NotImplementedError):
     """Raised by execute_golden when no golden is registered for an op."""
 
     def __init__(self, op):
-        op_name = op.name
-        op_type_name = type(op).__name__
-        super().__init__(f"{op_name}: no golden registered for {op_type_name}")
+        super().__init__(f"{op.name}: no golden registered for {type(op).__name__}")
         self.op = op
-        self.op_name = op_name
-        self.op_type_name = op_type_name

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Golden execution for a single TTNN op via CHISEL_GOLDEN_MAPPINGS.
+
+Golden interface: fn(op, inputs: Dict[str, GoldenMapTensor]) -> GoldenMapTensor | tuple.
+The executor normalizes the result to a tuple with one entry per SSA result
+followed by one entry per provided in-place operand.
+"""
+import logging
+from typing import Dict, Iterable, Optional, Tuple
+
+from ttmlir.ir import OpOperandList, Operation, Value
+
+from golden import get_chisel_golden_function, GoldenMapTensor
+
+from .exceptions import GoldenNotImplementedError
+from .ops import get_inplace_operands, get_op_outputs, is_tensor_value
+
+logger = logging.getLogger("chisel")
+
+
+def build_role_keyed_inputs(
+    op: Operation, ssa_inputs: Dict[str, GoldenMapTensor], asm_state
+) -> Dict[str, object]:
+    """Re-key `ssa_inputs` by operand role name (per OpView's OPERAND_NAMES).
+
+    Per role: `Value` -> tensor, `OpOperandList` -> list (Variadic), None ->
+    absent Optional. Non-tensor operands (e.g. `device`) become None.
+    """
+    operand_names = getattr(type(op), "OPERAND_NAMES", None)
+    assert operand_names is not None, (
+        f"{type(op).__name__} is missing OPERAND_NAMES; "
+        "OpView bindings must be codegened with operand names"
+    )
+
+    def lookup(val):
+        if not is_tensor_value(val):
+            return None
+        return ssa_inputs[val.get_name(asm_state)]
+
+    role_inputs: Dict[str, object] = {}
+    for name in operand_names:
+        accessor = getattr(op, name, None)
+        if accessor is None:
+            role_inputs[name] = None
+        elif isinstance(accessor, OpOperandList):
+            role_inputs[name] = [lookup(v) for v in accessor]
+        elif isinstance(accessor, Value):
+            role_inputs[name] = lookup(accessor)
+        else:
+            raise TypeError(
+                f"{type(op).__name__}.{name} unexpected type "
+                f"{type(accessor).__name__}"
+            )
+    return role_inputs
+
+
+def execute_golden(
+    op: Operation,
+    golden_inputs: Dict[str, object],
+) -> Optional[Tuple[GoldenMapTensor, ...]]:
+    """Run the registered golden for `op` and return its outputs as a tuple.
+
+    Returns None if the golden returns an unsupported type. Raises
+    GoldenNotImplementedError if no golden is registered for `op`.
+    """
+    golden_fn = get_chisel_golden_function(type(op))
+    if golden_fn is None:
+        raise GoldenNotImplementedError(op)
+
+    result = golden_fn(op, golden_inputs)
+
+    if isinstance(result, GoldenMapTensor):
+        tensors: Tuple[GoldenMapTensor, ...] = (result,)
+    elif isinstance(result, (list, tuple)) and all(
+        isinstance(t, GoldenMapTensor) for t in result
+    ):
+        tensors = tuple(result)
+    else:
+        msg = (
+            f"Golden for {type(op).__name__} returned unsupported type "
+            f"{type(result).__name__}"
+        )
+        logger.error(f"{op.name}: golden error ({msg})")
+        return None
+
+    ssa_count = len(get_op_outputs(op))
+    inplace_vals = get_provided_inplace_vals(op, get_inplace_operands(type(op)))
+    expected = ssa_count + len(inplace_vals)
+    assert len(tensors) == expected, (
+        f"Golden for {type(op).__name__} returned {len(tensors)} tensor(s) "
+        f"but op has {ssa_count} SSA output(s) + {len(inplace_vals)} mutated "
+        f"operand(s); fix CHISEL_GOLDEN_MAPPINGS to return SSA outputs first, "
+        f"then one tensor per provided in-place operand"
+    )
+    return tensors
+
+
+def get_provided_inplace_vals(
+    op: Operation, roles: Iterable[str]
+) -> list[tuple[str, Value]]:
+    """Return (role, value) pairs for in-place operands present on `op`.
+
+    Absent Optional operands are skipped; OpOperandList is expanded.
+    """
+    vals: list[tuple[str, Value]] = []
+    for role in roles:
+        accessor = getattr(op, role, None)
+        if accessor is None:
+            continue
+        if isinstance(accessor, OpOperandList):
+            vals.extend((role, v) for v in accessor)
+        else:
+            vals.append((role, accessor))
+    return vals

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -9,14 +9,18 @@ The executor normalizes the result to a tuple with one entry per SSA result
 followed by one entry per provided in-place operand.
 """
 import logging
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from ttmlir.ir import OpOperandList, Operation, Value
 
 from golden import get_chisel_golden_function, GoldenMapTensor
 
 from .exceptions import GoldenNotImplementedError
-from .ops import get_inplace_operands, get_op_outputs, is_tensor_value
+from .ops import (
+    get_flat_inplace_vals,
+    get_op_outputs,
+    is_tensor_value,
+)
 
 logger = logging.getLogger("chisel")
 
@@ -57,25 +61,6 @@ def build_role_keyed_inputs(
     return role_inputs
 
 
-def get_provided_inplace_vals(
-    op: Operation, roles: Iterable[str]
-) -> list[tuple[str, Value]]:
-    """Return (role, value) pairs for in-place operands present on `op`.
-
-    Absent Optional operands are skipped; OpOperandList is expanded.
-    """
-    vals: list[tuple[str, Value]] = []
-    for role in roles:
-        accessor = getattr(op, role, None)
-        if accessor is None:
-            continue
-        if isinstance(accessor, OpOperandList):
-            vals.extend((role, v) for v in accessor)
-        else:
-            vals.append((role, accessor))
-    return vals
-
-
 def execute_golden(
     op: Operation,
     golden_inputs: Dict[str, object],
@@ -106,7 +91,7 @@ def execute_golden(
         return None
 
     ssa_count = len(get_op_outputs(op))
-    inplace_vals = get_provided_inplace_vals(op, get_inplace_operands(type(op)))
+    inplace_vals = get_flat_inplace_vals(op)
     expected = ssa_count + len(inplace_vals)
     assert len(tensors) == expected, (
         f"Golden for {type(op).__name__} returned {len(tensors)} tensor(s) "

--- a/tools/chisel/chisel/executor.py
+++ b/tools/chisel/chisel/executor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -57,6 +57,25 @@ def build_role_keyed_inputs(
     return role_inputs
 
 
+def get_provided_inplace_vals(
+    op: Operation, roles: Iterable[str]
+) -> list[tuple[str, Value]]:
+    """Return (role, value) pairs for in-place operands present on `op`.
+
+    Absent Optional operands are skipped; OpOperandList is expanded.
+    """
+    vals: list[tuple[str, Value]] = []
+    for role in roles:
+        accessor = getattr(op, role, None)
+        if accessor is None:
+            continue
+        if isinstance(accessor, OpOperandList):
+            vals.extend((role, v) for v in accessor)
+        else:
+            vals.append((role, accessor))
+    return vals
+
+
 def execute_golden(
     op: Operation,
     golden_inputs: Dict[str, object],
@@ -96,22 +115,3 @@ def execute_golden(
         f"then one tensor per provided in-place operand"
     )
     return tensors
-
-
-def get_provided_inplace_vals(
-    op: Operation, roles: Iterable[str]
-) -> list[tuple[str, Value]]:
-    """Return (role, value) pairs for in-place operands present on `op`.
-
-    Absent Optional operands are skipped; OpOperandList is expanded.
-    """
-    vals: list[tuple[str, Value]] = []
-    for role in roles:
-        accessor = getattr(op, role, None)
-        if accessor is None:
-            continue
-        if isinstance(accessor, OpOperandList):
-            vals.extend((role, v) for v in accessor)
-        else:
-            vals.append((role, accessor))
-    return vals

--- a/tools/chisel/chisel/ops.py
+++ b/tools/chisel/chisel/ops.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-MLIR operation utilities: IRModule wrapper and tensor operand extraction.
+MLIR operation utilities: IRModule wrapper, tensor operand extraction, and
+chisel-specific op classification (non-executable / in-place).
 """
-from ttmlir.dialects import func
+from ttmlir.dialects import func, ttcore, ttnn
 from ttmlir.ir import (
     AsmState,
     BlockArgument,
@@ -18,22 +19,52 @@ from ttmlir.ir import (
 )
 
 
+# Ops not executable as goldens (device, I/O, control flow).
+CHISEL_NON_EXECUTABLE_OPS: set = {
+    ttnn.GetDeviceOp,
+    ttnn.LoadTensorOp,
+    ttcore.LoadCachedOp,
+    func.CallOp,
+}
+
+# Op class -> operand role names mutated via `Arg<..., [MemWrite]>` in ODS.
+# Goldens return SSA results first, then one tensor per *provided* memwrite
+# operand (absent Optional operands are skipped - see get_provided_inplace_vals).
+# Hand-maintained; TODO: derive from ODS (see python_op_schema_codegen.py).
+CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
+    ttnn.UpdateCacheOp: ("cache",),
+    ttnn.PagedUpdateCacheOp: ("cache",),
+    ttnn.FillCacheOp: ("cache",),
+    ttnn.PagedFillCacheOp: ("cache",),
+    ttnn.WriteTensorOp: ("device_tensor",),
+    ttnn.DumpTensorOp: (),
+    ttnn.DeallocateOp: (),
+    ttnn.BatchNormTrainingOp: ("running_mean", "running_var"),
+    ttnn.PointToPointOp: ("optional_output_tensor",),
+}
+
+
+def is_non_executable_op(op_class: type) -> bool:
+    return op_class in CHISEL_NON_EXECUTABLE_OPS
+
+
+def get_inplace_operands(op_class: type) -> tuple[str, ...]:
+    return CHISEL_INPLACE_OPS.get(op_class, ())
+
+
+def is_tensor_value(val) -> bool:
+    """True if `val` is a tensor-like MLIR Value (has shape and element_type)."""
+    return hasattr(val.type, "shape") and hasattr(val.type, "element_type")
+
+
 def get_op_outputs(op: Operation) -> list[OpResult]:
     """Extract output tensors (results with shape and element_type) from a MLIR operation."""
-    return [
-        result
-        for result in op.results
-        if hasattr(result.type, "shape") and hasattr(result.type, "element_type")
-    ]
+    return [result for result in op.results if is_tensor_value(result)]
 
 
 def get_op_inputs(op: Operation) -> list[Value]:
     """Extract input tensors (operands with shape and element_type) from a MLIR operation."""
-    return [
-        operand
-        for operand in op.operands
-        if hasattr(operand.type, "shape") and hasattr(operand.type, "element_type")
-    ]
+    return [operand for operand in op.operands if is_tensor_value(operand)]
 
 
 class IRModule:
@@ -62,13 +93,11 @@ class IRModule:
             ops, outputs = self._extract_function_ops(name)
             self._function_ops[name] = ops
             self._function_outputs[name] = outputs
-        self._asm_state: dict[str, AsmState] = {
-            name: AsmState(self._functions[name]) for name in functions
-        }
+        self._asm_state = AsmState(self.module.operation)
 
-    def get_asm_state(self, function_name: str) -> AsmState:
-        """AsmState for the given function (speeds up get_name calls)."""
-        return self._asm_state[function_name]
+    def get_asm_state(self) -> AsmState:
+        """Module-wide AsmState (speeds up get_name calls)."""
+        return self._asm_state
 
     def get_function(self, function_name: str) -> func.FuncOp:
         """The func.FuncOp for the given function."""
@@ -93,9 +122,8 @@ class IRModule:
         outputs = []
 
         def _visitor(op):
-            # Skip the FuncOp itself — Python bindings only expose walk() on
-            # Operation, not Region, so we walk the FuncOp and skip it to match
-            # the C++ entry.getBody().walk() in FuncOpToProgram.h.
+            # Python bindings only expose walk() on Operation; skip the FuncOp
+            # itself to match C++ entry.getBody().walk() in FuncOpToProgram.h.
             if op == func_op.operation:
                 return WalkResult.ADVANCE
             if op.name == "func.return":

--- a/tools/chisel/chisel/ops.py
+++ b/tools/chisel/chisel/ops.py
@@ -11,6 +11,7 @@ from ttmlir.ir import (
     BlockArgument,
     Context,
     Module,
+    OpOperandList,
     OpResult,
     Operation,
     Value,
@@ -29,7 +30,7 @@ _CHISEL_NON_EXECUTABLE_OPS: set = {
 
 # Op class -> operand role names mutated via `Arg<..., [MemWrite]>` in ODS.
 # Goldens return SSA results first, then one tensor per *provided* memwrite
-# operand (absent Optional operands are skipped - see get_provided_inplace_vals).
+# operand (absent Optional operands are skipped - see get_flat_inplace_vals).
 # Hand-maintained;
 # TODO(ndrakulic, #8385): derive from ODS via python_op_schema_codegen.py.
 _CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
@@ -66,6 +67,23 @@ def get_op_outputs(op: Operation) -> list[OpResult]:
 def get_op_inputs(op: Operation) -> list[Value]:
     """Extract input tensors (operands with shape and element_type) from a MLIR operation."""
     return [operand for operand in op.operands if is_tensor_value(operand)]
+
+
+def get_flat_inplace_vals(op: Operation) -> list[tuple[str, Value]]:
+    """Return (role, value) pairs for in-place operands present on `op`.
+
+    Absent Optional operands are skipped; OpOperandList is expanded.
+    """
+    vals: list[tuple[str, Value]] = []
+    for role in get_inplace_operands(type(op)):
+        accessor = getattr(op, role, None)
+        if accessor is None:
+            continue
+        if isinstance(accessor, OpOperandList):
+            vals.extend((role, v) for v in accessor)
+        else:
+            vals.append((role, accessor))
+    return vals
 
 
 class IRModule:

--- a/tools/chisel/chisel/ops.py
+++ b/tools/chisel/chisel/ops.py
@@ -20,7 +20,7 @@ from ttmlir.ir import (
 
 
 # Ops not executable as goldens (device, I/O, control flow).
-CHISEL_NON_EXECUTABLE_OPS: set = {
+_CHISEL_NON_EXECUTABLE_OPS: set = {
     ttnn.GetDeviceOp,
     ttnn.LoadTensorOp,
     ttcore.LoadCachedOp,
@@ -30,8 +30,9 @@ CHISEL_NON_EXECUTABLE_OPS: set = {
 # Op class -> operand role names mutated via `Arg<..., [MemWrite]>` in ODS.
 # Goldens return SSA results first, then one tensor per *provided* memwrite
 # operand (absent Optional operands are skipped - see get_provided_inplace_vals).
-# Hand-maintained; TODO: derive from ODS (see python_op_schema_codegen.py).
-CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
+# Hand-maintained;
+# TODO(ndrakulic, #8385): derive from ODS via python_op_schema_codegen.py.
+_CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
     ttnn.UpdateCacheOp: ("cache",),
     ttnn.PagedUpdateCacheOp: ("cache",),
     ttnn.FillCacheOp: ("cache",),
@@ -45,11 +46,11 @@ CHISEL_INPLACE_OPS: dict[type, tuple[str, ...]] = {
 
 
 def is_non_executable_op(op_class: type) -> bool:
-    return op_class in CHISEL_NON_EXECUTABLE_OPS
+    return op_class in _CHISEL_NON_EXECUTABLE_OPS
 
 
 def get_inplace_operands(op_class: type) -> tuple[str, ...]:
-    return CHISEL_INPLACE_OPS.get(op_class, ())
+    return _CHISEL_INPLACE_OPS.get(op_class, ())
 
 
 def is_tensor_value(val) -> bool:

--- a/tools/golden/__init__.py
+++ b/tools/golden/__init__.py
@@ -9,6 +9,8 @@ __all__ = [
     "unpack_mlir_attr",
     "get_golden_function",
     "GOLDEN_MAPPINGS",
+    "CHISEL_GOLDEN_MAPPINGS",
+    "get_chisel_golden_function",
     "get_pcc",
     "get_atol_rtol",
     "get_atol_rtol_pcc",

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -4085,11 +4085,10 @@ def ttir_batch_norm_training_golden(
     # running_mean = momentum * batch_mean + (1 - momentum) * running_mean
     # running_variance = momentum * batch_variance + (1 - momentum) * running_variance
     updated_running_mean = torch.add(
-        torch.mul(batch_mean_reshaped, momentum), torch.mul(running_mean, 1 - momentum)
+        torch.mul(batch_mean, momentum), torch.mul(running_mean, 1 - momentum)
     )
     updated_running_var = torch.add(
-        torch.mul(batch_var_reshaped, momentum),
-        torch.mul(running_variance, 1 - momentum),
+        torch.mul(batch_var, momentum), torch.mul(running_variance, 1 - momentum)
     )
 
     return (
@@ -8728,30 +8727,6 @@ def chisel_ttnn_batch_norm_inference(op, inputs):
     )
 
 
-def chisel_ttnn_batch_norm_training(op, inputs):
-    rm = inputs["running_mean"]
-    rv = inputs["running_var"]
-    out, urm, urv = ttir_batch_norm_training_golden(
-        input_tensor=inputs["input"],
-        scale=inputs["weight"],
-        offset=inputs["bias"],
-        running_mean=rm,
-        running_variance=rv,
-        epsilon_attr=op.attributes["epsilon"],
-        dimension_attr=1,
-        momentum_attr=op.attributes["momentum"],
-        output_type_mlir=op.results[0].type.element_type,
-        mean_output_type_mlir=op.results[0].type.element_type,
-        variance_output_type_mlir=op.results[0].type.element_type,
-    )
-    returns = [out]
-    if rm is not None:
-        returns.append(urm)
-    if rv is not None:
-        returns.append(urv)
-    return tuple(returns)
-
-
 def chisel_ttnn_distributed_rms_norm(op, inputs):
     return ttir_distributed_rms_norm_golden(
         input=inputs["input"],
@@ -9184,7 +9159,6 @@ CHISEL_GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.PrepareConvTranspose2dBiasOp: chisel_ttnn_prepare_conv_transpose2d_bias,
     # BatchNorm / DistRMSNorm / Scatter
     ttnn.BatchNormInferenceOp: chisel_ttnn_batch_norm_inference,
-    ttnn.BatchNormTrainingOp: chisel_ttnn_batch_norm_training,
     ttnn.DistributedRMSNormOp: chisel_ttnn_distributed_rms_norm,
     ttnn.ScatterOp: chisel_ttnn_scatter,
     # SDPA / Attention ops

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -8012,6 +8012,7 @@ def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
 
 
 # Chisel golden interface: fn(op, inputs: Dict[str, GoldenMapTensor]) -> GoldenMapTensor | tuple
+# TODO(ndrakulic, #8399) this needs unification with other goldens
 
 
 def _ttnn_unflatten_nhwc(tensor, batch_size, input_height, input_width, channels):
@@ -8143,14 +8144,18 @@ def chisel_debug_region_end(op, inputs):
 
 
 def chisel_ttnn_assign(op, inputs):
-    return inputs["input"].clone().to(
-        mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    return (
+        inputs["input"]
+        .clone()
+        .to(mlir_type_to_torch_dtype(op.results[0].type.element_type))
     )
 
 
 def chisel_ttnn_to_memory_config(op, inputs):
-    return inputs["input"].clone().to(
-        mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    return (
+        inputs["input"]
+        .clone()
+        .to(mlir_type_to_torch_dtype(op.results[0].type.element_type))
     )
 
 
@@ -8688,8 +8693,10 @@ def chisel_ttnn_prepare_conv2d_weights(op, inputs):
 
 
 def chisel_ttnn_prepare_conv2d_bias(op, inputs):
-    return inputs["bias_tensor"].clone().to(
-        mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    return (
+        inputs["bias_tensor"]
+        .clone()
+        .to(mlir_type_to_torch_dtype(op.results[0].type.element_type))
     )
 
 
@@ -8702,8 +8709,10 @@ def chisel_ttnn_prepare_conv_transpose2d_weights(op, inputs):
 
 
 def chisel_ttnn_prepare_conv_transpose2d_bias(op, inputs):
-    return inputs["bias_tensor"].clone().to(
-        mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    return (
+        inputs["bias_tensor"]
+        .clone()
+        .to(mlir_type_to_torch_dtype(op.results[0].type.element_type))
     )
 
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -28,7 +28,6 @@ import re
 import einops
 import torch
 import torch.nn.functional
-import torch.nn.functional as F
 from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy, debug, func
 from ttmlir.ir import *
 from ttmlir.passes import DataType
@@ -8508,7 +8507,7 @@ def chisel_ttnn_max_pool2d(op, inputs):
         if top == bottom and left == right:
             torch_padding = (top, left)
         else:
-            nchw = F.pad(
+            nchw = torch.nn.functional.pad(
                 nchw, [left, right, top, bottom], mode="constant", value=float("-inf")
             )
             torch_padding = 0

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -19,6 +19,7 @@ import re
 import einops
 import torch
 import torch.nn.functional
+import torch.nn.functional as F
 from ttmlir.dialects import ttir, stablehlo, d2m, ttnn, ttcore, sdy, debug, func
 from ttmlir.ir import *
 from ttmlir.passes import DataType
@@ -75,6 +76,7 @@ class GoldenMapTensor:
         "detach",
         "requires_grad_",
         "long",
+        "bool",
     ]
     _MUTATING_METHODS = {
         name: (
@@ -393,6 +395,16 @@ def unpack_mlir_attr(attr):
         array = np.array(attr)
         return array
     raise ValueError(f"Unexpected attribute type: {type(attr)}")
+
+
+def _attr_get(attrs, key, default=None):
+    """Safe attribute access for MLIR OpAttributeMap (which lacks .get())."""
+    return attrs[key] if key in attrs else default
+
+
+def _attr_get_value(attrs, key, default=None):
+    """Return `unpack_mlir_attr(attrs[key])` or `default` if `key` is absent."""
+    return unpack_mlir_attr(attrs[key]) if key in attrs else default
 
 
 def mlir_type_to_torch_dtype(mlir_type: Type) -> torch.dtype:
@@ -1462,12 +1474,12 @@ def ttir_all_to_all_dispatch_metadata_golden(
     """Cross-shard golden for all_to_all_dispatch_metadata.
 
     Mirrors tt-metal's gen_tensors_for_metadata_op / get_output_tensor:
-    - Dispatched: sparse routing — for each token and each of its K selected
+    - Dispatched: sparse routing - for each token and each of its K selected
       experts, the token is placed on the device that owns that expert.
       Non-routed slots are filled with zeros.
-    - Indices (metadata): all-gathered — every ring device gets the full set
+    - Indices (metadata): all-gathered - every ring device gets the full set
       of expert indices from all ring devices.
-    - Scores: all-gathered — same as indices.
+    - Scores: all-gathered - same as indices.
 
     expert_mapping has new format [1, 1, D, E] where entry [0, 0, d, e] is
     the linearized device ID that owns expert e (same for all d).
@@ -1482,11 +1494,11 @@ def ttir_all_to_all_dispatch_metadata_golden(
     grouped_indices = expert_indices.group_by_axis(cluster_axis)
     grouped_scores = expert_scores.group_by_axis(cluster_axis)
 
-    # expert_mapping is replicated — get from any device
+    # expert_mapping is replicated - get from any device
     mapping_tensor = list(expert_mapping._shard_map.values())[0]
-    # Shape is [1, 1, D, E] — squeeze to [D, E], use row 0 since all rows identical
+    # Shape is [1, 1, D, E] - squeeze to [D, E], use row 0 since all rows identical
     mapping_2d = mapping_tensor.reshape(-1, mapping_tensor.shape[-1])  # [D, E]
-    mapping_row = mapping_2d[0]  # [E] — mapping_row[e] = device_id owning expert e
+    mapping_row = mapping_2d[0]  # [E] - mapping_row[e] = device_id owning expert e
 
     out_dispatched = {}
     out_indices = {}
@@ -4065,10 +4077,11 @@ def ttir_batch_norm_training_golden(
     # running_mean = momentum * batch_mean + (1 - momentum) * running_mean
     # running_variance = momentum * batch_variance + (1 - momentum) * running_variance
     updated_running_mean = torch.add(
-        torch.mul(batch_mean, momentum), torch.mul(running_mean, 1 - momentum)
+        torch.mul(batch_mean_reshaped, momentum), torch.mul(running_mean, 1 - momentum)
     )
     updated_running_var = torch.add(
-        torch.mul(batch_var, momentum), torch.mul(running_variance, 1 - momentum)
+        torch.mul(batch_var_reshaped, momentum),
+        torch.mul(running_variance, 1 - momentum),
     )
 
     return (
@@ -4238,8 +4251,11 @@ def ttir_argmax_golden(
     keep_dim_attr: BoolAttr,
     output_type_mlir: Type,
 ) -> GoldenMapTensor:
-    dim_arg = unpack_mlir_attr(dim_arg_attr)
+    dim_arg = None if dim_arg_attr is None else unpack_mlir_attr(dim_arg_attr)
     keep_dim = unpack_mlir_attr(keep_dim_attr)
+
+    if isinstance(dim_arg, int):
+        dim_arg = [dim_arg]
 
     if dim_arg is None:
         result = torch.argmax(input_tensor, keepdim=keep_dim)
@@ -6839,7 +6855,7 @@ def ttnn_layer_norm_post_all_gather_golden(
     # then applies standard layer normalization.  Rather than replicating the
     # kernel's tiled-reduce logic (which depends on tile width, device count
     # and a bfloat16 scaler), we compute the reference output directly using
-    # the input tensor — exactly as tt-metal's own test does.
+    # the input tensor - exactly as tt-metal's own test does.
     del stats
 
     epsilon = unpack_mlir_attr(epsilon)
@@ -7371,7 +7387,13 @@ def ttir_sdpa_golden(
         seq_len_q = qk.shape[-2]
         seq_len_k = qk.shape[-1]
         causal_mask = torch.triu(
-            torch.full((seq_len_q, seq_len_k), float("-inf")), diagonal=1
+            torch.full(
+                (seq_len_q, seq_len_k),
+                float("-inf"),
+                dtype=qk.dtype,
+                device=qk.device,
+            ),
+            diagonal=1,
         )
         qk = torch.add(qk, causal_mask)
 
@@ -7744,7 +7766,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.DotGeneralOp: ttir_dot_general_golden,
     ttir.ScatterOp: ttir_scatter_golden,
     ttir.GatherOp: ttir_gather_golden,
-    # Layout operations (identity functions) — accept and ignore extra kwargs like reinterpretLayout
+    # Layout operations (identity functions) - accept and ignore extra kwargs like reinterpretLayout
     ttir.ToLayoutOp: ttir_to_layout_golden,
     # Cache operations
     ttir.FillCacheOp: fill_cache_golden,
@@ -7984,3 +8006,1241 @@ def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
         return GOLDEN_MAPPINGS[ttir_op_class]
 
     assert False, f"No golden function found for TTIR operation: {ttir_op_class}"
+
+
+def ttnn_assign_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    return input_tensor.clone().to(mlir_type_to_torch_dtype(output_type_mlir))
+
+
+def ttnn_to_memory_config_golden(
+    input_tensor: GoldenMapTensor, output_type_mlir: Type
+) -> GoldenMapTensor:
+    return input_tensor.clone().to(mlir_type_to_torch_dtype(output_type_mlir))
+
+
+# Chisel golden interface: fn(op, inputs: Dict[str, GoldenMapTensor]) -> GoldenMapTensor | tuple
+
+
+def _ttnn_unflatten_nhwc(tensor, batch_size, input_height, input_width, channels):
+    """Unflatten TTNN's [1, 1, N*H*W, C] layout to NHWC."""
+    return tensor.reshape(batch_size, input_height, input_width, channels)
+
+
+def _ttnn_flatten_nhwc(tensor):
+    """Flatten an NHWC tensor back to TTNN's [1, 1, N*H*W, C] layout."""
+    n, h, w, c = tensor.shape
+    return tensor.reshape(1, 1, n * h * w, c)
+
+
+def _chisel_unary(golden_fn):
+    def wrapper(op, inputs):
+        return golden_fn(
+            input_tensor=inputs["input"],
+            output_type_mlir=op.results[0].type.element_type,
+        )
+
+    return wrapper
+
+
+def _chisel_binary(golden_fn, *, rhs_kwarg="other_tensor"):
+    def wrapper(op, inputs):
+        return golden_fn(
+            input_tensor=inputs["lhs"],
+            output_type_mlir=op.results[0].type.element_type,
+            **{rhs_kwarg: inputs["rhs"]},
+        )
+
+    return wrapper
+
+
+def chisel_ttnn_where(op, inputs):
+    return ttnn_where_golden(
+        condition=inputs["first"].bool(),
+        x=inputs["second"],
+        y=inputs["third"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_clamp_tensor(op, inputs):
+    return ttnn_clamp_tensor_golden(
+        input_tensor=inputs["input"],
+        min_tensor=inputs["min"],
+        max_tensor=inputs["max"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_typecast(op, inputs):
+    return ttnn_typecast_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_to_layout(op, inputs):
+    return ttnn_to_layout_golden(
+        input_tensor=inputs["input"],
+        layout_attr=op.attributes["layout"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_leaky_relu(op, inputs):
+    return ttnn_leaky_relu_golden(
+        input_tensor=inputs["input"],
+        parameter_attr=op.attributes["parameter"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_clamp_scalar(op, inputs):
+    return ttnn_clamp_scalar_golden(
+        input_tensor=inputs["input"],
+        min_attr=op.attributes["min"],
+        max_attr=op.attributes["max"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_repeat_interleave(op, inputs):
+    return ttnn_repeat_interleave_golden(
+        input_tensor=inputs["input"],
+        repeats_attr=op.attributes["repeats"],
+        dim_attr=op.attributes["dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_matmul(op, inputs):
+    return ttnn_matmul_golden(
+        input_tensor=inputs["a"],
+        other_tensor=inputs["b"],
+        transpose_a_attr=op.attributes["transpose_a"],
+        transpose_b_attr=op.attributes["transpose_b"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_concat(op, inputs):
+    return ttnn_concat_golden(
+        input_tensors=tuple(inputs["inputs"]),
+        dim_attr=op.attributes["dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_repeat(op, inputs):
+    return ttnn_repeat_golden(
+        input_tensor=inputs["input"],
+        repeat_dims_attr=op.attributes["repeat_dims"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_debug_annotate(op, inputs):
+    return debug_annotate_golden(inputs["input"], op.attributes["annotation"])
+
+
+def chisel_debug_region_start(op, inputs):
+    return debug_region_start_golden(inputs["input"], op.attributes["region_id"])
+
+
+def chisel_debug_region_end(op, inputs):
+    return debug_region_end_golden(inputs["input"], op.attributes["region_id"])
+
+
+def chisel_ttnn_assign(op, inputs):
+    return ttnn_assign_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_to_memory_config(op, inputs):
+    return ttnn_to_memory_config_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_deallocate(op, inputs):
+    return ()
+
+
+def chisel_ttnn_linear(op, inputs):
+    return ttnn_linear_golden(
+        input_tensor=inputs["a"],
+        other_tensor=inputs["b"],
+        bias_tensor=inputs["bias"],
+        transpose_a_attr=op.attributes["transpose_a"],
+        transpose_b_attr=op.attributes["transpose_b"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_layer_norm(op, inputs):
+    # ttnn.layer_norm always normalizes over the last dimension of the input
+    # (the op carries no `normalized_shape` attribute, unlike its TTIR counterpart).
+    input_shape = list(op.operands[0].type.shape)
+    return ttnn_layer_norm_golden(
+        input=inputs["input"],
+        weight=inputs["weight"],
+        bias=inputs["bias"],
+        normalized_shape=[input_shape[-1]],
+        epsilon=op.attributes["epsilon"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_layer_norm_pre_all_gather(op, inputs):
+    return ttnn_layer_norm_pre_all_gather_golden(
+        input=inputs["input"],
+        residual_input=inputs["residual_input"],
+        recip=inputs["recip"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_layer_norm_post_all_gather(op, inputs):
+    return ttnn_layer_norm_post_all_gather_golden(
+        input=inputs["input"],
+        stats=inputs["stats"],
+        weight=inputs["weight"],
+        bias=inputs["bias"],
+        epsilon=op.attributes["epsilon"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_group_norm(op, inputs):
+    return ttnn_group_norm_golden(
+        input=inputs["input"],
+        weight=inputs["input_mask"],
+        bias=inputs["weight"],
+        num_groups=op.attributes["num_groups"],
+        epsilon=op.attributes["epsilon"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_rms_norm(op, inputs):
+    input_tensor = inputs["input"]
+    normalized_shape = [input_tensor.shape[-1]]
+    return rms_norm_golden(
+        input=input_tensor,
+        weight=inputs["weight"],
+        bias=inputs["bias"],
+        normalized_shape=normalized_shape,
+        epsilon=unpack_mlir_attr(op.attributes["epsilon"]),
+    )
+
+
+def chisel_ttnn_distribute_tensor(op, inputs):
+    return ttnn_distribute_tensor_golden(
+        input=inputs["input"],
+        mapper_config=op.attributes["mapper_config"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_aggregate_tensor(op, inputs):
+    return ttnn_aggregate_tensor_golden(
+        input=inputs["input"],
+        composer_config=op.attributes["composer_config"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_all_gather(op, inputs):
+    return ttnn_all_gather_golden(
+        input=inputs["input"],
+        all_gather_dim_attr=op.attributes["all_gather_dim"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_reduce_scatter(op, inputs):
+    return ttnn_reduce_scatter_golden(
+        input=inputs["input"],
+        reduce_type_attr=op.attributes["reduce_type"],
+        scatter_dim_attr=op.attributes["scatter_dim"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_all_reduce_async(op, inputs):
+    return ttir_all_reduce_golden(
+        input=inputs["input"],
+        reduce_type_attr=op.attributes["reduce_type"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_gather(op, inputs):
+    return ttnn_gather_dim_golden(
+        input_tensor=inputs["input"],
+        index=inputs["index"],
+        dim=op.attributes["dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_paged_flash_multi_latent_attention_decode(op, inputs):
+    return ttir_paged_flash_multi_latent_attention_decode_golden(
+        query=inputs["query"],
+        key=inputs["key"],
+        value=inputs["value"],
+        page_table=inputs["page_table"],
+        attention_mask=inputs["attention_mask"],
+        cur_pos_tensor=inputs["cur_pos_tensor"],
+        attention_sink=inputs["attention_sink"],
+        head_dim_v=op.attributes["head_dim_v"],
+        is_causal=_attr_get(op.attributes, "is_causal"),
+        scale=_attr_get(op.attributes, "scale"),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_sum(op, inputs):
+    return ttir_sum_golden(
+        input_tensor=inputs["input"],
+        dim_arg_attr=op.attributes["dim_arg"],
+        keep_dim_attr=op.attributes["keep_dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_max(op, inputs):
+    return ttir_max_golden(
+        input_tensor=inputs["input"],
+        dim_arg_attr=op.attributes["dim_arg"],
+        keep_dim_attr=op.attributes["keep_dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_mean(op, inputs):
+    return mean_golden(
+        input_tensor=inputs["input"],
+        dim_arg=_attr_get_value(op.attributes, "dim_arg"),
+        keep_dim=unpack_mlir_attr(op.attributes["keep_dim"]),
+    )
+
+
+def chisel_ttnn_min(op, inputs):
+    return min_golden(
+        input_tensor=inputs["input"],
+        dim_arg=_attr_get_value(op.attributes, "dim_arg"),
+        keep_dim=unpack_mlir_attr(op.attributes["keep_dim"]),
+    )
+
+
+def chisel_ttnn_prod(op, inputs):
+    dim_arg_val = _attr_get_value(op.attributes, "dim_arg")
+    if isinstance(dim_arg_val, int):
+        dim_arg_val = [dim_arg_val]
+    return prod_golden(
+        input_tensor=inputs["input"],
+        dim_arg=dim_arg_val,
+        keep_dim=unpack_mlir_attr(op.attributes["keep_dim"]),
+    )
+
+
+def chisel_ttnn_argmax(op, inputs):
+    input_tensor = inputs["input"]
+    keep_dim = unpack_mlir_attr(op.attributes["keep_dim"])
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    dim = _attr_get_value(op.attributes, "dim")
+    if dim is not None:
+        result = torch.argmax(input_tensor, dim=dim, keepdim=keep_dim)
+    else:
+        result = torch.argmax(input_tensor, keepdim=keep_dim)
+    return result.to(output_dtype)
+
+
+def chisel_ttnn_cumsum(op, inputs):
+    return ttir_cumsum_golden(
+        input_tensor=inputs["input"],
+        dim=op.attributes["dim"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_sort(op, inputs):
+    values, indices = ttir_sort_golden(
+        input_tensor=inputs["input"],
+        dim_attr=op.attributes["dim"],
+        descending_attr=op.attributes["descending"],
+        stable_attr=op.attributes["stable"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+    indices_dtype = mlir_type_to_torch_dtype(op.results[1].type.element_type)
+    return values, indices.to(indices_dtype)
+
+
+def chisel_ttnn_transpose(op, inputs):
+    return transpose_golden(
+        input_tensor=inputs["input"],
+        dim0=unpack_mlir_attr(op.attributes["dim0"]),
+        dim1=unpack_mlir_attr(op.attributes["dim1"]),
+    )
+
+
+def chisel_ttnn_reshape(op, inputs):
+    return reshape_golden(
+        input_tensor=inputs["input"], shape=unpack_mlir_attr(op.attributes["shape"])
+    )
+
+
+def chisel_ttnn_permute(op, inputs):
+    return ttir_permute_golden(
+        input_tensor=inputs["input"],
+        permutation_attr=op.attributes["permutation"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_slice_static(op, inputs):
+    return ttir_slice_golden(
+        input_tensor=inputs["input"],
+        begins=op.attributes["begins"],
+        ends=op.attributes["ends"],
+        step=op.attributes["step"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_slice_dynamic(op, inputs):
+    return dynamic_slice_golden(
+        input_tensor=inputs["input"],
+        begins=inputs["begins"],
+        ends=inputs["ends"],
+        step=_attr_get_value(op.attributes, "step"),
+    )
+
+
+def chisel_ttnn_topk(op, inputs):
+    values, indices = ttir_topk_golden(
+        input_tensor=inputs["input_tensor"],
+        k_attr=op.attributes["k"],
+        dim_attr=op.attributes["dim"],
+        largest_attr=op.attributes["largest"],
+        sorted_attr=op.attributes["sorted"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+    indices_dtype = mlir_type_to_torch_dtype(op.results[1].type.element_type)
+    return values, indices.to(indices_dtype)
+
+
+def chisel_ttnn_pad(op, inputs):
+    return ttir_pad_golden(
+        input_tensor=inputs["input"],
+        padding=op.attributes["padding"],
+        value=op.attributes["value"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_softmax(op, inputs):
+    return softmax_golden(
+        input_tensor=inputs["input"],
+        dimension=unpack_mlir_attr(op.attributes["dimension"]),
+    )
+
+
+def chisel_ttnn_hardsigmoid(op, inputs):
+    return ttir_hardsigmoid_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_embedding(op, inputs):
+    return ttir_embedding_golden(
+        indices_tensor=inputs["input"],
+        weight_tensor=inputs["weight"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_embedding_backward(op, inputs):
+    return ttir_embedding_backward_golden(
+        indices_tensor=inputs["input"],
+        weight_tensor=inputs["weight"],
+        in_gradient_tensor=inputs["in_gradient"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_gelu_backward(op, inputs):
+    return ttir_gelu_backward_golden(
+        grad=inputs["lhs"],
+        input=inputs["rhs"],
+        approximate=_attr_get_value(op.attributes, "approximate", default="none"),
+    )
+
+
+def chisel_ttnn_dropout(op, inputs):
+    return ttir_dropout_golden(
+        input_tensor=inputs["input"],
+        prob=op.attributes["prob"],
+        scale=op.attributes["scale"],
+        seed=op.attributes["seed"],
+        use_per_device_seed=op.attributes["use_per_device_seed"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_global_avg_pool2d(op, inputs):
+    return global_avg_pool2d_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_max_pool2d(op, inputs):
+    # TTNN max_pool2d receives a flat [1, 1, batch*H*W, C] tensor.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    channels = unpack_mlir_attr(op.attributes["channels"])
+    kernel_size = unpack_mlir_attr(op.attributes["kernel_size"])
+    stride = unpack_mlir_attr(op.attributes["stride"])
+    dilation = unpack_mlir_attr(op.attributes["dilation"])
+    ceil_mode = unpack_mlir_attr(op.attributes["ceil_mode"])
+    padding = unpack_mlir_attr(op.attributes["padding"])
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+
+    # Unflatten to NHWC then transpose to NCHW for PyTorch pooling.
+    nhwc = _ttnn_unflatten_nhwc(
+        inputs["input"], batch_size, input_height, input_width, channels
+    )
+    nchw = nhwc.transpose(-2, -1).transpose(-3, -2)
+
+    if isinstance(padding, (list, tuple)) and len(padding) == 4:
+        top, left, bottom, right = padding
+        if top == bottom and left == right:
+            torch_padding = (top, left)
+        else:
+            nchw = F.pad(
+                nchw, [left, right, top, bottom], mode="constant", value=float("-inf")
+            )
+            torch_padding = 0
+    else:
+        torch_padding = padding
+
+    result = torch.nn.MaxPool2d(
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=torch_padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+    )(nchw)
+
+    # Transpose back to NHWC and flatten to [1, 1, batch*H_out*W_out, C].
+    result = result.transpose(-3, -2).transpose(-2, -1).to(output_dtype)
+    return _ttnn_flatten_nhwc(result)
+
+
+def chisel_ttnn_avg_pool2d(op, inputs):
+    # TTNN input/output is flat [1, 1, N*H*W, C]; unflatten to NHWC, run pool, re-flatten.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    channels = unpack_mlir_attr(op.attributes["channels"])
+    nhwc = _ttnn_unflatten_nhwc(
+        inputs["input"], batch_size, input_height, input_width, channels
+    )
+    result_nhwc = avg_pool2d_golden(
+        input_tensor=nhwc,
+        kernel=unpack_mlir_attr(op.attributes["kernel_size"]),
+        stride=unpack_mlir_attr(op.attributes["stride"]),
+        padding=unpack_mlir_attr(op.attributes["padding"]),
+        ceil_mode=unpack_mlir_attr(op.attributes["ceil_mode"]),
+        count_include_pad=_attr_get_value(
+            op.attributes, "count_include_pad", default=True
+        ),
+    )
+    return _ttnn_flatten_nhwc(result_nhwc)
+
+
+def chisel_ttnn_max_pool2d_with_indices(op, inputs):
+    # TTNN input/output is flat [1, 1, N*H*W, C]; unflatten to NHWC, run pool, re-flatten.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    channels = unpack_mlir_attr(op.attributes["channels"])
+    nhwc = _ttnn_unflatten_nhwc(
+        inputs["input"], batch_size, input_height, input_width, channels
+    )
+    # TTNN padding is [pad_H, pad_W]; expand to [top, left, bottom, right] for the golden.
+    padding = unpack_mlir_attr(op.attributes["padding"])
+    if len(padding) == 2:
+        padding = [padding[0], padding[1], padding[0], padding[1]]
+    values_nhwc, indices_nhwc = ttir_max_pool2d_with_indices(
+        nhwc,
+        op.attributes["kernel_size"],
+        op.attributes["stride"],
+        padding,
+        op.attributes["dilation"],
+        op.attributes["ceil_mode"],
+        op.results[0].type.element_type,
+    )
+    indices_dtype = mlir_type_to_torch_dtype(op.results[1].type.element_type)
+    return (
+        _ttnn_flatten_nhwc(values_nhwc),
+        _ttnn_flatten_nhwc(indices_nhwc).to(indices_dtype),
+    )
+
+
+def chisel_ttnn_conv2d(op, inputs):
+    # TTNN input/output is flat [1, 1, N*H*W, C]; unflatten to NHWC, run conv, re-flatten.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    in_channels = unpack_mlir_attr(op.attributes["in_channels"])
+    out_channels = unpack_mlir_attr(op.attributes["out_channels"])
+    kh, kw = unpack_mlir_attr(op.attributes["kernel_size"])
+    groups = unpack_mlir_attr(op.attributes["groups"])
+    nhwc = _ttnn_unflatten_nhwc(
+        inputs["input"], batch_size, input_height, input_width, in_channels
+    )
+    # TTNN weight is [1, 1, (C_in/groups)*kH*kW, C_out]; reshape to OIHW for torch conv2d.
+    in_channels_per_group = in_channels // groups
+    weight_oihw = (
+        inputs["weight"]
+        .reshape(in_channels_per_group, kh, kw, out_channels)
+        .permute(3, 0, 1, 2)
+    )
+    result_nhwc = conv2d_golden(
+        input_tensor=nhwc,
+        weight=weight_oihw,
+        bias=inputs["bias"],
+        stride=op.attributes["stride"],
+        padding=op.attributes["padding"],
+        dilation=op.attributes["dilation"],
+        groups=op.attributes["groups"],
+        batch_dim=0,
+        height_dim=1,
+        width_dim=2,
+        channel_dim=3,
+    )
+    return _ttnn_flatten_nhwc(result_nhwc)
+
+
+def chisel_ttnn_conv3d(op, inputs):
+    # TTNN conv3d receives a flat [1, 1, batch*D*H*W, C] tensor; unflatten to NDHWC.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_depth = unpack_mlir_attr(op.attributes["input_depth"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    in_channels = unpack_mlir_attr(op.attributes["in_channels"])
+    out_channels = unpack_mlir_attr(op.attributes["out_channels"])
+    kernel_size = unpack_mlir_attr(op.attributes["kernel_size"])
+    input_ndhwc = inputs["input"].reshape(
+        batch_size, input_depth, input_height, input_width, in_channels
+    )
+    # TTNN weight is [K_D*K_H*K_W*C_in, C_out]; reshape to [C_out, C_in, K_D, K_H, K_W].
+    kd, kh, kw = kernel_size
+    weight_ncdhw = (
+        inputs["weight"]
+        .transpose(0, 1)
+        .reshape(out_channels, kd, kh, kw, in_channels)
+        .permute(0, 4, 1, 2, 3)
+    )
+    result_ndhwc = conv3d_golden(
+        input_tensor=input_ndhwc,
+        weight=weight_ncdhw,
+        bias=inputs["bias"],
+        stride=op.attributes["stride"],
+        padding=op.attributes["padding"],
+        groups=op.attributes["groups"],
+        batch_dim=0,
+        depth_dim=1,
+        height_dim=2,
+        width_dim=3,
+        channel_dim=4,
+        padding_mode=op.attributes["padding_mode"],
+    )
+    # TTNN result type is NDHWC (not flat), so return as-is.
+    return result_ndhwc
+
+
+def chisel_ttnn_conv_transpose2d(op, inputs):
+    # TTNN input/output is flat [1, 1, N*H*W, C]; unflatten to NHWC, run conv, re-flatten.
+    batch_size = unpack_mlir_attr(op.attributes["batch_size"])
+    input_height = unpack_mlir_attr(op.attributes["input_height"])
+    input_width = unpack_mlir_attr(op.attributes["input_width"])
+    in_channels = unpack_mlir_attr(op.attributes["in_channels"])
+    out_channels = unpack_mlir_attr(op.attributes["out_channels"])
+    kh, kw = unpack_mlir_attr(op.attributes["kernel_size"])
+    nhwc = inputs["input"].reshape(batch_size, input_height, input_width, in_channels)
+    # TTNN weight is [1, 1, C_in*kH*kW, C_out]; reshape to IOHW for torch conv_transpose2d.
+    weight_iohw = (
+        inputs["weight"].reshape(in_channels, kh, kw, out_channels).permute(0, 3, 1, 2)
+    )
+    result_nhwc = conv_transpose2d_golden(
+        input_tensor=nhwc,
+        weight=weight_iohw,
+        bias=inputs["bias"],
+        stride=op.attributes["stride"],
+        padding=op.attributes["padding"],
+        output_padding=op.attributes["output_padding"],
+        dilation=op.attributes["dilation"],
+        groups=op.attributes["groups"],
+        batch_dim=0,
+        height_dim=1,
+        width_dim=2,
+        channel_dim=3,
+    )
+    n, h_out, w_out, c_out = result_nhwc.shape
+    return result_nhwc.reshape(1, 1, n * h_out * w_out, c_out)
+
+
+def chisel_ttnn_prepare_conv2d_weights(op, inputs):
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    out_shape = list(op.results[0].type.shape)
+    # Permute [C_out, C_in, kH, kW] -> [C_in, kH, kW, C_out] then reshape to out_shape.
+    perm = inputs["weight_tensor"].permute(1, 2, 3, 0)
+    return perm.reshape(out_shape).to(output_dtype)
+
+
+def chisel_ttnn_prepare_conv2d_bias(op, inputs):
+    return ttnn_assign_golden(
+        input_tensor=inputs["bias_tensor"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_prepare_conv_transpose2d_weights(op, inputs):
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    out_shape = list(op.results[0].type.shape)
+    # Permute [C_in, C_out, kH, kW] -> [C_in, kH, kW, C_out] then reshape to out_shape.
+    perm = inputs["weight_tensor"].permute(0, 2, 3, 1)
+    return perm.reshape(out_shape).to(output_dtype)
+
+
+def chisel_ttnn_prepare_conv_transpose2d_bias(op, inputs):
+    return ttnn_assign_golden(
+        input_tensor=inputs["bias_tensor"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_batch_norm_inference(op, inputs):
+    return ttir_batch_norm_inference_golden(
+        input_tensor=inputs["input"],
+        scale=inputs["weight"],
+        offset=inputs["bias"],
+        mean=inputs["running_mean"],
+        variance=inputs["running_var"],
+        epsilon_attr=op.attributes["epsilon"],
+        dimension_attr=1,
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_batch_norm_training(op, inputs):
+    rm = inputs["running_mean"]
+    rv = inputs["running_var"]
+    out, urm, urv = ttir_batch_norm_training_golden(
+        input_tensor=inputs["input"],
+        scale=inputs["weight"],
+        offset=inputs["bias"],
+        running_mean=rm,
+        running_variance=rv,
+        epsilon_attr=op.attributes["epsilon"],
+        dimension_attr=1,
+        momentum_attr=op.attributes["momentum"],
+        output_type_mlir=op.results[0].type.element_type,
+        mean_output_type_mlir=op.results[0].type.element_type,
+        variance_output_type_mlir=op.results[0].type.element_type,
+    )
+    # SSA result, then provided memwrite operands (see CHISEL_INPLACE_OPS).
+    returns = [out]
+    if rm is not None:
+        returns.append(urm)
+    if rv is not None:
+        returns.append(urv)
+    return tuple(returns)
+
+
+def chisel_ttnn_distributed_rms_norm(op, inputs):
+    return ttir_distributed_rms_norm_golden(
+        input=inputs["input"],
+        weight=inputs["weight"],
+        residual=inputs["residual"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        epsilon_attr=op.attributes["epsilon"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_scatter(op, inputs):
+    return ttir_scatter_golden(
+        input_tensor=inputs["input"],
+        index=inputs["index"],
+        source=inputs["source"],
+        dim=op.attributes["dim"],
+        scatter_reduce_type_attr=op.attributes["scatter_reduce_type"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_scaled_dot_product_attention(op, inputs):
+    return ttir_sdpa_golden(
+        query=inputs["query"],
+        key=inputs["key"],
+        value=inputs["value"],
+        attention_mask=inputs["attention_mask"],
+        is_causal_attr=_attr_get(op.attributes, "is_causal"),
+        scale_attr=_attr_get(op.attributes, "scale"),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_scaled_dot_product_attention_decode(op, inputs):
+    return sdpa_decode_golden(
+        query=inputs["query"],
+        key=inputs["key"],
+        value=inputs["value"],
+        cur_pos_tensor=inputs["cur_pos_tensor"],
+        attention_mask=inputs["attention_mask"],
+        is_causal=_attr_get_value(op.attributes, "is_causal", default=True),
+        scale=_attr_get_value(op.attributes, "scale"),
+    )
+
+
+def chisel_ttnn_paged_scaled_dot_product_attention_decode(op, inputs):
+    return ttir_paged_sdpa_decode_golden(
+        query=inputs["query"],
+        key=inputs["key"],
+        value=inputs["value"],
+        page_table=inputs["page_table"],
+        output=None,
+        is_causal_attr=_attr_get(op.attributes, "is_causal"),
+        attention_mask=inputs["attention_mask"],
+        cur_pos_tensor=inputs["cur_pos_tensor"],
+        attention_sink=inputs["attention_sink"],
+        scale_attr=_attr_get(op.attributes, "scale"),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_fill_cache(op, inputs):
+    return fill_cache_golden(cache_tensor=inputs["cache"], input_tensor=inputs["input"])
+
+
+def chisel_ttnn_update_cache(op, inputs):
+    return update_cache_golden(
+        cache_tensor=inputs["cache"],
+        update_tensor=inputs["input"],
+        indices_tensor=inputs["update_index"],
+        batch_offset=op.attributes["batch_offset"],
+    )
+
+
+def chisel_ttnn_paged_fill_cache(op, inputs):
+    cache = inputs["cache"]
+    if cache.device.type == "meta":
+        return cache.clone()
+    return ttir_paged_fill_cache_golden(
+        cache_tensor=cache,
+        input_tensor=inputs["input"],
+        page_table_tensor=inputs["page_table"],
+        batch_idx_tensor=inputs["batch_idx_tensor"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_paged_update_cache(op, inputs):
+    cache = inputs["cache"]
+    if cache.device.type == "meta":
+        return cache.clone()
+    return ttir_paged_update_cache_golden(
+        cache_tensor=cache,
+        input_tensor=inputs["input"],
+        update_index_tensor=inputs["update_index"],
+        share_cache_attr=_attr_get(op.attributes, "share_cache", default=False),
+        page_table_tensor=inputs["page_table"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_all_reduce(op, inputs):
+    return ttir_all_reduce_golden(
+        input=inputs["input"],
+        reduce_type_attr=op.attributes["reduce_type"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_all_to_all_dispatch(op, inputs):
+    return ttir_all_to_all_dispatch_golden(
+        input_tensor=inputs["input_tensor"],
+        expert_indices=inputs["expert_indices"],
+        expert_mapping=inputs["expert_mapping"],
+        num_devices_attr=op.attributes["num_devices"],
+        cluster_axis_attr=op.attributes["cluster_axis"],
+        dispatched_type_mlir=op.results[0].type.element_type,
+        metadata_type_mlir=op.results[1].type.element_type,
+    )
+
+
+def chisel_ttnn_all_to_all_combine(op, inputs):
+    return all_to_all_combine_golden(
+        input_tensor=inputs["input_tensor"],
+        expert_metadata=inputs["expert_metadata"],
+        expert_mapping=inputs["expert_mapping"],
+        num_devices=unpack_mlir_attr(op.attributes["num_devices"]),
+        cluster_axis=unpack_mlir_attr(op.attributes["cluster_axis"]),
+        num_experts_per_tok=unpack_mlir_attr(op.attributes["num_experts_per_tok"]),
+    )
+
+
+def chisel_ttnn_concatenate_heads(op, inputs):
+    return ttir_concatenate_heads_golden(
+        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    )
+
+
+def chisel_ttnn_split_query_key_value_and_split_heads(op, inputs):
+    return ttir_split_query_key_value_and_split_heads_golden(
+        input_tensor=inputs["input_tensor"],
+        kv_input_tensor=inputs["kv_input_tensor"],
+        num_heads_attr=op.attributes["num_heads"],
+        num_kv_heads_attr=_attr_get(op.attributes, "num_kv_heads"),
+        transpose_key_attr=op.attributes["transpose_key"],
+        query_output_type_mlir=op.results[0].type.element_type,
+        key_output_type_mlir=op.results[1].type.element_type,
+        value_output_type_mlir=op.results[2].type.element_type,
+    )
+
+
+def chisel_ttnn_topk_router_gpt(op, inputs):
+    return ttir_topk_router_gpt_golden(
+        input_tensor=inputs["input"],
+        weight_tensor=inputs["weight"],
+        bias_tensor=inputs["bias"],
+        k_attr=op.attributes["k"],
+        _num_experts_attr=op.attributes["num_experts"],
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_moe_expert_token_remap(op, inputs):
+    return ttir_moe_expert_token_remap_golden(
+        topk_tensor=inputs["topk_tensor"],
+        expert_mapping=inputs["expert_mapping"],
+        expert_metadata=inputs["expert_metadata"],
+        reduction_size=unpack_mlir_attr(op.attributes["reduction_size"]),
+    )
+
+
+def chisel_ttnn_sparse_matmul(op, inputs):
+    return sparse_matmul_golden(
+        a=inputs["a"],
+        b=inputs["b"],
+        sparsity=inputs["sparsity"],
+        is_input_a_sparse=unpack_mlir_attr(op.attributes["is_input_a_sparse"]),
+        is_input_b_sparse=unpack_mlir_attr(op.attributes["is_input_b_sparse"]),
+        nnz=_attr_get_value(op.attributes, "nnz"),
+    )
+
+
+def chisel_ttnn_upsample(op, inputs):
+    input_tensor = inputs["input"]
+    scale_factor = unpack_mlir_attr(op.attributes["scale_factor"])
+    mode = unpack_mlir_attr(op.attributes["mode"])
+    # NHWC -> NCHW for torch.interpolate.
+    nchw = input_tensor.permute(0, 3, 1, 2).float()
+    h_in, w_in = nchw.shape[2], nchw.shape[3]
+    if isinstance(scale_factor, (list, tuple)):
+        scale_h, scale_w = scale_factor[0], scale_factor[1]
+    else:
+        scale_h = scale_w = scale_factor
+    output_size = (int(h_in * scale_h), int(w_in * scale_w))
+    # align_corners=False matches the default TTNN upsample behaviour.
+    align_corners = False if mode in ("bilinear", "bicubic", "linear") else None
+    interp_kwargs = (
+        {"align_corners": align_corners} if align_corners is not None else {}
+    )
+    result_nchw = torch.nn.functional.interpolate(
+        nchw, size=output_size, mode=mode, **interp_kwargs
+    )
+    return result_nchw.permute(0, 2, 3, 1).to(input_tensor.dtype)
+
+
+def chisel_ttnn_pow_scalar(op, inputs):
+    exponent = unpack_mlir_attr(op.attributes["rhs"])
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    return torch.pow(inputs["lhs"], exponent).to(output_dtype)
+
+
+def _chisel_mesh_shape_from_op(op) -> list:
+    """Return [rows, cols] mesh shape from the device operand, or [1, 1] if absent."""
+    for operand in op.operands:
+        try:
+            defining_op = operand.owner
+            if "mesh_shape" in defining_op.attributes:
+                ms = ttnn.ir.MeshShapeAttr.maybe_downcast(
+                    defining_op.attributes["mesh_shape"]
+                )
+                return [ms.y, ms.x]
+        except Exception:
+            continue
+    return [1, 1]
+
+
+def chisel_ttnn_arange(op, inputs):
+    # TTNN ArangeOp always produces a 1D result - no arange_dimension concept.
+    start = unpack_mlir_attr(op.attributes["start"])
+    end = unpack_mlir_attr(op.attributes["end"])
+    step = unpack_mlir_attr(op.attributes["step"])
+    output_shape = list(op.results[0].type.shape)
+    output_dtype = mlir_type_to_torch_dtype(op.results[0].type.element_type)
+    mesh_shape = _chisel_mesh_shape_from_op(op)
+    result = torch.arange(start=start, end=end, step=step).to(output_dtype)
+    if list(result.shape) != output_shape:
+        result = result.reshape(output_shape)
+    num_devices = mesh_shape[0] * mesh_shape[1]
+    return GoldenMapTensor({i: result.clone() for i in range(num_devices)}, mesh_shape)
+
+
+def chisel_ttnn_full(op, inputs):
+    shape = ttnn.ir.ShapeAttr.maybe_downcast(op.attributes["shape"]).shape
+    return ttir_full_golden(
+        shape_attr=shape,
+        fill_value_attr=op.attributes["fill_value"],
+        mesh_shape_attr=_chisel_mesh_shape_from_op(op),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_ones(op, inputs):
+    shape = ttnn.ir.ShapeAttr.maybe_downcast(op.attributes["shape"]).shape
+    return ttir_ones_golden(
+        shape=shape,
+        mesh_shape_attr=_chisel_mesh_shape_from_op(op),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_zeros(op, inputs):
+    shape = ttnn.ir.ShapeAttr.maybe_downcast(op.attributes["shape"]).shape
+    return ttir_zeros_golden(
+        shape=shape,
+        mesh_shape_attr=_chisel_mesh_shape_from_op(op),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_empty(op, inputs):
+    shape = ttnn.ir.ShapeAttr.maybe_downcast(op.attributes["shape"]).shape
+    return ttir_zeros_golden(
+        shape=shape,
+        mesh_shape_attr=_chisel_mesh_shape_from_op(op),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+def chisel_ttnn_dump_tensor(op, inputs):
+    return ()
+
+
+def chisel_ttnn_rand(op, inputs):
+    size = ttnn.ir.ShapeAttr.maybe_downcast(op.attributes["size"]).shape
+    return ttir_rand_golden(
+        size=size,
+        low=op.attributes["low"],
+        high=op.attributes["high"],
+        seed=op.attributes["seed"],
+        mesh_shape_attr=_chisel_mesh_shape_from_op(op),
+        output_type_mlir=op.results[0].type.element_type,
+    )
+
+
+CHISEL_GOLDEN_MAPPINGS: Dict[type, Callable] = {
+    # Unary ops
+    ttnn.AbsOp: _chisel_unary(ttnn_abs_golden),
+    ttnn.CbrtOp: _chisel_unary(ttnn_cbrt_golden),
+    ttnn.CeilOp: _chisel_unary(ttnn_ceil_golden),
+    ttnn.CosOp: _chisel_unary(ttnn_cos_golden),
+    ttnn.AcosOp: _chisel_unary(ttnn_acos_golden),
+    ttnn.ErfOp: _chisel_unary(ttnn_erf_golden),
+    ttnn.ErfcOp: _chisel_unary(ttnn_erfc_golden),
+    ttnn.ExpOp: _chisel_unary(ttnn_exp_golden),
+    ttnn.FloorOp: _chisel_unary(ttnn_floor_golden),
+    ttnn.GeluOp: _chisel_unary(ttnn_gelu_golden),
+    ttnn.IsFiniteOp: _chisel_unary(ttnn_isfinite_golden),
+    ttnn.NegOp: _chisel_unary(ttnn_neg_golden),
+    ttnn.TanOp: _chisel_unary(ttnn_tan_golden),
+    ttnn.AtanOp: _chisel_unary(ttnn_atan_golden),
+    ttnn.TanhOp: _chisel_unary(ttnn_tanh_golden),
+    ttnn.ReciprocalOp: _chisel_unary(ttnn_reciprocal_golden),
+    ttnn.ReluOp: _chisel_unary(ttnn_relu_golden),
+    ttnn.Relu6Op: _chisel_unary(ttnn_relu6_golden),
+    ttnn.RsqrtOp: _chisel_unary(ttnn_rsqrt_golden),
+    ttnn.SigmoidOp: _chisel_unary(ttnn_sigmoid_golden),
+    ttnn.SignOp: _chisel_unary(ttnn_sign_golden),
+    ttnn.SiluOp: _chisel_unary(ttnn_silu_golden),
+    ttnn.SinOp: _chisel_unary(ttnn_sin_golden),
+    ttnn.AsinOp: _chisel_unary(ttnn_asin_golden),
+    ttnn.SqrtOp: _chisel_unary(ttnn_sqrt_golden),
+    ttnn.LogOp: _chisel_unary(ttnn_log_golden),
+    ttnn.Log1pOp: _chisel_unary(ttnn_log1p_golden),
+    ttnn.Expm1Op: _chisel_unary(ttnn_expm1_golden),
+    ttnn.MishOp: _chisel_unary(ttnn_mish_golden),
+    ttnn.LogicalNotOp: _chisel_unary(ttnn_logical_not_golden),
+    ttnn.BitwiseNotOp: _chisel_unary(ttnn_bitwise_not_golden),
+    ttnn.ToDeviceOp: _chisel_unary(ttnn_to_device_golden),
+    ttnn.FromDeviceOp: _chisel_unary(ttnn_from_device_golden),
+    # Binary ops
+    ttnn.AddOp: _chisel_binary(ttnn_add_golden),
+    ttnn.Atan2Op: _chisel_binary(ttnn_atan2_golden),
+    ttnn.MultiplyOp: _chisel_binary(ttnn_multiply_golden),
+    ttnn.SubtractOp: _chisel_binary(ttnn_subtract_golden),
+    ttnn.DivideOp: _chisel_binary(ttnn_divide_golden),
+    ttnn.MaximumOp: _chisel_binary(ttnn_maximum_golden),
+    ttnn.MinimumOp: _chisel_binary(ttnn_minimum_golden),
+    ttnn.RemainderOp: _chisel_binary(ttnn_remainder_golden),
+    ttnn.PowTensorOp: _chisel_binary(ttnn_pow_tensor_golden),
+    ttnn.EqualOp: _chisel_binary(ttnn_eq_golden),
+    ttnn.NotEqualOp: _chisel_binary(ttnn_ne_golden),
+    ttnn.GreaterEqualOp: _chisel_binary(ttnn_ge_golden),
+    ttnn.GreaterThanOp: _chisel_binary(ttnn_gt_golden),
+    ttnn.LessEqualOp: _chisel_binary(ttnn_le_golden),
+    ttnn.LessThanOp: _chisel_binary(ttnn_lt_golden),
+    ttnn.LogicalAndOp: _chisel_binary(ttnn_logical_and_golden),
+    ttnn.LogicalOrOp: _chisel_binary(ttnn_logical_or_golden),
+    ttnn.LogicalXorOp: _chisel_binary(ttnn_logical_xor_golden),
+    ttnn.LogicalLeftShiftOp: _chisel_binary(
+        ttnn_logical_left_shift_golden, rhs_kwarg="shift_tensor"
+    ),
+    ttnn.LogicalRightShiftOp: _chisel_binary(
+        ttnn_logical_right_shift_golden, rhs_kwarg="shift_tensor"
+    ),
+    ttnn.BitwiseAndOp: _chisel_binary(ttnn_bitwise_and_golden),
+    ttnn.BitwiseOrOp: _chisel_binary(ttnn_bitwise_or_golden),
+    ttnn.BitwiseXorOp: _chisel_binary(ttnn_bitwise_xor_golden),
+    # Ternary ops
+    ttnn.WhereOp: chisel_ttnn_where,
+    ttnn.ClampTensorOp: chisel_ttnn_clamp_tensor,
+    # Type / layout ops
+    ttnn.TypecastOp: chisel_ttnn_typecast,
+    ttnn.ToLayoutOp: chisel_ttnn_to_layout,
+    # Unary + scalar attrs
+    ttnn.LeakyReluOp: chisel_ttnn_leaky_relu,
+    ttnn.ClampScalarOp: chisel_ttnn_clamp_scalar,
+    ttnn.RepeatInterleaveOp: chisel_ttnn_repeat_interleave,
+    # Binary + attrs
+    ttnn.MatmulOp: chisel_ttnn_matmul,
+    # Variadic + attrs
+    ttnn.ConcatOp: chisel_ttnn_concat,
+    ttnn.RepeatOp: chisel_ttnn_repeat,
+    # Optional tensors + attrs
+    ttnn.LinearOp: chisel_ttnn_linear,
+    ttnn.LayerNormOp: chisel_ttnn_layer_norm,
+    ttnn.LayerNormPreAllGatherOp: chisel_ttnn_layer_norm_pre_all_gather,
+    ttnn.LayerNormPostAllGatherOp: chisel_ttnn_layer_norm_post_all_gather,
+    ttnn.GroupNormOp: chisel_ttnn_group_norm,
+    ttnn.RMSNormOp: chisel_ttnn_rms_norm,
+    # CCL ops
+    ttnn.DistributeTensorOp: chisel_ttnn_distribute_tensor,
+    ttnn.AggregateTensorOp: chisel_ttnn_aggregate_tensor,
+    ttnn.AllGatherOp: chisel_ttnn_all_gather,
+    ttnn.ReduceScatterOp: chisel_ttnn_reduce_scatter,
+    ttnn.AllReduceAsyncOp: chisel_ttnn_all_reduce_async,
+    # Index-based
+    ttnn.GatherOp: chisel_ttnn_gather,
+    # Attention
+    ttnn.PagedFlashMultiLatentAttentionDecodeOp: chisel_ttnn_paged_flash_multi_latent_attention_decode,
+    # Layout / memory ops
+    ttnn.AssignOp: chisel_ttnn_assign,
+    ttnn.ToMemoryConfigOp: chisel_ttnn_to_memory_config,
+    ttnn.DeallocateOp: chisel_ttnn_deallocate,
+    # Reduction ops
+    ttnn.SumOp: chisel_ttnn_sum,
+    ttnn.MeanOp: chisel_ttnn_mean,
+    ttnn.MaxOp: chisel_ttnn_max,
+    ttnn.MinOp: chisel_ttnn_min,
+    ttnn.ProdOp: chisel_ttnn_prod,
+    ttnn.ArgMaxOp: chisel_ttnn_argmax,
+    ttnn.CumSumOp: chisel_ttnn_cumsum,
+    ttnn.SortOp: chisel_ttnn_sort,
+    # Shape/layout ops
+    ttnn.TransposeOp: chisel_ttnn_transpose,
+    ttnn.ReshapeOp: chisel_ttnn_reshape,
+    ttnn.PermuteOp: chisel_ttnn_permute,
+    ttnn.SliceStaticOp: chisel_ttnn_slice_static,
+    ttnn.SliceDynamicOp: chisel_ttnn_slice_dynamic,
+    ttnn.TopKOp: chisel_ttnn_topk,
+    ttnn.PadOp: chisel_ttnn_pad,
+    ttnn.SoftmaxOp: chisel_ttnn_softmax,
+    # NN / activation ops
+    ttnn.HardsigmoidOp: chisel_ttnn_hardsigmoid,
+    ttnn.EmbeddingOp: chisel_ttnn_embedding,
+    ttnn.EmbeddingBackwardOp: chisel_ttnn_embedding_backward,
+    ttnn.GeluBackwardOp: chisel_ttnn_gelu_backward,
+    ttnn.DropoutOp: chisel_ttnn_dropout,
+    # Conv/Pool ops
+    ttnn.GlobalAvgPool2dOp: chisel_ttnn_global_avg_pool2d,
+    ttnn.MaxPool2dOp: chisel_ttnn_max_pool2d,
+    ttnn.AvgPool2dOp: chisel_ttnn_avg_pool2d,
+    ttnn.MaxPool2dWithIndicesOp: chisel_ttnn_max_pool2d_with_indices,
+    ttnn.Conv2dOp: chisel_ttnn_conv2d,
+    ttnn.Conv3dOp: chisel_ttnn_conv3d,
+    ttnn.ConvTranspose2dOp: chisel_ttnn_conv_transpose2d,
+    ttnn.PrepareConv2dWeightsOp: chisel_ttnn_prepare_conv2d_weights,
+    ttnn.PrepareConv2dBiasOp: chisel_ttnn_prepare_conv2d_bias,
+    ttnn.PrepareConvTranspose2dWeightsOp: chisel_ttnn_prepare_conv_transpose2d_weights,
+    ttnn.PrepareConvTranspose2dBiasOp: chisel_ttnn_prepare_conv_transpose2d_bias,
+    # BatchNorm / DistRMSNorm / Scatter
+    ttnn.BatchNormInferenceOp: chisel_ttnn_batch_norm_inference,
+    ttnn.BatchNormTrainingOp: chisel_ttnn_batch_norm_training,
+    ttnn.DistributedRMSNormOp: chisel_ttnn_distributed_rms_norm,
+    ttnn.ScatterOp: chisel_ttnn_scatter,
+    # SDPA / Attention ops
+    ttnn.ScaledDotProductAttentionOp: chisel_ttnn_scaled_dot_product_attention,
+    ttnn.ScaledDotProductAttentionDecodeOp: chisel_ttnn_scaled_dot_product_attention_decode,
+    ttnn.PagedScaledDotProductAttentionDecodeOp: chisel_ttnn_paged_scaled_dot_product_attention_decode,
+    # Cache ops
+    ttnn.FillCacheOp: chisel_ttnn_fill_cache,
+    ttnn.UpdateCacheOp: chisel_ttnn_update_cache,
+    ttnn.PagedFillCacheOp: chisel_ttnn_paged_fill_cache,
+    ttnn.PagedUpdateCacheOp: chisel_ttnn_paged_update_cache,
+    # CCL ops
+    ttnn.AllReduceOp: chisel_ttnn_all_reduce,
+    ttnn.AllToAllDispatchOp: chisel_ttnn_all_to_all_dispatch,
+    ttnn.AllToAllCombineOp: chisel_ttnn_all_to_all_combine,
+    # NLP / attention-specific ops
+    ttnn.ConcatenateHeadsOp: chisel_ttnn_concatenate_heads,
+    ttnn.SplitQueryKeyValueAndSplitHeadsOp: chisel_ttnn_split_query_key_value_and_split_heads,
+    ttnn.TopKRouterGptOp: chisel_ttnn_topk_router_gpt,
+    ttnn.MoeExpertTokenRemapOp: chisel_ttnn_moe_expert_token_remap,
+    ttnn.SparseMatmulOp: chisel_ttnn_sparse_matmul,
+    # Remaining ops
+    ttnn.UpsampleOp: chisel_ttnn_upsample,
+    ttnn.PowScalarOp: chisel_ttnn_pow_scalar,
+    # Tensor creation stubs
+    ttnn.ArangeOp: chisel_ttnn_arange,
+    ttnn.FullOp: chisel_ttnn_full,
+    ttnn.OnesOp: chisel_ttnn_ones,
+    ttnn.ZerosOp: chisel_ttnn_zeros,
+    ttnn.RandOp: chisel_ttnn_rand,
+    # Tensor creation ops
+    ttnn.EmptyOp: chisel_ttnn_empty,
+    # Side-effect-only ops (no result)
+    ttnn.DumpTensorOp: chisel_ttnn_dump_tensor,
+    # Debug ops
+    debug.AnnotateOp: chisel_debug_annotate,
+    debug.RegionStartOp: chisel_debug_region_start,
+    debug.RegionEndOp: chisel_debug_region_end,
+}
+
+
+def get_chisel_golden_function(op_class: type) -> Optional[Callable]:
+    """Return the chisel golden for `op_class`, or None if unregistered."""
+    return CHISEL_GOLDEN_MAPPINGS.get(op_class, None)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -3,12 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Golden function mappings for TTIR and StableHLO operations.
+Golden function mappings for TTIR, StableHLO, TTNN, and related dialects.
 
-This module provides a centralized mapping between TTIR and StableHLO operations and their
-corresponding PyTorch golden reference implementations. Each golden function
-serves as a reference implementation that produces the expected output for
-comparison with TTIR or StableHLO operation results.
+Two registries live here, split by calling convention rather than by dialect:
+
+- ``GOLDEN_MAPPINGS`` — keyed by op class across all supported dialects
+  (TTIR, StableHLO, TTNN, D2M, SDY, Debug). Goldens take torch values plus raw
+  MLIR attributes; consumed by the builders in ``tools/builder/`` while
+  constructing IR.
+- ``CHISEL_GOLDEN_MAPPINGS`` — keyed by TTNN op class. Goldens take
+  ``(op, inputs: Dict[str, GoldenMapTensor])`` and return one tensor per SSA
+  result followed by one per provided in-place operand; consumed by
+  ``tools/chisel/chisel/executor.py`` when replaying flatbuffers.
+
+Each golden function is a PyTorch reference implementation that produces the
+expected output for comparison with the corresponding op's result.
 """
 
 from __future__ import annotations
@@ -1474,12 +1483,12 @@ def ttir_all_to_all_dispatch_metadata_golden(
     """Cross-shard golden for all_to_all_dispatch_metadata.
 
     Mirrors tt-metal's gen_tensors_for_metadata_op / get_output_tensor:
-    - Dispatched: sparse routing - for each token and each of its K selected
+    - Dispatched: sparse routing — for each token and each of its K selected
       experts, the token is placed on the device that owns that expert.
       Non-routed slots are filled with zeros.
-    - Indices (metadata): all-gathered - every ring device gets the full set
+    - Indices (metadata): all-gathered — every ring device gets the full set
       of expert indices from all ring devices.
-    - Scores: all-gathered - same as indices.
+    - Scores: all-gathered — same as indices.
 
     expert_mapping has new format [1, 1, D, E] where entry [0, 0, d, e] is
     the linearized device ID that owns expert e (same for all d).
@@ -1494,11 +1503,11 @@ def ttir_all_to_all_dispatch_metadata_golden(
     grouped_indices = expert_indices.group_by_axis(cluster_axis)
     grouped_scores = expert_scores.group_by_axis(cluster_axis)
 
-    # expert_mapping is replicated - get from any device
+    # expert_mapping is replicated — get from any device
     mapping_tensor = list(expert_mapping._shard_map.values())[0]
-    # Shape is [1, 1, D, E] - squeeze to [D, E], use row 0 since all rows identical
+    # Shape is [1, 1, D, E] — squeeze to [D, E], use row 0 since all rows identical
     mapping_2d = mapping_tensor.reshape(-1, mapping_tensor.shape[-1])  # [D, E]
-    mapping_row = mapping_2d[0]  # [E] - mapping_row[e] = device_id owning expert e
+    mapping_row = mapping_2d[0]  # [E] — mapping_row[e] = device_id owning expert e
 
     out_dispatched = {}
     out_indices = {}
@@ -6855,7 +6864,7 @@ def ttnn_layer_norm_post_all_gather_golden(
     # then applies standard layer normalization.  Rather than replicating the
     # kernel's tiled-reduce logic (which depends on tile width, device count
     # and a bfloat16 scaler), we compute the reference output directly using
-    # the input tensor - exactly as tt-metal's own test does.
+    # the input tensor — exactly as tt-metal's own test does.
     del stats
 
     epsilon = unpack_mlir_attr(epsilon)
@@ -7387,13 +7396,7 @@ def ttir_sdpa_golden(
         seq_len_q = qk.shape[-2]
         seq_len_k = qk.shape[-1]
         causal_mask = torch.triu(
-            torch.full(
-                (seq_len_q, seq_len_k),
-                float("-inf"),
-                dtype=qk.dtype,
-                device=qk.device,
-            ),
-            diagonal=1,
+            torch.full((seq_len_q, seq_len_k), float("-inf")), diagonal=1
         )
         qk = torch.add(qk, causal_mask)
 
@@ -7766,7 +7769,7 @@ GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttir.DotGeneralOp: ttir_dot_general_golden,
     ttir.ScatterOp: ttir_scatter_golden,
     ttir.GatherOp: ttir_gather_golden,
-    # Layout operations (identity functions) - accept and ignore extra kwargs like reinterpretLayout
+    # Layout operations (identity functions) — accept and ignore extra kwargs like reinterpretLayout
     ttir.ToLayoutOp: ttir_to_layout_golden,
     # Cache operations
     ttir.FillCacheOp: fill_cache_golden,
@@ -8008,18 +8011,6 @@ def get_golden_function(ttir_op_class: type, **kwargs) -> Optional[Callable]:
     assert False, f"No golden function found for TTIR operation: {ttir_op_class}"
 
 
-def ttnn_assign_golden(
-    input_tensor: GoldenMapTensor, output_type_mlir: Type
-) -> GoldenMapTensor:
-    return input_tensor.clone().to(mlir_type_to_torch_dtype(output_type_mlir))
-
-
-def ttnn_to_memory_config_golden(
-    input_tensor: GoldenMapTensor, output_type_mlir: Type
-) -> GoldenMapTensor:
-    return input_tensor.clone().to(mlir_type_to_torch_dtype(output_type_mlir))
-
-
 # Chisel golden interface: fn(op, inputs: Dict[str, GoldenMapTensor]) -> GoldenMapTensor | tuple
 
 
@@ -8152,14 +8143,14 @@ def chisel_debug_region_end(op, inputs):
 
 
 def chisel_ttnn_assign(op, inputs):
-    return ttnn_assign_golden(
-        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    return inputs["input"].clone().to(
+        mlir_type_to_torch_dtype(op.results[0].type.element_type)
     )
 
 
 def chisel_ttnn_to_memory_config(op, inputs):
-    return ttnn_to_memory_config_golden(
-        input_tensor=inputs["input"], output_type_mlir=op.results[0].type.element_type
+    return inputs["input"].clone().to(
+        mlir_type_to_torch_dtype(op.results[0].type.element_type)
     )
 
 
@@ -8207,17 +8198,6 @@ def chisel_ttnn_layer_norm_post_all_gather(op, inputs):
         stats=inputs["stats"],
         weight=inputs["weight"],
         bias=inputs["bias"],
-        epsilon=op.attributes["epsilon"],
-        output_type_mlir=op.results[0].type.element_type,
-    )
-
-
-def chisel_ttnn_group_norm(op, inputs):
-    return ttnn_group_norm_golden(
-        input=inputs["input"],
-        weight=inputs["input_mask"],
-        bias=inputs["weight"],
-        num_groups=op.attributes["num_groups"],
         epsilon=op.attributes["epsilon"],
         output_type_mlir=op.results[0].type.element_type,
     )
@@ -8637,17 +8617,18 @@ def chisel_ttnn_conv3d(op, inputs):
     input_width = unpack_mlir_attr(op.attributes["input_width"])
     in_channels = unpack_mlir_attr(op.attributes["in_channels"])
     out_channels = unpack_mlir_attr(op.attributes["out_channels"])
+    groups = unpack_mlir_attr(op.attributes["groups"])
     kernel_size = unpack_mlir_attr(op.attributes["kernel_size"])
     input_ndhwc = inputs["input"].reshape(
         batch_size, input_depth, input_height, input_width, in_channels
     )
-    # TTNN weight is [K_D*K_H*K_W*C_in, C_out]; reshape to [C_out, C_in, K_D, K_H, K_W].
+    # TTNN weight is [K_D*K_H*K_W*(C_in/groups), C_out]; reshape to OIDHW for torch conv3d.
     kd, kh, kw = kernel_size
+    in_channels_per_group = in_channels // groups
     weight_ncdhw = (
         inputs["weight"]
-        .transpose(0, 1)
-        .reshape(out_channels, kd, kh, kw, in_channels)
-        .permute(0, 4, 1, 2, 3)
+        .reshape(kd, kh, kw, in_channels_per_group, out_channels)
+        .permute(4, 3, 0, 1, 2)
     )
     result_ndhwc = conv3d_golden(
         input_tensor=input_ndhwc,
@@ -8707,9 +8688,8 @@ def chisel_ttnn_prepare_conv2d_weights(op, inputs):
 
 
 def chisel_ttnn_prepare_conv2d_bias(op, inputs):
-    return ttnn_assign_golden(
-        input_tensor=inputs["bias_tensor"],
-        output_type_mlir=op.results[0].type.element_type,
+    return inputs["bias_tensor"].clone().to(
+        mlir_type_to_torch_dtype(op.results[0].type.element_type)
     )
 
 
@@ -8722,9 +8702,8 @@ def chisel_ttnn_prepare_conv_transpose2d_weights(op, inputs):
 
 
 def chisel_ttnn_prepare_conv_transpose2d_bias(op, inputs):
-    return ttnn_assign_golden(
-        input_tensor=inputs["bias_tensor"],
-        output_type_mlir=op.results[0].type.element_type,
+    return inputs["bias_tensor"].clone().to(
+        mlir_type_to_torch_dtype(op.results[0].type.element_type)
     )
 
 
@@ -8757,7 +8736,6 @@ def chisel_ttnn_batch_norm_training(op, inputs):
         mean_output_type_mlir=op.results[0].type.element_type,
         variance_output_type_mlir=op.results[0].type.element_type,
     )
-    # SSA result, then provided memwrite operands (see CHISEL_INPLACE_OPS).
     returns = [out]
     if rm is not None:
         returns.append(urm)
@@ -9145,7 +9123,6 @@ CHISEL_GOLDEN_MAPPINGS: Dict[type, Callable] = {
     ttnn.LayerNormOp: chisel_ttnn_layer_norm,
     ttnn.LayerNormPreAllGatherOp: chisel_ttnn_layer_norm_pre_all_gather,
     ttnn.LayerNormPostAllGatherOp: chisel_ttnn_layer_norm_post_all_gather,
-    ttnn.GroupNormOp: chisel_ttnn_group_norm,
     ttnn.RMSNormOp: chisel_ttnn_rms_norm,
     # CCL ops
     ttnn.DistributeTensorOp: chisel_ttnn_distribute_tensor,


### PR DESCRIPTION
## Summary
- Register ~140 TTNN ops in a new `CHISEL_GOLDEN_MAPPINGS` table with a chisel-shaped interface: `fn(op, inputs) -> GoldenMapTensor | tuple`.
- Add `chisel/executor.py` to re-key SSA inputs by operand role, run the registered golden, and normalize results to `(SSA outputs..., mutated in-place operands...)`.
- Classify TTNN ops in `chisel/ops.py` as non-executable (device / I/O / control flow) or in-place (operands written via `MemWrite`); add `GoldenNotImplementedError` and switch `IRModule` to a module-wide `AsmState`.
- Add `test_golden_execution.py`: run every TTNN op in a flatbuffer on meta tensors and assert output shapes/dtypes match the MLIR types.
- Drive-by golden fixes: `argmax` `None` dim, `batch_norm_training` running-stat update, `sdpa` causal-mask dtype/device.

## Follow-ups
- Unify `CHISEL_GOLDEN_MAPPINGS` with the existing `GOLDEN_MAPPINGS` into a single registry once the interfaces converge.
- Add goldens for the remaining ops currently listed in `_KNOWN_NOT_IMPLEMENTED_OPS`, grouped into:
  - **Constant ops**: `ttnn.constant` — needs custom handling since it materializes a value rather than transforming inputs.
  - **Quantization ops**: `ttnn.quantize`, `ttnn.dequantize`, `ttnn.requantize` — blocked on chisel-side support for quantized tensor element types.
  - **LLM-specific ops**: `ttnn.nlp_create_qkv_heads_decode`, `ttnn.nlp_concat_heads`, `ttnn.nlp_concat_heads_decode`, `ttnn.rotary_embedding_llama`.
  - **Multichip ops**: `ttnn.mesh_shard`, `ttnn.mesh_partition` (and other CCL/distribution ops as we extend coverage).
