### PR TITLE
[ttnn-jit] Fix JIT perf collection reporting 0 ns / 0 programs

### DIFF
--- a/test/ttnn-jit/perf_ci/conftest.py
+++ b/test/ttnn-jit/perf_ci/conftest.py
@@ -37,9 +37,22 @@ def perf_device(request):
     """Open a device, yield it, then read profiler data and close.
 
     After the test body runs, we synchronize + read the device profiler so
-    ``get_latest_programs_perf_data`` returns only the ops from *this* test.
+    we can aggregate the ops executed during *this* test.
     Requires TT_METAL_DEVICE_PROFILER=1, TT_METAL_PROFILER_MID_RUN_DUMP=1,
     and TT_METAL_PROFILER_CPP_POST_PROCESS=1.
+
+    Note: we use ``get_all_programs_perf_data`` (not
+    ``get_latest_programs_perf_data``) because the JIT path runs through
+    ``tt::runtime::ttnn::ProgramExecutor::execute()``, which already triggers
+    an end-of-program ``ReadMeshDeviceProfilerResults`` when the runtime is
+    built with ``TT_RUNTIME_ENABLE_PERF_TRACE=ON`` (see
+    ``runtime/lib/ttnn/program_executor.cpp::readProfilerDataIfNeeded``).
+    The subsequent ``ttnn.ReadDeviceProfiler(device)`` call here would then
+    push an *empty* set as the "latest" entry, hiding the real JIT data.
+    Aggregating across all entries via ``get_all_programs_perf_data`` is
+    safe because the device profiler resets
+    ``device_programs_perf_analyses_map[device_id]`` whenever a device is
+    re-opened, so each test starts from a clean slate.
     """
     device = ttnn.open_device(device_id=0)
     yield device
@@ -49,7 +62,7 @@ def perf_device(request):
     try:
         ttnn.synchronize_device(device)
         ttnn.ReadDeviceProfiler(device)
-        data = ttnn.get_latest_programs_perf_data()
+        data = ttnn.get_all_programs_perf_data()
         for programs in data.values():
             for program in programs:
                 num_programs += 1


### PR DESCRIPTION
## Problem

In `run_perf_collect.sh`, every `[JIT]` test was reported as `0 ns (0 program(s)) [SKIPPED]` while `[TTNN]` tests reported real numbers, so the resulting Superset reports were missing all `jit_kernel_duration_ns` and `perf_ratio` measurements.

## Root cause

The runtime is built with `TT_RUNTIME_ENABLE_PERF_TRACE=ON`, so `ProgramExecutor::execute()` performs a forced end-of-program `ReadMeshDeviceProfilerResults` (`runtime/lib/ttnn/program_executor.cpp:231`). For JIT tests this:

1. Reads device markers and pushes one **non-empty** `ProgramAnalysisData` set into `device_programs_perf_analyses_map[device_id]`, then clears the device markers.
2. The `perf_device` fixture then calls `ttnn.ReadDeviceProfiler(device)`, which pushes a second, **empty** set (markers were just cleared).
3. `ttnn.get_latest_programs_perf_data()` returns `.back()` — the empty set.

Plain TTNN tests don't go through `ProgramExecutor`, so step 1 never happens and `latest` is correct.

## Fix

`test/ttnn-jit/perf_ci/conftest.py`: switch from `get_latest_programs_perf_data()` to `get_all_programs_perf_data()`. The aggregated view merges both pushes; the empty set is a no-op, and the real data survives. `DeviceProfiler`'s constructor resets the map per device-open, so each test still starts clean.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] [Nightly run](https://github.com/tenstorrent/tt-mlir/actions/runs/25678590475)
