### PR TITLE
[d2m] remove pack_done init from unpack_stall_on_pack

### DIFF
--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_reg_api.h
@@ -11,7 +11,6 @@ namespace experimental {
 // committed to L1. Call this before unpacking data that was just packed
 // by the previous linalg.generic to guarantee L1 read-after-write ordering.
 ALWI void unpack_stall_on_pack() {
-  PACK(t6_semaphore_init(semaphore::PACK_DONE, 0, 1));
   PACK(t6_semaphore_post<>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE));
   UNPACK(t6_semaphore_get<>(semaphore::PACK_DONE));


### PR DESCRIPTION
`PACK_DONE` is now properly initialized after this [tt-metal PR](https://github.com/tenstorrent/tt-metal/pull/43570).
