### PR TITLE
[D2M] Make remote_load/remote_store truly DPS after bufferization

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1753,12 +1753,22 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
       operation has multiple modes; the explicit CB form and unicast/multicast
       modes are both orthogonal and can be mixed and matched.
 
-      The basic form takes a local buffer as input and loads data into it:
+      The basic form takes a local buffer as input and loads data into it.
+      In tensor form (pre-bufferization), the op produces a result that aliases
+      the local buffer:
+
+      ```mlir
+      %result = d2m.remote_load %buffer %generic_operand[%i, %j]
+        : tensor<SY x SX x f32, ...>, tensor<GY x GX x SY x SX x f32, ...>
+        -> tensor<SY x SX x f32, ...>
+      ```
+
+      In memref form (post-bufferization), the op has no result; data is loaded
+      in-place into the local buffer:
 
       ```mlir
       d2m.remote_load %buffer %generic_operand[%i, %j]
         : memref<SY x SX x f32, ...>, memref<GY x GX x SY x SX x f32, ...>
-        -> memref<SY x SX x f32, ...>
       ```
 
       The explicit CB form takes a CB (from `d2m.get_cb`) as additional input;
@@ -1770,8 +1780,9 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
         : memref<GY x GX x SY x SX x f32, ...> into !d2m.cb<memref<SY x SX x f32, ...>>
       ```
 
-      In implicit form, the result matches the shard memref/tensor type and aliases
-      the input buffer.
+      In implicit tensor form (pre-bufferization), the result matches the shard
+      tensor type and aliases the input buffer. In implicit memref form
+      (post-bufferization), there is no result.
 
       ## High-Level Multicast Mode
 
@@ -1785,13 +1796,12 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
       NOTE: If implementing the high-level multicast is not feasible, the
       operation will be lowered to an equivalent unicast remote load instead.
 
-      Example with high-level multicast (implicit form):
+      Example with high-level multicast (implicit memref form):
 
       ```mlir
       // Cooperative multicast along dimension 0
       d2m.remote_load %buffer %memref[%i, %j] mcast[%c0]
         : memref<4x6xf32, #l1_>, memref<2x4x4x6xf32, #ttcore.shard<...>, #dram>
-        -> memref<4x6xf32, #l1_>
       ```
 
       ## Low-Level Multicast Mode
@@ -1809,13 +1819,12 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
         starting at `mcastStartIndex` with shape `mcastShape`
         - Receivers wait for the sender to complete
 
-      Example with low-level multicast (implicit form):
+      Example with low-level multicast (implicit memref form):
 
       ```mlir
       // Core 0 gathers and multicasts to a 1x4 region starting at mcore[0, 1]
       d2m.remote_load %buffer %memref[%i, %j] mcore[%c0, %c1] mshape[%c1, %c4]
         : memref<4x6xf32, #l1_>, memref<2x4x4x6xf32, #ttcore.shard<...>, #dram>
-        -> memref<4x6xf32, #l1_>
       ```
 
       Constraints:
@@ -2058,24 +2067,35 @@ def D2M_RemoteStoreOp : D2M_GenericRegionDatamovementOp<"remote_store",
       - Implicit form takes a plain memref/tensor as input to store; it doesn't
       assume a particular buffering implementation (CBs, scratchpad, etc).
 
+      In tensor form (pre-bufferization), the op produces a result that aliases
+      the operand:
+
+      ```mlir
+      // For an operand with device shape (GY x GX) x (SY x SX)
+      %result = d2m.remote_store %generic_operand[%i, %j] %buf
+        : tensor<GY x GX x SY x SX x f32, ...>, tensor<SY x SX x f32, ...>
+        -> tensor<GY x GX x SY x SX x f32, ...>
+      ```
+
+      In memref form (post-bufferization), the op has no result:
+
       ```mlir
       // For an operand with device shape (GY x GX) x (SY x SX)
       d2m.remote_store %generic_operand[%i, %j] %buf
         : memref<GY x GX x SY x SX x f32, ...>, memref<SY x SX x f32, ...>
-        -> memref<GY x GX x SY x SX x f32, ...>
       ```
 
       - Explicit CB form stores data from a concrete CB (from `d2m.get_cb`) to the remote operand.
 
       ```mlir
       d2m.remote_store %generic_operand[%i, %j] from %cb
-        : memref<GY x GX x SY x SX x f32, ...>, !d2m.cb<memref<SY x SX x f32, ...>>
-        -> memref<GY x GX x SY x SX x f32, ...>
+        : memref<GY x GX x SY x SX x f32, ...> from !d2m.cb<memref<SY x SX x f32, ...>>
       ```
 
-      In both forms, the result matches the type of the operand memref/tensor.
-      This allows using the result as yield value in a generic region, as well
-      as forming a complete use-chain from remote_load to remote_store.
+      In tensor form (pre-bufferization), the result matches the type of the
+      operand tensor, allowing it to be used as a yield value in a generic region
+      and forming a complete use-chain from remote_load to remote_store. In memref
+      form (post-bufferization), there is no result.
 
       Constraints:
       - The number of indices must equal N/2, where N is the memref/tensor rank.

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -1878,6 +1878,23 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
                      "ValueRange":$mcastDims),
       [{
         build($_builder, $_state, resultType, localBuffer, memref, indices, /*cb=*/Value{}, ValueRange(), ValueRange(), mcastDims);
+      }]>,
+      // Memref form, no result (post-bufferization DPS form)
+      OpBuilder<(ins "Value":$localBuffer, "Value":$memref, "ValueRange":$indices),
+      [{
+        build($_builder, $_state, /*result=*/TypeRange{}, localBuffer, memref, indices, /*cb=*/Value{}, ValueRange(), ValueRange(), ValueRange());
+      }]>,
+      // Memref form with low-level multicast, no result
+      OpBuilder<(ins "Value":$localBuffer, "Value":$memref, "ValueRange":$indices,
+                     "ValueRange":$mcastStartIndex, "ValueRange":$mcastShape),
+      [{
+        build($_builder, $_state, /*result=*/TypeRange{}, localBuffer, memref, indices, /*cb=*/Value{}, mcastStartIndex, mcastShape, ValueRange());
+      }]>,
+      // Memref form with high-level multicast, no result
+      OpBuilder<(ins "Value":$localBuffer, "Value":$memref, "ValueRange":$indices,
+                     "ValueRange":$mcastDims),
+      [{
+        build($_builder, $_state, /*result=*/TypeRange{}, localBuffer, memref, indices, /*cb=*/Value{}, ValueRange(), ValueRange(), mcastDims);
       }]>
     ];
 
@@ -1971,8 +1988,15 @@ def D2M_RemoteLoadOp : D2M_GenericRegionDatamovementOp<"remote_load",
       /// Returns the affine map operands (the grid indices).
       Operation::operand_range getMapOperands() { return getIndices(); }
 
-      /// Returns the value read by this operation.
-      Value getValue() { return getResult(); }
+      /// Returns the value read by this operation. In tensor form this is
+      /// the SSA result; in the post-bufferization memref form (no result),
+      /// the destination localBuffer plays that role.
+      Value getValue() {
+        if (Value result = getResult()) {
+          return result;
+        }
+        return getLocalBuffer();
+      }
 
       /// Returns an AffineMapAttr wrapping the affine map for this operation.
       AffineMapAttr getAffineMapAttr() {
@@ -2095,6 +2119,11 @@ def D2M_RemoteStoreOp : D2M_GenericRegionDatamovementOp<"remote_store",
       [{
         build($_builder, $_state, resultType, memref, indices, localBuffer, /*cb=*/Value{}, startDevice, deviceMcastShape, semaphore, semaphoreIndices);
       }]>
+      // Implicit memref form (no result, DPS form) does not have a dedicated
+      // convenience builder because its C++ signature would overlap with the
+      // existing CB-form builder above (both are (Value, ValueRange, Value)).
+      // Callers should use the raw build() entry point with an explicit
+      // TypeRange{} for results.
     ];
 
     let assemblyFormat = [{

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -579,8 +579,24 @@ bool LocalCopyOp::hasTensorSemantics() {
         "explicit CB form cannot have a result; result must only be present in "
         "implicit form.");
   }
-  if (hasLocalBuffer && !hasResultValue) {
-    return emitOpError("implicit form (with localBuffer) must have a result.");
+
+  // In implicit form, result presence is tied to the localBuffer's type:
+  //   - tensor localBuffer (pre-bufferization): result required (tensor SSA
+  //     value for downstream consumers).
+  //   - memref localBuffer (post-bufferization, DPS form): result absent; the
+  //     localBuffer itself is the destination.
+  if (hasLocalBuffer) {
+    bool localBufferIsTensor =
+        mlir::isa<RankedTensorType>(localBuffer.getType());
+    if (localBufferIsTensor && !hasResultValue) {
+      return emitOpError(
+          "implicit tensor form (with tensor localBuffer) must have a result.");
+    }
+    if (!localBufferIsTensor && hasResultValue) {
+      return emitOpError(
+          "implicit memref form (with memref localBuffer) must not have a "
+          "result; the localBuffer is the destination (DPS form).");
+    }
   }
 
   // Verify that tensor parameters are not allowed in explicit CB form
@@ -802,17 +818,31 @@ void WriteColMaskTileOp::getEffects(
         "present");
   }
 
-  // Verify result presence constraints (mirror RemoteLoadOp)
+  // Verify result presence constraints (mirror RemoteLoadOp).
   // Explicit CB form: CB present, localBuffer absent, result must NOT be
-  // present Implicit form: localBuffer present, CB absent, result MUST be
-  // present
+  // present.
+  // Implicit form: localBuffer present, CB absent. Result presence is tied
+  // to the destination memref's type:
+  //   - tensor memref (pre-bufferization): result required (tensor SSA value
+  //     consumed by yield).
+  //   - memref destination (post-bufferization, DPS form): result absent; the
+  //     destination memref itself is the result.
   if (hasCbOperand && hasResultValue) {
     return emitOpError(
         "explicit CB form cannot have a result; result must only be present in "
         "implicit form.");
   }
-  if (hasLocalBufferOperand && !hasResultValue) {
-    return emitOpError("implicit form (with localBuffer) must have a result.");
+  if (hasLocalBufferOperand) {
+    bool memrefIsTensor = mlir::isa<RankedTensorType>(getMemref().getType());
+    if (memrefIsTensor && !hasResultValue) {
+      return emitOpError(
+          "implicit tensor form (with tensor destination) must have a result.");
+    }
+    if (!memrefIsTensor && hasResultValue) {
+      return emitOpError(
+          "implicit memref form (with memref destination) must not have a "
+          "result; the destination memref is the result (DPS form).");
+    }
   }
 
   // Verify that tensor parameters are not allowed in explicit CB form
@@ -941,24 +971,13 @@ void WriteColMaskTileOp::getEffects(
     }
   }
 
-  // Verify result type matches memref type if result is present and in tensor
-  // mode
+  // Verify result type matches memref type (result only present in tensor
+  // form per the earlier presence check).
   if (hasResultValue) {
     Type memrefType = getMemref().getType();
-
-    // Only verify result type in tensor mode
-    if (mlir::isa<RankedTensorType>(memrefType)) {
-      Type resultType = getResult().getType();
-      // Result should match the destination memref type
-      if (resultType != memrefType) {
-        return emitOpError("result type must match memref type");
-      }
-    } else {
-      // In memref mode, result should be unused
-      if (!getResult().use_empty()) {
-        return emitOpError(
-            "result must be unused when memref operand has memref type");
-      }
+    Type resultType = getResult().getType();
+    if (resultType != memrefType) {
+      return emitOpError("result type must match memref type");
     }
   }
 
@@ -1419,43 +1438,23 @@ mlir::LogicalResult RemoteLoadOp::bufferize(
     return localBufferBuffer;
   }
 
-  // Convert result type to memref type
-  Type resultBufferType =
-      ttcore::getBufferType(result.getType(), /*isView=*/false);
-
-  // RemoteLoadOp always loads into L1 memory, so ensure the result type has
-  // L1 memory space. If the result type is a memref without memory space,
-  // add the L1 memory space attribute.
-  if (auto memrefType = mlir::dyn_cast<MemRefType>(resultBufferType)) {
-    if (!memrefType.getMemorySpace()) {
-      auto l1Attr = ttcore::MemorySpaceAttr::get(getContext(),
-                                                 ttcore::MemorySpace::DeviceL1);
-      resultBufferType =
-          MemRefType::get(memrefType.getShape(), memrefType.getElementType(),
-                          memrefType.getLayout(), l1Attr);
-    }
-  }
-
-  // Create a new RemoteLoadOp with bufferized operands (no CB, with result)
-  // Preserve the multicast form - either high-level (mcastDims) or low-level
-  // (mcastStartIndex/mcastShape)
-  RemoteLoadOp newOp;
+  // Create a new RemoteLoadOp with bufferized operands in DPS memref form
+  // (no CB, no result; the localBuffer is the destination). Preserve the
+  // multicast form - either high-level (mcastDims) or low-level
+  // (mcastStartIndex/mcastShape).
   if (isHighLevelMcast()) {
-    // High-level mcast form: use mcastDims builder
-    newOp = rewriter.create<RemoteLoadOp>(getLoc(), resultBufferType,
-                                          *localBufferBuffer, *memrefBuffer,
-                                          getIndices(), getMcastDims());
+    rewriter.create<RemoteLoadOp>(getLoc(), *localBufferBuffer, *memrefBuffer,
+                                  getIndices(), getMcastDims());
   } else {
-    // Low-level mcast form or no mcast: use mcastStartIndex/mcastShape builder
-    newOp = rewriter.create<RemoteLoadOp>(
-        getLoc(), resultBufferType, *localBufferBuffer, *memrefBuffer,
-        getIndices(), getMcastStartIndex(), getMcastShape());
+    rewriter.create<RemoteLoadOp>(getLoc(), *localBufferBuffer, *memrefBuffer,
+                                  getIndices(), getMcastStartIndex(),
+                                  getMcastShape());
   }
 
   // Create a ToTensorOp wrapper to maintain tensor semantics for downstream
-  // ops. This ensures that operations like linalg.generic still see tensors
-  // until they are bufferized. When they call getBuffer() during bufferization,
-  // they'll get the underlying memref (*localBufferBuffer).
+  // ops that still see the old tensor result. When they call getBuffer()
+  // during their own bufferization, they'll trace back to the underlying
+  // memref (*localBufferBuffer).
   auto toTensor = rewriter.create<bufferization::ToTensorOp>(
       getLoc(), result.getType(), *localBufferBuffer);
   rewriter.replaceAllUsesWith(result, toTensor.getResult());
@@ -1596,21 +1595,27 @@ mlir::LogicalResult RemoteStoreOp::bufferize(
     localBufferBufferized = *localBufferMaybe;
   }
 
-  // Convert result type to memref type
-  // In implicit form (localBuffer present), result is always required
+  // Pre-bufferization implicit form must carry a tensor result (yield value).
   Value result = getResult();
   if (!result) {
     return emitOpError("Expected result in implicit form during bufferization");
   }
 
-  Type resultBufferType =
-      ttcore::getBufferType(result.getType(), /*isView=*/false);
+  // Create a new RemoteStoreOp in DPS memref form (no result; destination
+  // memref is the result). Use the raw build() entry point so we can pass
+  // all the variadic operands.
+  rewriter.create<RemoteStoreOp>(
+      getLoc(), /*resultTypes=*/TypeRange{}, *memrefBuffer, getIndices(),
+      localBufferBufferized, /*cb=*/Value{}, getStartDevice(),
+      getDeviceMcastShape(), getSemaphore(), getSemaphoreIndices());
 
-  // Create a new RemoteStoreOp with bufferized operands and result
-  mlir::bufferization::replaceOpWithNewBufferizedOp<RemoteStoreOp>(
-      rewriter, *this, resultBufferType, *memrefBuffer, getIndices(),
-      localBufferBufferized, getStartDevice(), getDeviceMcastShape(),
-      getSemaphore(), getSemaphoreIndices());
+  // Create a ToTensorOp wrapper to maintain tensor semantics for the old
+  // tensor result. The only user is `d2m.yield`, which will erase itself
+  // during its own bufferization, so this wrapper is short-lived.
+  auto toTensor = rewriter.create<bufferization::ToTensorOp>(
+      getLoc(), result.getType(), *memrefBuffer);
+  rewriter.replaceAllUsesWith(result, toTensor.getResult());
+  rewriter.eraseOp(*this);
 
   return mlir::success();
 }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -2369,8 +2369,14 @@ static void repairParallelizedRegionTypes(d2m::GenericOp genericOp,
       }
     } else if (auto remoteLoadOp =
                    mlir::dyn_cast<d2m::RemoteLoadOp>(&clonedOp)) {
-      if (Value localBuffer = remoteLoadOp.getLocalBuffer()) {
-        remoteLoadOp.getResult().setType(localBuffer.getType());
+      // Only propagate type to the result in the tensor form (where a
+      // result is present). In the post-bufferization memref form there
+      // is no result and the localBuffer's defining op handles its own
+      // type retyping (e.g. the memref.alloc case above).
+      if (remoteLoadOp.hasResultForm()) {
+        if (Value localBuffer = remoteLoadOp.getLocalBuffer()) {
+          remoteLoadOp.getResult().setType(localBuffer.getType());
+        }
       }
     } else if (auto remoteStoreOp =
                    mlir::dyn_cast<d2m::RemoteStoreOp>(&clonedOp)) {

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1488,24 +1488,22 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                 }
 
                 if (operandIndex) {
-                  // Update the result type so the load result matches the
-                  // stream type now associated with the operand.
+                  // Update the localBuffer (destination) type so the load
+                  // matches the stream type now associated with the operand.
                   auto typeIt = operandCBTypeByIndex.find(*operandIndex);
                   if (typeIt != operandCBTypeByIndex.end()) {
                     Type newShardType = typeIt->second;
-                    op.getResult().setType(newShardType);
                     updateLocalBufferType(op, newShardType);
                     return;
                   }
                 }
 
-                if (Value localBuffer = op.getLocalBuffer()) {
-                  Type localBufferType = localBuffer.getType();
-                  if (localBufferType != op.getResult().getType()) {
-                    op.getResult().setType(localBufferType);
-                    updateLocalBufferType(op, localBufferType);
-                    return;
-                  }
+                // If a localBuffer is already typed (its defining op assigned
+                // a memref type), trust that and don't override it with the
+                // generic L1 shard type below. This preserves layouts like
+                // #ttcore.cb_layout<...> that were set up by upstream logic.
+                if (op.getLocalBuffer()) {
+                  return;
                 }
 
                 if (op.isImplicitForm()) {
@@ -1520,7 +1518,6 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
                         shardShape, shapedType.getElementType(), nullptr,
                         rewriter.getAttr<ttcore::MemorySpaceAttr>(
                             ttcore::MemorySpace::DeviceL1));
-                    op.getResult().setType(newShardType);
                     updateLocalBufferType(op, newShardType);
                   }
                 }

--- a/lib/Dialect/D2M/Transforms/LowerMulticastLoads.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerMulticastLoads.cpp
@@ -34,8 +34,8 @@ public:
   void lowerToUnicastFallback(RemoteLoadOp op,
                               PatternRewriter &rewriter) const {
     TT_assert(op.isImplicitForm());
-    rewriter.replaceOpWithNewOp<RemoteLoadOp>(
-        op, op.getLocalBuffer(), op.getMemref(), op.getIndices());
+    rewriter.replaceOpWithNewOp<RemoteLoadOp>(op, op.getLocalBuffer(),
+                                              op.getMemref(), op.getIndices());
   }
 
   LogicalResult matchAndRewrite(RemoteLoadOp op,
@@ -223,9 +223,9 @@ public:
 
     // Create replacement RemoteLoadOp with low-level multicast form.
     TT_assert(op.isImplicitForm());
-    rewriter.replaceOpWithNewOp<RemoteLoadOp>(
-        op, op.getLocalBuffer(), op.getMemref(), op.getIndices(),
-        mcastStartIndex, mcastShape);
+    rewriter.replaceOpWithNewOp<RemoteLoadOp>(op, op.getLocalBuffer(),
+                                              op.getMemref(), op.getIndices(),
+                                              mcastStartIndex, mcastShape);
 
     return success();
   }

--- a/lib/Dialect/D2M/Transforms/LowerMulticastLoads.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerMulticastLoads.cpp
@@ -34,9 +34,8 @@ public:
   void lowerToUnicastFallback(RemoteLoadOp op,
                               PatternRewriter &rewriter) const {
     TT_assert(op.isImplicitForm());
-    rewriter.replaceOpWithNewOp<RemoteLoadOp>(op, op.getResult().getType(),
-                                              op.getLocalBuffer(),
-                                              op.getMemref(), op.getIndices());
+    rewriter.replaceOpWithNewOp<RemoteLoadOp>(
+        op, op.getLocalBuffer(), op.getMemref(), op.getIndices());
   }
 
   LogicalResult matchAndRewrite(RemoteLoadOp op,
@@ -225,8 +224,8 @@ public:
     // Create replacement RemoteLoadOp with low-level multicast form.
     TT_assert(op.isImplicitForm());
     rewriter.replaceOpWithNewOp<RemoteLoadOp>(
-        op, op.getResult().getType(), op.getLocalBuffer(), op.getMemref(),
-        op.getIndices(), mcastStartIndex, mcastShape);
+        op, op.getLocalBuffer(), op.getMemref(), op.getIndices(),
+        mcastStartIndex, mcastShape);
 
     return success();
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_masking.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_masking.mlir
@@ -43,11 +43,11 @@ module attributes {ttcore.system_desc = #system_desc} {
       %buf1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf2 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf3 = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %0 = d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %2 = d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %4 = "d2m.block_mask"(%0, %buf3, %1, %2, %c50, %c64) <{fill_value = #ttcore.oob_val<inf>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %5 = d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      %4 = "d2m.block_mask"(%buf0, %buf3, %buf1, %buf2, %c50, %c64) <{fill_value = #ttcore.oob_val<inf>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }
@@ -102,11 +102,11 @@ module attributes {ttcore.system_desc = #system_desc} {
       %buf1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf2 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf3 = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %0 = d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %2 = d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %4 = "d2m.block_mask"(%0, %buf3, %1, %2, %c50, %c50) <{fill_value = #ttcore.oob_val<zero>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %5 = d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      %4 = "d2m.block_mask"(%buf0, %buf3, %buf1, %buf2, %c50, %c50) <{fill_value = #ttcore.oob_val<zero>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }
@@ -134,11 +134,11 @@ module attributes {ttcore.system_desc = #system_desc} {
       %buf1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf2 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf3 = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %0 = d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %2 = d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %4 = "d2m.block_mask"(%0, %buf3, %1, %2, %c50, %c50) <{fill_value = #ttcore.oob_val<neginf>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %5 = d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      %4 = "d2m.block_mask"(%buf0, %buf3, %buf1, %buf2, %c50, %c50) <{fill_value = #ttcore.oob_val<neginf>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }
@@ -166,11 +166,11 @@ module attributes {ttcore.system_desc = #system_desc} {
       %buf1 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf2 = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
       %buf3 = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %0 = d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %2 = d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-      %4 = "d2m.block_mask"(%0, %buf3, %1, %2, %c64, %c64) <{fill_value = #ttcore.oob_val<zero>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
-      %5 = d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf0 %arg0[%c0, %c0] : memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>
+      d2m.remote_load %buf1 %arg2[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      d2m.remote_load %buf2 %arg3[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard_1x1, #l1>
+      %4 = "d2m.block_mask"(%buf0, %buf3, %buf1, %buf2, %c64, %c64) <{fill_value = #ttcore.oob_val<zero>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1>}> : (memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, index, index) -> memref<2x2x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %arg1[%c0, %c0] %4 : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #shard_2x2, #l1>, memref<2x2x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/generate_outer_loops.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/generate_outer_loops.mlir
@@ -32,9 +32,9 @@ module {
   // CHECK-NEXT:     %[[OFF1:.*]] = d2m.block_offset(1)
   // CHECK-NEXT:     %[[IDX1:.*]] = affine.apply #{{.*}}(%[[J]])[%[[OFF1]]]
   // CHECK-NEXT:     %{{.*}} = memref.alloc
-  // CHECK-NEXT:     %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
+  // CHECK-NEXT:     d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}>
   // CHECK-NEXT:     %{{.*}} = memref.alloc
-  // CHECK-NEXT:     %{{.*}} = d2m.remote_store %{{.*}}[%[[IDX0]], %[[IDX1]]] %{{.*}} : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
+  // CHECK-NEXT:     d2m.remote_store %{{.*}}[%[[IDX0]], %[[IDX1]]] %{{.*}} : memref<{{.*}}>, memref<{{.*}}>
     // CHECK-NEXT:   } {d2m.blocking_loop = 1
     // CHECK-NEXT: } {d2m.blocking_loop = 0
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
@@ -46,9 +46,9 @@ module {
       %idx0 = d2m.block_index(0) : index
       %idx1 = d2m.block_index(1) : index
       %buffer_in = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %in = d2m.remote_load %buffer_in %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer_in %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
       %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %result = d2m.remote_store %alloc[%idx0, %idx1] %buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
+      d2m.remote_store %alloc[%idx0, %idx1] %buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
     }
     return
   }
@@ -78,10 +78,10 @@ module {
   // CHECK-NEXT:       %{{.*}} = memref.alloc
   // CHECK-NEXT:       %{{.*}} = memref.alloc
   // CHECK-NEXT:       %{{.*}} = memref.alloc
-  // CHECK-NEXT:       %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
-  // CHECK-NEXT:       %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
+  // CHECK-NEXT:       d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}>
+  // CHECK-NEXT:       d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}>
     // CHECK-NEXT:       "d2m.tile_matmul_block"
-    // CHECK-NEXT:       %{{.*}} = d2m.remote_store %{{.*}}[%[[IDX0]], %[[IDX1]]] %{{.*}} : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
+    // CHECK-NEXT:       d2m.remote_store %{{.*}}[%[[IDX0]], %[[IDX1]]] %{{.*}} : memref<{{.*}}>, memref<{{.*}}>
     // CHECK-NEXT:     } {d2m.blocking_loop = 2
     // CHECK-NEXT:   } {d2m.blocking_loop = 1
     // CHECK-NEXT: } {d2m.blocking_loop = 0
@@ -97,10 +97,10 @@ module {
       %buffer_lhs = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
       %buffer_rhs = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
       %buffer_out = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      %lhs = d2m.remote_load %buffer_lhs %stream0[%idx0, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      %rhs = d2m.remote_load %buffer_rhs %stream1[%idx0, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      "d2m.tile_matmul_block"(%lhs, %rhs, %buffer_out) : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) -> ()
-      %result = d2m.remote_store %alloc[%idx0, %idx1] %buffer_out : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>
+      d2m.remote_load %buffer_lhs %stream0[%idx0, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram>
+      d2m.remote_load %buffer_rhs %stream1[%idx0, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram>
+      "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) -> ()
+      d2m.remote_store %alloc[%idx0, %idx1] %buffer_out : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
     }
     return
   }
@@ -123,7 +123,7 @@ module {
   // CHECK-NEXT:     %[[OFF1:.*]] = d2m.block_offset(1)
   // CHECK-NEXT:     %[[IDX1:.*]] = affine.apply #{{.*}}(%[[J]])[%[[OFF1]]]
   // CHECK-NEXT:     %{{.*}} = memref.alloc
-  // CHECK-NEXT:     %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
+  // CHECK-NEXT:     d2m.remote_load %{{.*}} %{{.*}}[%[[IDX0]], %[[IDX1]]] : memref<{{.*}}>, memref<{{.*}}>
     // CHECK-NEXT:   } {d2m.blocking_loop = 1
     // CHECK-NEXT: } {d2m.blocking_loop = 0
     d2m.generic {block_factors = [1, 1], grid = #ttcore.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#d2m.thread<unified>]}
@@ -135,7 +135,7 @@ module {
       %idx0 = d2m.block_index(0) : index
       %idx1 = d2m.block_index(1) : index
       %buffer_mem = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %mem0 = d2m.remote_load %buffer_mem %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer_mem %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/hoist_cb_allocs.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/hoist_cb_allocs.mlir
@@ -24,8 +24,8 @@ func.func @hoist_cb_dealloc(
     %c0 = d2m.core_index(0) : index
     %c1 = d2m.core_index(1) : index
     %alloc_cb = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-    %0 = d2m.remote_load %alloc_cb %stream[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-    %1 = d2m.remote_store %out[%c0, %c1] %0 : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+    d2m.remote_load %alloc_cb %stream[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    d2m.remote_store %out[%c0, %c1] %alloc_cb : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
   }
   return
 }
@@ -49,10 +49,10 @@ func.func @hoist_multiple_cbs_dealloc(
     %c0 = d2m.core_index(0) : index
     %c1 = d2m.core_index(1) : index
     %alloc_cb0 = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-    %0 = d2m.remote_load %alloc_cb0 %stream0[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
+    d2m.remote_load %alloc_cb0 %stream0[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
     %alloc_cb1 = memref.alloc() {address = 2048 : i64, alignment = 16 : i64} : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-    %1 = d2m.remote_load %alloc_cb1 %stream1[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-    %2 = d2m.remote_store %out[%c0, %c1] %0 : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1> -> memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+    d2m.remote_load %alloc_cb1 %stream1[%c0, %c1] : memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+    d2m.remote_store %out[%c0, %c1] %alloc_cb0 : memref<2x2x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<4x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
   }
   return
 }

--- a/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_no_loop.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/insert_dst_register_access_no_loop.mlir
@@ -24,7 +24,7 @@ module {
       %alloc_cb = memref.alloc() {address = 103712 : i64, alignment = 16 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #cb_layout, #l1_>
       // Verify ordering: remote_load must come BEFORE acquire_dst
       // CHECK: d2m.remote_load
-      %0 = d2m.remote_load %alloc_cb %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #cb_layout, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard, #l1_> -> memref<1x1x!ttcore.tile<32x32, f32>, #cb_layout, #l1_>
+      d2m.remote_load %alloc_cb %in[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #cb_layout, #l1_>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #shard, #l1_>
       %alloc_out = memref.alloc() {alignment = 64 : i64, d2m.alias_for_operand = 1 : i64} : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
       // CHECK: d2m.fill_arange_tile
       d2m.fill_arange_tile to %alloc_cb : memref<1x1x!ttcore.tile<32x32, f32>, #cb_layout, #l1_>
@@ -55,7 +55,7 @@ module {
       memref.store %result, %alloc_out[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
       %core0_store = d2m.core_index(0) {phys_to_virt_map = affine_map<() -> ()>} : index
       %core1_store = d2m.core_index(1) {phys_to_virt_map = affine_map<() -> ()>} : index
-      %6 = d2m.remote_store %out[%core0_store, %core1_store] %alloc_out : memref<1x4x1x1x!ttcore.tile<32x32, f32>, #shard, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_store %out[%core0_store, %core1_store] %alloc_out : memref<1x4x1x1x!ttcore.tile<32x32, f32>, #shard, #l1_>, memref<1x1x!ttcore.tile<32x32, f32>, #l1_>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_ops_sharded_to_interleaved.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_load_store_ops_sharded_to_interleaved.mlir
@@ -35,8 +35,8 @@ module attributes {ttcore.system_desc = #system_desc} {
       %core0 = d2m.core_index(0) {phys_to_virt_map = #phys_to_virt} : index
       %core1 = d2m.core_index(1) {phys_to_virt_map = #phys_to_virt} : index
 
-      %0 = d2m.remote_load %cb_alias %arg0[%core0, %core1] : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, memref<1x64x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
-      %1 = d2m.remote_store %view[%core0, %core1] %cb_alias : memref<1x64x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<4>, #dram>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1> -> memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
+      d2m.remote_load %cb_alias %arg0[%core0, %core1] : memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, memref<1x64x1x1x!ttcore.tile<32x32, bf16>, #ttcore.shard<2048x2048, 1>, #l1>
+      d2m.remote_store %view[%core0, %core1] %cb_alias : memref<1x64x1x1x!ttcore.tile<32x32, bf16>, #ttcore.view<4>, #dram>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_multicast_loads.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_multicast_loads.mlir
@@ -30,9 +30,9 @@ module {
       // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
       // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
       // CHECK-DAG: %[[CORE0:.*]] = d2m.core_index(0)
-      // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%[[CORE0]], %[[C0]]] mshape[%[[C1]], %[[C4]]]
+      // CHECK: d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%[[CORE0]], %[[C0]]] mshape[%[[C1]], %[[C4]]]
       %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %load_result = d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c0] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c0] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
     }
     return
   }
@@ -59,9 +59,9 @@ module {
       // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
       // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
       // CHECK-DAG: %[[CORE1:.*]] = d2m.core_index(1)
-      // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%[[C0]], %[[CORE1]]] mshape[%[[C4]], %[[C1]]]
+      // CHECK: d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%[[C0]], %[[CORE1]]] mshape[%[[C4]], %[[C1]]]
       %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %load_result = d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<4x2x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<4x2x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
     }
     return
   }
@@ -84,11 +84,11 @@ module {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       // High-level mcast form on dim 0 with grid size 1 - should become unicast
-      // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] :
+      // CHECK: d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] :
       // CHECK-NOT: mcore[
       // CHECK-NOT: mshape[
       %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %load_result = d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<1x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer %stream[%c0, %c1] mcast[%c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<1x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/lower_to_explicit_form.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/lower_to_explicit_form.mlir
@@ -36,9 +36,9 @@ module {
       %idx0 = d2m.block_index(0) : index
       %idx1 = d2m.block_index(1) : index
       %buffer_in = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %in = d2m.remote_load %buffer_in %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+      d2m.remote_load %buffer_in %stream[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.view<4>, #dram>
       %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
-      %result = d2m.remote_store %alloc[%idx0, %idx1] %buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>
+      d2m.remote_store %alloc[%idx0, %idx1] %buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1_>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
     }
     return
   }
@@ -74,10 +74,10 @@ module {
       %buffer_lhs = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
       %buffer_rhs = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
       %buffer_out = memref.alloc() : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      %lhs = d2m.remote_load %buffer_lhs %stream0[%idx0, %idx2] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      %rhs = d2m.remote_load %buffer_rhs %stream1[%idx2, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram> -> memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
-      "d2m.tile_matmul_block"(%lhs, %rhs, %buffer_out) : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) -> ()
-      %result = d2m.remote_store %alloc[%idx0, %idx1] %buffer_out : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_> -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>
+      d2m.remote_load %buffer_lhs %stream0[%idx0, %idx2] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram>
+      d2m.remote_load %buffer_rhs %stream1[%idx2, %idx1] : memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #ttcore.view<4>, #dram>
+      "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) -> ()
+      d2m.remote_store %alloc[%idx0, %idx1] %buffer_out : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096, 1>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread.mlir
@@ -47,13 +47,13 @@ module attributes {ttcore.system_desc = #system_desc} {
         scf.for %arg2 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg1 : index
           %1 = arith.addi %core1, %arg2 : index
-          %2 = d2m.remote_load %cb_alloc %stream[%0, %1] mcore[%core0, %c0] mshape[%c1, %c4] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_load %cb_alloc %stream[%0, %1] mcore[%core0, %c0] mshape[%c1, %c4] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_alloc : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) outs(%cb_alloc2 : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
             %3 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             linalg.yield %3 : !ttcore.tile<32x32, f32>
           }
-          %4 = d2m.remote_store %alloc[%0, %1] %cb_alloc2 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+          d2m.remote_store %alloc[%0, %1] %cb_alloc2 : memref<4x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -98,13 +98,13 @@ module attributes {ttcore.system_desc = #system_desc} {
         scf.for %arg3 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg2 : index
           %1 = arith.addi %core1, %arg3 : index
-          %2 = d2m.remote_load %cb_0 %arg0[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_load %cb_0 %arg0[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_0 : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%cb_alloc : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
             %3 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             linalg.yield %3 : !ttcore.tile<32x32, f32>
           }
-          %4 = d2m.remote_store %stream[%0, %1] %cb_alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_store %stream[%0, %1] %cb_alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -155,13 +155,13 @@ module attributes {ttcore.system_desc = #system_desc} {
         scf.for %arg3 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg2 : index
           %1 = arith.addi %core1, %arg3 : index
-          %2 = d2m.remote_load %cb_in %stream_in[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_load %cb_in %stream_in[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_in : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) outs(%cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
             %3 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             linalg.yield %3 : !ttcore.tile<32x32, f32>
           }
-          %4 = d2m.remote_store %stream_out[%0, %1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_store %stream_out[%0, %1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -220,8 +220,8 @@ module attributes {ttcore.system_desc = #system_desc} {
         scf.for %arg4 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg3 : index
           %1 = arith.addi %core1, %arg4 : index
-          %2 = d2m.remote_load %cb_0 %alloc[%0, %1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-          %5 = d2m.remote_load %cb_1 %alloc_0[%0, %1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %cb_0 %alloc[%0, %1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+          d2m.remote_load %cb_1 %alloc_0[%0, %1] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
 
           linalg.generic {
             indexing_maps = [#map, #map, #map],
@@ -233,7 +233,7 @@ module attributes {ttcore.system_desc = #system_desc} {
             linalg.yield %add : !ttcore.tile<32x32, f32>
           }
 
-          %result = d2m.remote_store %alloc_1[%0, %1] %cb_2 : memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_store %alloc_1[%0, %1] %cb_2 : memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -298,8 +298,8 @@ module attributes {ttcore.system_desc = #system_desc} {
       %c1 = arith.constant 1 : index
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %2 = d2m.remote_load %cb0 %stream0[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
-      %3 = d2m.remote_load %cb1 %stream1[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %cb0 %stream0[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      d2m.remote_load %cb1 %stream1[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
       linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
         ins(%cb0, %cb1 : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>)
         outs(%cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
@@ -307,7 +307,7 @@ module attributes {ttcore.system_desc = #system_desc} {
         %add = "d2m.tile_add"(%in0, %in1) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
         linalg.yield %add : !ttcore.tile<32x32, f32>
       }
-      %4 = d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     }
     memref.dealloc %cb0 : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %cb1 : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
@@ -340,8 +340,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %shared %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
-      %1 = d2m.remote_store %stream_out[%core0, %core1] %shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %shared %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      d2m.remote_store %stream_out[%core0, %core1] %shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     }
     memref.dealloc %shared : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     return
@@ -373,8 +373,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %cb_shared %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_store %arg1[%core0, %core1] %cb_shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %cb_shared %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+      d2m.remote_store %arg1[%core0, %core1] %cb_shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }
@@ -405,8 +405,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %shared %arg0[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_store %stream_out[%core0, %core1] %shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %shared %arg0[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+      d2m.remote_store %stream_out[%core0, %core1] %shared : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }
@@ -432,8 +432,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %shared %input[%core0, %core1] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-      %1 = d2m.remote_store %output[%core0, %core1] %shared : memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
+      d2m.remote_load %shared %input[%core0, %core1] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+      d2m.remote_store %output[%core0, %core1] %shared : memref<4x3x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
     }
     memref.dealloc %shared : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
     return
@@ -475,7 +475,7 @@ module attributes {ttcore.system_desc = #system_desc} {
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
       // Streaming load from DRAM into the CB buffer
-      %0 = d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
       // Local copy rearranges data into scratch buffer
       d2m.local_copy %cb_buf, %scratch_buf indexing_maps = [#map, #map] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
       // Compute reads ONLY from scratch (not from cb_buf)
@@ -486,7 +486,7 @@ module attributes {ttcore.system_desc = #system_desc} {
         %2 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
         linalg.yield %2 : !ttcore.tile<32x32, f32>
       }
-      %3 = d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     }
     memref.dealloc %cb_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %scratch_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
@@ -530,7 +530,7 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
       d2m.local_copy %cb_buf, %scratch1 indexing_maps = [#map, #map] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
       d2m.local_copy %scratch1, %scratch2 indexing_maps = [#map, #map] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
       linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]}
@@ -540,7 +540,7 @@ module attributes {ttcore.system_desc = #system_desc} {
         %2 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
         linalg.yield %2 : !ttcore.tile<32x32, f32>
       }
-      %3 = d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     }
     memref.dealloc %cb_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %scratch1 : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
@@ -580,9 +580,9 @@ module attributes {ttcore.system_desc = #system_desc} {
     ^unified0:
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
-      %0 = d2m.remote_load %cb_buf %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %cb_buf %stream_in[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
       d2m.local_copy %cb_buf, %scratch_buf indexing_maps = [#map, #map] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
-      %1 = d2m.remote_store %stream_out[%core0, %core1] %scratch_buf : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_store %stream_out[%core0, %core1] %scratch_buf : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     }
     memref.dealloc %cb_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %scratch_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
@@ -643,7 +643,7 @@ module attributes {ttcore.system_desc = #system_desc} {
       %core0 = d2m.core_index(0) : index
       %core1 = d2m.core_index(1) : index
       // Load input from DRAM
-      %0 = d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_load %cb_buf %stream[%core0, %core1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
       // First compute: reads from load CB, writes to compute_out scratch
       linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]}
         ins(%cb_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>)
@@ -662,7 +662,7 @@ module attributes {ttcore.system_desc = #system_desc} {
         %2 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
         linalg.yield %2 : !ttcore.tile<32x32, f32>
       }
-      %3 = d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+      d2m.remote_store %alloc[%core0, %core1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     }
     memref.dealloc %cb_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
     memref.dealloc %compute_scratch_buf : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
@@ -71,14 +71,14 @@ module attributes {ttcore.system_desc = #system_desc} {
         scf.for %arg2 = %c0 to %c1 step %c1 {
           %0 = arith.addi %core0, %arg1 : index
           %1 = arith.addi %core1, %arg2 : index
-          %2 = d2m.remote_load %cb_in %stream[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>
+          d2m.remote_load %cb_in %stream[%0, %1] : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
           d2m.semaphore_wait %sem0, %c1 : !d2m.local_semaphore
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_in : memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<16384x4096, 2>, #l1>) outs(%cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
             %3 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             linalg.yield %3 : !ttcore.tile<32x32, f32>
           }
-          %4 = d2m.remote_store %alloc[%0, %1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_store %alloc[%0, %1] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -130,13 +130,13 @@ module attributes {ttcore.system_desc = #system_desc} {
       scf.for %arg1 = %c0 to %c1 step %c1 {
         scf.for %arg2 = %c0 to %c1 step %c1 {
           d2m.semaphore_wait %sem0, %c1 : !d2m.local_semaphore
-          %0 = d2m.remote_load %cb_in %arg0[%c0, %c0] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %cb_in %arg0[%c0, %c0] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_in : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
             %1 = "d2m.tile_exp"(%in) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
             linalg.yield %1 : !ttcore.tile<32x32, f32>
           }
-          %2 = d2m.remote_store %alloc[%c0, %c0] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_store %alloc[%c0, %c0] %cb_out : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_composite_view.mlir
@@ -26,8 +26,8 @@ func.func @test_composite_view() -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #tt
         %1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg2)[%block_offset0]
         %block_offset1 = d2m.block_offset(1) : index
         %2 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg3)[%block_offset1]
-        %3 = d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
-        %4 = d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>
+        d2m.remote_load %alloc_3 %0[%1, %2] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<l1>>
+        d2m.remote_store %alloc_2[%1, %2] %alloc_3 : memref<1x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<l1>>, memref<1x1x!ttcore.tile<32x32, f32>>
       } {d2m.blocking_loop = 1 : i64}
     } {d2m.blocking_loop = 0 : i64}
   }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_outer_inner_no_alias.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_outer_inner_no_alias.mlir
@@ -40,12 +40,12 @@ module {
           affine.for %j = 0 to %v {
             affine.for %k = 0 to %w {
               %l = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-              %x = d2m.remote_load %l %a[%i, %k] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+              d2m.remote_load %l %a[%i, %k] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1>
               %r = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-              %y = d2m.remote_load %r %b[%k, %j] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+              d2m.remote_load %r %b[%k, %j] : memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1>
               %o = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-              "d2m.tile_matmul_block"(%x, %y, %o) : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> ()
-              d2m.remote_store %c[%i, %j] %o : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1>
+              "d2m.tile_matmul_block"(%l, %r, %o) : (memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>) -> ()
+              d2m.remote_store %c[%i, %j] %o : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #s, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
             } {d2m.blocking_loop = 2}
           } {d2m.blocking_loop = 1}
         } {d2m.blocking_loop = 0}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_cb_layout_consistency.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_cb_layout_consistency.mlir
@@ -44,9 +44,9 @@ module {
           %idx1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%j)[%off1]
 
           %in0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-          %ld0 = d2m.remote_load %in0 %lhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %in0 %lhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           %in1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-          %ld1 = d2m.remote_load %in1 %rhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %in1 %rhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           %out = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
 
           linalg.generic {indexing_maps = [#eltwise, #eltwise, #eltwise], iterator_types = ["parallel", "parallel"]}
@@ -57,7 +57,7 @@ module {
             linalg.yield %sum : !ttcore.tile<32x32, f32>
           }
 
-          d2m.remote_store %add_out[%idx0, %idx1] %out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+          d2m.remote_store %add_out[%idx0, %idx1] %out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>>
         } {d2m.blocking_loop = 1 : i64}
       } {d2m.blocking_loop = 0 : i64}
     }
@@ -77,12 +77,12 @@ module {
           %idx1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%j)[%off1]
 
           %tile_in = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-          %ld = d2m.remote_load %tile_in %add_out[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %tile_in %add_out[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
 
           %scalar_out = memref.alloc() {alignment = 64 : i64} : memref<64x128xf32>
           %untilized = "d2m.tile_untilize_block"(%tile_in, %scalar_out) : (memref<2x4x!ttcore.tile<32x32, f32>>, memref<64x128xf32>) -> memref<64x128xf32>
 
-          d2m.remote_store %untilize_out[%idx0, %idx1] %scalar_out : memref<1x1x64x128xf32, #ttcore.shard<512x4, 1>, #l1>, memref<64x128xf32> -> memref<1x1x64x128xf32, #ttcore.shard<512x4, 1>, #l1>
+          d2m.remote_store %untilize_out[%idx0, %idx1] %scalar_out : memref<1x1x64x128xf32, #ttcore.shard<512x4, 1>, #l1>, memref<64x128xf32>
         } {d2m.blocking_loop = 1 : i64}
       } {d2m.blocking_loop = 0 : i64}
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_dealloc_order.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_reblock_dealloc_order.mlir
@@ -53,9 +53,9 @@ module {
           %idx1 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%j)[%off1]
 
           %in0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-          %ld0 = d2m.remote_load %in0 %lhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %in0 %lhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           %in1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-          %ld1 = d2m.remote_load %in1 %rhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+          d2m.remote_load %in1 %rhs[%idx0, %idx1] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           %out = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
 
           linalg.generic {indexing_maps = [#eltwise, #eltwise, #eltwise], iterator_types = ["parallel", "parallel"]}
@@ -66,7 +66,7 @@ module {
             linalg.yield %sum : !ttcore.tile<32x32, f32>
           }
 
-          d2m.remote_store %add_out[%idx0, %idx1] %out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+          d2m.remote_store %add_out[%idx0, %idx1] %out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>>
         } {d2m.blocking_loop = 1 : i64}
       } {d2m.blocking_loop = 0 : i64}
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_explicit_datamovement.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_explicit_datamovement.mlir
@@ -30,12 +30,12 @@ module {
       %cb1 = d2m.get_cb(1) : !d2m.cb<memref<3x4x!ttcore.tile<32x32, f32>, #l1>>
       %cb2 = d2m.get_cb(2) : !d2m.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1>>
       %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-      %0 = d2m.remote_load %buffer_lhs %lhs[%c0, %c0] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #dram> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %buffer_lhs %lhs[%c0, %c0] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #dram>
       %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-      %1 = d2m.remote_load %buffer_rhs %rhs[%c0, %c0] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+      d2m.remote_load %buffer_rhs %rhs[%c0, %c0] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
       %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-      "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-      %result = d2m.remote_store %out[%c0, %c0] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+      "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+      d2m.remote_store %out[%c0, %c0] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     }
     return
   }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_always.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_always.mlir
@@ -43,12 +43,12 @@ module {
         affine.for %iter1 = 0 to %bf1 {
           affine.for %iter2 = 0 to %bf2 {
             %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1>
             %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
             %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-            "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-            %result = d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+            "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+            d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
@@ -75,12 +75,12 @@ module {
         affine.for %iter1 = 0 to %bf1 {
           affine.for %iter2 = 0 to %bf2 {
             %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1>
             %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
             %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-            "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-            %result = d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+            "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+            d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_always_min.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_always_min.mlir
@@ -43,12 +43,12 @@ module {
         affine.for %iter1 = 0 to %bf1 {
           affine.for %iter2 = 0 to %bf2 {
             %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1>
             %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
             %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-            "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-            %result = d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+            "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+            d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_infer.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_infer.mlir
@@ -46,12 +46,12 @@ module {
         affine.for %iter1 = 0 to %bf1 {
           affine.for %iter2 = 0 to %bf2 {
             %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1>
             %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
             %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-            "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-            %result = d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+            "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+            d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
@@ -78,8 +78,8 @@ module {
       affine.for %iter0 = 0 to %bf0 {
         affine.for %iter1 = 0 to %bf1 {
           %buffer = memref.alloc() : memref<32x32xf32, #ttcore.memory_space<l1>>
-          %loaded = d2m.remote_load %buffer %view_arg0[%iter0, %iter1] : memref<32x32xf32, #ttcore.memory_space<l1>>, memref<1x1x32x32xf32, #ttcore.view<4>, #ttcore.memory_space<dram>> -> memref<32x32xf32, #ttcore.memory_space<l1>>
-          %stored = d2m.remote_store %out[%iter0, %iter1] %buffer : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #ttcore.memory_space<l1>>, memref<32x32xf32, #ttcore.memory_space<l1>> -> memref<32x32xf32, #ttcore.memory_space<l1>>
+          d2m.remote_load %buffer %view_arg0[%iter0, %iter1] : memref<32x32xf32, #ttcore.memory_space<l1>>, memref<1x1x32x32xf32, #ttcore.view<4>, #ttcore.memory_space<dram>>
+          d2m.remote_store %out[%iter0, %iter1] %buffer : memref<1x1x32x32xf32, #ttcore.shard<128x4, 1>, #ttcore.memory_space<l1>>, memref<32x32xf32, #ttcore.memory_space<l1>>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -90,8 +90,8 @@ module {
   // treated as CB-backed if both operands are streamed.
   // CHECK-LABEL: func @test_shared_load_store_buffer_has_cb_if_both_operands_are_streamed
   // CHECK: %[[BUFFER:.*]] = memref.alloc(){{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-  // CHECK: %[[LOAD:.*]] = d2m.remote_load %[[BUFFER]] {{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
-  // CHECK: d2m.remote_store {{.*}} %[[BUFFER]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+  // CHECK: d2m.remote_load %[[BUFFER]] {{.*}} : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #dram>
+  // CHECK: d2m.remote_store {{.*}} %[[BUFFER]] : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.cb_layout<4096x4096, 2>, #l1>
   func.func @test_shared_load_store_buffer_has_cb_if_both_operands_are_streamed(%arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<dram>>) {
     %view_arg0 = d2m.view_layout %arg0 remapping = #remap4 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<dram>> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<dram>>
     %out = memref.alloc() : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<dram>>
@@ -104,12 +104,12 @@ module {
       affine.for %iter0 = 0 to %bf0 {
         affine.for %iter1 = 0 to %bf1 {
           %buffer = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
-          %loaded = d2m.remote_load %buffer %view_arg0[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<dram>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+          d2m.remote_load %buffer %view_arg0[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #ttcore.memory_space<dram>>
           %c0 = arith.constant 0 : index
           %elt = memref.load %buffer[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
           %abs = "d2m.tile_abs"(%elt) : (!ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
           memref.store %abs, %buffer[%c0, %c0] : memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
-          %stored = d2m.remote_store %out[%iter0, %iter1] %buffer : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<dram>>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>> -> memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+          d2m.remote_store %out[%iter0, %iter1] %buffer : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #ttcore.memory_space<dram>>, memref<1x1x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }
@@ -132,9 +132,9 @@ module {
       affine.for %iter0 = 0 to %bf0 {
         affine.for %iter1 = 0 to %bf1 {
           %buffer_in = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #dram>
-          %in = d2m.remote_load %buffer_in %arg0_cast[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #dram>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram> -> memref<1x1x!ttcore.tile<32x32, f32>, #dram>
+          d2m.remote_load %buffer_in %arg0_cast[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #dram>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
           %buffer_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-          %result = d2m.remote_store %arg1_cast[%iter0, %iter1] %buffer_out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+          d2m.remote_store %arg1_cast[%iter0, %iter1] %buffer_out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_infer_min.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_stream_insert_rules_infer_min.mlir
@@ -45,12 +45,12 @@ module {
         affine.for %iter1 = 0 to %bf1 {
           affine.for %iter2 = 0 to %bf2 {
             %buffer_lhs = memref.alloc() : memref<2x3x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1> -> memref<2x3x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %lhs[%iter0, %iter2] : memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x2x3x!ttcore.tile<32x32, f32>, #ttcore.shard<12288x4096, 1>, #l1>
             %buffer_rhs = memref.alloc() : memref<3x4x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<3x4x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %rhs[%iter2, %iter1] : memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<1x1x3x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
             %buffer_out = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1>
-            "d2m.tile_matmul_block"(%0, %1, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
-            %result = d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
+            "d2m.tile_matmul_block"(%buffer_lhs, %buffer_rhs, %buffer_out) : (memref<2x3x!ttcore.tile<32x32, f32>, #l1>, memref<3x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>) -> ()
+            d2m.remote_store %r[%iter0, %iter1] %buffer_out : memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>, memref<2x4x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
@@ -75,9 +75,9 @@ module {
       affine.for %iter0 = 0 to %bf0 {
         affine.for %iter1 = 0 to %bf1 {
           %buffer_in = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #dram>
-          %in = d2m.remote_load %buffer_in %arg0_cast[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #dram>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram> -> memref<1x1x!ttcore.tile<32x32, f32>, #dram>
+          d2m.remote_load %buffer_in %arg0_cast[%iter0, %iter1] : memref<1x1x!ttcore.tile<32x32, f32>, #dram>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #dram>
           %buffer_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-          %result = d2m.remote_store %arg1_cast[%iter0, %iter1] %buffer_out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+          d2m.remote_store %arg1_cast[%iter0, %iter1] %buffer_out : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}
     }

--- a/test/ttmlir/Dialect/D2M/allocate/allocate_update_remote_ops_after_stream_insert.mlir
+++ b/test/ttmlir/Dialect/D2M/allocate/allocate_update_remote_ops_after_stream_insert.mlir
@@ -57,16 +57,16 @@ module attributes {ttcore.system_desc = #system_desc} {
             // Before fix: remote_load still references %view_5, causing verifier error
             // After fix: remote_load is updated to reference %stream
             %buffer_lhs = memref.alloc() : memref<1x2x!ttcore.tile<32x32, f32>, #l1>
-            %0 = d2m.remote_load %buffer_lhs %view_5[%iter0, %iter2] mcast[%c0] : memref<1x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x64x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x2x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_lhs %view_5[%iter0, %iter2] mcast[%c0] : memref<1x2x!ttcore.tile<32x32, f32>, #l1>, memref<1x64x1x2x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
             %buffer_rhs = memref.alloc() : memref<2x1x!ttcore.tile<32x32, f32>, #l1>
-            %1 = d2m.remote_load %buffer_rhs %view_6[%iter2, %iter1] mcast[%c1] : memref<2x1x!ttcore.tile<32x32, f32>, #l1>, memref<64x64x2x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<2x1x!ttcore.tile<32x32, f32>, #l1>
+            d2m.remote_load %buffer_rhs %view_6[%iter2, %iter1] mcast[%c1] : memref<2x1x!ttcore.tile<32x32, f32>, #l1>, memref<64x64x2x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
             %buffer_out = memref.alloc() : memref<1x1x!ttcore.tile<32x32, f32>, #l1>
-            linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0, %1 : memref<1x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x1x!ttcore.tile<32x32, f32>, #l1>) outs(%buffer_out : memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
+            linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%buffer_lhs, %buffer_rhs : memref<1x2x!ttcore.tile<32x32, f32>, #l1>, memref<2x1x!ttcore.tile<32x32, f32>, #l1>) outs(%buffer_out : memref<1x1x!ttcore.tile<32x32, f32>, #l1>) {
             ^bb0(%in: !ttcore.tile<32x32, f32>, %in_14: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
               %3 = "d2m.tile_matmul"(%in, %in_14, %out) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
               linalg.yield %3 : !ttcore.tile<32x32, f32>
             }
-            %2 = d2m.remote_store %view_out[%iter0, %iter1] %buffer_out : memref<1x64x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1> -> memref<1x64x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
+            d2m.remote_store %view_out[%iter0, %iter1] %buffer_out : memref<1x64x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>, #l1>
           } {d2m.blocking_loop = 2}
         } {d2m.blocking_loop = 1}
       } {d2m.blocking_loop = 0}

--- a/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/D2M/bufferization/bufferization.mlir
@@ -61,9 +61,9 @@ func.func @dma_bufferization() -> tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layo
     %iter1 = d2m.block_index(1) : index
     // CHECK: %[[BUFFER:.*]] = memref.alloc
     %buffer = tensor.empty() : tensor<1x1x!ttcore.tile<32x32, f32>>
-    // CHECK: d2m.remote_load %{{.*}} %[[VIEW]][{{.*}}, {{.*}}] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1> -> memref<1x1x!ttcore.tile<32x32, f32>, #l1>
+    // CHECK: d2m.remote_load %{{.*}} %[[VIEW]][{{.*}}, {{.*}}] : memref<1x1x!ttcore.tile<32x32, f32>>, memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.view<4>, #l1>
     %load_result = d2m.remote_load %buffer %view[%iter0, %iter1] : tensor<1x1x!ttcore.tile<32x32, f32>>, tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout_view> -> tensor<1x1x!ttcore.tile<32x32, f32>>
-    // CHECK: d2m.remote_store %[[ALLOC1]][{{.*}}, {{.*}}] {{.*}} : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>> -> memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    // CHECK: d2m.remote_store %[[ALLOC1]][{{.*}}, {{.*}}] {{.*}} : memref<2x2x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x!ttcore.tile<32x32, f32>>
     %store_result = d2m.remote_store %output[%iter0, %iter1] %load_result : tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout_grid2x2>, tensor<1x1x!ttcore.tile<32x32, f32>> -> tensor<2x2x1x1x!ttcore.tile<32x32, f32>, #layout_grid2x2>
 
     // CHECK: %[[DST_BUFFER:.*]] = memref.alloc

--- a/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/blocking_map_transfer.mlir
@@ -37,9 +37,9 @@ func.func @blocking_map_transfers_to_alloc(%arg0: !memref_tiled, %arg1: !memref_
     %block0 = d2m.block_index(0) : index
     %block1 = d2m.block_index(1) : index
     %e0 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %e1 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %intermediate = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
     linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -64,7 +64,7 @@ func.func @blocking_map_transfers_to_alloc(%arg0: !memref_tiled, %arg1: !memref_
       %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %s : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+    d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32>
   }
   return
 }
@@ -91,9 +91,9 @@ func.func @blocking_map_reblocks_fused_generic(%arg0: !memref_tiled_l1_8, %arg1:
     %block0 = d2m.block_index(0) : index
     %block1 = d2m.block_index(1) : index
     %e0 = memref.alloc() {alignment = 64 : i64} : memref<8x8x!tile_f32>
-    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<8x8x!tile_f32>, !memref_tiled_l1_8 -> memref<8x8x!tile_f32, #l1>
+    d2m.remote_load %e0 %arg0[%block0, %block1] : memref<8x8x!tile_f32>, !memref_tiled_l1_8
     %e1 = memref.alloc() {alignment = 64 : i64} : memref<8x8x!tile_f32>
-    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<8x8x!tile_f32>, !memref_tiled_l1_8 -> memref<8x8x!tile_f32, #l1>
+    d2m.remote_load %e1 %arg1[%block0, %block1] : memref<8x8x!tile_f32>, !memref_tiled_l1_8
     %intermediate = memref.alloc() {alignment = 64 : i64} : memref<8x8x!tile_f32>
     linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -118,7 +118,7 @@ func.func @blocking_map_reblocks_fused_generic(%arg0: !memref_tiled_l1_8, %arg1:
       %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %s : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled_dram_8, memref<8x8x!tile_f32> -> !memref_tiled_dram_8
+    d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled_dram_8, memref<8x8x!tile_f32>
   }
   return
 }

--- a/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
+++ b/test/ttmlir/Dialect/D2M/generic/insert_scratch_buffers.mlir
@@ -31,9 +31,9 @@ func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
     %block0 = d2m.block_index(0) : index
     %block1 = d2m.block_index(1) : index
     %e0 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %e1 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     // First add: tmp = a + b.
     %e2 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
     linalg.generic {
@@ -54,7 +54,7 @@ func.func @two_adds_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
       %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %s : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+    d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32>
   }
   return
 }
@@ -79,9 +79,9 @@ func.func @add_and_mul_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) 
     %block0 = d2m.block_index(0) : index
     %block1 = d2m.block_index(1) : index
     %e0 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %e1 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     // Add: tmp = a + b.
     %e2 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
     linalg.generic {
@@ -102,7 +102,7 @@ func.func @add_and_mul_gets_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) 
       %s = "d2m.tile_mul"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %s : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+    d2m.remote_store %out[%block0, %block1] %e3 : !memref_tiled, memref<4x4x!tile_f32>
   }
   return
 }
@@ -126,9 +126,9 @@ func.func @single_add_no_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
     %block0 = d2m.block_index(0) : index
     %block1 = d2m.block_index(1) : index
     %e0 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %a = d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e0 %arg0[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %e1 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
-    %b = d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled -> memref<4x4x!tile_f32, #l1>
+    d2m.remote_load %e1 %arg1[%block0, %block1] : memref<4x4x!tile_f32>, !memref_tiled
     %e2 = memref.alloc() {alignment = 64 : i64} : memref<4x4x!tile_f32>
     linalg.generic {
       indexing_maps = [#map, #map, #map],
@@ -138,7 +138,7 @@ func.func @single_add_no_scratch(%arg0: !memref_tiled, %arg1: !memref_tiled) {
       %s = "d2m.tile_add"(%in0, %in1) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %s : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %e2 : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+    d2m.remote_store %out[%block0, %block1] %e2 : !memref_tiled, memref<4x4x!tile_f32>
   }
   return
 }
@@ -180,7 +180,7 @@ func.func @generator_fused_generic_gets_scratch() {
       %sum = "d2m.tile_add"(%in, %in) : (!tile_f32, !tile_f32) -> !tile_f32
       linalg.yield %sum : !tile_f32
     }
-    %stored = d2m.remote_store %out[%block0, %block1] %result : !memref_tiled, memref<4x4x!tile_f32> -> !memref_tiled
+    d2m.remote_store %out[%block0, %block1] %result : !memref_tiled, memref<4x4x!tile_f32>
   }
   return
 }

--- a/test/ttmlir/Dialect/D2M/remote_load_store_asm_syntax.mlir
+++ b/test/ttmlir/Dialect/D2M/remote_load_store_asm_syntax.mlir
@@ -49,10 +49,10 @@ func.func @test_remote_load_with_result(
   %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
 
   // RemoteLoadOp with result (no CB)
-  // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
-  %result = d2m.remote_load %buffer %remote_src[%c0, %c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+  // CHECK: d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] : memref<{{.*}}>, memref<{{.*}}>
+  d2m.remote_load %buffer %remote_src[%c0, %c1] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
 
-  return %result : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+  return %buffer : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
 }
 
 // CHECK-LABEL: @test_remote_load_with_result_multicast
@@ -64,10 +64,10 @@ func.func @test_remote_load_with_result_multicast(
   %buffer = memref.alloc() : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
 
   // RemoteLoadOp with result and multicast (low-level multicast)
-  // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%{{.*}}, %{{.*}}] mshape[%{{.*}}, %{{.*}}] : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
-  %result = d2m.remote_load %buffer %remote_src[%c0, %c1] mcore[%c0, %c0] mshape[%c1, %c2] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+  // CHECK: d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%{{.*}}, %{{.*}}] mshape[%{{.*}}, %{{.*}}] : memref<{{.*}}>, memref<{{.*}}>
+  d2m.remote_load %buffer %remote_src[%c0, %c1] mcore[%c0, %c0] mshape[%c1, %c2] : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
 
-  return %result : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
+  return %buffer : memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
 }
 
 //===----------------------------------------------------------------------===//
@@ -83,8 +83,8 @@ func.func @test_remote_store_with_local_buffer(
 
   // RemoteStoreOp with local buffer (implicit form) - basic case
   // Result is required but must be unused when using memref types
-  // CHECK: %{{.*}} = d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] %{{.*}} : memref<{{.*}}>, memref<{{.*}}> -> memref<{{.*}}>
-  %result = d2m.remote_store %remote_dst[%c0, %c1] %local_buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>
+  // CHECK: d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] %{{.*}} : memref<{{.*}}>, memref<{{.*}}>
+  d2m.remote_store %remote_dst[%c0, %c1] %local_buffer : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #dram>, memref<2x4x!ttcore.tile<32x32, f32>, #l1_>
 
   return
 }

--- a/test/ttmlir/Dialect/D2M/remote_load_store_tensor_syntax.mlir
+++ b/test/ttmlir/Dialect/D2M/remote_load_store_tensor_syntax.mlir
@@ -35,7 +35,7 @@ func.func @test_remote_load_with_result_tensor(
   // RemoteLoadOp with result (no CB), tensor variant
   // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] : tensor<{{.*}}>, tensor<{{.*}}> -> tensor<{{.*}}>
   // BUFFERIZE: %[[ALLOC:[a-zA-Z0-9]+]] = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-  // BUFFERIZE: %{{.*}} = d2m.remote_load %[[ALLOC]] %{{.*}}[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // BUFFERIZE: d2m.remote_load %[[ALLOC]] %{{.*}}[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]>
   // BUFFERIZE: return %[[ALLOC]] : memref<2x4x!ttcore.tile<32x32, f32>>
   %result = d2m.remote_load %buffer %remote_src[%c0, %c1] : tensor<2x4x!ttcore.tile<32x32, f32>>, tensor<2x4x2x4x!ttcore.tile<32x32, f32>, #remote_layout> -> tensor<2x4x!ttcore.tile<32x32, f32>>
 
@@ -54,7 +54,7 @@ func.func @test_remote_load_with_result_multicast_tensor(
   // RemoteLoadOp with result and multicast (low-level multicast), tensor variant
   // CHECK: %{{.*}} = d2m.remote_load %{{.*}} %{{.*}}[%{{.*}}, %{{.*}}] mcore[%{{.*}}, %{{.*}}] mshape[%{{.*}}, %{{.*}}] : tensor<{{.*}}>, tensor<{{.*}}> -> tensor<{{.*}}>
   // BUFFERIZE: %[[ALLOC_MCAST:[a-zA-Z0-9]+]] = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-  // BUFFERIZE: %{{.*}} = d2m.remote_load %[[ALLOC_MCAST]] %{{.*}}[%{{.*}}, %{{.*}}] mcore[%{{.*}}, %{{.*}}] mshape[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
+  // BUFFERIZE: d2m.remote_load %[[ALLOC_MCAST]] %{{.*}}[%{{.*}}, %{{.*}}] mcore[%{{.*}}, %{{.*}}] mshape[%{{.*}}, %{{.*}}] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]>
   // BUFFERIZE: return %[[ALLOC_MCAST]] : memref<2x4x!ttcore.tile<32x32, f32>>
   %result = d2m.remote_load %buffer %remote_src[%c0, %c1] mcore[%c0, %c0] mshape[%c1, %c2] : tensor<2x4x!ttcore.tile<32x32, f32>>, tensor<2x4x2x4x!ttcore.tile<32x32, f32>, #remote_layout> -> tensor<2x4x!ttcore.tile<32x32, f32>>
 
@@ -77,7 +77,7 @@ func.func @test_remote_store_with_local_buffer_tensor(
   // Result is required for implicit form. For tensors it can be used, but after bufferization
   // to memrefs it must be unused.
   // CHECK: %{{.*}} = d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] %{{.*}} : tensor<{{.*}}>, tensor<{{.*}}> -> tensor<{{.*}}>
-  // BUFFERIZE: %{{.*}} = d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] %{{.*}} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]>, memref<2x4x!ttcore.tile<32x32, f32>> -> memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]>
+  // BUFFERIZE: d2m.remote_store %{{.*}}[%{{.*}}, %{{.*}}] %{{.*}} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #[[DRAM]]>, memref<2x4x!ttcore.tile<32x32, f32>>
   %result = d2m.remote_store %remote_dst[%c0, %c1] %local_buffer : tensor<2x4x2x4x!ttcore.tile<32x32, f32>, #remote_layout>, tensor<2x4x!ttcore.tile<32x32, f32>> -> tensor<2x4x2x4x!ttcore.tile<32x32, f32>, #remote_layout>
 
   return

--- a/test/unittests/D2MGenericAnalysis/TestD2MGenericAnalysis.cpp
+++ b/test/unittests/D2MGenericAnalysis/TestD2MGenericAnalysis.cpp
@@ -911,9 +911,9 @@ func.func @test(
     %block1 = d2m.block_index(1) : index
     %block2_6 = d2m.block_index(2) : index
     %alloc_7 = memref.alloc() {alignment = 64 : i64} : memref<2x4x!ttcore.tile<32x32, f32>>
-    %0 = d2m.remote_load %alloc_7 %in0[%block0, %block2] mcast[%c0] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<8x8x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.memory_space<l1>> -> memref<2x4x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+    d2m.remote_load %alloc_7 %in0[%block0, %block2] mcast[%c0] : memref<2x4x!ttcore.tile<32x32, f32>>, memref<8x8x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #ttcore.memory_space<l1>>
     %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<4x8x!ttcore.tile<32x32, f32>>
-    %1 = d2m.remote_load %alloc_8 %in1[%block2_6, %block1] mcast[%c1] : memref<4x8x!ttcore.tile<32x32, f32>>, memref<8x8x4x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #ttcore.memory_space<l1>> -> memref<4x8x!ttcore.tile<32x32, f32>, #ttcore.memory_space<l1>>
+    d2m.remote_load %alloc_8 %in1[%block2_6, %block1] mcast[%c1] : memref<4x8x!ttcore.tile<32x32, f32>>, memref<8x8x4x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #ttcore.memory_space<l1>>
     %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<2x8x!ttcore.tile<32x32, f32>>
     linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%alloc_7, %alloc_8 : memref<2x4x!ttcore.tile<32x32, f32>>, memref<4x8x!ttcore.tile<32x32, f32>>) outs(%alloc_9 : memref<2x8x!ttcore.tile<32x32, f32>>) {
     ^bb0(%in_tile: !ttcore.tile<32x32, f32>, %in_12: !ttcore.tile<32x32, f32>, %out_tile: !ttcore.tile<32x32, f32>):
@@ -922,7 +922,7 @@ func.func @test(
     }
     %block0_10 = d2m.block_index(0) : index
     %block1_11 = d2m.block_index(1) : index
-    %2 = d2m.remote_store %out[%block0_10, %block1_11] %alloc_9 : memref<8x8x2x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #ttcore.memory_space<l1>>, memref<2x8x!ttcore.tile<32x32, f32>> -> memref<8x8x2x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #ttcore.memory_space<l1>>
+    d2m.remote_store %out[%block0_10, %block1_11] %alloc_9 : memref<8x8x2x8x!ttcore.tile<32x32, f32>, #ttcore.shard<32768x4096, 1>, #ttcore.memory_space<l1>>, memref<2x8x!ttcore.tile<32x32, f32>>
   }
   return
 }


### PR DESCRIPTION
The remote_load and remote_store ops advertised DestinationStyleOpInterface but still produced an SSA result in the post-bufferization memref form, contradicting DPS conventions and leaving a dead value in the IR.

Both ops now have no result once bufferized; the localBuffer (load) or destination memref (store) is the result. The tensor form retains a result since downstream tensor consumers and d2m.yield need it.

- bufferize() for both ops emits the no-result memref form and wraps the bufferized destination in a bufferization.to_tensor so pending tensor users see a valid SSA value until they bufferize themselves.
- Verifier now requires: implicit tensor form has a result; implicit memref form has no result.
- getValue() (AffineReadOpInterface) returns localBuffer when no result is present.
- Allocate.cpp drops setType() on the result and short-circuits the fallback re-typing when the localBuffer is already typed, preserving #ttcore.cb_layout<...> annotations set by stream insertion.
- LowerMulticastLoads uses the no-result builder for replacement ops.
- repairParallelizedRegionTypes guards on hasResultForm() before propagating the localBuffer type to the (possibly absent) result.
- Lit tests and one C++ unit test updated to drop the now-illegal result binding and arrow on memref-form remote_load / remote_store.