### PR TITLE
Uplift third_party/tt-metal to d5a16537336229bee54fd4a6d8bd54c492abc7d1 2026-05-11

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=61e690c25202111b52cbc1fbc9148b6524070c6f
+ARG TT_METAL_DEPENDENCIES_COMMIT=d5a16537336229bee54fd4a6d8bd54c492abc7d1
 
 # Install dependencies
 RUN <<EOT

--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -42,6 +42,7 @@
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/n150" },
     { "runs-on": "n300",   "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/n300" },
     { "runs-on": "llmbox", "image": "tracy",  "script": "ttnn_runtime.sh", "args": "runtime/test/ttnn/python/distributed/llmbox" },
+    { "runs-on": "llmbox", "image": "speedy", "script": "ttrt.sh", "args": ["run", "Dialect/TTNN/trace/scenarios/llmbox", "--enable-program-cache", "--loops", "3"] },
     { "runs-on": "n300",   "image": "tracy",  "script": "runtime_debug.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "ttnn_standalone.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
@@ -21,10 +21,19 @@ ALWI void llk_unpack_tilize(uint32_t operand, uint32_t tile_index,
                                 1; // Remove header size added by descriptor
 
   WAYPOINT("UPTW");
+#ifndef ARCH_WORMHOLE
+  // tt-metal PR #43780 (commit c990d72) removed block_ct_dim for BH
+  _llk_unpack_tilize_(base_address + (start_tile_index * page_bytes),
+                      tile_index, unpack_src_format[operand_id],
+                      unpack_dst_format[operand_id], face_r_dim, num_faces,
+                      narrow_tile);
+#else
+  // Wormhole's _llk_unpack_tilize_ still takes block_ct_dim
   _llk_unpack_tilize_(base_address + (start_tile_index * page_bytes),
                       tile_index, unpack_src_format[operand_id],
                       unpack_dst_format[operand_id], block_ct_dim, face_r_dim,
                       num_faces, narrow_tile);
+#endif
   WAYPOINT("UPTD");
 }
 

--- a/runtime/lib/ttnn/operations/generic/generic_op.cpp
+++ b/runtime/lib/ttnn/operations/generic/generic_op.cpp
@@ -249,6 +249,7 @@ createKernelDescriptor(const ::tt::target::ttnn::KernelDescriptor &kernelDesc,
       .runtime_args = runtimeArgs,
       .common_runtime_args = commonRuntimeArgs,
       .config = createKernelConfigDescriptor(kernelDesc),
+      .compiler_include_paths = {},
       .buffer_bindings = {},
       .common_buffer_bindings = {}};
 

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -405,8 +405,6 @@ def test_distributed_rms_norm(
         (1, 1, 32, 512),
         (1, 1, 32, 4096),
         (1, 1, 32, 8192),
-        (32, 128),
-        (1, 32, 128),
     ]:
         pytest.skip(
             f"Hangs on n300 with has_weight=True and shape={shape} after metal uplift "

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "08ce2dc1594c264f262cdce6c56fc014af1f6bfd")
+set(TT_METAL_VERSION "d5a16537336229bee54fd4a6d8bd54c492abc7d1")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d5a16537336229bee54fd4a6d8bd54c492abc7d1

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25710949304
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/25710895463
      - Note: the above CI job was run from the tt-mlir commit currently in main (bb1deb417cef0e2c60147072cf7b6926a49ccca7) with these changes added to it.
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): N/A
  - [x] **Frontend fix PRs** ready (if needed by this uplift): N/A