### PR TITLE
[D2M] Use offset-aware grid range handling in GridSelection

### DIFF
--- a/include/ttmlir/AffineMapUtils.h
+++ b/include/ttmlir/AffineMapUtils.h
@@ -67,6 +67,51 @@ replaceAffineMapSymbols(mlir::AffineMap map, mlir::ArrayRef<int64_t> symbols) {
                                    map.getNumDims(), numResultSyms);
 }
 
+/// Returns a new affine map with constant offsets applied to a contiguous
+/// subset of map results.
+inline mlir::AffineMap applyOffsetsToAffineMapResults(
+    mlir::AffineMap map, mlir::ArrayRef<int64_t> offsets, unsigned startIndex) {
+  if (offsets.empty()) {
+    return map;
+  }
+  mlir::MLIRContext *ctx = map.getContext();
+  TT_assertv(startIndex + offsets.size() <= map.getNumResults(),
+             "Result offset range out of bounds");
+  unsigned endIndex = startIndex + offsets.size();
+  llvm::SmallVector<mlir::AffineExpr> remappedResults(map.getResults().begin(),
+                                                      map.getResults().end());
+  for (unsigned i = startIndex; i < endIndex; ++i) {
+    remappedResults[i] = remappedResults[i] +
+                         getAffineConstantExpr(offsets[i - startIndex], ctx);
+  }
+  return mlir::AffineMap::get(map.getNumDims(), map.getNumSymbols(),
+                              remappedResults, ctx);
+}
+
+/// Returns a new affine map with constant offsets applied to a contiguous
+/// subset of map input dimensions by replacing dim uses with (dim + offset).
+inline mlir::AffineMap applyOffsetsToAffineMapDims(
+    mlir::AffineMap map, mlir::ArrayRef<int64_t> offsets, unsigned startIndex) {
+  if (offsets.empty()) {
+    return map;
+  }
+  mlir::MLIRContext *ctx = map.getContext();
+  TT_assertv(startIndex + offsets.size() <= map.getNumDims(),
+             "Dim offset range out of bounds");
+  unsigned endIndex = startIndex + offsets.size();
+  llvm::SmallVector<mlir::AffineExpr> dimReplacements;
+  dimReplacements.reserve(map.getNumDims());
+  for (unsigned i = 0; i < map.getNumDims(); ++i) {
+    dimReplacements.push_back(getAffineDimExpr(i, ctx));
+  }
+  for (unsigned i = startIndex; i < endIndex; ++i) {
+    dimReplacements[i] = dimReplacements[i] +
+                         getAffineConstantExpr(offsets[i - startIndex], ctx);
+  }
+  return map.replaceDimsAndSymbols(dimReplacements, {}, map.getNumDims(),
+                                   map.getNumSymbols());
+}
+
 /// Generates an affine map translating ND grid + ND shard coordinates into ND
 /// grid + linearized offset.
 /// Example: strides=[4,2] -> (g0,g1,s0,s1) -> (g0,g1,4*s0+2*s1)

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -71,7 +71,9 @@ struct GridAnalysis {
 
 private:
   /// Analyze a single GenericOp and compute grid decisions for all operands.
-  void analyzeGenericOp(GenericOp genericOp, GenericGridAnalysisResult &result);
+  GenericGridAnalysisResult
+  analyzeGenericOp(GenericOp genericOp,
+                   const EffectiveTargetGridRange &effectiveTargetGridRange);
 
   /// Compute the effective target grid range for a generic, accounting for
   /// spatial region grid ranges.

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -30,14 +30,22 @@ struct OperandGridInfo {
   llvm::SmallVector<int64_t> viewSourceGrid;
 };
 
+/// Effective target grid range for a GenericOp.
+/// Shape is the 2D extent, offset is the 2D start coordinate on device grid.
+struct EffectiveTargetGridRange {
+  // The shape is always expected to be 2D.
+  llvm::SmallVector<int64_t> shape;
+  // Offset defaults to origin when the target range is the full device grid.
+  llvm::SmallVector<int64_t> offset = {0, 0};
+};
+
 /// Per-GenericOp analysis result containing all grid decisions.
 struct GenericGridAnalysisResult {
   llvm::SmallVector<OperandGridInfo, 4> operandInfos;
   llvm::SmallVector<llvm::SmallVector<int64_t>> normalizedOperandGrids;
-  // The effective target grid for this generic: the full device grid by
-  // default, or the range scoped by an enclosing d2m.spatial region. Used
-  // as the 2D placement bound for virtual grid physical mapping.
-  llvm::SmallVector<int64_t> effectiveTargetGrid;
+  // The effective target grid range for this generic: full device grid by
+  // default, or the range scoped by an enclosing d2m.spatial region.
+  EffectiveTargetGridRange effectiveTargetGridRange;
 };
 
 /// Module-level analysis that computes optimal grid assignments for all
@@ -63,12 +71,11 @@ struct GridAnalysis {
 
 private:
   /// Analyze a single GenericOp and compute grid decisions for all operands.
-  GenericGridAnalysisResult analyzeGenericOp(GenericOp genericOp,
-                                             ArrayRef<int64_t> targetGridShape);
+  void analyzeGenericOp(GenericOp genericOp, GenericGridAnalysisResult &result);
 
-  /// Compute the target grid shape for a generic, accounting for spatial
-  /// region grid ranges.
-  llvm::SmallVector<int64_t> getTargetGridShape(GenericOp genericOp) const;
+  /// Compute the effective target grid range for a generic, accounting for
+  /// spatial region grid ranges.
+  EffectiveTargetGridRange getTargetGridRange(GenericOp genericOp) const;
 
   /// Normalize operand grids within a generic to ensure consistency across
   /// operands sharing loop dimensions. Physical shapes are required to ensure

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -153,8 +153,11 @@ GridAnalysis::normalizeOperandGridsForGeneric(
   return normalizedOperandGrids;
 }
 
-void GridAnalysis::analyzeGenericOp(GenericOp genericOp,
-                                    GenericGridAnalysisResult &result) {
+GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
+    GenericOp genericOp,
+    const EffectiveTargetGridRange &effectiveTargetGridRange) {
+  GenericGridAnalysisResult result;
+  result.effectiveTargetGridRange = effectiveTargetGridRange;
   ArrayRef<int64_t> targetGridShape = result.effectiveTargetGridRange.shape;
 
   // Build per-operand target grids. When a loop dimension maps to different
@@ -288,7 +291,7 @@ void GridAnalysis::analyzeGenericOp(GenericOp genericOp,
     }
   }
 
-  return;
+  return result;
 }
 
 EffectiveTargetGridRange
@@ -327,9 +330,8 @@ GridAnalysis::GridAnalysis(Operation *moduleOp,
     }
 
     EffectiveTargetGridRange targetGridRange = getTargetGridRange(genericOp);
-    GenericGridAnalysisResult result;
-    result.effectiveTargetGridRange = std::move(targetGridRange);
-    analyzeGenericOp(genericOp, result);
+    GenericGridAnalysisResult result =
+        analyzeGenericOp(genericOp, targetGridRange);
     results[genericOp.getOperation()] =
         std::make_unique<GenericGridAnalysisResult>(std::move(result));
   });

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -153,11 +153,9 @@ GridAnalysis::normalizeOperandGridsForGeneric(
   return normalizedOperandGrids;
 }
 
-GenericGridAnalysisResult
-GridAnalysis::analyzeGenericOp(GenericOp genericOp,
-                               ArrayRef<int64_t> targetGridShape) {
-  GenericGridAnalysisResult result;
-  result.effectiveTargetGrid = llvm::SmallVector<int64_t>(targetGridShape);
+void GridAnalysis::analyzeGenericOp(GenericOp genericOp,
+                                    GenericGridAnalysisResult &result) {
+  ArrayRef<int64_t> targetGridShape = result.effectiveTargetGridRange.shape;
 
   // Build per-operand target grids. When a loop dimension maps to different
   // operand-dim positions across operands (e.g. matmul K is dim 1 of LHS but
@@ -290,11 +288,12 @@ GridAnalysis::analyzeGenericOp(GenericOp genericOp,
     }
   }
 
-  return result;
+  return;
 }
 
-llvm::SmallVector<int64_t>
-GridAnalysis::getTargetGridShape(GenericOp genericOp) const {
+EffectiveTargetGridRange
+GridAnalysis::getTargetGridRange(GenericOp genericOp) const {
+  EffectiveTargetGridRange targetGridRange;
   mlir::Region *region = genericOp->getParentRegion();
   if (auto spatialOp = mlir::dyn_cast<d2m::SpatialOp>(region->getParentOp())) {
     mlir::ArrayAttr gridRangesAttr = spatialOp.getGridRanges();
@@ -302,11 +301,17 @@ GridAnalysis::getTargetGridShape(GenericOp genericOp) const {
     if (gridRangesAttr && regionIndex < gridRangesAttr.size()) {
       ttcore::CoreRangeAttr range =
           mlir::cast<ttcore::CoreRangeAttr>(gridRangesAttr[regionIndex]);
-      return {range.getEndCoord().getY() - range.getStartCoord().getY() + 1,
-              range.getEndCoord().getX() - range.getStartCoord().getX() + 1};
+      targetGridRange.shape = {
+          range.getEndCoord().getY() - range.getStartCoord().getY() + 1,
+          range.getEndCoord().getX() - range.getStartCoord().getX() + 1};
+      targetGridRange.offset = {range.getStartCoord().getY(),
+                                range.getStartCoord().getX()};
+      return targetGridRange;
     }
   }
-  return llvm::SmallVector<int64_t>(deviceGridShape);
+  targetGridRange.shape = llvm::SmallVector<int64_t>(deviceGridShape);
+  targetGridRange.offset = {0, 0};
+  return targetGridRange;
 }
 
 GridAnalysis::GridAnalysis(Operation *moduleOp,
@@ -321,10 +326,12 @@ GridAnalysis::GridAnalysis(Operation *moduleOp,
       return;
     }
 
-    llvm::SmallVector<int64_t> targetGridShape = getTargetGridShape(genericOp);
+    EffectiveTargetGridRange targetGridRange = getTargetGridRange(genericOp);
+    GenericGridAnalysisResult result;
+    result.effectiveTargetGridRange = std::move(targetGridRange);
+    analyzeGenericOp(genericOp, result);
     results[genericOp.getOperation()] =
-        std::make_unique<GenericGridAnalysisResult>(
-            analyzeGenericOp(genericOp, targetGridShape));
+        std::make_unique<GenericGridAnalysisResult>(std::move(result));
   });
 }
 

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -37,8 +37,9 @@ namespace mlir::tt::d2m {
 
 static std::pair<mlir::AffineMapAttr, mlir::AffineMapAttr>
 deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
-                       ArrayRef<int64_t> effectiveTargetGrid,
+                       const EffectiveTargetGridRange &effectiveTargetGridRange,
                        OpBuilder &builder) {
+  ArrayRef<int64_t> effectiveTargetGridShape = effectiveTargetGridRange.shape;
   auto device = ttcore::lookupDevice(anchorOp);
   auto workerGridShape = device.getWorkerGrid().getShape();
   bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
@@ -48,12 +49,12 @@ deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
   }
 
   auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-      ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGrid);
+      ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGridShape);
   TT_assertv(!physicalGridShape.empty(),
              "Unable to find 2D rect that can fit virtual grid {} within "
              "device grid {}",
              ttmlir::utils::formatIterable(selectedGrid, "x"),
-             ttmlir::utils::formatIterable(effectiveTargetGrid, "x"));
+             ttmlir::utils::formatIterable(effectiveTargetGridShape, "x"));
   auto [forwardMap, inverseMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
       builder.getContext(), selectedGrid, physicalGridShape);
   return {AffineMapAttr::get(inverseMap), AffineMapAttr::get(forwardMap)};
@@ -62,11 +63,11 @@ deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
 // Update a ToLayoutOp and its associated EmptyOp to use a specified grid by
 // recreating the MetalLayoutAttr with the given grid and proper dimension
 // alignments.
-static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
-                                 ArrayRef<int64_t> targetGrid,
-                                 ArrayRef<int64_t> effectiveTargetGrid,
-                                 bool ttnnMode, ArrayRef<int64_t> optimalGrid,
-                                 OpBuilder &builder) {
+static void
+optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
+                     const EffectiveTargetGridRange &effectiveTargetGridRange,
+                     bool ttnnMode, ArrayRef<int64_t> optimalGrid,
+                     OpBuilder &builder) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
   if (!emptyOp) {
     return;
@@ -105,7 +106,7 @@ static void optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp,
   // has its own grid/shard strategy. VGM for DMA addresses is traced through
   // the stream's input at DMA lowering time.
   auto [virtualGridInverseMapping, virtualGridForwardMapping] =
-      deriveVirtualGridAttrs(toLayoutOp, optimalGrid, effectiveTargetGrid,
+      deriveVirtualGridAttrs(toLayoutOp, optimalGrid, effectiveTargetGridRange,
                              builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
@@ -295,20 +296,22 @@ optimizeTTNNMetalLayoutCastOpGrid(ttir::TTNNMetalLayoutCastOp castOp,
 // Transform phases — apply pre-computed grid decisions to the IR.
 // ----------------------------------------------------------------------------
 
-static void applyToLayoutUpdate(const OperandGridInfo &info,
-                                ArrayRef<int64_t> effectiveTargetGrid,
-                                bool ttnnMode, OpBuilder &builder) {
+static void
+applyToLayoutUpdate(const OperandGridInfo &info,
+                    const EffectiveTargetGridRange &effectiveTargetGridRange,
+                    bool ttnnMode, OpBuilder &builder) {
   auto toLayoutOp = info.operand.getDefiningOp<d2m::ToLayoutOp>();
-  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGrid,
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
                        ttnnMode, info.selectedGrid, builder);
 }
 
-static void applyBehindViewToLayoutUpdate(const OperandGridInfo &info,
-                                          ArrayRef<int64_t> effectiveTargetGrid,
-                                          bool ttnnMode, OpBuilder &builder) {
+static void applyBehindViewToLayoutUpdate(
+    const OperandGridInfo &info,
+    const EffectiveTargetGridRange &effectiveTargetGridRange, bool ttnnMode,
+    OpBuilder &builder) {
   auto view = info.operand.getDefiningOp<d2m::ViewLayoutOp>();
   auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>();
-  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGrid,
+  optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
                        ttnnMode, info.viewSourceGrid, builder);
 }
 
@@ -336,9 +339,11 @@ static void applyTTNNTensorUpdate(const OperandGridInfo &info,
   }
 }
 
-static void applyCompositeViewUpdate(const OperandGridInfo &info,
-                                     ArrayRef<int64_t> effectiveTargetGrid,
-                                     bool ttnnMode, OpBuilder &builder) {
+static void
+applyCompositeViewUpdate(const OperandGridInfo &info,
+                         EffectiveTargetGridRange effectiveTargetGrid,
+                         bool ttnnMode, OpBuilder &builder) {
+  ArrayRef<int64_t> effectiveTargetGridShape = effectiveTargetGrid.shape;
   auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
   const int32_t concatDim = compositeView.getDim();
   auto outType =
@@ -417,7 +422,7 @@ static void applyCompositeViewUpdate(const OperandGridInfo &info,
         auto newEmptyOp = builder.create<d2m::EmptyOp>(
             emptyOp.getLoc(), newInputType.getShape(),
             newInputType.getElementType(), newInputType.getEncoding(),
-            effectiveTargetGrid);
+            effectiveTargetGridShape);
         builder.setInsertionPoint(toLayoutOp);
         auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
             toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);
@@ -446,9 +451,10 @@ static void applyCompositeViewUpdate(const OperandGridInfo &info,
   compositeView.erase();
 }
 
-static void applyEmptyOpUpdate(const OperandGridInfo &info,
-                               ArrayRef<int64_t> effectiveTargetGrid,
-                               bool ttnnMode, OpBuilder &builder) {
+static void
+applyEmptyOpUpdate(const OperandGridInfo &info,
+                   const EffectiveTargetGridRange &effectiveTargetGridRange,
+                   bool ttnnMode, OpBuilder &builder) {
   EmptyOp emptyOp = info.operand.getDefiningOp<d2m::EmptyOp>();
   auto emptyType =
       mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
@@ -460,8 +466,8 @@ static void applyEmptyOpUpdate(const OperandGridInfo &info,
   // TODO (#8301): Avoid creating placeholder EmptyOp VGMs before grid
   // selection so this rewrite does not need to repair stale mappings.
   auto [virtualGridInverseMapping, virtualGridForwardMapping] =
-      deriveVirtualGridAttrs(emptyOp, info.selectedGrid, effectiveTargetGrid,
-                             builder);
+      deriveVirtualGridAttrs(emptyOp, info.selectedGrid,
+                             effectiveTargetGridRange, builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
       emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
@@ -624,11 +630,16 @@ recreateGenericOp(d2m::GenericOp genericOp,
 static LogicalResult applyGridDecisions(d2m::GenericOp genericOp,
                                         const GenericGridAnalysisResult &result,
                                         bool ttnnMode) {
-  // effectiveTargetGrid is the generic's target grid (full device grid, or
-  // the range scoped by an enclosing d2m.spatial region), used for virtual
-  // grid physical mapping. Per-operand target grids (info.targetGrid) are
-  // used for alignment computation.
-  ArrayRef<int64_t> effectiveTargetGrid = result.effectiveTargetGrid;
+  // effectiveTargetGridRange is the range of the generic's target grid (full
+  // device grid, or the range scoped by an enclosing d2m.spatial region), used
+  // for virtual grid physical mapping. Per-operand target grids
+  // (info.targetGrid) are used for alignment computation.
+  const EffectiveTargetGridRange &effectiveTargetGridRange =
+      result.effectiveTargetGridRange;
+  TT_assertv(effectiveTargetGridRange.shape.size() == 2u,
+             "Expected 2D effective target grid shape");
+  TT_assertv(effectiveTargetGridRange.offset.size() == 2u,
+             "Expected 2D effective target grid offset");
   OpBuilder builder(genericOp->getContext());
 
   // Classify operands upfront: once apply* mutates IR, defining ops for
@@ -671,20 +682,21 @@ static LogicalResult applyGridDecisions(d2m::GenericOp genericOp,
       applyTTNNTensorUpdate(info, builder);
       break;
     case Kind::CompositeView:
-      applyCompositeViewUpdate(info, effectiveTargetGrid, ttnnMode, builder);
+      applyCompositeViewUpdate(info, effectiveTargetGridRange, ttnnMode,
+                               builder);
       break;
     case Kind::ToLayout:
-      applyToLayoutUpdate(info, effectiveTargetGrid, ttnnMode, builder);
+      applyToLayoutUpdate(info, effectiveTargetGridRange, ttnnMode, builder);
       break;
     case Kind::Empty:
-      applyEmptyOpUpdate(info, effectiveTargetGrid, ttnnMode, builder);
+      applyEmptyOpUpdate(info, effectiveTargetGridRange, ttnnMode, builder);
       break;
     case Kind::ViewLayout:
     case Kind::Skip:
       break;
     }
     if (!info.viewSourceGrid.empty()) {
-      applyBehindViewToLayoutUpdate(info, effectiveTargetGrid, ttnnMode,
+      applyBehindViewToLayoutUpdate(info, effectiveTargetGridRange, ttnnMode,
                                     builder);
     }
   }

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -48,27 +48,34 @@ deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
   auto workerGridShape = device.getWorkerGrid().getShape();
   bool requiresVirtualization = ttmlir::d2m::utils::grids::requiresVirtualGrid(
       selectedGrid, workerGridShape);
-  if (!(requiresVirtualization || hasOffset)) {
+  if (!requiresVirtualization && !hasOffset) {
     return {mlir::AffineMapAttr(), mlir::AffineMapAttr()};
   }
-
-  SmallVector<int64_t> physicalGridShape;
+  AffineMap forwardMap;
+  AffineMap inverseMap;
   if (requiresVirtualization) {
-    physicalGridShape = utils::findLegalPhysicalGridForVolume(
-        ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGridShape);
+    SmallVector<int64_t> physicalGridShape =
+        utils::findLegalPhysicalGridForVolume(
+            ttmlir::utils::volume<int64_t>(selectedGrid),
+            effectiveTargetGridShape);
     TT_assertv(!physicalGridShape.empty(),
                "Unable to find 2D rect that can fit virtual grid {} within "
                "device grid {}",
                ttmlir::utils::formatIterable(selectedGrid, "x"),
                ttmlir::utils::formatIterable(effectiveTargetGridShape, "x"));
+    std::tie(forwardMap, inverseMap) =
+        ttmlir::d2m::utils::grids::createCoreVirtMaps(
+            builder.getContext(), selectedGrid, physicalGridShape);
   } else {
-    // Offset-only remap: preserve the same local 2D grid shape and translate it
-    // into the effective target range by applying offset to the affine maps.
-    physicalGridShape = llvm::SmallVector<int64_t>(selectedGrid);
+    // Offset-only remap without virtualization: start from identity mappings.
+    TT_assertv(selectedGrid.size() == 2u,
+               "Expected 2D selected grid for offset-only remap");
+    unsigned rank = selectedGrid.size() * 2;
+    forwardMap = AffineMap::getMultiDimIdentityMap(rank, builder.getContext());
+    inverseMap =
+        ttmlir::utils::createIdentityGridInverseMap(builder.getContext());
   }
 
-  auto [forwardMap, inverseMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
-      builder.getContext(), selectedGrid, physicalGridShape);
   if (hasOffset) {
     TT_assertv(effectiveTargetGridOffset.size() == 2u,
                "Expected 2D effective target grid offset");

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -40,23 +40,45 @@ deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
                        const EffectiveTargetGridRange &effectiveTargetGridRange,
                        OpBuilder &builder) {
   ArrayRef<int64_t> effectiveTargetGridShape = effectiveTargetGridRange.shape;
+  ArrayRef<int64_t> effectiveTargetGridOffset = effectiveTargetGridRange.offset;
+
+  bool hasOffset = llvm::any_of(effectiveTargetGridOffset,
+                                [](int64_t coord) { return coord != 0; });
   auto device = ttcore::lookupDevice(anchorOp);
   auto workerGridShape = device.getWorkerGrid().getShape();
-  bool isVirtual = ttmlir::d2m::utils::grids::requiresVirtualGrid(
+  bool requiresVirtualization = ttmlir::d2m::utils::grids::requiresVirtualGrid(
       selectedGrid, workerGridShape);
-  if (!isVirtual) {
+  if (!(requiresVirtualization || hasOffset)) {
     return {mlir::AffineMapAttr(), mlir::AffineMapAttr()};
   }
 
-  auto physicalGridShape = utils::findLegalPhysicalGridForVolume(
-      ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGridShape);
-  TT_assertv(!physicalGridShape.empty(),
-             "Unable to find 2D rect that can fit virtual grid {} within "
-             "device grid {}",
-             ttmlir::utils::formatIterable(selectedGrid, "x"),
-             ttmlir::utils::formatIterable(effectiveTargetGridShape, "x"));
+  SmallVector<int64_t> physicalGridShape;
+  if (requiresVirtualization) {
+    physicalGridShape = utils::findLegalPhysicalGridForVolume(
+        ttmlir::utils::volume<int64_t>(selectedGrid), effectiveTargetGridShape);
+    TT_assertv(!physicalGridShape.empty(),
+               "Unable to find 2D rect that can fit virtual grid {} within "
+               "device grid {}",
+               ttmlir::utils::formatIterable(selectedGrid, "x"),
+               ttmlir::utils::formatIterable(effectiveTargetGridShape, "x"));
+  } else {
+    // Offset-only remap: preserve the same local 2D grid shape and translate it
+    // into the effective target range by applying offset to the affine maps.
+    physicalGridShape = llvm::SmallVector<int64_t>(selectedGrid);
+  }
+
   auto [forwardMap, inverseMap] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
       builder.getContext(), selectedGrid, physicalGridShape);
+  if (hasOffset) {
+    TT_assertv(effectiveTargetGridOffset.size() == 2u,
+               "Expected 2D effective target grid offset");
+    forwardMap = ttmlir::utils::applyOffsetsToAffineMapResults(
+        forwardMap, effectiveTargetGridOffset, /*startIndex=*/0);
+    SmallVector<int64_t> inverseOffsets = {-effectiveTargetGridOffset[0],
+                                           -effectiveTargetGridOffset[1]};
+    inverseMap = ttmlir::utils::applyOffsetsToAffineMapDims(
+        inverseMap, inverseOffsets, /*startIndex=*/0);
+  }
   return {AffineMapAttr::get(inverseMap), AffineMapAttr::get(forwardMap)};
 }
 

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -121,6 +121,10 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
   }
 
   if (!needsOptimization) {
+    // A selected 1x1 grid does not require producer-side redistribution.
+    // In non-origin spatial regions, offset-aware mapping is materialized on
+    // the output path: applyEmptyOpUpdate updates the outs EmptyOp VGM, and
+    // deriveGridAttrForOutput rebuilds the generic grid mapping from it.
     return;
   }
 
@@ -364,10 +368,10 @@ static void applyTTNNTensorUpdate(const OperandGridInfo &info,
   }
 }
 
-static void
-applyCompositeViewUpdate(const OperandGridInfo &info,
-                         const EffectiveTargetGridRange &effectiveTargetGrid,
-                         bool ttnnMode, OpBuilder &builder) {
+static void applyCompositeViewUpdate(
+    const OperandGridInfo &info,
+    const EffectiveTargetGridRange &effectiveTargetGridRange, bool ttnnMode,
+    OpBuilder &builder) {
   auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
   const int32_t concatDim = compositeView.getDim();
   auto outType =
@@ -444,7 +448,7 @@ applyCompositeViewUpdate(const OperandGridInfo &info,
       auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
       if (emptyOp) {
         auto [virtualGridInverseMapping, virtualGridForwardMapping] =
-            deriveVirtualGridAttrs(inputOptimalGrid, effectiveTargetGrid,
+            deriveVirtualGridAttrs(inputOptimalGrid, effectiveTargetGridRange,
                                    builder);
         builder.setInsertionPoint(emptyOp);
         auto newEmptyOp = builder.create<d2m::EmptyOp>(

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -368,7 +368,6 @@ static void
 applyCompositeViewUpdate(const OperandGridInfo &info,
                          EffectiveTargetGridRange effectiveTargetGrid,
                          bool ttnnMode, OpBuilder &builder) {
-  ArrayRef<int64_t> effectiveTargetGridShape = effectiveTargetGrid.shape;
   auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
   const int32_t concatDim = compositeView.getDim();
   auto outType =
@@ -389,6 +388,7 @@ applyCompositeViewUpdate(const OperandGridInfo &info,
     }
 
     RankedTensorType newInputType;
+    llvm::SmallVector<int64_t> inputOptimalGrid;
     if (isTiled) {
       // Use the grid-aligned output type's dim alignments for the inputs, as
       // they should mostly match on non-concat dimensions.
@@ -416,7 +416,7 @@ applyCompositeViewUpdate(const OperandGridInfo &info,
           inputAlignments);
 
       auto inputPhysShape = newLayout.getPhysicalShape(tileShape);
-      auto inputOptimalGrid =
+      inputOptimalGrid =
           utils::computeOptimalGrid(inputType, inputPhysShape, info.targetGrid);
 
       auto deviceShape = newLayout.getDeviceShape(inputOptimalGrid, tileShape);
@@ -429,7 +429,7 @@ applyCompositeViewUpdate(const OperandGridInfo &info,
       // shard shapes.
       auto inputPhysShape =
           utils::computePhysicalShape(input, info.targetGrid, ttnnMode);
-      auto inputOptimalGrid =
+      inputOptimalGrid =
           utils::computeOptimalGrid(inputType, inputPhysShape, info.targetGrid);
       newInputType = utils::tensorWithOptimalGrid(inputType, info.targetGrid,
                                                   ttnnMode, inputOptimalGrid);
@@ -443,11 +443,13 @@ applyCompositeViewUpdate(const OperandGridInfo &info,
         toLayoutOp && input.hasOneUse()) {
       auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
       if (emptyOp) {
+        auto [virtualGridInverseMapping, virtualGridForwardMapping] =
+            deriveVirtualGridAttrs(inputOptimalGrid, effectiveTargetGrid,
+                                   builder);
         builder.setInsertionPoint(emptyOp);
         auto newEmptyOp = builder.create<d2m::EmptyOp>(
-            emptyOp.getLoc(), newInputType.getShape(),
-            newInputType.getElementType(), newInputType.getEncoding(),
-            effectiveTargetGridShape);
+            emptyOp.getLoc(), newInputType, virtualGridInverseMapping,
+            virtualGridForwardMapping);
         builder.setInsertionPoint(toLayoutOp);
         auto newToLayoutOp = builder.create<d2m::ToLayoutOp>(
             toLayoutOp.getLoc(), toLayoutOp.getInput(), newEmptyOp);

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -7,7 +7,6 @@
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
-#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
@@ -36,7 +35,7 @@ namespace mlir::tt::d2m {
 // ----------------------------------------------------------------------------
 
 static std::pair<mlir::AffineMapAttr, mlir::AffineMapAttr>
-deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
+deriveVirtualGridAttrs(ArrayRef<int64_t> selectedGrid,
                        const EffectiveTargetGridRange &effectiveTargetGridRange,
                        OpBuilder &builder) {
   ArrayRef<int64_t> effectiveTargetGridShape = effectiveTargetGridRange.shape;
@@ -44,10 +43,8 @@ deriveVirtualGridAttrs(Operation *anchorOp, ArrayRef<int64_t> selectedGrid,
 
   bool hasOffset = llvm::any_of(effectiveTargetGridOffset,
                                 [](int64_t coord) { return coord != 0; });
-  auto device = ttcore::lookupDevice(anchorOp);
-  auto workerGridShape = device.getWorkerGrid().getShape();
   bool requiresVirtualization = ttmlir::d2m::utils::grids::requiresVirtualGrid(
-      selectedGrid, workerGridShape);
+      selectedGrid, effectiveTargetGridShape);
   if (!requiresVirtualization && !hasOffset) {
     return {mlir::AffineMapAttr(), mlir::AffineMapAttr()};
   }
@@ -135,8 +132,7 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
   // has its own grid/shard strategy. VGM for DMA addresses is traced through
   // the stream's input at DMA lowering time.
   auto [virtualGridInverseMapping, virtualGridForwardMapping] =
-      deriveVirtualGridAttrs(toLayoutOp, optimalGrid, effectiveTargetGridRange,
-                             builder);
+      deriveVirtualGridAttrs(optimalGrid, effectiveTargetGridRange, builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
       emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,
@@ -495,8 +491,8 @@ applyEmptyOpUpdate(const OperandGridInfo &info,
   // TODO (#8301): Avoid creating placeholder EmptyOp VGMs before grid
   // selection so this rewrite does not need to repair stale mappings.
   auto [virtualGridInverseMapping, virtualGridForwardMapping] =
-      deriveVirtualGridAttrs(emptyOp, info.selectedGrid,
-                             effectiveTargetGridRange, builder);
+      deriveVirtualGridAttrs(info.selectedGrid, effectiveTargetGridRange,
+                             builder);
 
   auto newEmptyOp = builder.create<d2m::EmptyOp>(
       emptyOp.getLoc(), newTensorType, virtualGridInverseMapping,

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -366,7 +366,7 @@ static void applyTTNNTensorUpdate(const OperandGridInfo &info,
 
 static void
 applyCompositeViewUpdate(const OperandGridInfo &info,
-                         EffectiveTargetGridRange effectiveTargetGrid,
+                         const EffectiveTargetGridRange &effectiveTargetGrid,
                          bool ttnnMode, OpBuilder &builder) {
   auto compositeView = info.operand.getDefiningOp<d2m::CompositeViewOp>();
   const int32_t concatDim = compositeView.getDim();

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
@@ -281,6 +281,53 @@ module attributes {ttcore.device = #any_device} {
 }
 
 // -----
+// CompositeView fast-path in GridSelection rewrites single-use to_layout inputs.
+// In non-origin spatial ranges, the recreated to_layout output empties must
+// keep offset-aware VGM even when selected grid is 1x1 (no virtualization).
+#any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+#layout_in_1x1 = #ttcore.metal_layout<logical_shape = 64x64, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout_out_1x1 = #ttcore.metal_layout<logical_shape = 64x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+// CHECK-DAG: #[[FWD:map[0-9]*]] = affine_map<(d0, d1, d2, d3) -> (d0 + 2, d1 + 2, d2, d3)>
+// CHECK-DAG: #[[INV:map[0-9]*]] = affine_map<(d0, d1) -> (0, d0 - 2, d1 - 2)>
+// CHECK-LABEL: func.func @spatial_non_origin_composite_view_tlayout_single_use
+module attributes {ttcore.device = #any_device} {
+  func.func @spatial_non_origin_composite_view_tlayout_single_use(
+      %arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>)
+      -> tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1> {
+    %0 = d2m.empty() : tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>
+    %1 = d2m.to_layout %arg0, %0 : tensor<64x64xf32> into tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1> -> tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>
+    %2 = d2m.empty() : tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>
+    %3 = d2m.to_layout %arg1, %2 : tensor<64x64xf32> into tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1> -> tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>
+    %4 = "d2m.composite_view"(%1, %3) <{dim = 1 : si32}> : (tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>, tensor<1x1x2x2x!ttcore.tile<32x32, f32>, #layout_in_1x1>) -> tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>
+    %5 = d2m.empty() : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>
+    %6 = d2m.spatial {
+      grid_ranges = [#ttcore.core_range<(2, 2), (2, 2)>]
+    } ins(%4 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>) outs(%5 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>) {
+    ^region_0:
+      %7 = d2m.generic {
+        block_factors = [1, 1],
+        grid = #ttcore.grid<1x1>,
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0, d1)>],
+        iterator_types = [#ttcore.iterator_type<parallel>,
+                          #ttcore.iterator_type<parallel>],
+        threads = [#d2m.thread<unified>]
+      } ins(%4 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>)
+        outs(%5 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>) {
+        %out = tensor.empty() : tensor<2x4x!ttcore.tile<32x32, f32>>
+        d2m.yield %out : (tensor<2x4x!ttcore.tile<32x32, f32>>)
+      } : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>
+      d2m.spatial_yield %7 : (tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>)
+    } : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>
+    // CHECK: d2m.empty() {virtualGridForwardMapping = #[[FWD]], virtualGridInverseMapping = #[[INV]]}
+    // CHECK: d2m.to_layout %arg0
+    // CHECK: d2m.empty() {virtualGridForwardMapping = #[[FWD]], virtualGridInverseMapping = #[[INV]]}
+    // CHECK: d2m.to_layout %arg1
+    return %6 : tensor<1x1x2x4x!ttcore.tile<32x32, f32>, #layout_out_1x1>
+  }
+}
+
+// -----
 // Generic grid mapping from cast VGM: when spatial has non-origin grid_ranges
 // and the generic output is ttir.ttnn_metal_layout_cast with
 // virtual_grid_inverse_mapping (and virtual_grid_forward_mapping), the generic

--- a/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/grid_selection_spatial.mlir
@@ -128,6 +128,59 @@ module attributes {ttcore.device = #any_device} {
 }
 
 // -----
+// Two regions with direct empty outs (no view_layout in between): verify VGM
+// on non-origin region output is preserved on generic grid mapping.
+#any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+#layout_1x1 = #ttcore.metal_layout<logical_shape = 128x128, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#layout = #ttcore.metal_layout<logical_shape = 128x128, dim_alignments = 64x64, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1, sharded>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+// CHECK-LABEL: func.func @spatial_multi_region_two_ranges_direct_empty
+module attributes {ttcore.device = #any_device} {
+  func.func @spatial_multi_region_two_ranges_direct_empty()
+      -> (tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>,
+          tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>) {
+    %0 = d2m.empty() : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>
+    %1 = d2m.empty() {virtualGridInverseMapping = #vgm_11_inv, virtualGridForwardMapping = #vgm_11_fwd} : tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>
+    // CHECK: d2m.spatial
+    // CHECK-SAME: grid_ranges = [#ttcore.core_range<(0,0), (0,0)>, #ttcore.core_range<(1,1), (2,2)>]
+    %2:2 = d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (2, 2)>]}
+        ins() outs(%0, %1 : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>, tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>) {
+      ^region_0:
+        %3 = d2m.generic {
+          block_factors = [1, 1],
+          grid = #ttcore.grid<1x1>,
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>],
+          threads = [#d2m.thread<unified>]
+        } ins() outs(%0 : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>) {
+          %out = tensor.empty() : tensor<4x4x!ttcore.tile<32x32, f32>>
+          d2m.yield %out : (tensor<4x4x!ttcore.tile<32x32, f32>>)
+        } : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>
+        d2m.spatial_yield %3 : (tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>)
+      }, {
+      ^region_1:
+        %4 = d2m.generic {
+          block_factors = [1, 1],
+          grid = #ttcore.grid<2x2>,
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = [#ttcore.iterator_type<parallel>, #ttcore.iterator_type<parallel>],
+          threads = [#d2m.thread<unified>]
+        } ins() outs(%1 : tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>) {
+          %out = tensor.empty() : tensor<2x2x!ttcore.tile<32x32, f32>>
+          d2m.yield %out : (tensor<2x2x!ttcore.tile<32x32, f32>>)
+        } : tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>
+        d2m.spatial_yield %4 : (tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>)
+    } : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>, tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>
+    // CHECK: d2m.generic
+    // CHECK-SAME: grid = #ttcore.grid<1x1>,
+    // CHECK: d2m.generic
+    // CHECK-SAME: grid = #ttcore.grid<2x2, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>,
+    return %2#0, %2#1 : tensor<1x1x4x4x!ttcore.tile<32x32, f32>, #layout_1x1>, tensor<2x2x2x2x!ttcore.tile<32x32, f32>, #layout>
+  }
+}
+
+// -----
 // Four regions on an 8x8 device: each grid_range is a 4x4 square (quadrant).
 // Exercises spatial with more than two regions; each generic keeps grid 4x4.
 // Non-origin quadrants use d2m.empty VGM (offset from physical (y,x) to virtual 0..3).


### PR DESCRIPTION
### Ticket
closes #8368 

### Problem description
`d2m.spatial` `grid_ranges` carry both shape and offset semantics.
In the previous `GridSelection` flow, selected grids were materialized in a way that did not fully preserve offset semantics, which could cause virtual grid mapping to be dropped or become inconsistent in non-origin spatial regions.

In particular, when a d2m.generic output operand is defined by d2m.empty, the virtual-to-physical mapping could lose offset consistency after grid selection, leading to mismatches in the resulting d2m.generic grid attribute.

### What's changed
 - Updated grid selection analysis/application to treat selected regions as full grid ranges (shape + offset) rather than shape-only.
 - Added offset-aware handling when updating virtual mappings so non-origin spatial semantics are preserved.
 - Introduced shared affine-map utilities for applying offsets consistently.
 - Added a regression test for the non-origin spatial path where d2m.generic uses a direct d2m.empty output operand, and verified VGM is preserved in the resulting d2m.generic grid attribute.

### Checklist
- [x] New/Existing tests provide coverage for changes
